### PR TITLE
cleanup: Integrate PodMetadata into SandboxTemplate

### DIFF
--- a/extensions/api/v1alpha1/sandboxtemplate_types.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_types.go
@@ -31,8 +31,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 )
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
@@ -43,7 +43,7 @@ type SandboxTemplateSpec struct {
 	// template is the object that describes the pod spec that will be used to create
 	// an agent sandbox.
 	// +kubebuilder:validation:Required
-	PodTemplate corev1.PodTemplateSpec `json:"podTemplate" protobuf:"bytes,3,opt,name=podTemplate"`
+	PodTemplate sandboxv1alpha1.PodTemplate `json:"podTemplate" protobuf:"bytes,3,opt,name=podTemplate"`
 }
 
 // SandboxTemplateStatus defines the observed state of Sandbox.

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -254,9 +254,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 			Name:      claim.Name,
 		},
 	}
-	sandbox.Spec.PodTemplate.Spec = template.Spec.PodTemplate.Spec
-	sandbox.Spec.PodTemplate.ObjectMeta.Labels = template.Spec.PodTemplate.Labels
-	sandbox.Spec.PodTemplate.ObjectMeta.Annotations = template.Spec.PodTemplate.Annotations
+	sandbox.Spec.PodTemplate = template.Spec.PodTemplate
 	if err := controllerutil.SetControllerReference(claim, sandbox, r.Scheme); err != nil {
 		err = fmt.Errorf("failed to set controller reference for sandbox: %w", err)
 		logger.Error(err, "Error creating sandbox for claim: %q", claim.Name)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -43,7 +43,7 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: extensionsv1alpha1.SandboxTemplateSpec{
-			PodTemplate: corev1.PodTemplateSpec{
+			PodTemplate: v1alpha1.PodTemplate{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -251,7 +251,7 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: extensionsv1alpha1.SandboxTemplateSpec{
-			PodTemplate: corev1.PodTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -71,7 +71,7 @@ func createTemplate(name, namespace string) *extensionsv1alpha1.SandboxTemplate 
 			Namespace: namespace,
 		},
 		Spec: extensionsv1alpha1.SandboxTemplateSpec{
-			PodTemplate: corev1.PodTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -392,7 +392,7 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 				},
 			},
 			Spec: extensionsv1alpha1.SandboxTemplateSpec{
-				PodTemplate: corev1.PodTemplateSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -31,6 +31,15 @@ spec:
               podTemplate:
                 properties:
                   metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                     type: object
                   spec:
                     properties:
@@ -3802,6 +3811,8 @@ spec:
                     required:
                     - containers
                     type: object
+                required:
+                - spec
                 type: object
             required:
             - podTemplate


### PR DESCRIPTION
This commit integrates the PodMetadata struct into the SandboxTemplateSpec, allowing labels and annotations to be copied from the SandboxTemplate to the Sandbox.

This addresses issue #117.