### PR TITLE
Add unique label to pooled pods

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -39,6 +40,7 @@ import (
 )
 
 const (
+	poolPodIDLabel         = "agents.x-k8s.io/pool-pod-id"
 	sandboxTemplateRefHash = "agents.x-k8s.io/sandbox-template-ref-hash"
 	warmPoolSandboxLabel   = "agents.x-k8s.io/warm-pool-sandbox"
 )
@@ -258,6 +260,8 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	}
 	// Propagate template ref hash to pod template for NetworkPolicy targeting
 	podLabels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name)
+
+	podLabels[poolPodIDLabel] = string(uuid.NewUUID())
 
 	podAnnotations := make(map[string]string)
 	for k, v := range template.Spec.PodTemplate.ObjectMeta.Annotations {

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -418,6 +418,18 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 			// Verify pod template annotations
 			require.Equal(t, "from-podtemplate", sb.Spec.PodTemplate.ObjectMeta.Annotations["pod-annotation"])
 		}
+
+		// Verify each pod template has a unique pool-pod-id label
+		podIDs := make(map[string]struct{})
+		for _, pod := range list.Items {
+			id, ok := pod.Spec.PodTemplate.ObjectMeta.Labels[poolPodIDLabel]
+			require.True(t, ok, "pod %s should have %s label", pod.Name, poolPodIDLabel)
+			require.NotEmpty(t, id, "pool-pod-id should not be empty")
+			_, duplicate := podIDs[id]
+			require.False(t, duplicate, "pool-pod-id %s is not unique across pods", id)
+			podIDs[id] = struct{}{}
+		}
+		require.Len(t, podIDs, int(replicas))
 	})
 }
 


### PR DESCRIPTION
# Description

This PR ensures that all Pods created by the WarmPool controller start with a unique label. This should be aligned well with the goals for all Sandboxes to have a unique and stable identity (https://github.com/kubernetes-sigs/agent-sandbox?tab=readme-ov-file#desired-sandbox-characteristics)

In our case, we need this for enforcing different [Cilium Network Policies](https://docs.cilium.io/en/stable/security/policy/index.html) on each unique Sandbox once it's claimed from a Pool (CNPs rely on labels for selecting the Pods).

Note that it seems that someone else already had that idea:
https://github.com/kubernetes-sigs/agent-sandbox/blob/1df7e4dbf9d60f7200c8a8c979456d82e2a283b5/extensions/controllers/sandboxwarmpool_controller.go#L252
but the code which was commented out wouldn't work because the `pod` above uses `GenerateName` so `pod.Name` would be empty

# Testing
Deployed to a cluster, created a WarmPool, verified that pods had the expected label:

```
$ kubectl get pods -l agents.x-k8s.io/pool=bb4771e4 -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.agents\.x-k8s\.io/pool-pod-id}{"\n"}{end}'
my-warmpool-g8s6d	500144bf-06d8-4db1-8a2c-d4ae4694735d
my-warmpool-t9bnj	d13cdb28-b358-449d-b3ec-562a6fbc4428
```
 