### PR TITLE
test: implement e2e test scaffolding and simple test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ build:
 KIND_CLUSTER=agent-sandbox
 
 .PHONY: deploy-kind
-deploy-kind: all
+deploy-kind:
 	kind get clusters | grep ${KIND_CLUSTER} || kind create cluster --name ${KIND_CLUSTER}
+	kind export kubeconfig --name $(KIND_CLUSTER) --kubeconfig bin/KUBECONFIG
 	./dev/tools/push-images --image-prefix=kind.local/ --kind-cluster-name=${KIND_CLUSTER}
 	./dev/tools/deploy-to-kube --image-prefix=kind.local/
 
@@ -24,6 +25,10 @@ delete-kind:
 .PHONY: test-unit
 test-unit:
 	./dev/tools/test-unit
+
+.PHONY: test-e2e
+test-e2e:
+	./dev/tools/test-e2e
 
 .PHONY: lint-go
 lint-go:

--- a/dev/ci/presubmits/test-unit
+++ b/dev/ci/presubmits/test-unit
@@ -30,7 +30,7 @@ def main():
 
     artifact_dir = os.getenv("ARTIFACTS")
     if artifact_dir:
-        shutil.copy(f"{repo_root}/bin/junit.xml", f"{artifact_dir}/junit.xml")
+        shutil.copy(f"{repo_root}/bin/unit-junit.xml", f"{artifact_dir}/junit.xml")
 
     return exit_code
 

--- a/dev/tools/test-e2e
+++ b/dev/tools/test-e2e
@@ -13,26 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import shutil
+import subprocess
 import sys
 
 from shared import utils
 
 
 def main():
-    """ invokes e2e tests and outputs a junit report in the ARTIFACTS dir
-
-    The ARTIFACTS environment variable is set by prow.
-    """
+    """ invokes unit tests and outputs a junit results file """
     repo_root = utils.get_repo_root()
-    exit_code = utils.run_dev_tool("test-e2e")
 
-    artifact_dir = os.getenv("ARTIFACTS")
-    if artifact_dir:
-        shutil.copy(f"{repo_root}/bin/e2e-junit.xml", f"{artifact_dir}/junit.xml")
+    result = subprocess.run(["make", "deploy-kind"], cwd=repo_root)
+    if result.returncode != 0:
+        return result.returncode
 
