### PR TITLE
Fix watch mapping for Sandboxes with adopted pods

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -34,7 +34,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -572,7 +571,7 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sandboxv1alpha1.Sandbox{}).
-		Watches(&corev1.Pod{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labelSelectorPredicate)).
-		Watches(&corev1.Service{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(labelSelectorPredicate)).
+		Owns(&corev1.Pod{}, builder.WithPredicates(labelSelectorPredicate)).
+		Owns(&corev1.Service{}, builder.WithPredicates(labelSelectorPredicate)).
 		Complete(r)
 }

--- a/test/e2e/extensions/pythonruntime_test.go
+++ b/test/e2e/extensions/pythonruntime_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package extensions
 
 import (
 	"context"

--- a/test/e2e/extensions/warmpool_sandbox_watcher_test.go
+++ b/test/e2e/extensions/warmpool_sandbox_watcher_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestWarmPoolSandboxWatcher verifies that Sandboxes created from WarmPools watch the right underlying pods.
+func TestWarmPoolSandboxWatcher(t *testing.T) {
+	tc := framework.NewTestContext(t)
+
+	// Set up a namespace with unique name to avoid conflicts
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("warmpool-watcher-test-%d", time.Now().UnixNano())
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+
+	// Create a SandboxTemplate
+	template := &extensionsv1alpha1.SandboxTemplate{}
+	template.Name = "test-template"
+	template.Namespace = ns.Name
+	template.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:3.10",
+				},
+			},
+		},
+	}
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), template))
+
+	// Create a SandboxWarmPool
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
+	warmPool.Name = "test-warmpool"
+	warmPool.Namespace = ns.Name
+	warmPool.Spec.TemplateRef.Name = template.Name
+	warmPool.Spec.Replicas = 1
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), warmPool))
+
+	// Wait for warm pool to create a pod
+	var poolPodName string
+	require.Eventually(t, func() bool {
+		podList := &corev1.PodList{}
+		if err := tc.List(t.Context(), podList, client.InNamespace(ns.Name)); err != nil {
+			return false
+		}
+		for _, pod := range podList.Items {
+			if _, hasLabel := pod.Labels["agents.x-k8s.io/pool"]; hasLabel && pod.DeletionTimestamp.IsZero() {
+				poolPodName = pod.Name
+				return true
+			}
+		}
+		return false
+	}, 60*time.Second, 2*time.Second)
+
+	// Create a SandboxClaim to adopt the pod
+	claim := &extensionsv1alpha1.SandboxClaim{}
+	claim.Name = "test-claim"
+	claim.Namespace = ns.Name
+	claim.Spec.TemplateRef.Name = template.Name
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), claim))
+
+	// Wait for claim to create sandbox
+	var sandbox *sandboxv1alpha1.Sandbox
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: claim.Name, Namespace: ns.Name}, claim); err != nil {
+			return false
+		}
+		if claim.Status.SandboxStatus.Name == "" {
+			return false
+		}
+		sandbox = &sandboxv1alpha1.Sandbox{}
+		return tc.Get(t.Context(), types.NamespacedName{Name: claim.Status.SandboxStatus.Name, Namespace: ns.Name}, sandbox) == nil
+	}, 30*time.Second, 1*time.Second)
+
+	// Wait for pod to be adopted by sandbox
+	var adoptedPod *corev1.Pod
+	require.Eventually(t, func() bool {
+		adoptedPod = &corev1.Pod{}
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: poolPodName, Namespace: ns.Name}, adoptedPod); err != nil {
+			return false
+		}
+		return metav1.IsControlledBy(adoptedPod, sandbox)
+	}, 30*time.Second, 1*time.Second)
+
+	// Wait for sandbox to become ready
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: sandbox.Name, Namespace: ns.Name}, sandbox); err != nil {
+			return false
+		}
+		for _, cond := range sandbox.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 1*time.Second)
+
+	// Delete the pod
+	require.NoError(t, tc.Delete(t.Context(), adoptedPod))
+
+	// Verify sandbox status updates to reflect pod deletion.
+	// NOTE: This is the critical step that verifies that the Sandbox is watching the right pod.
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: sandbox.Name, Namespace: ns.Name}, sandbox); err != nil {
+			return false
+		}
+		for _, cond := range sandbox.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status != metav1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 500*time.Millisecond)
+}

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -48,6 +48,35 @@ type ClusterClient struct {
 	client client.Client
 }
 
