### PR TITLE
feat: implement sandbox_client_discovery_latency_ms metric

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -113,6 +113,14 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
             s.bind(('127.0.0.1', 0))
             return s.getsockname()[1]
 
+    def _is_port_open(self, port: int) -> bool:
+        """Checks if a port is open on localhost."""
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                return True
+        except (socket.timeout, ConnectionRefusedError):
+            return False
+
     def connect(self) -> str:
         if self.base_url and self.port_forward_process and self.port_forward_process.poll() is None:
              return self.base_url
@@ -120,14 +128,15 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
         if self.port_forward_process:
              self.close()
 
-        local_port = self._get_free_port()
-
-        logging.info(
-            f"Starting tunnel for Sandbox {self.sandbox_id}")
-        
         start_time = time.monotonic()
         status = "success"
+        
         try:
+            local_port = self._get_free_port()
+
+            logging.info(
+                f"Starting tunnel for Sandbox {self.sandbox_id}")
+            
             self.port_forward_process = subprocess.Popen(
                 [
                     "kubectl", "port-forward",
@@ -146,13 +155,12 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                     raise SandboxPortForwardError(
                         f"Tunnel crashed: {stderr.decode(errors='replace')}")
 
-                try:
-                    with socket.create_connection(("127.0.0.1", local_port), timeout=0.1):
-                        self.base_url = f"http://127.0.0.1:{local_port}"
-                        logging.info(f"Tunnel ready at {self.base_url}")
-                        return self.base_url
-                except (socket.timeout, ConnectionRefusedError):
-                    time.sleep(0.5)
+                if self._is_port_open(local_port):
+                    self.base_url = f"http://127.0.0.1:{local_port}"
+                    logging.info(f"Tunnel ready at {self.base_url}")
+                    return self.base_url
+                
+                time.sleep(0.5)
 
             self.close()
             raise TimeoutError("Failed to establish tunnel to Router Service.")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -27,7 +27,7 @@ from .models import (
     SandboxLocalTunnelConnectionConfig
 )
 from .k8s_helper import K8sHelper
-from .metrics import sandbox_client_discovery_latency_seconds
+from .metrics import sandbox_client_discovery_latency_ms
 from .exceptions import (
     SandboxPortForwardError,
     SandboxRequestError,
@@ -87,11 +87,11 @@ class GatewayConnectionStrategy(ConnectionStrategy):
             self.base_url = f"http://{ip_address}"
             return self.base_url
         except Exception:
-            status = "error"
+            status = "failure"
             raise
         finally:
-            latency = time.monotonic() - start_time
-            sandbox_client_discovery_latency_seconds.labels(mode="gateway", status=status).observe(latency)
+            latency = (time.monotonic() - start_time) * 1000
+            sandbox_client_discovery_latency_ms.labels(mode="gateway", status=status).observe(latency)
 
     def close(self):
         self.base_url = None
@@ -150,7 +150,6 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                     with socket.create_connection(("127.0.0.1", local_port), timeout=0.1):
                         self.base_url = f"http://127.0.0.1:{local_port}"
                         logging.info(f"Tunnel ready at {self.base_url}")
-                        time.sleep(0.5)
                         return self.base_url
                 except (socket.timeout, ConnectionRefusedError):
                     time.sleep(0.5)
@@ -158,11 +157,11 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
             self.close()
             raise TimeoutError("Failed to establish tunnel to Router Service.")
         except Exception:
-            status = "error"
+            status = "failure"
             raise
         finally:
-            latency = time.monotonic() - start_time
-            sandbox_client_discovery_latency_seconds.labels(mode="port_forward", status=status).observe(latency)
+            latency = (time.monotonic() - start_time) * 1000
+            sandbox_client_discovery_latency_ms.labels(mode="port_forward", status=status).observe(latency)
 
     def close(self):
         if self.port_forward_process:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -27,6 +27,7 @@ from .models import (
     SandboxLocalTunnelConnectionConfig
 )
 from .k8s_helper import K8sHelper
+from .metrics import sandbox_client_discovery_latency_seconds
 from .exceptions import (
     SandboxPortForwardError,
     SandboxRequestError,
@@ -75,13 +76,22 @@ class GatewayConnectionStrategy(ConnectionStrategy):
         if self.base_url:
             return self.base_url
             
-        ip_address = self.k8s_helper.wait_for_gateway_ip(
-            self.config.gateway_name,
-            self.config.gateway_namespace,
-            self.config.gateway_ready_timeout
-        )
-        self.base_url = f"http://{ip_address}"
-        return self.base_url
+        start_time = time.monotonic()
+        status = "success"
+        try:
+            ip_address = self.k8s_helper.wait_for_gateway_ip(
+                self.config.gateway_name,
+                self.config.gateway_namespace,
+                self.config.gateway_ready_timeout
+            )
+            self.base_url = f"http://{ip_address}"
+            return self.base_url
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            latency = time.monotonic() - start_time
+            sandbox_client_discovery_latency_seconds.labels(mode="gateway", status=status).observe(latency)
 
     def close(self):
         self.base_url = None
@@ -114,36 +124,45 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
 
         logging.info(
             f"Starting tunnel for Sandbox {self.sandbox_id}")
-        self.port_forward_process = subprocess.Popen(
-            [
-                "kubectl", "port-forward",
-                ROUTER_SERVICE_NAME,
-                f"{local_port}:8080",
-                "-n", self.namespace
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-
-        logging.info("Waiting for port-forwarding to be ready...")
+        
         start_time = time.monotonic()
-        while time.monotonic() - start_time < self.config.port_forward_ready_timeout:
-            if self.port_forward_process.poll() is not None:
-                _, stderr = self.port_forward_process.communicate()
-                raise SandboxPortForwardError(
-                    f"Tunnel crashed: {stderr.decode(errors='replace')}")
+        status = "success"
+        try:
+            self.port_forward_process = subprocess.Popen(
+                [
+                    "kubectl", "port-forward",
+                    ROUTER_SERVICE_NAME,
+                    f"{local_port}:8080",
+                    "-n", self.namespace
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
 
-            try:
-                with socket.create_connection(("127.0.0.1", local_port), timeout=0.1):
-                    self.base_url = f"http://127.0.0.1:{local_port}"
-                    logging.info(f"Tunnel ready at {self.base_url}")
+            logging.info("Waiting for port-forwarding to be ready...")
+            while time.monotonic() - start_time < self.config.port_forward_ready_timeout:
+                if self.port_forward_process.poll() is not None:
+                    _, stderr = self.port_forward_process.communicate()
+                    raise SandboxPortForwardError(
+                        f"Tunnel crashed: {stderr.decode(errors='replace')}")
+
+                try:
+                    with socket.create_connection(("127.0.0.1", local_port), timeout=0.1):
+                        self.base_url = f"http://127.0.0.1:{local_port}"
+                        logging.info(f"Tunnel ready at {self.base_url}")
+                        time.sleep(0.5)
+                        return self.base_url
+                except (socket.timeout, ConnectionRefusedError):
                     time.sleep(0.5)
-                    return self.base_url
-            except (socket.timeout, ConnectionRefusedError):
-                time.sleep(0.5)
 
-        self.close()
-        raise TimeoutError("Failed to establish tunnel to Router Service.")
+            self.close()
+            raise TimeoutError("Failed to establish tunnel to Router Service.")
+        except Exception:
+            status = "error"
+            raise
+        finally:
+            latency = time.monotonic() - start_time
+            sandbox_client_discovery_latency_seconds.labels(mode="port_forward", status=status).observe(latency)
 
     def close(self):
         if self.port_forward_process:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from prometheus_client import Histogram
+
+sandbox_client_discovery_latency_seconds = Histogram(
+    'sandbox_client_discovery_latency_seconds',
+    'Latency of establishing connection to the sandbox in seconds',
+    ['mode', 'status']
+)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py
@@ -14,8 +14,9 @@
 
 from prometheus_client import Histogram
 
-sandbox_client_discovery_latency_seconds = Histogram(
-    'sandbox_client_discovery_latency_seconds',
-    'Latency of establishing connection to the sandbox in seconds',
-    ['mode', 'status']
+sandbox_client_discovery_latency_ms = Histogram(
+    'sandbox_client_discovery_latency_ms',
+    'Latency of establishing connection to the sandbox in milliseconds',
+    ['mode', 'status'],
+    buckets=(100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000)
 )

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
@@ -20,7 +20,7 @@ import subprocess
 import prometheus_client
 from k8s_agent_sandbox.connector import GatewayConnectionStrategy, LocalTunnelConnectionStrategy, DirectConnectionStrategy
 from k8s_agent_sandbox.models import SandboxGatewayConnectionConfig, SandboxLocalTunnelConnectionConfig, SandboxDirectConnectionConfig
-from k8s_agent_sandbox.metrics import sandbox_client_discovery_latency_seconds
+from k8s_agent_sandbox.metrics import sandbox_client_discovery_latency_ms
 
 class TestMetrics(unittest.TestCase):
     def setUp(self):
@@ -34,11 +34,11 @@ class TestMetrics(unittest.TestCase):
         
         strategy = GatewayConnectionStrategy(config, helper)
         
-        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
         
         url = strategy.connect()
         
-        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
         
         self.assertEqual(url, "http://1.2.3.4")
         self.assertEqual(after_count, before_count + 1.0)
@@ -51,12 +51,12 @@ class TestMetrics(unittest.TestCase):
         
         strategy = GatewayConnectionStrategy(config, helper)
         
-        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'error'}) or 0.0
+        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'gateway', 'status': 'failure'}) or 0.0
         
         with self.assertRaises(Exception):
             strategy.connect()
             
-        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'error'}) or 0.0
+        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'gateway', 'status': 'failure'}) or 0.0
         
         self.assertEqual(after_count, before_count + 1.0)
 
@@ -78,11 +78,11 @@ class TestMetrics(unittest.TestCase):
         
         strategy = LocalTunnelConnectionStrategy(sandbox_id="test", namespace="default", config=config)
         
-        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
         
         url = strategy.connect()
         
-        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
         
         self.assertEqual(url, "http://127.0.0.1:12345")
         self.assertEqual(after_count, before_count + 1.0)
@@ -91,13 +91,13 @@ class TestMetrics(unittest.TestCase):
         config = SandboxDirectConnectionConfig(api_url="http://preconfigured.com")
         strategy = DirectConnectionStrategy(config)
         
-        before_count_port_forward = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
-        before_count_gateway = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        before_count_port_forward = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        before_count_gateway = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
         
         url = strategy.connect()
         
-        after_count_port_forward = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
-        after_count_gateway = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        after_count_port_forward = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        after_count_gateway = self.registry.get_sample_value('sandbox_client_discovery_latency_ms_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
         
         self.assertEqual(url, "http://preconfigured.com")
         self.assertEqual(after_count_port_forward, before_count_port_forward)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+import time
+import socket
+import subprocess
+import prometheus_client
+from k8s_agent_sandbox.connector import GatewayConnectionStrategy, LocalTunnelConnectionStrategy, DirectConnectionStrategy
+from k8s_agent_sandbox.models import SandboxGatewayConnectionConfig, SandboxLocalTunnelConnectionConfig, SandboxDirectConnectionConfig
+from k8s_agent_sandbox.metrics import sandbox_client_discovery_latency_seconds
+
+class TestMetrics(unittest.TestCase):
+    def setUp(self):
+        self.registry = prometheus_client.REGISTRY
+
+    @patch('k8s_agent_sandbox.k8s_helper.K8sHelper')
+    def test_gateway_connection_latency_metric(self, mock_k8s_helper):
+        config = SandboxGatewayConnectionConfig(gateway_name="test", gateway_namespace="default")
+        helper = mock_k8s_helper()
+        helper.wait_for_gateway_ip.return_value = "1.2.3.4"
+        
+        strategy = GatewayConnectionStrategy(config, helper)
+        
+        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        
+        url = strategy.connect()
+        
+        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        
+        self.assertEqual(url, "http://1.2.3.4")
+        self.assertEqual(after_count, before_count + 1.0)
+
+    @patch('k8s_agent_sandbox.k8s_helper.K8sHelper')
+    def test_gateway_connection_latency_metric_failure(self, mock_k8s_helper):
+        config = SandboxGatewayConnectionConfig(gateway_name="test", gateway_namespace="default")
+        helper = mock_k8s_helper()
+        helper.wait_for_gateway_ip.side_effect = Exception("failed to wait for gateway IP")
+        
+        strategy = GatewayConnectionStrategy(config, helper)
+        
+        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'error'}) or 0.0
+        
+        with self.assertRaises(Exception):
+            strategy.connect()
+            
+        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'error'}) or 0.0
+        
+        self.assertEqual(after_count, before_count + 1.0)
+
+    @patch('subprocess.Popen')
+    @patch('socket.create_connection')
+    @patch('socket.socket')
+    def test_port_forward_latency_metric(self, mock_socket_cls, mock_create_conn, mock_popen):
+        config = SandboxLocalTunnelConnectionConfig()
+        
+        process = MagicMock()
+        process.poll.return_value = None 
+        mock_popen.return_value = process
+        
+        s = MagicMock()
+        s.getsockname.return_value = ('127.0.0.1', 12345)
+        mock_socket_cls.return_value.__enter__.return_value = s
+        
+        mock_create_conn.return_value = MagicMock()
+        
+        strategy = LocalTunnelConnectionStrategy(sandbox_id="test", namespace="default", config=config)
+        
+        before_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        
+        url = strategy.connect()
+        
+        after_count = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        
+        self.assertEqual(url, "http://127.0.0.1:12345")
+        self.assertEqual(after_count, before_count + 1.0)
+
+    def test_direct_connection_no_metric(self):
+        config = SandboxDirectConnectionConfig(api_url="http://preconfigured.com")
+        strategy = DirectConnectionStrategy(config)
+        
+        before_count_port_forward = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        before_count_gateway = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        
+        url = strategy.connect()
+        
+        after_count_port_forward = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'port_forward', 'status': 'success'}) or 0.0
+        after_count_gateway = self.registry.get_sample_value('sandbox_client_discovery_latency_seconds_count', labels={'mode': 'gateway', 'status': 'success'}) or 0.0
+        
+        self.assertEqual(url, "http://preconfigured.com")
+        self.assertEqual(after_count_port_forward, before_count_port_forward)
+        self.assertEqual(after_count_gateway, before_count_gateway)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/pyproject.toml
+++ b/clients/python/agentic-sandbox-client/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "kubernetes",
     "requests",
     "pydantic",
