### PR TITLE
fix: add pvc annotations/labels from volume claim tpl

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"reflect"
 	"time"
 
@@ -167,7 +168,7 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	var allErrors error
 
 	// Reconcile PVCs
-	err := r.reconcilePVCs(ctx, sandbox)
+	err := r.reconcilePVCs(ctx, sandbox, nameHash)
 	allErrors = errors.Join(allErrors, err)
 
 	// Reconcile Pod
@@ -488,7 +489,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	return pod, nil
 }
 
-func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) error {
+func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) error {
 	log := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
@@ -508,11 +509,16 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 			return fmt.Errorf("PVC Get Failed: %w", err)
 		}
 
+		pvcLabels := maps.Clone(pvcTemplate.Labels)
+		pvcLabels[sandboxLabel] = nameHash
+
 		log.Info("Creating a new PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
 		pvc = &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      pvcName,
-				Namespace: sandbox.Namespace,
+				Name:        pvcName,
+				Namespace:   sandbox.Namespace,
+				Annotations: maps.Clone(pvcTemplate.Annotations),
+				Labels:      pvcLabels,
 			},
 			Spec: pvcTemplate.Spec,
 		}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -309,7 +309,9 @@ func TestReconcile(t *testing.T) {
 				VolumeClaimTemplates: []sandboxv1alpha1.PersistentVolumeClaimTemplate{
 					{
 						EmbeddedObjectMetadata: sandboxv1alpha1.EmbeddedObjectMetadata{
-							Name: "my-pvc",
+							Name:        "my-pvc",
+							Labels:      map[string]string{"custom-label": "label-val"},
+							Annotations: map[string]string{"custom-annotation": "anno-val"},
 						},
 						Spec: corev1.PersistentVolumeClaimSpec{
 							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -394,8 +396,13 @@ func TestReconcile(t *testing.T) {
 				// Verify PVC
 				&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            "my-pvc-sandbox-name",
-						Namespace:       sandboxNs,
+						Name:      "my-pvc-sandbox-name",
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"custom-label":                      "label-val",
+						},
+						Annotations:     map[string]string{"custom-annotation": "anno-val"},
 						ResourceVersion: "1",
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -666,7 +673,8 @@ func TestReconcilePod(t *testing.T) {
 					Namespace: sandboxNs,
 				},
 				Spec: sandboxv1alpha1.SandboxSpec{
-					Replicas: ptr.To(int32(0))},
+					Replicas: ptr.To(int32(0)),
+				},
 			},
 			wantPod: nil,
 		},


### PR DESCRIPTION
The Sandbox CRD lets you define volume claim templates, including metadata like labels and annotations. However, these aren’t synced to the generated PVC, so this PR fills that gap.