### PR TITLE
ci: add placeholder entrypoints for lint and e2e

### DIFF
--- a/dev/ci/presubmits/lint-go
+++ b/dev/ci/presubmits/lint-go
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def main():
+    print("TODO: implement linter check")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/ci/presubmits/test-e2e
+++ b/dev/ci/presubmits/test-e2e
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def main():
+    print("TODO: implement e2e tests")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds placeholder entrypoints for the go linter and e2e testing. This will enable setting up new prow jobs without disruption. Once the prow jobs are running, the functionality will be implemented.