### PR TITLE
tests: add a test to validate pause and resume feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,12 +51,15 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/onsi/ginkgo/v2 v2.23.3 // indirect
 	github.com/onsi/gomega v1.37.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
@@ -73,6 +75,8 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/Z
 github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 h1:NmZ1PKzSTQbuGHw9DGPFomqkkLWMC+vZCkfs+FHv1Vg=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3/go.mod h1:zQrxl1YP88HQlA6i9c63DSVPFklWpGX4OWAc9bFuaH4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -87,6 +91,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
+github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -95,6 +101,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.23.3 h1:edHxnszytJ4lD9D5Jjc4tiDkPBZ3siDeJJkUZJJVkp0=
 github.com/onsi/ginkgo/v2 v2.23.3/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -36,6 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	sandboxextensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
@@ -52,6 +56,8 @@ type ClusterClient struct {
 	T
 	client        client.Client
 	dynamicClient dynamic.Interface
+	clientset     kubernetes.Interface
+	restConfig    *rest.Config
 	scheme        *runtime.Scheme
 	watchSet      *WatchSet
 }
@@ -651,6 +657,50 @@ func (cl *ClusterClient) ExecuteOnNode(ctx context.Context, nodeName string, com
 	err := cmd.Run()
 	if err != nil {
 		return stdout.String(), stderr.String(), fmt.Errorf("docker exec failed: %w (stderr: %s)", err, stderr.String())
+	}
+
+	return stdout.String(), stderr.String(), nil
+}
+
+// PodExec executes a command in a container within a pod using client-go.
+func (cl *ClusterClient) PodExec(ctx context.Context, namespace, podName, containerName string, command []string, stdin io.Reader) (string, string, error) {
+	cl.Helper()
+
+	req := cl.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+
+	option := &corev1.PodExecOptions{
+		Container: containerName,
+		Command:   command,
+		Stdin:     stdin != nil,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}
+
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+
+	exec, err := remotecommand.NewSPDYExecutor(cl.restConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+
+	if err != nil {
+		return stdout.String(), stderr.String(), fmt.Errorf("pod exec failed: %w (stderr: %s)", err, stderr.String())
 	}
 
 	return stdout.String(), stderr.String(), nil

--- a/test/e2e/framework/context.go
+++ b/test/e2e/framework/context.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/agent-sandbox/controllers"
@@ -107,6 +108,11 @@ func NewTestContext(t T) *TestContext {
 		t.Fatalf("building HTTP client for rest config: %v", err)
 	}
 
+	clientset, err := kubernetes.NewForConfigAndClient(restConfig, httpClient)
+	if err != nil {
+		t.Fatalf("building kubernetes clientset: %v", err)
+	}
+
 	client, err := client.New(restConfig, client.Options{
 		Scheme:     controllers.Scheme,
 		HTTPClient: httpClient,
@@ -129,6 +135,8 @@ func NewTestContext(t T) *TestContext {
 		T:             t,
 		client:        client,
 		dynamicClient: dynamicClient,
+		clientset:     clientset,
+		restConfig:    restConfig,
 		scheme:        controllers.Scheme,
 		watchSet:      watchSet,
 	}

--- a/test/e2e/framework/predicates/sandbox.go
+++ b/test/e2e/framework/predicates/sandbox.go
@@ -56,7 +56,7 @@ func (s *sandboxHasStatusPredicate) Matches(obj client.Object) (bool, error) {
 		return false, err
 	}
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "Message", "ObservedGeneration"),
 	}
 	if diff := cmp.Diff(s.WantStatus, sandbox.Status, opts...); diff != "" {
 		return false, nil

--- a/test/e2e/pvc_persistence_test.go
+++ b/test/e2e/pvc_persistence_test.go
@@ -1,0 +1,316 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
+)
+
+const (
+	// pvcSandboxName is the sandbox name used throughout the test.
+	pvcSandboxName = "pvc-persistence-sandbox"
+
+	// workspacesPVCTemplateName is the volumeClaimTemplate name; the controller
+	// creates the PVC as "<templateName>-<sandboxName>".
+	workspacesPVCTemplateName = "workspaces"
+
+	// dataFilePath is the path inside the container where we write the generated file.
+	dataFilePath = "/workspaces/data.txt"
+
+	// dataContent is the data written to the PVC.
+	dataContent = "# Agent sandbox test data"
+)
+
+// TestPVCPersistenceAcrossReplicas tests the replicas=0/1 lifecycle of a sandbox with a PVC:
+//
+//  1. Creates a sandbox (busybox container) with a PVC mounted at /workspaces.
+//  2. Waits for sandbox to be ready, then writes a data file onto the PVC.
+//  3. Sets replicas=0: verifies pod is deleted, PVC and Sandbox CR are preserved.
+//  4. Sets replicas=1: verifies sandbox becomes ready again with the same PVC.
+//  5. Verifies the data file still exists on the PVC in the new pod.
+func TestPVCPersistenceAcrossReplicas(t *testing.T) {
+	tc := framework.NewTestContext(t)
+	ctx := t.Context()
+
+	nameHash := NameHash(pvcSandboxName)
+
+	// Namespace
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("pvc-persistence-test-%d", time.Now().UnixNano())
+	require.NoError(t, tc.CreateWithCleanup(ctx, ns))
+
+	// Sandbox with PVC
+	sandboxObj := pvcSandbox(ns.Name)
+	require.NoError(t, tc.CreateWithCleanup(ctx, sandboxObj))
+
+	pvcName := fmt.Sprintf("%s-%s", workspacesPVCTemplateName, pvcSandboxName)
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvc.Name = pvcName
+	pvc.Namespace = ns.Name
+
+	// Wait for sandbox to be ready with 1 replica
+	t.Logf("Waiting for sandbox to become ready (replicas=1)")
+	require.NoError(t, tc.WaitForObject(ctx, sandboxObj,
+		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
+			Service:       pvcSandboxName,
+			ServiceFQDN:   fmt.Sprintf("%s.%s.svc.cluster.local", pvcSandboxName, ns.Name),
+			Replicas:      1,
+			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+			Conditions: []metav1.Condition{
+				{
+					Message:            "Pod is Ready; Service Exists",
+					ObservedGeneration: 1,
+					Reason:             "DependenciesReady",
+					Status:             "True",
+					Type:               "Ready",
+				},
+			},
+		}),
+	))
+	t.Logf("Sandbox is ready with 1 replica")
+
+	// Verify PVC exists
+	tc.MustExist(pvc)
+	t.Logf("PVC %s/%s exists", ns.Name, pvcName)
+
+	// Generating code on PVC
+	t.Logf("Generating code on PVC at %s", dataFilePath)
+	// We use a dynamic timestamp to ensure we're verifying the exact content generated in this run.
+	generatedContent := fmt.Sprintf("# Dynamic code generated at %s\n\n%s", time.Now().Format(time.RFC3339), dataContent)
+	require.NoError(t, execWriteFileToPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath, generatedContent))
+
+	// Verify the write succeeded by reading back.
+	content, err := execReadFileFromPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath)
+	require.NoError(t, err, "failed to read back the file right after writing")
+	require.Contains(t, content, "Agent sandbox test data", "file contents wrong right after write")
+	t.Logf("Write verified: file is readable in original pod")
+
+	// Scale down to replicas=0
+	t.Logf("Setting replicas=0")
+	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1alpha1.Sandbox) {
+		obj.Spec.Replicas = ptr.To(int32(0))
+	})
+
+	// Wait for the sandbox status to reflect replicas=0
+	t.Logf("Waiting for sandbox status to show replicas=0...")
+	require.NoError(t, tc.WaitForObject(ctx, sandboxObj,
+		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
+			Service:       pvcSandboxName,
+			ServiceFQDN:   fmt.Sprintf("%s.%s.svc.cluster.local", pvcSandboxName, ns.Name),
+			Replicas:      0,
+			LabelSelector: "",
+			Conditions: []metav1.Condition{
+				{
+					Message:            "Pod does not exist, replicas is 0; Service Exists",
+					ObservedGeneration: 2,
+					Reason:             "DependenciesReady",
+					Status:             "True",
+					Type:               "Ready",
+				},
+			},
+		}),
+	))
+	t.Logf("Sandbox status shows replicas=0")
+
+	// Pod must be gone
+	pod := &corev1.Pod{}
+	pod.Name = pvcSandboxName
+	pod.Namespace = ns.Name
+	require.NoError(t, tc.WaitForObjectNotFound(ctx, pod))
+	t.Logf("Pod deleted")
+
+	// Sandbox CR still exists
+	require.NoError(t, tc.Get(ctx, types.NamespacedName{Name: pvcSandboxName, Namespace: ns.Name}, sandboxObj))
+	t.Logf("Sandbox CR still exists")
+
+	// PVC must still exist
+	tc.MustExist(pvc)
+	require.NoError(t, tc.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: ns.Name}, pvc))
+	originalPVCUID := pvc.UID
+	t.Logf("PVC %s/%s still exists (UID=%s)", ns.Name, pvcName, originalPVCUID)
+
+	// Scale back up to replicas=1
+	t.Logf("Setting replicas=1")
+	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1alpha1.Sandbox) {
+		obj.Spec.Replicas = ptr.To(int32(1))
+	})
+
+	// Wait for the sandbox status to be ready with 1 replica again
+	t.Logf("Waiting for sandbox to show replicas=1 and Ready=True...")
+	require.NoError(t, tc.WaitForObject(ctx, sandboxObj,
+		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
+			Service:       pvcSandboxName,
+			ServiceFQDN:   fmt.Sprintf("%s.%s.svc.cluster.local", pvcSandboxName, ns.Name),
+			Replicas:      1,
+			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+			Conditions: []metav1.Condition{
+				{
+					Message:            "Pod is Ready; Service Exists",
+					ObservedGeneration: 3,
+					Reason:             "DependenciesReady",
+					Status:             "True",
+					Type:               "Ready",
+				},
+			},
+		}),
+	))
+	t.Logf("Sandbox is ready again with 1 replica")
+
+	// The same PVC was reused (not recreated)
+	require.NoError(t, tc.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: ns.Name}, pvc))
+	require.Equal(t, originalPVCUID, pvc.UID,
+		"PVC UID changed — a new PVC was created instead of reusing the original")
+	t.Logf("Same PVC reused (UID=%s)", pvc.UID)
+
+	// Verify generated code survived the replicas=0/1 cycle
+	t.Logf("Verifying generated code persists in the new pod")
+	content, err = execReadFileFromPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath)
+	require.NoError(t, err, "failed to read generated code from pod after replicas=1 restore")
+	require.Contains(t, content, "Agent sandbox test data",
+		"expected dynamic content not found after PVC reattach — data was lost")
+	t.Logf("SUCCESS: generated code persisted across replicas=0/1 cycle")
+}
+
+// pvcSandbox returns a Sandbox spec with a PVC mounted at /workspaces.
+func pvcSandbox(ns string) *sandboxv1alpha1.Sandbox {
+	return &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcSandboxName,
+			Namespace: ns,
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "workspace",
+							Image: "busybox",
+							// Python container keeps running if we give it a sleep command.
+							Command: []string{"sh", "-c", "sleep infinity"},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      workspacesPVCTemplateName,
+									MountPath: "/workspaces",
+								},
+							},
+						},
+					},
+				},
+			},
+
+			VolumeClaimTemplates: []sandboxv1alpha1.PersistentVolumeClaimTemplate{
+				{
+					EmbeddedObjectMetadata: sandboxv1alpha1.EmbeddedObjectMetadata{
+						Name: workspacesPVCTemplateName,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// execWriteFileToPod writes content to a file inside a running pod via kubectl exec.
+// The -i flag is required to forward stdin to the remote process.
+func execWriteFileToPod(ctx context.Context, namespace, podName, filePath, content string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "exec", "-i", "-n", namespace, podName, "--",
+		"sh", "-c", fmt.Sprintf("cat > %s", filePath))
+	cmd.Stdin = strings.NewReader(content)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kubectl exec write to %s failed: %w (stderr: %s)", filePath, err, stderr.String())
+	}
+	return nil
+}
+
+// execWriteFileToPodWithRetry retries the write until the container is exec-able
+// (useful right after a pod starts up).
+func execWriteFileToPodWithRetry(ctx context.Context, namespace, podName, filePath, content string) error {
+	deadline := time.Now().Add(2 * time.Minute)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		err := execWriteFileToPod(ctx, namespace, podName, filePath, content)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+	return fmt.Errorf("timed out writing to %s in pod %s/%s: %w", filePath, namespace, podName, lastErr)
+}
+
+// execReadFileFromPod reads a file from inside a running pod via kubectl exec.
+func execReadFileFromPod(ctx context.Context, namespace, podName, filePath string) (string, error) {
+	cmd := exec.CommandContext(ctx, "kubectl", "exec", "-n", namespace, podName, "--",
+		"cat", filePath)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("kubectl exec read %s failed: %w (stderr: %s)", filePath, err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+// execReadFileFromPodWithRetry retries reading a file from the pod, waiting for
+// the container to become exec-able after a pod restart.
+func execReadFileFromPodWithRetry(ctx context.Context, namespace, podName, filePath string) (string, error) {
+	deadline := time.Now().Add(2 * time.Minute)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		content, err := execReadFileFromPod(ctx, namespace, podName, filePath)
+		if err == nil {
+			return content, nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+	return "", fmt.Errorf("timed out reading %s from pod %s/%s: %w", filePath, namespace, podName, lastErr)
+}

--- a/test/e2e/pvc_persistence_test.go
+++ b/test/e2e/pvc_persistence_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 The Kubernetes Authors.
+// Copyright The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,8 +61,11 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 	nameHash := NameHash(pvcSandboxName)
 
 	// Namespace
-	ns := &corev1.Namespace{}
-	ns.Name = fmt.Sprintf("pvc-persistence-test-%d", time.Now().UnixNano())
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("pvc-persistence-test-%d", time.Now().UnixNano()),
+		},
+	}
 	require.NoError(t, tc.CreateWithCleanup(ctx, ns))
 
 	// Sandbox with PVC
@@ -70,9 +73,12 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 	require.NoError(t, tc.CreateWithCleanup(ctx, sandboxObj))
 
 	pvcName := fmt.Sprintf("%s-%s", workspacesPVCTemplateName, pvcSandboxName)
-	pvc := &corev1.PersistentVolumeClaim{}
-	pvc.Name = pvcName
-	pvc.Namespace = ns.Name
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: ns.Name,
+		},
+	}
 
 	// Wait for sandbox to be ready with 1 replica
 	t.Logf("Waiting for sandbox to become ready (replicas=1)")
