### PR TITLE
Added Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,35 @@ flowchart TB
 
     Claim[SandboxClaim]
     Template[SandboxTemplate]
-    CRD[Sandbox CRD]
+    Sandbox[Sandbox]
 
+    ClaimController[Claim Controller]
     Controller[Sandbox Controller]
 
     Pod[Sandbox Pod]
-
     Runtime[Sandbox Runtime Environment]
 
     WarmPool[SandboxWarmPool]
 
+    %% User paths
+    User -->|creates| Sandbox
     User -->|creates| Claim
-    Claim -->|uses| Template
-    Template -->|creates| CRD
-    CRD -->|reconciled by| Controller
-    Controller -->|creates| Pod
+
+    %% Claim workflow
+    Claim -->|references| Template
+    Claim -->|reconciled by| ClaimController
+    ClaimController -->|creates| Sandbox
+
+    %% Pod handling
+    ClaimController -->|adopts pod from| WarmPool
+    Sandbox -->|reconciled by| Controller
+    Controller -->|creates Pod if needed| Pod
+
+    %% Runtime
     Pod --> Runtime
 
-    WarmPool -->|pre-warms| Pod
+    %% Warm pool
+    WarmPool -->|pre-warmed pods| Pod
 ```
 
 ## Installation


### PR DESCRIPTION
This PR adds a small Architecture section to the README with a diagram illustrating how the Sandbox CRD, controller, and sandbox pod relate to each other. While the README already explains the components, a visual overview helps new users and contributors quickly understand the system structure.
#379 