### PR TITLE
test: handle ErrProcessDone when killing port forward

### DIFF
--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -17,6 +17,7 @@ package framework
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -220,7 +221,7 @@ func (cl *ClusterClient) PortForward(ctx context.Context, pod types.NamespacedNa
 			}
 		}
 		cl.Log("killing port-forward")
-		if err := portForward.Process.Kill(); err != nil {
+		if err := portForward.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
 			cl.Errorf("failed to kill port-forward: %s", err)
 		}
 	}


### PR DESCRIPTION
There can be a race condition between checking that the process is already killed and attempting to kill the process. This change gracefully handles the error when the process is already done when attempting to kill the process.