### PR TITLE
feat: Added Disruption control example for Sandboxes

### DIFF
--- a/examples/manual-pdb/README.md
+++ b/examples/manual-pdb/README.md
@@ -1,0 +1,58 @@
+# Manual PodDisruptionBudget (PDB) Configuration
+
+This example demonstrates how to protect Sandboxes from voluntary disruptions (e.g., node drains, cluster upgrades) using standard Kubernetes manifests, without relying on the controller's automated disruption control.
+
+## How It Works (Shared Protection)
+
+In this manual workflow, you create a **single Shared PDB** per namespace. This PDB acts as a "security blanket" that protects **all** Sandboxes in that namespace, provided they opt-in via labels.
+
+### 1. The Matching Rule
+Protection is **not automatic**. A Sandbox is only protected if its Template metadata matches the PDB selector exactly.
+
+* **PDB Selector:** `matchLabels: { sandbox-disruption-policy: "manual-protection" }`
+* **Sandbox Template:** Must have `labels: { sandbox-disruption-policy: "manual-protection" }`
+
+Any Sandbox created in this namespace without this specific label will be ignored by the PDB and can be evicted at any time.
+
+### 2. The "Math" of Shared PDBs
+Because multiple Sandboxes share one PDB, we use `maxUnavailable: 0`.
+
+* **Scenario:** You have 3 Sandboxes running in the `dev-team` namespace.
+* **Logic:** `maxUnavailable: 0` tells Kubernetes: "You cannot voluntarily evict *any* pod that has this label."
+* **Result:** All 3 Sandboxes are protected individually.
+
+*Warning: Do not use `minAvailable: 1` for a shared PDB. If you have 3 sandboxes and require only 1 to be available, Kubernetes is allowed to evict the other 2 during maintenance.*
+
+## Usage Steps
+
+### Step 1: Apply the Template
+The template includes the required labels and the `safe-to-evict` annotation.
+```bash
+kubectl apply -f sandbox-template.yaml
+```
+
+### Step 2: Apply the Shared PDB (Once per Namespace)
+You must apply the PDB manifest to **every** namespace where you intend to run Sandboxes.
+
+```bash
+# Example for the 'default' namespace
+kubectl apply -f shared-pdb.yaml -n default
+```
+
+### Step 3: Create Sandbox Claims
+You can now create as many Claims as you want in that namespace.
+
+```bash
+# Example for the 'default' namespace
+kubectl apply -f sandbox-claim.yaml -n default
+```
+
+
+### Lifecycle & Cleanup (Important)
+Unlike the automated controller implementation, **manual PDBs do not clean themselves up.**
+
+- **When you delete a Sandbox:** The PDB remains active in the namespace.
+
+- **When you delete the last Sandbox:** You must manually delete the PDB if you want to remove the configuration.
+
+- **Risk:** If you delete the PDB while other Sandboxes are still running in that namespace, those Sandboxes immediately lose protection. Coordinate with your team before deleting the shared PDB.

--- a/examples/manual-pdb/sandboxclaim.yaml
+++ b/examples/manual-pdb/sandboxclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  # This will be the name of your sandbox pod and its associated resources.
+  name: manual-protection-claim
+  # This MUST be in the same namespace as the SandboxTemplate.
+  namespace: default
+spec:
+  sandboxTemplateRef:
+    # This name must exactly match the 'metadata.name' of your SandboxTemplate.
+    name: secure-template

--- a/examples/manual-pdb/sandboxtemplate.yaml
+++ b/examples/manual-pdb/sandboxtemplate.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: secure-template
+  namespace: default
+spec:
+  podTemplate:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        sandbox-disruption-policy: "manual-protection"
+        app: my-sandbox-app
+    spec:
+      containers:
+      - name: debug-container
+        image: nginx:alpine

--- a/examples/manual-pdb/shared-pdb.yaml
+++ b/examples/manual-pdb/shared-pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: shared-sandbox-pdb
+  # NOTE: This must be applied to the SAME namespace where the SandboxClaim creates the pod.
+  namespace: default
+spec:
+# CRITICAL: We use maxUnavailable: 0 because multiple Sandboxes share this PDB.
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      # This MUST match what we put in the Template
+      sandbox-disruption-policy: "manual-protection"

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -255,6 +255,9 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		},
 	}
 	sandbox.Spec.PodTemplate = template.Spec.PodTemplate
+	// TODO: this is a workaround, remove replica assignment related issue #202
+	replicas := int32(1)
+	sandbox.Spec.Replicas = &replicas
 	if err := controllerutil.SetControllerReference(claim, sandbox, r.Scheme); err != nil {
 		err = fmt.Errorf("failed to set controller reference for sandbox: %w", err)
 		logger.Error(err, "Error creating sandbox for claim: %q", claim.Name)


### PR DESCRIPTION
towards: #59 

This PR adds documentation and example manifests for manually configuring PodDisruptionBudgets (PDBs) for Sandboxes. It also includes a workaround fix to the SandboxClaim controller to ensure these manual PDBs function correctly without throwing warnings.

Following the discussion on handling PDBs via manifests rather than controller logic with @barney-s , I implemented the manual examples to verify the workflow.

During testing, I discovered that the manual approach is currently broken on the main branch due to the "Invisible Replicas" issue described #202 , though that isn't a blocker for this PR to be merged.
