### PR TITLE
chore: remove duplicate header scripts

### DIFF
--- a/.nwa-config.yaml
+++ b/.nwa-config.yaml
@@ -1,7 +1,0 @@
-nwa:
-  holder: The Kubernetes Authors
-  license: apache
-  year: "2025"
-  path:
-    - api/**/*.go
-  mute: true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ generate: install-generate-tools
 .PHONY: install-generate-tools
 install-generate-tools:
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
-	go install github.com/B1NARY-GR0UP/nwa@latest
 
 .PHONY: build
 build:

--- a/codegen.go
+++ b/codegen.go
@@ -17,4 +17,3 @@
 package agentsandbox
 
 //go:generate go tool -modfile=tools.mod sigs.k8s.io/controller-tools/cmd/controller-gen object crd:maxDescLen=0 paths="./..." output:crd:dir=k8s/crds
-//go:generate go tool -modfile=tools.mod nwa config -c add


### PR DESCRIPTION
We have some duplicate scripts for fixing headers in Go files,
remove the external dependency and consolidate.
