### PR TITLE
feat: Gracefully handle missing adopted pods

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -371,11 +371,10 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			log.Info("Adopted Pod from annotation not found, likely deleted", "PodName", podName)
 			// Intentionally do not create a new pod, as this was an adopted pod.
 			return nil, nil
-		} else {
-			// Pod not found and it wasn't an adopted one, fall through to create.
-			pod = nil
-			err = nil // Clear the error to allow creation flow
 		}
+		// Pod not found and it wasn't an adopted one, fall through to create.
+		pod = nil
+		err = nil // Clear the error to allow creation flow
 	}
 
 	// 1. PATH: Logic for deleting Pod when replicas is 0

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -858,7 +858,7 @@ func TestReconcilePod(t *testing.T) {
 			wantSandboxAnnotations: map[string]string{"other-annotation": "other-value"},
 		},
 		{
-			name: "adopted pod not found in cluster",
+			name:        "adopted pod not found in cluster",
 			initialObjs: []runtime.Object{},
 			sandbox: &sandboxv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes kubernetes-sigs/agent-sandbox#275

This PR fixes an issue where `Sandbox` and `SandboxClaim` resources would incorrectly remain in a `Ready: True` state after a pod adopted from a `SandboxWarmPool` was deleted, for example, due to a node drain.

### Solution:
The reconcilePod function in `sandbox_controller.go` has been updated to -
- Check if a pod is "adopted" by inspecting the extensions.agents.x-k8s.io/pod-name annotation on the 
`Sandbox` resource.
- If the annotated pod is not found in the cluster (e.g., drain / deleted), the reconciler now correctly:
    - Avoids any attempt to recreate the pod. Because the pod was from a `SandboxWarmPool`, the reconciler should not attempt to recreate it. 
    - Updates the `Sandbox` status conditions to reflect that the pod is missing, typically resulting in Ready: False. This status naturally propagates to the `SandboxClaim` (`computeReadyCondition` function that gets the update from `reconcilePod` function + `reconcileService` function).