### PR TITLE
tests: gather kubelet/containerd logs in artifacts

### DIFF
--- a/dev/tools/create-kind-cluster
+++ b/dev/tools/create-kind-cluster
@@ -17,12 +17,42 @@ import argparse
 import os
 import subprocess
 import sys
+import tempfile
+import textwrap
+
+
+def create_kind_config(kubelet_verbosity, containerd_loglevel=None):
+    """Create a kind config with kubelet verbosity and containerd settings."""
+    config = textwrap.dedent(f"""\
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        nodes:
+        - role: control-plane
+          kubeadmConfigPatches:
+          - |
+            kind: KubeletConfiguration
+            logging:
+              verbosity: {kubelet_verbosity}
+        """)
+    if containerd_loglevel:
+        config += textwrap.dedent(f"""\
+            containerdConfigPatches:
+            - |-
+              [debug]
+                level = "{containerd_loglevel}"
+            """)
+    return config
+
 
 def main():
     parser = argparse.ArgumentParser(description="Create a kind cluster.")
     parser.add_argument("name", help="The name of the cluster.")
     parser.add_argument("--recreate", action="store_true", help="Delete the cluster if it already exists.")
     parser.add_argument("--kubeconfig", help="Path to export the kubeconfig to.")
+    parser.add_argument("--containerd-loglevel", default="debug",
+                        help="Containerd log level (default: debug). Set to empty string to skip.")
+    parser.add_argument("--kubelet-verbosity", type=int, default=8,
+                        help="Kubelet verbosity level (requires cluster creation, not applied to existing clusters).")
     args = parser.parse_args()
 
     clusters = subprocess.run(["kind", "get", "clusters"], capture_output=True, text=True).stdout.splitlines()
@@ -38,7 +68,25 @@ def main():
 
     if not cluster_exists:
         print(f"Creating cluster '{args.name}'.")
-        subprocess.run(["kind", "create", "cluster", "--name", args.name], check=True)
+
+        create_cmd = ["kind", "create", "cluster", "--name", args.name]
+
+        # Create a temporary config file with kubelet verbosity and containerd settings
+        config_content = create_kind_config(args.kubelet_verbosity, args.containerd_loglevel)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(config_content)
+            config_path = f.name
+
+        print(f"Using kind config with kubelet verbosity: {args.kubelet_verbosity}")
+        create_cmd.extend(["--config", config_path])
+
+        try:
+            subprocess.run(create_cmd, check=True)
+        finally:
+            os.unlink(config_path)
+    else:
+        if args.kubelet_verbosity is not None or args.containerd_loglevel:
+            print(f"Note: --kubelet-verbosity and --containerd-loglevel require cluster recreation (use --recreate).")
 
     if args.kubeconfig:
         kubeconfig_dir = os.path.dirname(args.kubeconfig)

--- a/test/e2e/framework/componentlogs.go
+++ b/test/e2e/framework/componentlogs.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// NodeLogOptions holds options for retrieving node logs.
+type NodeLogOptions struct {
+	Since        time.Time
+	FilterByPod  types.NamespacedName
+	ArtifactsDir string
+}
+
+// MustGetKubeletLogs retrieves kubelet journal logs from a kind node.
+// It filters logs to show entries since the specified time.
+func (cl *ClusterClient) MustGetKubeletLogs(nodeName string, opt NodeLogOptions) {
+	cl.Helper()
+	ctx := cl.Context()
+
+	// Format time for journalctl --since flag
+	sinceStr := opt.Since.UTC().Format("2006-01-02 15:04:05.000")
+	stdout, stderr, err := cl.ExecuteOnNode(ctx, nodeName, []string{
+		"journalctl", "-u", "kubelet", "--utc", "--since", sinceStr, "--no-pager",
+	})
+	if err != nil {
+		cl.Fatalf("failed to get kubelet logs: %v (stderr: %s)", err, stderr)
+	}
+
+	p := filepath.Join(opt.ArtifactsDir, fmt.Sprintf("kubelet-%s.log", nodeName))
+	if err := os.WriteFile(p, []byte(stdout), 0o644); err != nil {
+		cl.Fatalf("failed to write kubelet logs to %s: %v", p, err)
+	}
+	cl.Logf("wrote kubelet logs to %s", p)
+}
+
+// MustGetContainerdLogs retrieves containerd journal logs from a kind node.
+// It filters logs to show entries since the specified time.
+func (cl *ClusterClient) MustGetContainerdLogs(nodeName string, opt NodeLogOptions) {
+	cl.Helper()
+	ctx := cl.Context()
+
+	// Format time for journalctl --since flag
+	sinceStr := opt.Since.UTC().Format("2006-01-02 15:04:05.000")
+	stdout, stderr, err := cl.ExecuteOnNode(ctx, nodeName, []string{
+		"journalctl", "-u", "containerd", "--utc", "--since", sinceStr, "--no-pager",
+	})
+	if err != nil {
+		cl.Fatalf("failed to get containerd logs: %v (stderr: %s)", err, stderr)
+	}
+
+	p := filepath.Join(opt.ArtifactsDir, fmt.Sprintf("containerd-%s.log", nodeName))
+	if err := os.WriteFile(p, []byte(stdout), 0o644); err != nil {
+		cl.Fatalf("failed to write containerd logs to %s: %v", p, err)
+	}
+	cl.Logf("wrote containerd logs to %s", p)
+}
+
+// gatherNodeLogs retrieves kubelet and containerd logs from the kind node
+// to understand timing between pod scheduling and container startup.
+func (cl *ClusterClient) MustGetNodeLogs(nodeName string, opt NodeLogOptions) {
+	cl.Helper()
+
+	if nodeName == "" {
+		cl.Fatalf("nodeName is required to get node logs")
+	}
+
+	cl.Logf("Gathering logs from node %s", nodeName)
+
+	cl.MustGetKubeletLogs(nodeName, opt)
+
+	cl.MustGetContainerdLogs(nodeName, opt)
+}

--- a/test/e2e/framework/testlogs.go
+++ b/test/e2e/framework/testlogs.go
@@ -35,7 +35,8 @@ func newLogCapturingT(t T, artifactsDir string) *logCapturingT {
 	logFile := filepath.Join(artifactsDir, "test.log")
 	f, err := os.Create(logFile)
 	if err != nil {
-		t.Fatalf("warning: failed to create test log file %s: %v", logFile, err)
+		t.Logf("warning: failed to create test log file %s: %v", logFile, err)
+		return &logCapturingT{T: t, startTime: time.Now()}
 	}
 
 	t.Cleanup(func() {


### PR DESCRIPTION
Collecting these logs alongside the test logs
lets us correlate events in the test with events
in kubelet and containerd.