@@ -135,9 +141,12 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 	t.Logf("Sandbox status shows replicas=0")
 
 	// Pod must be gone
-	pod := &corev1.Pod{}
-	pod.Name = pvcSandboxName
-	pod.Namespace = ns.Name
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcSandboxName,
+			Namespace: ns.Name,
+		},
+	}
 	require.NoError(t, tc.WaitForObjectNotFound(ctx, pod))
 	t.Logf("Pod deleted")
 

--- a/test/e2e/pvc_persistence_test.go
+++ b/test/e2e/pvc_persistence_test.go
@@ -15,10 +15,8 @@
 package e2e
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -86,8 +84,6 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod is Ready; Service Exists",
-					ObservedGeneration: 1,
 					Reason:             "DependenciesReady",
 					Status:             "True",
 					Type:               "Ready",
@@ -105,10 +101,10 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 	t.Logf("Generating code on PVC at %s", dataFilePath)
 	// We use a dynamic timestamp to ensure we're verifying the exact content generated in this run.
 	generatedContent := fmt.Sprintf("# Dynamic code generated at %s\n\n%s", time.Now().Format(time.RFC3339), dataContent)
-	require.NoError(t, execWriteFileToPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath, generatedContent))
+	require.NoError(t, execWriteFileToPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath, generatedContent, tc))
 
 	// Verify the write succeeded by reading back.
