### PR TITLE
WIP: tests: implement non-blocking watch with ConcurrentQueue

### DIFF
--- a/test/e2e/chromesandbox_test.go
+++ b/test/e2e/chromesandbox_test.go
@@ -20,27 +20,63 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
 
-// ChromeSandboxMetrics holds timing measurements for the chrome sandbox startup.
-type ChromeSandboxMetrics struct {
-	SandboxReady time.Duration // Time for sandbox to become ready
-	PodReady     time.Duration // Time for pod to become ready
-	ChromeReady  time.Duration // Time for chrome to respond on debug port
-	Total        time.Duration // Total time from start to chrome ready
+// AtomicTimeDuration is a wrapper around time.Duration that allows for concurrent updates and retrievals.
+type AtomicTimeDuration struct {
+	v uint64
 }
 
-func chromeSandbox() *sandboxv1alpha1.Sandbox {
+// Seconds returns the duration in seconds as a float64.
+func (s *AtomicTimeDuration) Seconds() float64 {
+	v := atomic.LoadUint64(&s.v)
+	d := time.Duration(v)
+	return d.Seconds()
+}
+
+// IsEmpty returns true if the duration is zero.
+func (s *AtomicTimeDuration) IsEmpty() bool {
+	return atomic.LoadUint64(&s.v) == 0
+}
+
+// Set sets the duration to the given value.
+func (s *AtomicTimeDuration) Set(d time.Duration) {
+	atomic.StoreUint64(&s.v, uint64(d))
+}
+
+// String returns the duration as a string.
+func (s *AtomicTimeDuration) String() string {
+	v := atomic.LoadUint64(&s.v)
+	d := time.Duration(v)
+	return d.String()
+}
+
+// ChromeSandboxMetrics holds timing measurements for the chrome sandbox startup.
+type ChromeSandboxMetrics struct {
+	SandboxReady AtomicTimeDuration // Time for sandbox to become ready
+	PodCreated   AtomicTimeDuration // Time for pod to be created
+	PodScheduled AtomicTimeDuration // Time for pod to be scheduled
+	PodRunning   AtomicTimeDuration // Time for pod to become running
+	PodReady     AtomicTimeDuration // Time for pod to become ready
+	ChromeReady  AtomicTimeDuration // Time for chrome to respond on debug port
+	Total        AtomicTimeDuration // Total time from start to chrome ready
+}
+
+func chromeSandbox(namespace string) *sandboxv1alpha1.Sandbox {
 	sandbox := &sandboxv1alpha1.Sandbox{}
 	sandbox.Name = "chrome-sandbox"
+	sandbox.Namespace = namespace
 	sandbox.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -71,6 +107,9 @@ func BenchmarkChromeSandboxStartup(b *testing.B) {
 		metrics := runChromeSandbox(framework.NewTestContext(b))
 		// Report custom metrics in addition to the default ns/op
 		b.ReportMetric(metrics.SandboxReady.Seconds(), "sandbox-ready-sec")
+		b.ReportMetric(metrics.PodCreated.Seconds(), "pod-created-sec")
+		b.ReportMetric(metrics.PodScheduled.Seconds(), "pod-scheduled-sec")
+		b.ReportMetric(metrics.PodRunning.Seconds(), "pod-running-sec")
 		b.ReportMetric(metrics.PodReady.Seconds(), "pod-ready-sec")
 		b.ReportMetric(metrics.ChromeReady.Seconds(), "chrome-ready-sec")
 	}
@@ -86,12 +125,68 @@ func runChromeSandbox(t *framework.TestContext) *ChromeSandboxMetrics {
 	metrics := &ChromeSandboxMetrics{}
 	startTime := time.Now()
 
-	sandboxObj := chromeSandbox()
-	sandboxObj.Namespace = ns.Name
-	t.MustCreateWithCleanup(sandboxObj)
-	t.MustWaitForObject(sandboxObj, predicates.ReadyConditionIsTrue)
+	go func() {
+		var lastValue *corev1.Pod
 
-	metrics.SandboxReady = time.Since(startTime)
+		gvr := corev1.SchemeGroupVersion.WithResource("pods")
+		watchFilter := framework.WatchFilter{
+			Namespace: ns.Name,
+		}
+
+		framework.MustWatch(t.ClusterClient, gvr, watchFilter, func(event watch.Event, obj *corev1.Pod) (bool, error) {
+			t.Logf("Pod event %s %s/%s", event.Type, obj.Namespace, obj.Name)
+
+			if lastValue != nil {
+				diff := cmp.Diff(lastValue, obj)
+				t.Logf("Pod diff: %s", diff)
+			}
+			lastValue = obj.DeepCopy()
+
+			if metrics.PodCreated.IsEmpty() {
+				metrics.PodCreated.Set(time.Since(startTime))
+			}
+
+			if metrics.PodRunning.IsEmpty() {
+				if obj.Status.Phase == corev1.PodRunning {
+					metrics.PodRunning.Set(time.Since(startTime))
+				}
+			}
+
+			if metrics.PodScheduled.IsEmpty() {
+				if obj.Spec.NodeName != "" {
+					metrics.PodScheduled.Set(time.Since(startTime))
+				}
+			}
+			return false, nil
+		})
+	}()
+
+	go func() {
+		var lastValue *sandboxv1alpha1.Sandbox
+
+		gvr := sandboxv1alpha1.GroupVersion.WithResource("sandboxes")
+		watchFilter := framework.WatchFilter{
+			Namespace: ns.Name,
+		}
+
+		framework.MustWatch(t.ClusterClient, gvr, watchFilter, func(event watch.Event, obj *sandboxv1alpha1.Sandbox) (bool, error) {
+			t.Logf("Sandbox event %s %s/%s", event.Type, obj.Namespace, obj.Name)
+
+			if lastValue != nil {
+				diff := cmp.Diff(lastValue, obj)
+				t.Logf("Sandbox diff: %s", diff)
+			}
+			lastValue = obj.DeepCopy()
+
+			return false, nil
+		})
+	}()
+
+	sandboxObj := chromeSandbox(ns.Name)
+	t.MustCreateWithCleanup(sandboxObj)
+
+	t.MustWaitForObject(sandboxObj, predicates.ReadyConditionIsTrue)
+	metrics.SandboxReady.Set(time.Since(startTime))
 
 	podID := types.NamespacedName{
 		Namespace: ns.Name,
@@ -102,13 +197,13 @@ func runChromeSandbox(t *framework.TestContext) *ChromeSandboxMetrics {
 	podObj.Namespace = podID.Namespace
 
 	t.MustWaitForObject(podObj, predicates.ReadyConditionIsTrue)
-	metrics.PodReady = time.Since(startTime)
+	metrics.PodReady.Set(time.Since(startTime))
 
 	if err := waitForChromeReady(t, podID); err != nil {
 		t.Fatalf("failed to wait for chrome ready: %v", err)
 	}
-	metrics.ChromeReady = time.Since(startTime)
-	metrics.Total = time.Since(startTime)
+	metrics.ChromeReady.Set(time.Since(startTime))
+	metrics.Total.Set(time.Since(startTime))
 
 	return metrics
 }

--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -120,11 +120,17 @@ func NewTestContext(t T) *TestContext {
 		t.Fatalf("building dynamic client: %v", err)
 	}
 
+	watchSet := NewWatchSet(dynamicClient)
+	t.Cleanup(func() {
+		watchSet.Close()
+	})
+
 	th.ClusterClient = &ClusterClient{
 		T:             t,
 		client:        client,
 		dynamicClient: dynamicClient,
 		scheme:        controllers.Scheme,
+		watchSet:      watchSet,
 	}
 	t.Cleanup(func() {
 		t.Helper()

--- a/test/e2e/framework/predicates/sandbox.go
+++ b/test/e2e/framework/predicates/sandbox.go
@@ -24,13 +24,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func validateSandbox(obj client.Object) (*sandboxv1alpha1.Sandbox, error) {
+func asSandbox(obj client.Object) (*sandboxv1alpha1.Sandbox, error) {
 	if obj == nil {
 		return nil, fmt.Errorf("sandbox object is nil")
 	}
-	sandbox, ok := obj.(*sandboxv1alpha1.Sandbox)
-	if !ok {
-		return nil, fmt.Errorf("got %T, want %T", obj, &sandboxv1alpha1.Sandbox{})
+	sandbox, err := asTyped[*sandboxv1alpha1.Sandbox](obj)
+	if err != nil {
+		return nil, err
 	}
 	return sandbox, nil
 }
@@ -51,7 +51,7 @@ func (s *sandboxHasStatusPredicate) String() string {
 }
 
 func (s *sandboxHasStatusPredicate) Matches(obj client.Object) (bool, error) {
-	sandbox, err := validateSandbox(obj)
+	sandbox, err := asSandbox(obj)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/framework/watchset.go
+++ b/test/e2e/framework/watchset.go
@@ -1,0 +1,292 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+// Subscription represents a subscription to events from a ResourceWatch.
+type Subscription struct {
+	// Events is the channel where events are delivered.
+	Events chan watch.Event
+
+	id uint64
+
+	// filter allows us to use a broader watch and filter events per subscription.
+	filter WatchFilter
+
+	resourceWatch *ResourceWatch
+}
+
+// ResourceWatch maintains a watch for a specific GVR+namespace combination.
+type ResourceWatch struct {
+	gvr       schema.GroupVersionResource
+	namespace string // empty for cluster-scoped resources
+
+	mu            sync.RWMutex
+	subscriptions map[uint64]*Subscription
+	nextSubID     uint64
+
+	dynamicClient dynamic.Interface
+
+	// cancelWatchLoop will cancel the watch loop
+	cancelWatchLoop context.CancelFunc
+}
+
+// WatchSet maintains persistent watches for resource types.
+type WatchSet struct {
+	mu            sync.RWMutex
+	watches       map[watchKey]*ResourceWatch
+	dynamicClient dynamic.Interface
+}
+
+// watchKey identifies a unique watch by GVR and namespace.
+type watchKey struct {
+	gvr       schema.GroupVersionResource
+	namespace string
+}
+
+// NewWatchSet creates a new WatchSet.
+func NewWatchSet(dynamicClient dynamic.Interface) *WatchSet {
+	return &WatchSet{
+		watches:       make(map[watchKey]*ResourceWatch),
+		dynamicClient: dynamicClient,
+	}
+}
+
+// getOrCreateWatch returns an existing watch or creates a new one.
+func (ws *WatchSet) getOrCreateWatch(ctx context.Context, gvr schema.GroupVersionResource, namespace string) *ResourceWatch {
+	key := watchKey{gvr: gvr, namespace: namespace}
+
+	// Try read lock first
+	ws.mu.RLock()
+	rw, ok := ws.watches[key]
+	ws.mu.RUnlock()
+	if ok {
+		return rw
+	}
+
+	// Need write lock to create
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if rw, ok := ws.watches[key]; ok {
+		return rw
+	}
+
+	// ctx, cancel := context.WithCancel(context.Background())
+	rw = &ResourceWatch{
+		gvr:           gvr,
+		namespace:     namespace,
+		subscriptions: make(map[uint64]*Subscription),
+		dynamicClient: ws.dynamicClient,
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	rw.cancelWatchLoop = cancel
+
+	go rw.watchLoop(ctx)
+
+	ws.watches[key] = rw
+	return rw
+}
+
+// Subscribe creates a subscription to events for a specific object key.
+// The key should be "namespace/name" for namespaced resources or just "name" for cluster-scoped.
+// Returns a Subscription that receives events matching the filter.
+func (ws *WatchSet) Subscribe(ctx context.Context, gvr schema.GroupVersionResource, filter WatchFilter) *Subscription {
+	watchNamespace := ""
+	if filter.Namespace != "" {
+		watchNamespace = filter.Namespace
+	}
+	rw := ws.getOrCreateWatch(ctx, gvr, watchNamespace)
+	return rw.subscribe(filter)
+}
+
+// Close removes a subscription
+func (s *Subscription) Close() {
+	s.resourceWatch.unsubscribe(s)
+}
+
+// Close stops all watches and cleans up resources.
+func (ws *WatchSet) Close() {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	for _, rw := range ws.watches {
+		rw.stop()
+	}
+	ws.watches = nil
+}
+
+type WatchFilter struct {
+	// Namespace is the namespace to filter on; empty means all namespaces.
+	Namespace string
+	// Name is the name to filter on; empty means all names.
+	Name string
+}
+
+// subscribe adds a new subscription with the given key filter.
+func (rw *ResourceWatch) subscribe(filter WatchFilter) *Subscription {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+
+	sub := &Subscription{
+		id:            rw.nextSubID,
+		Events:        make(chan watch.Event, 100), // Buffered to reduce blocking
+		filter:        filter,
+		resourceWatch: rw,
+	}
+	rw.nextSubID++
+	rw.subscriptions[sub.id] = sub
+
+	return sub
+}
+
+// unsubscribe removes a subscription.
+func (rw *ResourceWatch) unsubscribe(sub *Subscription) {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+
+	if _, ok := rw.subscriptions[sub.id]; ok {
+		delete(rw.subscriptions, sub.id)
+		close(sub.Events)
+	}
+
+	// TODO: Stop the watch if there are no more subscriptions
+}
+
+// stop cancels the watch and closes all subscriptions.
+func (rw *ResourceWatch) stop() {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+
+	rw.cancelWatchLoop()
+
+	for _, sub := range rw.subscriptions {
+		close(sub.Events)
+	}
+	rw.subscriptions = nil
+}
+
+// watchLoop runs the watch and broadcasts events to subscriptions.
+func (rw *ResourceWatch) watchLoop(ctx context.Context) {
+	var resourceVersion string
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Create the watch
+		var resourceInterface dynamic.ResourceInterface
+		if rw.namespace != "" {
+			resourceInterface = rw.dynamicClient.Resource(rw.gvr).Namespace(rw.namespace)
+		} else {
+			resourceInterface = rw.dynamicClient.Resource(rw.gvr)
+		}
+
+		listOptions := metav1.ListOptions{
+			Watch:           true,
+			ResourceVersion: resourceVersion,
+		}
+
+		watcher, err := resourceInterface.Watch(ctx, listOptions)
+		if err != nil {
+			// If context is done, exit
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				// Wait a bit before retrying
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+		}
+
+		// Process events
+		for {
+			select {
+			case <-ctx.Done():
+				watcher.Stop()
+				return
+
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					// Watch channel closed, restart with last resourceVersion
+					break
+				}
+
+				if event.Type == watch.Error {
+					// On error, restart from scratch
+					resourceVersion = ""
+					break
+				}
+
+				// Broadcast to matching subscriptions
+				rw.broadcast(event)
+			}
+		}
+	}
+}
+
+// broadcast sends an event to all matching subscriptions.
+func (rw *ResourceWatch) broadcast(event watch.Event) {
+	name := ""
+	namespace := ""
+
+	if event.Object != nil {
+		if typedObject, ok := event.Object.(metav1.Object); ok {
+			name = typedObject.GetName()
+			namespace = typedObject.GetNamespace()
+		} else {
+			klog.Warningf("broadcast: event object does not implement metav1.Object")
+		}
+	}
+
+	rw.mu.RLock()
+	defer rw.mu.RUnlock()
+
+	for _, sub := range rw.subscriptions {
+		if event.Type == watch.Error || event.Type == watch.Bookmark {
+			// Always send errors and bookmarks
+			sub.Events <- event
+			continue
+		}
+
+		// Check if subscription filter matches
+		if sub.filter.Namespace != "" && sub.filter.Namespace != namespace {
+			continue
+		}
+		if sub.filter.Name != "" && sub.filter.Name != name {
+			continue
+		}
+
+		// Send event
+		sub.Events <- event
+	}
+}


### PR DESCRIPTION
A naive implementation of channels blocks when the channel is full.
    
We can move to a more "classical" approach of a mutex and condition,
and we implement a ConcurrentQueue abstraction that is non-blocking,
and supports context cancellation and "closing" the queue.