### PR TITLE
Use a Deployment instead of a StatefulSet for the controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ deploy-kind:
 
 	@if [ "$(EXTENSIONS)" = "true" ]; then \
 		echo "🔧 Patching controller to enable extensions..."; \
-		kubectl patch statefulset agent-sandbox-controller \
+		kubectl patch deployment agent-sandbox-controller \
 			-n agent-sandbox-system \
 			-p '{"spec": {"template": {"spec": {"containers": [{"name": "agent-sandbox-controller", "args": ["--extensions=true"]}]}}}}'; \
 	fi

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -56,7 +56,7 @@ func main() {
 	var pprofMutexProfileFraction int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&extensions, "extensions", false, "Enable extensions controllers.")

--- a/examples/jupyterlab/README.md
+++ b/examples/jupyterlab/README.md
@@ -10,7 +10,7 @@ Make sure the agent-sandbox controller is running before proceeding:
 
 ```bash
 kubectl get pods -n agent-sandbox-system
-# Should show agent-sandbox-controller-0 in Running state
+# Should show agent-sandbox-controller-* in Running state
 ```
 
 ## Project Structure

--- a/examples/python-runtime-sandbox/run-test-kind.sh
+++ b/examples/python-runtime-sandbox/run-test-kind.sh
@@ -37,9 +37,9 @@ kubectl apply -f sandbox-python-kind.yaml
 # Cleanup function
 cleanup() {
     echo "Cleaning up python-runtime and sandbox controller..."
-    kubectl delete --ignore-not-found -f sandbox-python-kind.yaml
-    kubectl delete --ignore-not-found statefulset agent-sandbox-controller -n agent-sandbox-system
-    kubectl delete --ignore-not-found crd sandboxes.agents.x-k8s.io
+    kubectl delete --timeout=10s --ignore-not-found -f sandbox-python-kind.yaml
+    kubectl delete --timeout=10s --ignore-not-found deployment agent-sandbox-controller -n agent-sandbox-system
+    kubectl delete --timeout=10s --ignore-not-found crd sandboxes.agents.x-k8s.io
     echo "Deleting kind cluster..." 
     cd ../../
     make delete-kind

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -66,6 +66,7 @@ type SandboxClaimReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/k8s/controller.yaml
+++ b/k8s/controller.yaml
@@ -48,7 +48,7 @@ spec:
 
 ---
 
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: agent-sandbox-controller
@@ -56,7 +56,6 @@ metadata:
   labels:
     app: agent-sandbox-controller
 spec:
-  serviceName: agent-sandbox-controller
   replicas: 1
   selector:
     matchLabels:
@@ -70,3 +69,5 @@ spec:
       containers:
       - name: agent-sandbox-controller
         image: ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller # placeholder value, replaced by deployment scripts
+        args:
+        - --leader-elect=true

--- a/k8s/extensions-rbac.generated.yaml
+++ b/k8s/extensions-rbac.generated.yaml
@@ -36,6 +36,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims

--- a/k8s/extensions.controller.yaml
+++ b/k8s/extensions.controller.yaml
@@ -1,5 +1,5 @@
 ---
-kind: StatefulSet
+kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: agent-sandbox-controller
@@ -7,7 +7,6 @@ metadata:
   labels:
     app: agent-sandbox-controller
 spec:
-  serviceName: agent-sandbox-controller
   replicas: 1
   selector:
     matchLabels:
@@ -22,4 +21,5 @@ spec:
       - name: agent-sandbox-controller
         image: ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller # placeholder value, replaced by deployment scripts
         args:
+        - "--leader-elect=true"
         - "--extensions"

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -38,3 +38,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -464,7 +464,7 @@ func (cl *ClusterClient) validateAgentSandboxInstallation() error {
 		Name:      "agent-sandbox-controller",
 		Namespace: ns.Name,
 	}
-	ctrl := &appsv1.StatefulSet{}
+	ctrl := &appsv1.Deployment{}
 	ctrl.Name = ctrlNN.Name
 	ctrl.Namespace = ctrlNN.Namespace
 	cl.MustExist(ctrl)


### PR DESCRIPTION
# Description

While trying out the agent-sandbox project, I noticed that the main controller is deployed as a StatefulSet. I couldn't really find a justification for it in the commit history, so this looks like an oversight. The controller is stateless and doesn't require a stable network identity, so I don't really see a reason to use a much heavier abstraction here. Moreover, STS ordered rollout semantics are unnecessary for a stateless controller and could complicate scaling/updates if [leader election](https://github.com/kubernetes-sigs/agent-sandbox/blob/45e4a39c0e16357102b29784dcf9503db0a79a6c/cmd/agent-sandbox-controller/main.go#L67) is enabled for HA.

So my PR switches the controller to be deployed as a simple Deployment, I think it will make operations easier for everyone

# Migration Guide
The controller changed from StatefulSet to Deployment and leader election is now enabled by default. Before you deploy the new charts, you need to clean-up the existing StatefulSet (this will cause a brief disruption to Sandbox state reconciliation):
```bash
kubectl delete statefulset agent-sandbox-controller -n agent-sandbox-system
```
Then deploy the new charts. Verify that the Deployment has been properly created:
```bash
kubectl get deployment agent-sandbox-controller -n agent-sandbox-system
```

If needed, the rollback steps are:
```bash
kubectl delete deployment agent-sandbox-controller -n agent-sandbox-system
kubectl apply -f <previous-version-manifest.yaml>
```