### PR TITLE
fix: ensure consistent image tags and allow manual overrides

### DIFF
--- a/dev/ci/presubmits/test-e2e
+++ b/dev/ci/presubmits/test-e2e
@@ -20,21 +20,25 @@ import subprocess
 
 from shared import utils
 
+repo_root = utils.get_repo_root()
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+    
+from dev.tools.shared import utils as tools_utils
 
 def main():
     """ invokes e2e tests in kind cluster and outputs a junit report in the ARTIFACTS dir
 
     The ARTIFACTS environment variable is set by prow.
     """
-    repo_root = utils.get_repo_root()
-
+    image_tag = tools_utils.get_image_tag()
     result = subprocess.run([f"{repo_root}/dev/tools/create-kind-cluster", "e2e-test", "--recreate", "--kubeconfig", f"{repo_root}/bin/KUBECONFIG"])
     if result.returncode != 0:
         return result.returncode
-    result = subprocess.run([f"{repo_root}/dev/tools/push-images", "--kind-cluster-name", "e2e-test", "--image-prefix", "kind.local/"])
+    result = subprocess.run([f"{repo_root}/dev/tools/push-images", "--kind-cluster-name", "e2e-test", "--image-prefix", "kind.local/", "--image-tag", image_tag])
     if result.returncode != 0:
         return result.returncode
-    result = subprocess.run([f"{repo_root}/dev/tools/deploy-to-kube", "--image-prefix", "kind.local/"])
+    result = subprocess.run([f"{repo_root}/dev/tools/deploy-to-kube", "--image-prefix", "kind.local/", "--image-tag", image_tag])
     if result.returncode != 0:
         return result.returncode
     result = subprocess.run([f"{repo_root}/dev/tools/deploy-cloud-provider"])

--- a/dev/tools/deploy-to-kube
+++ b/dev/tools/deploy-to-kube
@@ -78,6 +78,9 @@ def main(args):
     prereq_docs = []
     other_docs = []
 
+    image_prefix = utils.get_image_prefix(args)
+    image_tag = args.image_tag or utils.get_image_tag()
+
     for root, dirs, files in os.walk(manifests_path):
         for filename in files:
             if not (filename.endswith(".yaml") or filename.endswith(".yml")):
@@ -89,9 +92,7 @@ def main(args):
                 docs = list(yaml.safe_load_all(f))
 
             service_name = os.path.basename(root)
-            image_prefix = utils.get_image_prefix(args)
-            image_tag = utils.get_image_tag()
-
+            
             # Process each document in the file
             for doc in docs:
                 if not doc: continue
@@ -127,5 +128,10 @@ if __name__ == "__main__":
                         help="prefix for the image name. requires slash at the end if a path",
                         type=str,
                         default=os.getenv("IMAGE_PREFIX"))
+    parser.add_argument("--image-tag",
+                        dest="image_tag",
+                        help="Image tag for this build. If not set, a default tag is generated based on date and git commit",
+                        type=str,
+                        default=os.getenv("IMAGE_TAG"))
     args = parser.parse_args()
     main(args)

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -38,7 +38,7 @@ def create_buildx_builder_if_not_exists():
     subprocess.run(["docker", "buildx", "use", builder_name], check=True)
 
 
-def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfile_path):
+def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfile_path, image_tag):
     platforms = "linux/amd64,linux/arm64"
     build_cmd = [
         "docker",
@@ -49,7 +49,7 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
     ]
     if args.docker_build_output_type == "registry":
         build_cmd.append("--platform=" + platforms)
-    image_name = utils.get_full_image_name(args, service_name)
+    image_name = utils.get_full_image_name(args, service_name, tag=image_tag)
     build_cmd.extend(["-t", image_name])
     for tag in args.extra_image_tags:  # additional image tags
         extra_tag = utils.get_full_image_name(args, service_name, tag=tag)
@@ -63,8 +63,8 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
     print(f"pushed image {image_name}")
 
 
-def load_kind_image(cluster_name, service_name, srcdir):
-    image_name = utils.get_full_image_name(args, service_name)
+def load_kind_image(args, cluster_name, service_name, srcdir, image_tag):
+    image_name = utils.get_full_image_name(args, service_name, tag=image_tag)
     build_cmd = [
         "kind",
         "load",
@@ -77,14 +77,15 @@ def load_kind_image(cluster_name, service_name, srcdir):
     print(f"loaded image {image_name} into kind cluster {args.kind_cluster_name}")
 
 
-def build_and_push_image(args, service_name, srcdir, dockerfile_path):
-    build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfile_path)
+def build_and_push_image(args, service_name, srcdir, dockerfile_path, image_tag):
+    build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfile_path, image_tag)
     if args.kind_cluster_name:
-        load_kind_image(args.kind_cluster_name, service_name, srcdir)
+        load_kind_image(args, args.kind_cluster_name, service_name, srcdir, image_tag)
 
 
 def main(args):
     """Builds and pushes all discovered Docker images."""
+    image_tag = args.image_tag or utils.get_image_tag()
     excluded_dirs = {"bin", "dev", "docs", "k8s", "site",
                      "temp", "tests", "tmp", ".venv"}
 
@@ -113,7 +114,7 @@ def main(args):
             print(f"create Docker buildx builder for {service_name}")
             create_buildx_builder_if_not_exists()
             print(f"building image for {service_name}")
-            build_and_push_image(args, service_name, context_dir, dockerfile_path)
+            build_and_push_image(args, service_name, context_dir, dockerfile_path, image_tag)
             # TODO: Handle duplicate service names in different paths
 
 
@@ -140,6 +141,11 @@ if __name__ == "__main__":
                         dest="controller_only",
                         action="store_true",
                         help="Only build and push the agent-sandbox-controller image.")
+    parser.add_argument("--image-tag",
+                        dest="image_tag",
+                        help="Image tag for this build. If not set, a default tag is generated based on date and git commit",
+                        type=str,
+                        default=os.getenv("IMAGE_TAG"))
     args = parser.parse_args()
 
     if args.kind_cluster_name:


### PR DESCRIPTION
### Description
This PR resolves an issue where image tags could become inconsistent between build and deployment phases (especially during date transitions). It also introduces the ability to manually specify an image tag to bypass the automatic generation logic.

### Changes
- **Python**: Updated `get_image_tag()` to support an optional `tag` parameter.
- **Makefile**: Refactored build and deploy targets to ensure a consistent `IMAGE_TAG` is used throughout the pipeline.
- **Logic**: Centralized the tag calculation to prevent mismatches caused by the date changing (crossing midnight) during the CI process.

### Why this is needed
In cloud CI/CD environments, if the build step and the deploy step calculate the tag separately, a midnight transition can cause the "Push" step to look for a tag that doesn't exist yet. Providing a manual override also increases flexibility for custom releases.

Fixes #326 