### PR TITLE
versionbump: update go version to 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-ARG GO_VERSION="1.25.3"
-
 # Build go binaries
 # See https://github.com/golang/go/issues/69255#issuecomment-2523276831
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.7 AS builder
 
 # Declare TARGETARCH to make it available in this build stage
 ARG TARGETARCH

--- a/dev/tools/go.mod
+++ b/dev/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox/dev/tools
 
-go 1.24.4
+go 1.25.7
 
 tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/examples/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our golang binaries in a separate stage to keep the final image small.
-FROM golang:1.25.1 AS builder
+FROM golang:1.25.7 AS builder
 
 WORKDIR /src
 

--- a/examples/chrome-sandbox/go.mod
+++ b/examples/chrome-sandbox/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox/examples/chrome-sandbox
 
-go 1.25.1
+go 1.25.7
 
 require k8s.io/klog/v2 v2.130.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox
 
-go 1.24.4
+go 1.25.7
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module github.com/kubernetes-sigs/agent-sandbox
 
-go 1.25.4
+go 1.25.7
 
 require github.com/google/docsy v0.12.0 // indirect

--- a/tools.mod
+++ b/tools.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox
 
-go 1.24.4
+go 1.25.7
 
 require (
 	k8s.io/api v0.34.0


### PR DESCRIPTION
Just updating to the latest to keep scanners happy.
