### PR TITLE
fix: set replicas status after shutdownTime expires

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -134,10 +134,13 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	// Reconcile Pod
 	pod, err := r.reconcilePod(ctx, sandbox, nameHash)
 	allErrors = errors.Join(allErrors, err)
-	if pod != nil {
+	if pod == nil {
+		sandbox.Status.Replicas = 0
+		sandbox.Status.LabelSelector = ""
+	} else {
 		sandbox.Status.Replicas = 1
+		sandbox.Status.LabelSelector = fmt.Sprintf("%s=%s", sandboxLabel, NameHash(sandbox.Name))
 	}
-	sandbox.Status.LabelSelector = fmt.Sprintf("%s=%s", sandboxLabel, NameHash(sandbox.Name))
 
 	// Reconcile Service
 	svc, err := r.reconcileService(ctx, sandbox, nameHash)

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -74,12 +74,10 @@ func TestSandboxReplicas(t *testing.T) {
 	// Wait for sandbox status to reflect new state
 	p = []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
-			Service:     "my-sandbox",
-			ServiceFQDN: "my-sandbox.my-sandbox-ns.svc.cluster.local",
-			// TODO: replicas status should be set to zero
-			Replicas: 1,
-			// TODO: should labelSelector be cleared?
-			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+			Service:       "my-sandbox",
+			ServiceFQDN:   "my-sandbox.my-sandbox-ns.svc.cluster.local",
+			Replicas:      0,
+			LabelSelector: "",
 			Conditions: []metav1.Condition{
 				{
 					Message:            "Pod does not exist, replicas is 0; Service Exists",


### PR DESCRIPTION
This change fixes a minor bug in the sandbox status in which the status.replicas and status.labelSelector fields were not cleared after the sandbox shutdownTime expires.

Fixes https://github.com/kubernetes-sigs/agent-sandbox/issues/97