### PR TITLE
Add policy for token automount instead of mutating in the controller

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -259,7 +259,6 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		annotations[k] = v
 	}
 
-	mutatedSpec := r.mutatedPodSpec(&sandbox.Spec.PodTemplate.Spec)
 	pod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        sandbox.Name,
@@ -267,7 +266,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			Labels:      labels,
 			Annotations: annotations,
 		},
-		Spec: *mutatedSpec,
+		Spec: sandbox.Spec.PodTemplate.Spec,
 	}
 	pod.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Pod"))
 	if err := ctrl.SetControllerReference(sandbox, pod, r.Scheme); err != nil {
@@ -279,16 +278,6 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		return nil, err
 	}
 	return pod, nil
-}
-
-func (r *SandboxReconciler) mutatedPodSpec(originalSpec *corev1.PodSpec) *corev1.PodSpec {
-	spec := originalSpec.DeepCopy()
-
-	// Force opting out of API credential automounting
-	automount := false
-	spec.AutomountServiceAccountToken = &automount
-
-	return spec
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/examples/policy/sandbox-automount-token-binding.yaml
+++ b/examples/policy/sandbox-automount-token-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "sandbox-automount-token-binding"
+spec:
+  policyName: "sandbox-automount-token-policy"
+  validationActions: [Deny]
+  matchResources:
+    # Adjust below to limit the scope of the policy
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system

--- a/examples/policy/sandbox-automount-token-policy.yaml
+++ b/examples/policy/sandbox-automount-token-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "sandbox-automount-token-policy"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups:   ["agents.x-k8s.io"]
+        apiVersions: ["v1alpha1"]
+        operations:  ["CREATE", "UPDATE"]
+        resources:   ["sandboxes"]
+  validations:
+    - expression: "object.spec.podTemplate.spec.automountServiceAccountToken == false"
+      message: "For security reasons, spec.podTemplate.spec.automountServiceAccountToken must be explicitly set to false for Sandbox resources."


### PR DESCRIPTION
Per discussion with @justinsb, instead of https://github.com/kubernetes-sigs/agent-sandbox/pull/48, add an example policy/binding for token automount. 

Fixes https://github.com/kubernetes-sigs/agent-sandbox/issues/41

@vicentefb @barney-s 