### PR TITLE
feat: added VAP example to enforce security defaults for podTemplate spec

### DIFF
--- a/examples/policy/vap/README.md
+++ b/examples/policy/vap/README.md
@@ -1,0 +1,263 @@
+# Secure Sandbox Admission Policy (VAP)
+
+This directory contains the **Validating Admission Policy (VAP)** for the Agent Sandbox. It acts as a cluster-level guardrail to enforce a "Secure by Default" posture for all sandbox workloads.
+
+## Enforced Security Controls
+
+This policy **rejects** any `Sandbox` resource that attempts to bypass the following critical security controls.
+
+| Control | Enforced Rule | Security Benefit |
+| :--- | :--- | :--- |
+| **Runtime Isolation** | `runtimeClassName: gvisor` | **Prevents Container Escape.** <br> Mandates the use of gVisor (a user-space kernel) to strongly isolate the untrusted workload from the underlying host kernel. |
+| **Node Isolation** | `hostNetwork: false` | **Protects Node Metadata.** <br> Prevents the sandbox from accessing the host's network namespace, effectively blocking access to the Cloud Metadata Server (169.254.169.254) and other localhost services. |
+| **Process Isolation** | `hostPID` & `hostIPC`: false | **Prevents Namespace Leaks.** <br> Ensures the sandbox cannot see or signal processes on the host node (`hostPID`) or use host inter-process communication mechanisms (`hostIPC`). |
+| **Network Isolation** | `ports.hostPort: Forbidden` | **Prevents Port Hijacking.** <br> Blocks containers from binding directly to ports on the host node's network interface, which would bypass network policies and consume node resources. |
+| **Identity Isolation** | `automountServiceAccountToken: false` | **Prevents K8s API Abuse.** <br> Ensures that the sandbox pod does not receive a Kubernetes Service Account token, preventing it from authenticating with or attacking the Kubernetes API server. |
+| **Identity Isolation** | `volumes.projected: No Tokens/Certs` | **Prevents Credential Bypass.** <br> Explicitly blocks the use of "Projected Volumes" to manually mount Service Account tokens or Pod Certificates (`ClusterTrustBundle` and `podCertificate`), closing loopholes that would allow attackers to bypass identity restrictions. |
+| **Filesystem Isolation** | `volumes.hostPath: Forbidden` | **Prevents Host Access.** <br> Strictly blocks mounting directories from the underlying node filesystem (e.g., `/var/run/docker.sock`), which is a common vector for container breakouts. |
+| **Filesystem Hardening** | `procMount: Default` | **Protects /proc Filesystem.** <br> Prevents the use of `Unmasked` proc mounts, which would expose sensitive kernel information typically hidden by the container runtime. |
+| **Kernel Hardening** | `sysctls: Forbidden` | **Prevents Kernel Tuning.** <br> Prohibits the modification of kernel parameters via `sysctls`, ensuring the shared kernel state remains consistent and secure. |
+| **Privilege Escalation** | `privileged: false` | **Maintains Isolation Boundary.** <br> Blocks "privileged" containers, which would otherwise allow the workload to access host devices and bypass almost all security restrictions. |
+| **Hardening** | `capabilities: drop ["ALL"]` | **Reduces Attack Surface.** <br> Strictly forces the removal of ALL Linux capabilities, implementing defense-in-depth even within the gVisor sandbox. |
+| **Hardening** | `capabilities.add: []` | **Prevents Permission Creep.** <br> Prohibits adding *any* Linux capabilities (like `NET_ADMIN` or `SYS_PTRACE`), ensuring the container remains strictly unprivileged even if other settings are loose. |
+| **DoS Protection** | `resources.limits` (CPU & Memory) | **Prevents Noisy Neighbors.** <br> Requires all containers to set resource limits, preventing a single compromised or buggy sandbox from starving the underlying node of resources. |
+| **User Isolation** | `runAsNonRoot: true` | **Defense in Depth.** <br> Enforces that the process cannot run as root. The policy checks both the Pod-level `securityContext` and the individual Container-level `securityContext` to ensure proper inheritance. |
+| **GKE Specific: Scheduling** | `nodeSelector: sandbox.gke.io/runtime: gvisor` | **Guarantees Runtime Target.** <br> Ensures the Kubernetes scheduler only places the Sandbox on node pools that have gVisor installed and configured. |
+| **GKE Specfic: Scheduling** | `tolerations: sandbox.gke.io/runtime=gvisor` | **Permits Runtime Target.** <br> Ensures the Sandbox is authorized to land on the dedicated, tainted gVisor node pool. |
+## Deployment
+
+This policy requires **Kubernetes v1.30+** (Standard on GKE Autopilot).
+
+### Defense in Depth
+1. **Apply the Policy Definition**
+
+This policy utilizes **CEL Variables** to merge `spec.containers`, `spec.initContainers` and `spec.ephemeralContainers` into a single validation stream. 
+
+This ensures that security controls (like `privileged: false`, `runAsNonRoot: true`, and `capabilities.drop`) are enforced on **every** container in the pod, preventing attackers from using "Side Door" attacks where malicious configuration is hidden inside an Init Container.
+
+```bash
+   kubectl apply -f secure-sandbox-policy.yaml
+```
+
+2. **Bind the Policy to the Cluster:**
+```bash
+    kubectl apply -f secure-sandbox-binding.yaml
+```
+
+## Testing & Verification
+To verify the policy is active, try creating a non-compliant sandbox.
+
+1. Compliant Sandbox (Should Succeed):
+
+```yaml
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: secure-sandbox
+spec:
+  podTemplate:
+    spec:
+      runtimeClassName: gvisor
+      hostNetwork: false
+      automountServiceAccountToken: false
+
+      nodeSelector:
+        sandbox.gke.io/runtime: gvisor
+      tolerations:
+      - key: sandbox.gke.io/runtime
+        operator: Equal
+        value: gvisor
+        effect: NoSchedule
+      
+      # 1. Init Containers (Must also be secure!)
+      initContainers:
+      - name: setup-data
+        image: alpine:3.18
+        command: ["/bin/sh", "-c", "echo 'initializing...'"]
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "64Mi"
+
+      # 2. Main Containers
+      containers:
+      - name: main-agent
+        image: python:3.11-slim
+        command: ["python3", "-c", "import time; time.sleep(3600)"]
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          # privileged: false       # Implied default, but policy enforces non-privileged
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+
+      # 3. Sidecar Containers (e.g., Log Shipper)
+      - name: log-sidecar
+        image: busybox:1.36
+        command: ["/bin/sh", "-c", "tail -f /dev/null"]
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
+```
+
+2. Non-Compliant Sandbox (Should Fail because of missing `runtimeClassName`):
+
+Since there's no `runtimeClassName` specified, the VAP will reject the creation of the Sandbox resource. 
+
+```yaml
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: insecure-sandbox
+spec:
+  podTemplate:
+    spec:
+      hostNetwork: false
+      containers:
+      - name: agent
+        image: python:3.11-slim
+```
+
+
+Expected Error:
+
+If you created a `Sandbox` resource directly: 
+
+```
+kubectl apply -f insecure-sandbox.yaml
+
+The sandboxes "insecure-sandbox" is invalid: : ValidatingAdmissionPolicy 'secure-sandbox-policy' with binding 'secure-sandbox-binding' denied request: Security Violation: All Sandboxes must use 'runtimeClassName: gvisor'
+```
+
+Or if you created a `SandboxTemplate` + `SandboxClaim` you should see the error in the controller logs. 
+```
+2026-02-11T01:32:35Z    ERROR   Error creating sandbox for claim        {"controller": "sandboxclaim", "controllerGroup": "extensions.agents.x-k8s.io", "controllerKind": "SandboxClaim", "SandboxClaim": {"name":"egress-test-claim","namespace":"default"}, "namespace": "default", "name": "egress-test-claim", "reconcileID": "c46a1f97-1286-4b73-9de0-364d01dda8a6", "claimName": "egress-test-claim", "error": "sandbox create error: sandboxes.agents.x-k8s.io \"egress-test-claim\" is forbidden: ValidatingAdmissionPolicy 'secure-sandbox-policy' with binding 'secure-sandbox-binding' denied request: Security Violation: All Sandboxes must use 'runtimeClassName: gvisor'"}
+```
+
+
+3. Verify Init Container Protection
+Attempt to create a Sandbox with a secure main container but a privileged init container.
+
+**Manifest (`bad-init.yaml`):**
+```yaml
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: side-door-attack
+spec:
+  podTemplate:
+    spec:
+      runtimeClassName: gvisor
+      automountServiceAccountToken: false
+      hostNetwork: false
+      containers:
+      - name: innocent-worker
+        image: alpine
+        securityContext: { runAsNonRoot: true, capabilities: { drop: ["ALL"] } }
+        resources: { limits: { cpu: "100m", memory: "128Mi" } }
+      initContainers:
+      - name: evil-setup
+        image: alpine
+        securityContext: { privileged: true } # <--- MALICIOUS
+  ```
+Expected error: 
+
+```
+The sandboxes "side-door-attack" is invalid: 
+* <nil>: Security Violation: Privileged containers are not allowed (checked in containers, initContainers, and ephemeralContainers).
+```
+
+
+
+### Automated Integration Tests
+We include an automated integration test suite (`policy_test.go`) that verifies these controls against a real Kubernetes API server.
+
+Prerequisites
+To run the tests locally, you need the setup-envtest tool to download the Kubernetes API server binary (no full cluster required).
+
+1. Install the tool:
+
+```
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+# This downloads the correct kube-apiserver and etcd for your OS/Arch
+go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use 1.30
+go: downloading sigs.k8s.io/controller-runtime v0.23.1
+go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260216173200-e4c1c38bcbdb
+go: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260216173200-e4c1c38bcbdb requires go >= 1.25.0; switching to go1.25.7
+go: downloading github.com/spf13/afero v1.12.0
+go: downloading go.uber.org/multierr v1.10.0
+go: downloading golang.org/x/text v0.33.0
+Version: 1.30.0
+OS/Arch: linux/amd64
+Path: /your/path/.local/share/kubebuilder-envtest/k8s/1.30.0-linux-amd64
+```
+
+### Running the Tests
+Run the Go test suite, pointing `KUBEBUILDER_ASSETS` to the path from step 1.
+
+```
+KUBEBUILDER_ASSETS="/your/path/.local/share/kubebuilder-envtest/k8s/1.30.0-linux-amd64" go test -v -tags integration ./examples/policy/vap/
+```
+
+### Expected Output
+
+You should see the test spin up a local API server, apply the policy, and reject the insecure scenarios.
+
+```
+=== RUN   TestSecureSandboxVAP
+=== RUN   TestSecureSandboxVAP/Success:_Secure_Sandbox
+=== RUN   TestSecureSandboxVAP/Violation:_Runtime_Class_(Not_gvisor)
+=== RUN   TestSecureSandboxVAP/Violation:_HostNetwork_is_True
+=== RUN   TestSecureSandboxVAP/Violation:_HostPID_is_True
+=== RUN   TestSecureSandboxVAP/Violation:_HostIPC_is_True
+=== RUN   TestSecureSandboxVAP/Violation:_HostPort_Used
+=== RUN   TestSecureSandboxVAP/Violation:_Automount_Service_Account_Token
+=== RUN   TestSecureSandboxVAP/Violation:_Projected_Volume_(Token)
+=== RUN   TestSecureSandboxVAP/Violation:_HostPath_Volume
+=== RUN   TestSecureSandboxVAP/Violation:_Unmasked_ProcMount
+=== RUN   TestSecureSandboxVAP/Violation:_Sysctls_Set
+=== RUN   TestSecureSandboxVAP/Violation:_Privileged_Container
+=== RUN   TestSecureSandboxVAP/Violation:_Capabilities_(Didn't_Drop)
+=== RUN   TestSecureSandboxVAP/Violation:_Capabilities_(Added)
+=== RUN   TestSecureSandboxVAP/Violation:_RunAsRoot
+=== RUN   TestSecureSandboxVAP/Violation:_Missing_Resource_Limits
+=== RUN   TestSecureSandboxVAP/Violation:_Wrong_Node_Selector
+=== RUN   TestSecureSandboxVAP/Violation:_Missing_Toleration
+--- PASS: TestSecureSandboxVAP (7.31s)
+    --- PASS: TestSecureSandboxVAP/Success:_Secure_Sandbox (2.05s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Runtime_Class_(Not_gvisor) (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_HostNetwork_is_True (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_HostPID_is_True (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_HostIPC_is_True (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_HostPort_Used (0.01s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Automount_Service_Account_Token (0.01s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Projected_Volume_(Token) (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_HostPath_Volume (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Unmasked_ProcMount (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Sysctls_Set (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Privileged_Container (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Capabilities_(Didn't_Drop) (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Capabilities_(Added) (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_RunAsRoot (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Missing_Resource_Limits (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Wrong_Node_Selector (0.00s)
+    --- PASS: TestSecureSandboxVAP/Violation:_Missing_Toleration (0.00s)
+PASS
+ok      sigs.k8s.io/agent-sandbox/examples/policy/vap   7.481s
+```

