### PR TITLE
Properly propagate labels and annotations to WarmPool pods

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -216,14 +216,13 @@ func (r *SandboxWarmPoolReconciler) createPoolPod(ctx context.Context, warmPool 
 		return err
 	}
 
-	// Copy labels from pod template
-	for k, v := range template.ObjectMeta.Labels {
+	for k, v := range template.Spec.PodTemplate.ObjectMeta.Labels {
 		podLabels[k] = v
 	}
 
 	// Create annotations for the pod
 	podAnnotations := make(map[string]string)
-	for k, v := range template.ObjectMeta.Annotations {
+	for k, v := range template.Spec.PodTemplate.ObjectMeta.Annotations {
 		podAnnotations[k] = v
 	}
 

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -393,6 +393,15 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 			},
 			Spec: extensionsv1alpha1.SandboxTemplateSpec{
 				PodTemplate: sandboxv1alpha1.PodTemplate{
+					ObjectMeta: sandboxv1alpha1.PodMetadata{
+						Labels: map[string]string{
+							"pod-label": "from-podtemplate",
+							"version":   "2.0",
+						},
+						Annotations: map[string]string{
+							"pod-annotation": "from-podtemplate",
+						},
+					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
@@ -446,12 +455,18 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 			require.Equal(t, sandboxcontrollers.NameHash(templateName), pod.Labels[sandboxTemplateRefHash],
 				"pod %s should have correct sandbox template ref label", pod.Name)
 
-			// Verify template labels are also present
-			require.Equal(t, "test-app", pod.Labels["app"])
-			require.Equal(t, "1.0", pod.Labels["version"])
+			// Verify labels from pod template
+			require.Equal(t, "2.0", pod.Labels["version"])
+			require.Equal(t, "from-podtemplate", pod.Labels["pod-label"])
 
-			// Verify annotations
-			require.Equal(t, "test pod", pod.Annotations["description"])
+			// Verify sandbox template labels are not propagated
+			require.NotContains(t, pod.Labels, "app")
+
+			// Verify annotations from pod template
+			require.Equal(t, "from-podtemplate", pod.Annotations["pod-annotation"])
+
+			// Verify sandbox template metadata annotations are not propagated
+			require.NotContains(t, pod.Annotations, "description")
 		}
 	})
 }


### PR DESCRIPTION
# Description
I noticed that labels and annotations are not properly propagated from the `SandboxTemplate` to pods created by the `SandboxWarmPool` controller.

Example before my change:
```yaml
apiVersion: extensions.agents.x-k8s.io/v1alpha1
kind: SandboxTemplate
metadata:
  name: my-sandbox-template
  namespace: my-namespace 
  labels:
    sandbox-template-label: some-value-1  <----- This was copied over
spec:
  podTemplate:
    metadata:
      labels:
        pod-template-label: some-value-2  <----- This was ignored
    spec:
      containers: [...]
```
Looking at the resulting pod which is part of the pool, it only had `sandbox-template-label: some-value-1`.

My commit simply copies over the metadata from the `podTemplate` (which IMO make more sense to propagate vs the metadata of the `SandboxTemplate` itself)

**Update**: in order to align the behavior of this controller with other standard Kube controllers, I removed the label propagation from the high level `SandboxTemplate` object and only kept labels from the actual `podTemplate`

# Testing
- Added a unit test
- Deployed a forked version of the controller in my Kube cluster, confirmed that labels were carried over from the `podTemplate` 