### PR TITLE
Allow sandboxclaim's metadata to be passed to the sandbox

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -250,8 +250,10 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	logger.Info("creating sandbox from template", "template", template.Name)
 	sandbox := &v1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: claim.Namespace,
-			Name:      claim.Name,
+			Namespace:   claim.Namespace,
+			Name:        claim.Name,
+			Labels:      claim.Labels,
+			Annotations: claim.Annotations,
 		},
 	}
 	sandbox.Spec.PodTemplate = template.Spec.PodTemplate

--- a/extensions/examples/sandboxclaim.yaml
+++ b/extensions/examples/sandboxclaim.yaml
@@ -5,6 +5,10 @@ metadata:
   name: my-secure-sandbox
   # This MUST be in the same namespace as the SandboxTemplate.
   namespace: default
+  labels:
+    test-label: test-value
+  annotations:
+    test-annotation: test-annotation-value
 spec:
   #shutdownTime: "2025-10-28T02:50:00Z"
   # It points to the template.


### PR DESCRIPTION
This allows a user to create a sandbox with customized labels.