### PR TITLE
add LeaderElectionNamespace and LeaderElectionID

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -156,7 +156,7 @@ func main() {
 		HealthProbeBindAddress:  probeAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionNamespace: leaderElectionNamespace,
-		LeaderElectionID:        "agent-sandbox-controller",
+		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Add flags for the the enablement of  leader election ensures high availability by allowing only one active instance to lead, preventing conflicts in distributed systems