### PR TITLE
Add a micro benchmark for using SandboxClaims with Chrome Sandbox.

### DIFF
--- a/test/e2e/chromesandbox_claim_test.go
+++ b/test/e2e/chromesandbox_claim_test.go
@@ -68,12 +68,16 @@ func BenchmarkChromeSandboxClaimStartup(b *testing.B) {
 	template := &extensionsv1alpha1.SandboxTemplate{}
 	template.Name = "chrome-template"
 	template.Namespace = ns.Name
+	imageTag := os.Getenv("IMAGE_TAG")
+	if imageTag == "" {
+		imageTag = "latest"
+	}
 	template.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:            "chrome-sandbox",
-					Image:           fmt.Sprintf("kind.local/chrome-sandbox:%s", os.Getenv("IMAGE_TAG")),
+					Image:           fmt.Sprintf("kind.local/chrome-sandbox:%s", imageTag),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 				},
 			},
@@ -108,14 +112,12 @@ func BenchmarkChromeSandboxClaimStartup(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			metrics, err := runChromeSandboxClaim(tc, ns.Name, template.Name)
+			metrics := runChromeSandboxClaim(tc, ns.Name, template.Name)
 
-			if err == nil {
-				mu.Lock()
-				totalClaimReadySec += metrics.ClaimReady.Seconds()
-				totalClaims++
-				mu.Unlock()
-			}
+			mu.Lock()
+			totalClaimReadySec += metrics.ClaimReady.Seconds()
+			totalClaims++
+			mu.Unlock()
 		}
 	})
 
@@ -124,7 +126,7 @@ func BenchmarkChromeSandboxClaimStartup(b *testing.B) {
 	}
 }
 
