### PR TITLE
chrome-sandbox: install chromium to support arm

### DIFF
--- a/examples/chrome-sandbox/images/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/images/chrome-sandbox/Dockerfile
@@ -21,37 +21,10 @@ RUN apt-get update && apt-get install -y \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-#----------------------
-# Install necessary packages for Chrome (dpkg package requires them)
-RUN apt-get update && apt-get install -y \
-    fonts-liberation \
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libc6 \
-    libcairo2 \
-    libcups2 \
-    libdbus-1-3 \
-    libexpat1 \
-    libcurl4 \
-    libgbm1 \
-    libgtk-4-1 \
-    libnss3 \
-    libpango-1.0-0 \
-    libvulkan1 \
-    libxcb1 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxkbcommon0 \
-    libxrandr2 \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
 
-# Download and install Google Chrome from dpkg
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && dpkg -i google-chrome-stable_current_amd64.deb \
-    && rm google-chrome-stable_current_amd64.deb
+# Download and install chromium package
+# (We previously tried directly install the deb package, but it does not yet appear to be packaged for linux/arm64)
+RUN apt-get update && apt-get install --yes --no-install-recommends chromium
 
 # Create a non-root user to run Chrome.
 RUN groupadd -r chrome && useradd -r -g chrome -G audio,video chrome \

--- a/examples/chrome-sandbox/scripts/start-chrome
+++ b/examples/chrome-sandbox/scripts/start-chrome
@@ -37,4 +37,4 @@ flags+=(--user-data-dir=/tmp/chrome-data) # DevTools remote debugging requires a
 
 
 # Launch Chrome
-google-chrome "${flags[@]}" "https://www.google.com"
+chromium "${flags[@]}" "https://www.google.com"


### PR DESCRIPTION
The deb package for Google Chrome is not available for arm64,
so use chromium as packaged by debian instead.