--- a/examples/policy/vap/policy_test.go
+++ b/examples/policy/vap/policy_test.go
@@ -1,0 +1,392 @@
+//go:build integration
+// +build integration
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+)
+
+func TestSecureSandboxVAP(t *testing.T) {
+	// 1. Setup EnvTest
+	crdPath := filepath.Join("..", "..", "..", "k8s", "crds")
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdPath},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("Failed to start test environment: %v", err)
+	}
+	defer testEnv.Stop()
+
+	// 2. Create Client
+	scheme := runtime.NewScheme()
+	_ = sandboxv1alpha1.AddToScheme(scheme)
+	_ = admissionregistrationv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// 3. Apply Policy
+	if err := applyYAML(ctx, k8sClient, "secure-sandbox-policy.yaml"); err != nil {
+		t.Fatalf("Failed to apply VAP: %v", err)
+	}
+	if err := applyYAML(ctx, k8sClient, "secure-sandbox-binding.yaml"); err != nil {
+		t.Fatalf("Failed to apply VAP Binding: %v", err)
+	}
+
+	// Base secure spec to clone for failure cases
+	secureSpec := corev1.PodSpec{
+		RuntimeClassName:             ptr.To("gvisor"),
+		HostNetwork:                  false,
+		AutomountServiceAccountToken: ptr.To(false),
+		NodeSelector:                 map[string]string{"sandbox.gke.io/runtime": "gvisor"},
+		Tolerations: []corev1.Toleration{
+			{Key: "sandbox.gke.io/runtime", Value: "gvisor", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual},
+		},
+		Containers: []corev1.Container{
+			{
+				Name:  "test",
+				Image: "nginx",
+				SecurityContext: &corev1.SecurityContext{
+					RunAsNonRoot: ptr.To(true),
+					Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					ProcMount:    ptr.To(corev1.DefaultProcMount),
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    parserQuantity("100m"),
+						corev1.ResourceMemory: parserQuantity("128Mi"),
+					},
+				},
+			},
+		},
+	}
+
+	// 4. Test Scenarios
+	tests := []struct {
+		name          string
+		mutateSpec    func(spec *corev1.PodSpec) // Function to inject the vulnerability
+		expectAllowed bool
+	}{
+		// --- 1. Success Case ---
+		{
+			name:          "Success: Secure Sandbox",
+			mutateSpec:    func(spec *corev1.PodSpec) {}, // No changes
+			expectAllowed: true,
+		},
+
+		// --- 2. Isolation Violations ---
+		{
+			name: "Violation: Runtime Class (Not gvisor)",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.RuntimeClassName = ptr.To("runc")
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: HostNetwork is True",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.HostNetwork = true
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: HostPID is True",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.HostPID = true
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: HostIPC is True",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.HostIPC = true
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: HostPort Used",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].Ports = []corev1.ContainerPort{
+					{ContainerPort: 80, HostPort: 8080},
+				}
+			},
+			expectAllowed: false,
+		},
+
+		// --- 3. Identity Violations ---
+		{
+			name: "Violation: Automount Service Account Token",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.AutomountServiceAccountToken = ptr.To(true)
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Projected Volume (ClusterTrustBundle / Pod Certs)",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Volumes = []corev1.Volume{
+					{
+						Name: "cert-vol",
+						VolumeSource: corev1.VolumeSource{
+							Projected: &corev1.ProjectedVolumeSource{
+								Sources: []corev1.VolumeProjection{
+									{ClusterTrustBundle: &corev1.ClusterTrustBundleProjection{Name: ptr.To("my-cert")}},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Capabilities (Dropped NET_RAW instead of ALL)",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				// We drop NET_RAW, but the policy strictly requires ALL now.
+				spec.Containers[0].SecurityContext.Capabilities.Drop = []corev1.Capability{"NET_RAW"}
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Success: Pod-level RunAsNonRoot is inherited",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				// Remove container-level runAsNonRoot
+				spec.Containers[0].SecurityContext.RunAsNonRoot = nil
+				// Set it at the Pod level instead
+				spec.SecurityContext = &corev1.PodSecurityContext{
+					RunAsNonRoot: ptr.To(true),
+				}
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "Violation: Container overrides Pod-level RunAsNonRoot to false",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				// Pod says true
+				spec.SecurityContext = &corev1.PodSecurityContext{
+					RunAsNonRoot: ptr.To(true),
+				}
+				// Container maliciously overrides to false
+				spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(false)
+			},
+			expectAllowed: false,
+		},
+
+		// --- 4. Filesystem & Kernel Violations ---
+		{
+			name: "Violation: HostPath Volume",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Volumes = []corev1.Volume{
+					{
+						Name: "host-vol",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{Path: "/tmp"},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Unmasked ProcMount",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].SecurityContext.ProcMount = ptr.To(corev1.UnmaskedProcMount)
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Sysctls Set",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.SecurityContext = &corev1.PodSecurityContext{
+					Sysctls: []corev1.Sysctl{{Name: "net.ipv4.ip_forward", Value: "1"}},
+				}
+			},
+			expectAllowed: false,
+		},
+
+		// --- 5. Hardening Violations ---
+		{
+			name: "Violation: Privileged Container",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].SecurityContext.Privileged = ptr.To(true)
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Capabilities (Didn't Drop)",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].SecurityContext.Capabilities.Drop = []corev1.Capability{}
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Capabilities (Added)",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].SecurityContext.Capabilities.Add = []corev1.Capability{"NET_ADMIN"}
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: RunAsRoot",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].SecurityContext.RunAsNonRoot = ptr.To(false)
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Missing Resource Limits",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].Resources.Limits = nil
+			},
+			expectAllowed: false,
+		},
+
+		// --- 6. Scheduling Violations ---
+		{
+			name: "Violation: Wrong Node Selector",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.NodeSelector = nil
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Missing Toleration",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Tolerations = nil
+			},
+			expectAllowed: false,
+		},
+		{
+			name: "Violation: Projected Volume (PodCertificate)",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Volumes = []corev1.Volume{
+					{
+						Name: "podcert-vol",
+						VolumeSource: corev1.VolumeSource{
+							Projected: &corev1.ProjectedVolumeSource{
+								Sources: []corev1.VolumeProjection{
+									{
+										// Blocks the exact attack vector Michael mentioned
+										PodCertificate: &corev1.PodCertificateProjection{
+											SignerName:           "coolcert.example.com/foo",
+											CredentialBundlePath: "credentialbundle.pem",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// DeepCopy the secure spec to start fresh every time
+			sandbox := &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					PodTemplate: sandboxv1alpha1.PodTemplate{
+						Spec: *secureSpec.DeepCopy(),
+					},
+				},
+			}
+
+			// Apply the vulnerability
+			tc.mutateSpec(&sandbox.Spec.PodTemplate.Spec)
+
+			// Attempt Creation
+			err := k8sClient.Create(ctx, sandbox)
+
+			if tc.expectAllowed {
+				if err != nil {
+					t.Fatalf("Expected Sandbox to be created, but got error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("Security Fail: Expected VAP to reject insecure Sandbox, but it was allowed!")
+				}
+				// Cleanup failed sandbox (not strictly needed since Create failed, but good practice for allowed ones)
+			}
+			// Cleanup allowed sandboxes
+			if err == nil {
+				_ = k8sClient.Delete(ctx, sandbox)
+			}
+		})
+	}
+}
+
+// Helper to apply YAML files
+func applyYAML(ctx context.Context, c client.Client, filename string) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	decoder := yaml.NewYAMLOrJSONDecoder(os.NewFile(0, filename), 4096)
+	_ = decoder
+
+	obj := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	if filename == "secure-sandbox-binding.yaml" {
+		binding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		if err := yaml.Unmarshal(data, binding); err != nil {
+			return err
+		}
+		binding.ResourceVersion = ""
+		return c.Create(ctx, binding)
+	}
+
+	if err := yaml.Unmarshal(data, obj); err != nil {
+		return err
+	}
+	obj.ResourceVersion = ""
+	return c.Create(ctx, obj)
+}
+
+// Helper for resource quantities
+func parserQuantity(q string) resource.Quantity {
+	val, _ := resource.ParseQuantity(q)
+	return val
+}

--- a/examples/policy/vap/secure-sandbox-binding.yaml
+++ b/examples/policy/vap/secure-sandbox-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: secure-sandbox-binding
+spec:
+  policyName: secure-sandbox-policy
+  validationActions: [Deny]
+  matchResources:
+    # Apply to all namespaces by default
+    # You can restrict this with namespaceSelector if needed for local dev
+    namespaceSelector:
+      matchExpressions:
+      - key: "kubernetes.io/metadata.name"
+        operator: NotIn
+        values: ["kube-system", "agents-system"] # Exclude system namespaces if necessary

--- a/examples/policy/vap/secure-sandbox-policy.yaml
+++ b/examples/policy/vap/secure-sandbox-policy.yaml
@@ -1,0 +1,162 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: secure-sandbox-policy
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["agents.x-k8s.io"]
+      apiVersions: ["v1alpha1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["sandboxes"]
+  
+  # Define a variable to check ALL container types: containers, initContainers, and ephemeralContainers.
+  variables:
+    - name: allContainers
+      expression: >-
+        object.spec.podTemplate.spec.containers +
+        (has(object.spec.podTemplate.spec.initContainers) ? object.spec.podTemplate.spec.initContainers : []) +
+        (has(object.spec.podTemplate.spec.ephemeralContainers) ? object.spec.podTemplate.spec.ephemeralContainers : [])
+
+  validations:
+    # 1. Runtime Isolation
+    # All sandboxes must use gVisor to prevent container escape.
+    - expression: "has(object.spec.podTemplate.spec.runtimeClassName) && object.spec.podTemplate.spec.runtimeClassName == 'gvisor'"
+      message: "Security Violation: All Sandboxes must use 'runtimeClassName: gvisor'"
+
+    # 2. Network Isolation (Metadata Server Protection)
+    # Host networking allows access to 169.254.169.254 (Node Metadata). This must be blocked.
+    - expression: "!has(object.spec.podTemplate.spec.hostNetwork) || object.spec.podTemplate.spec.hostNetwork == false"
+      message: "Security Violation: 'hostNetwork: true' is strictly prohibited. Sandboxes must be isolated from the node network."
+
+    # 3. Identity Isolation (K8s API Access)
+    # Sandboxes must not mount K8s ServiceAccount tokens to prevent API abuse.
+    - expression: "has(object.spec.podTemplate.spec.automountServiceAccountToken) && object.spec.podTemplate.spec.automountServiceAccountToken == false"
+      message: "Security Violation: 'automountServiceAccountToken' must be explicitly set to 'false'. Sandbox workloads are not permitted to access the K8s API."
+
+    # 4. Privilege Escalation Prevention
+    # Privileged containers break isolation boundaries.
+    - expression: >-
+        variables.allContainers.all(c, 
+           !has(c.securityContext) || 
+           !has(c.securityContext.privileged) ||
+           c.securityContext.privileged == false
+        )
+      message: "Security Violation: Privileged containers are not allowed (checked in containers, initContainers, and ephemeralContainers)."
+
+    # 5. Capabilities Hardening (Defense in Depth)
+    # Drop ALL capabilities.
+    - expression: >-
+        variables.allContainers.all(c, 
+           has(c.securityContext) &&
+           has(c.securityContext.capabilities) &&
+           has(c.securityContext.capabilities.drop) &&
+           'ALL' in c.securityContext.capabilities.drop
+        )
+      message: "Security Violation: All containers must explicitly drop 'ALL' capabilities in securityContext."
+
+    # 6. DoS Protection (Resource Limits)
+    # Prevent noisy neighbors by enforcing memory/cpu limits.
+    - expression: >-
+        variables.allContainers.all(c, 
+           has(c.resources) && 
+           has(c.resources.limits) && 
+           has(c.resources.limits.memory) && 
+           has(c.resources.limits.cpu)
+        )
+      message: "Security Violation: All containers must define resource limits (cpu and memory) to prevent DoS."
+
+    # 7. Root User Restriction
+    # Containers must not run as root. Checks Pod-level inheritance and Container-level overrides.
+    - expression: >-
+        variables.allContainers.all(c, 
+          (has(c.securityContext) && has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == true) ||
+          ((!has(c.securityContext) || !has(c.securityContext.runAsNonRoot)) && 
+           has(object.spec.podTemplate.spec.securityContext) && 
+           has(object.spec.podTemplate.spec.securityContext.runAsNonRoot) && 
+           object.spec.podTemplate.spec.securityContext.runAsNonRoot == true)
+        )
+      message: "Security Violation: Pods or Containers must set 'runAsNonRoot: true', and containers cannot override it to false."
+
+    # 8. Identity Isolation (Projected Volumes)
+    # Blocks manual mounting of ServiceAccount tokens, ClusterTrustBundles, and PodCertificates.
+    - expression: >-
+        !has(object.spec.podTemplate.spec.volumes) ||
+        !object.spec.podTemplate.spec.volumes.exists(v, 
+           has(v.projected) && 
+           has(v.projected.sources) && 
+           v.projected.sources.exists(s, has(s.serviceAccountToken) || has(s.clusterTrustBundle) || has(s.podCertificate))
+        )
+      message: "Security Violation: Projected Service Account Tokens, ClusterTrustBundles, and PodCertificates are prohibited."
+
+    # 9. Filesystem Isolation (HostPath)
+    # HostPath volumes allow attackers to access the underlying node filesystem.
+    - expression: >-
+        !has(object.spec.podTemplate.spec.volumes) ||
+        !object.spec.podTemplate.spec.volumes.exists(v, has(v.hostPath))
+      message: "Security Violation: HostPath volumes are strictly prohibited. You cannot mount host directories."
+    
+    # 10. Capabilities Hardening (No Adds)
+    # Prevent adding dangerous capabilities back after dropping them.
+    - expression: >-
+        variables.allContainers.all(c, 
+           !has(c.securityContext) ||
+           !has(c.securityContext.capabilities) ||
+           !has(c.securityContext.capabilities.add) ||
+           size(c.securityContext.capabilities.add) == 0
+        )
+      message: "Security Violation: Capabilities.add must be empty. You cannot add capabilities."
+    
+    # 11. Process & IPC Isolation
+    # Prevent sharing PID/IPC namespaces with the host.
+    - expression: >-
+        (!has(object.spec.podTemplate.spec.hostPID) || object.spec.podTemplate.spec.hostPID == false) && 
+        (!has(object.spec.podTemplate.spec.hostIPC) || object.spec.podTemplate.spec.hostIPC == false)
+      message: "Security Violation: 'hostPID' and 'hostIPC' must be false."
+
+    # 12. Network Isolation (HostPort)
+    # Binding to a host port allows bypassing network policy and claiming node resources.
+    - expression: >-
+        variables.allContainers.all(c, 
+          !has(c.ports) || 
+          c.ports.all(p, !has(p.hostPort))
+        )
+      message: "Security Violation: 'hostPort' usage is prohibited."
+
+    # 13. Kernel Hardening (Sysctls)
+    # Prevent modifying kernel parameters.
+    - expression: >-
+        !has(object.spec.podTemplate.spec.securityContext) ||
+        !has(object.spec.podTemplate.spec.securityContext.sysctls) ||
+        size(object.spec.podTemplate.spec.securityContext.sysctls) == 0
+      message: "Security Violation: Custom 'sysctls' are prohibited."
+
+    # 14. Filesystem Hardening (ProcMount)
+    # Prevent unmasking /proc paths (which could leak host info).
+    - expression: >-
+        variables.allContainers.all(c, 
+           !has(c.securityContext) ||
+           !has(c.securityContext.procMount) ||
+           c.securityContext.procMount == 'Default'
+        )
+      message: "Security Violation: 'procMount' must be 'Default' (Unmasked is prohibited)."
+
+    # 15. GKE Scheduling (Node Selector)
+    # Ensure the workload lands on a node capable of running gVisor.
+    - expression: >-
+        has(object.spec.podTemplate.spec.nodeSelector) && 
+        'sandbox.gke.io/runtime' in object.spec.podTemplate.spec.nodeSelector && 
+        object.spec.podTemplate.spec.nodeSelector['sandbox.gke.io/runtime'] == 'gvisor'
+      message: "Scheduling Violation: Sandboxes must be scheduled on gVisor nodes (nodeSelector 'sandbox.gke.io/runtime: gvisor')."
+
+    # 16. GKE Scheduling (Tolerations)
+    # Ensure the workload can tolerate the gVisor taint.
+    - expression: >-
+         has(object.spec.podTemplate.spec.tolerations) &&
+         object.spec.podTemplate.spec.tolerations.exists(t, 
+           t.key == 'sandbox.gke.io/runtime' && 
+           t.value == 'gvisor' && 
+           t.effect == 'NoSchedule'
+         )
+      message: "Scheduling Violation: Sandboxes must tolerate the gVisor taint ('sandbox.gke.io/runtime=gvisor:NoSchedule')."


### PR DESCRIPTION
fixes #262 , #261 

This PR introduces a VAP example with 16 distinct security controls across all containers, init containers, and ephemeral containers in a Sandbox pod. Key enforcements include:

- Runtime & Scheduling: Mandates runtimeClassName: gvisor and enforces the necessary nodeSelector and tolerations to ensure workloads land on isolated node pools.
- Node & Network Isolation: Strictly prohibits hostNetwork, hostPID, hostIPC, and hostPort usage to prevent node metadata exposure and namespace leaks.
- Identity Isolation: Enforces automountServiceAccountToken: false and explicitly blocks Projected volumes from mounting ServiceAccount tokens or Pod Certificates (ClusterTrustBundle).
- Filesystem & Kernel Hardening: Blocks hostPath volumes, unmasked procMount paths, and custom sysctls.
- Privilege Escalation & Defense in Depth: Blocks privileged containers, requires processes to runAsNonRoot (properly evaluating Pod-level inheritance), strictly mandates dropping ALL Linux capabilities, and prevents any from being added back via capabilities.add.
- DoS Protection: Enforces CPU and Memory resource limits on all containers to prevent noisy-neighbor node starvation.

This PR also includes an integration test (`examples/policy/vap/policy_test.go`).

Utilizes `sigs.k8s.io/controller-runtime/pkg/envtest` to spin up a local Kubernetes v1.30 API server.

Verifies the CEL expressions by applying the VAP and intentionally attempting to create Sandboxes with isolated vulnerabilities (e.g., privileged containers, wrong runtime classes, malicious volume mounts).