-    return exit_code
+    result = subprocess.run(utils.go_tool_args(
+        "gotestsum", f"--junitfile={repo_root}/bin/e2e-junit.xml",
+        "--", "./test/e2e/...", "--parallel=1"
+    ), cwd=repo_root)
+    return result.returncode
 
 
 if __name__ == "__main__":

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -23,7 +23,8 @@ def main():
     """ invokes unit tests and outputs a junit results file """
     repo_root = utils.get_repo_root()
     result = subprocess.run(utils.go_tool_args(
-        "gotestsum", f"--junitfile={repo_root}/bin/junit.xml",
+        "gotestsum", f"--junitfile={repo_root}/bin/unit-junit.xml",
+        "--", "./controllers/...",
     ), cwd=repo_root)
 
     return result.returncode

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,29 @@
+# E2E testing
+
+This guide provides instructions for running e2e tests.
+
+## Prerequisites
+
+See the [development guide](../../docs/development.md) for prerequisite tools
+and for instructions on how to build/deploy agent-sandbox.
+
+## Running the e2e tests
+
+The e2e tests assume that the cluster is created and that the kubeconfig for the
+cluster lives in `bin/KUBECONFIG`. This can be used to connect the e2e tests to
+an arbitrary cluster, but for the sake of this guide we will use a
+[kind cluster](https://github.com/kubernetes-sigs/kind).
+
+First create a kind cluster and install `agent-sandbox`:
+
+```shell
+make deploy-kind
+```
+
+Next, run the e2e tests on the newly created kind cluster:
+
+```shell
+go test ./test/e2e/... --parallel=1
+```
+
+Note: the `--parallel=1` argument makes sure only a single test runs at a time.

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
+)
+
+func simpleSandbox(ns string) *sandboxv1alpha1.Sandbox {
+	sandboxObj := &sandboxv1alpha1.Sandbox{}
+	sandboxObj.Name = "my-sandbox"
+	sandboxObj.Namespace = ns
+	sandboxObj.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{ // Use a simple pause container as a basic test
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:3.10",
+				},
+			},
+		},
+		ObjectMeta: sandboxv1alpha1.PodMetadata{
+			Annotations: map[string]string{"test-anno-key": "val-1"},
+			Labels:      map[string]string{"test-label-key": "val-2"},
+		},
+	}
+	return sandboxObj
+}
+
+func TestSimpleSandbox(t *testing.T) {
+	tc := framework.NewTestContext(t)
+
+	// Set up a namespace
+	ns := &corev1.Namespace{}
+	ns.Name = "my-sandbox-ns"
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+	// Create a Sandbox Object
+	sandboxObj := simpleSandbox(ns.Name)
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), sandboxObj))
+
+	// Assert Sandbox object status reconciles as expected
+	p := []predicates.ObjectPredicate{
+		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
+			Service:     "my-sandbox",
+			ServiceFQDN: "my-sandbox.my-sandbox-ns.svc.cluster.local",
+			Conditions: []metav1.Condition{
+				{
+					Message:            "Pod is Ready; Service Exists",
+					ObservedGeneration: 1,
+					Reason:             "DependenciesReady",
+					Status:             "True",
+					Type:               "Ready",
+				},
+			},
+		}),
+	}
+	require.NoError(t, tc.WaitForObject(t.Context(), sandboxObj, p...))
+	// Assert Pod object exists with expected fields
+	p = []predicates.ObjectPredicate{
+		predicates.HasAnnotation("test-anno-key", "val-1"),
+		predicates.HasLabel("test-label-key", "val-2"),
+		predicates.HasOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion:         "agents.x-k8s.io/v1alpha1",
+				BlockOwnerDeletion: ptr.To(true),
+				Controller:         ptr.To(true),
+				Kind:               "Sandbox",
+				Name:               "my-sandbox",
+				UID:                sandboxObj.UID,
+			},
+		}),
+	}
+	pod := &corev1.Pod{}
+	pod.Name = "my-sandbox"
+	pod.Namespace = "my-sandbox-ns"
+	require.NoError(t, tc.ValidateObject(t.Context(), pod, p...))
+	// Assert Service object exists with expected fields
+	p = []predicates.ObjectPredicate{
+		predicates.HasOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion:         "agents.x-k8s.io/v1alpha1",
+				BlockOwnerDeletion: ptr.To(true),
+				Controller:         ptr.To(true),
+				Kind:               "Sandbox",
+				Name:               "my-sandbox",
+				UID:                sandboxObj.UID,
+			},
+		}),
+	}
+	service := &corev1.Service{}
+	service.Name = "my-sandbox"
+	service.Namespace = "my-sandbox-ns"
+	require.NoError(t, tc.ValidateObject(t.Context(), service, p...))
+}

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ClusterClient is an abstraction layer for test cases to interact with the cluster.
+type ClusterClient struct {
+	*testing.T
+	client client.Client
+}
+
+// CreateWithCleanup creates the specified object and cleans up the object after
+// the test completes.
+func (cl *ClusterClient) CreateWithCleanup(ctx context.Context, obj client.Object) error {
+	cl.Helper()
+	nn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	cl.Logf("Creating object %T (%s)", obj, nn.String())
+	if err := cl.client.Create(ctx, obj); err != nil {
+		return fmt.Errorf("CreateWithCleanup %T (%s): %w", obj, nn.String(), err)
+	}
+	cl.Cleanup(func() {
+		cl.Helper()
+		cl.Logf("Deleting object %T (%s)", obj, nn.String())
+		// Use context.Background because test context is done during cleanup
+		if err := cl.client.Delete(context.Background(), obj); err != nil && !k8serrors.IsNotFound(err) {
+			cl.Errorf("CreateWithCleanup %T (%s): %s", obj, nn.String(), err)
+		}
+	})
+	return nil
+}
+
+// ValidateObject verifies the specified object exists and satisfies the provided
+// predicates.
+func (cl *ClusterClient) ValidateObject(ctx context.Context, obj client.Object, p ...predicates.ObjectPredicate) error {
+	cl.Helper()
+	nn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	cl.Logf("ValidateObject %T (%s)", obj, nn.String())
+	if err := cl.client.Get(ctx, nn, obj); err != nil {
+		return fmt.Errorf("ValidateObject %T (%s): %w", obj, nn.String(), err)
+	}
+	for _, predicate := range p {
+		if err := predicate(obj); err != nil {
+			return fmt.Errorf("ValidateObject %T (%s): %w", obj, nn.String(), err)
+		}
+	}
+	return nil
+}
+
+// WaitForObject waits for the specified object to exist and satisfy the provided
+// predicates.
+func (cl *ClusterClient) WaitForObject(ctx context.Context, obj client.Object, p ...predicates.ObjectPredicate) error {
+	cl.Helper()
+	// Static 30 second timeout, this can be adjusted if needed
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	var validationErr error
+	for {
+		select {
+		case <-timeoutCtx.Done():
+			return fmt.Errorf("timed out waiting for object: %w", validationErr)
+		default:
+			if validationErr = cl.ValidateObject(timeoutCtx, obj, p...); validationErr == nil {
+				return nil
+			}
+			// Simple sleep for fixed duration (basic MVP)
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+// validateAgentSandboxInstallation verifies agent-sandbox system components are
+// installed.
+func (cl *ClusterClient) validateAgentSandboxInstallation(ctx context.Context) error {
+	cl.Helper()
+	// verify CRDs exist
+	crds := []string{
+		"sandboxes.agents.x-k8s.io",
+		"sandboxclaims.extensions.agents.x-k8s.io",
+		"sandboxtemplates.extensions.agents.x-k8s.io",
+	}
+	for _, name := range crds {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		crd.Name = name
+		if err := cl.ValidateObject(ctx, crd); err != nil {
+			return fmt.Errorf("expected %T (%s) to exist: %w", crd, name, err)
+		}
+	}
+	// verify agent-sandbox-system namespace exists
+	ns := &corev1.Namespace{}
+	ns.Name = "agent-sandbox-system"
+	if err := cl.ValidateObject(ctx, ns); err != nil {
+		return fmt.Errorf("expected %T (%s) to exist: %w", ns, ns.Name, err)
+	}
+	// verify agent-sandbox-controller exists
+	ctrlNN := types.NamespacedName{
+		Name:      "agent-sandbox-controller",
+		Namespace: ns.Name,
+	}
+	ctrl := &appsv1.StatefulSet{}
+	ctrl.Name = ctrlNN.Name
+	ctrl.Namespace = ctrlNN.Namespace
+	if err := cl.ValidateObject(ctx, ctrl); err != nil {
+		return fmt.Errorf("expected %T (%s) to exist: %w", ctrl, ctrlNN.String(), err)
+	}
+	return nil
+}

--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -1,0 +1,91 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/agent-sandbox/controllers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// root directory of the agent-sandbox repository
+	repoRoot = filepath.FromSlash("../..")
+	// The e2e tests use the context specified in the local KUBECONFIG file.
+	// A localized KUBECONFIG is used to create an explicit cluster contract with
+	// the tests.
+	kubeconfig = filepath.Join(repoRoot, "bin", "KUBECONFIG")
+)
+
+func init() {
+	utilruntime.Must(apiextensionsv1.AddToScheme(controllers.Scheme))
+}
+
+// TestContext is a helper for managing e2e test scaffolding.
+type TestContext struct {
+	*testing.T
+	ClusterClient
+}
+
+// NewTestContext creates a new TestContext. This should be called at the beginning
+// of each e2e test to construct needed test scaffolding.
+func NewTestContext(t *testing.T) *TestContext {
+	t.Helper()
+	th := &TestContext{
+		T: t,
+	}
+	restCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cl, err := client.New(restCfg, client.Options{
+		Scheme: controllers.Scheme,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	th.ClusterClient = ClusterClient{
+		T:      t,
+		client: cl,
+	}
+	t.Cleanup(func() {
+		if err := th.afterEach(); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := th.beforeEach(); err != nil {
+		t.Fatal(err)
+	}
+	return th
+}
+
+// beforeEach runs before each test case is executed.
+func (th *TestContext) beforeEach() error {
+	return th.validateAgentSandboxInstallation(context.Background())
+}
+
+// afterEach runs after each test case is executed.
+func (th *TestContext) afterEach() error {
+	return nil // currently no-op, add functionality as needed
+}

--- a/test/e2e/framework/predicates/metadata.go
+++ b/test/e2e/framework/predicates/metadata.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicates
+
+import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HasAnnotation verifies the object has the specified annotation
+func HasAnnotation(key, wantVal string) ObjectPredicate {
+	return func(obj client.Object) error {
+		if obj == nil {
+			return fmt.Errorf("object is nil")
+		}
+		if got, ok := obj.GetAnnotations()[key]; !ok {
+			return fmt.Errorf("annotation %s missing", key)
+		} else if wantVal != got {
+			return fmt.Errorf("want annotation %s=%s, got %s", key, wantVal, got)
+		}
+		return nil
+	}
+}
+
+// HasLabel verifies the object has the specified label
+func HasLabel(key, wantVal string) ObjectPredicate {
+	return func(obj client.Object) error {
+		if obj == nil {
+			return fmt.Errorf("object is nil")
+		}
+		if got, ok := obj.GetLabels()[key]; !ok {
+			return fmt.Errorf("label %s missing", key)
+		} else if wantVal != got {
+			return fmt.Errorf("want label %s=%s, got %s", key, wantVal, got)
+		}
+		return nil
+	}
+}
+
+// HasOwnerReferences verifies the object has the specified owner references
+func HasOwnerReferences(want []metav1.OwnerReference) ObjectPredicate {
+	return func(obj client.Object) error {
+		if obj == nil {
+			return fmt.Errorf("object is nil")
+		}
+		opts := []cmp.Option{
+			cmpopts.SortSlices(func(a, b metav1.OwnerReference) bool { return a.UID < b.UID }),
+		}
+		if diff := cmp.Diff(want, obj.GetOwnerReferences(), opts...); diff != "" {
+			return fmt.Errorf("unexpected ownerReferences (-want,+got):\n%s", diff)
+		}
+		return nil
+	}
+}

--- a/test/e2e/framework/predicates/predicates.go
+++ b/test/e2e/framework/predicates/predicates.go
@@ -1,0 +1,19 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicates
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+type ObjectPredicate func(obj client.Object) error

--- a/test/e2e/framework/predicates/sandbox.go
+++ b/test/e2e/framework/predicates/sandbox.go
@@ -1,0 +1,53 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicates
+
+import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func validateSandbox(obj client.Object) (*sandboxv1alpha1.Sandbox, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("sandbox object is nil")
+	}
+	sandbox, ok := obj.(*sandboxv1alpha1.Sandbox)
+	if !ok {
+		return nil, fmt.Errorf("got %T, want %T", obj, &sandboxv1alpha1.Sandbox{})
+	}
+	return sandbox, nil
+}
+
+// SandboxHasStatus verifies that the Sandbox object has the specified status
+func SandboxHasStatus(status sandboxv1alpha1.SandboxStatus) ObjectPredicate {
+	return func(obj client.Object) error {
+		sandbox, err := validateSandbox(obj)
+		if err != nil {
+			return err
+		}
+		opts := []cmp.Option{
+			cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+		}
+		if diff := cmp.Diff(status, sandbox.Status, opts...); diff != "" {
+			return fmt.Errorf("unexpected sandbox status (-want,+got):\n%s", diff)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This change implements the entrypoint to invoke the e2e tests and the scaffolding for writing e2e tests. A simple e2e test is also added to verify basic behavior and demonstrate the pattern for writing e2e test cases.