### PR TITLE
tests: predicates should return (bool, error)

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -111,7 +111,7 @@ func TestSimpleSandbox(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.Name = "my-sandbox"
 	pod.Namespace = ns.Name
-	require.NoError(t, tc.ValidateObject(t.Context(), pod, p...))
+	tc.MustMatchPredicates(pod, p...)
 	// Assert Service object exists with expected fields
 	p = []predicates.ObjectPredicate{
 		predicates.HasOwnerReferences([]metav1.OwnerReference{
@@ -128,5 +128,5 @@ func TestSimpleSandbox(t *testing.T) {
 	service := &corev1.Service{}
 	service.Name = "my-sandbox"
 	service.Namespace = ns.Name
-	require.NoError(t, tc.ValidateObject(t.Context(), service, p...))
+	tc.MustMatchPredicates(service, p...)
 }

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -120,21 +120,55 @@ func (cl *ClusterClient) MustCreateWithCleanup(obj client.Object) {
 	}
 }
 
-// ValidateObject verifies the specified object exists and satisfies the provided
+// MatchesPredicates verifies the specified object exists and satisfies the provided
 // predicates.
-func (cl *ClusterClient) ValidateObject(ctx context.Context, obj client.Object, p ...predicates.ObjectPredicate) error {
+func (cl *ClusterClient) MatchesPredicates(ctx context.Context, obj client.Object, p ...predicates.ObjectPredicate) (bool, error) {
 	cl.Helper()
 	nn := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-	cl.Logf("ValidateObject %T (%s)", obj, nn.String())
+	cl.Logf("MatchesPredicates %T (%s)", obj, nn.String())
 	if err := cl.client.Get(ctx, nn, obj); err != nil {
-		return fmt.Errorf("ValidateObject %T (%s): %w", obj, nn.String(), err)
+		return false, fmt.Errorf("MatchesPredicates %T (%s): %w", obj, nn.String(), err)
 	}
 	for _, predicate := range p {
-		if err := predicate(obj); err != nil {
-			return fmt.Errorf("ValidateObject %T (%s): %w", obj, nn.String(), err)
+		predicateMatches, err := predicate(obj)
+		if err != nil {
+			return false, fmt.Errorf("MatchesPredicates %T (%s): %w", obj, nn.String(), err)
+		}
+		if !predicateMatches {
+			return false, nil
 		}
 	}
-	return nil
+	return true, nil
+}
+
+// MustMatchPredicates is a wrapper around MatchesPredicates that fails the test if the object
+// does not exist, if the predicates are not satisfied or if there is an error during evaluation.
+func (cl *ClusterClient) MustMatchPredicates(obj client.Object, p ...predicates.ObjectPredicate) {
+	cl.Helper()
+	ctx := cl.Context()
+
+	matchesPredicates, err := cl.MatchesPredicates(ctx, obj, p...)
+	if err != nil {
+		cl.Fatalf("MustMatchPredicates(%T) failed with: %v", obj, err)
+	}
+	if !matchesPredicates {
+		cl.Fatalf("MustMatchPredicates(%T) predicates not satisfied", obj)
+	}
+}
+
+// MustExist fails the test if the object does not exist.
+func (cl *ClusterClient) MustExist(obj client.Object) {
+	cl.Helper()
+	ctx := cl.Context()
+
+	// We call MatchesPredicates without any predicates to just check for existence
+	matchesPredicates, err := cl.MatchesPredicates(ctx, obj)
+	if err != nil {
+		cl.Fatalf("MustExist(%T) failed with: %v", obj, err)
+	}
+	if !matchesPredicates {
+		cl.Fatalf("MustExist(%T) object does not exist", obj)
+	}
 }
 
 // ValidateObjectNotFound verifies the specified object does not exist.
@@ -168,14 +202,17 @@ func (cl *ClusterClient) WaitForObject(ctx context.Context, obj client.Object, p
 		cl.Helper()
 		cl.Logf("WaitForObject %T (%s) took %s", obj, nn, time.Since(start))
 	}()
-	var validationErr error
 	for {
 		select {
 		case <-ctx.Done():
 			cl.Logf("Timed out waiting for object %s/%s", obj.GetNamespace(), obj.GetName())
-			return fmt.Errorf("timed out waiting for object: %w", validationErr)
+			return fmt.Errorf("timed out waiting for object %s/%s", obj.GetNamespace(), obj.GetName())
 		default:
-			if validationErr = cl.ValidateObject(ctx, obj, p...); validationErr == nil {
+			matchesPredicates, validationErr := cl.MatchesPredicates(ctx, obj, p...)
+			if validationErr != nil {
+				return validationErr
+			}
+			if matchesPredicates {
 				return nil
 			}
 			// Simple sleep for fixed duration (basic MVP)
@@ -223,7 +260,7 @@ func (cl *ClusterClient) WaitForObjectNotFound(ctx context.Context, obj client.O
 
 // validateAgentSandboxInstallation verifies agent-sandbox system components are
 // installed.
-func (cl *ClusterClient) validateAgentSandboxInstallation(ctx context.Context) error {
+func (cl *ClusterClient) validateAgentSandboxInstallation() error {
 	cl.Helper()
 	// verify CRDs exist
 	crds := []string{
@@ -235,16 +272,12 @@ func (cl *ClusterClient) validateAgentSandboxInstallation(ctx context.Context) e
 	for _, name := range crds {
 		crd := &apiextensionsv1.CustomResourceDefinition{}
 		crd.Name = name
-		if err := cl.ValidateObject(ctx, crd); err != nil {
-			return fmt.Errorf("expected %T (%s) to exist: %w", crd, name, err)
-		}
+		cl.MustExist(crd)
 	}
 	// verify agent-sandbox-system namespace exists
 	ns := &corev1.Namespace{}
 	ns.Name = "agent-sandbox-system"
-	if err := cl.ValidateObject(ctx, ns); err != nil {
-		return fmt.Errorf("expected %T (%s) to exist: %w", ns, ns.Name, err)
-	}
+	cl.MustExist(ns)
 	// verify agent-sandbox-controller exists
 	ctrlNN := types.NamespacedName{
 		Name:      "agent-sandbox-controller",
@@ -253,9 +286,7 @@ func (cl *ClusterClient) validateAgentSandboxInstallation(ctx context.Context) e
 	ctrl := &appsv1.StatefulSet{}
 	ctrl.Name = ctrlNN.Name
 	ctrl.Namespace = ctrlNN.Namespace
-	if err := cl.ValidateObject(ctx, ctrl); err != nil {
-		return fmt.Errorf("expected %T (%s) to exist: %w", ctrl, ctrlNN.String(), err)
-	}
+	cl.MustExist(ctrl)
 	return nil
 }
 

--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -102,7 +102,7 @@ func NewTestContext(t T) *TestContext {
 // beforeEach runs before each test case is executed.
 func (th *TestContext) beforeEach() error {
 	th.Helper()
-	return th.validateAgentSandboxInstallation(context.Background())
+	return th.validateAgentSandboxInstallation()
 }
 
 // afterEach runs after each test case is executed.

--- a/test/e2e/framework/predicates/metadata.go
+++ b/test/e2e/framework/predicates/metadata.go
@@ -25,60 +25,60 @@ import (
 
 // HasAnnotation verifies the object has the specified annotation
 func HasAnnotation(key, wantVal string) ObjectPredicate {
-	return func(obj client.Object) error {
+	return func(obj client.Object) (bool, error) {
 		if obj == nil {
-			return fmt.Errorf("object is nil")
+			return false, fmt.Errorf("object is nil")
 		}
 		if got, ok := obj.GetAnnotations()[key]; !ok {
-			return fmt.Errorf("annotation %s missing", key)
+			return false, fmt.Errorf("annotation %s missing", key)
 		} else if wantVal != got {
-			return fmt.Errorf("want annotation %s=%s, got %s", key, wantVal, got)
+			return false, nil
 		}
-		return nil
+		return true, nil
 	}
 }
 
 // HasLabel verifies the object has the specified label
 func HasLabel(key, wantVal string) ObjectPredicate {
-	return func(obj client.Object) error {
+	return func(obj client.Object) (bool, error) {
 		if obj == nil {
-			return fmt.Errorf("object is nil")
+			return false, fmt.Errorf("object is nil")
 		}
 		if got, ok := obj.GetLabels()[key]; !ok {
-			return fmt.Errorf("label %s missing", key)
+			return false, fmt.Errorf("label %s missing", key)
 		} else if wantVal != got {
-			return fmt.Errorf("want label %s=%s, got %s", key, wantVal, got)
+			return false, nil
 		}
-		return nil
+		return true, nil
 	}
 }
 
 // HasOwnerReferences verifies the object has the specified owner references
 func HasOwnerReferences(want []metav1.OwnerReference) ObjectPredicate {
-	return func(obj client.Object) error {
+	return func(obj client.Object) (bool, error) {
 		if obj == nil {
-			return fmt.Errorf("object is nil")
+			return false, fmt.Errorf("object is nil")
 		}
 		opts := []cmp.Option{
 			cmpopts.SortSlices(func(a, b metav1.OwnerReference) bool { return a.UID < b.UID }),
 		}
 		if diff := cmp.Diff(want, obj.GetOwnerReferences(), opts...); diff != "" {
-			return fmt.Errorf("unexpected ownerReferences (-want,+got):\n%s", diff)
+			return false, nil
 		}
-		return nil
+		return true, nil
 	}
 }
 
 // NotDeleted verifies the object has no deletion timestamp
 func NotDeleted() ObjectPredicate {
-	return func(obj client.Object) error {
+	return func(obj client.Object) (bool, error) {
 		if obj == nil {
-			return fmt.Errorf("object is nil")
+			return false, fmt.Errorf("object is nil")
 		}
 		deletionTimestamp := obj.GetDeletionTimestamp()
 		if deletionTimestamp != nil {
-			return fmt.Errorf("unexpected deletionTimestamp: %s", deletionTimestamp)
+			return false, nil
 		}
-		return nil
+		return true, nil
 	}
 }

--- a/test/e2e/framework/predicates/predicates.go
+++ b/test/e2e/framework/predicates/predicates.go
@@ -16,4 +16,7 @@ package predicates
 
 import "sigs.k8s.io/controller-runtime/pkg/client"
 
-type ObjectPredicate func(obj client.Object) error
+// ObjectPredicate is a function that evaluates a predicate against a client.Object.
+// When the predicate matches, it returns true.
+// If there is an error during evaluation, it returns an error.
+type ObjectPredicate func(obj client.Object) (bool, error)

--- a/test/e2e/framework/predicates/sandbox.go
+++ b/test/e2e/framework/predicates/sandbox.go
@@ -37,17 +37,17 @@ func validateSandbox(obj client.Object) (*sandboxv1alpha1.Sandbox, error) {
 
 // SandboxHasStatus verifies that the Sandbox object has the specified status
 func SandboxHasStatus(status sandboxv1alpha1.SandboxStatus) ObjectPredicate {
-	return func(obj client.Object) error {
+	return func(obj client.Object) (bool, error) {
 		sandbox, err := validateSandbox(obj)
 		if err != nil {
-			return err
+			return false, err
 		}
 		opts := []cmp.Option{
 			cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 		}
 		if diff := cmp.Diff(status, sandbox.Status, opts...); diff != "" {
-			return fmt.Errorf("unexpected sandbox status (-want,+got):\n%s", diff)
+			return false, nil
 		}
-		return nil
+		return true, nil
 	}
 }

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -62,11 +62,12 @@ func TestSandboxReplicas(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.Name = "my-sandbox"
 	pod.Namespace = "my-sandbox-ns"
-	require.NoError(t, tc.ValidateObject(t.Context(), pod))
+	tc.MustExist(pod)
+
 	service := &corev1.Service{}
 	service.Name = "my-sandbox"
 	service.Namespace = "my-sandbox-ns"
-	require.NoError(t, tc.ValidateObject(t.Context(), service))
+	tc.MustExist(service)
 
 	// Set replicas to zero
 	sandboxObj.Spec.Replicas = ptr.To(int32(0))
@@ -92,5 +93,5 @@ func TestSandboxReplicas(t *testing.T) {
 	require.NoError(t, tc.WaitForObject(t.Context(), sandboxObj, p...))
 	// Verify Pod is deleted but Service still exists
 	require.NoError(t, tc.WaitForObjectNotFound(t.Context(), pod))
-	require.NoError(t, tc.ValidateObject(t.Context(), service, predicates.NotDeleted()))
+	tc.MustMatchPredicates(service, predicates.NotDeleted())
 }

--- a/test/e2e/shutdown_test.go
+++ b/test/e2e/shutdown_test.go
@@ -62,11 +62,11 @@ func TestSandboxShutdownTime(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.Name = "my-sandbox"
 	pod.Namespace = ns.Name
-	require.NoError(t, tc.ValidateObject(t.Context(), pod))
+	tc.MustExist(pod)
 	service := &corev1.Service{}
 	service.Name = "my-sandbox"
 	service.Namespace = ns.Name
-	require.NoError(t, tc.ValidateObject(t.Context(), service))
+	tc.MustExist(service)
 
 	// Set a shutdown time that ends shortly
 	shutdown := metav1.NewTime(time.Now().Add(10 * time.Second))


### PR DESCRIPTION
Combining the error and the result means we cannot catch errors, which we want to do in tests