### PR TITLE
feat: Embed automount into podTemplate spec in extensions

### DIFF
--- a/extensions/api/v1alpha1/sandboxtemplate_types.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_types.go
@@ -42,6 +42,8 @@ import (
 type SandboxTemplateSpec struct {
 	// template is the object that describes the pod spec that will be used to create
 	// an agent sandbox.
+	// If AutomountServiceAccountToken is not specified in the PodSpec, it defaults to false
+	// to ensure a secure-by-default environment.
 	// +kubebuilder:validation:Required
 	PodTemplate sandboxv1alpha1.PodTemplate `json:"podTemplate" protobuf:"bytes,3,opt,name=podTemplate"`
 }


### PR DESCRIPTION
Related to #41 but will now be embedded by default into the `podTemplate` spec when a sandbox is created via a template + claim. With this, we wouldn't need to use VAP in extensions. 