### PR TITLE
Minor fixes

### DIFF
--- a/examples/composing-sandbox-nw-policies/README.md
+++ b/examples/composing-sandbox-nw-policies/README.md
@@ -34,11 +34,21 @@ KRO is a powerful tool for defining and managing composite resources in Kubernet
 
 ## Example: Using KRO to create an `AgenticSandbox`
 
+### Clone the repository
+First, clone the repository and navigate to the repository directory
+```
+# Clone the repository
+git clone https://github.com/kubernetes-sigs/agent-sandbox.git
+
+# Navigate to the repository directory
+cd agent-sandbox
+```
+
 ### Install KRO
 
-First, install KRO on your cluster:
+Install KRO on your cluster, by running the script:
 ```
-dev/tools/install-kro
+./dev/tools/install-kro
 ```
 
 ### Create RGD
@@ -46,6 +56,10 @@ dev/tools/install-kro
 Install the `ResourceGraphDefinition` (RGD) which defines our new `AgenticSandbox` CRD
 
 ```
+# Switch to the examples directory
+cd examples/composing-sandbox-nw-policies
+
+# Install the RGD
 kubectl apply -f rgd.yaml
 ```
 

--- a/examples/jupyterlab/files/download_models.py
+++ b/examples/jupyterlab/files/download_models.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from huggingface_hub import snapshot_download
+
+if __name__ == "__main__":
+    model_names = [
+        "Qwen/Qwen3-Embedding-0.6B",
+        "distilbert-base-uncased-finetuned-sst-2-english",
+    ]
+
+    cache_dir = sys.argv[1] if len(sys.argv) > 1 else None
+    
+    for model_name in model_names:
+        print(f"--- Downloading {model_name} ---")
+        try:
+            if cache_dir:
+                snapshot_download(repo_id=model_name, cache_dir=cache_dir)
+            else:
+                snapshot_download(repo_id=model_name)
+            print(f"Successfully cached {model_name}")
+        except Exception as e:
+            print(f"Failed to download {model_name}. Error: {e}")
+
+    print("--- Model download process finished. ---")