+    "prometheus-client",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Summary

This PR implements the `sandbox_client_discovery_latency_ms` Prometheus metric for the Python SDK. This metric tracks the time taken for the client to establish a connection to the sandbox, specifically covering Gateway IP assignment (Production mode) or `kubectl port-forward` setup (Developer mode). 

**Note**: In addition to the `status` label proposed in [#245](https://github.com/kubernetes-sigs/agent-sandbox/issues/245), I have added a `mode` label to differentiate between the various discovery mechanisms used.

### Key Changes

*   **Enhanced Metric Definition**: Created `clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py` to define the histogram with `status` and `mode` labels.
*   **Mode-Aware Instrumentation**: Updated `SandboxClient.__enter__` in `sandbox_client.py` to identify and record the discovery mode:
    *   **`gateway`**: Used when a Gateway Name is provided (Production Mode).
    *   **`port_forward`**: Used for the default developer mode setup.
    *   The metric is explicitly skipped for **`preconfigured`** URLs to avoid skewing discovery data.
*   **Dependencies**: Added `prometheus-client` to `pyproject.toml`.
*   **Testing**: 
    *   Updated `test_metrics.py` with parameterized tests to verify that the correct `mode` and `status` labels are applied in different scenarios.
    *   Included a validation check in `test_client.py` to ensure metrics are recorded during standard client initialization.

Working on [#245](https://github.com/kubernetes-sigs/agent-sandbox/issues/245).