+// List retrieves a list of objects matching the provided options.
+func (cl *ClusterClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	cl.Helper()
+	if err := cl.client.List(ctx, list, opts...); err != nil {
+		return fmt.Errorf("list %T: %w", list, err)
+	}
+	return nil
+}
+
+// Delete deletes the specified object from the cluster.
+func (cl *ClusterClient) Delete(ctx context.Context, obj client.Object) error {
+	cl.Helper()
+	nn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+	cl.Logf("Deleting object %T (%s)", obj, nn.String())
+	if err := cl.client.Delete(ctx, obj); err != nil {
+		return fmt.Errorf("delete %T (%s): %w", obj, nn.String(), err)
+	}
+	return nil
+}
+
+// Get retrieves an object from the cluster.
+func (cl *ClusterClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+	cl.Helper()
+	if err := cl.client.Get(ctx, key, obj); err != nil {
+		return fmt.Errorf("get %T (%s): %w", obj, key.String(), err)
+	}
+	return nil
+}
+
 // Update an object that already exists on the cluster.
 func (cl *ClusterClient) Update(ctx context.Context, obj client.Object) error {
 	cl.Helper()
@@ -182,6 +211,7 @@ func (cl *ClusterClient) validateAgentSandboxInstallation(ctx context.Context) e
 		"sandboxes.agents.x-k8s.io",
 		"sandboxclaims.extensions.agents.x-k8s.io",
 		"sandboxtemplates.extensions.agents.x-k8s.io",
+		"sandboxwarmpools.extensions.agents.x-k8s.io",
 	}
 	for _, name := range crds {
 		crd := &apiextensionsv1.CustomResourceDefinition{}

--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -17,6 +17,7 @@ package framework
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -29,7 +30,7 @@ import (
 
 var (
 	// root directory of the agent-sandbox repository
-	repoRoot = filepath.FromSlash("../..")
+	repoRoot = getRepoRoot()
 	// The e2e tests use the context specified in the local KUBECONFIG file.
 	// A localized KUBECONFIG is used to create an explicit cluster contract with
 	// the tests.
@@ -39,6 +40,14 @@ var (
 func init() {
 	utilruntime.Must(apiextensionsv1.AddToScheme(controllers.Scheme))
 	utilruntime.Must(extensionsv1alpha1.AddToScheme(controllers.Scheme))
+}
+
+func getRepoRoot() string {
+	// This file is at <repo>/test/e2e/framework/context.go, so 3 Dir() hops (framework -> e2e -> test -> repo)
+	// gives us the repository root regardless of the test package working directory.
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	return filepath.Dir(filepath.Dir(filepath.Dir(dir)))
 }
 
 // TestContext is a helper for managing e2e test scaffolding.


### PR DESCRIPTION
# Description
When a Sandbox was adopting a pod from a WarmPool, the Sandbox controller was not properly watching the pod because its name didn't match the Sandbox name. Here is an example:
1. WarmPool creates a pod: `test-warmpool-5dqwk`
2. I create a `SandboxClaim` called `test-claim-sandbox` which in turn creates a new Sandbox called `test-claim-sandbox` as well
3. This Sandbox adopted the pod `test-warmpool-5dqwk`
4. Pod gets deleted but the Sandbox doesn't notice, its `Status.Conditions` are not being updated properly, it still says `Pod is Ready` 

The controller logs keep showing this message:
```
2025-11-26T15:57:21Z	INFO	sandbox resource not found. Ignoring since object must be deleted	
{"controller": "sandbox", "controllerGroup": "agents.x-k8s.io", "controllerKind": "Sandbox", "Sandbox": {"name":"test-warmpool-5dqwk","namespace":"warmpool-test-ns"}, "namespace": "warmpool-test-ns", "name": "test-warmpool-5dqwk", "reconcileID": "701d78e2-fd80-4c4b-8cd7-75793ffba2ab"}
```

The problem comes from this line:
https://github.com/kubernetes-sigs/agent-sandbox/blob/36c411a2f1cbf76b83e1bb02ae0d28451221c653/controllers/sandbox_controller.go#L543
`EnqueueRequestForObject` creates reconcile requests using the Pod's name (`test-warmpool-5dqwk`), not the Sandbox's name (`test-claim-sandbox`)

This PR fixes the issue by making sure that the reconciliation logic actually looks at the OwnerRef of the pod instead of using the pod name, because it doesn't necessarily match the Sandbox name. 

I think a real longer-term fix should be something like this https://github.com/kubernetes-sigs/agent-sandbox/pull/162 btw.

# Testing
I think the only way to actually test this requires a real Kube cluster (this behavior is really hard to mock), so I wrote an E2E test which replicates the issue by deleting an adopted pod and checking that the status got propagated to the owner Sandbox. As expected, the test fails before my commit and succeeds afterwards.