-func runChromeSandboxClaim(tc *framework.TestContext, namespace, templateName string) (*ChromeSandboxClaimMetrics, error) {
+func runChromeSandboxClaim(tc *framework.TestContext, namespace, templateName string) *ChromeSandboxClaimMetrics {
 	metrics := &ChromeSandboxClaimMetrics{}
 
 	// Unique name for this claim
@@ -147,14 +149,12 @@ func runChromeSandboxClaim(tc *framework.TestContext, namespace, templateName st
 
 	// 2. Wait for Claim Ready
 	// We use the common predicates
-	if err := tc.WaitForObject(tc.Context(), claim, predicates.ReadyConditionIsTrue); err != nil {
-		tc.Logf("Failed to wait for claim %s ready: %v", claimName, err)
-		return metrics, err
-	}
+	tc.MustWaitForObject(claim, predicates.ReadyConditionIsTrue)
+
 	metrics.ClaimReady.Set(time.Since(startTime))
 	tc.Logf("Claim %s is ready", claimName)
 
-	return metrics, nil
+	return metrics
 }
 
 var claimCounter int64

--- a/test/e2e/chromesandbox_claim_test.go
+++ b/test/e2e/chromesandbox_claim_test.go
@@ -39,6 +39,7 @@ type ChromeSandboxClaimMetrics struct {
 
 // BenchmarkChromeSandboxClaimStartup measures the time for Chrome to start in a sandbox claim.
 // Run with: go test -bench=BenchmarkChromeSandboxClaimStartup -benchtime=10x ./test/e2e/...
+// To add parallelism, use the -cpu flag (e.g., -cpu=1,2,4).
 // Make sure that WARM_POOL_SIZE is set appropriately to account for the number of parallel
 // test iterations.
 func BenchmarkChromeSandboxClaimStartup(b *testing.B) {

--- a/test/e2e/chromesandbox_claim_test.go
+++ b/test/e2e/chromesandbox_claim_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
+)
+
+// ChromeSandboxClaimMetrics holds timing measurements for the chrome sandbox claim startup.
+type ChromeSandboxClaimMetrics struct {
+	ClaimReady AtomicTimeDuration // Time for claim to become ready
+}
+
+// BenchmarkChromeSandboxClaimStartup measures the time for Chrome to start in a sandbox claim.
+// Run with: go test -bench=BenchmarkChromeSandboxClaimStartup -benchtime=10x ./test/e2e/...
+func BenchmarkChromeSandboxClaimStartup(b *testing.B) {
+	// Configuration from environment variables
+	warmPoolSize := 6
+	if s := os.Getenv("WARM_POOL_SIZE"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			warmPoolSize = v
+		}
+	}
+	parallelism := 3
+	if s := os.Getenv("PARALLELISM"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			parallelism = v
+		}
+	}
+
+	b.Logf("Benchmark Configuration: WarmPoolSize=%d, Parallelism=%d", warmPoolSize, parallelism)
+
+	tc := framework.NewTestContext(b)
+	ctx := tc.Context()
+
+	// 1. Setup Namespace
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("chrome-claim-bench-%d", time.Now().UnixNano())
+	tc.MustCreateWithCleanup(ns)
+
+	// 2. Setup SandboxTemplate
+	template := &extensionsv1alpha1.SandboxTemplate{}
+	template.Name = "chrome-template"
+	template.Namespace = ns.Name
+	template.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "chrome-sandbox",
+					Image:           fmt.Sprintf("kind.local/chrome-sandbox:%s", os.Getenv("IMAGE_TAG")),
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+	tc.MustCreateWithCleanup(template)
+
+	// 3. Setup SandboxWarmPool
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
+	warmPool.Name = "chrome-warmpool"
+	warmPool.Namespace = ns.Name
+	warmPool.Spec.Replicas = int32(warmPoolSize)
+	warmPool.Spec.TemplateRef.Name = template.Name
+	tc.MustCreateWithCleanup(warmPool)
+
+	// 4. Wait for WarmPool to be Ready
+	b.Logf("Waiting for WarmPool to be ready with %d replicas...", warmPoolSize)
+	// We use WaitLoop with a timeout
+	if err := tc.WaitForWarmPoolReady(ctx, types.NamespacedName{Name: warmPool.Name, Namespace: warmPool.Namespace}); err != nil {
+		b.Fatalf("WarmPool failed to become ready: %v", err)
+	}
+	b.Logf("WarmPool is ready.")
+	var (
+		mu                 sync.Mutex
+		totalClaimReadySec float64
+		totalClaims        int
+	)
+
+	// 5. Benchmark Loop
+	b.SetParallelism(parallelism)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			metrics, err := runChromeSandboxClaim(tc, ns.Name, template.Name)
+
+			if err == nil {
+				mu.Lock()
+				totalClaimReadySec += metrics.ClaimReady.Seconds()
+				totalClaims++
+				mu.Unlock()
+			}
+		}
+	})
+
+	if totalClaims > 0 {
+		b.ReportMetric(totalClaimReadySec/float64(totalClaims), "claim-ready-sec/op")
+	}
+}
+
+func runChromeSandboxClaim(tc *framework.TestContext, namespace, templateName string) (*ChromeSandboxClaimMetrics, error) {
+	metrics := &ChromeSandboxClaimMetrics{}
+
+	// Unique name for this claim
+	claimName := fmt.Sprintf("claim-%d-%d", time.Now().UnixNano(), atomic.AddInt64(&claimCounter, 1))
+
+	claim := &extensionsv1alpha1.SandboxClaim{}
+	claim.Name = claimName
+	claim.Namespace = namespace
+	claim.Spec.TemplateRef.Name = templateName
+	claim.Spec.Lifecycle = &extensionsv1alpha1.Lifecycle{
+		ShutdownPolicy: extensionsv1alpha1.ShutdownPolicyDelete,
+	}
+
+	startTime := time.Now()
+
+	// 1. Create Claim
+	// This will automatically delete the claim at the end of the test.
+	tc.MustCreateWithCleanup(claim)
+	tc.Logf("Created claim %s", claimName)
+
+	// 2. Wait for Claim Ready
+	// We use the common predicates
+	if err := tc.WaitForObject(tc.Context(), claim, predicates.ReadyConditionIsTrue); err != nil {
+		tc.Logf("Failed to wait for claim %s ready: %v", claimName, err)
+		return metrics, err
+	}
+	metrics.ClaimReady.Set(time.Since(startTime))
+	tc.Logf("Claim %s is ready", claimName)
+
+	return metrics, nil
+}
+
+var claimCounter int64

