### PR TITLE
Load test recipes with cluster loader 2.

### DIFF
--- a/dev/load-test/agent-sandbox-load-test.yaml
+++ b/dev/load-test/agent-sandbox-load-test.yaml
@@ -20,7 +20,7 @@ steps:
     Method: PodStartupLatency # Warning: this only measures the downstream Pod latency, not the end-to-end Sandbox lifecycle
     Params:
       action: start
-      labelSelector: "app=agent-sandbox-load-test"
+      labelSelector: "group=agent-sandbox-load-test"
 - name: Create Sandboxes
   phases:
   - namespaceRange: {min: 1, max: {{$namespaces}}}
@@ -29,13 +29,15 @@ steps:
     objectBundle:
     - basename: agent-env
       objectTemplatePath: "cluster-loader-sandbox.yaml"
+      templateFillMap:
+        Group: agent-sandbox-load-test
 - name: Wait for Sandboxes to be Ready
   measurements:
   - Identifier: WaitForSandboxes
     Method: WaitForRunningPods
     Params:
       action: start
-      labelSelector: "app=agent-sandbox-load-test"
+      labelSelector: "group=agent-sandbox-load-test"
       desiredPodCount: {{MultiplyInt $replicas $namespaces}}
 - name: Gather Results
   measurements:
@@ -43,7 +45,7 @@ steps:
     Method: PodStartupLatency
     Params:
       action: gather
-      labelSelector: "app=agent-sandbox-load-test"
+      labelSelector: "group=agent-sandbox-load-test"
 - name: Delete Sandboxes
   phases:
   - namespaceRange: {min: 1, max: {{$namespaces}}}

--- a/dev/load-test/cluster-loader-sandbox.yaml
+++ b/dev/load-test/cluster-loader-sandbox.yaml
@@ -1,15 +1,16 @@
 apiVersion: agents.x-k8s.io/v1alpha1
 kind: Sandbox
 metadata:
-  # CL2 will automatically populate {{.Name}}
   name: {{.Name}}
 spec:
   podTemplate:
     metadata:
       labels:
-        app: agent-sandbox-load-test
+        group: {{.Group}}
     spec:
+      terminationGracePeriodSeconds: 1
+      restartPolicy: Never
       containers:
       - name: sample-sandbox
         image: alpine
-        command: ["/bin/sh", "-c", "echo 'Hello from the Agent Sandbox!'; sleep 300"]
+        command: ["/bin/sh", "-c", "echo 'Hello from the Agent Sandbox!'; sleep 3600"]

--- a/dev/load-test/test-recipes/high-volume-test.yaml
+++ b/dev/load-test/test-recipes/high-volume-test.yaml
@@ -1,0 +1,77 @@
+{{$rampUpQps := DefaultParam .CL2_RAMP_UP_QPS 10}}
+{{$rampDownQps := DefaultParam .CL2_RAMP_DOWN_QPS 50}}
+{{$replicas := DefaultParam .CL2_REPLICAS 100}} # Keep increasing this to find the max.
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+name: high-volume-test
+automanagedNamespaces: {{$namespaces}}
+
+tuningSets:
+- name: RampUp
+  qpsLoad:
+    qps: {{$rampUpQps}}
+- name: RampDown
+  qpsLoad:
+    qps: {{$rampDownQps}}
+
+steps:
+# 1. Start Metric Measurement
+- name: Start Metric Measurement
+  measurements:
+  - identifier: SchedulingThroughput
+    method: SchedulingThroughput
+    params:
+      action: start
+  # TODO: Replace PodStartupLatency with GenericPrometheusQuery 
+  # once agent_sandbox_creation_latency_ms metrics are available to measure 
+  # end-to-end controller overhead.
+  - identifier: SandboxStartupLatency
+    method: PodStartupLatency # Warning: this only measures the downstream Pod latency, not the end-to-end Sandbox lifecycle
+    params:
+      action: start
+      labelSelector: "group=linear-rampup"
+
+# 2. Increase the Load with Linear Ramp Up with a steady qps of {{$rampUpQps}} / sec.
+- name: Linear Ramp Up
+  phases:
+  - name: Scale Up
+    namespaceRange: {min: 1, max: {{$namespaces}}}
+    tuningSet: RampUp
+    replicasPerNamespace: {{$replicas}}
+    objectBundle:
+    - basename: agent-sandbox
+      identifier: "linear-rampup"
+      objectTemplatePath: ../cluster-loader-sandbox.yaml
+      templateFillMap:
+        Group: linear-rampup
+    waits:
+    - type: Running
+      labelSelector: "group=linear-rampup"
+
+- name: Wait for Prometheus Scrape
+  measurements:
+  - identifier: Wait
+    method: Sleep
+    params:
+      duration: 20s
+
+# 3. Gather Measurement
+- name: Gather Latency Measurement
+  measurements:
+  - identifier: SchedulingThroughput
+    method: SchedulingThroughput
+    params:
+      action: gather
+  - identifier: SandboxStartupLatency
+    method: PodStartupLatency
+    params:
+      action: gather
+
+# 4. Delete Sandboxes to keep the cluster clean
+- name: Cleanup Sandboxes
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: RampDown
+    objectBundle:
+    - basename: agent-sandbox
+      objectTemplatePath: ../cluster-loader-sandbox.yaml

