### PR TITLE
feat: Implement pause for sandbox

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -88,7 +88,30 @@ type SandboxSpec struct {
 	// If a time in the past is provided, the sandbox will be deleted immediately.
 	// +kubebuilder:validation:Format="date-time"
 	ShutdownTime *metav1.Time `json:"shutdownTime,omitempty"`
+
+	// RunMode indicates the desired state of the sandbox.
+	// The valid values are "Active", "Suspended".
+	// If not specified, the default is "Active".
+	// When the RunMode is set to "Suspended", the sandbox's pod will be deleted.
+	// When the RunMode is set to "Active", a pod will be created if one does not already exist.
+	// The volume claims will not be deleted when the RunMode is set to "Suspended".
+	// +optional
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=Active
+	// +kubebuilder:validation:Enum=Active;Suspended
+	RunMode RunModeType `json:"runMode,omitempty" protobuf:"bytes,5,opt,name=runMode"`
 }
+
+// RunModeType defines the strategy for running a sandbox.
+// +kubebuilder:validation:Enum=Active;Suspended
+type RunModeType string
+
+const (
+	// RunModeActive indicates that the sandbox should be running.
+	RunModeActive RunModeType = "Active"
+	// RunModeSuspended indicates that the sandbox should be paused.
+	RunModeSuspended RunModeType = "Suspended"
+)
 
 // SandboxStatus defines the observed state of Sandbox.
 type SandboxStatus struct {

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3814,6 +3814,16 @@ spec:
                 required:
                 - spec
                 type: object
+              runMode:
+                allOf:
+                - enum:
+                  - Active
+                  - Suspended
+                - enum:
+                  - Active
+                  - Suspended
+                default: Active
+                type: string
               shutdownTime:
                 format: date-time
                 type: string


### PR DESCRIPTION
This commit introduces the .spec.runStrategy field to the Sandbox API, allowing users to pause and resume sandboxes.

When runStrategy is set to Paused, the controller will delete the pod associated with the sandbox, while preserving the PVC and service. When runStrategy is set to Running or is not specified, the controller will create the pod if it does not exist.

This feature provides more control over the lifecycle of sandboxes, allowing users to temporarily stop a sandbox without losing its state.

This implements #36 (phase 1)