--- a/examples/jupyterlab/files/experiment.ipynb
+++ b/examples/jupyterlab/files/experiment.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "header",
+   "metadata": {},
+   "source": [
+    "# Fine-Tuning HuggingFace Models in Isolated Sandboxes\n",
+    "\n",
+    "This notebook demonstrates a complete ML workflow: loading a model from HuggingFace and fine-tuning it on custom data.\n",
+    "\n",
+    "**Why isolation matters:**\n",
+    "- This runs in your own sandbox - your packages and training don't affect other team members\n",
+    "- You can safely experiment with any HuggingFace model without risking shared infrastructure\n",
+    "- Other data scientists work independently in their own sandboxes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step1",
+   "metadata": {},
+   "source": [
+    "## Step 1: Load Model from HuggingFace\n",
+    "\n",
+    "We'll use a pre-trained sentiment analysis model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, AutoModelForSequenceClassification, Trainer, TrainingArguments\n",
+    "from datasets import Dataset\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "\n",
+    "# Load model from HuggingFace\n",
+    "model_name = \"distilbert-base-uncased-finetuned-sst-2-english\"\n",
+    "print(f\"Loading: {model_name}\")\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(model_name)\n",
+    "\n",
+    "print(f\"Loaded successfully ({model.num_parameters():,} parameters)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step2",
+   "metadata": {},
+   "source": [
+    "## Step 2: Test Baseline Performance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baseline",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test on sample reviews\n",
+    "reviews = [\n",
+    "    \"This product is amazing! Best purchase ever.\",\n",
+    "    \"Terrible quality. Complete waste of money.\",\n",
+    "    \"It's okay, nothing special.\"\n",
+    "]\n",
+    "\n",
+    "print(\"Baseline predictions:\\n\")\n",
+    "for review in reviews:\n",
+    "    inputs = tokenizer(review, return_tensors=\"pt\", truncation=True, padding=True)\n",
+    "    outputs = model(**inputs)\n",
+    "    probs = torch.softmax(outputs.logits, dim=1)\n",
+    "    \n",
+    "    sentiment = \"POSITIVE\" if probs[0][1] > 0.5 else \"NEGATIVE\"\n",
+    "    conf = probs[0][1].item() if sentiment == \"POSITIVE\" else probs[0][0].item()\n",
+    "    \n",
+    "    print(f\"{sentiment} ({conf:.0%}): {review}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step3",
+   "metadata": {},
+   "source": [
+    "## Step 3: Prepare Training Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "data",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create training dataset\n",
+    "train_data = {\n",
+    "    'text': [\n",
+    "        \"Outstanding quality and service\",\n",
+    "        \"Very poor experience, not recommended\",\n",
+    "        \"Exceptional value for money\",\n",
+    "        \"Disappointed, requesting refund\",\n",
+    "        \"Highly recommend to everyone\",\n",
+    "        \"Defective product, broke immediately\",\n",
+    "        \"Perfect for my needs\",\n",
+    "        \"Terrible customer support\",\n",
+    "        \"Exceeded expectations\",\n",
+    "        \"Complete waste of time and money\",\n",
+    "        \"Will definitely buy again\",\n",
+    "        \"Avoid this product\",\n",
+    "        \"Exactly what I needed\",\n",
+    "        \"Very disappointed with purchase\",\n",
+    "        \"Best in its category\",\n",
+    "        \"Poor quality, not as described\",\n",
+    "    ],\n",
+    "    'label': [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]\n",
+    "}\n",
+    "\n",
+    "val_data = {\n",
+    "    'text': [\n",
+    "        \"Great product, worth it\",\n",
+    "        \"Awful, do not buy\",\n",
+    "        \"Excellent quality\",\n",
+    "        \"Total disappointment\",\n",
+    "    ],\n",
+    "    'label': [1, 0, 1, 0]\n",
+    "}\n",
+    "\n",
+    "# Create datasets\n",
+    "train_dataset = Dataset.from_dict(train_data)\n",
+    "val_dataset = Dataset.from_dict(val_data)\n",
+    "\n",
+    "# Tokenize\n",
+    "def tokenize(examples):\n",
+    "    return tokenizer(examples['text'], padding='max_length', truncation=True, max_length=128)\n",
+    "\n",
+    "train_dataset = train_dataset.map(tokenize, batched=True)\n",
+    "val_dataset = val_dataset.map(tokenize, batched=True)\n",
+    "\n",
+    "print(f\"Training samples: {len(train_dataset)}\")\n",
+    "print(f\"Validation samples: {len(val_dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step4",
+   "metadata": {},
+   "source": [
+    "## Step 4: Fine-Tune the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "train",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Training configuration\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir='./results',\n",
+    "    num_train_epochs=3,\n",
+    "    per_device_train_batch_size=4,\n",
+    "    per_device_eval_batch_size=4,\n",
+    "    warmup_steps=10,\n",
+    "    weight_decay=0.01,\n",
+    "    logging_steps=5,\n",
+    "    eval_strategy=\"epoch\",\n",
+    "    save_strategy=\"epoch\",\n",
+    "    load_best_model_at_end=True,\n",
+    ")\n",
+    "\n",
+    "def compute_metrics(eval_pred):\n",
+    "    predictions, labels = eval_pred\n",
+    "    predictions = np.argmax(predictions, axis=1)\n",
+    "    return {'accuracy': (predictions == labels).mean()}\n",
+    "\n",
+    "# Initialize trainer\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=training_args,\n",
+    "    train_dataset=train_dataset,\n",
+    "    eval_dataset=val_dataset,\n",
+    "    compute_metrics=compute_metrics,\n",
+    ")\n",
+    "\n",
+    "print(\"Starting fine-tuning...\")\n",
+    "result = trainer.train()\n",
+    "\n",
+    "print(f\"Training complete\")\n",
+    "print(f\"Final loss: {result.training_loss:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step5",
+   "metadata": {},
+   "source": [
+    "## Step 5: Evaluate Fine-Tuned Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eval",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate\n",
+    "eval_results = trainer.evaluate()\n",
+    "print(f\"Validation Accuracy: {eval_results['eval_accuracy']:.1%}\")\n",
+    "\n",
+    "# Test on original reviews\n",
+    "print(\"\\nFine-tuned predictions:\\n\")\n",
+    "for review in reviews:\n",
+    "    inputs = tokenizer(review, return_tensors=\"pt\", truncation=True, padding=True)\n",
+    "    outputs = model(**inputs)\n",
+    "    probs = torch.softmax(outputs.logits, dim=1)\n",
+    "    \n",
+    "    sentiment = \"POSITIVE\" if probs[0][1] > 0.5 else \"NEGATIVE\"\n",
+    "    conf = probs[0][1].item() if sentiment == \"POSITIVE\" else probs[0][0].item()\n",
+    "    \n",
+    "    print(f\"{sentiment} ({conf:.0%}): {review}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "step6",
+   "metadata": {},
+   "source": [
+    "## Step 6: Save the Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "save",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to persistent workspace\n",
+    "save_dir = \"./fine_tuned_model\"\n",
+    "model.save_pretrained(save_dir)\n",
+    "tokenizer.save_pretrained(save_dir)\n",
+    "\n",
+    "print(f\"Model saved to {save_dir}\")\n",
+    "print(\"This is in your persistent workspace and survives pod restarts\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/jupyterlab/files/requirements.txt
+++ b/examples/jupyterlab/files/requirements.txt
@@ -1,0 +1,6 @@
+transformers>=4.51.0
+torch
+huggingface_hub
+ipywidgets
+datasets
+accelerate>=0.26.0

--- a/examples/jupyterlab/files/welcome.ipynb
+++ b/examples/jupyterlab/files/welcome.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8048aa56-4549-4afa-b8b0-d111cc7020c3",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Requires transformers>=4.51.0\n\nimport torch\nimport torch.nn.functional as F\n\nfrom torch import Tensor\nfrom transformers import AutoTokenizer, AutoModel\n\n\ndef last_token_pool(last_hidden_states: Tensor,\n                 attention_mask: Tensor) -> Tensor:\n    left_padding = (attention_mask[:, -1].sum() == attention_mask.shape[0])\n    if left_padding:\n        return last_hidden_states[:, -1]\n    else:\n        sequence_lengths = attention_mask.sum(dim=1) - 1\n        batch_size = last_hidden_states.shape[0]\n        return last_hidden_states[torch.arange(batch_size, device=last_hidden_states.device), sequence_lengths]\n\n\ndef get_detailed_instruct(task_description: str, query: str) -> str:\n    return f'Instruct: {task_description}\\nQuery:{query}'\n\n# Each query must come with a one-sentence instruction that describes the task\ntask = 'Given a web search query, retrieve relevant passages that answer the query'\n\nqueries = [\n    get_detailed_instruct(task, 'What is the capital of China?'),\n    get_detailed_instruct(task, 'Explain gravity')\n]\n# No need to add instruction for retrieval documents\ndocuments = [\n    \"The capital of China is Beijing.\",\n    \"Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.\"\n]\ninput_texts = queries + documents\n\ntokenizer = AutoTokenizer.from_pretrained('Qwen/Qwen3-Embedding-0.6B', padding_side='left')\nmodel = AutoModel.from_pretrained('Qwen/Qwen3-Embedding-0.6B')\n\nmax_length = 8192\n\n# Tokenize the input texts\nbatch_dict = tokenizer(\n    input_texts,\n    padding=True,\n    truncation=True,\n    max_length=max_length,\n    return_tensors=\"pt\",\n)\nbatch_dict.to(model.device)\noutputs = model(**batch_dict)\nembeddings = last_token_pool(outputs.last_hidden_state, batch_dict['attention_mask'])\n\n# normalize embeddings\nembeddings = F.normalize(embeddings, p=2, dim=1)\nscores = (embeddings[:2] @ embeddings[2:].T)\nprint(scores.tolist())"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/jupyterlab/jupyterlab-full.yaml
+++ b/examples/jupyterlab/jupyterlab-full.yaml
@@ -1,0 +1,292 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jupyter-init-files
+  namespace: default
+data:
+  download_models.py: |
+    import sys
+    from huggingface_hub import snapshot_download
+
+    if __name__ == "__main__":
+        model_names = [
+            "Qwen/Qwen3-Embedding-0.6B",
+            "distilbert-base-uncased-finetuned-sst-2-english",
+        ]
+
+        cache_dir = sys.argv[1] if len(sys.argv) > 1 else None
+        
+        for model_name in model_names:
+            print(f"--- Downloading {model_name} ---")
+            try:
+                if cache_dir:
+                    snapshot_download(repo_id=model_name, cache_dir=cache_dir)
+                else:
+                    snapshot_download(repo_id=model_name)
+                print(f"Successfully cached {model_name}")
+            except Exception as e:
+                print(f"Failed to download {model_name}. Error: {e}")
+
+        print("--- Model download process finished. ---")
+
+  welcome.ipynb: |
+    {
+     "cells": [
+      {
+       "cell_type": "code",
+       "execution_count": null,
+       "id": "8048aa56-4549-4afa-b8b0-d111cc7020c3",
+       "metadata": {},
+       "outputs": [],
+       "source": [
+        "# Requires transformers>=4.51.0\n",
+        "\n",
+        "import torch\n",
+        "import torch.nn.functional as F\n",
+        "\n",
+        "from torch import Tensor\n",
+        "from transformers import AutoTokenizer, AutoModel\n",
+        "\n",
+        "\n",
+        "def last_token_pool(last_hidden_states: Tensor,\n",
+        "                 attention_mask: Tensor) -> Tensor:\n",
+        "    left_padding = (attention_mask[:, -1].sum() == attention_mask.shape[0])\n",
+        "    if left_padding:\n",
+        "        return last_hidden_states[:, -1]\n",
+        "    else:\n",
+        "        sequence_lengths = attention_mask.sum(dim=1) - 1\n",
+        "        batch_size = last_hidden_states.shape[0]\n",
+        "        return last_hidden_states[torch.arange(batch_size, device=last_hidden_states.device), sequence_lengths]\n",
+        "\n",
+        "\n",
+        "def get_detailed_instruct(task_description: str, query: str) -> str:\n",
+        "    return f'Instruct: {task_description}\\nQuery:{query}'\n",
+        "\n",
+        "# Each query must come with a one-sentence instruction that describes the task\n",
+        "task = 'Given a web search query, retrieve relevant passages that answer the query'\n",
+        "\n",
+        "queries = [\n",
+        "    get_detailed_instruct(task, 'What is the capital of China?'),\n",
+        "    get_detailed_instruct(task, 'Explain gravity')\n",
+        "]\n",
+        "# No need to add instruction for retrieval documents\n",
+        "documents = [\n",
+        "    \"The capital of China is Beijing.\",\n",
+        "    \"Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.\"\n",
+        "]\n",
+        "input_texts = queries + documents\n",
+        "\n",
+        "tokenizer = AutoTokenizer.from_pretrained('Qwen/Qwen3-Embedding-0.6B', padding_side='left')\n",
+        "model = AutoModel.from_pretrained('Qwen/Qwen3-Embedding-0.6B')\n",
+        "\n",
+        "max_length = 8192\n",
+        "\n",
+        "\n",
+        "# Tokenize the input texts\n",
+        "batch_dict = tokenizer(\n",
+        "    input_texts,\n",
+        "    padding=True,\n",
+        "    truncation=True,\n",
+        "    max_length=max_length,\n",
+        "    return_tensors=\"pt\",\n",
+        ")\n",
+        "batch_dict.to(model.device)\n",
+        "outputs = model(**batch_dict)\n",
+        "embeddings = last_token_pool(outputs.last_hidden_state, batch_dict['attention_mask'])\n",
+        "\n",
+        "# normalize embeddings\n",
+        "embeddings = F.normalize(embeddings, p=2, dim=1)\n",
+        "scores = (embeddings[:2] @ embeddings[2:].T)\n",
+        "print(scores.tolist())"
+       ]
+      }
+     ],
+     "metadata": {
+      "kernelspec": {
+       "display_name": "Python 3 (ipykernel)",
+       "language": "python",
+       "name": "python3"
+      },
+      "language_info": {
+       "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+       },
+       "file_extension": ".py",
+       "mimetype": "text/x-python",
+       "name": "python",
+       "nbconvert_exporter": "python",
+       "pygments_lexer": "ipython3",
+       "version": "3.12.10"
+      }
+     },
+     "nbformat": 4,
+     "nbformat_minor": 5
+    }
+
+  requirements.txt: |
+    transformers>=4.51.0
+    torch
+    huggingface_hub
+    ipywidgets
+
+---
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: jupyterlab-sandbox
+  namespace: default
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        app: jupyterlab
+        sandbox: jupyterlab
+    spec:
+      initContainers:
+        - name: setup-environment
+          image: jupyterhub/k8s-singleuser-sample:4.2.0
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+              
+              if [ -f /home/jovyan/.initialized ]; then
+                echo "Already initialized, skipping..."
+                exit 0
+              fi
+              
+              mkdir -p /home/jovyan/.pip-cache
+              mkdir -p /home/jovyan/.tmp
+              mkdir -p /home/jovyan/work
+              mkdir -p /home/jovyan/.local
+              mkdir -p /home/jovyan/.cache/huggingface
+              
+              echo "Installing Python dependencies to persistent storage..."
+              PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+              export PYTHONPATH=/home/jovyan/.local/lib/python${PYTHON_VERSION}/site-packages
+              pip install --no-cache-dir \
+                --target=/home/jovyan/.local/lib/python${PYTHON_VERSION}/site-packages \
+                -r /config/requirements.txt
+
+              python /config/download_models.py "$HF_HOME"
+              
+              echo "Copying notebook files..."
+              cp /config/welcome.ipynb /home/jovyan/work/welcome.ipynb
+
+              touch /home/jovyan/.initialized
+
+              echo "Initialization complete!"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-hf-token
+                  key: token
+            - name: HF_HOME
+              value: /home/jovyan/.cache/huggingface
+            - name: PIP_CACHE_DIR
+              value: /home/jovyan/.pip-cache
+            - name: TMPDIR
+              value: /home/jovyan/.tmp
+            - name: TEMP
+              value: /home/jovyan/.tmp
+            - name: TMP
+              value: /home/jovyan/.tmp
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/jovyan
+            - name: init-files
+              mountPath: /config
+              readOnly: true
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "2Gi"
+              ephemeral-storage: "10Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+              ephemeral-storage: "10Gi"
+          securityContext:
+            runAsUser: 1000  # jovyan user
+            runAsGroup: 100  # users group
+            allowPrivilegeEscalation: false
+
+      securityContext:
+        fsGroup: 100  # users group - for volume permissions
+
+      containers:
+        - name: jupyterlab
+          image: jupyterhub/k8s-singleuser-sample:4.2.0
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+              export PYTHONPATH=/home/jovyan/.local/lib/python${PYTHON_VERSION}/site-packages
+              # WARNING: The following configuration disables critical security features:
+              # - token='' and password='' disable authentication entirely
+              # - allow_origin='*' allows requests from any origin (CORS security risk)
+              # - disable_check_xsrf=True disables CSRF protection
+              # - ip=0.0.0.0 binds to all interfaces
+              #
+              # These settings are ONLY appropriate for isolated sandbox environments.
+              # DO NOT use this configuration if the pod/service is exposed outside the cluster.
+              # For production or exposed deployments, enable authentication and restrict origins.
+              exec jupyter lab \
+                --ip=0.0.0.0 \
+                --port=8888 \
+                --notebook-dir=/home/jovyan/work \
+                --ServerApp.token='' \
+                --ServerApp.password='' \
+                --ServerApp.allow_origin='*' \
+                --ServerApp.disable_check_xsrf=True
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-hf-token
+                  key: token
+            - name: JUPYTER_ENABLE_LAB
+              value: "yes"
+            - name: HF_HOME
+              value: /home/jovyan/.cache/huggingface
+          ports:
+            - containerPort: 8888
+              name: notebook
+              protocol: TCP
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/jovyan
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+              ephemeral-storage: "1Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+              ephemeral-storage: "2Gi"
+          securityContext:
+            runAsUser: 1000  # jovyan user
+            runAsGroup: 100  # users group
+            allowPrivilegeEscalation: false
+
+      volumes:
+        - name: init-files
+          configMap:
+            name: jupyter-init-files
+
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi

--- a/examples/jupyterlab/jupyterlab.yaml
+++ b/examples/jupyterlab/jupyterlab.yaml
@@ -1,0 +1,167 @@
+# NOTE: This manifest requires the 'jupyter-init-files' ConfigMap to be created first.
+# Create it using:
+#   kubectl create configmap jupyter-init-files \
+#     --from-file=files/download_models.py \
+#     --from-file=files/requirements.txt \
+#     --from-file=files/welcome.ipynb \
+#     --namespace=default
+#
+# For the all-in-one deployment with ConfigMap included, use jupyterlab-full.yaml instead.
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: jupyterlab-sandbox
+  namespace: default
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        app: jupyterlab
+        sandbox: jupyterlab
+    spec:
+      initContainers:
+        - name: setup-environment
+          image: jupyterhub/k8s-singleuser-sample:4.2.0
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+              
+              if [ -f /home/jovyan/.initialized ]; then
+                echo "Already initialized, skipping..."
+                exit 0
+              fi
+              
+              mkdir -p /home/jovyan/.pip-cache
+              mkdir -p /home/jovyan/.tmp
+              mkdir -p /home/jovyan/work
+              mkdir -p /home/jovyan/.local
+              mkdir -p /home/jovyan/.cache/huggingface
+              
+              echo "Installing Python dependencies to persistent storage..."
+              PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+              export PYTHONPATH=/home/jovyan/.local/lib/python${PYTHON_VERSION}/site-packages
+              pip install --no-cache-dir \
+                --target=/home/jovyan/.local/lib/python${PYTHON_VERSION}/site-packages \
+                -r /config/requirements.txt
+
+              python /config/download_models.py "$HF_HOME"
+
+              echo "Copying notebook files..."
+              cp /config/welcome.ipynb /home/jovyan/work/welcome.ipynb
+
+              touch /home/jovyan/.initialized
+
+              echo "Initialization complete!"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-hf-token
+                  key: token
+            - name: HF_HOME
+              value: /home/jovyan/.cache/huggingface
+            - name: PIP_CACHE_DIR
+              value: /home/jovyan/.pip-cache
+            - name: TMPDIR
+              value: /home/jovyan/.tmp
+            - name: TEMP
+              value: /home/jovyan/.tmp
+            - name: TMP
+              value: /home/jovyan/.tmp
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/jovyan
+            - name: init-files
+              mountPath: /config
+              readOnly: true
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "2Gi"
+              ephemeral-storage: "10Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+              ephemeral-storage: "10Gi"
+          securityContext:
+            runAsUser: 1000  # jovyan user
+            runAsGroup: 100  # users group
+            allowPrivilegeEscalation: false
+
+      securityContext:
+        fsGroup: 100  # users group - for volume permissions
+
+      containers:
+        - name: jupyterlab
+          image: jupyterhub/k8s-singleuser-sample:4.2.0
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              PYTHON_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+              export PYTHONPATH=/home/jovyan/.local/lib/python${PYTHON_VERSION}/site-packages
+              # WARNING: The following configuration disables critical security features:
+              # - token='' and password='' disable authentication entirely
+              # - allow_origin='*' allows requests from any origin (CORS security risk)
+              # - disable_check_xsrf=True disables CSRF protection
+              # - ip=0.0.0.0 binds to all interfaces
+              #
+              # These settings are ONLY appropriate for isolated sandbox environments.
+              # DO NOT use this configuration if the pod/service is exposed outside the cluster.
+              # For production or exposed deployments, enable authentication and restrict origins.
+              exec jupyter lab \
+                --ip=0.0.0.0 \
+                --port=8888 \
+                --notebook-dir=/home/jovyan/work \
+                --ServerApp.token='' \
+                --ServerApp.password='' \
+                --ServerApp.allow_origin='*' \
+                --ServerApp.disable_check_xsrf=True
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: jupyter-hf-token
+                  key: token
+            - name: JUPYTER_ENABLE_LAB
+              value: "yes"
+            - name: HF_HOME
+              value: /home/jovyan/.cache/huggingface
+          ports:
+            - containerPort: 8888
+              name: notebook
+              protocol: TCP
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/jovyan
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+              ephemeral-storage: "1Gi"
+            limits:
+              cpu: "4"
+              memory: "8Gi"
+              ephemeral-storage: "2Gi"
+          securityContext:
+            runAsUser: 1000  # jovyan user
+            runAsGroup: 100  # users group
+            allowPrivilegeEscalation: false
+
+      volumes:
+        - name: init-files
+          configMap:
+            name: jupyter-init-files
+
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi

--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -63,10 +63,14 @@ export HF_TOKEN='your_huggingface_token_here'
 
 Get a token from [HuggingFace](https://huggingface.co/settings/tokens).
 
-### 3. Navigate to the examples, langchain directory
+### 3. Clone the repository and navigate to the examples, coding-agent directory
 
 ```bash
-cd examples/langchain
+# Clone the repository
+git clone https://github.com/kubernetes-sigs/agent-sandbox.git
+
+# Navigate to the examples/coding-agent directory
+cd examples/coding-agent
 ```
 
 ### 4. Set your huggingface token
@@ -110,7 +114,7 @@ kubectl wait --for=condition=ready pod -l app=coding-agent --timeout=600s
 ### 6. Use the Agent
 
 ```bash
-# Attach to the agent & hit enter to get interraction prompt
+# Attach to the agent & hit enter to get interaction prompt
 kubectl attach -it coding-agent-sandbox
 
 # Example usage:


### PR DESCRIPTION
## Summary

This PR includes a collection of fixes and improvements across several example guides and a new JupyterLab example.

### JupyterLab example (new)
- Add `examples/jupyterlab/` with two deployment options:
  - `jupyterlab-full.yaml`: all-in-one manifest (ConfigMap + Sandbox)
  - `jupyterlab.yaml`: minimal manifest requiring a separately created ConfigMap
- Add `files/download_models.py`: script to pre-download HuggingFace models (`Qwen/Qwen3-Embedding-0.6B`, `distilbert-base-uncased-finetuned-sst-2-english`) into persistent storage
- Add `files/experiment.ipynb`: notebook demonstrating a complete ML workflow — loading, fine-tuning, evaluating, and saving a HuggingFace sentiment model
- Add `files/welcome.ipynb`: sample notebook using `Qwen3-Embedding-0.6B` for semantic search
- Add `files/requirements.txt`: Python dependencies for the JupyterLab environment
- Use dynamic Python version detection (`python3 -c "import sys; ..."`) instead of hardcoding paths, so the setup survives base image updates
- Set `PYTHONPATH` in both initContainer and main container so installed packages are importable
- Add clear security warning comments in YAML for the disabled-auth JupyterLab configuration (XSRF disabled, open CORS, no token) with explicit note that this is only for isolated sandbox environments
- Replace HuggingFace token injection via `sed`/manual YAML editing with `kubectl create secret` instructions
- Add `jupyter-init-files` ConfigMap creation note at the top of `jupyterlab.yaml`

### composing-sandbox-nw-policies guide
- Add missing "Clone the repository" step at the start
- Fix script invocation: `dev/tools/install-kro` → `./dev/tools/install-kro`
- Add `cd examples/composing-sandbox-nw-policies` step before `kubectl apply`

### langchain guide
- Fix wrong directory in step 3: was `cd examples/langchain`, corrected to `cd examples/coding-agent`
- Add `git clone` step before the `cd` instruction
- Fix typo: `interraction` → `interaction`

### jupyterlab guide (README)
- Fix broken link: `../../INSTALL.md` → `../../README.md`
- Update file tree to include `experiment.ipynb`
- Reorder setup steps: create HuggingFace secret before creating ConfigMap
