### PR TITLE
chore: explicitly define metrics and healthz container ports

### DIFF
--- a/k8s/controller.yaml
+++ b/k8s/controller.yaml
@@ -42,8 +42,9 @@ spec:
   selector:
     app: agent-sandbox-controller
   ports:
-  - port: 80
-    targetPort: 8080
+  - name: metrics
+    port: 8080
+    targetPort: metrics
     protocol: TCP
 
 ---
@@ -71,3 +72,10 @@ spec:
         image: ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller # placeholder value, replaced by deployment scripts
         args:
         - --leader-elect=true
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        - name: healthz
+          containerPort: 8081
+          protocol: TCP

--- a/k8s/extensions.controller.yaml
+++ b/k8s/extensions.controller.yaml
@@ -23,3 +23,10 @@ spec:
         args:
         - "--leader-elect=true"
         - "--extensions"
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        - name: healthz
+          containerPort: 8081
+          protocol: TCP


### PR DESCRIPTION
Currently, the controller actively serves metrics on :8080 and health probes on :8081, and our Service routes to 8080. However, the `Deployment` template omits the `containerPort` definitions.

This PR explicitly defines the metrics (8080) and healthz (8081) ports on the container spec. This is a standard k8s best practice that makes the manifest self-documenting. 

It makes the controller 'Prometheus-Ready' out of the box, allowing users in the community to target the controller using standard `PodMonitor` or `ServiceMonitor` resources via named ports (port: metrics) without needing to write custom patches.

## Release Note

```release-note
ACTION REQUIRED: The `agent-sandbox-controller` metrics Service port has been changed from `80` to `8080` to align with controller-runtime best practices and avoid conflicts with primary HTTP traffic. If you have custom `ServiceMonitor` resources or Prometheus scraping configurations targeting port 80 for this service, you must update them to port 8080.