--- a/dev/load-test/test-recipes/medium-scale-concurrent-load-test.yaml
+++ b/dev/load-test/test-recipes/medium-scale-concurrent-load-test.yaml
@@ -1,0 +1,95 @@
+{{$constantChurnQps := DefaultParam .CL2_CONSTANT_CHURN_QPS 2}}
+{{$quickDeleteQps := DefaultParam .CL2_QUICK_DELETE_QPS 100}}
+{{$replicas := DefaultParam .CL2_REPLICAS 1200}}
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+name: performance-churn-test-steady-state
+automanagedNamespaces: {{$namespaces}}
+
+tuningSets:
+- name: ConstantChurn
+  qpsLoad:
+    qps: {{$constantChurnQps}}
+- name: QuickFinalDeletion
+  qpsLoad:
+    qps: {{$quickDeleteQps}}
+
+steps:
+# 1. Initial Warmup to establish steady state for Group A
+- name: Initial Warmup
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: {{$replicas}}
+    tuningSet: ConstantChurn
+    objectBundle:
+    - basename: churn-initial-warmup-group
+      objectTemplatePath: ../cluster-loader-sandbox.yaml
+      templateFillMap:
+        Group: initial-warmup-group
+    waits:
+    - type: Running
+      labelSelector: "group=initial-warmup-group"
+
+# # 2. Start Measurements for Group B sandbox creations
+- name: Start Measurements
+  measurements:
+  # TODO: Replace PodStartupLatency with GenericPrometheusQuery 
+  # once agent_sandbox_creation_latency_ms metrics are available to measure 
+  # end-to-end controller overhead.
+  - identifier: SandboxStartupLatency
+    method: PodStartupLatency # Warning: this only measures the downstream Pod latency, not the end-to-end Sandbox lifecycle
+    params:
+      action: start
+      labelSelector: "group=continuous-churn-group"
+
+# # 3. Create Continuous Churn Loop with sandboxes getting created 
+# # in Group B while sandboxes in Group A are getting deleted concurrently 
+# # to maintain steady state.
+- name: Continuous Churn Cycle
+  phases:
+  - name: Create
+    namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: {{$replicas}}
+    tuningSet: ConstantChurn
+    objectBundle:
+    - basename: churn-continuous-churn-group
+      objectTemplatePath: ../cluster-loader-sandbox.yaml
+      templateFillMap:
+        Group: continuous-churn-group
+    waits:
+    - type: Running
+      labelSelector: "group=continuous-churn-group"
+  - name: Delete
+    namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: ConstantChurn
+    objectBundle:
+    - basename: churn-initial-warmup-group
+      objectTemplatePath: ../cluster-loader-sandbox.yaml
+    waits:
+    - type: Deleted
+      labelSelector: "group=initial-warmup-group"
+
+# # 4. Gather Measurements for Group B sandbox creations
+- name: Gather Measurements
+  measurements:
+  - identifier: SandboxStartupLatency
+    method: PodStartupLatency
+    params:
+      action: gather
+      labelSelector: "group=continuous-churn-group"
+
+# 5. Cleanup any remaining Sandboxes to keep the cluster clean
+- name: Cleanup Remaining Sandboxes
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: ConstantChurn
+    objectBundle:
+    - basename: churn-initial-warmup-group
+      objectTemplatePath: ../cluster-loader-sandbox.yaml
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: QuickFinalDeletion
+    objectBundle:
+    - basename: churn-continuous-churn-group
+      objectTemplatePath: ../cluster-loader-sandbox.yaml