-	content, err := execReadFileFromPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath)
+	content, err := execReadFileFromPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath, tc)
 	require.NoError(t, err, "failed to read back the file right after writing")
 	require.Contains(t, content, "Agent sandbox test data", "file contents wrong right after write")
 	t.Logf("Write verified: file is readable in original pod")
@@ -129,8 +125,6 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 			LabelSelector: "",
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod does not exist, replicas is 0; Service Exists",
-					ObservedGeneration: 2,
 					Reason:             "DependenciesReady",
 					Status:             "True",
 					Type:               "Ready",
@@ -173,8 +167,6 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod is Ready; Service Exists",
-					ObservedGeneration: 3,
 					Reason:             "DependenciesReady",
 					Status:             "True",
 					Type:               "Ready",
@@ -192,7 +184,7 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 
 	// Verify generated code survived the replicas=0/1 cycle
 	t.Logf("Verifying generated code persists in the new pod")
-	content, err = execReadFileFromPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath)
+	content, err = execReadFileFromPodWithRetry(ctx, ns.Name, pvcSandboxName, dataFilePath, tc)
 	require.NoError(t, err, "failed to read generated code from pod after replicas=1 restore")
 	require.Contains(t, content, "Agent sandbox test data",
 		"expected dynamic content not found after PVC reattach — data was lost")
