### PR TITLE
ci: fix image prefix for staging registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,8 +14,8 @@ steps:
 # Cloud Build will use this to push the image to the registry.
 # This should match the image name that is built by the push-images script.
 images:
-  - "${_IMAGE_PREFIX}/$PROJECT_ID/agent-sandbox-controller:$_GIT_TAG-$_CONFIG"
-  - "${_IMAGE_PREFIX}/$PROJECT_ID/agent-sandbox-controller:latest-$_CONFIG"
+  - "${_IMAGE_PREFIX}/agent-sandbox-controller:$_GIT_TAG-$_CONFIG"
+  - "${_IMAGE_PREFIX}/agent-sandbox-controller:latest-$_CONFIG"
 
 options:
   enableStructuredLogging: true
@@ -25,4 +25,4 @@ options:
 substitutions:
   _GIT_TAG: "12345"
   _CONFIG: main
-  _IMAGE_PREFIX: "us-central1-docker.pkg.dev"
+  _IMAGE_PREFIX: "us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox"


### PR DESCRIPTION
The postsubmit/cloudbuild job was not using the proper image prefix for the k8s staging registry. This change intends to fix the image prefix so the images are properly published.

Ref: https://github.com/kubernetes-sigs/agent-sandbox/issues/53