### PR TITLE
add ownerRef to sandboxClaim

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -194,6 +194,12 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 	if templateErr == nil || k8errors.IsNotFound(templateErr) {
 		// This ensures the firewall is up before the pod starts.
 		if template != nil {
+			// Set the template as an owner of the claim so ArgoCD can track the
+			// claim and its child resources (sandbox, pods) under the template.
+			if err := r.ensureClaimOwnerRef(ctx, claim, template); err != nil {
+				return nil, fmt.Errorf("failed to set owner reference on claim: %w", err)
+			}
+
 			if npErr := r.reconcileNetworkPolicy(ctx, claim, template); npErr != nil {
 				return nil, fmt.Errorf("failed to reconcile network policy: %w", npErr)
 			}
@@ -521,6 +527,23 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	}
 
 	return r.createSandbox(ctx, claim, template)
+}
+
+// ensureClaimOwnerRef sets the SandboxTemplate as a (non-controller) owner of the
+// SandboxClaim so that ArgoCD can display the claim and its child resources
+// (Sandbox, pods) as part of the template's resource tree.
+func (r *SandboxClaimReconciler) ensureClaimOwnerRef(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, template *extensionsv1alpha1.SandboxTemplate) error {
+	for _, ref := range claim.OwnerReferences {
+		if ref.UID == template.UID {
+			return nil
+		}
+	}
+
+	patch := client.MergeFrom(claim.DeepCopy())
+	if err := controllerutil.SetOwnerReference(template, claim, r.Scheme); err != nil {
+		return err
+	}
+	return r.Patch(ctx, claim, patch)
 }
 
 func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*extensionsv1alpha1.SandboxTemplate, error) {


### PR DESCRIPTION
https://github.com/kubernetes-sigs/agent-sandbox/issues/385

This is nice to have for those using argoCD, as it will display in application UI  under sandboxTemplate when a sandbox is created via python SDK 

OwnerRef is Controller = false  so it is not a disruptive change and does not clash with warmPool logic.

example from kind cluster testing: 
```
apiVersion: extensions.agents.x-k8s.io/v1alpha1
kind: SandboxClaim
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"extensions.agents.x-k8s.io/v1alpha1","kind":"SandboxClaim","metadata":{"annotations":{},"name":"test-claim","namespace":"default"},"spec":{"sandboxTemplateRef":{"name":"test-template"}}}
  creationTimestamp: "2026-03-10T18:25:41Z"
  generation: 1
  name: test-claim
  namespace: default
  ownerReferences:
  - apiVersion: extensions.agents.x-k8s.io/v1alpha1
    kind: SandboxTemplate
    name: test-template
    uid: b40b4568-ddda-4022-826e-c2b219b35fa0
  resourceVersion: "717"
  uid: 21d20fb6-e393-4397-89b8-e8a6527ae5ad
spec:
  sandboxTemplateRef:
    name: test-template
status:
  conditions:
  - lastTransitionTime: "2026-03-10T18:26:40Z"
    message: Pod is Ready; Service Exists
    observedGeneration: 1
    reason: DependenciesReady
    status: "True"
    type: Ready
  sandbox:
    Name: test-claim
   ```