@@ -238,7 +230,7 @@ func pvcSandbox(ns string) *sandboxv1alpha1.Sandbox {
 						},
 						Resources: corev1.VolumeResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceStorage: resource.MustParse("1Gi"),
+								corev1.ResourceStorage: resource.MustParse("50Mi"),
 							},
 						},
 					},
@@ -248,27 +240,21 @@ func pvcSandbox(ns string) *sandboxv1alpha1.Sandbox {
 	}
 }
 
-// execWriteFileToPod writes content to a file inside a running pod via kubectl exec.
-// The -i flag is required to forward stdin to the remote process.
-func execWriteFileToPod(ctx context.Context, namespace, podName, filePath, content string) error {
-	cmd := exec.CommandContext(ctx, "kubectl", "exec", "-i", "-n", namespace, podName, "--",
-		"sh", "-c", fmt.Sprintf("cat > %s", filePath))
-	cmd.Stdin = strings.NewReader(content)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("kubectl exec write to %s failed: %w (stderr: %s)", filePath, err, stderr.String())
-	}
-	return nil
+// execWriteFileToPod writes content to a file inside a running pod via native client-go exec.
+func execWriteFileToPod(ctx context.Context, namespace, podName, filePath, content string, tc *framework.TestContext) error {
+	// Busybox doesn't have a sophisticated way to write files from stdin,
+	// but 'cat > path' works fine.
+	_, _, err := tc.PodExec(ctx, namespace, podName, "workspace", []string{"sh", "-c", fmt.Sprintf("cat > %s", filePath)}, strings.NewReader(content))
+	return err
 }
 
 // execWriteFileToPodWithRetry retries the write until the container is exec-able
 // (useful right after a pod starts up).
