### PR TITLE
Add LangChain DeepAgents backend adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ kill-cloud-provider-kind:
 test-unit:
 	./dev/tools/test-unit
 
+.PHONY: test-langchain
+test-langchain:
+	uv run pytest clients/python/langchain-agent-sandbox/tests/ -v --junitxml=bin/langchain-backend-junit.xml
+
 .PHONY: test-e2e
 test-e2e:
 	RACE=$(RACE) ./dev/ci/presubmits/test-e2e

--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ To interact with the agent-sandbox programmatically, you can use the Python SDK.
 
 For detailed installation and usage instructions, please refer to the [Python SDK README](clients/python/agentic-sandbox-client/README.md).
 
+### LangChain DeepAgents Integration
+
+The [langchain-agent-sandbox](clients/python/langchain-agent-sandbox/) package provides an official [DeepAgents](https://docs.langchain.com/deepagents) backend adapter. It implements `SandboxBackendProtocol` and supports session reattach, managed lifecycle, and policy enforcement.
+
+```python
+from k8s_agent_sandbox import SandboxClient
+from langchain_agent_sandbox import AgentSandboxBackend
+from deepagents import create_deep_agent
+
+client = SandboxClient()
+with AgentSandboxBackend.from_template(client, "python-sandbox") as backend:
+    agent = create_deep_agent(backend=backend)
+    result = agent.invoke("Run the analysis")
+```
+
+See the [LangChain adapter README](clients/python/langchain-agent-sandbox/README.md) for quickstart, session reattach, and policy usage.
+
 ## Configuration
 
 For advanced scale and concurrency tuning (e.g., API QPS and worker counts), please see the [Configuration Guide](docs/configuration.md).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -240,17 +240,44 @@ class AsyncK8sHelper:
                 return None
             raise
 
-    async def list_sandbox_claims(self, namespace: str) -> list[str]:
-        """Lists all SandboxClaim custom resources in a namespace."""
+    async def get_sandbox_claim(self, name: str, namespace: str):
+        """Gets a SandboxClaim custom resource (or ``None`` if it doesn't exist)."""
         await self._ensure_initialized()
 
         try:
-            response = await self.custom_objects_api.list_namespaced_custom_object(
+            return await self.custom_objects_api.get_namespaced_custom_object(
+                group=CLAIM_API_GROUP,
+                version=CLAIM_API_VERSION,
+                namespace=namespace,
+                plural=CLAIM_PLURAL_NAME,
+                name=name,
+            )
+        except client.ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def list_sandbox_claims(self, namespace: str, label_selector: str | None = None) -> list[str]:
+        """Lists all SandboxClaim custom resources in a namespace.
+
+        Args:
+            namespace: Kubernetes namespace to list claims in.
+            label_selector: Optional Kubernetes label selector string
+                (e.g. ``"app=myapp,env=prod"``). When set, only claims
+                matching the selector are returned.
+        """
+        await self._ensure_initialized()
+
+        try:
+            kwargs: dict = dict(
                 group=CLAIM_API_GROUP,
                 version=CLAIM_API_VERSION,
                 namespace=namespace,
                 plural=CLAIM_PLURAL_NAME,
             )
+            if label_selector is not None:
+                kwargs["label_selector"] = label_selector
+            response = await self.custom_objects_api.list_namespaced_custom_object(**kwargs)
             return [
                 item.get("metadata", {}).get("name")
                 for item in response.get("items", [])

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -173,9 +173,26 @@ class AsyncSandboxClient(Generic[T]):
         return sandbox
 
     async def get_sandbox(
-        self, claim_name: str, namespace: str = "default", resolve_timeout: int = 30
+        self,
+        claim_name: str,
+        namespace: str = "default",
+        resolve_timeout: int = 30,
+        template_name: str | None = None,
     ) -> T:
         """Retrieves an existing sandbox handle given a sandbox claim name.
+
+        Args:
+            claim_name: Name of the SandboxClaim to attach to.
+            namespace: Kubernetes namespace the claim lives in.
+            resolve_timeout: Seconds to wait while resolving the sandbox
+                name from the claim status.
+            template_name: Optional SandboxTemplate name to validate against
+                the existing claim's ``spec.sandboxTemplateRef.name``.
+                When supplied and the claim references a different
+                template, ``ValueError`` is raised before returning a
+                handle. Mirrors the sync ``SandboxClient.get_sandbox``
+                guard so async session-reattach callers get the same
+                refuse-on-mismatch semantics.
 
         Example::
 
@@ -188,12 +205,36 @@ class AsyncSandboxClient(Generic[T]):
             existing = self._active_connection_sandboxes.get(key)
 
         try:
+            if template_name is not None:
+                claim_object = await self.k8s_helper.get_sandbox_claim(
+                    claim_name, namespace
+                )
+                if not claim_object:
+                    raise SandboxNotFoundError(
+                        f"SandboxClaim '{claim_name}' not found in namespace '{namespace}'."
+                    )
+                existing_template = (
+                    claim_object.get("spec", {})
+                    .get("sandboxTemplateRef", {})
+                    .get("name")
+                )
+                if existing_template != template_name:
+                    raise ValueError(
+                        f"SandboxClaim '{claim_name}' in namespace '{namespace}' references "
+                        f"template '{existing_template}', not '{template_name}'. Refusing "
+                        f"to reattach."
+                    )
             sandbox_id = await self.k8s_helper.resolve_sandbox_name(
                 claim_name, namespace, timeout=resolve_timeout
             )
             sandbox_object = await self.k8s_helper.get_sandbox(sandbox_id, namespace)
             if not sandbox_object:
                 raise SandboxNotFoundError(f"Underlying Sandbox '{sandbox_id}' not found.")
+        except ValueError:
+            # Template mismatch is a signed-off refusal — propagate
+            # untouched so the caller sees the security-relevant reason
+            # rather than a generic "not found" wrap.
+            raise
         except Exception as e:
             if existing:
                 await existing.terminate()
@@ -232,9 +273,16 @@ class AsyncSandboxClient(Generic[T]):
                     self._active_connection_sandboxes.pop(key, None)
             return list(self._active_connection_sandboxes.keys())
 
-    async def list_all_sandboxes(self, namespace: str = "default") -> list[str]:
-        """Lists all SandboxClaim names in the Kubernetes cluster for a namespace."""
-        return await self.k8s_helper.list_sandbox_claims(namespace)
+    async def list_all_sandboxes(self, namespace: str = "default", label_selector: str | None = None) -> list[str]:
+        """Lists all SandboxClaim names in the Kubernetes cluster for a namespace.
+
+        Args:
+            namespace: Kubernetes namespace to list claims in.
+            label_selector: Optional Kubernetes label selector string
+                (e.g. ``"app=myapp"``). When set, only claims matching
+                the selector are returned.
+        """
+        return await self.k8s_helper.list_sandbox_claims(namespace, label_selector=label_selector)
 
     async def delete_sandbox(self, claim_name: str, namespace: str = "default"):
         """Stops the client side connection and deletes the Kubernetes resources."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/async_filesystem.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/async_filesystem.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import logging
-import os
 import urllib.parse
 
 from k8s_agent_sandbox.async_connector import AsyncSandboxConnector
+from k8s_agent_sandbox.files.filesystem import Filesystem
 from k8s_agent_sandbox.models import FileEntry
 from k8s_agent_sandbox.trace_manager import async_trace_span, trace
 
@@ -41,12 +41,18 @@ class AsyncFilesystem:
         if isinstance(content, str):
             content = content.encode("utf-8")
 
-        filename = os.path.basename(path)
-        files_payload = {"file": (filename, content)}
+        # Use the same hardened sanitizer as the sync twin — rejects
+        # empty / bare-'.', embedded NUL and ASCII control characters,
+        # and any '..' segment after normalisation. os.path.basename
+        # alone is not sufficient: basename("foo\x00../etc/passwd")
+        # returns the string unchanged, and the NUL truncates at the
+        # runtime's C layer.
+        safe_path = Filesystem._safe_upload_path(path)
+        files_payload = {"file": (safe_path, content)}
         await self.connector.send_request(
             "POST", "upload", files=files_payload, timeout=timeout
         )
-        logging.info(f"File '{filename}' uploaded successfully.")
+        logging.info(f"File '{path}' uploaded successfully.")
 
     @async_trace_span("read")
     async def read(self, path: str, timeout: int = 60) -> bytes:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/filesystem.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/filesystem.py
@@ -40,11 +40,48 @@ class Filesystem:
         if isinstance(content, str):
             content = content.encode('utf-8')
 
-        filename = os.path.basename(path)
-        files_payload = {'file': (filename, content)}
+        # The sandbox runtime uses the multipart ``filename`` field as a
+        # relative destination path under its base directory (e.g. /app).
+        # ``os.path.join`` on the server will honor absolute paths and
+        # ``..`` segments, so a caller could otherwise escape the
+        # confinement by sending filename='/etc/passwd' or '../etc/...'.
+        # Sanitize here to guarantee the filename is a normalized
+        # relative path with no upward traversal.
+        safe_path = self._safe_upload_path(path)
+        files_payload = {'file': (safe_path, content)}
         self.connector.send_request("POST", "upload",
                       files=files_payload, timeout=timeout)
-        logging.info(f"File '{filename}' uploaded successfully.")
+        logging.info(f"File '{path}' uploaded successfully.")
+
+    @staticmethod
+    def _safe_upload_path(path: str) -> str:
+        """Return a relative, ``..``-free filename safe to send as multipart filename.
+
+        Rejects NUL bytes and ASCII control characters before normalisation:
+        ``os.path.normpath`` preserves embedded NULs, and a NUL in the
+        filename truncates at the runtime's C/syscall layer. Without this
+        check ``foo\\x00../etc/passwd`` would survive the ``..`` split (no
+        part equals ``".."`` because the NUL-prefixed segment doesn't
+        match) yet resolve to ``foo`` on the filesystem — or worse,
+        something server-dependent. Match the defence already applied in
+        the langchain backend's ``_to_internal``.
+        """
+        stripped = path.strip()
+        if not stripped:
+            raise ValueError("Upload path cannot be empty.")
+        if any(ord(c) < 0x20 for c in stripped):
+            raise ValueError(
+                f"Upload path contains ASCII control characters: {path!r}"
+            )
+        normalized = os.path.normpath(stripped).lstrip("/")
+        if not normalized or normalized == ".":
+            raise ValueError(f"Upload path '{path}' does not name a file.")
+        parts = normalized.split(os.sep)
+        if any(part == ".." for part in parts):
+            raise ValueError(
+                f"Upload path '{path}' escapes the sandbox root."
+            )
+        return normalized
 
     @trace_span("read")
     def read(self, path: str, timeout: int = 60) -> bytes:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -198,15 +198,40 @@ class K8sHelper:
                 return None
             raise
 
-    def list_sandbox_claims(self, namespace: str) -> List[str]:
-        """Lists all SandboxClaim custom resources in a namespace."""
+    def get_sandbox_claim(self, name: str, namespace: str):
+        """Gets a SandboxClaim custom resource (or ``None`` if it doesn't exist)."""
         try:
-            response = self.custom_objects_api.list_namespaced_custom_object(
+            return self.custom_objects_api.get_namespaced_custom_object(
                 group=CLAIM_API_GROUP,
                 version=CLAIM_API_VERSION,
                 namespace=namespace,
-                plural=CLAIM_PLURAL_NAME
+                plural=CLAIM_PLURAL_NAME,
+                name=name
             )
+        except client.ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    def list_sandbox_claims(self, namespace: str, label_selector: str | None = None) -> List[str]:
+        """Lists all SandboxClaim custom resources in a namespace.
+
+        Args:
+            namespace: Kubernetes namespace to list claims in.
+            label_selector: Optional Kubernetes label selector string
+                (e.g. ``"app=myapp,env=prod"``). When set, only claims
+                matching the selector are returned.
+        """
+        try:
+            kwargs: dict = dict(
+                group=CLAIM_API_GROUP,
+                version=CLAIM_API_VERSION,
+                namespace=namespace,
+                plural=CLAIM_PLURAL_NAME,
+            )
+            if label_selector is not None:
+                kwargs["label_selector"] = label_selector
+            response = self.custom_objects_api.list_namespaced_custom_object(**kwargs)
             return [
                 item.get("metadata", {}).get("name") 
                 for item in response.get("items", []) 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -171,11 +171,24 @@ class Sandbox:
         logging.info(f"Connection to sandbox claim '{self.claim_name}' has been closed.")
     
     def terminate(self):
-        """Permanent deletion of all server side infrastructure and client side connection."""
+        """Permanent deletion of all server side infrastructure and client side connection.
+
+        Idempotent: calling ``terminate()`` repeatedly is a no-op after the
+        first successful delete. ``self.claim_name`` is cleared after the
+        claim is deleted so a subsequent call does not issue a second DELETE
+        that would return 404.
+        """
         # Close the client side connection and trace manager lifecycle
         self.close_connection()
-        
+
+        if not self.claim_name:
+            # Already deleted (or never successfully created a claim).
+            return
+
         # Delete this Sandbox
-        self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
+        claim_name = self.claim_name
+        self.k8s_helper.delete_sandbox_claim(claim_name, self.namespace)
+        # Clear after successful delete so a retry does not 404.
+        self.claim_name = None
 
  

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Kubernetes Authors.
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -153,15 +153,36 @@ class SandboxClient(Generic[T]):
         self._active_connection_sandboxes[(namespace, claim_name)] = sandbox
         return sandbox
 
-    def get_sandbox(self, claim_name: str, namespace: str = "default", resolve_timeout: int = 30) -> T:
+    def get_sandbox(
+        self,
+        claim_name: str,
+        namespace: str = "default",
+        resolve_timeout: int = 30,
+        template_name: str | None = None,
+    ) -> T:
         """
-        Retrieves an existing sandbox handle given a sandbox claim name. 
+        Retrieves an existing sandbox handle given a sandbox claim name.
         If the handle is closed or missing, it re-attaches to the infrastructure.
-        
+
+        Args:
+            claim_name: Name of the SandboxClaim to attach to.
+            namespace: Kubernetes namespace the claim lives in.
+            resolve_timeout: Seconds to wait while resolving the sandbox
+                name from the claim status.
+            template_name: Optional SandboxTemplate name to validate against
+                the existing claim's ``spec.sandboxTemplateRef.name``.
+                When supplied and the existing claim references a different
+                template, a ``ValueError`` is raised before returning a
+                handle. This prevents surprising silent reconnects when the
+                caller expects a specific template.
+
         Example:
-        
+
             >>> client = SandboxClient()
-            >>> sandbox = client.get_sandbox("sandbox-claim-1234abcd")
+            >>> sandbox = client.get_sandbox(
+            ...     "sandbox-claim-1234abcd",
+            ...     template_name="python-sandbox-template",
+            ... )
             >>> sandbox.commands.run("ls -la")
         """
         key = (namespace, claim_name)
@@ -169,10 +190,29 @@ class SandboxClient(Generic[T]):
 
         # Check if the sandbox actually exists in Kubernetes
         try:
+            if template_name is not None:
+                claim_object = self.k8s_helper.get_sandbox_claim(claim_name, namespace)
+                if not claim_object:
+                    raise SandboxNotFoundError(
+                        f"SandboxClaim '{claim_name}' not found in namespace '{namespace}'."
+                    )
+                existing_template = (
+                    claim_object.get("spec", {})
+                    .get("sandboxTemplateRef", {})
+                    .get("name")
+                )
+                if existing_template != template_name:
+                    raise ValueError(
+                        f"SandboxClaim '{claim_name}' in namespace '{namespace}' references "
+                        f"template '{existing_template}', not '{template_name}'. Refusing "
+                        f"to reattach."
+                    )
             sandbox_id = self.k8s_helper.resolve_sandbox_name(claim_name, namespace, timeout=resolve_timeout)
             sandbox_object = self.k8s_helper.get_sandbox(sandbox_id, namespace)
             if not sandbox_object:
                 raise SandboxNotFoundError(f"Underlying Sandbox '{sandbox_id}' not found.")
+        except ValueError:
+            raise
         except Exception as e:
             if existing:
                 existing.terminate()
@@ -182,7 +222,7 @@ class SandboxClient(Generic[T]):
         # If it's already in the registry and active (and verified on K8s), return the existing object
         if existing and existing.is_active:
             return existing
-            
+
         # If the sandbox is not active, pop it out from the tracking list
         if existing:
             self._active_connection_sandboxes.pop(key, None)
@@ -196,7 +236,7 @@ class SandboxClient(Generic[T]):
             tracer_config=self.tracer_config,
             k8s_helper=self.k8s_helper
         )
-        
+
         self._active_connection_sandboxes[key] = new_handle
         return new_handle
     
@@ -216,18 +256,24 @@ class SandboxClient(Generic[T]):
                 self._active_connection_sandboxes.pop(key, None)
         return list(self._active_connection_sandboxes.keys())
       
-    def list_all_sandboxes(self, namespace: str = "default") -> List[str]:
+    def list_all_sandboxes(self, namespace: str = "default", label_selector: str | None = None) -> List[str]:
         """
-        Lists all SandboxClaim names currently existing in the Kubernetes cluster 
+        Lists all SandboxClaim names currently existing in the Kubernetes cluster
         for the given namespace.
-        
+
+        Args:
+            namespace: Kubernetes namespace to list claims in.
+            label_selector: Optional Kubernetes label selector string
+                (e.g. ``"app=myapp"``). When set, only claims matching
+                the selector are returned.
+
         Example:
-        
+
             >>> client = SandboxClient()
             >>> print(client.list_all_sandboxes(namespace="default"))
             ['sandbox-claim-1234abcd', 'sandbox-claim-5678efgh']
         """
-        return self.k8s_helper.list_sandbox_claims(namespace)
+        return self.k8s_helper.list_sandbox_claims(namespace, label_selector=label_selector)
 
     def delete_sandbox(self, claim_name: str, namespace: str = "default"):
         """Stops the client side connection and deletes the Kubernetes resources.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_review_fixes.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_review_fixes.py
@@ -1,0 +1,211 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for PR #310 review fixes (C4, J1, J3)."""
+
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from k8s_agent_sandbox.files.async_filesystem import AsyncFilesystem
+from k8s_agent_sandbox.files.filesystem import Filesystem
+from k8s_agent_sandbox.sandbox import Sandbox
+
+
+class TestFilesystemSafeUploadPath(unittest.TestCase):
+    """C4: SDK must sanitize multipart filenames so the runtime cannot be
+    tricked into writing outside its base directory."""
+
+    def test_basename_is_preserved(self):
+        self.assertEqual(Filesystem._safe_upload_path("foo.txt"), "foo.txt")
+
+    def test_relative_subpath_is_preserved(self):
+        self.assertEqual(Filesystem._safe_upload_path("dir/foo.txt"), "dir/foo.txt")
+
+    def test_leading_slash_is_stripped(self):
+        # An absolute-looking path gets normalized to a relative path under the runtime root.
+        self.assertEqual(Filesystem._safe_upload_path("/dir/foo.txt"), "dir/foo.txt")
+
+    def test_double_slash_collapses(self):
+        self.assertEqual(Filesystem._safe_upload_path("dir//foo.txt"), "dir/foo.txt")
+
+    def test_parent_traversal_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "escapes the sandbox root"):
+            Filesystem._safe_upload_path("../etc/passwd")
+
+    def test_embedded_parent_traversal_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "escapes the sandbox root"):
+            Filesystem._safe_upload_path("dir/../../etc/passwd")
+
+    def test_absolute_etc_is_not_allowed_to_escape(self):
+        # /etc/passwd normalizes to "etc/passwd" relative to the runtime root.
+        self.assertEqual(Filesystem._safe_upload_path("/etc/passwd"), "etc/passwd")
+
+    def test_empty_path_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "empty"):
+            Filesystem._safe_upload_path("")
+
+    def test_bare_dot_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not name a file"):
+            Filesystem._safe_upload_path(".")
+
+    def test_embedded_nul_is_rejected(self):
+        # os.path.normpath keeps embedded NULs intact, and the NUL byte
+        # truncates at the runtime's C/syscall layer — without the
+        # control-char check, "foo\x00../etc/passwd" would survive the
+        # "..-in-parts" filter (no segment equals "..") and then silently
+        # resolve to "foo" on the server.
+        with self.assertRaisesRegex(ValueError, "control characters"):
+            Filesystem._safe_upload_path("foo\x00../etc/passwd")
+
+    def test_control_chars_are_rejected(self):
+        # Newlines, tabs, form feeds etc. can split HTTP headers or
+        # confuse multipart parsers downstream.
+        for bad in ("foo\nbar.txt", "foo\tbar.txt", "foo\rbar.txt"):
+            with self.assertRaisesRegex(ValueError, "control characters"):
+                Filesystem._safe_upload_path(bad)
+
+
+class TestAsyncFilesystemSafeUploadPath(unittest.TestCase):
+    """The async twin must apply the same sanitizer as the sync one —
+    otherwise the NUL-truncation / '..' escape vector is only half-fixed.
+    """
+
+    def _make_fs(self) -> AsyncFilesystem:
+        connector = MagicMock()
+        tracer = MagicMock()
+        return AsyncFilesystem(connector, tracer, trace_service_name="test")
+
+    def test_async_write_rejects_embedded_nul(self):
+        fs = self._make_fs()
+        with self.assertRaisesRegex(ValueError, "control characters"):
+            asyncio.run(fs.write("foo\x00../etc/passwd", b"payload"))
+
+    def test_async_write_rejects_parent_traversal(self):
+        fs = self._make_fs()
+        with self.assertRaisesRegex(ValueError, "escapes the sandbox root"):
+            asyncio.run(fs.write("../etc/passwd", b"payload"))
+
+
+class TestSandboxTerminateIdempotent(unittest.TestCase):
+    """J3: `Sandbox.terminate()` must be idempotent — a second call must not
+    issue a redundant DELETE that would return 404."""
+
+    @patch('k8s_agent_sandbox.sandbox.Filesystem')
+    @patch('k8s_agent_sandbox.sandbox.CommandExecutor')
+    @patch('k8s_agent_sandbox.sandbox.create_tracer_manager')
+    @patch('k8s_agent_sandbox.sandbox.SandboxConnector')
+    def _build_sandbox(self, mock_connector, mock_tracer, mock_cmd, mock_files):
+        mock_tracer.return_value = (MagicMock(), MagicMock())
+        from k8s_agent_sandbox.models import (
+            SandboxLocalTunnelConnectionConfig, SandboxTracerConfig,
+        )
+        k8s_helper = MagicMock()
+        return Sandbox(
+            claim_name="my-claim",
+            sandbox_id="my-claim",
+            namespace="demo",
+            connection_config=SandboxLocalTunnelConnectionConfig(),
+            tracer_config=SandboxTracerConfig(),
+            k8s_helper=k8s_helper,
+        ), k8s_helper
+
+    def test_second_terminate_does_not_redelete(self):
+        sandbox, helper = self._build_sandbox()
+
+        sandbox.terminate()
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 1)
+        self.assertIsNone(sandbox.claim_name)
+
+        # Second call must be a no-op.
+        sandbox.terminate()
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 1)
+
+    def test_failed_terminate_preserves_claim_name_for_retry(self):
+        """When delete_sandbox_claim raises, claim_name must NOT be cleared —
+        otherwise a transient 5xx / network blip would hide the error and
+        the caller would have no handle to retry or clean up manually."""
+        sandbox, helper = self._build_sandbox()
+
+        helper.delete_sandbox_claim.side_effect = RuntimeError("transient 500")
+
+        with self.assertRaisesRegex(RuntimeError, "transient 500"):
+            sandbox.terminate()
+
+        # claim_name must be preserved so the caller can retry.
+        self.assertEqual(sandbox.claim_name, "my-claim")
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 1)
+
+        # Retry succeeds and clears the handle.
+        helper.delete_sandbox_claim.side_effect = None
+        sandbox.terminate()
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 2)
+        self.assertIsNone(sandbox.claim_name)
+
+
+class TestSandboxClientTemplateVerification(unittest.TestCase):
+    """J1: `get_sandbox(template_name=...)` must refuse to reconnect to a claim
+    whose sandboxTemplateRef doesn't match the requested template."""
+
+    def _build_client(self):
+        from k8s_agent_sandbox.sandbox_client import SandboxClient
+        with patch('k8s_agent_sandbox.sandbox_client.K8sHelper') as mock_helper_cls:
+            client = SandboxClient()
+            client.k8s_helper = mock_helper_cls.return_value
+            return client
+
+    def test_mismatched_template_raises_value_error(self):
+        client = self._build_client()
+        client.k8s_helper.get_sandbox_claim.return_value = {
+            "spec": {"sandboxTemplateRef": {"name": "python-secure"}},
+        }
+
+        with self.assertRaisesRegex(ValueError, "references template 'python-secure'"):
+            client.get_sandbox(
+                "claim-1",
+                namespace="demo",
+                template_name="other-template",
+            )
+
+    def test_matching_template_does_not_short_circuit_reconnect(self):
+        client = self._build_client()
+        client.k8s_helper.get_sandbox_claim.return_value = {
+            "spec": {"sandboxTemplateRef": {"name": "python-secure"}},
+        }
+        client.k8s_helper.resolve_sandbox_name.return_value = "sandbox-1"
+        client.k8s_helper.get_sandbox.return_value = {"metadata": {"name": "sandbox-1"}}
+
+        with patch.object(client, 'sandbox_class') as sandbox_cls:
+            client.get_sandbox(
+                "claim-1",
+                namespace="demo",
+                template_name="python-secure",
+            )
+            sandbox_cls.assert_called_once()
+
+    def test_missing_claim_raises_not_found(self):
+        from k8s_agent_sandbox.exceptions import SandboxNotFoundError
+        client = self._build_client()
+        client.k8s_helper.get_sandbox_claim.return_value = None
+
+        with self.assertRaises(SandboxNotFoundError):
+            client.get_sandbox(
+                "claim-1",
+                namespace="demo",
+                template_name="python-secure",
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -153,7 +153,7 @@ class TestSandboxClient(unittest.TestCase):
         
         result = self.client.list_all_sandboxes("test-namespace")
         
-        self.mock_k8s_helper.list_sandbox_claims.assert_called_once_with("test-namespace")
+        self.mock_k8s_helper.list_sandbox_claims.assert_called_once_with("test-namespace", label_selector=None)
         self.assertEqual(result, ["sandbox-1", "sandbox-2"])
 
     def test_delete_sandbox_in_registry(self):

--- a/clients/python/langchain-agent-sandbox/README.md
+++ b/clients/python/langchain-agent-sandbox/README.md
@@ -1,0 +1,320 @@
+# LangChain Agent Sandbox Backend
+
+A LangChain DeepAgents backend that connects to Kubernetes-native sandbox runtimes via the agent-sandbox Python SDK. Provides secure, isolated execution environments for AI agents with full filesystem virtualization, session reattach, and drain-safe lifecycle management.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    A["Agent Code"] --> B["AgentSandbox\nBackend"]
+    B --> C["SandboxClient\n(SDK)"]
+    C --> D["Sandbox Router\n(K8s Service)"]
+    D --> E["Sandbox Pod\n(Isolated Runtime)"]
+```
+
+Connection mode (tunnel, gateway, direct) is configured on the `SandboxClient` -- the adapter does not expose transport details:
+
+| Mode | When to Use | SandboxClient Config |
+|------|-------------|---------------------|
+| **Tunnel** | Local development, CI | `SandboxLocalTunnelConnectionConfig()` |
+| **Gateway** | Cloud deployments | `SandboxGatewayConnectionConfig(gateway_name=...)` |
+| **Direct** | In-cluster, custom domains | `SandboxDirectConnectionConfig(api_url=...)` |
+
+## Installation
+
+```sh
+pip install "git+https://github.com/kubernetes-sigs/agent-sandbox.git@main#subdirectory=clients/python/langchain-agent-sandbox"
+pip install "git+https://github.com/kubernetes-sigs/agent-sandbox.git@main#subdirectory=clients/python/agentic-sandbox-client"
+```
+
+**Requirements:** Python 3.11+, `k8s-agent-sandbox`, `deepagents>=0.5.0`, Kubernetes cluster with agent-sandbox controller, `kubectl`.
+
+## Quickstart
+
+### From existing sandbox (unmanaged)
+
+```python
+from k8s_agent_sandbox import SandboxClient
+from langchain_agent_sandbox import AgentSandboxBackend
+
+client = SandboxClient()
+sandbox = client.create_sandbox(template="my-template")
+
+backend = AgentSandboxBackend.from_existing(sandbox, root_dir="/app")
+result = backend.execute("echo hello")
+# Caller manages lifecycle: client.delete_sandbox(sandbox.claim_name)
+```
+
+### From template (managed lifecycle)
+
+```python
+from k8s_agent_sandbox import SandboxClient
+from deepagents import create_deep_agent
+from langchain_agent_sandbox import AgentSandboxBackend
+
+client = SandboxClient()  # tunnel mode by default
+
+with AgentSandboxBackend.from_template(
+    client,
+    template_name="python-sandbox",
+    namespace="default",
+) as backend:
+    agent = create_deep_agent(backend=backend)
+    result = agent.invoke("Create a hello world script")
+```
+
+### Session reattach (multi-turn agents)
+
+```python
+from k8s_agent_sandbox import SandboxClient
+from langchain_agent_sandbox import AgentSandboxBackend
+
+client = SandboxClient()
+
+# First invocation: creates a new sandbox with session label
+with AgentSandboxBackend.from_template(
+    client,
+    template_name="python-sandbox",
+    session_id="thread-abc123",
+) as backend:
+    backend.execute("echo 'state persists' > /app/state.txt")
+    # On exit: detaches without deleting (session sandbox persists)
+
+# Later invocation: reattaches to the same sandbox
+with AgentSandboxBackend.from_template(
+    client,
+    template_name="python-sandbox",
+    session_id="thread-abc123",
+) as backend:
+    result = backend.read("/state.txt")
+    # File from previous invocation is still there
+```
+
+**How it works:** When `session_id` is set, `__enter__` searches for an existing
+SandboxClaim labelled `agent-sandbox.sigs.k8s.io/session-id=<session_id>`. If found,
+it reattaches via `SandboxClient.get_sandbox()`. If not found, it creates a new sandbox
+with that label. On `__exit__`, reattached sandboxes are detached (not deleted) so they
+persist for future invocations.
+
+### Factory pattern
+
+For use with `create_deep_agent(backend=...)`:
+
+```python
+from deepagents import create_deep_agent
+from langchain_agent_sandbox import create_sandbox_backend_factory
+
+factory = create_sandbox_backend_factory(
+    template_name="python-runtime",
+    namespace="agents",
+    client=client,
+)
+
+agent = create_deep_agent(backend=factory)
+result = agent.invoke("Analyze the project structure")
+```
+
+The factory eagerly provisions the sandbox and registers a `weakref.finalize` cleanup
+handler so the sandbox is torn down on GC or at interpreter shutdown.
+
+### With policies
+
+```python
+from langchain_agent_sandbox import AgentSandboxBackend, SandboxPolicyWrapper
+
+client = SandboxClient()
+
+with AgentSandboxBackend.from_template(client, "my-template") as backend:
+    secured = SandboxPolicyWrapper(
+        backend,
+        deny_prefixes=["/etc", "/sys", "/proc"],
+        deny_commands=["rm -rf", "shutdown"],
+        audit_log=lambda op, target, meta: print(f"[AUDIT] {op}: {target}"),
+        strict_audit=False,  # default: fail-open
+    )
+    agent = create_deep_agent(backend=secured)
+    result = agent.invoke("Run the analysis script")
+```
+
+The policy wrapper implements `SandboxBackendProtocol` and can be used anywhere a
+backend is expected. It is a best-effort guardrail -- kernel-level isolation (gVisor,
+Kata Containers) provides the real security boundary.
+
+## Connection Modes
+
+All connection configuration is on `SandboxClient`, not the adapter:
+
+```python
+from k8s_agent_sandbox import SandboxClient
+from k8s_agent_sandbox.models import (
+    SandboxLocalTunnelConnectionConfig,
+    SandboxGatewayConnectionConfig,
+    SandboxDirectConnectionConfig,
+)
+
+# Developer mode (default -- auto port-forward)
+client = SandboxClient()
+
+# Production mode (gateway)
+client = SandboxClient(
+    connection_config=SandboxGatewayConnectionConfig(
+        gateway_name="external-http-gateway",
+        gateway_namespace="agent-sandbox-system",
+    )
+)
+
+# Direct mode (in-cluster or custom domain)
+client = SandboxClient(
+    connection_config=SandboxDirectConnectionConfig(
+        api_url="http://sandbox-router.default.svc:8080",
+    )
+)
+```
+
+To enable tracing, pass a `SandboxTracerConfig`:
+
+```python
+from k8s_agent_sandbox.models import SandboxTracerConfig
+
+client = SandboxClient(
+    tracer_config=SandboxTracerConfig(enable_tracing=True),
+)
+```
+
+## API Reference
+
+### AgentSandboxBackend
+
+```python
+class AgentSandboxBackend(SandboxBackendProtocol):
+    @classmethod
+    def from_existing(
+        cls,
+        sandbox: Sandbox,
+        root_dir: str = "/app",
+        allow_absolute_paths: bool = False,
+    ) -> AgentSandboxBackend: ...
+
+    @classmethod
+    def from_template(
+        cls,
+        client: SandboxClient,
+        template_name: str,
+        namespace: str = "default",
+        root_dir: str = "/app",
+        allow_absolute_paths: bool = False,
+        sandbox_ready_timeout: int = 180,
+        labels: Optional[Dict[str, str]] = None,
+        shutdown_after_seconds: Optional[int] = None,
+        session_id: Optional[str] = None,
+        default_timeout_seconds: Optional[int] = 120,
+    ) -> AgentSandboxBackend: ...
+
+    @staticmethod
+    def delete_all(
+        client: SandboxClient,
+        namespace: str = "default",
+        best_effort: bool = True,
+        label_selector: Optional[str] = None,
+    ) -> int: ...
+
+    @property
+    def id(self) -> str: ...
+    # Returns "{namespace}/{claim_name}", e.g. "default/sandbox-claim-a1b2c3d4"
+```
+
+**Protocol methods:**
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `execute(command, *, timeout=None)` | `ExecuteResponse` | Run shell command (cwd is `root_dir`) |
+| `ls(path)` | `LsResult` | List directory (native endpoint, includes size/modified_at) |
+| `read(file_path, offset, limit)` | `ReadResult` | Read file content (strict UTF-8) |
+| `write(file_path, content)` | `WriteResult` | Create new file (fails if exists) |
+| `edit(file_path, old, new, replace_all)` | `EditResult` | Replace string in file |
+| `grep(pattern, path, glob)` | `GrepResult` | Search file contents |
+| `glob(pattern, path)` | `GlobResult` | Find files by pattern (includes size/modified_at) |
+| `upload_files(files)` | `List[FileUploadResponse]` | Upload files (per-file partial success) |
+| `download_files(paths)` | `List[FileDownloadResponse]` | Download files (per-file partial success) |
+
+Async variants are provided by the `SandboxBackendProtocol` base class via `asyncio.to_thread`.
+
+### create_sandbox_backend_factory
+
+```python
+def create_sandbox_backend_factory(
+    template_name: str,
+    namespace: str = "default",
+    **kwargs,
+) -> Callable[[Any], AgentSandboxBackend]: ...
+```
+
+Returns a factory for `create_deep_agent(backend=...)`. Accepts the same kwargs as `from_template()` (including `client`, `session_id`, etc.).
+
+### SandboxPolicyWrapper
+
+```python
+class SandboxPolicyWrapper(SandboxBackendProtocol):
+    def __init__(
+        self,
+        backend: AgentSandboxBackend,
+        deny_prefixes: Optional[List[str]] = None,
+        deny_commands: Optional[List[str]] = None,
+        audit_log: Optional[Callable[[str, str, dict], None]] = None,
+        *,
+        strict_audit: bool = False,
+    ) -> None: ...
+```
+
+Implements `SandboxBackendProtocol` -- can be used as a drop-in backend replacement.
+Read ops pass through; write/edit/execute/upload are guarded by prefix and command checks.
+When `strict_audit=True`, operations are refused if the audit callback raises.
+
+## Key Features
+
+### Path virtualization
+
+All file ops are virtualized under `root_dir` (default `/app`):
+- Public `/file.txt` maps to internal `/app/file.txt`
+- Path traversal (`../`) is blocked
+- NUL bytes and control characters are rejected
+- `allow_absolute_paths=True` permits writes outside root_dir
+
+### Execute cwd alignment
+
+`execute()` runs commands with `cd {root_dir} && {command}` so the shell's
+working directory matches the virtual root used by `ls`/`read`/`write`.
+
+### Default timeout
+
+`from_template()` sets `default_timeout_seconds=120` -- a conservative default
+below the sandbox-router's 180s proxy timeout. When `execute(timeout=N)` is called
+with an explicit timeout, it takes precedence. Set `default_timeout_seconds=None`
+to use the SDK's own default (60s).
+
+### Drain-safe lifecycle
+
+`__exit__` waits for all in-flight operations to complete before deleting the
+sandbox claim, mirroring the Go SDK's drain semantics. New operations are
+rejected with `RuntimeError` once draining starts.
+
+### Namespace-qualified identity
+
+`backend.id` returns `"{namespace}/{claim_name}"` to prevent collisions across namespaces.
+
+## Sandbox Image Requirements
+
+The sandbox container image must include: `sh`, `grep`, `find` (with `-printf`), `mkdir`, `test`.
+
+## Development
+
+```sh
+uv sync
+uv run pytest tests/ -v
+```
+
+## Related
+
+- [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) - Kubernetes CRD and controller
+- [agentic-sandbox-client](../agentic-sandbox-client) - Core Python SDK
+- [DeepAgents](https://docs.langchain.com/deepagents) - LangChain agent framework

--- a/clients/python/langchain-agent-sandbox/langchain_agent_sandbox/__init__.py
+++ b/clients/python/langchain-agent-sandbox/langchain_agent_sandbox/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .backend import (
+    AgentSandboxBackend,
+    SandboxPolicyWrapper,
+    create_sandbox_backend_factory,
+)
+
+__all__ = [
+    "AgentSandboxBackend",
+    "SandboxPolicyWrapper",
+    "create_sandbox_backend_factory",
+]

--- a/clients/python/langchain-agent-sandbox/langchain_agent_sandbox/backend.py
+++ b/clients/python/langchain-agent-sandbox/langchain_agent_sandbox/backend.py
@@ -1,0 +1,1842 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import base64
+import logging
+import posixpath
+import re
+import shlex
+import threading
+import weakref
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Optional, Dict, List, Union, Tuple, Any, cast
+
+from k8s_agent_sandbox import SandboxClient
+from k8s_agent_sandbox.sandbox import Sandbox
+
+try:
+    from deepagents.backends.protocol import (
+        EditResult,
+        ExecuteResponse,
+        FileData,
+        FileDownloadResponse,
+        FileInfo,
+        FileUploadResponse,
+        GlobResult,
+        GrepMatch,
+        GrepResult,
+        LsResult,
+        ReadResult,
+        SandboxBackendProtocol,
+        WriteResult,
+    )
+    from deepagents.backends.utils import create_file_data
+except (ImportError, ModuleNotFoundError) as exc:
+    raise ImportError(
+        "deepagents>=0.5.0 is required to use langchain-agent-sandbox"
+    ) from exc
+
+try:
+    from langgraph._internal._constants import CONFIG_KEY_SEND
+    from langgraph.config import get_config
+except (ImportError, ModuleNotFoundError):
+    CONFIG_KEY_SEND = None  # type: ignore[assignment]
+    get_config = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+# `requests` is a transitive dependency of `k8s_agent_sandbox`, so the
+# import is always satisfiable when this module is importable, but we
+# guard it defensively so a future SDK refactor that drops requests
+# doesn't break our own import.
+try:
+    from requests.exceptions import Timeout as _RequestsTimeout
+except ImportError:  # pragma: no cover - defensive
+    _RequestsTimeout = None  # type: ignore[assignment]
+
+# `httpx` is used by the SDK's async transport. Imported defensively
+# so the timeout walker also catches `httpx.TimeoutException` if a
+# future code path surfaces an async-transport exception synchronously.
+try:
+    from httpx import TimeoutException as _HttpxTimeout
+except ImportError:  # pragma: no cover - defensive
+    _HttpxTimeout = None  # type: ignore[assignment]
+
+
+def _is_timeout_exception(exc: BaseException) -> bool:
+    """Return True if ``exc`` (or any chained cause/context) is a timeout.
+
+    Walks ``__cause__``/``__context__`` so wrapped exceptions are
+    detected even when the backend doesn't import the wrapper class
+    directly. Three layers of detection, in order:
+
+    1. The Python builtin ``TimeoutError``.
+    2. Known transport-level timeout types (``requests.exceptions.Timeout``,
+       ``httpx.TimeoutException``) if installed.
+    3. A duck-typed fallback on the exception class name (``"timeout"``
+       substring) — catches future SDK exception classes that don't
+       chain via ``raise ... from e`` and that we haven't seen yet.
+       This is a soft signal but strictly better than the hard miss
+       that bare ``except TimeoutError`` produced before.
+
+    The duck-typed fallback can produce false positives if a non-timeout
+    exception class happens to contain "timeout" in its name. The
+    tradeoff is acceptable: ``execute()`` already classifies any
+    unhandled exception as a generic failure with ``exit_code=-1``,
+    so escalating it to ``exit_code=-2`` (timeout) for an exception
+    named ``"FooTimeoutPolicyError"`` is a strictly better signal than
+    flattening it to a generic error.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, TimeoutError):
+            return True
+        if _RequestsTimeout is not None and isinstance(cur, _RequestsTimeout):
+            return True
+        if _HttpxTimeout is not None and isinstance(cur, _HttpxTimeout):
+            return True
+        # Duck-typed fallback for exceptions that don't chain via
+        # `from e` (background workers, asyncio.to_thread boundaries,
+        # explicit `raise X() from None`, future SDK exception types).
+        if "timeout" in type(cur).__name__.lower():
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+def _compile_glob(pattern: str) -> Callable[[str], bool]:
+    """Compile a glob pattern into a matcher that correctly handles ``**``.
+
+    ``pathlib.PurePath.match`` in Python 3.11 treats ``**`` as two literal
+    ``*`` wildcards (equivalent to a single ``*``), which means a pattern
+    like ``**/langchain_e2e.txt`` fails to match ``langchain_e2e.txt`` at
+    the root of the search. Agent-driven glob calls routinely write
+    ``**/...`` patterns expecting recursive semantics, so we translate
+    the pattern to a regex ourselves.
+
+    Supported syntax:
+        ``**``  -- zero or more path components (greedy, slashes allowed)
+        ``*``   -- any characters except ``/``
+        ``?``   -- any single character except ``/``
+        ``[..]``-- character class (passed through to the regex engine)
+
+    ``**/X`` matches ``X`` at any depth including the root (equivalent
+    to ``X`` OR ``*/X`` OR ``*/*/X`` ...). Patterns that contain no
+    ``/`` are treated as a basename match -- ``*.py`` finds every
+    ``.py`` file in the search tree, mirroring ``pathlib.PurePath.match``
+    semantics that existing callers rely on.
+    """
+    # A pattern without any `/` matches against the basename only. This
+    # preserves the existing behavior of calls like `glob("*.py")` which
+    # walkers interpret as "any .py file in the search tree", and it
+    # matches what `pathlib.PurePath.match` does for non-path patterns.
+    if "/" not in pattern:
+        segment_regex = _translate_glob_segment(pattern)
+        compiled_basename = re.compile("^" + segment_regex + "$")
+        return lambda path: compiled_basename.fullmatch(posixpath.basename(path)) is not None
+
+    # Split the pattern on `/` into segments. Collapse consecutive `**`
+    # segments since `**/**` is semantically identical to a single `**`.
+    segments = pattern.split("/")
+    collapsed: List[str] = []
+    for seg in segments:
+        if seg == "**" and collapsed and collapsed[-1] == "**":
+            continue
+        collapsed.append(seg)
+    segments = collapsed
+
+    # Pattern is just `**` (after collapsing) → matches anything.
+    if len(segments) == 1 and segments[0] == "**":
+        return lambda path: True
+
+    # Build the regex piece by piece. The key invariant: `**` always
+    # consumes its surrounding slashes, never adds a spurious one.
+    # That means a middle `**` produces `/(?:[^/]+/)*` so `a/**/b`
+    # requires at least `a/b` (zero intermediate components) and rejects
+    # `ab`. Leading `**` produces `(?:[^/]+/)*` (zero or more full
+    # components followed by a slash, then the next literal segment
+    # follows without an extra slash). Trailing `**` produces `/.*` so
+    # `a/**` matches `a/`, `a/b`, and `a/b/c`, but NOT bare `a` —
+    # mirroring the gitignore semantic that "x/**" means "things inside
+    # x/".
+    regex_parts: List[str] = []
+    for i, seg in enumerate(segments):
+        is_first = i == 0
+        is_last = i == len(segments) - 1
+
+        if seg == "**":
+            if is_first:
+                # Leading: emit zero-or-more components with trailing /.
+                # The next literal segment will NOT get a prepended `/`.
+                regex_parts.append("(?:[^/]+/)*")
+            elif is_last:
+                # Trailing: require a slash plus anything (possibly
+                # empty). `a/**` matches `a/`, `a/b`, `a/b/c` but not
+                # bare `a` itself, mirroring the gitignore semantic
+                # that "x/**" means "things inside x/".
+                regex_parts.append("/.*")
+            else:
+                # Middle: require the literal slash that was part of
+                # the pattern, plus zero or more components with their
+                # own trailing slashes. The next literal segment will
+                # NOT get a prepended `/` because this block ends in
+                # one already.
+                regex_parts.append("/(?:[^/]+/)*")
+            continue
+
+        # Literal segment (possibly with `*`, `?`, `[...]` wildcards).
+        # Emit a `/` separator unless this is the first segment or the
+        # previous segment was a `**` token that already produced a
+        # trailing slash.
+        if not is_first:
+            prev = segments[i - 1]
+            if prev != "**":
+                regex_parts.append("/")
+            # else: previous `**` token already ends with `/`, don't
+            # emit a second one.
+        regex_parts.append(_translate_glob_segment(seg))
+
+    regex_str = "^" + "".join(regex_parts) + "$"
+    compiled = re.compile(regex_str)
+    return lambda path: compiled.fullmatch(path) is not None
+
+
+def _translate_glob_segment(segment: str) -> str:
+    """Translate one path segment (no `/`) into a regex fragment."""
+    out: List[str] = []
+    i = 0
+    while i < len(segment):
+        c = segment[i]
+        if c == "*":
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c == "[":
+            end = segment.find("]", i + 1)
+            if end == -1:
+                out.append(re.escape(c))
+                i += 1
+            else:
+                out.append(segment[i : end + 1])
+                i = end + 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return "".join(out)
+
+
+class AgentSandboxBackend(SandboxBackendProtocol):
+    """DeepAgents backend adapter for agent-sandbox runtimes.
+
+    Implements the DeepAgents SandboxBackendProtocol by wrapping a Sandbox handle.
+    All file operations are virtualized under `root_dir` (default: /app).
+
+    Requirements:
+        - Sandbox image must have GNU coreutils: sh, grep, find (with -printf), mkdir, test
+        - Sandbox handle must be connected before use
+
+    Note:
+        The backend can optionally manage the sandbox lifecycle when created via from_template().
+        When manage_lifecycle=True, the backend must be used as a context manager.
+    """
+
+    SESSION_LABEL_KEY = "agent-sandbox.sigs.k8s.io/session-id"
+    """Kubernetes label key used for session-based sandbox reattach."""
+
+    def __init__(
+        self,
+        sandbox: Sandbox,
+        root_dir: str = "/app",
+        manage_lifecycle: bool = False,
+        allow_absolute_paths: bool = False,
+        sdk_client: Optional[SandboxClient] = None,
+        runtime_root: str = "/app",
+        _template: Optional[str] = None,
+        _namespace: str = "default",
+        _sandbox_ready_timeout: int = 180,
+        _labels: Optional[Dict[str, str]] = None,
+        _shutdown_after_seconds: Optional[int] = None,
+        _session_id: Optional[str] = None,
+        _default_timeout_seconds: Optional[int] = None,
+    ) -> None:
+        if not root_dir.startswith("/"):
+            raise ValueError(f"root_dir must be an absolute path, got: {root_dir}")
+        if not runtime_root.startswith("/"):
+            raise ValueError(f"runtime_root must be an absolute path, got: {runtime_root}")
+        self._sandbox: Optional[Sandbox] = sandbox
+        self._root_dir = posixpath.normpath(root_dir)
+        # Path the sandbox runtime treats as its filesystem base — the
+        # SDK file APIs (``files.read`` / ``files.list`` / ``files.exists``
+        # / ``files.write``) interpret their path argument as relative to
+        # this directory. Default ``/app`` matches the example runtime.
+        self._runtime_root = posixpath.normpath(runtime_root)
+        self._manage_lifecycle = manage_lifecycle
+        self._allow_absolute_paths = allow_absolute_paths
+        self._sdk_client = sdk_client
+        self._template = _template
+        self._namespace = _namespace
+        self._sandbox_ready_timeout = _sandbox_ready_timeout
+        self._labels = _labels
+        self._shutdown_after_seconds = _shutdown_after_seconds
+        self._session_id = _session_id
+        self._default_timeout_seconds = _default_timeout_seconds
+        self._reattached = False
+        self._draining = False
+        self._inflight = 0
+        self._inflight_cv = threading.Condition(threading.Lock())
+
+    def _send_files_update(self, update: dict[str, Any]) -> None:
+        """Queue a ``files`` channel write via LangGraph's CONFIG_KEY_SEND.
+
+        Follows the same contract as ``StateBackend._send_files_update`` so
+        that ``state["files"]`` stays in sync with the sandbox filesystem.
+        Silently no-ops when called outside a LangGraph graph context (e.g.
+        unit tests, standalone scripts).
+        """
+        if get_config is None or CONFIG_KEY_SEND is None:
+            return
+        try:
+            config = get_config()
+        except RuntimeError:
+            return
+        send = config.get("configurable", {}).get(CONFIG_KEY_SEND)
+        if send is None:
+            return
+        send([("files", update)])
+
+    def _try_reattach(self) -> bool:
+        """Try to reattach to an existing sandbox by session_id label.
+
+        Returns True if a sandbox was found and reattached, False otherwise.
+
+        Safety invariants:
+
+        - Multi-match is refused, not silently resolved. In a shared
+          namespace another tenant could plant a claim with a matching
+          ``session-id`` label; picking ``claims[0]`` would hand them
+          this session's subsequent reads/writes/commands. Similarly,
+          stale claims from a prior run can mask a newer one if we pick
+          arbitrarily. When ``len(claims) > 1`` we log loudly and treat
+          the session as unresolvable so the caller creates a fresh
+          sandbox instead of attaching to the wrong one.
+        - Template is verified via ``get_sandbox(template_name=...)``
+          (see J1). A ``ValueError`` from that check is a signed-off
+          refusal — re-raise it instead of swallowing to ``False``,
+          otherwise a mismatched claim silently falls through to a
+          fresh create and the agent loses continuity without any
+          operator-visible signal.
+        """
+        assert self._sdk_client is not None
+        if self._session_id is None:
+            return False
+        selector = f"{self.SESSION_LABEL_KEY}={self._session_id}"
+        try:
+            claims = self._sdk_client.list_all_sandboxes(
+                namespace=self._namespace, label_selector=selector,
+            )
+        except Exception as e:
+            logger.warning(
+                "Session lookup failed for session_id=%s: %s",
+                self._session_id, e,
+            )
+            return False
+        if not claims:
+            return False
+        if len(claims) > 1:
+            logger.error(
+                "Refusing to reattach: %d claims match session_id=%s (%s). "
+                "Resolve by deleting the stale claim(s) before retrying.",
+                len(claims), self._session_id, claims,
+            )
+            return False
+        claim_name = claims[0]
+        try:
+            self._sandbox = self._sdk_client.get_sandbox(
+                claim_name=claim_name,
+                namespace=self._namespace,
+                template_name=self._template,
+            )
+            self._reattached = True
+            logger.info(
+                "Reattached to existing sandbox '%s' for session '%s'",
+                claim_name, self._session_id,
+            )
+            return True
+        except ValueError:
+            # Template mismatch — a claim with our session-id label
+            # exists but was created from a different template. Do NOT
+            # swallow: surface to the caller so they see the security-
+            # relevant refusal instead of a silent fresh-create.
+            raise
+        except Exception as e:
+            logger.warning(
+                "Reattach to '%s' failed for session '%s': %s",
+                claim_name, self._session_id, e,
+            )
+            return False
+
+    @contextmanager
+    def _track_op(self):
+        """Track an in-flight operation for drain-on-close.
+
+        ``__exit__`` sets ``_draining`` and waits for ``_inflight`` to
+        reach zero before deleting the sandbox. This prevents claim
+        deletion while an ``execute()`` or file operation is mid-flight
+        — particularly relevant for the factory pattern where
+        ``weakref.finalize`` can fire from GC at any time.
+        """
+        with self._inflight_cv:
+            if self._draining:
+                raise RuntimeError("Backend is shutting down")
+            self._inflight += 1
+        try:
+            yield
+        finally:
+            with self._inflight_cv:
+                self._inflight -= 1
+                if self._inflight == 0:
+                    self._inflight_cv.notify_all()
+
+    def __enter__(self) -> "AgentSandboxBackend":
+        if self._manage_lifecycle:
+            if self._sdk_client is None:
+                raise RuntimeError(
+                    "Cannot manage lifecycle without an sdk_client. "
+                    "Use from_template() to create a managed backend."
+                )
+            self._reattached = False
+            self._draining = False
+            if not self._try_reattach():
+                create_kwargs: Dict[str, Any] = {
+                    "template": self._template,
+                    "namespace": self._namespace,
+                    "sandbox_ready_timeout": self._sandbox_ready_timeout,
+                }
+                # Merge session_id into labels so the sandbox can be
+                # found again by future invocations with the same session_id.
+                labels = dict(self._labels) if self._labels else {}
+                if self._session_id is not None:
+                    labels[self.SESSION_LABEL_KEY] = self._session_id
+                if labels:
+                    create_kwargs["labels"] = labels
+                if self._shutdown_after_seconds is not None:
+                    create_kwargs["shutdown_after_seconds"] = self._shutdown_after_seconds
+                self._sandbox = self._sdk_client.create_sandbox(**create_kwargs)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._manage_lifecycle and self._sandbox is not None:
+            # Signal draining and wait for in-flight ops to finish
+            # before deleting the claim. Mirrors Go SDK's Close()
+            # which sets draining + waits on inflightOps.
+            with self._inflight_cv:
+                self._draining = True
+                while self._inflight > 0:
+                    self._inflight_cv.wait()
+            if self._reattached:
+                self._sandbox = None
+                return
+            claim: str = self._sandbox.claim_name
+            ns: str = self._sandbox.namespace
+            cleanup_error: Optional[BaseException] = None
+            assert self._sdk_client is not None
+            try:
+                self._sdk_client.delete_sandbox(claim_name=claim, namespace=ns)
+            except Exception as e:
+                cleanup_error = e
+                logger.error(
+                    "Failed to delete sandbox (claim=%s, namespace=%s): %s",
+                    claim, ns, e,
+                )
+            finally:
+                self._sandbox = None
+            if cleanup_error is not None:
+                if exc_type is None:
+                    raise cleanup_error
+                if exc is not None:
+                    raise BaseExceptionGroup(
+                        "sandbox cleanup failed during exception unwind",
+                        [exc, cleanup_error],
+                    ) from None
+                import warnings
+                warnings.warn(
+                    f"sandbox cleanup failed during exception unwind: "
+                    f"{type(cleanup_error).__name__}: {cleanup_error}",
+                    ResourceWarning,
+                    stacklevel=2,
+                )
+
+    async def __aenter__(self) -> "AgentSandboxBackend":
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self.__exit__(exc_type, exc, tb)
+
+    @classmethod
+    def from_existing(
+        cls,
+        sandbox: Sandbox,
+        root_dir: str = "/app",
+        allow_absolute_paths: bool = False,
+    ) -> "AgentSandboxBackend":
+        """Wrap an existing, already-connected Sandbox handle.
+
+        Use this when the caller manages the sandbox lifecycle externally
+        (e.g. via ``SandboxClient.create_sandbox()`` or
+        ``SandboxClient.get_sandbox()``).  The backend will **not**
+        create or delete the sandbox on enter/exit.
+
+        Args:
+            sandbox: A connected Sandbox instance.
+            root_dir: Virtual root for file operations.
+            allow_absolute_paths: If True, write/upload operations may
+                target absolute paths outside root_dir.
+
+        Returns:
+            AgentSandboxBackend in unmanaged mode.
+        """
+        return cls(
+            sandbox=sandbox,
+            root_dir=root_dir,
+            manage_lifecycle=False,
+            allow_absolute_paths=allow_absolute_paths,
+        )
+
+    @classmethod
+    def from_template(
+        cls,
+        client: SandboxClient,
+        template_name: str,
+        namespace: str = "default",
+        root_dir: str = "/app",
+        allow_absolute_paths: bool = False,
+        sandbox_ready_timeout: int = 180,
+        labels: Optional[Dict[str, str]] = None,
+        shutdown_after_seconds: Optional[int] = None,
+        session_id: Optional[str] = None,
+        default_timeout_seconds: Optional[int] = 120,
+    ) -> "AgentSandboxBackend":
+        """Create a backend with lifecycle management via SandboxClient.
+
+        The sandbox will be automatically created on ``__enter__`` and
+        deleted on ``__exit__`` when the backend is used as a context manager.
+
+        When ``session_id`` is provided, ``__enter__`` will first search
+        for an existing SandboxClaim labelled with
+        ``agent-sandbox.sigs.k8s.io/session-id=<session_id>`` in the
+        given namespace.  If found, the backend reattaches to that
+        sandbox (via ``SandboxClient.get_sandbox``).  If not found, a
+        new sandbox is created with that label.  This enables
+        multi-turn agents to resume work in the same persistent sandbox
+        across invocations — leveraging agent-sandbox's stable identity
+        and persistent storage.
+
+        Args:
+            client: Pre-configured ``SandboxClient``. Connection mode
+                (gateway, tunnel, direct) and tracing are configured on
+                the client — the adapter does not expose transport details.
+            template_name: Name of the SandboxTemplate to claim.
+            namespace: Kubernetes namespace for the sandbox.
+            root_dir: Virtual root for file operations.
+            allow_absolute_paths: If True, write/upload operations may
+                target absolute paths outside root_dir.
+            sandbox_ready_timeout: Timeout in seconds waiting for sandbox
+                readiness.
+            labels: Kubernetes labels to attach to the SandboxClaim.
+            shutdown_after_seconds: Time-to-live in seconds. After this
+                duration the controller auto-deletes the claim.
+            session_id: Stable session identifier for sandbox reuse.
+                When set, ``__enter__`` looks up an existing sandbox
+                by label before creating a new one.
+            default_timeout_seconds: Default timeout for ``execute()``
+                when the caller doesn't pass an explicit ``timeout``.
+                Set to ``None`` to use the SDK's own default. The
+                default of 120 s is conservative — the sandbox-router
+                proxy times out at 180 s in Gateway/Tunnel mode.
+
+        Returns:
+            AgentSandboxBackend with manage_lifecycle=True.
+        """
+        return cls(
+            sandbox=None,  # type: ignore[arg-type]
+            root_dir=root_dir,
+            manage_lifecycle=True,
+            allow_absolute_paths=allow_absolute_paths,
+            sdk_client=client,
+            _template=template_name,
+            _namespace=namespace,
+            _sandbox_ready_timeout=sandbox_ready_timeout,
+            _labels=labels,
+            _shutdown_after_seconds=shutdown_after_seconds,
+            _session_id=session_id,
+            _default_timeout_seconds=default_timeout_seconds,
+        )
+
+    def _assert_sandbox(self) -> Sandbox:
+        """Return the sandbox handle or raise if not initialized.
+
+        Guards every public method that talks to the sandbox so that a
+        forgotten ``__enter__`` on a ``from_template()`` backend produces
+        a clear ``RuntimeError`` instead of an opaque
+        ``AttributeError: 'NoneType' object has no attribute 'commands'``
+        buried inside a generic error result.
+        """
+        if self._sandbox is None:
+            raise RuntimeError(
+                "Sandbox is not initialized. Use 'with backend:' "
+                "(context manager) or call '__enter__()' first."
+            )
+        return self._sandbox
+
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: Optional[int] = None,
+    ) -> ExecuteResponse:
+        """Execute a shell command in the sandbox.
+
+        The command runs with its working directory set to ``root_dir``
+        so that relative paths in shell commands resolve consistently
+        with the paths exposed by ``ls`` / ``read`` / ``write``.
+
+        Args:
+            command: Shell command to execute.
+            timeout: Maximum time in seconds to wait for the command to complete.
+                If None, no explicit timeout is passed and the underlying
+                sandbox client's default applies.
+
+        Returns:
+            ExecuteResponse with combined stdout/stderr output and exit code.
+            On timeout, exit_code=-2 and output is prefixed with "Timed out".
+            On other failures, exit_code=-1.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            wrapped = f"sh -c {shlex.quote(f'cd {self._root_dir} && {command}')}"
+            effective_timeout = timeout if timeout is not None else self._default_timeout_seconds
+            try:
+                if effective_timeout is not None:
+                    result = sandbox.commands.run(wrapped, timeout=effective_timeout)
+                else:
+                    result = sandbox.commands.run(wrapped)
+            except Exception as e:
+                if _is_timeout_exception(e):
+                    logger.warning("execute timed out for command: %s", e)
+                    return ExecuteResponse(
+                        output=f"Timed out: {e}",
+                        exit_code=-2,
+                        truncated=False,
+                    )
+                logger.error("execute failed: %s", e)
+                return ExecuteResponse(
+                    output=f"Error: {e}",
+                    exit_code=-1,
+                    truncated=False,
+                )
+            combined = result.stdout
+            if result.stderr:
+                combined = f"{combined}\n{result.stderr}" if combined else result.stderr
+            return ExecuteResponse(
+                output=combined,
+                exit_code=result.exit_code,
+                truncated=False,
+            )
+
+    def ls(self, path: str) -> LsResult:
+        """List directory contents.
+
+        Uses the sandbox runtime's native ``/list/{path}`` endpoint which
+        returns structured JSON (name, size, type, mod_time). This
+        populates the ``size`` and ``modified_at`` optional fields on
+        ``FileInfo`` that the ``SandboxBackendProtocol`` supports.
+
+        Args:
+            path: Directory path to list.
+
+        Returns:
+            LsResult with entries on success, or ``error`` populated on
+            failure. Entries are always an empty list when ``error`` is
+            set, so callers iterating over ``entries`` without checking
+            ``error`` still work.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            try:
+                internal_path = self._to_internal(path)
+                file_entries = sandbox.files.list(self._to_runtime_relative(internal_path))
+            except Exception as e:
+                logger.warning("ls failed for path '%s': %s", path, e)
+                return LsResult(entries=[], error=f"Cannot list '{path}': {e}")
+
+            entries: List[FileInfo] = []
+            public_dir = self._normalize_public_dir(path)
+            for fe in file_entries:
+                name = fe.name
+                if name in (".", ".."):
+                    continue
+                is_dir = fe.type == "directory"
+                public_path = posixpath.join(public_dir, name)
+                info = FileInfo(path=public_path, is_dir=is_dir)
+                if fe.size is not None:
+                    info["size"] = fe.size
+                if fe.mod_time is not None:
+                    info["modified_at"] = datetime.fromtimestamp(
+                        fe.mod_time, tz=timezone.utc,
+                    ).isoformat()
+                entries.append(info)
+
+            entries.sort(key=lambda item: item["path"])
+            return LsResult(entries=entries)
+
+    def read(
+        self,
+        file_path: str,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> ReadResult:
+        """Read file content for the requested line range.
+
+        Returns raw (unformatted) content — the middleware handles
+        line-number formatting and long-line chunking. Content is decoded
+        strictly as UTF-8; non-UTF-8 files are reported as an error so the
+        caller isn't handed lossy data mislabeled as utf-8.
+
+        Args:
+            file_path: Path to the file to read.
+            offset: 0-based line index to start reading from.
+            limit: Maximum number of lines to return.
+
+        Returns:
+            ReadResult with file_data on success, or `error` populated on
+            read failure, decode failure, or an out-of-range offset on a
+            non-empty file. Empty files always succeed with empty content
+            regardless of offset.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            try:
+                internal_path = self._to_internal(file_path)
+                content = self._read_bytes_at(internal_path)
+            except Exception as e:
+                logger.warning("Failed to read file '%s': %s", file_path, e)
+                return ReadResult(error=f"Failed to read '{file_path}': {e}")
+
+            try:
+                decoded = content.decode("utf-8")
+            except UnicodeDecodeError as e:
+                logger.warning("Failed to decode '%s' as UTF-8: %s", file_path, e)
+                return ReadResult(
+                    error=f"Cannot decode '{file_path}' as UTF-8: {e}"
+                )
+
+            lines = decoded.splitlines()
+            if not lines:
+                return ReadResult(file_data=FileData(content="", encoding="utf-8"))
+
+            start = max(0, offset)
+            if start >= len(lines):
+                return ReadResult(
+                    error=f"Line offset {offset} exceeds file length ({len(lines)} lines)"
+                )
+            end = min(len(lines), start + limit)
+            selected = "\n".join(lines[start:end])
+            return ReadResult(file_data=FileData(content=selected, encoding="utf-8"))
+
+    def grep(
+        self,
+        pattern: str,
+        path: Optional[str] = None,
+        glob: Optional[str] = None,
+    ) -> GrepResult:
+        """Search for a literal text pattern in files.
+
+        Args:
+            pattern: Fixed string pattern to search for.
+            path: Base path to search in (default: /).
+            glob: Optional glob pattern to filter files (e.g., "*.py").
+
+        Returns:
+            GrepResult with matches on success or error message on failure.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            base_path = path or "/"
+            internal_path = self._to_internal(base_path)
+
+            grep_opts = "-rHnFZ"
+            parts = ["grep", grep_opts]
+            if glob:
+                parts.append(f"--include={shlex.quote(glob)}")
+            parts.extend(["-e", shlex.quote(pattern), shlex.quote(internal_path)])
+            command = " ".join(parts)
+            try:
+                run_kwargs: Dict[str, Any] = {}
+                if self._default_timeout_seconds is not None:
+                    run_kwargs["timeout"] = self._default_timeout_seconds
+                result = sandbox.commands.run(command, **run_kwargs)
+            except Exception as e:
+                logger.warning("grep failed in '%s': %s", base_path, e)
+                return GrepResult(matches=[], error=f"grep failed in '{base_path}': {e}")
+            if result.exit_code >= 2:
+                detail = (
+                    result.stderr.strip()
+                    or result.stdout.strip()
+                    or f"exit code {result.exit_code}"
+                )
+                return GrepResult(
+                    matches=[],
+                    error=f"grep failed in '{base_path}': {detail}",
+                )
+            if not result.stdout.strip():
+                return GrepResult(matches=[])
+
+            matches: List[GrepMatch] = []
+            for line in result.stdout.splitlines():
+                nul_pos = line.find("\0")
+                if nul_pos < 0:
+                    parts = line.split(":", 2)
+                    if len(parts) != 3:
+                        logger.debug("Skipping malformed grep output line: %s", line)
+                        continue
+                    raw_path, line_no, text = parts
+                else:
+                    raw_path = line[:nul_pos]
+                    remainder = line[nul_pos + 1:]
+                    parts = remainder.split(":", 1)
+                    if len(parts) != 2:
+                        logger.debug("Skipping malformed grep output line: %s", line)
+                        continue
+                    line_no, text = parts
+                public_path = self._to_public(raw_path)
+                try:
+                    line_int = int(line_no)
+                except ValueError:
+                    logger.debug("Skipping grep line with invalid line number: %s", line)
+                    continue
+                matches.append(GrepMatch(path=public_path, line=line_int, text=text))
+
+            return GrepResult(matches=matches)
+
+    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        """Find files matching a glob pattern.
+
+        Args:
+            pattern: Glob pattern to match (e.g., "*.py", "**/*.txt").
+            path: Base path to search in.
+
+        Returns:
+            GlobResult with matching entries on success, or `error` populated
+            on total failure. On partial failures (e.g. permission denied on
+            a subdirectory), available results are still returned without an
+            error so callers can proceed with what was accessible.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            internal_path = self._to_internal(path)
+
+            normalized_pattern = pattern.lstrip("/")
+            try:
+                matcher = _compile_glob(normalized_pattern)
+            except re.error as e:
+                return GlobResult(
+                    matches=[],
+                    error=f"invalid glob pattern {pattern!r}: {e}",
+                )
+            except Exception as e:
+                logger.error(
+                    "glob matcher compilation failed for pattern %r: %s: %s",
+                    pattern, type(e).__name__, e,
+                )
+                return GlobResult(
+                    matches=[],
+                    error=(
+                        f"internal error compiling glob pattern {pattern!r}: "
+                        f"{type(e).__name__}: {e}"
+                    ),
+                )
+
+            # NUL-delimited fields guard against whitespace or newlines in
+            # pathnames — splitting on spaces breaks if any component
+            # contains one, silently dropping or mis-attributing matches.
+            # Record format: "<type>\\t<size>\\t<mtime>\\t<path>\\0"
+            command = (
+                f"find -L {shlex.quote(internal_path)} -mindepth 1"
+                f" \\( -type d -printf 'd\\t%s\\t%T@\\t%p\\0' \\)"
+                f" -o \\( -printf 'f\\t%s\\t%T@\\t%p\\0' \\)"
+            )
+            try:
+                run_kwargs: Dict[str, Any] = {}
+                if self._default_timeout_seconds is not None:
+                    run_kwargs["timeout"] = self._default_timeout_seconds
+                result = sandbox.commands.run(command, **run_kwargs)
+            except Exception as e:
+                logger.warning("glob failed for path '%s': %s", path, e)
+                return GlobResult(matches=[], error=f"glob failed in '{path}': {e}")
+            if result.exit_code != 0:
+                detail = result.stderr.strip() or f"exit code {result.exit_code}"
+                logger.warning(
+                    "glob partial failure for path '%s': exit_code=%d, stderr=%s",
+                    path, result.exit_code, result.stderr
+                )
+                if not result.stdout:
+                    return GlobResult(matches=[], error=f"glob failed in '{path}': {detail}")
+
+            entries: List[FileInfo] = []
+            for record in result.stdout.split("\x00"):
+                if not record:
+                    continue
+                parts = record.split("\t", 3)
+                if len(parts) != 4:
+                    logger.debug("glob: malformed record %r", record)
+                    continue
+                type_char, size_str, mod_str, raw = parts
+                if type_char not in ("d", "f"):
+                    continue
+                rel_path = posixpath.relpath(raw, internal_path)
+                if matcher(rel_path):
+                    public_path = self._to_public(raw)
+                    info = FileInfo(path=public_path, is_dir=(type_char == "d"))
+                    try:
+                        info["size"] = int(size_str)
+                    except ValueError:
+                        logger.debug("glob: unparseable size %r for %s", size_str, raw)
+                    try:
+                        info["modified_at"] = datetime.fromtimestamp(
+                            float(mod_str), tz=timezone.utc,
+                        ).isoformat()
+                    except (ValueError, OSError):
+                        logger.debug("glob: unparseable mod_time %r for %s", mod_str, raw)
+                    entries.append(info)
+
+            entries.sort(key=lambda item: item["path"])
+            return GlobResult(matches=entries)
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Create a new file with the given content.
+
+        Args:
+            file_path: Path for the new file.
+            content: Content to write.
+
+        Returns:
+            WriteResult with error=None on success, or error message on failure.
+            Fails if file already exists.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            try:
+                internal_path = self._resolve_write_path(file_path)
+            except ValueError as e:
+                return WriteResult(
+                    error=f"Error: Invalid path '{file_path}': {e}",
+                    path=file_path,
+                )
+
+            try:
+                if self._path_exists_at(internal_path):
+                    return WriteResult(
+                        error=f"File '{file_path}' already exists",
+                        path=file_path,
+                    )
+                self._ensure_parent_dir(internal_path)
+                payload = content.encode("utf-8") if isinstance(content, str) else content
+                self._write_bytes_at(internal_path, payload)
+            except Exception as e:
+                logger.error("write failed for '%s': %s", file_path, e)
+                return WriteResult(
+                    error=f"Error writing '{file_path}': {e}",
+                    path=file_path,
+                )
+            self._send_files_update({file_path: create_file_data(content)})
+            return WriteResult(path=file_path)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """Replace a string in a file.
+
+        Args:
+            file_path: Path to the file to edit.
+            old_string: String to find and replace.
+            new_string: Replacement string.
+            replace_all: If True, replace all occurrences. If False, requires
+                         exactly one occurrence.
+
+        Returns:
+            EditResult with error=None on success, or error message on failure.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            try:
+                internal_path = self._resolve_write_path(file_path)
+            except ValueError as e:
+                return EditResult(
+                    error=f"Error: Invalid path '{file_path}': {e}",
+                    path=file_path,
+                    occurrences=0,
+                )
+            try:
+                raw = self._read_bytes_at(internal_path)
+            except Exception as e:
+                logger.warning("Failed to read file '%s' for edit: %s", file_path, e)
+                return EditResult(
+                    error=f"Error reading '{file_path}': {e}",
+                    path=file_path,
+                    occurrences=0,
+                )
+
+            try:
+                content = raw.decode("utf-8")
+            except UnicodeDecodeError as e:
+                logger.warning("Failed to decode '%s' as UTF-8 for edit: %s", file_path, e)
+                return EditResult(
+                    error=f"Error: Cannot edit '{file_path}': not valid UTF-8 ({e})",
+                    path=file_path,
+                    occurrences=0,
+                )
+            occurrences = content.count(old_string)
+            if occurrences == 0:
+                return EditResult(
+                    error=f"Error: String not found in file: '{old_string}'",
+                    path=file_path,
+                    occurrences=0,
+                )
+            if not replace_all and occurrences > 1:
+                return EditResult(
+                    error=(
+                        f"Error: String '{old_string}' appears multiple times. "
+                        "Use replace_all=True to replace all occurrences."
+                    ),
+                    path=file_path,
+                    occurrences=occurrences,
+                )
+
+            if replace_all:
+                updated = content.replace(old_string, new_string)
+            else:
+                updated = content.replace(old_string, new_string, 1)
+            try:
+                self._write_bytes_at(internal_path, updated.encode("utf-8"))
+            except Exception as e:
+                logger.error("edit upload failed for '%s': %s", file_path, e)
+                return EditResult(
+                    error=f"Error writing '{file_path}': {e}",
+                    path=file_path,
+                    occurrences=0,
+                )
+            self._send_files_update({file_path: create_file_data(updated)})
+            return EditResult(
+                path=file_path,
+                occurrences=occurrences if replace_all else 1,
+            )
+
+    def upload_files(
+        self, files: Union[Dict[str, bytes], Iterable[Tuple[str, bytes]]]
+    ) -> List[FileUploadResponse]:
+        """Upload multiple files to the sandbox.
+
+        Args:
+            files: Dict or iterable of (path, content) pairs.
+
+        Returns:
+            List of FileUploadResponse for each file.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            pairs = cast(
+                List[Tuple[str, bytes]],
+                list(files.items()) if isinstance(files, dict) else list(files),
+            )
+            responses: List[FileUploadResponse] = []
+            for path, payload in pairs:
+                try:
+                    internal_path = self._resolve_write_path(path)
+                except ValueError as e:
+                    logger.warning("Invalid path '%s': %s", path, e)
+                    responses.append(FileUploadResponse(path=path, error="invalid_path"))
+                    continue
+
+                state = self._file_state(internal_path)
+                if state == "error":
+                    responses.append(FileUploadResponse(path=path, error=cast(Any, "upload_failed")))
+                    continue
+                if state == "dir":
+                    responses.append(FileUploadResponse(path=path, error="is_directory"))
+                    continue
+                if state == "denied":
+                    responses.append(FileUploadResponse(path=path, error="permission_denied"))
+                    continue
+
+                parent_dir = posixpath.dirname(internal_path)
+                parent_state = self._dir_state(parent_dir)
+                if parent_state == "error":
+                    responses.append(FileUploadResponse(path=path, error=cast(Any, "upload_failed")))
+                    continue
+                if parent_state == "not_dir":
+                    responses.append(FileUploadResponse(path=path, error="invalid_path"))
+                    continue
+                if parent_state == "denied":
+                    responses.append(FileUploadResponse(path=path, error="permission_denied"))
+                    continue
+                if parent_state == "missing":
+                    try:
+                        self._ensure_parent_dir(internal_path)
+                    except Exception as e:
+                        logger.error(
+                            "Failed to create parent dir for upload '%s': %s: %s",
+                            path, type(e).__name__, e,
+                        )
+                        responses.append(FileUploadResponse(path=path, error=cast(Any, "upload_failed")))
+                        continue
+
+                try:
+                    self._write_bytes_at(internal_path, payload)
+                    responses.append(FileUploadResponse(path=path, error=None))
+                except Exception as e:
+                    logger.error("Upload failed for '%s': %s: %s", path, type(e).__name__, e)
+                    responses.append(FileUploadResponse(path=path, error=cast(Any, "upload_failed")))
+
+            # Batch-send state updates for all successfully uploaded files.
+            files_update: dict[str, Any] = {}
+            for resp, (orig_path, payload) in zip(responses, pairs):
+                if resp.error is None:
+                    try:
+                        text = payload.decode("utf-8")
+                    except UnicodeDecodeError:
+                        import base64 as _b64
+                        text = _b64.b64encode(payload).decode("ascii")
+                    files_update[orig_path] = create_file_data(text)
+            if files_update:
+                self._send_files_update(files_update)
+
+            return responses
+
+    def download_files(self, paths: Iterable[str]) -> List[FileDownloadResponse]:
+        """Download multiple files from the sandbox.
+
+        Args:
+            paths: Iterable of file paths to download.
+
+        Returns:
+            List of FileDownloadResponse for each file.
+        """
+        sandbox = self._assert_sandbox()
+        with self._track_op():
+            responses: List[FileDownloadResponse] = []
+            for path in paths:
+                try:
+                    internal_path = self._to_internal(path)
+                except ValueError as e:
+                    logger.warning("Invalid path '%s': %s", path, e)
+                    responses.append(FileDownloadResponse(path=path, content=None, error="invalid_path"))
+                    continue
+                state = self._file_state(internal_path)
+                if state == "error":
+                    responses.append(FileDownloadResponse(path=path, content=None, error=cast(Any, "download_failed")))
+                    continue
+                if state == "missing":
+                    responses.append(FileDownloadResponse(path=path, content=None, error="file_not_found"))
+                    continue
+                if state == "dir":
+                    responses.append(FileDownloadResponse(path=path, content=None, error="is_directory"))
+                    continue
+                if state == "denied":
+                    responses.append(FileDownloadResponse(path=path, content=None, error="permission_denied"))
+                    continue
+                try:
+                    content = self._read_bytes_at(internal_path)
+                    responses.append(FileDownloadResponse(path=path, content=content, error=None))
+                except Exception as e:
+                    logger.error("Download failed for '%s': %s: %s", path, type(e).__name__, e)
+                    responses.append(FileDownloadResponse(path=path, content=None, error=cast(Any, "download_failed")))
+            return responses
+
+    def _ensure_parent_dir(self, internal_path: str) -> None:
+        assert self._sandbox is not None
+        parent = posixpath.dirname(internal_path)
+        command = shlex.join(["mkdir", "-p", parent])
+        result = self._sandbox.commands.run(command)
+        if result.exit_code != 0:
+            error_msg = result.stderr.strip() if result.stderr else f"mkdir failed with exit code {result.exit_code}"
+            raise RuntimeError(f"Cannot create parent directory '{parent}': {error_msg}")
+
+    def _resolve_write_path(self, path: str) -> str:
+        """Resolve a write path while allowing absolute paths outside root_dir."""
+        candidate = path.strip()
+        if not candidate:
+            raise ValueError("empty path")
+        normalized = posixpath.normpath(candidate)
+        if (
+            self._allow_absolute_paths
+            and normalized.startswith("/")
+            and normalized != self._root_dir
+            and not normalized.startswith(self._root_dir + "/")
+        ):
+            return normalized
+        return self._to_internal(candidate)
+
+    def _to_internal(self, path: str) -> str:
+        """Convert a public virtual path to an internal filesystem path.
+
+        All paths are treated as relative to root_dir after normalization:
+        - Leading slashes are stripped: '/file.txt' -> '{root_dir}/file.txt'
+        - Paths already containing root_dir prefix are normalized
+        - Paths that escape root_dir (.. or ../) raise ValueError
+
+        Args:
+            path: Public virtual path.
+
+        Returns:
+            Internal filesystem path under root_dir.
+
+        Raises:
+            ValueError: If the path escapes root_dir or contains control chars.
+        """
+        stripped = path.strip() or "/"
+        # Reject NUL bytes and ASCII control characters. A NUL byte in a
+        # path passes Python's normpath check but gets truncated at the
+        # C/syscall layer when the sandbox runtime processes it — so
+        # "/app/safe\x00../../etc/passwd" would pass our relpath defense
+        # but resolve to "/app/safe" on the filesystem.
+        if any(ord(c) < 0x20 for c in stripped):
+            raise ValueError(
+                f"Path contains ASCII control characters: {path!r}"
+            )
+        normalized = stripped
+        if normalized == self._root_dir or normalized.startswith(self._root_dir + "/"):
+            normalized = normalized[len(self._root_dir):]
+        normalized = normalized.lstrip("/")
+        internal_path = posixpath.normpath(posixpath.join(self._root_dir, normalized))
+        rel = posixpath.relpath(internal_path, self._root_dir)
+        if rel == ".." or rel.startswith("../"):
+            raise ValueError(f"Path '{path}' escapes root_dir '{self._root_dir}'")
+        return internal_path
+
+    def _to_relative(self, path: str) -> str:
+        internal_path = self._to_internal(path)
+        rel = posixpath.relpath(internal_path, self._root_dir)
+        return "." if rel == "." else rel
+
+    def _to_runtime_relative(self, internal_path: str) -> str:
+        """Convert an internal absolute path to a runtime-root-relative path.
+
+        The sandbox runtime's file APIs (``files.read`` / ``files.list`` /
+        ``files.exists`` / ``files.write``) treat the path argument as
+        relative to ``runtime_root`` (default ``/app``). This helper
+        bridges the gap between our internal absolute paths (rooted under
+        ``root_dir``, which may differ from ``runtime_root``) and what the
+        runtime expects.
+
+        Raises ValueError if ``internal_path`` escapes ``runtime_root``.
+        """
+        rel = posixpath.relpath(internal_path, self._runtime_root)
+        if rel == ".." or rel.startswith("../"):
+            raise ValueError(
+                f"Internal path '{internal_path}' is outside runtime_root "
+                f"'{self._runtime_root}'"
+            )
+        return "." if rel == "." else rel
+
+    # ---- Dual-mode file IO helpers --------------------------------------
+    #
+    # The runtime file API (``sandbox.files.*``) is anchored at
+    # ``runtime_root`` and rejects paths outside it (as of the C4 SDK
+    # sanitizer). When ``allow_absolute_paths=True`` callers can target
+    # paths outside ``runtime_root`` (e.g. /tmp/...); for those we fall
+    # back to running shell commands to honor the same operations
+    # safely, so the feature keeps working without re-introducing the
+    # upload-path-traversal vector.
+
+    def _write_bytes_at(self, internal_path: str, payload: bytes) -> None:
+        """Write ``payload`` to ``internal_path`` via file API or shell fallback."""
+        assert self._sandbox is not None
+        try:
+            runtime_rel = self._to_runtime_relative(internal_path)
+        except ValueError:
+            runtime_rel = None
+        if runtime_rel is not None:
+            self._sandbox.files.write(runtime_rel, payload)
+            return
+        encoded = base64.b64encode(payload).decode("ascii")
+        pipeline = (
+            f"printf %s {shlex.quote(encoded)} "
+            f"| base64 -d > {shlex.quote(internal_path)}"
+        )
+        command = f"sh -c {shlex.quote(pipeline)}"
+        result = self._sandbox.commands.run(command)
+        if result.exit_code != 0:
+            detail = result.stderr.strip() or f"exit code {result.exit_code}"
+            raise RuntimeError(f"Write to '{internal_path}' failed: {detail}")
+
+    def _read_bytes_at(self, internal_path: str) -> bytes:
+        """Read bytes from ``internal_path`` via file API or shell fallback."""
+        assert self._sandbox is not None
+        try:
+            runtime_rel = self._to_runtime_relative(internal_path)
+        except ValueError:
+            runtime_rel = None
+        if runtime_rel is not None:
+            return self._sandbox.files.read(runtime_rel)
+        command = f"sh -c {shlex.quote(f'base64 < {shlex.quote(internal_path)}')}"
+        result = self._sandbox.commands.run(command)
+        if result.exit_code != 0:
+            detail = result.stderr.strip() or f"exit code {result.exit_code}"
+            raise RuntimeError(f"Read from '{internal_path}' failed: {detail}")
+        try:
+            return base64.b64decode(result.stdout)
+        except Exception as e:
+            raise RuntimeError(f"Decode of '{internal_path}' output failed: {e}") from e
+
+    def _path_exists_at(self, internal_path: str) -> bool:
+        """Check whether ``internal_path`` exists via file API or shell fallback."""
+        assert self._sandbox is not None
+        try:
+            runtime_rel = self._to_runtime_relative(internal_path)
+        except ValueError:
+            runtime_rel = None
+        if runtime_rel is not None:
+            return self._sandbox.files.exists(runtime_rel)
+        command = f"sh -c {shlex.quote(f'test -e {shlex.quote(internal_path)}')}"
+        result = self._sandbox.commands.run(command)
+        return result.exit_code == 0
+
+    def _to_public(self, internal_path: str) -> str:
+        rel = posixpath.relpath(internal_path, self._root_dir)
+        if rel == ".":
+            return "/"
+        return "/" + rel
+
+    def _normalize_public_dir(self, path: str) -> str:
+        if not path or path == "/":
+            return "/"
+        if path == self._root_dir or path.startswith(self._root_dir + "/"):
+            path = path[len(self._root_dir):]
+        return "/" + path.strip("/")
+
+    def _probe_state(
+        self, check_script: str, valid: frozenset, label: str,
+    ) -> str:
+        """Run a shell probe and validate the single-word stdout result."""
+        assert self._sandbox is not None
+        result = self._sandbox.commands.run(f"sh -c {shlex.quote(check_script)}")
+        output = result.stdout.strip()
+        if not output and result.exit_code != 0:
+            logger.warning(
+                "_%s command failed: exit_code=%d, stderr=%s",
+                label, result.exit_code, result.stderr,
+            )
+            return "error"
+        state = output or "missing"
+        if state not in valid:
+            logger.warning("_%s returned unexpected value %r", label, state)
+            return "error"
+        return state
+
+    _FILE_STATE_VALID = frozenset({"missing", "dir", "file", "denied"})
+
+    def _file_state(self, internal_path: str) -> str:
+        """Returns: 'missing', 'dir', 'file', 'denied', or 'error'."""
+        check = (
+            f"if [ ! -e {shlex.quote(internal_path)} ]; then echo missing; exit 0; fi; "
+            f"if [ -d {shlex.quote(internal_path)} ]; then echo dir; exit 0; fi; "
+            f"if [ -r {shlex.quote(internal_path)} ]; then echo file; else echo denied; fi"
+        )
+        return self._probe_state(check, self._FILE_STATE_VALID, "file_state")
+
+    _DIR_STATE_VALID = frozenset({"missing", "writable", "denied", "not_dir"})
+
+    def _dir_state(self, internal_path: str) -> str:
+        """Returns: 'missing', 'writable', 'denied', 'not_dir', or 'error'."""
+        check = (
+            f"if [ ! -e {shlex.quote(internal_path)} ]; then echo missing; exit 0; fi; "
+            f"if [ -d {shlex.quote(internal_path)} ]; then "
+            f"if [ -w {shlex.quote(internal_path)} ]; then echo writable; else echo denied; fi; "
+            f"exit 0; fi; "
+            f"echo not_dir"
+        )
+        return self._probe_state(check, self._DIR_STATE_VALID, "dir_state")
+
+    @staticmethod
+    def delete_all(
+        client: SandboxClient,
+        namespace: str = "default",
+        best_effort: bool = True,
+        label_selector: Optional[str] = None,
+    ) -> int:
+        """Delete SandboxClaims in the given namespace.
+
+        When ``label_selector`` is provided, only claims matching the
+        selector are deleted — safe for use in shared namespaces.
+        Without a selector, **all** claims in the namespace are deleted.
+
+        Args:
+            client: Pre-configured ``SandboxClient``.
+            namespace: Kubernetes namespace to clean up.
+            best_effort: If True (default), log delete failures and
+                continue. If False, raise on the first failure.
+            label_selector: Optional Kubernetes label selector string
+                (e.g. ``"app=myapp"``). When set, only claims matching
+                the selector are deleted.
+
+        Returns:
+            Number of claims successfully deleted.
+
+        Raises:
+            Exception: On delete failure when ``best_effort=False``.
+        """
+        claims = client.list_all_sandboxes(
+            namespace=namespace, label_selector=label_selector,
+        )
+        deleted = 0
+        for claim in claims:
+            try:
+                client.delete_sandbox(claim_name=claim, namespace=namespace)
+                deleted += 1
+            except Exception as e:
+                if best_effort:
+                    logger.warning(
+                        "delete_all: failed to delete '%s' in namespace '%s': %s",
+                        claim, namespace, e,
+                    )
+                else:
+                    raise
+        return deleted
+
+    @property
+    def id(self) -> str:
+        """Return a namespace-qualified sandbox identifier.
+
+        Format: ``{namespace}/{claim_name}``. Namespace-qualification
+        prevents collisions when multiple namespaces are in use.
+        Falls back to ``"agent-sandbox"`` before ``__enter__`` is called.
+        """
+        if self._sandbox is not None:
+            ns = getattr(self._sandbox, "namespace", None) or "default"
+            claim = getattr(self._sandbox, "claim_name", None)
+            if claim:
+                return f"{ns}/{claim}"
+        return "agent-sandbox"
+
+
+def create_sandbox_backend_factory(
+    template_name: str,
+    namespace: str = "default",
+    **kwargs: Any,
+) -> Callable[[Any], AgentSandboxBackend]:
+    """Create a BackendFactory for use with create_deep_agent().
+
+    This factory function returns a callable that creates an AgentSandboxBackend
+    when invoked with a ToolRuntime. The ToolRuntime provides state and store,
+    but our backend doesn't need them since execution happens in the sandbox.
+
+    The factory eagerly provisions the sandbox before returning, so the
+    returned backend is immediately usable for `execute`/`ls`/`read`/etc.
+    A finalizer is registered to delete the sandbox when the backend is
+    garbage-collected or at interpreter shutdown -- the deepagents
+    ``create_deep_agent(backend=...)`` contract uses the factory result
+    directly without a ``with`` block, so the lifecycle has to be
+    managed transparently rather than via a context manager.
+
+    If you DO want context-manager semantics (eager teardown on exit
+    rather than GC-time), use ``AgentSandboxBackend.from_template(...)``
+    directly inside a ``with`` block.
+
+    Usage:
+        from deepagents import create_deep_agent
+        from langchain_agent_sandbox import create_sandbox_backend_factory
+
+        agent = create_deep_agent(
+            backend=create_sandbox_backend_factory("my-template")
+        )
+
+    Args:
+        template_name: Name of the SandboxTemplate to claim.
+        namespace: Kubernetes namespace for the sandbox.
+        **kwargs: Additional arguments passed to AgentSandboxBackend.from_template().
+
+    Returns:
+        A factory callable that accepts a ToolRuntime and returns a fully
+        initialized AgentSandboxBackend.
+    """
+    def factory(_runtime: Any) -> AgentSandboxBackend:
+        backend = AgentSandboxBackend.from_template(
+            template_name=template_name,
+            namespace=namespace,
+            **kwargs,
+        )
+        # Eagerly enter so the sandbox is provisioned and `_sandbox` is
+        # populated before the deepagents agent loop starts calling
+        # methods on it. Without this, the first execute()/ls()/etc.
+        # raises `AttributeError: 'NoneType' object has no attribute
+        # 'commands'` because from_template() defers sandbox creation
+        # to __enter__.
+        backend.__enter__()
+        # Register a finalizer that tears the sandbox down when the
+        # backend is garbage-collected OR at interpreter shutdown
+        # (whichever comes first). weakref.finalize captures strong
+        # references to the SDK client and sandbox handle in its
+        # closure, so the cleanup can fire even after the backend
+        # itself is collected. If the user explicitly calls __exit__
+        # on the backend, the finalizer's redundant cleanup attempt
+        # 404s and is silently swallowed by `_factory_atexit_cleanup`.
+        #
+        # The finalize handle is also stored on the backend so it can
+        # be invoked deterministically from tests (calling
+        # `backend._finalizer()` triggers the cleanup synchronously
+        # without relying on `del + gc.collect()` GC ordering).
+        backend._finalizer = weakref.finalize(  # type: ignore[attr-defined]
+            backend,
+            _factory_atexit_cleanup,
+            backend._sdk_client,
+            backend._sandbox,
+        )
+        return backend
+
+    return factory
+
+
+def _factory_atexit_cleanup(sdk_client: Any, sandbox: Any) -> None:
+    """Best-effort sandbox teardown for factory-created backends.
+
+    Called by ``weakref.finalize`` when the backend is garbage-collected
+    OR at interpreter shutdown. Two failure modes are silenced:
+
+    1. A 404 from the SDK — the user already called ``__exit__``
+       explicitly and the claim is already gone. Not actionable.
+    2. Any exception while logging — at interpreter shutdown the
+       logging subsystem may already be torn down, and a finalizer
+       that raises during shutdown produces a confusing traceback.
+
+    Every other failure (auth expiry, network partition, RBAC
+    revocation, API outage, malformed claim, transient 5xx) is logged
+    at ERROR so operators can see leaked sandboxes. Logging-during-GC
+    is safe; the shutdown-only concern is handled by the inner guard.
+    """
+    if sdk_client is None or sandbox is None:
+        return
+    claim = getattr(sandbox, "claim_name", None)
+    ns = getattr(sandbox, "namespace", None)
+    if claim is None:
+        return
+    try:
+        sdk_client.delete_sandbox(claim_name=claim, namespace=ns)
+    except Exception as e:
+        # 404 means the user's explicit __exit__ already cleaned up;
+        # this finalizer is the redundant best-effort path. Status
+        # comes from either the kubernetes ApiException shape or the
+        # requests Response shape, depending on which transport raised.
+        status = getattr(e, "status", None) or getattr(
+            getattr(e, "response", None), "status_code", None
+        )
+        if status == 404:
+            return
+        # Log the leak so it's at least visible. Wrap in its own try
+        # because at interpreter shutdown the logging machinery can
+        # be partially torn down — a logging failure inside the
+        # finalizer must not propagate.
+        try:
+            logger.error(
+                "Finalizer failed to delete sandbox (claim=%s, namespace=%s): "
+                "%s: %s",
+                claim, ns, type(e).__name__, e,
+            )
+        except Exception:
+            pass
+
+
+class SandboxPolicyWrapper(SandboxBackendProtocol):
+    """Wraps AgentSandboxBackend with policy enforcement.
+
+    Provides best-effort restrictions on sandbox operations as an
+    application-layer guardrail. **This is not a security boundary**
+    -- the underlying sandbox controller and kernel-level isolation
+    (gVisor, Kata Containers, etc.) are the real security boundary.
+
+    Features:
+    - deny_prefixes: Block writes/edits under certain paths
+      (e.g., /etc, /sys). Paths are canonicalized before matching so
+      traversal-style bypasses like `/app/../etc` are caught.
+    - deny_commands: Substring match against execute() commands
+      (e.g., "rm -rf"). This is trivially bypassable via aliases or
+      shell variations -- treat it as a speed bump, not a barrier.
+    - audit_log: Optional callable invoked for every write / edit /
+      execute / upload operation. By default, callback failures are
+      logged at WARNING and the operation proceeds (fail-open). Set
+      ``strict_audit=True`` to refuse operations whose audit log
+      cannot be written -- use this when audit completeness matters
+      more than availability (e.g. compliance environments).
+
+    Audit log callback signature:
+        def audit_log(operation: str, target: str, metadata: dict) -> None:
+            # operation: "write", "edit", "execute", "upload"
+            # target: file path or command string
+            # metadata: {"size": int} for write/upload, {"replace_all": bool} for edit
+
+    Usage:
+        backend = AgentSandboxBackend.from_template("my-template")
+        wrapped = SandboxPolicyWrapper(
+            backend,
+            deny_prefixes=["/etc", "/sys", "/proc"],
+            deny_commands=["rm -rf", "shutdown", "reboot"],
+            audit_log=lambda op, target, meta: print(f"{op}: {target}"),
+            strict_audit=False,  # default: fail-open audit
+        )
+    """
+
+    def __init__(
+        self,
+        backend: AgentSandboxBackend,
+        deny_prefixes: Optional[List[str]] = None,
+        deny_commands: Optional[List[str]] = None,
+        audit_log: Optional[Callable[[str, str, dict], None]] = None,
+        *,
+        strict_audit: bool = False,
+    ) -> None:
+        self._backend = backend
+        self._deny_prefixes_write: List[str] = []
+        self._deny_prefixes_edit: List[str] = []
+        self._deny_prefixes_canonical: List[str] = []
+        for prefix in (deny_prefixes or []):
+            self._deny_prefixes_write.append(
+                self._normalize_prefix(self._resolve_prefix(prefix, for_write=True))
+            )
+            self._deny_prefixes_edit.append(
+                self._normalize_prefix(self._resolve_prefix(prefix, for_write=False))
+            )
+            self._deny_prefixes_canonical.append(
+                self._normalize_prefix(self._canonicalize_path(prefix))
+            )
+        self._deny_commands = deny_commands or []
+        self._audit_log = audit_log
+        self._strict_audit = strict_audit
+
+    def __enter__(self) -> "SandboxPolicyWrapper":
+        self._backend.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._backend.__exit__(exc_type, exc, tb)
+
+    async def __aenter__(self) -> "SandboxPolicyWrapper":
+        return self.__enter__()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self.__exit__(exc_type, exc, tb)
+
+    def _emit_audit(self, operation: str, target: str, metadata: dict) -> Optional[str]:
+        """Invoke the audit log callback if configured.
+
+        Returns ``None`` on success (or when no audit log is set), and
+        a deny-reason string when the operation should be refused. In
+        ``strict_audit=False`` mode (the default), audit failures are
+        logged at WARNING with full operation context (including
+        ``exc_info``) and the operation proceeds. In ``strict_audit=True``
+        mode, the same failures cause this method to return a refusal
+        string that callers convert into a per-operation denied result.
+        """
+        if self._audit_log is None:
+            return None
+        try:
+            self._audit_log(operation, target, metadata)
+            return None
+        except Exception as e:
+            if self._strict_audit:
+                logger.error(
+                    "Audit log callback failed for %s on %s "
+                    "(strict mode: refusing operation); metadata=%s",
+                    operation, target, metadata,
+                    exc_info=True,
+                )
+                return f"Audit log unavailable; refusing {operation}: {e}"
+            # Fail-open: include operation/target/metadata so SREs can
+            # diagnose audit-pipeline failures without grepping through
+            # the request log to find which call wasn't recorded.
+            # `exc_info=True` preserves the traceback for non-trivial
+            # callback failures (e.g. transient ConnectionError vs.
+            # configuration bug).
+            logger.warning(
+                "Audit log callback failed for %s on %s "
+                "(fail-open: operation will proceed); metadata=%s",
+                operation, target, metadata,
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _canonicalize_path(path: str) -> str:
+        normalized = posixpath.normpath(path.strip() or "/")
+        return "/" + normalized.lstrip("/")
+
+    @staticmethod
+    def _normalize_prefix(path: str) -> str:
+        canonical_path = SandboxPolicyWrapper._canonicalize_path(path)
+        return canonical_path.rstrip("/") + "/" if canonical_path != "/" else "/"
+
+    def _resolve_prefix(self, path: str, for_write: bool) -> str:
+        stripped = path.strip() or "/"
+        if stripped == "/":
+            return "/"
+        try:
+            if for_write:
+                return self._backend._resolve_write_path(stripped)
+            return self._backend._to_internal(stripped)
+        except ValueError:
+            return self._canonicalize_path(stripped)
+
+    def _resolve_candidate_path(self, path: str, for_write: bool) -> str:
+        try:
+            if for_write:
+                return self._backend._resolve_write_path(path)
+            return self._backend._to_internal(path)
+        except ValueError:
+            return self._canonicalize_path(path)
+
+    def _is_denied_path(self, path: str, for_write: bool) -> bool:
+        normalized = self._normalize_prefix(self._resolve_candidate_path(path, for_write))
+        deny_prefixes = self._deny_prefixes_write if for_write else self._deny_prefixes_edit
+        if any(normalized.startswith(prefix) for prefix in deny_prefixes):
+            return True
+
+        # Catch traversal-style bypasses (e.g. /app/../etc) using canonical path checks.
+        parts = [part for part in path.split("/") if part]
+        if ".." in parts:
+            canonical = self._normalize_prefix(self._canonicalize_path(path))
+            return any(canonical.startswith(prefix) for prefix in self._deny_prefixes_canonical)
+
+        return False
+
+    def _is_denied_command(self, cmd: str) -> bool:
+        return any(pattern in cmd for pattern in self._deny_commands)
+
+    def ls(self, path: str) -> LsResult:
+        return self._backend.ls(path)
+
+    def read(
+        self,
+        file_path: str,
+        offset: int = 0,
+        limit: int = 2000,
+    ) -> ReadResult:
+        return self._backend.read(file_path, offset, limit)
+
+    def grep(
+        self,
+        pattern: str,
+        path: Optional[str] = None,
+        glob: Optional[str] = None,
+    ) -> GrepResult:
+        return self._backend.grep(pattern, path, glob)
+
+    def glob(self, pattern: str, path: str = "/") -> GlobResult:
+        return self._backend.glob(pattern, path)
+
+    def download_files(self, paths: Iterable[str]) -> List[FileDownloadResponse]:
+        return self._backend.download_files(paths)
+
+    def write(self, file_path: str, content: str) -> WriteResult:
+        """Write file with policy check."""
+        if self._is_denied_path(file_path, for_write=True):
+            return WriteResult(
+                error=f"Policy denied: writes not allowed under '{file_path}'",
+                path=file_path,
+            )
+        deny = self._emit_audit("write", file_path, {"size": len(content)})
+        if deny is not None:
+            return WriteResult(error=deny, path=file_path)
+        return self._backend.write(file_path, content)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        replace_all: bool = False,
+    ) -> EditResult:
+        """Edit file with policy check."""
+        if self._is_denied_path(file_path, for_write=False):
+            return EditResult(
+                error=f"Policy denied: edits not allowed under '{file_path}'",
+                path=file_path,
+                occurrences=0,
+            )
+        deny = self._emit_audit("edit", file_path, {"replace_all": replace_all})
+        if deny is not None:
+            return EditResult(error=deny, path=file_path, occurrences=0)
+        return self._backend.edit(file_path, old_string, new_string, replace_all)
+
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: Optional[int] = None,
+    ) -> ExecuteResponse:
+        """Execute command with policy check."""
+        if self._is_denied_command(command):
+            return ExecuteResponse(
+                output="Policy denied: command blocked by policy",
+                exit_code=1,
+                truncated=False,
+            )
+        deny = self._emit_audit("execute", command, {})
+        if deny is not None:
+            return ExecuteResponse(output=deny, exit_code=1, truncated=False)
+        return self._backend.execute(command, timeout=timeout)
+
+    def upload_files(
+        self, files: Union[Dict[str, bytes], Iterable[Tuple[str, bytes]]]
+    ) -> List[FileUploadResponse]:
+        """Upload files with policy check. Preserves input order in responses."""
+        pairs = cast(
+            List[Tuple[str, bytes]],
+            list(files.items()) if isinstance(files, dict) else list(files),
+        )
+        responses: List[Optional[FileUploadResponse]] = [None] * len(pairs)
+        allowed: List[Tuple[int, str, bytes]] = []
+
+        for idx, (path, payload) in enumerate(pairs):
+            if self._is_denied_path(path, for_write=True):
+                responses[idx] = FileUploadResponse(path=path, error=cast(Any, "policy_denied"))
+                continue
+            deny = self._emit_audit("upload", path, {"size": len(payload)})
+            if deny is not None:
+                responses[idx] = FileUploadResponse(path=path, error=cast(Any, deny))
+                continue
+            allowed.append((idx, path, payload))
+
+        if allowed:
+            backend_items = [(path, payload) for _, path, payload in allowed]
+            backend_responses = self._backend.upload_files(backend_items)
+            for (idx, _, _), resp in zip(allowed, backend_responses):
+                responses[idx] = resp
+
+        return responses  # type: ignore[return-value]
+
+    @property
+    def id(self) -> str:
+        return self._backend.id
+
+

--- a/clients/python/langchain-agent-sandbox/pyproject.toml
+++ b/clients/python/langchain-agent-sandbox/pyproject.toml
@@ -1,0 +1,58 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "langchain-agent-sandbox"
+version = "0.1.0"
+description = "LangChain DeepAgents backend for Kubernetes agent-sandbox."
+readme = "README.md"
+requires-python = ">=3.11"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "k8s-agent-sandbox",
+    "deepagents>=0.5.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/kubernetes-sigs/agent-sandbox"
+"Bug Tracker" = "https://github.com/kubernetes-sigs/agent-sandbox/issues"
+
+[tool.setuptools]
+packages = ["langchain_agent_sandbox"]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21.0",
+]
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
+[tool.uv.sources]
+k8s-agent-sandbox = { path = "../agentic-sandbox-client", editable = true }
+
+[tool.mypy]
+python_version = "3.11"
+warn_unused_ignores = true
+no_implicit_optional = true
+
+[[tool.mypy.overrides]]
+module = ["k8s_agent_sandbox.*", "deepagents.*", "pytest.*"]
+ignore_missing_imports = true

--- a/clients/python/langchain-agent-sandbox/tests/test_backend.py
+++ b/clients/python/langchain-agent-sandbox/tests/test_backend.py
@@ -1,0 +1,2842 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_agent_sandbox import (
+    AgentSandboxBackend,
+    SandboxPolicyWrapper,
+    create_sandbox_backend_factory,
+)
+
+
+class _FileEntry:
+    """Minimal stand-in for k8s_agent_sandbox.models.FileEntry."""
+    def __init__(self, name: str, size: int, type: str, mod_time: float):
+        self.name = name
+        self.size = size
+        self.type = type
+        self.mod_time = mod_time
+
+
+class _StubCommands:
+    def __init__(self, run_result):
+        self.run_result = run_result
+        self.last_command = None
+        self.last_kwargs: dict = {}
+        self.calls: list = []
+
+    def run(self, command, **kwargs):
+        self.last_command = command
+        self.last_kwargs = kwargs
+        self.calls.append((command, kwargs))
+        return self.run_result
+
+
+class _StubFiles:
+    def __init__(self, read_bytes=b"", list_entries=None):
+        self.read_bytes = read_bytes
+        self.last_read_path = None
+        self._list_entries = list_entries
+        self.write_calls: list = []
+        self._write_error: Exception | None = None
+
+    def read(self, path, timeout=60):
+        self.last_read_path = path
+        return self.read_bytes
+
+    def write(self, path, content, timeout=60):
+        if self._write_error is not None:
+            raise self._write_error
+        self.write_calls.append((path, content))
+
+    def list(self, path, timeout=60):
+        if self._list_entries is not None:
+            return self._list_entries
+        return []
+
+    def exists(self, path, timeout=60):
+        return False
+
+
+class _StubConnector:
+    def __init__(self):
+        self.requests = []
+
+    def send_request(self, method, endpoint, **kwargs):
+        self.requests.append((method, endpoint, kwargs))
+        return SimpleNamespace(status_code=200)
+
+
+class StubSandbox:
+    """Mimics the upstream Sandbox handle API for unit testing."""
+
+    def __init__(self, run_result=None, read_bytes=b"", list_entries=None):
+        run_result = run_result or SimpleNamespace(stdout="", stderr="", exit_code=0)
+        self.commands = _StubCommands(run_result)
+        self.files = _StubFiles(read_bytes=read_bytes, list_entries=list_entries)
+        self.connector = _StubConnector()
+        self.claim_name = None
+        self.sandbox_id = None
+        self.namespace = "default"
+        self.is_active = True
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
+
+def test_execute_combines_output_and_stderr():
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="err", exit_code=1))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.execute("echo test")
+
+    _require(result.output == "ok\nerr", "Unexpected combined output")
+    _require(result.exit_code == 1, "Unexpected exit code")
+    _require(result.truncated is False, "Unexpected truncation flag")
+
+
+def test_read_missing_file_returns_error():
+    client = StubSandbox()
+    client.files.read = lambda path, timeout=60: (_ for _ in ()).throw(
+        RuntimeError("file not found")
+    )
+    backend = AgentSandboxBackend(client)
+
+    response = backend.read("/missing.txt")
+
+    _require(response.error is not None, "Expected read error")
+    _require("missing.txt" in response.error, f"Expected path in error: {response.error}")
+    _require("file not found" in response.error, "Expected original exception message in error")
+    _require(response.file_data is None, "Expected file_data to be None on error")
+
+
+def test_write_existing_file_returns_error():
+    client = StubSandbox()
+    client.files.exists = lambda path, timeout=60: True
+    backend = AgentSandboxBackend(client)
+
+    result = backend.write("/exists.txt", "data")
+
+    _require(result.error is not None, "Expected write error")
+    _require("already exists" in result.error, "Unexpected write error message")
+
+
+def test_edit_multiple_occurrences_without_replace_all():
+    client = StubSandbox(read_bytes=b"alpha beta alpha")
+    backend = AgentSandboxBackend(client)
+
+    result = backend.edit("/file.txt", "alpha", "gamma", replace_all=False)
+
+    _require(result.error is not None, "Expected edit error")
+    _require("appears multiple times" in result.error, "Unexpected edit error message")
+    _require(result.occurrences == 2, "Unexpected occurrences count")
+
+
+def test_to_internal_blocks_escape():
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+
+    with pytest.raises(ValueError):
+        backend._to_internal("../../etc/passwd")
+
+
+def test_ls_parses_entries():
+    client = StubSandbox(list_entries=[
+        _FileEntry(name="file.txt", size=100, type="file", mod_time=1700000000.0),
+        _FileEntry(name="subdir", size=4096, type="directory", mod_time=1700000001.0),
+    ])
+    backend = AgentSandboxBackend(client)
+
+    result = backend.ls("/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    entries = result.entries
+    _require(len(entries) == 2, "Unexpected number of entries")
+    _require(entries[0]["path"] == "/file.txt", "Unexpected first entry path")
+    _require(entries[0]["is_dir"] is False, "Unexpected first entry type")
+    _require(entries[1]["path"] == "/subdir", "Unexpected second entry path")
+    _require(entries[1]["is_dir"] is True, "Unexpected second entry type")
+
+
+def test_ls_populates_size_and_modified_at():
+    """The native /list endpoint returns size and mod_time which should be
+    mapped to the FileInfo optional fields."""
+    client = StubSandbox(list_entries=[
+        _FileEntry(name="data.csv", size=42, type="file", mod_time=1700000000.0),
+    ])
+    backend = AgentSandboxBackend(client)
+
+    result = backend.ls("/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    entry = result.entries[0]
+    _require(entry.get("size") == 42, f"Expected size=42, got {entry.get('size')}")
+    _require(
+        entry.get("modified_at") is not None,
+        "Expected modified_at to be set",
+    )
+    _require("2023-11-14" in entry["modified_at"], f"Unexpected modified_at: {entry['modified_at']}")
+
+
+def test_ls_filters_dot_and_dotdot():
+    """The /list endpoint may return '.' and '..' entries — these must be filtered."""
+    client = StubSandbox(list_entries=[
+        _FileEntry(name=".", size=4096, type="directory", mod_time=0.0),
+        _FileEntry(name="..", size=4096, type="directory", mod_time=0.0),
+        _FileEntry(name="file.txt", size=100, type="file", mod_time=1700000000.0),
+        _FileEntry(name="dir", size=4096, type="directory", mod_time=1700000001.0),
+    ])
+    backend = AgentSandboxBackend(client)
+
+    result = backend.ls("/")
+
+    entries = result.entries
+    _require(len(entries) == 2, f"Expected 2 entries (no . or ..), got {len(entries)}")
+    paths = [e["path"] for e in entries]
+    _require("/." not in paths and "/.." not in paths, f"Dot entries leaked: {paths}")
+
+
+def test_upload_files_invalid_path():
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._to_internal = lambda _: (_ for _ in ()).throw(ValueError("escape"))
+
+    responses = backend.upload_files({"/bad": b"payload"})
+
+    _require(responses[0].error == "invalid_path", "Unexpected upload error code")
+
+
+def test_upload_files_creates_missing_parent_directory():
+    """upload_files should mkdir -p the parent chain like write() does.
+
+    The deepagents protocol expects `uploadFiles` to work against
+    fresh paths without requiring the caller to pre-create directory
+    trees. Matches the behavior of write() and keeps parity with the
+    deepagents-js shared standard tests, which seed nested initial
+    files through the same code path.
+    """
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "missing"
+    # Simulate a missing parent: _dir_state returns "missing" the first
+    # time (for the initial check) — after _ensure_parent_dir runs via
+    # mkdir -p, the upload proceeds.
+    backend._dir_state = lambda _: "missing"
+    mkdir_calls = []
+    backend._ensure_parent_dir = lambda path: mkdir_calls.append(path)
+    uploaded = []
+    client.files.write = lambda path, content, timeout=60: uploaded.append((path, content))
+
+    responses = backend.upload_files([("/nested/dir/file.txt", b"payload")])
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error is None, f"Expected success, got {responses[0].error}")
+    _require(len(mkdir_calls) == 1, f"Expected one mkdir, got {mkdir_calls}")
+    _require(mkdir_calls[0] == "/app/nested/dir/file.txt", f"Unexpected mkdir target: {mkdir_calls}")
+    # Paths are sent to the runtime relative to runtime_root (/app).
+    _require(uploaded == [("nested/dir/file.txt", b"payload")], f"Unexpected upload: {uploaded}")
+
+
+def test_download_files_missing():
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "missing"
+
+    responses = backend.download_files(["/missing.txt"])
+
+    _require(responses[0].error == "file_not_found", "Unexpected download error code")
+
+
+def test_grep_returns_matches():
+    grep_output = "/app/test.py:10:def foo():\n/app/test.py:20:    foo()\n"
+    client = StubSandbox(run_result=SimpleNamespace(stdout=grep_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+
+    result = backend.grep("foo", path="/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    matches = result.matches
+    _require(len(matches) == 2, f"Expected 2 matches, got {len(matches)}")
+    _require(matches[0]["path"] == "/test.py", f"Unexpected path: {matches[0]['path']}")
+    _require(matches[0]["line"] == 10, f"Unexpected line: {matches[0]['line']}")
+    _require(matches[0]["text"] == "def foo():", f"Unexpected text: {matches[0]['text']}")
+
+
+def test_grep_error_uses_stderr_for_message():
+    """grep exit code >= 2 should surface stderr content in the error message.
+
+    Since the grep command no longer uses `2>&1` (the sandbox runtime
+    doesn't go through a shell, so that redirect became a literal
+    filename arg to grep), the real error text lives on the stderr
+    channel. The error message must read from stderr, not stdout.
+    """
+    client = StubSandbox(
+        run_result=SimpleNamespace(
+            stdout="",
+            stderr="grep: /app/nonexistent: No such file or directory",
+            exit_code=2,
+        )
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("pattern", path="/nonexistent")
+
+    _require(result.error is not None, "Expected error")
+    _require("grep failed" in result.error, f"Unexpected error message prefix: {result.error}")
+    _require(
+        "No such file or directory" in result.error,
+        f"Expected stderr text in error message, got: {result.error!r}",
+    )
+    _require(result.matches == [], "Expected empty matches alongside error")
+
+
+def test_grep_error_falls_back_to_stdout_when_stderr_empty():
+    """If stderr is empty for some reason, fall back to stdout content."""
+    client = StubSandbox(
+        run_result=SimpleNamespace(
+            stdout="legacy-error-on-stdout",
+            stderr="",
+            exit_code=2,
+        )
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("pattern", path="/nonexistent")
+
+    _require(result.error is not None, "Expected error")
+    _require(
+        "legacy-error-on-stdout" in result.error,
+        f"Expected stdout fallback, got: {result.error!r}",
+    )
+
+
+def test_grep_error_reports_exit_code_when_both_streams_empty():
+    """With both streams empty, surface the exit code instead of 'unknown'."""
+    client = StubSandbox(
+        run_result=SimpleNamespace(stdout="", stderr="", exit_code=3)
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("pattern", path="/nonexistent")
+
+    _require(result.error is not None, "Expected error")
+    _require("exit code 3" in result.error, f"Expected exit code in error, got: {result.error!r}")
+
+
+def test_glob_returns_matching_files():
+    find_output = (
+        "f\t0\t0\t/app/src/main.py\x00"
+        "f\t0\t0\t/app/src/utils.py\x00"
+        "f\t0\t0\t/app/tests/test_main.py\x00"
+    )
+    client = StubSandbox(run_result=SimpleNamespace(stdout=find_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("*.py", path="/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    matches = result.matches
+    _require(len(matches) == 3, f"Expected 3 matches, got {len(matches)}")
+    _require(matches[0]["is_dir"] is False, "Expected files, not directories")
+
+
+def test_glob_double_star_matches_root_and_nested():
+    """`**/X` should match X at any depth including the root."""
+    find_output = (
+        "f\t0\t0\t/app/target.txt\x00"
+        "f\t0\t0\t/app/sub/target.txt\x00"
+        "f\t0\t0\t/app/deep/nest/target.txt\x00"
+        "f\t0\t0\t/app/other.txt\x00"
+    )
+    client = StubSandbox(run_result=SimpleNamespace(stdout=find_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("**/target.txt", path="/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    paths = sorted(m["path"] for m in result.matches)
+    _require(
+        paths == ["/deep/nest/target.txt", "/sub/target.txt", "/target.txt"],
+        f"Expected root + 2 nested matches, got {paths}",
+    )
+
+
+def test_glob_prefix_double_star_pattern():
+    """`src/**/*.ts` should match .ts files at any depth under src/."""
+    find_output = (
+        "f\t0\t0\t/app/src/a.ts\x00"
+        "f\t0\t0\t/app/src/dir/b.ts\x00"
+        "f\t0\t0\t/app/src/dir/nested/c.ts\x00"
+        "f\t0\t0\t/app/src/a.js\x00"
+        "f\t0\t0\t/app/other/x.ts\x00"
+    )
+    client = StubSandbox(run_result=SimpleNamespace(stdout=find_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("src/**/*.ts", path="/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    paths = sorted(m["path"] for m in result.matches)
+    _require(
+        paths == ["/src/a.ts", "/src/dir/b.ts", "/src/dir/nested/c.ts"],
+        f"Unexpected matches: {paths}",
+    )
+
+
+# --- Direct unit tests for _compile_glob -----------------------------------
+#
+# The regex translation layer has ~8 distinct code paths (basename
+# fallback, leading/middle/trailing `**`, collapsed `**`, character
+# class, `?` wildcard, literal escape). These tests exercise it at
+# the helper level so a regression in the translator is caught before
+# it slips into backend.glob() and ships as a silent empty-matches
+# bug like the pre-fix `a/**/b` matching `ab`.
+
+
+def _match(pattern: str, path: str) -> bool:
+    from langchain_agent_sandbox.backend import _compile_glob
+
+    return _compile_glob(pattern)(path)
+
+
+def test_compile_glob_basename_fallback_no_slash():
+    """Patterns with no `/` match against the basename, at any depth."""
+    assert _match("*.py", "main.py") is True
+    assert _match("*.py", "nested/main.py") is True
+    assert _match("*.py", "main.txt") is False
+
+
+def test_compile_glob_question_mark_wildcard():
+    """`?` matches exactly one character and does not cross `/`."""
+    assert _match("file?.txt", "file1.txt") is True
+    assert _match("file?.txt", "fileA.txt") is True
+    assert _match("file?.txt", "file12.txt") is False
+    assert _match("src/file?.txt", "src/file1.txt") is True
+    assert _match("src/file?.txt", "src/file/txt") is False
+
+
+def test_compile_glob_character_class():
+    """`[abc]` matches one of the listed characters."""
+    assert _match("[abc].txt", "a.txt") is True
+    assert _match("[abc].txt", "b.txt") is True
+    assert _match("[abc].txt", "d.txt") is False
+
+
+def test_compile_glob_unterminated_character_class_is_literal():
+    """`[` without a closing `]` is treated as a literal `[`."""
+    # The translator escapes the `[` when there's no closing bracket
+    # rather than producing an invalid regex. A file literally named
+    # `file[abc.py` should then match the pattern.
+    assert _match("src/file[abc.py", "src/file[abc.py") is True
+    assert _match("src/file[abc.py", "src/filea.py") is False
+
+
+def test_compile_glob_leading_double_star():
+    """`**/X` matches X at any depth including root."""
+    assert _match("**/x", "x") is True
+    assert _match("**/x", "a/x") is True
+    assert _match("**/x", "a/b/x") is True
+    assert _match("**/x", "ax") is False
+
+
+def test_compile_glob_middle_double_star_requires_adjoining_slashes():
+    """Critical: `a/**/b` must NOT match `ab`.
+
+    Regression test for the fix where the middle-`**` translation
+    previously compiled `a/**/b` to `^a(?:.*/)?b$`, which matched
+    `"ab"` because `(?:.*/)?` can match the empty string and collapse
+    the two literal slashes away. The correct regex is
+    `^a/(?:[^/]+/)*b$`, requiring at least `a/b`.
+    """
+    assert _match("a/**/b", "ab") is False  # the bug
+    assert _match("a/**/b", "a/b") is True
+    assert _match("a/**/b", "a/x/b") is True
+    assert _match("a/**/b", "a/x/y/b") is True
+    assert _match("a/**/b", "a/b/c") is False
+    assert _match("a/**/b", "x/a/b") is False
+
+
+def test_compile_glob_trailing_double_star():
+    """`a/**` matches things inside `a/`, not bare `a`."""
+    assert _match("a/**", "a") is False  # gitignore semantic
+    assert _match("a/**", "a/b") is True
+    assert _match("a/**", "a/b/c") is True
+    assert _match("a/**", "ab") is False
+
+
+def test_compile_glob_multiple_double_stars():
+    """`a/**/b/**/c` matches c after b after a at any depth."""
+    assert _match("a/**/b/**/c", "a/b/c") is True
+    assert _match("a/**/b/**/c", "a/x/b/c") is True
+    assert _match("a/**/b/**/c", "a/b/x/c") is True
+    assert _match("a/**/b/**/c", "a/x/y/b/z/c") is True
+    assert _match("a/**/b/**/c", "a/c") is False
+    assert _match("a/**/b/**/c", "abc") is False
+
+
+def test_compile_glob_consecutive_double_stars_collapse():
+    """`**/**` is semantically identical to a single `**`."""
+    assert _match("**/**/x", "x") is True
+    assert _match("**/**/x", "a/x") is True
+    assert _match("**/**/x", "a/b/x") is True
+
+
+def test_compile_glob_standalone_double_star_matches_everything():
+    """A pattern of just `**` matches any path."""
+    assert _match("**", "anything") is True
+    assert _match("**", "a/b/c") is True
+    assert _match("**", "") is True
+
+
+def test_glob_returns_typed_error_for_malformed_pattern():
+    """An invalid regex character class should yield GlobResult(error=...), not raise."""
+    # Pattern contains a reverse character range (`z-a`) which the
+    # regex engine rejects with re.error. _compile_glob passes
+    # character classes through to the engine literally, so this
+    # surfaces as a compilation failure that glob() must catch and
+    # convert to a typed error — otherwise the agent sees a Python
+    # traceback instead of a usable response.
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("src/file[z-a].py", path="/")
+
+    _require(result.error is not None, "Expected typed error for malformed pattern")
+    _require(
+        "invalid glob pattern" in result.error,
+        f"Expected helpful error prefix, got: {result.error!r}",
+    )
+    _require(result.matches == [], "Expected empty matches on malformed pattern")
+
+
+def test_glob_returns_error_with_empty_matches_on_failure():
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="No such directory", exit_code=1))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("*.py", path="/nonexistent")
+
+    _require(result.matches == [], f"Expected empty matches, got {result.matches}")
+    _require(result.error is not None, "Expected error to be populated on total failure")
+    _require("No such directory" in result.error, f"Expected stderr in error, got: {result.error}")
+
+
+def test_ls_returns_error_with_empty_entries_on_failure():
+    client = StubSandbox()
+    # Make the list() call raise so the error path fires.
+    client.files.list = lambda path, timeout=60: (_ for _ in ()).throw(
+        RuntimeError("No such directory")
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.ls("/nonexistent")
+
+    _require(result.entries == [], f"Expected empty entries, got {result.entries}")
+    _require(result.error is not None, "Expected error to be populated on failure")
+    _require("No such directory" in result.error, f"Expected stderr in error, got: {result.error}")
+
+
+def test_edit_success_with_replace_all():
+    client = StubSandbox(read_bytes=b"foo bar foo baz foo")
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+    backend._upload_bytes = lambda path, content: None
+
+    result = backend.edit("/file.txt", "foo", "qux", replace_all=True)
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    _require(result.occurrences == 3, f"Expected 3 occurrences, got {result.occurrences}")
+
+
+def test_edit_success_single_occurrence():
+    client = StubSandbox(read_bytes=b"hello world")
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+    backend._upload_bytes = lambda path, content: None
+
+    result = backend.edit("/file.txt", "world", "universe", replace_all=False)
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    _require(result.occurrences == 1, f"Expected 1 occurrence, got {result.occurrences}")
+
+
+def test_to_internal_blocks_sibling_directory_escape():
+    """Test that /appfoo doesn't match when root_dir=/app."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+
+    # This path should fail because /appfoo is not under /app
+    with pytest.raises(ValueError):
+        backend._to_internal("/../appfoo/secret")
+
+
+def test_to_internal_allows_root_dir_itself():
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+
+    result = backend._to_internal("/")
+
+    _require(result == "/app", f"Expected /app, got {result}")
+
+
+def test_write_allows_absolute_path_outside_root_dir():
+    """Writes to a path outside runtime_root go via commands.run + base64,
+    not through the multipart upload API (which is confined to /app)."""
+    # `test -e` returns non-zero when the file is missing, so both the
+    # existence probe and the base64 write should see exit_code=1 here
+    # (neither cares about stdout). Simpler: stub returns exit_code=1
+    # for the existence probe which maps to "does not exist".
+    class _SeqCommands:
+        def __init__(self):
+            self.calls: list = []
+
+        def run(self, command, **kwargs):
+            self.calls.append((command, kwargs))
+            # Existence probe: "test -e …" → exit 1 means missing.
+            if "test -e" in command:
+                return SimpleNamespace(stdout="", stderr="", exit_code=1)
+            # base64 write succeeds.
+            return SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+    client = StubSandbox()
+    client.commands = _SeqCommands()
+    backend = AgentSandboxBackend(client, root_dir="/app", allow_absolute_paths=True)
+    backend._ensure_parent_dir = lambda path: None
+
+    result = backend.write("/tmp/nested/file.txt", "hello")
+
+    _require(result.error is None, f"Unexpected write error: {result.error}")
+    # The upload endpoint must NOT be used for out-of-root paths.
+    _require(client.files.write_calls == [], f"Unexpected multipart upload: {client.files.write_calls}")
+    # Exactly two shell calls: one `test -e` existence probe, one base64 write.
+    shell_calls = [call for (call, _kwargs) in client.commands.calls]
+    _require(len(shell_calls) == 2, f"Expected 2 shell calls, got {shell_calls}")
+    _require("test -e" in shell_calls[0], f"First call should be existence probe, got: {shell_calls[0]}")
+    _require("/tmp/nested/file.txt" in shell_calls[0], f"Existence probe must target the absolute path: {shell_calls[0]}")
+    _require("base64 -d" in shell_calls[1], f"Second call should write via base64, got: {shell_calls[1]}")
+    _require("/tmp/nested/file.txt" in shell_calls[1], f"Write must target the absolute path: {shell_calls[1]}")
+
+
+def test_upload_files_allows_absolute_path_outside_root_dir():
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app", allow_absolute_paths=True)
+    backend._file_state = lambda _: "missing"
+    backend._dir_state = lambda _: "writable"
+
+    responses = backend.upload_files({"/tmp/nested/file.txt": b"payload"})
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error is None, f"Expected success, got error={responses[0].error}")
+    _require(client.files.write_calls == [], f"Unexpected multipart upload: {client.files.write_calls}")
+    shell_calls = [call for (call, _kwargs) in client.commands.calls]
+    base64_writes = [call for call in shell_calls if "base64 -d" in call]
+    _require(len(base64_writes) == 1, f"Expected one base64 write, got {base64_writes}")
+    _require("/tmp/nested/file.txt" in base64_writes[0], f"Write target mismatch: {base64_writes[0]}")
+
+
+def test_write_absolute_path_defaults_to_root_virtualization():
+    """Without allow_absolute_paths the caller's /tmp/... is virtualized under
+    root_dir, so exists/write target /app/tmp/... (runtime-relative ``tmp/...``)."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+    seen = {}
+
+    def fake_exists(path, timeout=60):
+        seen["exists"] = path
+        return False
+
+    client.files.exists = fake_exists
+    backend._ensure_parent_dir = lambda _path: None
+    client.files.write = lambda _path, _content, timeout=60: None
+
+    result = backend.write("/tmp/nested/file.txt", "hello")
+
+    _require(result.error is None, f"Unexpected write error: {result.error}")
+    # Runtime-relative under /app: "tmp/nested/file.txt" (no leading "/app/").
+    _require(seen["exists"] == "tmp/nested/file.txt", f"Unexpected path mapping: {seen['exists']}")
+
+
+def test_ensure_parent_dir_raises_on_failure():
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="Permission denied", exit_code=1))
+    backend = AgentSandboxBackend(client)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        backend._ensure_parent_dir("/app/nested/file.txt")
+
+    _require("Cannot create parent directory" in str(exc_info.value), f"Unexpected error: {exc_info.value}")
+
+
+# --- Factory pattern tests ---
+
+
+def test_factory_pattern_creates_backend():
+    """Test that create_sandbox_backend_factory returns a working factory."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    factory = create_sandbox_backend_factory(
+        template_name="test-template",
+        namespace="test-ns",
+        root_dir="/workspace",
+        client=mock_client,
+    )
+
+    # Factory should be callable
+    _require(callable(factory), "Factory should be callable")
+
+    # Call factory with a mock runtime
+    mock_runtime = MagicMock()
+    backend = factory(mock_runtime)
+
+    # Should return an AgentSandboxBackend
+    _require(isinstance(backend, AgentSandboxBackend), "Factory should return AgentSandboxBackend")
+
+    _require(backend._template == "test-template", "Expected _template=test-template")
+    _require(backend._namespace == "test-ns", "Expected _namespace=test-ns")
+    _require(backend._root_dir == "/workspace", f"Expected root_dir=/workspace, got {backend._root_dir}")
+
+
+def test_factory_pattern_passes_kwargs():
+    """Test that factory passes additional kwargs to from_template."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    factory = create_sandbox_backend_factory(
+        template_name="my-template",
+        namespace="prod",
+        client=mock_client,
+    )
+
+    backend = factory(MagicMock())
+
+    # Verify template/namespace stored for deferred creation
+    _require(backend._template == "my-template", "Expected _template=my-template")
+    _require(backend._namespace == "prod", "Expected _namespace=prod")
+    _require(backend._sdk_client is mock_client, "Expected pre-built client")
+
+
+def test_factory_eagerly_provisions_sandbox():
+    """The factory must provision the sandbox before returning.
+
+    Regression test: deepagents calls factory(_runtime) and uses the
+    returned backend directly without `with`. If the factory only
+    returned an un-entered `from_template()` backend, the first call
+    to execute()/ls()/etc. would dereference `self._sandbox` (still
+    None) and raise AttributeError. The factory must call
+    `__enter__()` eagerly.
+    """
+    mock_sdk = MagicMock()
+    mock_sandbox = MagicMock()
+    mock_sdk.create_sandbox.return_value = mock_sandbox
+
+    factory = create_sandbox_backend_factory(template_name="t", client=mock_sdk)
+    backend = factory(MagicMock())
+
+    # The sandbox handle must be populated, not None.
+    _require(
+        backend._sandbox is not None,
+        "Factory should eagerly enter the backend (sandbox is still None)",
+    )
+    _require(
+        backend._sandbox is mock_sandbox,
+        f"Expected the sandbox returned by sdk_client.create_sandbox, got {backend._sandbox}",
+    )
+
+    # sdk_client.create_sandbox must have been called once.
+    mock_sdk.create_sandbox.assert_called_once()
+
+
+def test_factory_registers_finalizer_for_cleanup():
+    """The factory must register a finalizer that deletes the sandbox.
+
+    Without this, a factory-provisioned sandbox would leak in the
+    cluster because deepagents never calls `__exit__` on the backend.
+    The finalizer is exposed as `backend._finalizer` so the test can
+    invoke it deterministically rather than relying on `del backend +
+    gc.collect()` GC ordering (which is fragile under MagicMock ref
+    retention and alternative interpreters).
+    """
+    mock_sdk = MagicMock()
+    mock_sandbox = MagicMock()
+    mock_sandbox.claim_name = "sandbox-claim-abc123"
+    mock_sandbox.namespace = "default"
+    mock_sdk.create_sandbox.return_value = mock_sandbox
+
+    factory = create_sandbox_backend_factory(template_name="t", client=mock_sdk)
+    backend = factory(MagicMock())
+
+    # Verify the finalizer was registered and is alive.
+    _require(
+        hasattr(backend, "_finalizer"),
+        "Factory did not expose backend._finalizer",
+    )
+    _require(backend._finalizer.alive, "Finalizer should be alive after factory")
+
+    # Trigger cleanup synchronously via the exposed handle.
+    backend._finalizer()
+
+    _require(
+        backend._finalizer.alive is False,
+        "Finalizer should be marked dead after explicit invocation",
+    )
+    mock_sdk.delete_sandbox.assert_called_once_with(
+        claim_name="sandbox-claim-abc123",
+        namespace="default",
+    )
+
+
+def test_factory_finalizer_swallows_delete_errors(recwarn):
+    """Cleanup errors during finalizer execution must not raise.
+
+    Uses the exposed `_finalizer` handle to invoke cleanup deterministically
+    and asserts that no exception escapes. The previous version relied on
+    `del + gc.collect()` and `assert_called_once()` — but unraisable-in-
+    finalizer exceptions become `sys.unraisablehook` calls under CPython,
+    not test failures, so the swallow guarantee was untested. Calling the
+    finalizer directly turns "must not raise" into a real assertion via
+    `pytest.raises(...)` inversion.
+    """
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = RuntimeError("API unreachable")
+    mock_sandbox = MagicMock()
+    mock_sandbox.claim_name = "sandbox-claim-xyz789"
+    mock_sandbox.namespace = "default"
+    mock_sdk.create_sandbox.return_value = mock_sandbox
+
+    factory = create_sandbox_backend_factory(template_name="t", client=mock_sdk)
+    backend = factory(MagicMock())
+
+    # Synchronous, deterministic invocation. If the finalizer
+    # raised, this would propagate and fail the test directly —
+    # which is exactly what we want to assert it does NOT do.
+    backend._finalizer()
+
+    # The non-404 RuntimeError should have been logged at ERROR
+    # (not silently swallowed) by `_factory_atexit_cleanup`.
+    mock_sdk.delete_sandbox.assert_called_once()
+
+
+def test_factory_finalizer_silently_swallows_404():
+    """A 404 from delete_sandbox is the redundant-cleanup case and must be silent.
+
+    Pins the contract that the user's explicit `__exit__` already
+    cleaned up the claim, so the finalizer's redundant attempt sees a
+    404 and doesn't log an error. Probes the SDK exception shape used
+    by the kubernetes-client (`status` attr) and the requests-style
+    shape (`response.status_code`).
+    """
+    class _FakeApiException(Exception):
+        def __init__(self, status):
+            super().__init__(f"HTTP {status}")
+            self.status = status
+
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = _FakeApiException(404)
+    mock_sandbox = MagicMock()
+    mock_sandbox.claim_name = "sandbox-claim-already-gone"
+    mock_sandbox.namespace = "default"
+    mock_sdk.create_sandbox.return_value = mock_sandbox
+
+    factory = create_sandbox_backend_factory(template_name="t", client=mock_sdk)
+    backend = factory(MagicMock())
+
+    # Must not raise.
+    backend._finalizer()
+    mock_sdk.delete_sandbox.assert_called_once()
+
+
+def test_factory_finalizer_logs_non_404_failures(caplog):
+    """Non-404 delete failures must be logged so the leak is operator-visible."""
+    import logging
+
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = RuntimeError("API unreachable")
+    mock_sandbox = MagicMock()
+    mock_sandbox.claim_name = "sandbox-claim-leaked"
+    mock_sandbox.namespace = "default"
+    mock_sdk.create_sandbox.return_value = mock_sandbox
+
+    factory = create_sandbox_backend_factory(template_name="t", client=mock_sdk)
+    backend = factory(MagicMock())
+
+    with caplog.at_level(logging.ERROR, logger="langchain_agent_sandbox.backend"):
+        backend._finalizer()
+
+    _require(
+        any("Finalizer failed to delete sandbox" in r.message for r in caplog.records),
+        f"Expected finalizer leak log, got records: {[r.message for r in caplog.records]}",
+    )
+    _require(
+        any("API unreachable" in r.message for r in caplog.records),
+        "Expected underlying error message in finalizer log",
+    )
+
+
+# --- from_template lifecycle tests ----------------------------------------
+
+
+def test_from_template_enter_failure_propagates():
+    """If create_sandbox fails inside __enter__, the exception propagates.
+
+    Pins the current behavior so a refactor that silently swallows the
+    failure won't slip through. The factory wrapper has its own
+    finalizer-based cleanup, but a user using `from_template()` directly
+    inside a `with` block expects an exception when provisioning fails.
+    """
+    mock_sdk = MagicMock()
+    mock_sdk.create_sandbox.side_effect = RuntimeError("template not found")
+
+    backend = AgentSandboxBackend(
+        sandbox=None,  # type: ignore[arg-type]
+        manage_lifecycle=True,
+        sdk_client=mock_sdk,
+        _template="missing",
+        _namespace="default",
+    )
+
+    try:
+        backend.__enter__()
+    except RuntimeError as e:
+        _require("template not found" in str(e), f"Unexpected message: {e}")
+    else:
+        pytest.fail("Expected RuntimeError to propagate from __enter__")
+
+    # _sandbox should still be None — nothing was provisioned, so
+    # nothing should be torn down. A subsequent __exit__ on this
+    # backend (e.g. from a `with` block that caught the error) must
+    # be a no-op.
+    _require(backend._sandbox is None, "Expected _sandbox to remain None")
+    backend.__exit__(RuntimeError, RuntimeError("test"), None)
+    mock_sdk.delete_sandbox.assert_not_called()
+
+
+def test_exit_does_not_delete_when_manage_lifecycle_false():
+    """`manage_lifecycle=False` opts out of automatic cleanup on __exit__.
+
+    This is the contract for users who want to attach an existing
+    Sandbox handle and manage its lifecycle separately. A regression
+    that ignored the flag would surprise-delete user-managed sandboxes.
+    """
+    mock_sdk = MagicMock()
+    sandbox = StubSandbox()
+    sandbox.claim_name = "user-managed-claim"
+
+    backend = AgentSandboxBackend(
+        sandbox=sandbox,
+        manage_lifecycle=False,
+        sdk_client=mock_sdk,
+    )
+
+    # Enter the backend (no-op when manage_lifecycle=False — the
+    # provided sandbox is used as-is) then exit it.
+    backend.__enter__()
+    backend.__exit__(None, None, None)
+
+    mock_sdk.delete_sandbox.assert_not_called()
+
+
+def test_exit_reraises_cleanup_error_on_happy_path():
+    """When the user's `with` block exits cleanly, a delete failure must surface.
+
+    Otherwise leaked sandboxes are silent — the user thinks their
+    cleanup ran but the controller still has the claim around.
+    """
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = RuntimeError("API unreachable")
+    sandbox = StubSandbox()
+    sandbox.claim_name = "leaked-claim"
+
+    backend = AgentSandboxBackend(
+        sandbox=sandbox,
+        manage_lifecycle=True,
+        sdk_client=mock_sdk,
+    )
+    backend.__enter__()
+
+    try:
+        backend.__exit__(None, None, None)
+    except RuntimeError as e:
+        _require("API unreachable" in str(e), f"Unexpected message: {e}")
+    else:
+        pytest.fail("Expected cleanup RuntimeError to be re-raised on the happy path")
+
+
+def test_exit_warns_when_cleanup_fails_with_traceback_only_unwind():
+    """When __exit__ is called with exc=None but exc_type set (tb-only path),
+    cleanup failure surfaces as a ResourceWarning rather than raising.
+
+    Edge case: some context-manager invocations pass `(exc_type, None, tb)`
+    when the exception value has been consumed. ExceptionGroup needs a
+    real exception instance, so we fall back to a ResourceWarning to
+    keep the leak visible to operators.
+    """
+    import warnings
+
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = RuntimeError("teardown also broken")
+    sandbox = StubSandbox()
+    sandbox.claim_name = "leaked-claim"
+
+    backend = AgentSandboxBackend(
+        sandbox=sandbox,
+        manage_lifecycle=True,
+        sdk_client=mock_sdk,
+    )
+    backend.__enter__()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        backend.__exit__(ValueError, None, None)
+
+    _require(
+        any(issubclass(w.category, ResourceWarning) for w in caught),
+        f"Expected ResourceWarning for tb-only unwind, got: {[w.category for w in caught]}",
+    )
+    mock_sdk.delete_sandbox.assert_called_once()
+
+
+# --- Policy wrapper tests ---
+
+
+def test_policy_wrapper_blocks_denied_paths():
+    """Test that write/edit are blocked on denied path prefixes."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(
+        backend,
+        deny_prefixes=["/etc", "/sys"],
+    )
+
+    # Write to denied path
+    result = wrapped.write("/etc/passwd", "bad content")
+    _require(result.error is not None, "Expected write to be denied")
+    _require("Policy denied" in result.error, f"Unexpected error: {result.error}")
+
+    # Edit on denied path
+    result = wrapped.edit("/sys/kernel/config", "old", "new")
+    _require(result.error is not None, "Expected edit to be denied")
+    _require("Policy denied" in result.error, f"Unexpected error: {result.error}")
+
+
+def test_policy_wrapper_canonicalizes_denied_paths():
+    """Policy checks should block normalized traversal paths like /app/../etc."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(backend, deny_prefixes=["/etc"])
+
+    result = wrapped.write("/app/../etc/passwd", "bad content")
+    _require(result.error is not None, "Expected write to be denied")
+    _require("Policy denied" in result.error, f"Unexpected error: {result.error}")
+
+    responses = wrapped.upload_files({"/app/../etc/shadow": b"bad"})
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error == "policy_denied", f"Expected policy_denied, got {responses[0].error}")
+
+
+def test_policy_wrapper_write_resolution_distinguishes_absolute_and_relative_prefixes():
+    """With absolute write mode enabled, /etc policy should not block relative etc/* under root_dir."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app", allow_absolute_paths=True)
+    backend._exists = lambda _: False
+    backend._ensure_parent_dir = lambda _: None
+    backend._upload_bytes = lambda _path, _content: None
+    wrapped = SandboxPolicyWrapper(backend, deny_prefixes=["/etc"])
+
+    relative_result = wrapped.write("etc/config.txt", "safe")
+    _require(relative_result.error is None, f"Unexpected relative-path deny: {relative_result.error}")
+
+    absolute_result = wrapped.write("/etc/passwd", "bad")
+    _require(absolute_result.error is not None, "Expected absolute /etc write to be denied")
+    _require("Policy denied" in absolute_result.error, f"Unexpected error: {absolute_result.error}")
+
+
+def test_policy_wrapper_blocks_denied_commands():
+    """Test that execute is blocked on denied command patterns."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(
+        backend,
+        deny_commands=["rm -rf", "shutdown", "reboot"],
+    )
+
+    result = wrapped.execute("rm -rf /")
+    _require(result.exit_code == 1, "Expected command to fail")
+    _require("Policy denied" in result.output, f"Unexpected output: {result.output}")
+
+    result = wrapped.execute("sudo shutdown now")
+    _require(result.exit_code == 1, "Expected command to fail")
+    _require("Policy denied" in result.output, f"Unexpected output: {result.output}")
+
+
+def test_policy_wrapper_passes_allowed_operations():
+    """Test that non-denied operations work through the wrapper."""
+    client = StubSandbox(
+        run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0),
+        read_bytes=b"file content",
+    )
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: False  # For write test
+    backend._ensure_parent_dir = lambda _: None
+    backend._upload_bytes = lambda path, content: None
+
+    wrapped = SandboxPolicyWrapper(
+        backend,
+        deny_prefixes=["/etc"],
+        deny_commands=["rm -rf"],
+    )
+
+    # Allowed command should work
+    result = wrapped.execute("echo hello")
+    _require(result.exit_code == 0, "Expected command to succeed")
+    _require(result.output == "ok", f"Unexpected output: {result.output}")
+
+    # Write to allowed path should work
+    result = wrapped.write("/app/file.txt", "content")
+    _require(result.error is None, f"Unexpected error: {result.error}")
+
+
+def test_policy_wrapper_audit_log_called():
+    """Test that audit callback is invoked for operations."""
+    audit_calls = []
+
+    def audit_log(operation: str, target: str, meta: dict):
+        audit_calls.append((operation, target, meta))
+
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: False
+    backend._ensure_parent_dir = lambda _: None
+    backend._upload_bytes = lambda path, content: None
+
+    wrapped = SandboxPolicyWrapper(backend, audit_log=audit_log)
+
+    # Execute should be logged
+    wrapped.execute("echo test")
+    _require(len(audit_calls) == 1, f"Expected 1 audit call, got {len(audit_calls)}")
+    _require(audit_calls[0][0] == "execute", f"Expected execute, got {audit_calls[0][0]}")
+    _require(audit_calls[0][1] == "echo test", f"Unexpected target: {audit_calls[0][1]}")
+
+    # Write should be logged
+    wrapped.write("/app/file.txt", "hello")
+    _require(len(audit_calls) == 2, f"Expected 2 audit calls, got {len(audit_calls)}")
+    _require(audit_calls[1][0] == "write", f"Expected write, got {audit_calls[1][0]}")
+    _require(audit_calls[1][2]["size"] == 5, f"Expected size 5, got {audit_calls[1][2]}")
+
+
+def test_policy_wrapper_upload_files_filters_denied():
+    """Test that upload_files filters out denied paths."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "missing"
+    backend._dir_state = lambda _: "writable"
+    backend._upload_bytes = lambda path, content: None
+
+    wrapped = SandboxPolicyWrapper(backend, deny_prefixes=["/etc"])
+
+    responses = wrapped.upload_files({
+        "/etc/passwd": b"bad",
+        "/app/good.txt": b"good",
+    })
+
+    # Should have 2 responses
+    _require(len(responses) == 2, f"Expected 2 responses, got {len(responses)}")
+
+    # Find the denied one
+    denied = [r for r in responses if r.path == "/etc/passwd"]
+    _require(len(denied) == 1, "Expected denied response for /etc/passwd")
+    _require(denied[0].error == "policy_denied", f"Expected policy_denied, got {denied[0].error}")
+
+
+def test_policy_wrapper_read_operations_pass_through():
+    """Test that read operations pass through without policy checks."""
+    grep_output = "/app/test.py:10:def foo():\n"
+    client = StubSandbox(
+        run_result=SimpleNamespace(stdout=grep_output, stderr="", exit_code=0),
+        read_bytes=b"content",
+    )
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+
+    # Even with very restrictive policies, reads should work
+    wrapped = SandboxPolicyWrapper(
+        backend,
+        deny_prefixes=["/"],  # Would block everything if applied to reads
+        deny_commands=["grep"],  # grep is used internally
+    )
+
+    # grep should still work
+    result = wrapped.grep("foo", path="/")
+    _require(result.error is None, f"Expected no error, got {result.error}")
+    _require(isinstance(result.matches, list), "Expected list of matches")
+
+
+def test_policy_wrapper_context_manager():
+    """Test that policy wrapper works as context manager."""
+    # Use MagicMock for context manager support
+    mock_sandbox = MagicMock()
+    mock_sdk_client = MagicMock()
+    mock_sdk_client.create_sandbox.return_value = mock_sandbox
+
+    backend = AgentSandboxBackend(
+        sandbox=None,
+        manage_lifecycle=True,
+        sdk_client=mock_sdk_client,
+        _template="test",
+        _namespace="default",
+    )
+    wrapped = SandboxPolicyWrapper(backend)
+
+    with wrapped:
+        mock_sdk_client.create_sandbox.assert_called_once()
+
+    mock_sdk_client.delete_sandbox.assert_called_once()
+
+
+# --- Additional coverage tests ---
+
+
+def test_root_dir_must_be_absolute():
+    """Test that root_dir validation rejects relative paths."""
+    client = StubSandbox()
+
+    with pytest.raises(ValueError) as exc_info:
+        AgentSandboxBackend(client, root_dir="relative/path")
+
+    _require("absolute path" in str(exc_info.value), f"Unexpected error: {exc_info.value}")
+
+
+def test_upload_files_returns_upload_failed_on_exception():
+    """Test that upload_files handles exceptions gracefully."""
+    client = StubSandbox()
+    client.files.write = lambda path, content, timeout=60: (_ for _ in ()).throw(RuntimeError("write failed"))
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "missing"
+    backend._dir_state = lambda _: "writable"
+
+    responses = backend.upload_files({"/app/file.txt": b"data"})
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error == "upload_failed", f"Expected upload_failed, got {responses[0].error}")
+
+
+def test_download_files_returns_download_failed_on_exception():
+    """Test that download_files handles exceptions gracefully."""
+    client = StubSandbox()
+    client.files.read = lambda path, timeout=60: (_ for _ in ()).throw(RuntimeError("read failed"))
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "file"
+
+    responses = backend.download_files(["/app/file.txt"])
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error == "download_failed", f"Expected download_failed, got {responses[0].error}")
+
+
+@pytest.mark.asyncio
+async def test_aexecute_delegates_to_execute():
+    """Test that async execute delegates correctly."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="async-ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = await backend.aexecute("echo test")
+
+    _require(result.output == "async-ok", f"Unexpected output: {result.output}")
+    _require(result.exit_code == 0, f"Unexpected exit code: {result.exit_code}")
+
+
+def test_read_with_offset_beyond_file_length():
+    """Test read() with offset larger than file length returns an error."""
+    client = StubSandbox(read_bytes=b"line1\nline2\nline3")
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+
+    result = backend.read("/file.txt", offset=100, limit=10)
+
+    _require(result.error is not None, "Expected error for offset beyond file length")
+    _require("exceeds file length" in result.error, f"Unexpected error: {result.error}")
+    _require(result.file_data is None, "Expected file_data to be None on error")
+
+
+def test_read_with_offset_and_limit():
+    """Test read() pagination returns raw content sliced by offset/limit."""
+    client = StubSandbox(read_bytes=b"line0\nline1\nline2\nline3\nline4")
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+
+    result = backend.read("/file.txt", offset=1, limit=2)
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    content = result.file_data["content"]
+    _require(result.file_data["encoding"] == "utf-8", "Expected utf-8 encoding")
+    # offset=1 means start at line index 1 (2nd line), get 2 lines — raw, unnumbered.
+    _require(content == "line1\nline2", f"Unexpected content: {content!r}")
+
+
+def test_edit_string_not_found_returns_error():
+    """Test edit() when old_string is not found."""
+    client = StubSandbox(read_bytes=b"hello world")
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+
+    result = backend.edit("/file.txt", "missing", "replacement")
+
+    _require(result.error is not None, "Expected error for missing string")
+    _require("not found" in result.error, f"Unexpected error: {result.error}")
+    _require(result.occurrences == 0, f"Expected 0 occurrences, got {result.occurrences}")
+
+
+def test_id_property_returns_claim_name_when_available():
+    """Test id property returns namespace-qualified claim_name when available."""
+    sandbox = StubSandbox()
+    sandbox.claim_name = "my-claim"
+    backend = AgentSandboxBackend(sandbox)
+
+    _require(backend.id == "default/my-claim", f"Expected default/my-claim, got {backend.id}")
+
+
+def test_id_property_returns_default_when_no_claim():
+    """Test id property returns default when no claim_name set."""
+    sandbox = StubSandbox()
+    sandbox.sandbox_id = "my-sandbox"
+    backend = AgentSandboxBackend(sandbox)
+
+    _require(backend.id == "agent-sandbox", f"Expected agent-sandbox, got {backend.id}")
+
+
+def test_id_property_returns_default_when_no_names():
+    """Test id property returns default when no names available."""
+    sandbox = StubSandbox()
+    backend = AgentSandboxBackend(sandbox)
+
+    _require(backend.id == "agent-sandbox", f"Expected agent-sandbox, got {backend.id}")
+
+
+def test_grep_ignores_malformed_lines():
+    """Test grep handles malformed output lines gracefully."""
+    # Mix of valid and malformed lines
+    grep_output = "/app/file.py:10:valid match\nmalformed line without colons\n/app/file.py:invalid:line number\n"
+    client = StubSandbox(run_result=SimpleNamespace(stdout=grep_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+
+    result = backend.grep("valid", path="/")
+
+    # Should only get the one valid match
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    matches = result.matches
+    _require(len(matches) == 1, f"Expected 1 match, got {len(matches)}")
+    _require(matches[0]["text"] == "valid match", f"Unexpected text: {matches[0]['text']}")
+
+
+@pytest.mark.asyncio
+async def test_policy_wrapper_async_write_enforces_policy():
+    """Test that async write operations enforce policy."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(backend, deny_prefixes=["/etc"])
+
+    result = await wrapped.awrite("/etc/passwd", "bad content")
+
+    _require(result.error is not None, "Expected write to be denied")
+    _require("Policy denied" in result.error, f"Unexpected error: {result.error}")
+
+
+@pytest.mark.asyncio
+async def test_policy_wrapper_async_execute_enforces_policy():
+    """Test that async execute operations enforce policy."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(backend, deny_commands=["rm -rf"])
+
+    result = await wrapped.aexecute("rm -rf /")
+
+    _require(result.exit_code == 1, "Expected command to fail")
+    _require("Policy denied" in result.output, f"Unexpected output: {result.output}")
+
+
+# --- Additional tests for PR review coverage ---
+
+
+def test_from_template_creates_managed_backend():
+    """Test from_template creates backend with manage_lifecycle=True."""
+    mock_client = MagicMock()
+
+    backend = AgentSandboxBackend.from_template(
+        client=mock_client,
+        template_name="test-template",
+        namespace="test-ns",
+        root_dir="/workspace",
+        allow_absolute_paths=True,
+    )
+
+    # Verify manage_lifecycle is True
+    _require(backend._manage_lifecycle is True, "Expected manage_lifecycle=True")
+    _require(backend._root_dir == "/workspace", f"Expected /workspace, got {backend._root_dir}")
+    _require(backend._allow_absolute_paths is True, "Expected allow_absolute_paths=True")
+    _require(backend._template == "test-template", "Expected _template=test-template")
+    _require(backend._namespace == "test-ns", "Expected _namespace=test-ns")
+    _require(backend._sdk_client is mock_client, "Expected pre-built client")
+
+
+def test_edit_nonexistent_file_returns_error():
+    """Test edit() returns error when file doesn't exist."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: False
+
+    result = backend.edit("/nonexistent.txt", "old", "new")
+
+    _require(result.error is not None, "Expected error for non-existent file")
+    _require("not found" in result.error, f"Unexpected error: {result.error}")
+    _require(result.path == "/nonexistent.txt", f"Unexpected path: {result.path}")
+    _require(result.occurrences == 0, f"Expected 0 occurrences, got {result.occurrences}")
+
+
+def test_download_files_directory_returns_error():
+    """Test download_files returns is_directory error for directories."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "dir"
+
+    responses = backend.download_files(["/app/somedir"])
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error == "is_directory", f"Expected is_directory, got {responses[0].error}")
+    _require(responses[0].content is None, "Expected content to be None")
+
+
+def test_upload_files_existing_directory_returns_error():
+    """Test upload_files returns is_directory error when target is a directory."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "dir"
+
+    responses = backend.upload_files({"/app/somedir": b"data"})
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error == "is_directory", f"Expected is_directory, got {responses[0].error}")
+
+
+def test_upload_files_permission_denied_file():
+    """Test upload_files returns permission_denied for unreadable target."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "denied"
+
+    responses = backend.upload_files({"/app/restricted": b"data"})
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(responses[0].error == "permission_denied", f"Expected permission_denied, got {responses[0].error}")
+
+
+def test_audit_log_exception_does_not_block_operation():
+    """Default fail-open behavior: failing audit log doesn't prevent operation."""
+    def failing_audit_log(operation: str, target: str, meta: dict):
+        raise Exception("Audit service unavailable")
+
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(backend, audit_log=failing_audit_log)
+
+    # Execute should still work despite audit log failure
+    result = wrapped.execute("echo test")
+    _require(result.exit_code == 0, "Expected command to succeed despite audit failure")
+    _require(result.output == "ok", f"Unexpected output: {result.output}")
+
+
+def test_strict_audit_blocks_execute_when_audit_log_fails():
+    """strict_audit=True: a failing audit log refuses execute()."""
+    def failing_audit_log(operation: str, target: str, meta: dict):
+        raise RuntimeError("SIEM unreachable")
+
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=failing_audit_log, strict_audit=True,
+    )
+
+    result = wrapped.execute("echo test")
+
+    _require(result.exit_code == 1, "Expected command to be refused")
+    _require(
+        "Audit log unavailable" in result.output,
+        f"Expected refusal message, got: {result.output!r}",
+    )
+    # The underlying backend.execute should NOT have been called.
+    _require(
+        client.commands.last_command is None,
+        "Backend execute must not run when audit fails in strict mode",
+    )
+
+
+def test_strict_audit_blocks_write_when_audit_log_fails():
+    """strict_audit=True: a failing audit log refuses write()."""
+    def failing_audit_log(operation: str, target: str, meta: dict):
+        raise RuntimeError("SIEM unreachable")
+
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: False
+    backend._ensure_parent_dir = lambda _: None
+    upload_calls = []
+    backend._upload_bytes = lambda path, content: upload_calls.append((path, content))
+
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=failing_audit_log, strict_audit=True,
+    )
+
+    result = wrapped.write("/app/file.txt", "content")
+
+    _require(result.error is not None, "Expected write to be refused")
+    _require(
+        "Audit log unavailable" in result.error,
+        f"Expected refusal message, got: {result.error!r}",
+    )
+    _require(upload_calls == [], "Backend write must not run when audit fails in strict mode")
+
+
+def test_strict_audit_blocks_upload_files_when_audit_log_fails():
+    """strict_audit=True: a failing audit log refuses upload_files entries."""
+    def failing_audit_log(operation: str, target: str, meta: dict):
+        raise RuntimeError("SIEM unreachable")
+
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "missing"
+    backend._dir_state = lambda _: "writable"
+    upload_calls = []
+    backend._upload_bytes = lambda path, content: upload_calls.append((path, content))
+
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=failing_audit_log, strict_audit=True,
+    )
+
+    responses = wrapped.upload_files([("/app/file.txt", b"data")])
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(
+        responses[0].error is not None and "Audit log unavailable" in responses[0].error,
+        f"Expected audit-failure deny string, got {responses[0].error!r}",
+    )
+    _require(upload_calls == [], "Backend upload must not run when audit fails in strict mode")
+
+
+def test_strict_audit_passes_through_when_audit_log_succeeds():
+    """strict_audit=True only blocks on FAILURE — happy path still works."""
+    audit_calls = []
+
+    def good_audit_log(operation: str, target: str, meta: dict):
+        audit_calls.append((operation, target, meta))
+
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=good_audit_log, strict_audit=True,
+    )
+
+    result = wrapped.execute("echo test")
+
+    _require(result.exit_code == 0, "Expected command to succeed")
+    _require(len(audit_calls) == 1, f"Expected 1 audit call, got {len(audit_calls)}")
+    _require(audit_calls[0][0] == "execute", f"Unexpected operation: {audit_calls[0][0]}")
+
+
+def test_strict_audit_blocks_edit_when_audit_log_fails():
+    """strict_audit=True: a failing audit log refuses edit().
+
+    Pins parity with execute/write/upload — without this test, a
+    refactor that drops the deny check from SandboxPolicyWrapper.edit
+    would not be caught.
+    """
+    def failing_audit_log(operation: str, target: str, meta: dict):
+        raise RuntimeError("SIEM unreachable")
+
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    edit_calls = []
+    backend.edit = lambda *a, **kw: edit_calls.append((a, kw))  # type: ignore[assignment]
+
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=failing_audit_log, strict_audit=True,
+    )
+
+    result = wrapped.edit("/app/file.txt", "old", "new", replace_all=False)
+
+    _require(result.error is not None, "Expected edit to be refused")
+    _require(
+        "Audit log unavailable" in result.error,
+        f"Expected refusal message, got: {result.error!r}",
+    )
+    _require(result.occurrences == 0, "Expected occurrences=0 on refusal")
+    _require(edit_calls == [], "Backend edit must not run when audit fails in strict mode")
+
+
+def test_strict_audit_with_no_audit_log_is_a_noop():
+    """strict_audit=True + audit_log=None must NOT refuse operations.
+
+    Strict mode only matters when there's a callback to fail. A
+    regression that accidentally treated `audit_log=None` as "no audit
+    available, refuse" would break every wrapper that opts into strict
+    mode without configuring a callback.
+    """
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=None, strict_audit=True,
+    )
+
+    result = wrapped.execute("echo test")
+
+    _require(result.exit_code == 0, f"Expected exit_code=0, got {result.exit_code}")
+    _require(result.output == "ok", f"Unexpected output: {result.output!r}")
+
+
+def test_strict_audit_upload_files_preserves_deny_detail():
+    """strict_audit upload must surface the deny string, not 'policy_denied'.
+
+    Pins the consistency fix: write/edit preserve the deny string in
+    their error fields, and upload_files used to flatten it to
+    'policy_denied'. After the fix, the audit-failure detail
+    propagates so callers can distinguish 'audit pipeline down' from
+    a deny_prefixes hit.
+    """
+    def failing_audit_log(operation: str, target: str, meta: dict):
+        raise RuntimeError("SIEM unreachable")
+
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    backend._file_state = lambda _: "missing"
+    backend._dir_state = lambda _: "writable"
+
+    wrapped = SandboxPolicyWrapper(
+        backend, audit_log=failing_audit_log, strict_audit=True,
+    )
+
+    responses = wrapped.upload_files([("/app/file.txt", b"data")])
+
+    _require(len(responses) == 1, f"Expected 1 response, got {len(responses)}")
+    _require(
+        responses[0].error is not None and "Audit log unavailable" in responses[0].error,
+        f"Expected deny detail in error, got {responses[0].error!r}",
+    )
+    _require(
+        "SIEM unreachable" in responses[0].error,
+        f"Expected underlying error in deny string, got {responses[0].error!r}",
+    )
+
+
+@pytest.mark.parametrize(
+    "operation,call",
+    [
+        ("write", lambda w: w.write("/app/x.txt", "data")),
+        ("edit", lambda w: w.edit("/app/x.txt", "old", "new", False)),
+        (
+            "upload",
+            lambda w: w.upload_files([("/app/x.txt", b"data")]),
+        ),
+    ],
+)
+def test_default_audit_failure_does_not_block_write_edit_upload(operation, call):
+    """Fail-open is the default: a failing audit log must not block write/edit/upload.
+
+    Previously only `execute` had explicit fail-open coverage. A
+    refactor that accidentally made any of these fail-closed by
+    default would slip through. Parametrized over the three remaining
+    audited operations.
+    """
+    audit_attempts = []
+
+    def failing_audit_log(op: str, target: str, meta: dict):
+        audit_attempts.append((op, target))
+        raise RuntimeError("audit pipe down")
+
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="", exit_code=0))
+    # Stub sandbox.files methods so the test exercises the wrapper's
+    # decision logic without going through real file ops.
+    client.files.exists = lambda path, timeout=60: False
+    upload_calls = []
+    client.files.write = lambda path, content, timeout=60: upload_calls.append((path, content))
+    backend = AgentSandboxBackend(client)
+    backend._ensure_parent_dir = lambda _: None
+    backend._file_state = lambda _: "missing"
+    backend._dir_state = lambda _: "writable"
+
+    # edit() exercises a different code path: stub the underlying
+    # backend.edit so we can assert the wrapper called through.
+    edit_calls = []
+    real_edit = backend.edit
+    def stub_edit(*a, **kw):
+        edit_calls.append((a, kw))
+        return real_edit.__class__  # placeholder; not used
+    if operation == "edit":
+        from langchain_agent_sandbox.backend import EditResult
+        backend.edit = lambda *a, **kw: (  # type: ignore[assignment]
+            edit_calls.append((a, kw)) or EditResult(error=None, path=a[0], occurrences=1)
+        )
+
+    wrapped = SandboxPolicyWrapper(backend, audit_log=failing_audit_log)
+
+    result = call(wrapped)
+
+    _require(
+        len(audit_attempts) >= 1,
+        f"Expected audit log to have been invoked, got {audit_attempts}",
+    )
+
+    if operation == "upload":
+        _require(
+            len(result) == 1 and result[0].error is None,
+            f"Expected upload to succeed in fail-open mode, got {result}",
+        )
+        _require(
+            len(upload_calls) == 1,
+            f"Expected backend upload to run, got {upload_calls}",
+        )
+    elif operation == "write":
+        _require(
+            result.error is None,
+            f"Expected write to succeed in fail-open mode, got error={result.error!r}",
+        )
+        _require(
+            len(upload_calls) == 1,
+            f"Expected backend upload to run, got {upload_calls}",
+        )
+    elif operation == "edit":
+        _require(
+            result.error is None,
+            f"Expected edit to succeed in fail-open mode, got error={result.error!r}",
+        )
+        _require(
+            len(edit_calls) == 1,
+            f"Expected backend edit to run, got {edit_calls}",
+        )
+
+
+def test_exit_logs_cleanup_error_when_masked_by_user_exception(caplog):
+    """When a user exception is in flight, the cleanup error must be logged.
+
+    Pins the contract that cleanup failures during exception unwind
+    are surfaced via logging — a refactor that dropped the
+    `logger.error` call would silently lose the leak signal.
+    """
+    import logging
+
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = RuntimeError("teardown also broken")
+    sandbox = StubSandbox()
+    sandbox.claim_name = "leaked-claim"
+
+    backend = AgentSandboxBackend(
+        sandbox=sandbox,
+        manage_lifecycle=True,
+        sdk_client=mock_sdk,
+    )
+    backend.__enter__()
+
+    user_exc = ValueError("the original problem")
+    with caplog.at_level(logging.ERROR, logger="langchain_agent_sandbox.backend"):
+        # __exit__ on the user-exception path should bundle both via
+        # ExceptionGroup and also log. We don't assert no-raise here
+        # because the new behavior IS to raise an ExceptionGroup —
+        # see test_exit_raises_exception_group_when_cleanup_fails_during_unwind.
+        try:
+            backend.__exit__(type(user_exc), user_exc, None)
+        except BaseExceptionGroup:
+            pass
+
+    _require(
+        any("Failed to delete sandbox" in r.message for r in caplog.records),
+        f"Expected cleanup-failure log on the masked path, got {[r.message for r in caplog.records]}",
+    )
+
+
+def test_exit_raises_exception_group_when_cleanup_fails_during_unwind():
+    """Cleanup failure during exception unwind raises BaseExceptionGroup.
+
+    The previous behavior swallowed the cleanup error and re-raised
+    only the user exception, hiding the leaked sandbox. The new
+    behavior bundles both into an ExceptionGroup so neither is lost.
+    """
+    mock_sdk = MagicMock()
+    mock_sdk.delete_sandbox.side_effect = RuntimeError("teardown also broken")
+    sandbox = StubSandbox()
+    sandbox.claim_name = "leaked-claim"
+
+    backend = AgentSandboxBackend(
+        sandbox=sandbox,
+        manage_lifecycle=True,
+        sdk_client=mock_sdk,
+    )
+    backend.__enter__()
+
+    user_exc = ValueError("the original problem")
+    try:
+        backend.__exit__(type(user_exc), user_exc, None)
+    except BaseExceptionGroup as eg:
+        # Both exceptions must be present in the group.
+        types = {type(e) for e in eg.exceptions}
+        _require(
+            ValueError in types,
+            f"Expected ValueError in ExceptionGroup, got {types}",
+        )
+        _require(
+            RuntimeError in types,
+            f"Expected RuntimeError in ExceptionGroup, got {types}",
+        )
+        # Original user exception should be one of the peers, not chained.
+        _require(
+            any(e is user_exc for e in eg.exceptions),
+            "Original user exception should be a peer in the ExceptionGroup",
+        )
+    else:
+        pytest.fail("Expected BaseExceptionGroup to be raised")
+
+
+# --- Path traversal, error propagation, and find/grep edge cases ---
+
+
+def test_to_internal_allows_dotdot_prefix_filenames():
+    """Filenames like '..foo' are valid and should not be blocked."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+
+    result = backend._to_internal("..foo")
+
+    _require(result == "/app/..foo", f"Expected /app/..foo, got {result}")
+
+
+def test_to_internal_still_blocks_traversal():
+    """Ensure actual traversal like '../' is still blocked after the ..foo fix."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+
+    with pytest.raises(ValueError):
+        backend._to_internal("../etc/passwd")
+
+    with pytest.raises(ValueError):
+        backend._to_internal("..")
+
+
+def test_read_error_propagates_exception_message():
+    """read() should include the underlying exception message in its error response."""
+    client = StubSandbox()
+    client.files.read = lambda path, timeout=60: (_ for _ in ()).throw(
+        PermissionError("permission denied")
+    )
+    backend = AgentSandboxBackend(client)
+
+    response = backend.read("/secret.txt")
+
+    _require(response.error is not None, "Expected error")
+    _require("permission denied" in response.error, f"Expected exception message in error, got: {response.error}")
+    _require("not found" not in response.error, f"Should not say 'not found' for permission errors: {response.error}")
+
+
+def test_grep_handles_colons_in_filenames():
+    """grep with -Z uses null bytes to separate filenames, handling colons."""
+    # Simulate grep -Z output: filename\0line_no:text
+    grep_output = "/app/config:prod.yaml\x0015:key: value\n/app/normal.txt\x005:other: match\n"
+    client = StubSandbox(run_result=SimpleNamespace(stdout=grep_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("key", path="/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    matches = result.matches
+    _require(len(matches) == 2, f"Expected 2 matches, got {len(matches)}")
+    _require(matches[0]["path"] == "/config:prod.yaml", f"Unexpected path: {matches[0]['path']}")
+    _require(matches[0]["line"] == 15, f"Unexpected line: {matches[0]['line']}")
+    _require(matches[0]["text"] == "key: value", f"Unexpected text: {matches[0]['text']}")
+
+
+def test_grep_fallback_without_null_bytes():
+    """grep output without null bytes falls back to colon splitting."""
+    grep_output = "/app/file.py:10:def foo():\n"
+    client = StubSandbox(run_result=SimpleNamespace(stdout=grep_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("foo", path="/")
+
+    matches = result.matches
+    _require(len(matches) == 1, f"Expected 1 match, got {len(matches)}")
+    _require(matches[0]["path"] == "/file.py", f"Unexpected path: {matches[0]['path']}")
+
+
+def test_glob_preserves_matches_on_partial_find_failure():
+    """find returning non-zero exit (e.g. permission denied on one dir) should keep valid matches."""
+    find_output = (
+        "f\t0\t0\t/app/accessible.py\x00"
+        "d\t0\t0\t/app/subdir\x00"
+    )
+    client = StubSandbox(
+        run_result=SimpleNamespace(
+            stdout=find_output,
+            stderr="find: '/app/restricted': Permission denied",
+            exit_code=1,
+        )
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("*", path="/")
+
+    matches = result.matches
+    _require(len(matches) == 2, f"Expected 2 matches from partial results, got {len(matches)}")
+    paths = [e["path"] for e in matches]
+    _require("/accessible.py" in paths, f"Expected /accessible.py in results: {paths}")
+    _require("/subdir" in paths, f"Expected /subdir in results: {paths}")
+
+
+def test_glob_returns_error_on_total_find_failure():
+    """find returning non-zero with no stdout should populate error."""
+    client = StubSandbox(
+        run_result=SimpleNamespace(
+            stdout="",
+            stderr="find: '/app/nonexistent': No such file or directory",
+            exit_code=1,
+        )
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("*.py", path="/nonexistent")
+
+    _require(result.matches == [], f"Expected empty matches, got {result.matches}")
+    _require(result.error is not None, "Expected error to be populated on total failure")
+    _require("No such file" in result.error, f"Expected stderr in error, got: {result.error}")
+
+
+def test_glob_partial_failure_returns_matches_without_error():
+    """Partial find failure (some stdout produced) should keep matches, no error."""
+    find_output = "f\t0\t0\t/app/accessible.py\x00"
+    client = StubSandbox(
+        run_result=SimpleNamespace(
+            stdout=find_output,
+            stderr="find: '/app/restricted': Permission denied",
+            exit_code=1,
+        )
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("*.py", path="/")
+
+    _require(result.error is None, f"Expected no error on partial success, got: {result.error}")
+    _require(len(result.matches) == 1, f"Expected 1 match, got {len(result.matches)}")
+
+
+def test_glob_find_command_uses_symlink_follow():
+    """find command should use -L to follow symlinks."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    backend.glob("*.py", path="/")
+
+    cmd = client.commands.last_command
+    _require("find -L " in cmd, f"Expected 'find -L' in command, got: {cmd}")
+
+
+def test_to_internal_allows_dotdot_prefix_in_nested_path():
+    """Filenames like '..config' inside subdirectories should not be blocked."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+
+    result = backend._to_internal("subdir/..config")
+
+    _require(result == "/app/subdir/..config", f"Expected /app/subdir/..config, got {result}")
+
+
+def test_to_internal_allows_triple_dot_filename():
+    """Triple-dot '...' is a valid filename and should not be blocked."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client, root_dir="/app")
+
+    result = backend._to_internal("...")
+
+    _require(result == "/app/...", f"Expected /app/..., got {result}")
+
+
+def test_grep_command_includes_z_flag():
+    """grep command should include -Z for null-byte filename delimiters."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="", exit_code=1))
+    backend = AgentSandboxBackend(client)
+
+    backend.grep("pattern", path="/")
+
+    cmd = client.commands.last_command
+    _require("-rHnFZ" in cmd, f"Expected -rHnFZ in command, got: {cmd}")
+
+
+def test_grep_skips_null_line_with_no_colon_in_remainder():
+    """grep output with null byte but malformed remainder should be skipped."""
+    grep_output = "/app/good.py\x005:match\n/app/bad.py\x00malformed\n"
+    client = StubSandbox(run_result=SimpleNamespace(stdout=grep_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("match", path="/")
+
+    matches = result.matches
+    _require(len(matches) == 1, f"Expected 1 match (malformed skipped), got {len(matches)}")
+    _require(matches[0]["path"] == "/good.py", f"Unexpected path: {matches[0]['path']}")
+
+
+def test_read_missing_file_includes_failed_to_read():
+    """read() error format should use 'Failed to read' prefix."""
+    client = StubSandbox()
+    client.files.read = lambda path, timeout=60: (_ for _ in ()).throw(
+        RuntimeError("file not found")
+    )
+    backend = AgentSandboxBackend(client)
+
+    response = backend.read("/missing.txt")
+
+    _require(response.error is not None, "Expected error")
+    _require("Failed to read" in response.error, f"Expected 'Failed to read' in error, got: {response.error}")
+
+
+# --- Post-review hardening: exception paths, timeout forwarding, encoding ---
+
+
+def test_ls_handles_sandbox_exception():
+    """ls should surface transport errors via LsResult.error, not crash."""
+    client = StubSandbox()
+    client.files.list = lambda path, timeout=60: (_ for _ in ()).throw(
+        RuntimeError("connection dropped")
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.ls("/")
+
+    _require(result.error is not None, "Expected error")
+    _require(result.entries == [], "Expected empty entries on exception")
+    _require("connection dropped" in result.error, f"Expected exception message, got: {result.error}")
+
+
+def test_grep_handles_sandbox_exception():
+    """grep should surface transport errors via GrepResult.error, not crash."""
+    client = StubSandbox()
+    client.commands.run = lambda cmd, **kw: (_ for _ in ()).throw(
+        RuntimeError("connection dropped")
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.grep("pattern", path="/")
+
+    _require(result.error is not None, "Expected error")
+    _require(result.matches == [], "Expected empty matches on exception")
+    _require("connection dropped" in result.error, f"Expected exception message, got: {result.error}")
+
+
+def test_glob_handles_sandbox_exception():
+    """glob should surface transport errors via GlobResult.error, not crash."""
+    client = StubSandbox()
+    client.commands.run = lambda cmd, **kw: (_ for _ in ()).throw(
+        RuntimeError("connection dropped")
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("*.py", path="/")
+
+    _require(result.error is not None, "Expected error")
+    _require(result.matches == [], "Expected empty matches on exception")
+    _require("connection dropped" in result.error, f"Expected exception message, got: {result.error}")
+
+
+def test_read_empty_file_with_offset_returns_empty_content():
+    """Reading an empty file with any offset should succeed with empty content."""
+    client = StubSandbox(read_bytes=b"")
+    backend = AgentSandboxBackend(client)
+
+    result = backend.read("/empty.txt", offset=42, limit=10)
+
+    _require(result.error is None, f"Expected success on empty file, got: {result.error}")
+    _require(result.file_data is not None, "Expected file_data to be populated")
+    _require(result.file_data["content"] == "", f"Expected empty content, got: {result.file_data['content']!r}")
+    _require(result.file_data["encoding"] == "utf-8", "Expected utf-8 encoding")
+
+
+def test_read_offset_equals_line_count_returns_error():
+    """Off-by-one boundary: offset equal to line count should error."""
+    client = StubSandbox(read_bytes=b"line1\nline2\nline3")
+    backend = AgentSandboxBackend(client)
+
+    result = backend.read("/file.txt", offset=3, limit=10)
+
+    _require(result.error is not None, "Expected error at boundary")
+    _require("exceeds file length" in result.error, f"Unexpected error: {result.error}")
+
+
+def test_read_invalid_utf8_returns_error():
+    """Non-UTF-8 content should be reported as an error, not silently replaced."""
+    # 0xff is not valid UTF-8 and would silently become U+FFFD under errors="replace"
+    client = StubSandbox(read_bytes=b"valid\nline\n\xff\xfe invalid")
+    backend = AgentSandboxBackend(client)
+
+    result = backend.read("/binary.bin")
+
+    _require(result.error is not None, "Expected error for invalid UTF-8")
+    _require("UTF-8" in result.error, f"Expected UTF-8 mention in error, got: {result.error}")
+    _require(result.file_data is None, "Expected no file_data on decode error")
+
+
+def test_edit_invalid_utf8_returns_error_without_writing():
+    """edit() on a non-UTF-8 file should error before any write, preventing corruption."""
+    client = StubSandbox(read_bytes=b"\xff\xfe not utf-8")
+    backend = AgentSandboxBackend(client)
+    backend._exists = lambda _: True
+    uploaded = []
+    backend._upload_bytes = lambda path, content: uploaded.append((path, content))
+
+    result = backend.edit("/binary.bin", "foo", "bar")
+
+    _require(result.error is not None, "Expected error for invalid UTF-8")
+    _require("UTF-8" in result.error, f"Expected UTF-8 mention in error, got: {result.error}")
+    _require(uploaded == [], f"Edit must not write when decode fails, got uploads: {uploaded}")
+
+
+def test_execute_forwards_timeout_when_provided():
+    """execute(timeout=N) must pass timeout kwarg to the sandbox command runner."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    backend.execute("echo test", timeout=30)
+
+    _require(
+        client.commands.last_kwargs.get("timeout") == 30,
+        f"Expected timeout=30 forwarded, got kwargs: {client.commands.last_kwargs}",
+    )
+
+
+def test_execute_omits_timeout_kwarg_when_none():
+    """execute() without timeout must NOT pass the kwarg (use sandbox default)."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    backend.execute("echo test")
+
+    _require(
+        "timeout" not in client.commands.last_kwargs,
+        f"Expected no timeout kwarg, got: {client.commands.last_kwargs}",
+    )
+
+
+def test_execute_returns_timeout_exit_code_on_builtin_timeout_error():
+    """execute() should return exit_code=-2 on a direct Python TimeoutError."""
+    client = StubSandbox()
+    client.commands.run = lambda cmd, **kw: (_ for _ in ()).throw(
+        TimeoutError("command exceeded 5s")
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.execute("sleep 10", timeout=5)
+
+    _require(result.exit_code == -2, f"Expected exit_code=-2 on timeout, got {result.exit_code}")
+    _require("Timed out" in result.output, f"Expected 'Timed out' prefix, got: {result.output}")
+    _require("command exceeded 5s" in result.output, f"Expected original message, got: {result.output}")
+
+
+def test_execute_returns_timeout_exit_code_on_wrapped_requests_timeout():
+    """execute() should detect a requests.exceptions.Timeout buried in the cause chain.
+
+    The k8s_agent_sandbox SDK's connector catches requests.exceptions.Timeout
+    and re-raises as SandboxRequestError via `raise ... from e`. A real HTTP
+    read timeout therefore arrives at the backend as a RuntimeError subclass
+    whose __cause__ is the original Timeout — NOT as a builtin TimeoutError.
+    This test simulates that exact shape with a custom wrapper class that
+    mirrors SandboxRequestError's inheritance (RuntimeError, not TimeoutError)
+    and verifies the cause-chain walker still classifies it as a timeout.
+    """
+    from requests.exceptions import ReadTimeout
+
+    class _FakeSandboxRequestError(RuntimeError):
+        """Stand-in for k8s_agent_sandbox.exceptions.SandboxRequestError."""
+
+    original = ReadTimeout("HTTPConnectionPool(...): Read timed out. (read timeout=5)")
+    wrapped = _FakeSandboxRequestError("Failed to communicate with the sandbox at ...")
+    wrapped.__cause__ = original
+
+    client = StubSandbox()
+    client.commands.run = lambda cmd, **kw: (_ for _ in ()).throw(wrapped)
+    backend = AgentSandboxBackend(client)
+
+    result = backend.execute("sleep 10", timeout=5)
+
+    _require(result.exit_code == -2, f"Expected exit_code=-2 on wrapped timeout, got {result.exit_code}")
+    _require("Timed out" in result.output, f"Expected 'Timed out' prefix, got: {result.output}")
+
+
+def test_execute_returns_generic_error_exit_code_on_other_exception():
+    """execute() should keep exit_code=-1 for non-timeout exceptions (distinguishable)."""
+    client = StubSandbox()
+    client.commands.run = lambda cmd, **kw: (_ for _ in ()).throw(RuntimeError("boom"))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.execute("echo test")
+
+    _require(result.exit_code == -1, f"Expected exit_code=-1, got {result.exit_code}")
+    _require("Error: boom" in result.output, f"Expected 'Error:' prefix, got: {result.output}")
+
+
+@pytest.mark.asyncio
+async def test_aexecute_forwards_timeout():
+    """aexecute(timeout=N) must pass the timeout kwarg through."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    await backend.aexecute("echo test", timeout=15)
+
+    _require(
+        client.commands.last_kwargs.get("timeout") == 15,
+        f"Expected timeout=15 forwarded, got kwargs: {client.commands.last_kwargs}",
+    )
+
+
+def test_policy_wrapper_execute_forwards_timeout():
+    """SandboxPolicyWrapper.execute must forward timeout to the backend."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(backend)
+
+    wrapped.execute("echo test", timeout=45)
+
+    _require(
+        client.commands.last_kwargs.get("timeout") == 45,
+        f"Expected timeout=45 forwarded through wrapper, got: {client.commands.last_kwargs}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for new features added in round-4 (labels, shutdown_after_seconds,
+# delete_all, size/modified_at in glob)
+# ---------------------------------------------------------------------------
+
+
+def test_from_template_passes_labels_and_shutdown():
+    """from_template stores labels and shutdown_after_seconds for __enter__."""
+    mock_client = MagicMock()
+
+    backend = AgentSandboxBackend.from_template(
+        client=mock_client,
+        template_name="test-template",
+        labels={"team": "infra", "suite": "e2e"},
+        shutdown_after_seconds=600,
+    )
+
+    _require(backend._labels == {"team": "infra", "suite": "e2e"}, "labels not stored")
+    _require(backend._shutdown_after_seconds == 600, "shutdown_after_seconds not stored")
+
+
+def test_from_template_enter_passes_labels_to_create():
+    """__enter__ should forward labels and shutdown_after_seconds to create_sandbox."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        client=mock_client,
+        template_name="test-tmpl",
+        labels={"owner": "ci"},
+        shutdown_after_seconds=300,
+    )
+    backend.__enter__()
+
+    create_kwargs = mock_client.create_sandbox.call_args
+    _require(create_kwargs.kwargs.get("labels") == {"owner": "ci"}, "labels not passed to create_sandbox")
+    _require(create_kwargs.kwargs.get("shutdown_after_seconds") == 300, "shutdown_after_seconds not passed")
+
+    # Cleanup: don't actually delete
+    backend._manage_lifecycle = False
+
+
+def test_from_template_enter_omits_none_labels():
+    """__enter__ should NOT pass labels= when it was not specified (None)."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(client=mock_client, template_name="test-tmpl")
+    backend.__enter__()
+
+    create_kwargs = mock_client.create_sandbox.call_args
+    _require("labels" not in create_kwargs.kwargs, "labels should not be passed when None")
+    _require("shutdown_after_seconds" not in create_kwargs.kwargs, "shutdown_after_seconds should not be passed when None")
+
+    backend._manage_lifecycle = False
+
+
+def test_delete_all_deletes_listed_claims():
+    """delete_all should list all claims and delete each one."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["claim-a", "claim-b"]
+
+    deleted = AgentSandboxBackend.delete_all(client=mock_client, namespace="test-ns")
+
+    _require(deleted == 2, f"Expected 2 deletions, got {deleted}")
+    _require(mock_client.delete_sandbox.call_count == 2, "Expected delete_sandbox called twice")
+    calls = mock_client.delete_sandbox.call_args_list
+    _require(
+        calls[0].kwargs.get("claim_name") == "claim-a",
+        f"First delete should be claim-a, got {calls[0]}",
+    )
+    _require(
+        calls[1].kwargs.get("claim_name") == "claim-b",
+        f"Second delete should be claim-b, got {calls[1]}",
+    )
+
+
+def test_delete_all_best_effort_continues_on_failure():
+    """delete_all with best_effort=True should log failures and continue."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["claim-a", "claim-b"]
+    mock_client.delete_sandbox.side_effect = [RuntimeError("boom"), None]
+
+    deleted = AgentSandboxBackend.delete_all(client=mock_client, namespace="test-ns", best_effort=True)
+
+    _require(deleted == 1, f"Expected 1 successful deletion, got {deleted}")
+
+
+def test_delete_all_raises_on_failure_when_not_best_effort():
+    """delete_all with best_effort=False should raise on first failure."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["claim-a"]
+    mock_client.delete_sandbox.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        AgentSandboxBackend.delete_all(client=mock_client, namespace="test-ns", best_effort=False)
+
+
+def test_glob_populates_size_and_modified_at():
+    """glob() with the new find -printf format should populate size + modified_at."""
+    # The new format is: "f <size> <mod_time> <path>" or "d <size> <mod_time> <path>"
+    find_output = (
+        "f\t1024\t1700000000.0\t/app/data.csv\x00"
+        "d\t4096\t1700000001.0\t/app/subdir\x00"
+    )
+    client = StubSandbox(run_result=SimpleNamespace(stdout=find_output, stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    result = backend.glob("**", path="/")
+
+    _require(result.error is None, f"Unexpected error: {result.error}")
+    entries = result.matches
+    _require(len(entries) == 2, f"Expected 2 entries, got {len(entries)}")
+    csv_entry = next(e for e in entries if "data.csv" in e["path"])
+    _require(csv_entry.get("size") == 1024, f"Expected size=1024, got {csv_entry.get('size')}")
+    _require(csv_entry.get("modified_at") is not None, "Expected modified_at on csv_entry")
+    _require(csv_entry["is_dir"] is False, "Expected data.csv to not be a dir")
+    dir_entry = next(e for e in entries if "subdir" in e["path"])
+    _require(dir_entry["is_dir"] is True, "Expected subdir to be a dir")
+    _require(dir_entry.get("size") == 4096, f"Expected size=4096, got {dir_entry.get('size')}")
+
+
+@pytest.mark.asyncio
+async def test_policy_wrapper_aexecute_forwards_timeout():
+    """SandboxPolicyWrapper.aexecute must forward timeout to the backend."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+    wrapped = SandboxPolicyWrapper(backend)
+
+    await wrapped.aexecute("echo test", timeout=60)
+
+    _require(
+        client.commands.last_kwargs.get("timeout") == 60,
+        f"Expected timeout=60 forwarded through async wrapper, got: {client.commands.last_kwargs}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for review fixes (sandbox None guard, NUL bytes, edit error message,
+# _file_state/_dir_state whitelist)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_raises_when_sandbox_is_none():
+    """Calling execute without __enter__ on a from_template() backend
+    should produce a clear RuntimeError, not an opaque AttributeError."""
+    backend = AgentSandboxBackend.from_template(client=MagicMock(), template_name="t")
+    # sandbox is None because __enter__ was never called
+    with pytest.raises(RuntimeError, match="not initialized"):
+        backend.execute("echo hi")
+
+
+def test_ls_raises_when_sandbox_is_none():
+    backend = AgentSandboxBackend.from_template(client=MagicMock(), template_name="t")
+    with pytest.raises(RuntimeError, match="not initialized"):
+        backend.ls("/")
+
+
+def test_upload_files_raises_when_sandbox_is_none():
+    backend = AgentSandboxBackend.from_template(client=MagicMock(), template_name="t")
+    with pytest.raises(RuntimeError, match="not initialized"):
+        backend.upload_files({"/a.txt": b"x"})
+
+
+def test_to_internal_rejects_nul_byte():
+    """Paths containing NUL bytes must be rejected to prevent C-level
+    string truncation that would bypass the relpath traversal defense."""
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+
+    with pytest.raises(ValueError, match="control characters"):
+        backend._to_internal("/app/report\x00attack.sh")
+
+
+def test_to_internal_rejects_newline():
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+
+    with pytest.raises(ValueError, match="control characters"):
+        backend._to_internal("/app/foo\nbar.txt")
+
+
+def test_edit_error_includes_exception_message():
+    """edit() should include the actual exception in the error, not
+    hardcoded 'not found' regardless of failure type."""
+    client = StubSandbox()
+    client.files.read = lambda path, timeout=60: (_ for _ in ()).throw(
+        RuntimeError("connection timed out")
+    )
+    backend = AgentSandboxBackend(client)
+
+    result = backend.edit("/file.txt", "old", "new")
+
+    _require(result.error is not None, "Expected error")
+    _require(
+        "connection timed out" in result.error,
+        f"Expected exception message in error, got: {result.error}",
+    )
+    _require(
+        "not found" not in result.error.lower(),
+        f"Should not say 'not found' for a timeout: {result.error}",
+    )
+
+
+def test_file_state_rejects_unexpected_output():
+    """_file_state should return 'error' for unexpected sandbox stdout."""
+    client = StubSandbox(
+        run_result=SimpleNamespace(stdout="something_unexpected\n", stderr="", exit_code=0)
+    )
+    backend = AgentSandboxBackend(client)
+
+    state = backend._file_state("/app/test.txt")
+    _require(state == "error", f"Expected 'error' for unexpected output, got {state!r}")
+
+
+def test_dir_state_rejects_unexpected_output():
+    """_dir_state should return 'error' for unexpected sandbox stdout."""
+    client = StubSandbox(
+        run_result=SimpleNamespace(stdout="multiline\ngarbage\n", stderr="", exit_code=0)
+    )
+    backend = AgentSandboxBackend(client)
+
+    state = backend._dir_state("/app/dir")
+    _require(state == "error", f"Expected 'error' for unexpected output, got {state!r}")
+
+
+# ── from_existing() ──
+
+
+def test_from_existing_returns_unmanaged_backend():
+    """from_existing() should create a non-lifecycle-managed backend."""
+    sandbox = StubSandbox()
+    backend = AgentSandboxBackend.from_existing(sandbox, root_dir="/workspace")
+
+    _require(backend._manage_lifecycle is False, "Expected unmanaged lifecycle")
+    _require(backend._root_dir == "/workspace", f"Unexpected root_dir: {backend._root_dir}")
+    _require(backend._sandbox is sandbox, "Expected same sandbox reference")
+
+
+def test_from_existing_enter_exit_does_not_delete():
+    """from_existing() backends should not delete sandbox on __exit__."""
+    sandbox = StubSandbox()
+    sandbox.claim_name = "my-claim"
+    backend = AgentSandboxBackend.from_existing(sandbox)
+
+    with backend:
+        pass
+    # sandbox reference should still be set (not cleared like managed mode)
+    # Actually for unmanaged, __exit__ does nothing so sandbox stays
+    _require(backend._sandbox is sandbox, "Should not clear sandbox ref in unmanaged mode")
+
+
+# ── from_template(client=...) ──
+
+
+def test_from_template_accepts_prebuilt_client():
+    """from_template(client=...) should use the provided client."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="my-template",
+        client=mock_client,
+    )
+    _require(backend._sdk_client is mock_client, "Expected pre-built client")
+
+    # When entering, it should use the pre-built client
+    with backend:
+        mock_client.create_sandbox.assert_called_once()
+
+
+def test_from_template_client_is_stored():
+    """When client= is provided, it should be stored as the sdk_client."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+    mock_client.list_all_sandboxes.return_value = []
+
+    backend = AgentSandboxBackend.from_template(
+        client=mock_client,
+        template_name="t",
+    )
+    _require(backend._sdk_client is mock_client, "Should use provided client")
+
+
+# ── session_id reattach ──
+
+
+def test_session_id_creates_sandbox_with_session_label():
+    """When session_id is set and no existing sandbox found, create with label."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = []  # no existing
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="my-template",
+        session_id="thread-abc",
+        client=mock_client,
+    )
+    with backend:
+        pass
+
+    # Verify label was set on create
+    call_kwargs = mock_client.create_sandbox.call_args
+    labels = call_kwargs.kwargs.get("labels") or call_kwargs[1].get("labels", {})
+    _require(
+        labels.get("agent-sandbox.sigs.k8s.io/session-id") == "thread-abc",
+        f"Expected session-id label, got labels: {labels}",
+    )
+
+
+def test_session_id_reattaches_to_existing_sandbox():
+    """When session_id finds an existing claim, reattach instead of creating."""
+    mock_client = MagicMock()
+    existing_sandbox = StubSandbox()
+    existing_sandbox.claim_name = "sandbox-claim-existing"
+    mock_client.list_all_sandboxes.return_value = ["sandbox-claim-existing"]
+    mock_client.get_sandbox.return_value = existing_sandbox
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="my-template",
+        session_id="thread-abc",
+        client=mock_client,
+    )
+    with backend:
+        _require(
+            backend._sandbox is existing_sandbox,
+            "Expected reattached sandbox",
+        )
+        _require(backend._reattached is True, "Expected _reattached=True")
+
+    # Should NOT have called create_sandbox
+    mock_client.create_sandbox.assert_not_called()
+    # And should NOT have deleted (reattached sandboxes persist)
+    mock_client.delete_sandbox.assert_not_called()
+    # Reattach must pass template_name so the SDK can refuse a claim
+    # whose sandboxTemplateRef doesn't match.
+    mock_client.get_sandbox.assert_called_once()
+    kwargs = mock_client.get_sandbox.call_args.kwargs
+    _require(
+        kwargs.get("template_name") == "my-template",
+        f"Expected template_name=my-template on reattach, got: {kwargs}",
+    )
+
+
+def test_session_id_refuses_reattach_on_multi_match():
+    """When multiple claims share a session_id label, do NOT silently pick one.
+
+    In a shared namespace another tenant could plant a claim with a
+    matching session-id label; picking claims[0] would hand them the
+    session's reads/writes. Multi-match must fall through to a fresh
+    create (logged at ERROR).
+    """
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = [
+        "session-claim-one",
+        "session-claim-two",
+    ]
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="my-template",
+        session_id="ambiguous",
+        client=mock_client,
+    )
+    with backend:
+        _require(backend._reattached is False, "Must not have reattached on multi-match")
+
+    # Never call get_sandbox when multi-match — don't leak reads to whichever claim.
+    mock_client.get_sandbox.assert_not_called()
+    mock_client.create_sandbox.assert_called_once()
+
+
+def test_session_id_propagates_template_mismatch():
+    """If the claim's template doesn't match, the SDK raises ValueError.
+
+    The backend must NOT swallow this into a silent fresh-create — the
+    caller needs the signal so they can investigate (stale session?
+    tenant collision?) rather than lose session continuity unnoticed.
+    """
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["matching-claim"]
+    mock_client.get_sandbox.side_effect = ValueError(
+        "SandboxClaim 'matching-claim' references template 'other', not 'mine'"
+    )
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="mine",
+        session_id="thread-x",
+        client=mock_client,
+    )
+    with pytest.raises(ValueError, match="references template 'other'"):
+        backend.__enter__()
+
+
+def test_session_id_falls_back_to_create_on_reattach_failure():
+    """When get_sandbox fails, fall back to creating a new sandbox."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["stale-claim"]
+    mock_client.get_sandbox.side_effect = RuntimeError("sandbox gone")
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="my-template",
+        session_id="thread-abc",
+        client=mock_client,
+    )
+    with backend:
+        _require(backend._reattached is False, "Should not be reattached")
+
+    mock_client.create_sandbox.assert_called_once()
+
+
+def test_session_id_lookup_uses_label_selector():
+    """Session reattach should query with label_selector."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = []
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="t",
+        session_id="my-session",
+        client=mock_client,
+    )
+    with backend:
+        pass
+
+    mock_client.list_all_sandboxes.assert_called_once_with(
+        namespace="default",
+        label_selector="agent-sandbox.sigs.k8s.io/session-id=my-session",
+    )
+
+
+def test_session_id_merges_with_existing_labels():
+    """Session label should merge with user-provided labels."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = []
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="t",
+        session_id="s1",
+        labels={"team": "ml"},
+        client=mock_client,
+    )
+    with backend:
+        pass
+
+    call_kwargs = mock_client.create_sandbox.call_args
+    labels = call_kwargs.kwargs.get("labels") or call_kwargs[1].get("labels", {})
+    _require(labels.get("team") == "ml", f"Expected user label, got: {labels}")
+    _require(
+        labels.get("agent-sandbox.sigs.k8s.io/session-id") == "s1",
+        f"Expected session label, got: {labels}",
+    )
+
+
+def test_no_session_id_skips_reattach():
+    """Without session_id, enter should create directly (no list_all_sandboxes)."""
+    mock_client = MagicMock()
+    mock_client.create_sandbox.return_value = StubSandbox()
+
+    backend = AgentSandboxBackend.from_template(
+        template_name="t",
+        client=mock_client,
+    )
+    with backend:
+        pass
+
+    mock_client.list_all_sandboxes.assert_not_called()
+
+
+# ── execute cwd alignment ──
+
+
+def test_execute_prepends_cd_to_root_dir():
+    """execute() should wrap commands with cd to root_dir."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client, root_dir="/workspace")
+
+    backend.execute("ls -la")
+
+    cmd = client.commands.last_command
+    _require("cd /workspace && ls -la" in cmd, f"Expected cd+command in: {cmd}")
+    _require(cmd.startswith("sh -c "), f"Expected sh -c wrapper, got: {cmd}")
+
+
+def test_execute_cwd_default_root_dir():
+    """Default root_dir /app should appear in the cd prefix."""
+    client = StubSandbox(run_result=SimpleNamespace(stdout="", stderr="", exit_code=0))
+    backend = AgentSandboxBackend(client)
+
+    backend.execute("echo hi")
+
+    cmd = client.commands.last_command
+    _require(cmd == "sh -c 'cd /app && echo hi'", f"Unexpected command: {cmd}")
+
+
+# ── SandboxPolicyWrapper protocol conformance ──
+
+
+def test_policy_wrapper_is_sandbox_backend_protocol():
+    """SandboxPolicyWrapper should be an instance of SandboxBackendProtocol."""
+    from deepagents.backends.protocol import SandboxBackendProtocol
+
+    client = StubSandbox()
+    backend = AgentSandboxBackend(client)
+    wrapper = SandboxPolicyWrapper(backend)
+
+    _require(
+        isinstance(wrapper, SandboxBackendProtocol),
+        "SandboxPolicyWrapper should implement SandboxBackendProtocol",
+    )
+
+
+def test_policy_wrapper_id_delegates():
+    """SandboxPolicyWrapper.id should delegate to backend."""
+    client = StubSandbox()
+    client.claim_name = "test-claim"
+    backend = AgentSandboxBackend(client)
+    wrapper = SandboxPolicyWrapper(backend)
+
+    _require(wrapper.id == "default/test-claim", f"Expected 'default/test-claim', got: {wrapper.id}")
+
+
+# ── delete_all with label_selector ──
+
+
+def test_delete_all_with_label_selector():
+    """delete_all should pass label_selector to list_all_sandboxes."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["claim-1"]
+    mock_client.delete_sandbox.return_value = None
+
+    deleted = AgentSandboxBackend.delete_all(
+        client=mock_client,
+        namespace="test-ns",
+        label_selector="team=ml",
+    )
+
+    mock_client.list_all_sandboxes.assert_called_once_with(
+        namespace="test-ns",
+        label_selector="team=ml",
+    )
+    _require(deleted == 1, f"Expected 1 deleted, got {deleted}")
+
+
+def test_delete_all_with_prebuilt_client():
+    """delete_all should use provided client instead of building one."""
+    mock_client = MagicMock()
+    mock_client.list_all_sandboxes.return_value = ["c1", "c2"]
+    mock_client.delete_sandbox.return_value = None
+
+    deleted = AgentSandboxBackend.delete_all(
+        namespace="ns",
+        client=mock_client,
+    )
+
+    _require(deleted == 2, f"Expected 2 deleted, got {deleted}")
+    mock_client.list_all_sandboxes.assert_called_once()
+
+
+# ── drain semantics ──
+
+
+def test_exit_waits_for_inflight_operations():
+    """__exit__ should wait for in-flight operations before deleting."""
+    import threading
+    import time
+
+    mock_client = MagicMock()
+    sandbox = StubSandbox(run_result=SimpleNamespace(stdout="ok", stderr="", exit_code=0))
+    mock_client.create_sandbox.return_value = sandbox
+    mock_client.delete_sandbox.return_value = None
+
+    backend = AgentSandboxBackend.from_template(
+        client=mock_client,
+        template_name="t",
+    )
+    backend.__enter__()
+
+    delete_called_at = []
+
+    def tracking_delete(**kwargs):
+        delete_called_at.append(time.monotonic())
+
+    mock_client.delete_sandbox.side_effect = tracking_delete
+
+    # Start an execute in a background thread that takes 0.2s
+    op_started = threading.Event()
+    op_finished = threading.Event()
+
+    def slow_run(command, **kwargs):
+        op_started.set()
+        time.sleep(0.2)
+        op_finished.set()
+        return SimpleNamespace(stdout="done", stderr="", exit_code=0)
+
+    sandbox.commands.run = slow_run
+
+    t = threading.Thread(target=backend.execute, args=("sleep 0.2",))
+    t.start()
+
+    # Wait for the operation to start
+    op_started.wait(timeout=2)
+
+    # Now exit — should block until the operation finishes
+    backend.__exit__(None, None, None)
+
+    t.join(timeout=2)
+    _require(op_finished.is_set(), "Operation should have finished before exit returned")
+    _require(len(delete_called_at) == 1, "delete_sandbox should have been called")
+
+
+def test_draining_rejects_new_operations():
+    """Once draining is set, new operations should raise RuntimeError."""
+    sandbox = StubSandbox()
+    backend = AgentSandboxBackend(sandbox)
+    backend._draining = True
+
+    with pytest.raises(RuntimeError, match="shutting down"):
+        backend.execute("echo hi")

--- a/clients/python/langchain-agent-sandbox/uv.lock
+++ b/clients/python/langchain-agent-sandbox/uv.lock
@@ -1,0 +1,1516 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.91.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/b5/f39ae52ce035490217203581b9bfca8ca853c3a497961d0e5a2f091d0233/anthropic-0.91.0.tar.gz", hash = "sha256:a6afd894d55c26504e3d33909fb3f174d0db7d63369bfe9bb387da3e2806076a", size = 599272, upload-time = "2026-04-07T18:41:17.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/1e/7f06da237fde2d7f760a1b61a554c0e780dffe1d264e5aacd0287a7a142b/anthropic-0.91.0-py3-none-any.whl", hash = "sha256:b8672878642774198aa6272f40eb526b9ca11c2a72d4a935d867d445c7371f68", size = 481829, upload-time = "2026-04-07T18:41:15.326Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
+    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
+    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
+    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
+    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
+    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
+    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/19/f748958276519adf6a0c1e79e7b8860b4830dda55ccdf29f2719b5fc499c/cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59", size = 749301, upload-time = "2026-01-28T00:24:37.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/99/157aae7949a5f30d51fcb1a9851e8ebd5c74bf99b5285d8bb4b8b9ee641e/cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485", size = 7173686, upload-time = "2026-01-28T00:23:07.515Z" },
+    { url = "https://files.pythonhosted.org/packages/87/91/874b8910903159043b5c6a123b7e79c4559ddd1896e38967567942635778/cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc", size = 4275871, upload-time = "2026-01-28T00:23:09.439Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/35/690e809be77896111f5b195ede56e4b4ed0435b428c2f2b6d35046fbb5e8/cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0", size = 4423124, upload-time = "2026-01-28T00:23:11.529Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/5b/a26407d4f79d61ca4bebaa9213feafdd8806dc69d3d290ce24996d3cfe43/cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa", size = 4277090, upload-time = "2026-01-28T00:23:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d8/4bb7aec442a9049827aa34cee1aa83803e528fa55da9a9d45d01d1bb933e/cryptography-46.0.4-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81", size = 4947652, upload-time = "2026-01-28T00:23:14.554Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/08/f83e2e0814248b844265802d081f2fac2f1cbe6cd258e72ba14ff006823a/cryptography-46.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255", size = 4455157, upload-time = "2026-01-28T00:23:16.443Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/05/19d849cf4096448779d2dcc9bb27d097457dac36f7273ffa875a93b5884c/cryptography-46.0.4-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e", size = 3981078, upload-time = "2026-01-28T00:23:17.838Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/89/f7bac81d66ba7cde867a743ea5b37537b32b5c633c473002b26a226f703f/cryptography-46.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c", size = 4276213, upload-time = "2026-01-28T00:23:19.257Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9f/7133e41f24edd827020ad21b068736e792bc68eecf66d93c924ad4719fb3/cryptography-46.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32", size = 4912190, upload-time = "2026-01-28T00:23:21.244Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/6d43cbaddf6f65b24816e4af187d211f0bc536a29961f69faedc48501d8e/cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616", size = 4454641, upload-time = "2026-01-28T00:23:22.866Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4f/ebd0473ad656a0ac912a16bd07db0f5d85184924e14fc88feecae2492834/cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0", size = 4405159, upload-time = "2026-01-28T00:23:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f7/7923886f32dc47e27adeff8246e976d77258fd2aa3efdd1754e4e323bf49/cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0", size = 4666059, upload-time = "2026-01-28T00:23:26.766Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a7/0fca0fd3591dffc297278a61813d7f661a14243dd60f499a7a5b48acb52a/cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5", size = 3026378, upload-time = "2026-01-28T00:23:28.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/12/652c84b6f9873f0909374864a57b003686c642ea48c84d6c7e2c515e6da5/cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b", size = 3478614, upload-time = "2026-01-28T00:23:30.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/27/542b029f293a5cce59349d799d4d8484b3b1654a7b9a0585c266e974a488/cryptography-46.0.4-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908", size = 7116417, upload-time = "2026-01-28T00:23:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f5/559c25b77f40b6bf828eabaf988efb8b0e17b573545edb503368ca0a2a03/cryptography-46.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da", size = 4264508, upload-time = "2026-01-28T00:23:34.264Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a1/551fa162d33074b660dc35c9bc3616fefa21a0e8c1edd27b92559902e408/cryptography-46.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829", size = 4409080, upload-time = "2026-01-28T00:23:35.793Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/4d8d129a755f5d6df1bbee69ea2f35ebfa954fa1847690d1db2e8bca46a5/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2", size = 4270039, upload-time = "2026-01-28T00:23:37.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f5/ed3fcddd0a5e39321e595e144615399e47e7c153a1fb8c4862aec3151ff9/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:c92010b58a51196a5f41c3795190203ac52edfd5dc3ff99149b4659eba9d2085", size = 4926748, upload-time = "2026-01-28T00:23:38.884Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ae/9f03d5f0c0c00e85ecb34f06d3b79599f20630e4db91b8a6e56e8f83d410/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:829c2b12bbc5428ab02d6b7f7e9bbfd53e33efd6672d21341f2177470171ad8b", size = 4442307, upload-time = "2026-01-28T00:23:40.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/22/e0f9f2dae8040695103369cf2283ef9ac8abe4d51f68710bec2afd232609/cryptography-46.0.4-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:62217ba44bf81b30abaeda1488686a04a702a261e26f87db51ff61d9d3510abd", size = 3959253, upload-time = "2026-01-28T00:23:42.827Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5b/6a43fcccc51dae4d101ac7d378a8724d1ba3de628a24e11bf2f4f43cba4d/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:9c2da296c8d3415b93e6053f5a728649a87a48ce084a9aaf51d6e46c87c7f2d2", size = 4269372, upload-time = "2026-01-28T00:23:44.655Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b7/0f6b8c1dd0779df2b526e78978ff00462355e31c0a6f6cff8a3e99889c90/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9b34d8ba84454641a6bf4d6762d15847ecbd85c1316c0a7984e6e4e9f748ec2e", size = 4891908, upload-time = "2026-01-28T00:23:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/17/259409b8349aa10535358807a472c6a695cf84f106022268d31cea2b6c97/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f", size = 4441254, upload-time = "2026-01-28T00:23:48.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fe/e4a1b0c989b00cee5ffa0764401767e2d1cf59f45530963b894129fd5dce/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82", size = 4396520, upload-time = "2026-01-28T00:23:50.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/ba8fd9657d27076eb40d6a2f941b23429a3c3d2f56f5a921d6b936a27bc9/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c", size = 4651479, upload-time = "2026-01-28T00:23:51.674Z" },
+    { url = "https://files.pythonhosted.org/packages/00/03/0de4ed43c71c31e4fe954edd50b9d28d658fef56555eba7641696370a8e2/cryptography-46.0.4-cp314-cp314t-win32.whl", hash = "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061", size = 3001986, upload-time = "2026-01-28T00:23:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/70/81830b59df7682917d7a10f833c4dab2a5574cd664e86d18139f2b421329/cryptography-46.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7", size = 3468288, upload-time = "2026-01-28T00:23:55.09Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f7/f648fdbb61d0d45902d3f374217451385edc7e7768d1b03ff1d0e5ffc17b/cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab", size = 7169583, upload-time = "2026-01-28T00:23:56.558Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cc/8f3224cbb2a928de7298d6ed4790f5ebc48114e02bdc9559196bfb12435d/cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef", size = 4275419, upload-time = "2026-01-28T00:23:58.364Z" },
+    { url = "https://files.pythonhosted.org/packages/17/43/4a18faa7a872d00e4264855134ba82d23546c850a70ff209e04ee200e76f/cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d", size = 4419058, upload-time = "2026-01-28T00:23:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/64/6651969409821d791ba12346a124f55e1b76f66a819254ae840a965d4b9c/cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973", size = 4278151, upload-time = "2026-01-28T00:24:01.731Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0b/a7fce65ee08c3c02f7a8310cc090a732344066b990ac63a9dfd0a655d321/cryptography-46.0.4-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4", size = 4939441, upload-time = "2026-01-28T00:24:03.175Z" },
+    { url = "https://files.pythonhosted.org/packages/db/a7/20c5701e2cd3e1dfd7a19d2290c522a5f435dd30957d431dcb531d0f1413/cryptography-46.0.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af", size = 4451617, upload-time = "2026-01-28T00:24:05.403Z" },
+    { url = "https://files.pythonhosted.org/packages/00/dc/3e16030ea9aa47b63af6524c354933b4fb0e352257c792c4deeb0edae367/cryptography-46.0.4-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263", size = 3977774, upload-time = "2026-01-28T00:24:06.851Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c8/ad93f14118252717b465880368721c963975ac4b941b7ef88f3c56bf2897/cryptography-46.0.4-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095", size = 4277008, upload-time = "2026-01-28T00:24:08.926Z" },
+    { url = "https://files.pythonhosted.org/packages/00/cf/89c99698151c00a4631fbfcfcf459d308213ac29e321b0ff44ceeeac82f1/cryptography-46.0.4-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b", size = 4903339, upload-time = "2026-01-28T00:24:12.009Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c3/c90a2cb358de4ac9309b26acf49b2a100957e1ff5cc1e98e6c4996576710/cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019", size = 4451216, upload-time = "2026-01-28T00:24:13.975Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2c/8d7f4171388a10208671e181ca43cdc0e596d8259ebacbbcfbd16de593da/cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4", size = 4404299, upload-time = "2026-01-28T00:24:16.169Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/cbb2036e450980f65c6e0a173b73a56ff3bccd8998965dea5cc9ddd424a5/cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b", size = 4664837, upload-time = "2026-01-28T00:24:17.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/21/f7433d18fe6d5845329cbdc597e30caf983229c7a245bcf54afecc555938/cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc", size = 3009779, upload-time = "2026-01-28T00:24:20.198Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/6a/bd2e7caa2facffedf172a45c1a02e551e6d7d4828658c9a245516a598d94/cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976", size = 3466633, upload-time = "2026-01-28T00:24:21.851Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e0/f9c6c53e1f2a1c2507f00f2faba00f01d2f334b35b0fbfe5286715da2184/cryptography-46.0.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:766330cce7416c92b5e90c3bb71b1b79521760cdcfc3a6a1a182d4c9fab23d2b", size = 3476316, upload-time = "2026-01-28T00:24:24.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7a/f8d2d13227a9a1a9fe9c7442b057efecffa41f1e3c51d8622f26b9edbe8f/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c236a44acfb610e70f6b3e1c3ca20ff24459659231ef2f8c48e879e2d32b73da", size = 4216693, upload-time = "2026-01-28T00:24:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/de/3787054e8f7972658370198753835d9d680f6cd4a39df9f877b57f0dd69c/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8a15fb869670efa8f83cbffbc8753c1abf236883225aed74cd179b720ac9ec80", size = 4382765, upload-time = "2026-01-28T00:24:27.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5f/60e0afb019973ba6a0b322e86b3d61edf487a4f5597618a430a2a15f2d22/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:fdc3daab53b212472f1524d070735b2f0c214239df131903bae1d598016fa822", size = 4216066, upload-time = "2026-01-28T00:24:29.056Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8e/bf4a0de294f147fee66f879d9bae6f8e8d61515558e3d12785dd90eca0be/cryptography-46.0.4-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:44cc0675b27cadb71bdbb96099cca1fa051cd11d2ade09e5cd3a2edb929ed947", size = 4382025, upload-time = "2026-01-28T00:24:30.681Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f4/9ceb90cfd6a3847069b0b0b353fd3075dc69b49defc70182d8af0c4ca390/cryptography-46.0.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3", size = 3406043, upload-time = "2026-01-28T00:24:32.236Z" },
+]
+
+[[package]]
+name = "deepagents"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langchain-google-genai" },
+    { name = "langsmith" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/69/a28e6cd6dd037a28720ae82ef69eacdf8cf8b5291870ac6760e66796b1ae/deepagents-0.5.1.tar.gz", hash = "sha256:5d2b5e1a50dfbf2af97800725d7ac9850e96bab022365e0c2fc3f6291f279635", size = 110322, upload-time = "2026-04-07T22:58:04.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/97/30b8ca49a72c7bf555732dc33ca623e3883b3e030b1b55f3085d92c6f289/deepagents-0.5.1-py3-none-any.whl", hash = "sha256:714853597feee9b24e7385fa575b72568536dcb263b9e91f3ba5d2fd073967a1", size = 123746, upload-time = "2026-04-07T22:58:03.341Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/3f/a753be0dcee352b7d63bc6d1ba14a72591d63b6391dac0cdff7ac168c530/google_genai-1.60.0.tar.gz", hash = "sha256:9768061775fddfaecfefb0d6d7a6cabefb3952ebd246cd5f65247151c07d33d1", size = 487721, upload-time = "2026-01-21T22:17:30.398Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/e5/384b1f383917b5f0ae92e28f47bc27b16e3d26cd9bacb25e9f8ecab3c8fe/google_genai-1.60.0-py3-none-any.whl", hash = "sha256:967338378ffecebec19a8ed90cf8797b26818bacbefd7846a9280beb1099f7f3", size = 719431, upload-time = "2026-01-21T22:17:28.086Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/f9/eaca4633486b527ebe7e681c431f529b63fe2709e7c5242fc0f43f77ce63/jiter-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d8f8a7e317190b2c2d60eb2e8aa835270b008139562d70fe732e1c0020ec53c9", size = 316435, upload-time = "2025-11-09T20:47:02.087Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c1/40c9f7c22f5e6ff715f28113ebaba27ab85f9af2660ad6e1dd6425d14c19/jiter-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2218228a077e784c6c8f1a8e5d6b8cb1dea62ce25811c356364848554b2056cd", size = 320548, upload-time = "2025-11-09T20:47:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1b/efbb68fe87e7711b00d2cfd1f26bb4bfc25a10539aefeaa7727329ffb9cb/jiter-0.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9354ccaa2982bf2188fd5f57f79f800ef622ec67beb8329903abf6b10da7d423", size = 351915, upload-time = "2025-11-09T20:47:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/c06e659888c128ad1e838123d0638f0efad90cc30860cb5f74dd3f2fc0b3/jiter-0.12.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2607185ea89b4af9a604d4c7ec40e45d3ad03ee66998b031134bc510232bb7", size = 368966, upload-time = "2025-11-09T20:47:06.508Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/20/058db4ae5fb07cf6a4ab2e9b9294416f606d8e467fb74c2184b2a1eeacba/jiter-0.12.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a585a5e42d25f2e71db5f10b171f5e5ea641d3aa44f7df745aa965606111cc2", size = 482047, upload-time = "2025-11-09T20:47:08.382Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bb/dc2b1c122275e1de2eb12905015d61e8316b2f888bdaac34221c301495d6/jiter-0.12.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd9e21d34edff5a663c631f850edcb786719c960ce887a5661e9c828a53a95d9", size = 380835, upload-time = "2025-11-09T20:47:09.81Z" },
+    { url = "https://files.pythonhosted.org/packages/23/7d/38f9cd337575349de16da575ee57ddb2d5a64d425c9367f5ef9e4612e32e/jiter-0.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a612534770470686cd5431478dc5a1b660eceb410abade6b1b74e320ca98de6", size = 364587, upload-time = "2025-11-09T20:47:11.529Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a3/b13e8e61e70f0bb06085099c4e2462647f53cc2ca97614f7fedcaa2bb9f3/jiter-0.12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3985aea37d40a908f887b34d05111e0aae822943796ebf8338877fee2ab67725", size = 390492, upload-time = "2025-11-09T20:47:12.993Z" },
+    { url = "https://files.pythonhosted.org/packages/07/71/e0d11422ed027e21422f7bc1883c61deba2d9752b720538430c1deadfbca/jiter-0.12.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b1207af186495f48f72529f8d86671903c8c10127cac6381b11dddc4aaa52df6", size = 522046, upload-time = "2025-11-09T20:47:14.6Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/59/b968a9aa7102a8375dbbdfbd2aeebe563c7e5dddf0f47c9ef1588a97e224/jiter-0.12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ef2fb241de583934c9915a33120ecc06d94aa3381a134570f59eed784e87001e", size = 513392, upload-time = "2025-11-09T20:47:16.011Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/e4/7df62002499080dbd61b505c5cb351aa09e9959d176cac2aa8da6f93b13b/jiter-0.12.0-cp311-cp311-win32.whl", hash = "sha256:453b6035672fecce8007465896a25b28a6b59cfe8fbc974b2563a92f5a92a67c", size = 206096, upload-time = "2025-11-09T20:47:17.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/60/1032b30ae0572196b0de0e87dce3b6c26a1eff71aad5fe43dee3082d32e0/jiter-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:ca264b9603973c2ad9435c71a8ec8b49f8f715ab5ba421c85a51cde9887e421f", size = 204899, upload-time = "2025-11-09T20:47:19.365Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d5/c145e526fccdb834063fb45c071df78b0cc426bbaf6de38b0781f45d956f/jiter-0.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:cb00ef392e7d684f2754598c02c409f376ddcef857aae796d559e6cacc2d78a5", size = 188070, upload-time = "2025-11-09T20:47:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/5b9f7b4983f1b542c64e84165075335e8a236fa9e2ea03a0c79780062be8/jiter-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:305e061fa82f4680607a775b2e8e0bcb071cd2205ac38e6ef48c8dd5ebe1cf37", size = 314449, upload-time = "2025-11-09T20:47:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/e8efa0e78de00db0aee82c0cf9e8b3f2027efd7f8a71f859d8f4be8e98ef/jiter-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c1860627048e302a528333c9307c818c547f214d8659b0705d2195e1a94b274", size = 319855, upload-time = "2025-11-09T20:47:24.779Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/894cd88e60b5d58af53bec5c6759d1292bd0b37a8b5f60f07abf7a63ae5f/jiter-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df37577a4f8408f7e0ec3205d2a8f87672af8f17008358063a4d6425b6081ce3", size = 350171, upload-time = "2025-11-09T20:47:26.469Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/27/a7b818b9979ac31b3763d25f3653ec3a954044d5e9f5d87f2f247d679fd1/jiter-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fdd787356c1c13a4f40b43c2156276ef7a71eb487d98472476476d803fb2cf", size = 365590, upload-time = "2025-11-09T20:47:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7e/e46195801a97673a83746170b17984aa8ac4a455746354516d02ca5541b4/jiter-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eb5db8d9c65b112aacf14fcd0faae9913d07a8afea5ed06ccdd12b724e966a1", size = 479462, upload-time = "2025-11-09T20:47:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/f833bfb009ab4bd11b1c9406d333e3b4357709ed0570bb48c7c06d78c7dd/jiter-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73c568cc27c473f82480abc15d1301adf333a7ea4f2e813d6a2c7d8b6ba8d0df", size = 378983, upload-time = "2025-11-09T20:47:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b3/7a69d77943cc837d30165643db753471aff5df39692d598da880a6e51c24/jiter-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4321e8a3d868919bcb1abb1db550d41f2b5b326f72df29e53b2df8b006eb9403", size = 361328, upload-time = "2025-11-09T20:47:33.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/a78f90caf48d65ba70d8c6efc6f23150bc39dc3389d65bbec2a95c7bc628/jiter-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a51bad79f8cc9cac2b4b705039f814049142e0050f30d91695a2d9a6611f126", size = 386740, upload-time = "2025-11-09T20:47:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/5d31c2cc8e1b6a6bcf3c5721e4ca0a3633d1ab4754b09bc7084f6c4f5327/jiter-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2a67b678f6a5f1dd6c36d642d7db83e456bc8b104788262aaefc11a22339f5a9", size = 520875, upload-time = "2025-11-09T20:47:36.058Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b5/4df540fae4e9f68c54b8dab004bd8c943a752f0b00efd6e7d64aa3850339/jiter-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efe1a211fe1fd14762adea941e3cfd6c611a136e28da6c39272dbb7a1bbe6a86", size = 511457, upload-time = "2025-11-09T20:47:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/07/65/86b74010e450a1a77b2c1aabb91d4a91dd3cd5afce99f34d75fd1ac64b19/jiter-0.12.0-cp312-cp312-win32.whl", hash = "sha256:d779d97c834b4278276ec703dc3fc1735fca50af63eb7262f05bdb4e62203d44", size = 204546, upload-time = "2025-11-09T20:47:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/6659f537f9562d963488e3e55573498a442503ced01f7e169e96a6110383/jiter-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8269062060212b373316fe69236096aaf4c49022d267c6736eebd66bbbc60bb", size = 205196, upload-time = "2025-11-09T20:47:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f4/935304f5169edadfec7f9c01eacbce4c90bb9a82035ac1de1f3bd2d40be6/jiter-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:06cb970936c65de926d648af0ed3d21857f026b1cf5525cb2947aa5e01e05789", size = 186100, upload-time = "2025-11-09T20:47:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a6/97209693b177716e22576ee1161674d1d58029eb178e01866a0422b69224/jiter-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6cc49d5130a14b732e0612bc76ae8db3b49898732223ef8b7599aa8d9810683e", size = 313658, upload-time = "2025-11-09T20:47:44.424Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4d/125c5c1537c7d8ee73ad3d530a442d6c619714b95027143f1b61c0b4dfe0/jiter-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37f27a32ce36364d2fa4f7fdc507279db604d27d239ea2e044c8f148410defe1", size = 318605, upload-time = "2025-11-09T20:47:45.973Z" },
+    { url = "https://files.pythonhosted.org/packages/99/bf/a840b89847885064c41a5f52de6e312e91fa84a520848ee56c97e4fa0205/jiter-0.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbc0944aa3d4b4773e348cda635252824a78f4ba44328e042ef1ff3f6080d1cf", size = 349803, upload-time = "2025-11-09T20:47:47.535Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/88/e63441c28e0db50e305ae23e19c1d8fae012d78ed55365da392c1f34b09c/jiter-0.12.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da25c62d4ee1ffbacb97fac6dfe4dcd6759ebdc9015991e92a6eae5816287f44", size = 365120, upload-time = "2025-11-09T20:47:49.284Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7c/49b02714af4343970eb8aca63396bc1c82fa01197dbb1e9b0d274b550d4e/jiter-0.12.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:048485c654b838140b007390b8182ba9774621103bd4d77c9c3f6f117474ba45", size = 479918, upload-time = "2025-11-09T20:47:50.807Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ba/0a809817fdd5a1db80490b9150645f3aae16afad166960bcd562be194f3b/jiter-0.12.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:635e737fbb7315bef0037c19b88b799143d2d7d3507e61a76751025226b3ac87", size = 379008, upload-time = "2025-11-09T20:47:52.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/c9fc0232e736c8877d9e6d83d6eeb0ba4e90c6c073835cc2e8f73fdeef51/jiter-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e017c417b1ebda911bd13b1e40612704b1f5420e30695112efdbed8a4b389ed", size = 361785, upload-time = "2025-11-09T20:47:53.512Z" },
+    { url = "https://files.pythonhosted.org/packages/96/61/61f69b7e442e97ca6cd53086ddc1cf59fb830549bc72c0a293713a60c525/jiter-0.12.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:89b0bfb8b2bf2351fba36bb211ef8bfceba73ef58e7f0c68fb67b5a2795ca2f9", size = 386108, upload-time = "2025-11-09T20:47:54.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2e/76bb3332f28550c8f1eba3bf6e5efe211efda0ddbbaf24976bc7078d42a5/jiter-0.12.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f5aa5427a629a824a543672778c9ce0c5e556550d1569bb6ea28a85015287626", size = 519937, upload-time = "2025-11-09T20:47:56.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d6/fa96efa87dc8bff2094fb947f51f66368fa56d8d4fc9e77b25d7fbb23375/jiter-0.12.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed53b3d6acbcb0fd0b90f20c7cb3b24c357fe82a3518934d4edfa8c6898e498c", size = 510853, upload-time = "2025-11-09T20:47:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/28/93f67fdb4d5904a708119a6ab58a8f1ec226ff10a94a282e0215402a8462/jiter-0.12.0-cp313-cp313-win32.whl", hash = "sha256:4747de73d6b8c78f2e253a2787930f4fffc68da7fa319739f57437f95963c4de", size = 204699, upload-time = "2025-11-09T20:47:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1f/30b0eb087045a0abe2a5c9c0c0c8da110875a1d3be83afd4a9a4e548be3c/jiter-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:e25012eb0c456fcc13354255d0338cd5397cce26c77b2832b3c4e2e255ea5d9a", size = 204258, upload-time = "2025-11-09T20:48:01.01Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f4/2b4daf99b96bce6fc47971890b14b2a36aef88d7beb9f057fafa032c6141/jiter-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:c97b92c54fe6110138c872add030a1f99aea2401ddcdaa21edf74705a646dd60", size = 185503, upload-time = "2025-11-09T20:48:02.35Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/67bb15a7061d6fe20b9b2a2fd783e296a1e0f93468252c093481a2f00efa/jiter-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53839b35a38f56b8be26a7851a48b89bc47e5d88e900929df10ed93b95fea3d6", size = 317965, upload-time = "2025-11-09T20:48:03.783Z" },
+    { url = "https://files.pythonhosted.org/packages/18/af/1788031cd22e29c3b14bc6ca80b16a39a0b10e611367ffd480c06a259831/jiter-0.12.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f669548e55c91ab47fef8bddd9c954dab1938644e715ea49d7e117015110a4", size = 345831, upload-time = "2025-11-09T20:48:05.55Z" },
+    { url = "https://files.pythonhosted.org/packages/05/17/710bf8472d1dff0d3caf4ced6031060091c1320f84ee7d5dcbed1f352417/jiter-0.12.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351d54f2b09a41600ffea43d081522d792e81dcfb915f6d2d242744c1cc48beb", size = 361272, upload-time = "2025-11-09T20:48:06.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/1dcc4618b59761fef92d10bcbb0b038b5160be653b003651566a185f1a5c/jiter-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2a5e90604620f94bf62264e7c2c038704d38217b7465b863896c6d7c902b06c7", size = 204604, upload-time = "2025-11-09T20:48:08.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/32/63cb1d9f1c5c6632a783c0052cde9ef7ba82688f7065e2f0d5f10a7e3edb/jiter-0.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:88ef757017e78d2860f96250f9393b7b577b06a956ad102c29c8237554380db3", size = 185628, upload-time = "2025-11-09T20:48:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/45c9f0dbe4a1416b2b9a8a6d1236459540f43d7fb8883cff769a8db0612d/jiter-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c46d927acd09c67a9fb1416df45c5a04c27e83aae969267e98fba35b74e99525", size = 312478, upload-time = "2025-11-09T20:48:10.898Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a7/54ae75613ba9e0f55fcb0bc5d1f807823b5167cc944e9333ff322e9f07dd/jiter-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:774ff60b27a84a85b27b88cd5583899c59940bcc126caca97eb2a9df6aa00c49", size = 318706, upload-time = "2025-11-09T20:48:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/2aa241ad2c10774baf6c37f8b8e1f39c07db358f1329f4eb40eba179c2a2/jiter-0.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5433fab222fb072237df3f637d01b81f040a07dcac1cb4a5c75c7aa9ed0bef1", size = 351894, upload-time = "2025-11-09T20:48:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4f/0f2759522719133a9042781b18cc94e335b6d290f5e2d3e6899d6af933e3/jiter-0.12.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8c593c6e71c07866ec6bfb790e202a833eeec885022296aff6b9e0b92d6a70e", size = 365714, upload-time = "2025-11-09T20:48:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6f/806b895f476582c62a2f52c453151edd8a0fde5411b0497baaa41018e878/jiter-0.12.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90d32894d4c6877a87ae00c6b915b609406819dce8bc0d4e962e4de2784e567e", size = 478989, upload-time = "2025-11-09T20:48:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6c/012d894dc6e1033acd8db2b8346add33e413ec1c7c002598915278a37f79/jiter-0.12.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:798e46eed9eb10c3adbbacbd3bdb5ecd4cf7064e453d00dbef08802dae6937ff", size = 378615, upload-time = "2025-11-09T20:48:18.614Z" },
+    { url = "https://files.pythonhosted.org/packages/87/30/d718d599f6700163e28e2c71c0bbaf6dace692e7df2592fd793ac9276717/jiter-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3f1368f0a6719ea80013a4eb90ba72e75d7ea67cfc7846db2ca504f3df0169a", size = 364745, upload-time = "2025-11-09T20:48:20.117Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/85/315b45ce4b6ddc7d7fceca24068543b02bdc8782942f4ee49d652e2cc89f/jiter-0.12.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65f04a9d0b4406f7e51279710b27484af411896246200e461d80d3ba0caa901a", size = 386502, upload-time = "2025-11-09T20:48:21.543Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0b/ce0434fb40c5b24b368fe81b17074d2840748b4952256bab451b72290a49/jiter-0.12.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:fd990541982a24281d12b67a335e44f117e4c6cbad3c3b75c7dea68bf4ce3a67", size = 519845, upload-time = "2025-11-09T20:48:22.964Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a3/7a7a4488ba052767846b9c916d208b3ed114e3eb670ee984e4c565b9cf0d/jiter-0.12.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b111b0e9152fa7df870ecaebb0bd30240d9f7fff1f2003bcb4ed0f519941820b", size = 510701, upload-time = "2025-11-09T20:48:24.483Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/16/052ffbf9d0467b70af24e30f91e0579e13ded0c17bb4a8eb2aed3cb60131/jiter-0.12.0-cp314-cp314-win32.whl", hash = "sha256:a78befb9cc0a45b5a5a0d537b06f8544c2ebb60d19d02c41ff15da28a9e22d42", size = 205029, upload-time = "2025-11-09T20:48:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/18/3cf1f3f0ccc789f76b9a754bdb7a6977e5d1d671ee97a9e14f7eb728d80e/jiter-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:e1fe01c082f6aafbe5c8faf0ff074f38dfb911d53f07ec333ca03f8f6226debf", size = 204960, upload-time = "2025-11-09T20:48:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/02/68/736821e52ecfdeeb0f024b8ab01b5a229f6b9293bbdb444c27efade50b0f/jiter-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:d72f3b5a432a4c546ea4bedc84cce0c3404874f1d1676260b9c7f048a9855451", size = 185529, upload-time = "2025-11-09T20:48:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/30/61/12ed8ee7a643cce29ac97c2281f9ce3956eb76b037e88d290f4ed0d41480/jiter-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e6ded41aeba3603f9728ed2b6196e4df875348ab97b28fc8afff115ed42ba7a7", size = 318974, upload-time = "2025-11-09T20:48:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c6/f3041ede6d0ed5e0e79ff0de4c8f14f401bbf196f2ef3971cdbe5fd08d1d/jiter-0.12.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a947920902420a6ada6ad51892082521978e9dd44a802663b001436e4b771684", size = 345932, upload-time = "2025-11-09T20:48:32.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/4d94835889edd01ad0e2dbfc05f7bdfaed46292e7b504a6ac7839aa00edb/jiter-0.12.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:add5e227e0554d3a52cf390a7635edaffdf4f8fce4fdbcef3cc2055bb396a30c", size = 367243, upload-time = "2025-11-09T20:48:34.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/76/0051b0ac2816253a99d27baf3dda198663aff882fa6ea7deeb94046da24e/jiter-0.12.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f9b1cda8fcb736250d7e8711d4580ebf004a46771432be0ae4796944b5dfa5d", size = 479315, upload-time = "2025-11-09T20:48:35.507Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/83f793acd68e5cb24e483f44f482a1a15601848b9b6f199dacb970098f77/jiter-0.12.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:deeb12a2223fe0135c7ff1356a143d57f95bbf1f4a66584f1fc74df21d86b993", size = 380714, upload-time = "2025-11-09T20:48:40.014Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/4808a88338ad2c228b1126b93fcd8ba145e919e886fe910d578230dabe3b/jiter-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c596cc0f4cb574877550ce4ecd51f8037469146addd676d7c1a30ebe6391923f", size = 365168, upload-time = "2025-11-09T20:48:41.462Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d4/04619a9e8095b42aef436b5aeb4c0282b4ff1b27d1db1508df9f5dc82750/jiter-0.12.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ab4c823b216a4aeab3fdbf579c5843165756bd9ad87cc6b1c65919c4715f783", size = 387893, upload-time = "2025-11-09T20:48:42.921Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ea/d3c7e62e4546fdc39197fa4a4315a563a89b95b6d54c0d25373842a59cbe/jiter-0.12.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e427eee51149edf962203ff8db75a7514ab89be5cb623fb9cea1f20b54f1107b", size = 520828, upload-time = "2025-11-09T20:48:44.278Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0b/c6d3562a03fd767e31cb119d9041ea7958c3c80cb3d753eafb19b3b18349/jiter-0.12.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:edb868841f84c111255ba5e80339d386d937ec1fdce419518ce1bd9370fac5b6", size = 511009, upload-time = "2025-11-09T20:48:45.726Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/51/2cb4468b3448a8385ebcd15059d325c9ce67df4e2758d133ab9442b19834/jiter-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8bbcfe2791dfdb7c5e48baf646d37a6a3dcb5a97a032017741dea9f817dca183", size = 205110, upload-time = "2025-11-09T20:48:47.033Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c5/ae5ec83dec9c2d1af805fd5fe8f74ebded9c8670c5210ec7820ce0dbeb1e/jiter-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2fa940963bf02e1d8226027ef461e36af472dea85d36054ff835aeed944dd873", size = 205223, upload-time = "2025-11-09T20:48:49.076Z" },
+    { url = "https://files.pythonhosted.org/packages/97/9a/3c5391907277f0e55195550cf3fa8e293ae9ee0c00fb402fec1e38c0c82f/jiter-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:506c9708dd29b27288f9f8f1140c3cb0e3d8ddb045956d7757b1fa0e0f39a473", size = 185564, upload-time = "2025-11-09T20:48:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/54/5339ef1ecaa881c6948669956567a64d2670941925f245c434f494ffb0e5/jiter-0.12.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:4739a4657179ebf08f85914ce50332495811004cc1747852e8b2041ed2aab9b8", size = 311144, upload-time = "2025-11-09T20:49:10.503Z" },
+    { url = "https://files.pythonhosted.org/packages/27/74/3446c652bffbd5e81ab354e388b1b5fc1d20daac34ee0ed11ff096b1b01a/jiter-0.12.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:41da8def934bf7bec16cb24bd33c0ca62126d2d45d81d17b864bd5ad721393c3", size = 305877, upload-time = "2025-11-09T20:49:12.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f4/ed76ef9043450f57aac2d4fbeb27175aa0eb9c38f833be6ef6379b3b9a86/jiter-0.12.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c44ee814f499c082e69872d426b624987dbc5943ab06e9bbaa4f81989fdb79e", size = 340419, upload-time = "2025-11-09T20:49:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/21/01/857d4608f5edb0664aa791a3d45702e1a5bcfff9934da74035e7b9803846/jiter-0.12.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd2097de91cf03eaa27b3cbdb969addf83f0179c6afc41bbc4513705e013c65d", size = 347212, upload-time = "2025-11-09T20:49:15.643Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f5/12efb8ada5f5c9edc1d4555fe383c1fb2eac05ac5859258a72d61981d999/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e8547883d7b96ef2e5fe22b88f8a4c8725a56e7f4abafff20fd5272d634c7ecb", size = 309974, upload-time = "2025-11-09T20:49:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+]
+
+[[package]]
+name = "k8s-agent-sandbox"
+source = { editable = "../agentic-sandbox-client" }
+dependencies = [
+    { name = "kubernetes" },
+    { name = "pydantic" },
+    { name = "requests" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", marker = "extra == 'async'" },
+    { name = "httpx", marker = "extra == 'test'" },
+    { name = "kubernetes" },
+    { name = "kubernetes-asyncio", marker = "extra == 'async'" },
+    { name = "kubernetes-asyncio", marker = "extra == 'test'" },
+    { name = "opentelemetry-api", marker = "extra == 'tracing'", specifier = "~=1.39.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'tracing'", specifier = "~=1.39.0" },
+    { name = "opentelemetry-instrumentation-requests", marker = "extra == 'tracing'", specifier = "~=0.60b0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = "~=1.39.0" },
+    { name = "pydantic" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-asyncio", marker = "extra == 'test'" },
+    { name = "pytest-xdist", marker = "extra == 'test'" },
+    { name = "requests" },
+]
+provides-extras = ["async", "test", "tracing"]
+
+[[package]]
+name = "kubernetes"
+version = "35.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+]
+
+[[package]]
+name = "langchain"
+version = "1.2.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/3f/888a7099d2bd2917f8b0c3ffc7e347f1e664cf64267820b0b923c4f339fc/langchain-1.2.15.tar.gz", hash = "sha256:1717b6719daefae90b2728314a5e2a117ff916291e2862595b6c3d6fba33d652", size = 574732, upload-time = "2026-04-03T14:26:03.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/e8/a3b8cb0005553f6a876865073c81ef93bd7c5b18381bcb9ba4013af96ebc/langchain-1.2.15-py3-none-any.whl", hash = "sha256:e349db349cb3e9550c4044077cf90a1717691756cc236438404b23500e615874", size = 112714, upload-time = "2026-04-03T14:26:02.557Z" },
+]
+
+[[package]]
+name = "langchain-agent-sandbox"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "deepagents" },
+    { name = "k8s-agent-sandbox" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "deepagents", specifier = ">=0.5.0" },
+    { name = "k8s-agent-sandbox", editable = "../agentic-sandbox-client" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
+]
+provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+]
+
+[[package]]
+name = "langchain-anthropic"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c7/259d4d805c6ac90c8695714fc15498a4557bb515eb24f692fd611966e383/langchain_anthropic-1.4.0.tar.gz", hash = "sha256:bbf64e99f9149a34ba67813e9582b2160a0968de9e9f54f7ba8d1658f253c2e5", size = 674360, upload-time = "2026-03-17T18:42:20.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/c0/77f99373276d4f06c38a887ef6023f101cfc7ba3b2bf9af37064cdbadde5/langchain_anthropic-1.4.0-py3-none-any.whl", hash = "sha256:c84f55722336935f7574d5771598e674f3959fdca0b51de14c9788dbf52761be", size = 48463, upload-time = "2026-03-17T18:42:19.742Z" },
+]
+
+[[package]]
+name = "langchain-core"
+version = "1.2.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/5c/56d19a252bbb26247b7a7cd20821d48804d7ca03212fec709cd8db7c2516/langchain_core-1.2.27.tar.gz", hash = "sha256:c18372e4c4c1454d49bf23a2e484431e71bd39b64173a0f621f0fc283d7183a4", size = 844935, upload-time = "2026-04-07T14:56:32.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/c3/6e0865bc130c448270eb9511b47863a3f9145cdb519b19f6e4758fa63d6f/langchain_core-1.2.27-py3-none-any.whl", hash = "sha256:9ecd6b0393b969fe88f6b9b309367134080ab095946d79e6937dd3911aa42bd5", size = 508315, upload-time = "2026-04-07T14:56:30.93Z" },
+]
+
+[[package]]
+name = "langchain-google-genai"
+version = "4.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filetype" },
+    { name = "google-genai" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/63/e7d148f903cebfef50109da71378f411166f068d66f79b9e16a62dbacf41/langchain_google_genai-4.2.1.tar.gz", hash = "sha256:7f44487a0337535897e3bba9a1d6605d722629e034f757ffa8755af0aa85daa8", size = 278288, upload-time = "2026-02-19T19:29:19.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/7e/46c5973bd8b10a5c4c8a77136cf536e658796380a17c740246074901b038/langchain_google_genai-4.2.1-py3-none-any.whl", hash = "sha256:a7735289cf94ca3a684d830e09196aac8f6e75e647e3a0a1c3c9dc534ceb985e", size = 66500, upload-time = "2026-02-19T19:29:18.002Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/76/55a18c59dedf39688d72c4b06af73a5e3ea0d1a01bc867b88fbf0659f203/langgraph_checkpoint-4.0.0.tar.gz", hash = "sha256:814d1bd050fac029476558d8e68d87bce9009a0262d04a2c14b918255954a624", size = 137320, upload-time = "2026-01-12T20:30:26.38Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/de/ddd53b7032e623f3c7bcdab2b44e8bf635e468f62e10e5ff1946f62c9356/langgraph_checkpoint-4.0.0-py3-none-any.whl", hash = "sha256:3fa9b2635a7c5ac28b338f631abf6a030c3b508b7b9ce17c22611513b589c784", size = 46329, upload-time = "2026-01-12T20:30:25.2Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/0f/ed0634c222eed48a31ba48eab6881f94ad690d65e44fe7ca838240a260c1/langgraph_sdk-0.3.3.tar.gz", hash = "sha256:c34c3dce3b6848755eb61f0c94369d1ba04aceeb1b76015db1ea7362c544fb26", size = 130589, upload-time = "2026-01-13T00:30:43.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/be/4ad511bacfdd854afb12974f407cb30010dceb982dc20c55491867b34526/langgraph_sdk-0.3.3-py3-none-any.whl", hash = "sha256:a52ebaf09d91143e55378bb2d0b033ed98f57f48c9ad35c8f81493b88705fc7b", size = 67021, upload-time = "2026-01-13T00:30:42.264Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "uuid-utils" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/3d/04a79fb7f0e72af88e26295d3b9ab88e5204eafb723a8ed3a948f8df1f19/langsmith-0.6.6.tar.gz", hash = "sha256:64ba70e7b795cff3c498fe6f2586314da1cc855471a5e5b6a357950324af3874", size = 953566, upload-time = "2026-01-27T17:37:21.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/81/62c5cc980a3f5a7476792769616792e0df8ba9c8c4730195ec700a56a962/langsmith-0.6.6-py3-none-any.whl", hash = "sha256:fe655e73b198cd00d0ecd00a26046eaf1f78cd0b2f0d94d1e5591f3143c5f592", size = 308542, upload-time = "2026-01-27T17:37:19.201Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/a3/4e09c61a5f0c521cba0bb433639610ae037437669f1a4cbc93799e731d78/orjson-3.11.6.tar.gz", hash = "sha256:0a54c72259f35299fd033042367df781c2f66d10252955ca1efb7db309b954cb", size = 6175856, upload-time = "2026-01-29T15:13:07.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/fd/d6b0a36854179b93ed77839f107c4089d91cccc9f9ba1b752b6e3bac5f34/orjson-3.11.6-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e259e85a81d76d9665f03d6129e09e4435531870de5961ddcd0bf6e3a7fde7d7", size = 250029, upload-time = "2026-01-29T15:11:35.942Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/bb/22902619826641cf3b627c24aab62e2ad6b571bdd1d34733abb0dd57f67a/orjson-3.11.6-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:52263949f41b4a4822c6b1353bcc5ee2f7109d53a3b493501d3369d6d0e7937a", size = 134518, upload-time = "2026-01-29T15:11:37.347Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/7a818da4bba1de711a9653c420749c0ac95ef8f8651cbc1dca551f462fe0/orjson-3.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6439e742fa7834a24698d358a27346bb203bff356ae0402e7f5df8f749c621a8", size = 137917, upload-time = "2026-01-29T15:11:38.511Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0f/02846c1cac8e205cb3822dd8aa8f9114acda216f41fd1999ace6b543418d/orjson-3.11.6-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b81ffd68f084b4e993e3867acb554a049fa7787cc8710bbcc1e26965580d99be", size = 134923, upload-time = "2026-01-29T15:11:39.711Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cf/aeaf683001b474bb3c3c757073a4231dfdfe8467fceaefa5bfd40902c99f/orjson-3.11.6-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5a5468e5e60f7ef6d7f9044b06c8f94a3c56ba528c6e4f7f06ae95164b595ec", size = 140752, upload-time = "2026-01-29T15:11:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fe/dad52d8315a65f084044a0819d74c4c9daf9ebe0681d30f525b0d29a31f0/orjson-3.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:72c5005eb45bd2535632d4f3bec7ad392832cfc46b62a3021da3b48a67734b45", size = 144201, upload-time = "2026-01-29T15:11:42.537Z" },
+    { url = "https://files.pythonhosted.org/packages/36/bc/ab070dd421565b831801077f1e390c4d4af8bfcecafc110336680a33866b/orjson-3.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b14dd49f3462b014455a28a4d810d3549bf990567653eb43765cd847df09145", size = 142380, upload-time = "2026-01-29T15:11:44.309Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d8/4b581c725c3a308717f28bf45a9fdac210bca08b67e8430143699413ff06/orjson-3.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e0bb2c1ea30ef302f0f89f9bf3e7f9ab5e2af29dc9f80eb87aa99788e4e2d65", size = 145582, upload-time = "2026-01-29T15:11:45.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a2/09aab99b39f9a7f175ea8fa29adb9933a3d01e7d5d603cdee7f1c40c8da2/orjson-3.11.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:825e0a85d189533c6bff7e2fc417a28f6fcea53d27125c4551979aecd6c9a197", size = 147270, upload-time = "2026-01-29T15:11:46.782Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2f/5ef8eaf7829dc50da3bf497c7775b21ee88437bc8c41f959aa3504ca6631/orjson-3.11.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:b04575417a26530637f6ab4b1f7b4f666eb0433491091da4de38611f97f2fcf3", size = 421222, upload-time = "2026-01-29T15:11:48.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b0/dd6b941294c2b5b13da5fdc7e749e58d0c55a5114ab37497155e83050e95/orjson-3.11.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:b83eb2e40e8c4da6d6b340ee6b1d6125f5195eb1b0ebb7eac23c6d9d4f92d224", size = 155562, upload-time = "2026-01-29T15:11:49.408Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/09/43924331a847476ae2f9a16bd6d3c9dab301265006212ba0d3d7fd58763a/orjson-3.11.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1f42da604ee65a6b87eef858c913ce3e5777872b19321d11e6fc6d21de89b64f", size = 147432, upload-time = "2026-01-29T15:11:50.635Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e9/d9865961081816909f6b49d880749dbbd88425afd7c5bbce0549e2290d77/orjson-3.11.6-cp311-cp311-win32.whl", hash = "sha256:5ae45df804f2d344cffb36c43fdf03c82fb6cd247f5faa41e21891b40dfbf733", size = 139623, upload-time = "2026-01-29T15:11:51.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f9/6836edb92f76eec1082919101eb1145d2f9c33c8f2c5e6fa399b82a2aaa8/orjson-3.11.6-cp311-cp311-win_amd64.whl", hash = "sha256:f4295948d65ace0a2d8f2c4ccc429668b7eb8af547578ec882e16bf79b0050b2", size = 136647, upload-time = "2026-01-29T15:11:53.454Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/0c/4954082eea948c9ae52ee0bcbaa2f99da3216a71bcc314ab129bde22e565/orjson-3.11.6-cp311-cp311-win_arm64.whl", hash = "sha256:314e9c45e0b81b547e3a1cfa3df3e07a815821b3dac9fe8cb75014071d0c16a4", size = 135327, upload-time = "2026-01-29T15:11:56.616Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ba/759f2879f41910b7e5e0cdbd9cf82a4f017c527fb0e972e9869ca7fe4c8e/orjson-3.11.6-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:6f03f30cd8953f75f2a439070c743c7336d10ee940da918d71c6f3556af3ddcf", size = 249988, upload-time = "2026-01-29T15:11:58.294Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/70/54cecb929e6c8b10104fcf580b0cc7dc551aa193e83787dd6f3daba28bb5/orjson-3.11.6-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:af44baae65ef386ad971469a8557a0673bb042b0b9fd4397becd9c2dfaa02588", size = 134445, upload-time = "2026-01-29T15:11:59.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6f/ec0309154457b9ba1ad05f11faa4441f76037152f75e1ac577db3ce7ca96/orjson-3.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c310a48542094e4f7dbb6ac076880994986dda8ca9186a58c3cb70a3514d3231", size = 137708, upload-time = "2026-01-29T15:12:01.488Z" },
+    { url = "https://files.pythonhosted.org/packages/20/52/3c71b80840f8bab9cb26417302707b7716b7d25f863f3a541bcfa232fe6e/orjson-3.11.6-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d8dfa7a5d387f15ecad94cb6b2d2d5f4aeea64efd8d526bfc03c9812d01e1cc0", size = 134798, upload-time = "2026-01-29T15:12:02.705Z" },
+    { url = "https://files.pythonhosted.org/packages/30/51/b490a43b22ff736282360bd02e6bded455cf31dfc3224e01cd39f919bbd2/orjson-3.11.6-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ba8daee3e999411b50f8b50dbb0a3071dd1845f3f9a1a0a6fa6de86d1689d84d", size = 140839, upload-time = "2026-01-29T15:12:03.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bc/4bcfe4280c1bc63c5291bb96f98298845b6355da2226d3400e17e7b51e53/orjson-3.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f89d104c974eafd7436d7a5fdbc57f7a1e776789959a2f4f1b2eab5c62a339f4", size = 144080, upload-time = "2026-01-29T15:12:05.151Z" },
+    { url = "https://files.pythonhosted.org/packages/01/74/22970f9ead9ab1f1b5f8c227a6c3aa8d71cd2c5acd005868a1d44f2362fa/orjson-3.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2e2e2456788ca5ea75616c40da06fc885a7dc0389780e8a41bf7c5389ba257b", size = 142435, upload-time = "2026-01-29T15:12:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/29/34/d564aff85847ab92c82ee43a7a203683566c2fca0723a5f50aebbe759603/orjson-3.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a42efebc45afabb1448001e90458c4020d5c64fbac8a8dc4045b777db76cb5a", size = 145631, upload-time = "2026-01-29T15:12:08.351Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ef/016957a3890752c4aa2368326ea69fa53cdc1fdae0a94a542b6410dbdf52/orjson-3.11.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71b7cbef8471324966c3738c90ba38775563ef01b512feb5ad4805682188d1b9", size = 147058, upload-time = "2026-01-29T15:12:10.023Z" },
+    { url = "https://files.pythonhosted.org/packages/56/cc/9a899c3972085645b3225569f91a30e221f441e5dc8126e6d060b971c252/orjson-3.11.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:f8515e5910f454fe9a8e13c2bb9dc4bae4c1836313e967e72eb8a4ad874f0248", size = 421161, upload-time = "2026-01-29T15:12:11.308Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a8/767d3fbd6d9b8fdee76974db40619399355fd49bf91a6dd2c4b6909ccf05/orjson-3.11.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:300360edf27c8c9bf7047345a94fddf3a8b8922df0ff69d71d854a170cb375cf", size = 155757, upload-time = "2026-01-29T15:12:12.776Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/205cd69ac87e2272e13ef3f5f03a3d4657e317e38c1b08aaa2ef97060bbc/orjson-3.11.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:caaed4dad39e271adfadc106fab634d173b2bb23d9cf7e67bd645f879175ebfc", size = 147446, upload-time = "2026-01-29T15:12:14.166Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c5/dd9f22aa9f27c54c7d05cc32f4580c9ac9b6f13811eeb81d6c4c3f50d6b1/orjson-3.11.6-cp312-cp312-win32.whl", hash = "sha256:955368c11808c89793e847830e1b1007503a5923ddadc108547d3b77df761044", size = 139717, upload-time = "2026-01-29T15:12:15.7Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/e62fc50d904486970315a1654b8cfb5832eb46abb18cd5405118e7e1fc79/orjson-3.11.6-cp312-cp312-win_amd64.whl", hash = "sha256:2c68de30131481150073d90a5d227a4a421982f42c025ecdfb66157f9579e06f", size = 136711, upload-time = "2026-01-29T15:12:17.055Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3d/b4fefad8bdf91e0fe212eb04975aeb36ea92997269d68857efcc7eb1dda3/orjson-3.11.6-cp312-cp312-win_arm64.whl", hash = "sha256:65dfa096f4e3a5e02834b681f539a87fbe85adc82001383c0db907557f666bfc", size = 135212, upload-time = "2026-01-29T15:12:18.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/45/d9c71c8c321277bc1ceebf599bc55ba826ae538b7c61f287e9a7e71bd589/orjson-3.11.6-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e4ae1670caabb598a88d385798692ce2a1b2f078971b3329cfb85253c6097f5b", size = 249828, upload-time = "2026-01-29T15:12:20.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7e/4afcf4cfa9c2f93846d70eee9c53c3c0123286edcbeb530b7e9bd2aea1b2/orjson-3.11.6-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:2c6b81f47b13dac2caa5d20fbc953c75eb802543abf48403a4703ed3bff225f0", size = 134339, upload-time = "2026-01-29T15:12:22.01Z" },
+    { url = "https://files.pythonhosted.org/packages/40/10/6d2b8a064c8d2411d3d0ea6ab43125fae70152aef6bea77bb50fa54d4097/orjson-3.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:647d6d034e463764e86670644bdcaf8e68b076e6e74783383b01085ae9ab334f", size = 137662, upload-time = "2026-01-29T15:12:23.307Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/50/5804ea7d586baf83ee88969eefda97a24f9a5bdba0727f73e16305175b26/orjson-3.11.6-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8523b9cc4ef174ae52414f7699e95ee657c16aa18b3c3c285d48d7966cce9081", size = 134626, upload-time = "2026-01-29T15:12:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/f0492ed43e376722bb4afd648e06cc1e627fc7ec8ff55f6ee739277813ea/orjson-3.11.6-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:313dfd7184cde50c733fc0d5c8c0e2f09017b573afd11dc36bd7476b30b4cb17", size = 140873, upload-time = "2026-01-29T15:12:26.369Z" },
+    { url = "https://files.pythonhosted.org/packages/10/15/6f874857463421794a303a39ac5494786ad46a4ab46d92bda6705d78c5aa/orjson-3.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905ee036064ff1e1fd1fb800055ac477cdcb547a78c22c1bc2bbf8d5d1a6fb42", size = 144044, upload-time = "2026-01-29T15:12:28.082Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c7/b7223a3a70f1d0cc2d86953825de45f33877ee1b124a91ca1f79aa6e643f/orjson-3.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce374cb98411356ba906914441fc993f271a7a666d838d8de0e0900dd4a4bc12", size = 142396, upload-time = "2026-01-29T15:12:30.529Z" },
+    { url = "https://files.pythonhosted.org/packages/87/e3/aa1b6d3ad3cd80f10394134f73ae92a1d11fdbe974c34aa199cc18bb5fcf/orjson-3.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cded072b9f65fcfd188aead45efa5bd528ba552add619b3ad2a81f67400ec450", size = 145600, upload-time = "2026-01-29T15:12:31.848Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/cf/e4aac5a46cbd39d7e769ef8650efa851dfce22df1ba97ae2b33efe893b12/orjson-3.11.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ab85bdbc138e1f73a234db6bb2e4cc1f0fcec8f4bd2bd2430e957a01aadf746", size = 146967, upload-time = "2026-01-29T15:12:33.203Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/04/975b86a4bcf6cfeda47aad15956d52fbeda280811206e9967380fa9355c8/orjson-3.11.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:351b96b614e3c37a27b8ab048239ebc1e0be76cc17481a430d70a77fb95d3844", size = 421003, upload-time = "2026-01-29T15:12:35.097Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d1/0369d0baf40eea5ff2300cebfe209883b2473ab4aa4c4974c8bd5ee42bb2/orjson-3.11.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f9959c85576beae5cdcaaf39510b15105f1ee8b70d5dacd90152617f57be8c83", size = 155695, upload-time = "2026-01-29T15:12:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1f/d10c6d6ae26ff1d7c3eea6fd048280ef2e796d4fb260c5424fd021f68ecf/orjson-3.11.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75682d62b1b16b61a30716d7a2ec1f4c36195de4a1c61f6665aedd947b93a5d5", size = 147392, upload-time = "2026-01-29T15:12:37.876Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/43/7479921c174441a0aa5277c313732e20713c0969ac303be9f03d88d3db5d/orjson-3.11.6-cp313-cp313-win32.whl", hash = "sha256:40dc277999c2ef227dcc13072be879b4cfd325502daeb5c35ed768f706f2bf30", size = 139718, upload-time = "2026-01-29T15:12:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/88/bc/9ffe7dfbf8454bc4e75bb8bf3a405ed9e0598df1d3535bb4adcd46be07d0/orjson-3.11.6-cp313-cp313-win_amd64.whl", hash = "sha256:f0f6e9f8ff7905660bc3c8a54cd4a675aa98f7f175cf00a59815e2ff42c0d916", size = 136635, upload-time = "2026-01-29T15:12:40.593Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7e/51fa90b451470447ea5023b20d83331ec741ae28d1e6d8ed547c24e7de14/orjson-3.11.6-cp313-cp313-win_arm64.whl", hash = "sha256:1608999478664de848e5900ce41f25c4ecdfc4beacbc632b6fd55e1a586e5d38", size = 135175, upload-time = "2026-01-29T15:12:41.997Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9f/46ca908abaeeec7560638ff20276ab327b980d73b3cc2f5b205b4a1c60b3/orjson-3.11.6-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:6026db2692041d2a23fe2545606df591687787825ad5821971ef0974f2c47630", size = 249823, upload-time = "2026-01-29T15:12:43.332Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/78/ca478089818d18c9cd04f79c43f74ddd031b63c70fa2a946eb5e85414623/orjson-3.11.6-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:132b0ab2e20c73afa85cf142e547511feb3d2f5b7943468984658f3952b467d4", size = 134328, upload-time = "2026-01-29T15:12:45.171Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5e/cbb9d830ed4e47f4375ad8eef8e4fff1bf1328437732c3809054fc4e80be/orjson-3.11.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b376fb05f20a96ec117d47987dd3b39265c635725bda40661b4c5b73b77b5fde", size = 137651, upload-time = "2026-01-29T15:12:46.602Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3a/35df6558c5bc3a65ce0961aefee7f8364e59af78749fc796ea255bfa0cf5/orjson-3.11.6-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:954dae4e080574672a1dfcf2a840eddef0f27bd89b0e94903dd0824e9c1db060", size = 134596, upload-time = "2026-01-29T15:12:47.95Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8e/3d32dd7b7f26a19cc4512d6ed0ae3429567c71feef720fe699ff43c5bc9e/orjson-3.11.6-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe515bb89d59e1e4b48637a964f480b35c0a2676de24e65e55310f6016cca7ce", size = 140923, upload-time = "2026-01-29T15:12:49.333Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/1efbf5c99b3304f25d6f0d493a8d1492ee98693637c10ce65d57be839d7b/orjson-3.11.6-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:380f9709c275917af28feb086813923251e11ee10687257cd7f1ea188bcd4485", size = 144068, upload-time = "2026-01-29T15:12:50.927Z" },
+    { url = "https://files.pythonhosted.org/packages/82/83/0d19eeb5be797de217303bbb55dde58dba26f996ed905d301d98fd2d4637/orjson-3.11.6-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8173e0d3f6081e7034c51cf984036d02f6bab2a2126de5a759d79f8e5a140e7", size = 142493, upload-time = "2026-01-29T15:12:52.432Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a7/573fec3df4dc8fc259b7770dc6c0656f91adce6e19330c78d23f87945d1e/orjson-3.11.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dddf9ba706294906c56ef5150a958317b09aa3a8a48df1c52ccf22ec1907eac", size = 145616, upload-time = "2026-01-29T15:12:53.903Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/0e/23551b16f21690f7fd5122e3cf40fdca5d77052a434d0071990f97f5fe2f/orjson-3.11.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:cbae5c34588dc79938dffb0b6fbe8c531f4dc8a6ad7f39759a9eb5d2da405ef2", size = 146951, upload-time = "2026-01-29T15:12:55.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/63/5e6c8f39805c39123a18e412434ea364349ee0012548d08aa586e2bd6aa9/orjson-3.11.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:f75c318640acbddc419733b57f8a07515e587a939d8f54363654041fd1f4e465", size = 421024, upload-time = "2026-01-29T15:12:57.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4d/724975cf0087f6550bd01fd62203418afc0ea33fd099aed318c5bcc52df8/orjson-3.11.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e0ab8d13aa2a3e98b4a43487c9205b2c92c38c054b4237777484d503357c8437", size = 155774, upload-time = "2026-01-29T15:12:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a3/f4c4e3f46b55db29e0a5f20493b924fc791092d9a03ff2068c9fe6c1002f/orjson-3.11.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f884c7fb1020d44612bd7ac0db0babba0e2f78b68d9a650c7959bf99c783773f", size = 147393, upload-time = "2026-01-29T15:13:00.769Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/86/6f5529dd27230966171ee126cecb237ed08e9f05f6102bfaf63e5b32277d/orjson-3.11.6-cp314-cp314-win32.whl", hash = "sha256:8d1035d1b25732ec9f971e833a3e299d2b1a330236f75e6fd945ad982c76aaf3", size = 139760, upload-time = "2026-01-29T15:13:02.173Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b5/91ae7037b2894a6b5002fb33f4fbccec98424a928469835c3837fbb22a9b/orjson-3.11.6-cp314-cp314-win_amd64.whl", hash = "sha256:931607a8865d21682bb72de54231655c86df1870502d2962dbfd12c82890d077", size = 136633, upload-time = "2026-01-29T15:13:04.267Z" },
+    { url = "https://files.pythonhosted.org/packages/55/74/f473a3ec7a0a7ebc825ca8e3c86763f7d039f379860c81ba12dcdd456547/orjson-3.11.6-cp314-cp314-win_arm64.whl", hash = "sha256:fe71f6b283f4f1832204ab8235ce07adad145052614f77c876fcf0dac97bc06f", size = 135168, upload-time = "2026-01-29T15:13:05.932Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/7c/3a926e847516e67bc6838634f2e54e24381105b4e80f9338dc35cca0086b/uuid_utils-0.14.0.tar.gz", hash = "sha256:fc5bac21e9933ea6c590433c11aa54aaca599f690c08069e364eb13a12f670b4", size = 22072, upload-time = "2026-01-20T20:37:15.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/42/42d003f4a99ddc901eef2fd41acb3694163835e037fb6dde79ad68a72342/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f6695c0bed8b18a904321e115afe73b34444bc8451d0ce3244a1ec3b84deb0e5", size = 601786, upload-time = "2026-01-20T20:37:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e6/775dfb91f74b18f7207e3201eb31ee666d286579990dc69dd50db2d92813/uuid_utils-0.14.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4f0a730bbf2d8bb2c11b93e1005e91769f2f533fa1125ed1f00fd15b6fcc732b", size = 303943, upload-time = "2026-01-20T20:37:18.767Z" },
+    { url = "https://files.pythonhosted.org/packages/17/82/ea5f5e85560b08a1f30cdc65f75e76494dc7aba9773f679e7eaa27370229/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40ce3fd1a4fdedae618fc3edc8faf91897012469169d600133470f49fd699ed3", size = 340467, upload-time = "2026-01-20T20:37:11.794Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/33/54b06415767f4569882e99b6470c6c8eeb97422686a6d432464f9967fd91/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:09ae4a98416a440e78f7d9543d11b11cae4bab538b7ed94ec5da5221481748f2", size = 346333, upload-time = "2026-01-20T20:37:12.818Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/10/a6bce636b8f95e65dc84bf4a58ce8205b8e0a2a300a38cdbc83a3f763d27/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:971e8c26b90d8ae727e7f2ac3ee23e265971d448b3672882f2eb44828b2b8c3e", size = 470859, upload-time = "2026-01-20T20:37:01.512Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/27/84121c51ea72f013f0e03d0886bcdfa96b31c9b83c98300a7bd5cc4fa191/uuid_utils-0.14.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5cde1fa82804a8f9d2907b7aec2009d440062c63f04abbdb825fce717a5e860", size = 341988, upload-time = "2026-01-20T20:37:22.881Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a4/01c1c7af5e6a44f20b40183e8dac37d6ed83e7dc9e8df85370a15959b804/uuid_utils-0.14.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7343862a2359e0bd48a7f3dfb5105877a1728677818bb694d9f40703264a2db", size = 365784, upload-time = "2026-01-20T20:37:10.808Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f0/65ee43ec617b8b6b1bf2a5aecd56a069a08cca3d9340c1de86024331bde3/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c51e4818fdb08ccec12dc7083a01f49507b4608770a0ab22368001685d59381b", size = 523750, upload-time = "2026-01-20T20:37:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d3/6bf503e3f135a5dfe705a65e6f89f19bccd55ac3fb16cb5d3ec5ba5388b8/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:181bbcccb6f93d80a8504b5bd47b311a1c31395139596edbc47b154b0685b533", size = 615818, upload-time = "2026-01-20T20:37:21.816Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6c/99937dd78d07f73bba831c8dc9469dfe4696539eba2fc269ae1b92752f9e/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:5c8ae96101c3524ba8dbf762b6f05e9e9d896544786c503a727c5bf5cb9af1a7", size = 580831, upload-time = "2026-01-20T20:37:19.691Z" },
+    { url = "https://files.pythonhosted.org/packages/44/fa/bbc9e2c25abd09a293b9b097a0d8fc16acd6a92854f0ec080f1ea7ad8bb3/uuid_utils-0.14.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00ac3c6edfdaff7e1eed041f4800ae09a3361287be780d7610a90fdcde9befdc", size = 546333, upload-time = "2026-01-20T20:37:03.117Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/9b/e5e99b324b1b5f0c62882230455786df0bc66f67eff3b452447e703f45d2/uuid_utils-0.14.0-cp39-abi3-win32.whl", hash = "sha256:ec2fd80adf8e0e6589d40699e6f6df94c93edcc16dd999be0438dd007c77b151", size = 177319, upload-time = "2026-01-20T20:37:04.208Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/2c7d417ea483b6ff7820c948678fdf2ac98899dc7e43bb15852faa95acaf/uuid_utils-0.14.0-cp39-abi3-win_amd64.whl", hash = "sha256:efe881eb43a5504fad922644cb93d725fd8a6a6d949bd5a4b4b7d1a1587c7fd1", size = 182566, upload-time = "2026-01-20T20:37:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/49e4bdda28e962fbd7266684171ee29b3d92019116971d58783e51770745/uuid_utils-0.14.0-cp39-abi3-win_arm64.whl", hash = "sha256:32b372b8fd4ebd44d3a219e093fe981af4afdeda2994ee7db208ab065cfcd080", size = 182809, upload-time = "2026-01-20T20:37:05.139Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/03/1f1146e32e94d1f260dfabc81e1649102083303fb4ad549775c943425d9a/uuid_utils-0.14.0-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:762e8d67992ac4d2454e24a141a1c82142b5bde10409818c62adbe9924ebc86d", size = 587430, upload-time = "2026-01-20T20:37:24.998Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ba/d5a7469362594d885fd9219fe9e851efbe65101d3ef1ef25ea321d7ce841/uuid_utils-0.14.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:40be5bf0b13aa849d9062abc86c198be6a25ff35316ce0b89fc25f3bac6d525e", size = 298106, upload-time = "2026-01-20T20:37:23.896Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/11/3dafb2a5502586f59fd49e93f5802cd5face82921b3a0f3abb5f357cb879/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:191a90a6f3940d1b7322b6e6cceff4dd533c943659e0a15f788674407856a515", size = 333423, upload-time = "2026-01-20T20:37:17.828Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f2/c8987663f0cdcf4d717a36d85b5db2a5589df0a4e129aa10f16f4380ef48/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4aa4525f4ad82f9d9c842f9a3703f1539c1808affbaec07bb1b842f6b8b96aa5", size = 338659, upload-time = "2026-01-20T20:37:14.286Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c8/929d81665d83f0b2ffaecb8e66c3091a50f62c7cb5b65e678bd75a96684e/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cdbd82ff20147461caefc375551595ecf77ebb384e46267f128aca45a0f2cdfc", size = 467029, upload-time = "2026-01-20T20:37:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a0/27d7daa1bfed7163f4ccaf52d7d2f4ad7bb1002a85b45077938b91ee584f/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff57e8a5d540006ce73cf0841a643d445afe78ba12e75ac53a95ca2924a56be", size = 333298, upload-time = "2026-01-20T20:37:07.271Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d4/acad86ce012b42ce18a12f31ee2aa3cbeeb98664f865f05f68c882945913/uuid_utils-0.14.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3fd9112ca96978361201e669729784f26c71fecc9c13a7f8a07162c31bd4d1e2", size = 359217, upload-time = "2026-01-20T20:36:59.687Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
+    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/84/30869e01909fb37a6cc7e18688ee8bf1e42d57e7e0777636bd47524c43c7/xxhash-3.6.0.tar.gz", hash = "sha256:f0162a78b13a0d7617b2845b90c763339d1f1d82bb04a4b07f4ab535cc5e05d6", size = 85160, upload-time = "2025-10-02T14:37:08.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/d4/cc2f0400e9154df4b9964249da78ebd72f318e35ccc425e9f403c392f22a/xxhash-3.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b47bbd8cf2d72797f3c2772eaaac0ded3d3af26481a26d7d7d41dc2d3c46b04a", size = 32844, upload-time = "2025-10-02T14:34:14.037Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ec/1cc11cd13e26ea8bc3cb4af4eaadd8d46d5014aebb67be3f71fb0b68802a/xxhash-3.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2b6821e94346f96db75abaa6e255706fb06ebd530899ed76d32cd99f20dc52fa", size = 30809, upload-time = "2025-10-02T14:34:15.484Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/19fe357ea348d98ca22f456f75a30ac0916b51c753e1f8b2e0e6fb884cce/xxhash-3.6.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d0a9751f71a1a65ce3584e9cae4467651c7e70c9d31017fa57574583a4540248", size = 194665, upload-time = "2025-10-02T14:34:16.541Z" },
+    { url = "https://files.pythonhosted.org/packages/90/3b/d1f1a8f5442a5fd8beedae110c5af7604dc37349a8e16519c13c19a9a2de/xxhash-3.6.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b29ee68625ab37b04c0b40c3fafdf24d2f75ccd778333cfb698f65f6c463f62", size = 213550, upload-time = "2025-10-02T14:34:17.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ef/3a9b05eb527457d5db13a135a2ae1a26c80fecd624d20f3e8dcc4cb170f3/xxhash-3.6.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6812c25fe0d6c36a46ccb002f40f27ac903bf18af9f6dd8f9669cb4d176ab18f", size = 212384, upload-time = "2025-10-02T14:34:19.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/18/ccc194ee698c6c623acbf0f8c2969811a8a4b6185af5e824cd27b9e4fd3e/xxhash-3.6.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4ccbff013972390b51a18ef1255ef5ac125c92dc9143b2d1909f59abc765540e", size = 445749, upload-time = "2025-10-02T14:34:20.659Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/86/cf2c0321dc3940a7aa73076f4fd677a0fb3e405cb297ead7d864fd90847e/xxhash-3.6.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:297b7fbf86c82c550e12e8fb71968b3f033d27b874276ba3624ea868c11165a8", size = 193880, upload-time = "2025-10-02T14:34:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fb/96213c8560e6f948a1ecc9a7613f8032b19ee45f747f4fca4eb31bb6d6ed/xxhash-3.6.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dea26ae1eb293db089798d3973a5fc928a18fdd97cc8801226fae705b02b14b0", size = 210912, upload-time = "2025-10-02T14:34:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/40/aa/4395e669b0606a096d6788f40dbdf2b819d6773aa290c19e6e83cbfc312f/xxhash-3.6.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7a0b169aafb98f4284f73635a8e93f0735f9cbde17bd5ec332480484241aaa77", size = 198654, upload-time = "2025-10-02T14:34:25.644Z" },
+    { url = "https://files.pythonhosted.org/packages/67/74/b044fcd6b3d89e9b1b665924d85d3f400636c23590226feb1eb09e1176ce/xxhash-3.6.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:08d45aef063a4531b785cd72de4887766d01dc8f362a515693df349fdb825e0c", size = 210867, upload-time = "2025-10-02T14:34:27.203Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fd/3ce73bf753b08cb19daee1eb14aa0d7fe331f8da9c02dd95316ddfe5275e/xxhash-3.6.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:929142361a48ee07f09121fe9e96a84950e8d4df3bb298ca5d88061969f34d7b", size = 414012, upload-time = "2025-10-02T14:34:28.409Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b3/5a4241309217c5c876f156b10778f3ab3af7ba7e3259e6d5f5c7d0129eb2/xxhash-3.6.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:51312c768403d8540487dbbfb557454cfc55589bbde6424456951f7fcd4facb3", size = 191409, upload-time = "2025-10-02T14:34:29.696Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/99bfbc15fb9abb9a72b088c1d95219fc4782b7d01fc835bd5744d66dd0b8/xxhash-3.6.0-cp311-cp311-win32.whl", hash = "sha256:d1927a69feddc24c987b337ce81ac15c4720955b667fe9b588e02254b80446fd", size = 30574, upload-time = "2025-10-02T14:34:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/65/79/9d24d7f53819fe301b231044ea362ce64e86c74f6e8c8e51320de248b3e5/xxhash-3.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:26734cdc2d4ffe449b41d186bbeac416f704a482ed835d375a5c0cb02bc63fef", size = 31481, upload-time = "2025-10-02T14:34:32.062Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4e/15cd0e3e8772071344eab2961ce83f6e485111fed8beb491a3f1ce100270/xxhash-3.6.0-cp311-cp311-win_arm64.whl", hash = "sha256:d72f67ef8bf36e05f5b6c65e8524f265bd61071471cd4cf1d36743ebeeeb06b7", size = 27861, upload-time = "2025-10-02T14:34:33.555Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/d9412f3d7d462347e4511181dea65e47e0d0e16e26fbee2ea86a2aefb657/xxhash-3.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:01362c4331775398e7bb34e3ab403bc9ee9f7c497bc7dee6272114055277dd3c", size = 32744, upload-time = "2025-10-02T14:34:34.622Z" },
+    { url = "https://files.pythonhosted.org/packages/79/35/0429ee11d035fc33abe32dca1b2b69e8c18d236547b9a9b72c1929189b9a/xxhash-3.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b7b2df81a23f8cb99656378e72501b2cb41b1827c0f5a86f87d6b06b69f9f204", size = 30816, upload-time = "2025-10-02T14:34:36.043Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f2/57eb99aa0f7d98624c0932c5b9a170e1806406cdbcdb510546634a1359e0/xxhash-3.6.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dc94790144e66b14f67b10ac8ed75b39ca47536bf8800eb7c24b50271ea0c490", size = 194035, upload-time = "2025-10-02T14:34:37.354Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ed/6224ba353690d73af7a3f1c7cdb1fc1b002e38f783cb991ae338e1eb3d79/xxhash-3.6.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93f107c673bccf0d592cdba077dedaf52fe7f42dcd7676eba1f6d6f0c3efffd2", size = 212914, upload-time = "2025-10-02T14:34:38.6Z" },
+    { url = "https://files.pythonhosted.org/packages/38/86/fb6b6130d8dd6b8942cc17ab4d90e223653a89aa32ad2776f8af7064ed13/xxhash-3.6.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2aa5ee3444c25b69813663c9f8067dcfaa2e126dc55e8dddf40f4d1c25d7effa", size = 212163, upload-time = "2025-10-02T14:34:39.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/e84875682b0593e884ad73b2d40767b5790d417bde603cceb6878901d647/xxhash-3.6.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7f99123f0e1194fa59cc69ad46dbae2e07becec5df50a0509a808f90a0f03f0", size = 445411, upload-time = "2025-10-02T14:34:41.569Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4f/426f91b96701ec2f37bb2b8cec664eff4f658a11f3fa9d94f0a887ea6d2b/xxhash-3.6.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49e03e6fe2cac4a1bc64952dd250cf0dbc5ef4ebb7b8d96bce82e2de163c82a2", size = 193883, upload-time = "2025-10-02T14:34:43.249Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5a/ddbb83eee8e28b778eacfc5a85c969673e4023cdeedcfcef61f36731610b/xxhash-3.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bd17fede52a17a4f9a7bc4472a5867cb0b160deeb431795c0e4abe158bc784e9", size = 210392, upload-time = "2025-10-02T14:34:45.042Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c2/ff69efd07c8c074ccdf0a4f36fcdd3d27363665bcdf4ba399abebe643465/xxhash-3.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6fb5f5476bef678f69db04f2bd1efbed3030d2aba305b0fc1773645f187d6a4e", size = 197898, upload-time = "2025-10-02T14:34:46.302Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ca/faa05ac19b3b622c7c9317ac3e23954187516298a091eb02c976d0d3dd45/xxhash-3.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:843b52f6d88071f87eba1631b684fcb4b2068cd2180a0224122fe4ef011a9374", size = 210655, upload-time = "2025-10-02T14:34:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/7a/06aa7482345480cc0cb597f5c875b11a82c3953f534394f620b0be2f700c/xxhash-3.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7d14a6cfaf03b1b6f5f9790f76880601ccc7896aff7ab9cd8978a939c1eb7e0d", size = 414001, upload-time = "2025-10-02T14:34:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/23/07/63ffb386cd47029aa2916b3d2f454e6cc5b9f5c5ada3790377d5430084e7/xxhash-3.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:418daf3db71e1413cfe211c2f9a528456936645c17f46b5204705581a45390ae", size = 191431, upload-time = "2025-10-02T14:34:50.798Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/93/14fde614cadb4ddf5e7cebf8918b7e8fac5ae7861c1875964f17e678205c/xxhash-3.6.0-cp312-cp312-win32.whl", hash = "sha256:50fc255f39428a27299c20e280d6193d8b63b8ef8028995323bf834a026b4fbb", size = 30617, upload-time = "2025-10-02T14:34:51.954Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5d/0d125536cbe7565a83d06e43783389ecae0c0f2ed037b48ede185de477c0/xxhash-3.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0f2ab8c715630565ab8991b536ecded9416d615538be8ecddce43ccf26cbc7c", size = 31534, upload-time = "2025-10-02T14:34:53.276Z" },
+    { url = "https://files.pythonhosted.org/packages/54/85/6ec269b0952ec7e36ba019125982cf11d91256a778c7c3f98a4c5043d283/xxhash-3.6.0-cp312-cp312-win_arm64.whl", hash = "sha256:eae5c13f3bc455a3bbb68bdc513912dc7356de7e2280363ea235f71f54064829", size = 27876, upload-time = "2025-10-02T14:34:54.371Z" },
+    { url = "https://files.pythonhosted.org/packages/33/76/35d05267ac82f53ae9b0e554da7c5e281ee61f3cad44c743f0fcd354f211/xxhash-3.6.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:599e64ba7f67472481ceb6ee80fa3bd828fd61ba59fb11475572cc5ee52b89ec", size = 32738, upload-time = "2025-10-02T14:34:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/3fbce1cd96534a95e35d5120637bf29b0d7f5d8fa2f6374e31b4156dd419/xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d8b8aaa30fca4f16f0c84a5c8d7ddee0e25250ec2796c973775373257dde8f1", size = 30821, upload-time = "2025-10-02T14:34:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ea/d387530ca7ecfa183cb358027f1833297c6ac6098223fd14f9782cd0015c/xxhash-3.6.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d597acf8506d6e7101a4a44a5e428977a51c0fadbbfd3c39650cca9253f6e5a6", size = 194127, upload-time = "2025-10-02T14:34:59.21Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/0c/71435dcb99874b09a43b8d7c54071e600a7481e42b3e3ce1eb5226a5711a/xxhash-3.6.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:858dc935963a33bc33490128edc1c12b0c14d9c7ebaa4e387a7869ecc4f3e263", size = 212975, upload-time = "2025-10-02T14:35:00.816Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7a/c2b3d071e4bb4a90b7057228a99b10d51744878f4a8a6dd643c8bd897620/xxhash-3.6.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ba284920194615cb8edf73bf52236ce2e1664ccd4a38fdb543506413529cc546", size = 212241, upload-time = "2025-10-02T14:35:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/640b6eac0128e215f177df99eadcd0f1b7c42c274ab6a394a05059694c5a/xxhash-3.6.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b54219177f6c6674d5378bd862c6aedf64725f70dd29c472eaae154df1a2e89", size = 445471, upload-time = "2025-10-02T14:35:03.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/3c3d3ef071b051cc3abbe3721ffb8365033a172613c04af2da89d5548a87/xxhash-3.6.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42c36dd7dbad2f5238950c377fcbf6811b1cdb1c444fab447960030cea60504d", size = 193936, upload-time = "2025-10-02T14:35:05.013Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/bd/4a5f68381939219abfe1c22a9e3a5854a4f6f6f3c4983a87d255f21f2e5d/xxhash-3.6.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f22927652cba98c44639ffdc7aaf35828dccf679b10b31c4ad72a5b530a18eb7", size = 210440, upload-time = "2025-10-02T14:35:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/37/b80fe3d5cfb9faff01a02121a0f4d565eb7237e9e5fc66e73017e74dcd36/xxhash-3.6.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b45fad44d9c5c119e9c6fbf2e1c656a46dc68e280275007bbfd3d572b21426db", size = 197990, upload-time = "2025-10-02T14:35:07.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/fd/2c0a00c97b9e18f72e1f240ad4e8f8a90fd9d408289ba9c7c495ed7dc05c/xxhash-3.6.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6f2580ffab1a8b68ef2b901cde7e55fa8da5e4be0977c68f78fc80f3c143de42", size = 210689, upload-time = "2025-10-02T14:35:09.438Z" },
+    { url = "https://files.pythonhosted.org/packages/93/86/5dd8076a926b9a95db3206aba20d89a7fc14dd5aac16e5c4de4b56033140/xxhash-3.6.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40c391dd3cd041ebc3ffe6f2c862f402e306eb571422e0aa918d8070ba31da11", size = 414068, upload-time = "2025-10-02T14:35:11.162Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3c/0bb129170ee8f3650f08e993baee550a09593462a5cddd8e44d0011102b1/xxhash-3.6.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f205badabde7aafd1a31e8ca2a3e5a763107a71c397c4481d6a804eb5063d8bd", size = 191495, upload-time = "2025-10-02T14:35:12.971Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3a/6797e0114c21d1725e2577508e24006fd7ff1d8c0c502d3b52e45c1771d8/xxhash-3.6.0-cp313-cp313-win32.whl", hash = "sha256:2577b276e060b73b73a53042ea5bd5203d3e6347ce0d09f98500f418a9fcf799", size = 30620, upload-time = "2025-10-02T14:35:14.129Z" },
+    { url = "https://files.pythonhosted.org/packages/86/15/9bc32671e9a38b413a76d24722a2bf8784a132c043063a8f5152d390b0f9/xxhash-3.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:757320d45d2fbcce8f30c42a6b2f47862967aea7bf458b9625b4bbe7ee390392", size = 31542, upload-time = "2025-10-02T14:35:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c5/cc01e4f6188656e56112d6a8e0dfe298a16934b8c47a247236549a3f7695/xxhash-3.6.0-cp313-cp313-win_arm64.whl", hash = "sha256:457b8f85dec5825eed7b69c11ae86834a018b8e3df5e77783c999663da2f96d6", size = 27880, upload-time = "2025-10-02T14:35:16.315Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/30/25e5321c8732759e930c555176d37e24ab84365482d257c3b16362235212/xxhash-3.6.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a42e633d75cdad6d625434e3468126c73f13f7584545a9cf34e883aa1710e702", size = 32956, upload-time = "2025-10-02T14:35:17.413Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3c/0573299560d7d9f8ab1838f1efc021a280b5ae5ae2e849034ef3dee18810/xxhash-3.6.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:568a6d743219e717b07b4e03b0a828ce593833e498c3b64752e0f5df6bfe84db", size = 31072, upload-time = "2025-10-02T14:35:18.844Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1c/52d83a06e417cd9d4137722693424885cc9878249beb3a7c829e74bf7ce9/xxhash-3.6.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bec91b562d8012dae276af8025a55811b875baace6af510412a5e58e3121bc54", size = 196409, upload-time = "2025-10-02T14:35:20.31Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8e/c6d158d12a79bbd0b878f8355432075fc82759e356ab5a111463422a239b/xxhash-3.6.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78e7f2f4c521c30ad5e786fdd6bae89d47a32672a80195467b5de0480aa97b1f", size = 215736, upload-time = "2025-10-02T14:35:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/68/c4c80614716345d55071a396cf03d06e34b5f4917a467faf43083c995155/xxhash-3.6.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ed0df1b11a79856df5ffcab572cbd6b9627034c1c748c5566fa79df9048a7c5", size = 214833, upload-time = "2025-10-02T14:35:23.32Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e9/ae27c8ffec8b953efa84c7c4a6c6802c263d587b9fc0d6e7cea64e08c3af/xxhash-3.6.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0e4edbfc7d420925b0dd5e792478ed393d6e75ff8fc219a6546fb446b6a417b1", size = 448348, upload-time = "2025-10-02T14:35:25.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6b/33e21afb1b5b3f46b74b6bd1913639066af218d704cc0941404ca717fc57/xxhash-3.6.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fba27a198363a7ef87f8c0f6b171ec36b674fe9053742c58dd7e3201c1ab30ee", size = 196070, upload-time = "2025-10-02T14:35:26.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b6/fcabd337bc5fa624e7203aa0fa7d0c49eed22f72e93229431752bddc83d9/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:794fe9145fe60191c6532fa95063765529770edcdd67b3d537793e8004cabbfd", size = 212907, upload-time = "2025-10-02T14:35:28.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d3/9ee6160e644d660fcf176c5825e61411c7f62648728f69c79ba237250143/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:6105ef7e62b5ac73a837778efc331a591d8442f8ef5c7e102376506cb4ae2729", size = 200839, upload-time = "2025-10-02T14:35:29.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/98/e8de5baa5109394baf5118f5e72ab21a86387c4f89b0e77ef3e2f6b0327b/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f01375c0e55395b814a679b3eea205db7919ac2af213f4a6682e01220e5fe292", size = 213304, upload-time = "2025-10-02T14:35:31.222Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1d/71056535dec5c3177eeb53e38e3d367dd1d16e024e63b1cee208d572a033/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d706dca2d24d834a4661619dcacf51a75c16d65985718d6a7d73c1eeeb903ddf", size = 416930, upload-time = "2025-10-02T14:35:32.517Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6c/5cbde9de2cd967c322e651c65c543700b19e7ae3e0aae8ece3469bf9683d/xxhash-3.6.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f059d9faeacd49c0215d66f4056e1326c80503f51a1532ca336a385edadd033", size = 193787, upload-time = "2025-10-02T14:35:33.827Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fa/0172e350361d61febcea941b0cc541d6e6c8d65d153e85f850a7b256ff8a/xxhash-3.6.0-cp313-cp313t-win32.whl", hash = "sha256:1244460adc3a9be84731d72b8e80625788e5815b68da3da8b83f78115a40a7ec", size = 30916, upload-time = "2025-10-02T14:35:35.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e6/e8cf858a2b19d6d45820f072eff1bea413910592ff17157cabc5f1227a16/xxhash-3.6.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b1e420ef35c503869c4064f4a2f2b08ad6431ab7b229a05cce39d74268bca6b8", size = 31799, upload-time = "2025-10-02T14:35:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/064b197e855bfb7b343210e82490ae672f8bc7cdf3ddb02e92f64304ee8a/xxhash-3.6.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ec44b73a4220623235f67a996c862049f375df3b1052d9899f40a6382c32d746", size = 28044, upload-time = "2025-10-02T14:35:37.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/5e/0138bc4484ea9b897864d59fce9be9086030825bc778b76cb5a33a906d37/xxhash-3.6.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a40a3d35b204b7cc7643cbcf8c9976d818cb47befcfac8bbefec8038ac363f3e", size = 32754, upload-time = "2025-10-02T14:35:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d7/5dac2eb2ec75fd771957a13e5dda560efb2176d5203f39502a5fc571f899/xxhash-3.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a54844be970d3fc22630b32d515e79a90d0a3ddb2644d8d7402e3c4c8da61405", size = 30846, upload-time = "2025-10-02T14:35:39.6Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/71/8bc5be2bb00deb5682e92e8da955ebe5fa982da13a69da5a40a4c8db12fb/xxhash-3.6.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:016e9190af8f0a4e3741343777710e3d5717427f175adfdc3e72508f59e2a7f3", size = 194343, upload-time = "2025-10-02T14:35:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/52badfb2aecec2c377ddf1ae75f55db3ba2d321c5e164f14461c90837ef3/xxhash-3.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4f6f72232f849eb9d0141e2ebe2677ece15adfd0fa599bc058aad83c714bb2c6", size = 213074, upload-time = "2025-10-02T14:35:42.29Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2b/ae46b4e9b92e537fa30d03dbc19cdae57ed407e9c26d163895e968e3de85/xxhash-3.6.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63275a8aba7865e44b1813d2177e0f5ea7eadad3dd063a21f7cf9afdc7054063", size = 212388, upload-time = "2025-10-02T14:35:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/80/49f88d3afc724b4ac7fbd664c8452d6db51b49915be48c6982659e0e7942/xxhash-3.6.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cd01fa2aa00d8b017c97eb46b9a794fbdca53fc14f845f5a328c71254b0abb7", size = 445614, upload-time = "2025-10-02T14:35:45.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ba/603ce3961e339413543d8cd44f21f2c80e2a7c5cfe692a7b1f2cccf58f3c/xxhash-3.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0226aa89035b62b6a86d3c68df4d7c1f47a342b8683da2b60cedcddb46c4d95b", size = 194024, upload-time = "2025-10-02T14:35:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d1/8e225ff7113bf81545cfdcd79eef124a7b7064a0bba53605ff39590b95c2/xxhash-3.6.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c6e193e9f56e4ca4923c61238cdaced324f0feac782544eb4c6d55ad5cc99ddd", size = 210541, upload-time = "2025-10-02T14:35:48.301Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/58/0f89d149f0bad89def1a8dd38feb50ccdeb643d9797ec84707091d4cb494/xxhash-3.6.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9176dcaddf4ca963d4deb93866d739a343c01c969231dbe21680e13a5d1a5bf0", size = 198305, upload-time = "2025-10-02T14:35:49.584Z" },
+    { url = "https://files.pythonhosted.org/packages/11/38/5eab81580703c4df93feb5f32ff8fa7fe1e2c51c1f183ee4e48d4bb9d3d7/xxhash-3.6.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c1ce4009c97a752e682b897aa99aef84191077a9433eb237774689f14f8ec152", size = 210848, upload-time = "2025-10-02T14:35:50.877Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6b/953dc4b05c3ce678abca756416e4c130d2382f877a9c30a20d08ee6a77c0/xxhash-3.6.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:8cb2f4f679b01513b7adbb9b1b2f0f9cdc31b70007eaf9d59d0878809f385b11", size = 414142, upload-time = "2025-10-02T14:35:52.15Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a9/238ec0d4e81a10eb5026d4a6972677cbc898ba6c8b9dbaec12ae001b1b35/xxhash-3.6.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:653a91d7c2ab54a92c19ccf43508b6a555440b9be1bc8be553376778be7f20b5", size = 191547, upload-time = "2025-10-02T14:35:53.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ee/3cf8589e06c2164ac77c3bf0aa127012801128f1feebf2a079272da5737c/xxhash-3.6.0-cp314-cp314-win32.whl", hash = "sha256:a756fe893389483ee8c394d06b5ab765d96e68fbbfe6fde7aa17e11f5720559f", size = 31214, upload-time = "2025-10-02T14:35:54.746Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5d/a19552fbc6ad4cb54ff953c3908bbc095f4a921bc569433d791f755186f1/xxhash-3.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:39be8e4e142550ef69629c9cd71b88c90e9a5db703fecbcf265546d9536ca4ad", size = 32290, upload-time = "2025-10-02T14:35:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/11/dafa0643bc30442c887b55baf8e73353a344ee89c1901b5a5c54a6c17d39/xxhash-3.6.0-cp314-cp314-win_arm64.whl", hash = "sha256:25915e6000338999236f1eb68a02a32c3275ac338628a7eaa5a269c401995679", size = 28795, upload-time = "2025-10-02T14:35:57.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/db/0e99732ed7f64182aef4a6fb145e1a295558deec2a746265dcdec12d191e/xxhash-3.6.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c5294f596a9017ca5a3e3f8884c00b91ab2ad2933cf288f4923c3fd4346cf3d4", size = 32955, upload-time = "2025-10-02T14:35:58.267Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f4/2a7c3c68e564a099becfa44bb3d398810cc0ff6749b0d3cb8ccb93f23c14/xxhash-3.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1cf9dcc4ab9cff01dfbba78544297a3a01dafd60f3bde4e2bfd016cf7e4ddc67", size = 31072, upload-time = "2025-10-02T14:35:59.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d9/72a29cddc7250e8a5819dad5d466facb5dc4c802ce120645630149127e73/xxhash-3.6.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:01262da8798422d0685f7cef03b2bd3f4f46511b02830861df548d7def4402ad", size = 196579, upload-time = "2025-10-02T14:36:00.838Z" },
+    { url = "https://files.pythonhosted.org/packages/63/93/b21590e1e381040e2ca305a884d89e1c345b347404f7780f07f2cdd47ef4/xxhash-3.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51a73fb7cb3a3ead9f7a8b583ffd9b8038e277cdb8cb87cf890e88b3456afa0b", size = 215854, upload-time = "2025-10-02T14:36:02.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b8/edab8a7d4fa14e924b29be877d54155dcbd8b80be85ea00d2be3413a9ed4/xxhash-3.6.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b9c6df83594f7df8f7f708ce5ebeacfc69f72c9fbaaababf6cf4758eaada0c9b", size = 214965, upload-time = "2025-10-02T14:36:03.507Z" },
+    { url = "https://files.pythonhosted.org/packages/27/67/dfa980ac7f0d509d54ea0d5a486d2bb4b80c3f1bb22b66e6a05d3efaf6c0/xxhash-3.6.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:627f0af069b0ea56f312fd5189001c24578868643203bca1abbc2c52d3a6f3ca", size = 448484, upload-time = "2025-10-02T14:36:04.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/63/8ffc2cc97e811c0ca5d00ab36604b3ea6f4254f20b7bc658ca825ce6c954/xxhash-3.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa912c62f842dfd013c5f21a642c9c10cd9f4c4e943e0af83618b4a404d9091a", size = 196162, upload-time = "2025-10-02T14:36:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/77/07f0e7a3edd11a6097e990f6e5b815b6592459cb16dae990d967693e6ea9/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b465afd7909db30168ab62afe40b2fcf79eedc0b89a6c0ab3123515dc0df8b99", size = 213007, upload-time = "2025-10-02T14:36:07.733Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d8/bc5fa0d152837117eb0bef6f83f956c509332ce133c91c63ce07ee7c4873/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a881851cf38b0a70e7c4d3ce81fc7afd86fbc2a024f4cfb2a97cf49ce04b75d3", size = 200956, upload-time = "2025-10-02T14:36:09.106Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a5/d749334130de9411783873e9b98ecc46688dad5db64ca6e04b02acc8b473/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:9b3222c686a919a0f3253cfc12bb118b8b103506612253b5baeaac10d8027cf6", size = 213401, upload-time = "2025-10-02T14:36:10.585Z" },
+    { url = "https://files.pythonhosted.org/packages/89/72/abed959c956a4bfc72b58c0384bb7940663c678127538634d896b1195c10/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:c5aa639bc113e9286137cec8fadc20e9cd732b2cc385c0b7fa673b84fc1f2a93", size = 417083, upload-time = "2025-10-02T14:36:12.276Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b3/62fd2b586283b7d7d665fb98e266decadf31f058f1cf6c478741f68af0cb/xxhash-3.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5c1343d49ac102799905e115aee590183c3921d475356cb24b4de29a4bc56518", size = 193913, upload-time = "2025-10-02T14:36:14.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+    { url = "https://files.pythonhosted.org/packages/93/1e/8aec23647a34a249f62e2398c42955acd9b4c6ed5cf08cbea94dc46f78d2/xxhash-3.6.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0f7b7e2ec26c1666ad5fc9dbfa426a6a3367ceaf79db5dd76264659d509d73b0", size = 30662, upload-time = "2025-10-02T14:37:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/b14510b38ba91caf43006209db846a696ceea6a847a0c9ba0a5b1adc53d6/xxhash-3.6.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5dc1e14d14fa0f5789ec29a7062004b5933964bb9b02aae6622b8f530dc40296", size = 41056, upload-time = "2025-10-02T14:37:02.879Z" },
+    { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", size = 36251, upload-time = "2025-10-02T14:37:04.44Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", size = 32481, upload-time = "2025-10-02T14:37:05.869Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", size = 31565, upload-time = "2025-10-02T14:37:06.966Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
+]

--- a/dev/tools/test-e2e
+++ b/dev/tools/test-e2e
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 The Kubernetes Authors.
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,13 +93,24 @@ def setup_python_sdk(repo_root, env):
     # Install in editable mode within the virtual environment
     pip_executable = os.path.join(venv_path, "bin", "pip")
     install_cmd = [pip_executable, "install", "-e", f"{sdk_path}[test]"]
-    # Install in editable mode
     print(f"Running command: {' '.join(install_cmd)}")
     result = subprocess.run(install_cmd, env=env, cwd=repo_root, check=False)
     if result.returncode != 0:
         print("Failed to install Python SDK.")
         return False
     print("Python SDK installed successfully.")
+
+    # Install langchain-agent-sandbox if present
+    langchain_path = os.path.join(repo_root, "clients", "python", "langchain-agent-sandbox")
+    if os.path.isdir(langchain_path):
+        install_cmd = [pip_executable, "install", "-e", f"{langchain_path}[test]"]
+        print(f"Running command: {' '.join(install_cmd)}")
+        result = subprocess.run(install_cmd, env=env, cwd=repo_root, check=False)
+        if result.returncode != 0:
+            print("WARNING: Failed to install langchain-agent-sandbox, e2e tests for it will be skipped.")
+        else:
+            print("langchain-agent-sandbox installed successfully.")
+
     return True
 
 

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 The Kubernetes Authors.
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,13 @@ PYTHON_TEST_SUITES = [
         "name": "k8s-agent-sandbox",
         "dir": os.path.join("clients", "python", "agentic-sandbox-client", "k8s_agent_sandbox"),
         "requirements": "requirements.txt",
-    }
+    },
+    {
+        "name": "langchain-agent-sandbox",
+        "dir": os.path.join("clients", "python", "langchain-agent-sandbox", "tests"),
+        "package_dir": os.path.join("clients", "python", "langchain-agent-sandbox"),
+        "requirements": None,
+    },
 ]
 
 
@@ -72,15 +78,25 @@ def run_python_tests(repo_root):
         env = os.environ.copy()
         env["PIP_EXTRA_INDEX_URL"] = os.environ.get("PIP_EXTRA_INDEX_URL", "https://pypi.org/simple/")
 
-        req_file = os.path.join(test_dir, suite["requirements"])
-        if os.path.isfile(req_file):
+        if suite.get("requirements"):
+            req_file = os.path.join(test_dir, suite["requirements"])
+            if os.path.isfile(req_file):
+                subprocess.check_call(
+                    [venv_pip, "install", "--quiet", "-r", req_file], env=env)
+        if suite.get("package_dir"):
+            # install local dependencies first (e.g., k8s-agent-sandbox for langchain)
+            sdk_path = os.path.join(repo_root, "clients", "python", "agentic-sandbox-client")
             subprocess.check_call(
-                [venv_pip, "install", "--quiet", "-r", req_file], env=env)
+                [venv_pip, "install", "--quiet", "-e", sdk_path], env=env)
+            # install the package with test extras from its pyproject.toml
+            package_dir = os.path.join(repo_root, suite["package_dir"])
+            subprocess.check_call(
+                [venv_pip, "install", "--quiet", "-e", ".[test]"], cwd=package_dir, env=env)
         elif suite["name"] == "k8s-agent-sandbox":
             # install the package itself with test extras
             package_dir = os.path.dirname(test_dir)
             subprocess.check_call(
-            [venv_pip, "install", "--quiet", "-e", ".[test]"], cwd=package_dir, env=env)
+                [venv_pip, "install", "--quiet", "-e", ".[test]"], cwd=package_dir, env=env)
 
         subprocess.check_call(
             [venv_pip, "install", "--quiet", "pytest"], env=env)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -27,3 +27,15 @@ go test ./test/e2e/... --parallel=1
 ```
 
 Note: the `--parallel=1` argument makes sure only a single test runs at a time.
+
+## LangChain DeepAgents adapter e2e (optional)
+
+The DeepAgents adapter e2e test is gated by environment variables so it can run
+against an existing cluster/router without extra setup. Set:
+
+- `LANGCHAIN_SANDBOX_TEMPLATE` (required)
+- `LANGCHAIN_NAMESPACE` (optional, default: `default`)
+- `LANGCHAIN_GATEWAY_NAME` or `LANGCHAIN_API_URL` (required unless `LANGCHAIN_USE_TUNNEL=1`)
+- `LANGCHAIN_GATEWAY_NAMESPACE` (optional)
+- `LANGCHAIN_SERVER_PORT` (optional, default: `8888`)
+- `LANGCHAIN_ROOT_DIR` (optional, default: `/app`)

--- a/test/e2e/clients/python/test_e2e_langchain_backend.py
+++ b/test/e2e/clients/python/test_e2e_langchain_backend.py
@@ -1,0 +1,665 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E tests for the langchain-agent-sandbox DeepAgents backend adapter.
+
+Exercises every public method of AgentSandboxBackend against a real
+sandbox pod running in a kind cluster. Tests are grouped by feature
+area and run in a fixed order within each test function.
+
+Required environment:
+    LANGCHAIN_SANDBOX_TEMPLATE  - SandboxTemplate name (e.g. python-deepagent)
+    LANGCHAIN_USE_TUNNEL=1      - or LANGCHAIN_API_URL / LANGCHAIN_GATEWAY_NAME
+
+Optional:
+    LANGCHAIN_NAMESPACE         - default: "default"
+    LANGCHAIN_GATEWAY_NAMESPACE - default: same as LANGCHAIN_NAMESPACE
+    LANGCHAIN_SERVER_PORT       - default: 8888
+    LANGCHAIN_ROOT_DIR          - default: /app
+"""
+
+import os
+from typing import Optional
+
+import pytest
+
+try:
+    from langchain_agent_sandbox import (
+        AgentSandboxBackend,
+        SandboxPolicyWrapper,
+    )
+    from k8s_agent_sandbox import SandboxClient
+    from k8s_agent_sandbox.models import (
+        SandboxDirectConnectionConfig,
+        SandboxGatewayConnectionConfig,
+        SandboxLocalTunnelConnectionConfig,
+    )
+except ImportError:
+    pytest.skip("langchain-agent-sandbox not installed", allow_module_level=True)
+
+
+REQUIRED_TEMPLATE_ENV = "LANGCHAIN_SANDBOX_TEMPLATE"
+
+
+def _get_env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.environ.get(name, default)
+    return value if value not in (None, "") else None
+
+
+def _should_skip() -> Optional[str]:
+    template_name = _get_env(REQUIRED_TEMPLATE_ENV)
+    if not template_name:
+        return f"Missing {REQUIRED_TEMPLATE_ENV} env var"
+
+    api_url = _get_env("LANGCHAIN_API_URL")
+    gateway_name = _get_env("LANGCHAIN_GATEWAY_NAME")
+    allow_tunnel = _get_env("LANGCHAIN_USE_TUNNEL", "0") == "1"
+
+    if not api_url and not gateway_name and not allow_tunnel:
+        return (
+            "Set LANGCHAIN_API_URL or LANGCHAIN_GATEWAY_NAME to connect, "
+            "or LANGCHAIN_USE_TUNNEL=1 to allow kubectl port-forward"
+        )
+    return None
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
+
+def _build_client():
+    """Build a SandboxClient from env vars."""
+    api_url = _get_env("LANGCHAIN_API_URL")
+    gateway_name = _get_env("LANGCHAIN_GATEWAY_NAME")
+    gateway_namespace = _get_env(
+        "LANGCHAIN_GATEWAY_NAMESPACE",
+        _get_env("LANGCHAIN_NAMESPACE", "default"),
+    )
+    server_port = int(_get_env("LANGCHAIN_SERVER_PORT", "8888"))
+
+    if api_url:
+        connection_config = SandboxDirectConnectionConfig(
+            api_url=api_url, server_port=server_port,
+        )
+    elif gateway_name:
+        connection_config = SandboxGatewayConnectionConfig(
+            gateway_name=gateway_name,
+            gateway_namespace=gateway_namespace,
+            server_port=server_port,
+        )
+    else:
+        connection_config = SandboxLocalTunnelConnectionConfig(
+            server_port=server_port,
+        )
+    return SandboxClient(connection_config=connection_config)
+
+
+def _template_name():
+    return _get_env(REQUIRED_TEMPLATE_ENV)
+
+
+def _namespace():
+    return _get_env("LANGCHAIN_NAMESPACE", "default")
+
+
+def _root_dir():
+    return _get_env("LANGCHAIN_ROOT_DIR", "/app")
+
+
+# ── Core protocol: execute, ls, read, write, edit, grep, glob ──
+
+
+@pytest.mark.e2e
+def test_execute_basic():
+    """execute() runs a command and returns combined output."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        result = backend.execute("echo 'hello from deepagents'")
+        _require("hello from deepagents" in result.output, f"Unexpected output: {result.output}")
+        _require(result.exit_code == 0, f"Expected exit_code=0, got {result.exit_code}")
+        _require(result.truncated is False, "Unexpected truncation")
+
+
+@pytest.mark.e2e
+def test_execute_nonzero_exit_code():
+    """execute() returns non-zero exit code for failing commands."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        result = backend.execute("exit 42")
+        _require(result.exit_code == 42, f"Expected exit_code=42, got {result.exit_code}")
+
+
+@pytest.mark.e2e
+def test_execute_cwd_is_root_dir():
+    """execute() should run commands with cwd set to root_dir."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    root = _root_dir()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=root,
+    ) as backend:
+        result = backend.execute("pwd")
+        _require(
+            result.output.strip() == root,
+            f"Expected cwd={root}, got: {result.output.strip()}",
+        )
+
+
+@pytest.mark.e2e
+def test_execute_with_timeout():
+    """execute(timeout=N) should pass timeout to the sandbox."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        # Short command with explicit timeout should succeed
+        result = backend.execute("echo fast", timeout=30)
+        _require(result.exit_code == 0, f"Expected exit_code=0, got {result.exit_code}")
+
+
+@pytest.mark.e2e
+def test_ls_lists_directory():
+    """ls() returns structured directory entries with metadata."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        # Create a file so ls has something to list
+        backend.execute("echo content > ls_test.txt && mkdir -p ls_subdir")
+
+        ls_result = backend.ls("/")
+        _require(ls_result.error is None, f"ls failed: {ls_result.error}")
+        _require(len(ls_result.entries) > 0, "ls returned no entries")
+
+        # Find our file
+        file_entry = next(
+            (e for e in ls_result.entries if e["path"].endswith("ls_test.txt")),
+            None,
+        )
+        _require(file_entry is not None, "ls_test.txt not found in ls output")
+        _require(file_entry["is_dir"] is False, "ls_test.txt should not be a directory")
+
+        # Find our directory
+        dir_entry = next(
+            (e for e in ls_result.entries if e["path"].endswith("ls_subdir")),
+            None,
+        )
+        _require(dir_entry is not None, "ls_subdir not found in ls output")
+        _require(dir_entry["is_dir"] is True, "ls_subdir should be a directory")
+
+        # Check metadata fields are populated
+        if file_entry.get("size") is not None:
+            _require(file_entry["size"] > 0, "File size should be > 0")
+        if file_entry.get("modified_at") is not None:
+            _require(len(file_entry["modified_at"]) > 0, "modified_at should be non-empty")
+
+
+@pytest.mark.e2e
+def test_write_read_edit_lifecycle():
+    """Full write → read → edit → read lifecycle."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        # Write
+        file_path = "/lifecycle_test.txt"
+        write_res = backend.write(file_path, "line1\nline2\nline3\n")
+        _require(write_res.error is None, f"Write failed: {write_res.error}")
+
+        # Write again should fail (file exists)
+        write_dup = backend.write(file_path, "duplicate")
+        _require(write_dup.error is not None, "Write to existing file should fail")
+        _require("already exists" in write_dup.error, f"Unexpected error: {write_dup.error}")
+
+        # Read full
+        read_res = backend.read(file_path)
+        _require(read_res.error is None, f"Read failed: {read_res.error}")
+        _require("line1" in read_res.file_data["content"], "Missing line1")
+        _require("line3" in read_res.file_data["content"], "Missing line3")
+
+        # Read with offset and limit
+        read_slice = backend.read(file_path, offset=1, limit=1)
+        _require(read_slice.error is None, f"Read slice failed: {read_slice.error}")
+        _require(
+            "line2" in read_slice.file_data["content"],
+            f"Expected line2 at offset=1, got: {read_slice.file_data['content']}",
+        )
+
+        # Edit single occurrence
+        edit_res = backend.edit(file_path, "line2", "REPLACED")
+        _require(edit_res.error is None, f"Edit failed: {edit_res.error}")
+        _require(edit_res.occurrences == 1, f"Expected 1 occurrence, got {edit_res.occurrences}")
+
+        # Verify edit
+        read_after = backend.read(file_path)
+        _require("REPLACED" in read_after.file_data["content"], "Edit didn't take effect")
+        _require("line2" not in read_after.file_data["content"], "Old text still present")
+
+        # Edit with replace_all
+        edit_all = backend.edit(file_path, "line", "LINE", replace_all=True)
+        _require(edit_all.error is None, f"Edit all failed: {edit_all.error}")
+        _require(edit_all.occurrences == 2, f"Expected 2 occurrences, got {edit_all.occurrences}")
+
+
+@pytest.mark.e2e
+def test_grep_basic_and_with_glob():
+    """grep() finds matches, with optional glob filter."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        backend.write("/grep_target.py", "# grep marker alpha\nprint('hello')\n")
+        backend.write("/grep_other.txt", "# grep marker alpha in txt\n")
+
+        # Basic grep
+        grep_res = backend.grep("grep marker alpha", path="/")
+        _require(grep_res.error is None, f"Grep failed: {grep_res.error}")
+        _require(len(grep_res.matches) >= 2, f"Expected >=2 matches, got {len(grep_res.matches)}")
+
+        # Grep with glob filter — only .py files
+        grep_py = backend.grep("grep marker alpha", path="/", glob="*.py")
+        _require(grep_py.error is None, f"Grep with glob failed: {grep_py.error}")
+        _require(
+            all(m["path"].endswith(".py") for m in grep_py.matches),
+            f"Glob filter didn't work: {[m['path'] for m in grep_py.matches]}",
+        )
+
+        # Grep no match
+        grep_none = backend.grep("zzz_no_match_zzz", path="/")
+        _require(grep_none.error is None, "No-match grep should not error")
+        _require(len(grep_none.matches) == 0, "Expected 0 matches for non-existent pattern")
+
+
+@pytest.mark.e2e
+def test_glob_with_metadata():
+    """glob() finds files by pattern and includes size/modified_at."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        backend.write("/glob_test.py", "print('hello')\n")
+        backend.execute("mkdir -p subdir && echo data > subdir/nested.py")
+
+        glob_res = backend.glob("**/*.py", path="/")
+        _require(glob_res.error is None, f"Glob failed: {glob_res.error}")
+        _require(len(glob_res.matches) >= 1, f"Expected >=1 match, got {len(glob_res.matches)}")
+
+        # Verify at least one match has metadata
+        match = glob_res.matches[0]
+        _require("path" in match, "Match missing 'path'")
+        _require("is_dir" in match, "Match missing 'is_dir'")
+        # size and modified_at are optional but should be populated by our implementation
+        if match.get("size") is not None:
+            _require(isinstance(match["size"], int), f"size should be int, got {type(match['size'])}")
+        if match.get("modified_at") is not None:
+            _require(len(match["modified_at"]) > 0, "modified_at should be non-empty")
+
+
+# ── File transfer: upload_files, download_files ──
+
+
+@pytest.mark.e2e
+def test_upload_download_roundtrip():
+    """upload_files + download_files roundtrip with multiple files."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        files = [
+            ("/upload_a.bin", b"\x00\x01\x02\x03"),
+            ("/nested/upload_b.txt", b"hello upload"),
+        ]
+        upload_res = backend.upload_files(files)
+        _require(len(upload_res) == 2, f"Expected 2 responses, got {len(upload_res)}")
+        for i, resp in enumerate(upload_res):
+            _require(resp.error is None, f"Upload [{i}] failed: {resp.error}")
+
+        download_res = backend.download_files(["/upload_a.bin", "/nested/upload_b.txt"])
+        _require(len(download_res) == 2, f"Expected 2 download responses, got {len(download_res)}")
+        _require(download_res[0].content == b"\x00\x01\x02\x03", "Binary roundtrip failed")
+        _require(download_res[1].content == b"hello upload", "Text roundtrip failed")
+
+
+@pytest.mark.e2e
+def test_download_missing_file():
+    """download_files returns file_not_found for non-existent files."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        downloads = backend.download_files(["/does_not_exist_xyz.txt"])
+        _require(downloads[0].error is not None, "Expected error for missing file")
+        _require(downloads[0].content is None, "Content should be None for missing file")
+
+
+# ── Lifecycle: from_existing, id, session_id ──
+
+
+@pytest.mark.e2e
+def test_from_existing_unmanaged():
+    """from_existing() wraps a sandbox without managing lifecycle."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    sandbox = client.create_sandbox(
+        template=_template_name(), namespace=_namespace(),
+    )
+    try:
+        backend = AgentSandboxBackend.from_existing(sandbox, root_dir=_root_dir())
+        result = backend.execute("echo from_existing works")
+        _require(
+            "from_existing works" in result.output,
+            f"Unexpected output: {result.output}",
+        )
+        _require(result.exit_code == 0, f"Unexpected exit code: {result.exit_code}")
+    finally:
+        client.delete_sandbox(
+            claim_name=sandbox.claim_name, namespace=sandbox.namespace,
+        )
+
+
+@pytest.mark.e2e
+def test_id_is_namespace_qualified():
+    """backend.id returns {namespace}/{claim_name}."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        backend_id = backend.id
+        _require("/" in backend_id, f"id should be namespace-qualified, got: {backend_id}")
+        ns, claim = backend_id.split("/", 1)
+        _require(ns == _namespace(), f"Expected namespace={_namespace()}, got {ns}")
+        _require(len(claim) > 0, "Claim name should be non-empty")
+
+
+@pytest.mark.e2e
+def test_session_reattach():
+    """session_id enables sandbox reuse across invocations."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    import uuid
+    session_id = f"e2e-test-{uuid.uuid4().hex[:8]}"
+    client = _build_client()
+
+    # First invocation: create sandbox with session label, write state
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+        session_id=session_id,
+    ) as backend:
+        first_id = backend.id
+        backend.execute("echo 'persisted state' > /app/session_state.txt")
+        # On exit: detaches without deleting (session sandbox persists)
+
+    # Second invocation: reattach to the same sandbox
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+        session_id=session_id,
+    ) as backend:
+        _require(backend._reattached is True, "Should have reattached")
+        _require(backend.id == first_id, f"Should reuse same sandbox: {backend.id} != {first_id}")
+
+        # Verify state persisted
+        read_res = backend.read("/session_state.txt")
+        _require(read_res.error is None, f"Read failed: {read_res.error}")
+        _require(
+            "persisted state" in read_res.file_data["content"],
+            f"State didn't persist: {read_res.file_data['content']}",
+        )
+
+    # Cleanup: delete the session sandbox
+    AgentSandboxBackend.delete_all(
+        client, namespace=_namespace(),
+        label_selector=f"agent-sandbox.sigs.k8s.io/session-id={session_id}",
+    )
+
+
+# ── delete_all ──
+
+
+@pytest.mark.e2e
+def test_delete_all_with_label_selector():
+    """delete_all(label_selector=...) only deletes matching claims.
+
+    Creates a labeled SandboxClaim via the SDK directly (without the
+    backend context manager, whose ``__exit__`` would delete it first)
+    and then verifies ``delete_all`` removes exactly the labeled claim.
+    """
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    import uuid
+    label_value = f"e2e-cleanup-{uuid.uuid4().hex[:8]}"
+    label_selector = f"e2e-test={label_value}"
+    client = _build_client()
+
+    # Create a labeled claim directly — no context manager means nothing
+    # else will try to tear it down before delete_all runs.
+    sandbox = client.create_sandbox(
+        template=_template_name(),
+        namespace=_namespace(),
+        labels={"e2e-test": label_value},
+    )
+    try:
+        matching_before = client.list_all_sandboxes(
+            namespace=_namespace(), label_selector=label_selector,
+        )
+        _require(
+            sandbox.claim_name in matching_before,
+            f"Labeled claim '{sandbox.claim_name}' not found via selector; "
+            f"selector returned {matching_before}",
+        )
+    finally:
+        # Always drop our local handle to the port-forward / tunnel before
+        # delete_all runs, so the kubelet delete isn't racing a live conn.
+        try:
+            sandbox.close_connection()
+        except Exception:
+            pass
+
+    deleted = AgentSandboxBackend.delete_all(
+        client, namespace=_namespace(),
+        label_selector=label_selector,
+    )
+    _require(deleted >= 1, f"Expected to delete >=1 claim, deleted {deleted}")
+
+    matching_after = client.list_all_sandboxes(
+        namespace=_namespace(), label_selector=label_selector,
+    )
+    _require(
+        not matching_after,
+        f"Selector still matches after delete_all: {matching_after}",
+    )
+
+
+# ── Policy wrapper ──
+
+
+@pytest.mark.e2e
+def test_policy_wrapper_blocks_denied_command():
+    """SandboxPolicyWrapper blocks denied commands."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        wrapper = SandboxPolicyWrapper(
+            backend,
+            deny_commands=["rm -rf"],
+        )
+
+        # Allowed command
+        result = wrapper.execute("echo allowed")
+        _require(result.exit_code == 0, "Allowed command should succeed")
+
+        # Denied command
+        result = wrapper.execute("rm -rf /tmp/something")
+        _require(
+            "Policy denied" in result.output,
+            f"Expected policy denial, got: {result.output}",
+        )
+        _require(result.exit_code == 1, "Denied command should return exit_code=1")
+
+        # Read ops pass through
+        ls_res = wrapper.ls("/")
+        _require(ls_res.error is None, "ls should pass through policy wrapper")
+
+
+@pytest.mark.e2e
+def test_policy_wrapper_blocks_denied_path():
+    """SandboxPolicyWrapper blocks writes to denied paths."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+        allow_absolute_paths=True,
+    ) as backend:
+        wrapper = SandboxPolicyWrapper(
+            backend,
+            deny_prefixes=["/etc"],
+        )
+
+        # Denied write
+        result = wrapper.write("/etc/should_fail.txt", "nope")
+        _require(result.error is not None, "Write to /etc should be denied")
+        _require("Policy denied" in result.error, f"Unexpected error: {result.error}")
+
+
+# ── Simple skill test (agent invoke) ──
+
+
+@pytest.mark.e2e
+def test_agent_invoke_simple_skill():
+    """A DeepAgent with sandbox backend can execute a simple task."""
+    skip_reason = _should_skip()
+    if skip_reason:
+        pytest.skip(skip_reason)
+
+    # This test requires an LLM API key
+    has_api_key = any(
+        os.environ.get(key) for key in [
+            "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY",
+        ]
+    )
+    if not has_api_key:
+        pytest.skip("No LLM API key set (ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_API_KEY)")
+
+    try:
+        from deepagents import create_deep_agent
+    except ImportError:
+        pytest.skip("deepagents not installed")
+
+    # Get an LLM model
+    model = None
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        from langchain_anthropic import ChatAnthropic
+        model = ChatAnthropic(model="claude-sonnet-4-20250514")
+    elif os.environ.get("OPENAI_API_KEY"):
+        from langchain_openai import ChatOpenAI
+        model = ChatOpenAI(model="gpt-4o")
+    elif os.environ.get("GOOGLE_API_KEY"):
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        model = ChatGoogleGenerativeAI(model="gemini-1.5-pro")
+
+    client = _build_client()
+    with AgentSandboxBackend.from_template(
+        client, template_name=_template_name(),
+        namespace=_namespace(), root_dir=_root_dir(),
+    ) as backend:
+        agent = create_deep_agent(model=model, backend=backend)
+        result = agent.invoke(
+            "Create a file called /app/skill_test.txt containing exactly "
+            "'skill test passed' and nothing else."
+        )
+
+        # Verify the agent created the file
+        read_res = backend.read("/skill_test.txt")
+        _require(read_res.error is None, f"Read failed: {read_res.error}")
+        _require(
+            "skill test passed" in read_res.file_data["content"],
+            f"Agent didn't create expected file content: {read_res.file_data['content']}",
+        )


### PR DESCRIPTION
## Summary

Adds a [LangChain DeepAgents](https://github.com/langchain-ai/deepagents) backend that uses agent-sandbox for isolated code execution. Implements `SandboxBackendProtocol` so LangChain agents can spin up Kubernetes sandboxes to run code, read/write files, and clean up after themselves.

We've been using this at [Mayflower](https://mayflower.de) to run LangChain agents on our clusters and wanted to contribute it back upstream.

## Changes

**1. New `langchain-agent-sandbox` package** (`clients/python/langchain-agent-sandbox/`)
- `AgentSandboxBackend` wrapping `Sandbox` handles for execute, read, write, edit, grep, glob, upload, and download
- Path virtualization under configurable `root_dir` with escape detection via `posixpath.relpath`
- `SandboxPolicyWrapper` for path and command restrictions (best-effort guardrail, not a security boundary)
- `WarmPoolBackend` for pre-warmed sandbox pod adoption
- `create_sandbox_backend_factory` for dependency-injected construction
- 57 unit tests covering backend lifecycle, file operations, and policy configurations

**2. CI integration** (`dev/tools/test-unit`, `dev/tools/test-e2e`, `Makefile`)
- Langchain tests registered in `test-unit` Python test suites
- Langchain package installed in `test-e2e` virtual environment
- `make test-langchain` target for quick iteration

**3. E2E test** (`test/e2e/clients/python/`)
- End-to-end test exercising the full backend against a kind cluster
- Module-level skip guard when `langchain-agent-sandbox` is not installed

**4. Example application** (`examples/langchain-deepagents/`)
- Working example with skills, sandbox template, and kind cluster test script

## How to Test

```bash
# Unit tests (57 tests)
make test-langchain

# Or via the full unit test suite
make test-unit

# E2E (requires kind cluster with extensions)
make deploy-kind EXTENSIONS=true
uv run pytest test/e2e/clients/python/test_e2e_langchain_backend.py -v
```

## Notes

- Depends on the `deepagents` package from LangChain (listed in pyproject.toml)
- Does not modify `agentic-sandbox-client` — uses the existing SDK API as-is
- Happy to split into smaller PRs or adjust the approach based on feedback