### PR TITLE
nit: Update example Sandbox CR 

### DIFF
--- a/examples/sandbox-ns.yaml
+++ b/examples/sandbox-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sandbox-ns

--- a/examples/sandbox-sa.yaml
+++ b/examples/sandbox-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: your-sandbox-sa
+  namespace: sandbox-ns

--- a/examples/sandbox.yaml
+++ b/examples/sandbox.yaml
@@ -2,6 +2,7 @@ apiVersion: agents.x-k8s.io/v1alpha1
 kind: Sandbox
 metadata:
   name: sandbox-example
+  namespace: sandbox-ns
 spec:
   podTemplate:
     metadata:
@@ -10,6 +11,8 @@ spec:
       annotations:
         test: "yes"
     spec:
+      # Each sandboxed pod can use a distinct KSA, then they will have distinct identities
+      serviceAccountName: your-sandbox-sa
       containers:
       - name: my-container
         image: busybox


### PR DESCRIPTION
Make the use of namespace and serviceAccountName fields explicit in the Sandbox CR example