### PR TITLE
Fix permission for PR analytics

### DIFF
--- a/.github/workflows/pr-analytics.yml
+++ b/.github/workflows/pr-analytics.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required for creating reports (as issues)
     steps:
       - name: "Generate PR Report"
         uses: AlexSim93/pull-request-analytics-action@v4.10.0


### PR DESCRIPTION
By default, `GITHUB_TOKEN` is granted read-only access (adheres to the principle of least privilege). 