--- a/dev/load-test/test-recipes/throughput-test.yaml
+++ b/dev/load-test/test-recipes/throughput-test.yaml
@@ -1,0 +1,102 @@
+{{$qps := DefaultParam .CL2_THROUGHPUT_QPS 200}} # Keep increasing this to find the max. 
+{{$quickDeleteQps := DefaultParam .CL2_QUICK_DELETE_QPS 100}}
+{{$replicas := DefaultParam .CL2_REPLICAS 12000}}
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+name: throughput-test
+namespace:
+  number: {{$namespaces}}
+  prefix: throughput-test-ns
+  deleteAutomanagedNamespaces: true
+
+tuningSets:
+- name: ConstantRate
+  qpsLoad:
+    qps: {{$qps}}
+- name: QuickFinalDeletion
+  qpsLoad:
+    qps: {{$quickDeleteQps}}
+
+steps:
+- name: Start Throughput Monitor
+  measurements:
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: start
+  - Identifier: ReadyPerSecond
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      # Query: We sum the rate of pods entering 'Running' phase.
+      # We use a 5m window to smooth out scraping intervals.
+      query: sum(kube_pod_status_phase{phase="Running", namespace=~"throughput-test-ns-.*"})[5m])
+      metricName: "Throughput"
+      metricVersion: "v1"
+      unit: "pods/s"
+  # TODO: Replace PodStartupLatency with GenericPrometheusQuery 
+  # once agent_sandbox_creation_latency_ms metrics are available to measure 
+  # end-to-end controller overhead.
+  - Identifier: SandboxStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: "group=throughput-test"
+
+
+- name: Create Workload
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: {{$replicas}} # Create high enough number
+    tuningSet: ConstantRate
+    objectBundle:
+    - basename: agent-pod
+      objectTemplatePath: "../cluster-loader-sandbox.yaml"
+      templateFillMap:
+        Group: throughput-test
+
+- name: Wait for all pods to be Running before gathering results
+  measurements:
+  - Identifier: WaitForRunning
+    Method: WaitForRunningPods
+    Params:
+      action: start
+      labelSelector: "group=throughput-test"
+      desiredPodCount: {{MultiplyInt $replicas $namespaces}}
+      timeout: 60m
+
+- name: Wait for Prometheus Scrape
+  measurements:
+  - Identifier: Wait
+    Method: Sleep
+    Params:
+      duration: 30s
+
+- name: Gather Throughput Results
+  measurements:
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: gather
+  - Identifier: ReadyPerSecond
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+  - Identifier: SandboxStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+      labelSelector: "group=throughput-test"
+
+- name: Delete Sandboxes
+  phases:
+  - namespaceRange:
+      min: 1
+      max: {{$namespaces}}
+    replicasPerNamespace: 0
+    tuningSet: QuickFinalDeletion
+    objectBundle:
+    - basename: agent-pod
+      objectTemplatePath: "../cluster-loader-sandbox.yaml"
+      

--- a/dev/load-test/test-recipes/warmpool-test/cluster-loader-sandbox-claim.yaml
+++ b/dev/load-test/test-recipes/warmpool-test/cluster-loader-sandbox-claim.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: {{.Name}}
+spec:
+  sandboxTemplateRef:
+    name: {{.TemplateName}}

--- a/dev/load-test/test-recipes/warmpool-test/cluster-loader-sandbox-template.yaml
+++ b/dev/load-test/test-recipes/warmpool-test/cluster-loader-sandbox-template.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: {{.Name}}
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        latency-type: {{.LatencyType}}
+    spec:
+      restartPolicy: Never 
+      runtimeClassName: {{.RuntimeClass}}
+      containers:
+        - name: python-agent
+          image: python:3.11-slim
+          command: ["/bin/sh", "-c"]
+          args: ["echo 'Hello from the Sandbox!' && sleep 3600"]

--- a/dev/load-test/test-recipes/warmpool-test/cluster-loader-warmpool.yaml
+++ b/dev/load-test/test-recipes/warmpool-test/cluster-loader-warmpool.yaml
@@ -1,0 +1,9 @@
+# Warmpool Template
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: {{.Name}}
+spec:
+  replicas: {{.Replicas}}
+  sandboxTemplateRef:
+    name: {{.TemplateName}}

