### PR TITLE
ci: add basic boilerplate for invoking unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ deploy-kind:
 .PHONY: delete-kind
 delete-kind:
 	kind delete cluster --name ${KIND_CLUSTER}
+
+.PHONY: test-unit
+test-unit:
+	./dev/ci/presubmits/test-unit

--- a/dev/ci/presubmits/test-unit
+++ b/dev/ci/presubmits/test-unit
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File is initially implemented as a noop so that a presubmit prowjob can safely
+# be added without any disruption. Once the presubmit is added, a subsequent PR
+# can actually invoke the unit tests (e.g. go test).
+def main():
+    print("TODO: invoke unit tests once they are confirmed passing")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds a basic entrypoint that is intended for invoking unit tests. It is initially implemented as a no-op to ensure that the new prowjob does not cause any disruption (for example, if another PR is merged with broken unit tests).

Once the prowjob is created, a subsequent PR will update this script to actually invoke the unit tests.

---

Note: prowjob is being added in https://github.com/kubernetes/test-infra/pull/35603