### PR TITLE
test: add coverage for sandbox top level Reconcile

### DIFF
--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -18,15 +18,38 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
+	return fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithStatusSubresource(&sandboxv1alpha1.Sandbox{}).
+		WithRuntimeObjects(initialObjs...).
+		Build()
+}
+
+func sandboxControllerRef(name string) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         "agents.x-k8s.io/v1alpha1",
+		Kind:               "Sandbox",
+		Name:               name,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+}
 
 func TestComputeReadyCondition(t *testing.T) {
 	r := &SandboxReconciler{}
@@ -154,6 +177,248 @@ func TestComputeReadyCondition(t *testing.T) {
 	}
 }
 
+func TestReconcile(t *testing.T) {
+	sandboxName := "sandbox-name"
+	sandboxNs := "sandbox-ns"
+	testCases := []struct {
+		name        string
+		initialObjs []runtime.Object
+		sandboxSpec sandboxv1alpha1.SandboxSpec
+		wantStatus  sandboxv1alpha1.SandboxStatus
+		wantObjs    []client.Object
+	}{
+		{
+			name: "minimal sandbox spec with Pod and Service",
+			// Input sandbox spec
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+					},
+				},
+			},
+			// Verify Sandbox status
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Service:     sandboxName,
+				ServiceFQDN: "sandbox-name.sandbox-ns.svc.cluster.local",
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "DependenciesNotReady",
+						Message:            "Pod exists with phase: ; Service Exists",
+					},
+				},
+			},
+			wantObjs: []client.Object{
+				// Verify Pod
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+					},
+				},
+				// Verify Service
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						ClusterIP: "None",
+					},
+				},
+			},
+		},
+		{
+			name: "sandbox spec with PVC, Pod, and Service",
+			// Input sandbox spec
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+					},
+					ObjectMeta: sandboxv1alpha1.PodMetadata{
+						Labels: map[string]string{
+							"custom-label": "label-val",
+						},
+						Annotations: map[string]string{
+							"custom-annotation": "anno-val",
+						},
+					},
+				},
+				VolumeClaimTemplates: []sandboxv1alpha1.PersistentVolumeClaimTemplate{
+					{
+						EmbeddedObjectMetadata: sandboxv1alpha1.EmbeddedObjectMetadata{
+							Name: "my-pvc",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.VolumeResourceRequirements{
+								Requests: corev1.ResourceList{
+									"storage": resource.MustParse("10Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+			// Verify Sandbox status
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Service:     sandboxName,
+				ServiceFQDN: "sandbox-name.sandbox-ns.svc.cluster.local",
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "DependenciesNotReady",
+						Message:            "Pod exists with phase: ; Service Exists",
+					},
+				},
+			},
+			wantObjs: []client.Object{
+				// Verify Pod
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"custom-label":                      "label-val",
+						},
+						Annotations: map[string]string{
+							"custom-annotation": "anno-val",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "my-pvc",
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "my-pvc-sandbox-name",
+										ReadOnly:  false,
+									},
+								},
+							},
+						},
+					},
+				},
+				// Verify Service
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						ClusterIP: "None",
+					},
+				},
+				// Verify PVC
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "my-pvc-sandbox-name",
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								"storage": resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sb := &sandboxv1alpha1.Sandbox{}
+			sb.Name = sandboxName
+			sb.Namespace = sandboxNs
+			sb.Generation = 1
+			sb.Spec = tc.sandboxSpec
+			r := SandboxReconciler{
+				Client: newFakeClient(append(tc.initialObjs, sb)...),
+				Scheme: Scheme,
+			}
+
+			_, err := r.Reconcile(t.Context(), ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+				},
+			})
+			require.NoError(t, err)
+			// Validate Sandbox status
+			liveSandbox := &sandboxv1alpha1.Sandbox{}
+			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, liveSandbox))
+			opts := []cmp.Option{
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+			}
+			if diff := cmp.Diff(tc.wantStatus, liveSandbox.Status, opts...); diff != "" {
+				t.Fatalf("unexpected sandbox status (-want,+got):\n%s", diff)
+			}
+			// Validate the other objects from the "cluster" (fake client)
+			for _, obj := range tc.wantObjs {
+				liveObj := obj.DeepCopyObject().(client.Object)
+				err = r.Get(t.Context(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, liveObj)
+				require.NoError(t, err)
+				require.Equal(t, obj, liveObj)
+			}
+		})
+	}
+}
+
 func TestReconcilePod(t *testing.T) {
 	sandboxName := "sandbox-name"
 	sandboxNs := "sandbox-ns"
@@ -238,15 +503,7 @@ func TestReconcilePod(t *testing.T) {
 					Annotations: map[string]string{
 						"custom-annotation": "anno-val",
 					},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "agents.x-k8s.io/v1alpha1",
-							Kind:               "Sandbox",
-							Name:               sandboxName,
-							Controller:         ptr.To(true),
-							BlockOwnerDeletion: ptr.To(true),
-						},
-					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -262,7 +519,7 @@ func TestReconcilePod(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := SandboxReconciler{
-				Client: fake.NewFakeClient(tc.initialObjs...),
+				Client: newFakeClient(tc.initialObjs...),
 				Scheme: Scheme,
 			}
 


### PR DESCRIPTION
This change adds a unit test for the top level Reconcile function of the sandbox controller. This test case can be used to verify coarser functionality of the Reconcile loop.