--- a/dev/load-test/test-recipes/warmpool-test/warmpool-burst-test.yaml
+++ b/dev/load-test/test-recipes/warmpool-test/warmpool-burst-test.yaml
@@ -1,0 +1,137 @@
+{{$runtimeClass := DefaultParam .CL2_RUNTIME_CLASS "gvisor"}}
+{{$rampUpQps := DefaultParam .CL2_RAMP_UP_QPS 100}}
+{{$rampDownQps := DefaultParam .CL2_RAMP_DOWN_QPS 50}}
+{{$replicas := DefaultParam .CL2_REPLICAS 100}}
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+name: warmpool-burst-test
+automanagedNamespaces: {{$namespaces}}
+
+tuningSets:
+- name: RampUp
+  qpsLoad:
+    qps: {{$rampUpQps}} 
+- name: RampDown
+  qpsLoad:
+    qps: {{$rampDownQps}} 
+
+steps:
+# --- 1. SETUP INFRASTRUCTURE ---
+- name: Create Sandbox Templates
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: RampUp
+    objectBundle:
+    - basename: perf-template-warm
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"
+      templateFillMap:
+        LatencyType: warm
+        RuntimeClass: {{$runtimeClass}}
+    - basename: perf-template-cold
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"
+      templateFillMap:
+        LatencyType: cold
+        RuntimeClass: {{$runtimeClass}}
+
+- name: Create Warmpools
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: RampUp
+    objectBundle:
+    - basename: warmpool
+      objectTemplatePath: "cluster-loader-warmpool.yaml"
+      templateFillMap:
+        TemplateName: perf-template-warm-0
+        Replicas: {{$replicas}}
+    waits:
+    - type: Running
+      labelSelector: "agents.x-k8s.io/pool"
+
+# --- 2. DRAIN WARMPOOL (Excluded from Cold Measurement) ---
+# TODO: Add a measurement once we have the metric to measure acquistion from warmpool.
+- name: Claim with Warmpool
+  phases:
+  - name: Drain Pool
+    namespaceRange: {min: 1, max: {{$namespaces}}}
+    tuningSet: RampUp
+    replicasPerNamespace: {{$replicas}} 
+    objectBundle:
+    - basename: warmpool-claim
+      objectTemplatePath: cluster-loader-sandbox-claim.yaml
+      templateFillMap:
+        TemplateName: perf-template-warm-0
+        LatencyType: warm # Labeled as warm to stay out of cold metrics
+    waits:
+    - type: Running
+      labelSelector: "latency-type=warm"
+
+# --- 3. MEASUREMENT: COLD START ---
+- name: Start Cold Latency Measurement
+  measurements:
+  # TODO: Replace PodStartupLatency with GenericPrometheusQuery 
+  # once agent_sandbox_creation_latency_ms metrics are available to measure 
+  # end-to-end controller overhead.
+  - identifier: ColdAcquisitionLatency
+    method: PodStartupLatency
+    params:
+      action: start
+      labelSelector: "latency-type=cold" # Explicitly watch ONLY cold pods
+
+- name: Claim without Warmpool
+  phases:
+  - name: Cold Start {{$replicas}}
+    namespaceRange: {min: 1, max: {{$namespaces}}}
+    tuningSet: RampUp
+    replicasPerNamespace: {{$replicas}} # Requesting {{$replicas}} specifically for the cold phase
+    objectBundle:
+    - basename: cold-claim
+      objectTemplatePath: cluster-loader-sandbox-claim.yaml
+      templateFillMap:
+        TemplateName: perf-template-cold-0
+        LatencyType: cold # This matches the measurement selector
+    waits:
+    - type: Running
+      labelSelector: "latency-type=cold"
+
+- name: Gather Cold Latency Measurement
+  measurements:
+  - identifier: ColdAcquisitionLatency
+    method: PodStartupLatency
+    params:
+      action: gather
+
+# --- 4. CLEANUP ---
+- name: Wait before deletion
+  measurements:
+  - identifier: Wait
+    method: Sleep
+    params:
+      duration: 20s
+
+- name: Cleanup All Claims
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: RampDown
+    objectBundle:
+    - basename: warmpool-claim
+      objectTemplatePath: cluster-loader-sandbox-claim.yaml
+    - basename: cold-claim
+      objectTemplatePath: cluster-loader-sandbox-claim.yaml
+    waits:
+    - type: Deleted
+      labelSelector: "agents.x-k8s.io/sandbox-name-hash"
+
+- name: Delete Warmpools and Templates
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: RampDown
+    objectBundle:
+    - basename: warmpool
+      objectTemplatePath: "cluster-loader-warmpool.yaml"
+    - basename: perf-template-warm
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"
+    - basename: perf-template-cold
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"


### PR DESCRIPTION
This PR creates 4 custom test recipes that performs 4 different tests. These test can be used to run different scenarios with different cloud providers.

1. `throughput-test` - This test allows varying the creation rate QPS and checking how QPS variation affects Pod scheduling and ready rate.
2. `medium-scale-concurrent-load-test` - This test allows the simultaneous creation and deletion of sandboxes to determine the latency during varying sustained loads.
3. `high-volume-test` - This test linearly scales up sandboxes at a constant QPS to check how increasing the sandboxes affect agent controller and the cluster.
4. `warmpool-burst-test` - This test calculates the pod acquisition latency for cold start. Currently we don't emit any warm pool acquisition metrics.
