### PR TITLE
Ensure a Docker builder is running for multi-platform

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -23,14 +23,45 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "shared"))
 import utils
 
 
+def create_buildx_builder_if_not_exists():
+    builder_name = "agent-sandbox-builder"
+    try:
+        subprocess.run(
+            ["docker", "buildx", "inspect", builder_name],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        print(f"buildx builder '{builder_name}' already exists.")
+    except subprocess.CalledProcessError:
+        print(f"creating buildx builder '{builder_name}'.")
+        subprocess.run(
+            ["docker", "buildx", "create", "--name", builder_name], check=True
+        )
+    subprocess.run(["docker", "buildx", "use", builder_name], check=True)
+
+
 def build_and_push_image_with_docker_buildx(image_name, srcdir, dockerfile_path):
     platforms = "linux/amd64,linux/arm64"
-    build_cmd = ["docker", "buildx", "build", "--output=type=registry", "--platform=" + platforms, "-t", image_name, "-f", dockerfile_path, "."]
+    build_cmd = [
+        "docker",
+        "buildx",
+        "build",
+        "--output=type=registry",
+        "--platform=" + platforms,
+        "-t",
+        image_name,
+        "-f",
+        dockerfile_path,
+        ".",
+    ]
     subprocess.run(build_cmd, cwd=srcdir, check=True)
     print(f"pushed image {image_name}")
 
+
 def build_and_push_image(image_name, srcdir, dockerfile_path):
     build_and_push_image_with_docker_buildx(image_name, srcdir, dockerfile_path)
+
 
 def main():
     """Builds and pushes docker images."""
@@ -51,8 +82,11 @@ def main():
 
             image_name = utils.get_full_image_name(service_name)
 
+            print(f"create Docker buildx builder for {service_name}")
+            create_buildx_builder_if_not_exists()
             print(f"building image for {service_name} with tag {image_name}")
             build_and_push_image(image_name, srcdir, dockerfile_path)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Ensure a Docker builder is created before we start a multi-platform build.