-func execWriteFileToPodWithRetry(ctx context.Context, namespace, podName, filePath, content string) error {
+func execWriteFileToPodWithRetry(ctx context.Context, namespace, podName, filePath, content string, tc *framework.TestContext) error {
 	deadline := time.Now().Add(2 * time.Minute)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		err := execWriteFileToPod(ctx, namespace, podName, filePath, content)
+		err := execWriteFileToPod(ctx, namespace, podName, filePath, content, tc)
 		if err == nil {
 			return nil
 		}
@@ -282,26 +268,19 @@ func execWriteFileToPodWithRetry(ctx context.Context, namespace, podName, filePa
 	return fmt.Errorf("timed out writing to %s in pod %s/%s: %w", filePath, namespace, podName, lastErr)
 }
 
-// execReadFileFromPod reads a file from inside a running pod via kubectl exec.
-func execReadFileFromPod(ctx context.Context, namespace, podName, filePath string) (string, error) {
-	cmd := exec.CommandContext(ctx, "kubectl", "exec", "-n", namespace, podName, "--",
-		"cat", filePath)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("kubectl exec read %s failed: %w (stderr: %s)", filePath, err, stderr.String())
-	}
-	return stdout.String(), nil
+// execReadFileFromPod reads a file from inside a running pod via native client-go exec.
+func execReadFileFromPod(ctx context.Context, namespace, podName, filePath string, tc *framework.TestContext) (string, error) {
+	stdout, _, err := tc.PodExec(ctx, namespace, podName, "workspace", []string{"cat", filePath}, nil)
+	return stdout, err
 }
 
 // execReadFileFromPodWithRetry retries reading a file from the pod, waiting for
 // the container to become exec-able after a pod restart.
-func execReadFileFromPodWithRetry(ctx context.Context, namespace, podName, filePath string) (string, error) {
+func execReadFileFromPodWithRetry(ctx context.Context, namespace, podName, filePath string, tc *framework.TestContext) (string, error) {
 	deadline := time.Now().Add(2 * time.Minute)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		content, err := execReadFileFromPod(ctx, namespace, podName, filePath)
+		content, err := execReadFileFromPod(ctx, namespace, podName, filePath, tc)
 		if err == nil {
 			return content, nil
 		}

--- a/test/e2e/pvc_persistence_test.go
+++ b/test/e2e/pvc_persistence_test.go
@@ -84,9 +84,9 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Reason:             "DependenciesReady",
-					Status:             "True",
-					Type:               "Ready",
+					Reason: "DependenciesReady",
+					Status: "True",
+					Type:   "Ready",
 				},
 			},
 		}),
