### PR TITLE
feat: add GitHub Actions workflow linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Fixes #327
Adds GitHub Actions workflow validation using `actionlint` to catch errors before merging.

## Changes
- Add `actionlint` tool to validate workflow YAML files
- Add `dev/tools/lint-workflows` script
- Add `dev/ci/presubmits/lint-workflows` presubmit check
- Add `.github/workflows/ci.yml` to run lint and tests on PRs
- Add `make lint-workflows` target

