### PR TITLE
tests: create MustUpdateObject helper

### DIFF
--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -63,7 +63,7 @@ type T interface {
 // TestContext is a helper for managing e2e test scaffolding.
 type TestContext struct {
 	T
-	ClusterClient
+	*ClusterClient
 	artifactsDir string
 }
 
@@ -120,7 +120,7 @@ func NewTestContext(t T) *TestContext {
 		t.Fatalf("building dynamic client: %v", err)
 	}
 
-	th.ClusterClient = ClusterClient{
+	th.ClusterClient = &ClusterClient{
 		T:             t,
 		client:        client,
 		dynamicClient: dynamicClient,

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -70,8 +70,10 @@ func TestSandboxReplicas(t *testing.T) {
 	tc.MustExist(service)
 
 	// Set replicas to zero
-	sandboxObj.Spec.Replicas = ptr.To(int32(0))
-	require.NoError(t, tc.Update(t.Context(), sandboxObj))
+	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1alpha1.Sandbox) {
+		obj.Spec.Replicas = ptr.To(int32(0))
+	})
+
 	// Wait for sandbox status to reflect new state
 	p = []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{

--- a/test/e2e/shutdown_test.go
+++ b/test/e2e/shutdown_test.go
@@ -70,8 +70,10 @@ func TestSandboxShutdownTime(t *testing.T) {
 
 	// Set a shutdown time that ends shortly
 	shutdown := metav1.NewTime(time.Now().Add(10 * time.Second))
-	sandboxObj.Spec.ShutdownTime = &shutdown
-	require.NoError(t, tc.Update(t.Context(), sandboxObj))
+	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1alpha1.Sandbox) {
+		obj.Spec.ShutdownTime = &shutdown
+	})
+
 	// Wait for sandbox status to reflect new state
 	p = []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{


### PR DESCRIPTION
When tests start running quickly (with watch),
we run into concurrency failures.

Create a helper to update an object with retry.
