### PR TITLE
Cleanup: creates a controller-only flag to speed up dev builds

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -85,10 +85,11 @@ def build_and_push_image(args, service_name, srcdir, dockerfile_path):
 
 def main(args):
     """Builds and pushes all discovered Docker images."""
-    excluded_dirs = {"dev", "docs", "k8s", "site",
-                     "tests", "bin", ".venv", "tmp", "temp"}
+    excluded_dirs = {"bin", "dev", "docs", "k8s", "site",
+                     "temp", "tests", "tmp", ".venv"}
 
     if args.controller_only:
+        # TODO: Implement an explicit inclusion strategy for controller only Dockerfile.
         excluded_dirs.update({"examples", "clients"})
 
     for root, dirs, files in os.walk(".", topdown=True):


### PR DESCRIPTION
This pull request introduces a `--controller-only` flag to the `./dev/tools/push-images --image-prefix={my-repo}` script.

This change reduces build times to <2 min for the controller only. Currently builds can take ~20-30 minutes, to when using the `./dev/tools/push-images --image-prefix={my-repo}` tool as it is building all of the subdirectories with Dockerfiles even though the client and examples directories are not needed for the controller build. This change will greatly help speed up development of the controller component.