### PR TITLE
controllers/sandbox_controller: add RBAC for finalizers

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -65,6 +65,7 @@ type SandboxReconciler struct {
 }
 
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -33,6 +33,7 @@ rules:
 - apiGroups:
   - agents.x-k8s.io
   resources:
+  - sandboxes/finalizers
   - sandboxes/status
   verbs:
   - get


### PR DESCRIPTION
Otherwise running any sandbox example would produce this error:

ERROR Failed to create {"controller": "sandbox", "controllerGroup": "agents.x-k8s.io", "controllerKind": "Sandbox", "Sandbox": {"name":"sandbox-example","namespace":"default"}, "namespace": "default", "name": "sandbox-example", "reconcileID": "11660701-d8c3-48c0-be19-c6e986aebe69", "Service.Namespace": "default", "Service.Name": "sandbox-example", "error": "services \"sandbox-example\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}