--- a/test/e2e/chromesandbox_claim_test.go
+++ b/test/e2e/chromesandbox_claim_test.go
@@ -39,22 +39,17 @@ type ChromeSandboxClaimMetrics struct {
 
 // BenchmarkChromeSandboxClaimStartup measures the time for Chrome to start in a sandbox claim.
 // Run with: go test -bench=BenchmarkChromeSandboxClaimStartup -benchtime=10x ./test/e2e/...
+// Make sure that WARM_POOL_SIZE is set appropriately to account for the number of parallel
+// test iterations.
 func BenchmarkChromeSandboxClaimStartup(b *testing.B) {
 	// Configuration from environment variables
-	warmPoolSize := 6
+	warmPoolSize := 10
 	if s := os.Getenv("WARM_POOL_SIZE"); s != "" {
 		if v, err := strconv.Atoi(s); err == nil {
 			warmPoolSize = v
 		}
 	}
-	parallelism := 3
-	if s := os.Getenv("PARALLELISM"); s != "" {
-		if v, err := strconv.Atoi(s); err == nil {
-			parallelism = v
-		}
-	}
-
-	b.Logf("Benchmark Configuration: WarmPoolSize=%d, Parallelism=%d", warmPoolSize, parallelism)
+	b.Logf("Benchmark Configuration: WarmPoolSize=%d", warmPoolSize)
 
 	tc := framework.NewTestContext(b)
 	ctx := tc.Context()
@@ -107,7 +102,6 @@ func BenchmarkChromeSandboxClaimStartup(b *testing.B) {
 	)
 
 	// 5. Benchmark Loop
-	b.SetParallelism(parallelism)
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {

--- a/test/e2e/chromesandbox_test.go
+++ b/test/e2e/chromesandbox_test.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"sync/atomic"
+
 	"testing"
 	"time"
 
@@ -32,35 +32,6 @@ import (
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
-
-// AtomicTimeDuration is a wrapper around time.Duration that allows for concurrent updates and retrievals.
-type AtomicTimeDuration struct {
-	v uint64
-}
-
-// Seconds returns the duration in seconds as a float64.
-func (s *AtomicTimeDuration) Seconds() float64 {
-	v := atomic.LoadUint64(&s.v)
-	d := time.Duration(v)
-	return d.Seconds()
-}
-
-// IsEmpty returns true if the duration is zero.
-func (s *AtomicTimeDuration) IsEmpty() bool {
-	return atomic.LoadUint64(&s.v) == 0
-}
-
-// Set sets the duration to the given value.
-func (s *AtomicTimeDuration) Set(d time.Duration) {
-	atomic.StoreUint64(&s.v, uint64(d))
-}
-
-// String returns the duration as a string.
-func (s *AtomicTimeDuration) String() string {
-	v := atomic.LoadUint64(&s.v)
-	d := time.Duration(v)
-	return d.String()
-}
 
 // ChromeSandboxMetrics holds timing measurements for the chrome sandbox startup.
 type ChromeSandboxMetrics struct {

--- a/test/e2e/chromesandbox_test.go
+++ b/test/e2e/chromesandbox_test.go
@@ -45,6 +45,11 @@ type ChromeSandboxMetrics struct {
 }
 
 func chromeSandbox(namespace string) *sandboxv1alpha1.Sandbox {
+	imageTag := os.Getenv("IMAGE_TAG")
+	if imageTag == "" {
+		imageTag = "latest"
+	}
+
 	sandbox := &sandboxv1alpha1.Sandbox{}
 	sandbox.Name = "chrome-sandbox"
 	sandbox.Namespace = namespace
@@ -54,7 +59,7 @@ func chromeSandbox(namespace string) *sandboxv1alpha1.Sandbox {
 				{
 					Name: "chrome-sandbox",
 					// might be nice to remove the IMAGE_TAG env var so this is easier to run from IDE
-					Image:           fmt.Sprintf("kind.local/chrome-sandbox:%s", os.Getenv("IMAGE_TAG")),
+					Image:           fmt.Sprintf("kind.local/chrome-sandbox:%s", imageTag),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 				},
 			},

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// AtomicTimeDuration is a wrapper around time.Duration that allows for concurrent updates and retrievals.
+type AtomicTimeDuration struct {
+	v uint64
+}
+
+// Seconds returns the duration in seconds as a float64.
+func (s *AtomicTimeDuration) Seconds() float64 {
+	v := atomic.LoadUint64(&s.v)
+	d := time.Duration(v)
+	return d.Seconds()
+}
+
+// IsEmpty returns true if the duration is zero.
+func (s *AtomicTimeDuration) IsEmpty() bool {
+	return atomic.LoadUint64(&s.v) == 0
+}
+
+// Set sets the duration to the given value.
+func (s *AtomicTimeDuration) Set(d time.Duration) {
+	atomic.StoreUint64(&s.v, uint64(d))
+}
+
+// String returns the duration as a string.
+func (s *AtomicTimeDuration) String() string {
+	v := atomic.LoadUint64(&s.v)
+	d := time.Duration(v)
+	return d.String()
+}


### PR DESCRIPTION
The goal here is to be able to build on top of the existing benchmark's use case and understand additional time that a SandboxClaim adds.