@@ -125,9 +125,9 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 			LabelSelector: "",
 			Conditions: []metav1.Condition{
 				{
-					Reason:             "DependenciesReady",
-					Status:             "True",
-					Type:               "Ready",
+					Reason: "DependenciesReady",
+					Status: "True",
+					Type:   "Ready",
 				},
 			},
 		}),
@@ -167,9 +167,9 @@ func TestPVCPersistenceAcrossReplicas(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Reason:             "DependenciesReady",
-					Status:             "True",
-					Type:               "Ready",
+					Reason: "DependenciesReady",
+					Status: "True",
+					Type:   "Ready",
 				},
 			},
 		}),


### PR DESCRIPTION
**Description**

Fixes #248 
Add a e2e test that tests out the pause and resume functionality implemented in #82: 

1. Create a Pod with a PVC and some generated data.
2. Scale the replicas to 0, controller should delete the pod associated with the sandbox.
3. Sandbox CR should remain consistent.
4. Scale the replicas to 1, the controller will recreate the pod. Verify that the data is intact on the PVC.

This test addresses the request made in #248.

**Testing Done**
```
   pvc_persistence_test.go:68: WaitForObjectNotFound *v1.Namespace (/pvc-persistence-test-1772168327331581080) took 43.463444028s
--- PASS: TestPVCPersistenceAcrossReplicas (89.90s)
```
