### PR TITLE
perf(warmpool): implement server-side apply status patch

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -276,8 +276,21 @@ func (r *SandboxWarmPoolReconciler) updateStatus(ctx context.Context, oldStatus 
 		return nil
 	}
 
-	if err := r.Status().Update(ctx, warmPool); err != nil {
-		log.Error(err, "Failed to update SandboxWarmPool status")
+	patch := &extensionsv1alpha1.SandboxWarmPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: extensionsv1alpha1.GroupVersion.String(),
+			Kind:       "SandboxWarmPool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      warmPool.Name,
+			Namespace: warmPool.Namespace,
+		},
+		Status: warmPool.Status,
+	}
+
+	// Send the Server-Side Apply request to update the status subresource
+	if err := r.Status().Patch(ctx, patch, client.Apply, client.FieldOwner("warmpool-controller"), client.ForceOwnership); err != nil {
+		log.Error(err, "Failed to apply SandboxWarmPool status via SSA")
 		return err
 	}
 


### PR DESCRIPTION
this contributes to #346 

Currently, the `SandboxWarmPool` controller faces significant bottlenecks when scaling to large numbers of replicas (e.g., 300-600+). Sequential API operations, combined with standard `Update` calls and default rate limiters, result in "context deadline exceeded" timeouts, 409 Conflict spikes, and severe delays during burst provisioning.

This PR introduces an optimization to the status update. 

1. With Server-Side Apply Status Patch: The warmpool controller's status API calls dropped to just ~183 PATCH requests to track the entire lifecycle of 900 warmpool pods (600 initial + 300 replenished).

To validate this change and isolate API bottlenecks, I ran high-concurrency scale tests using 150 concurrent workers, a 600-pod Warmpool, and 300 SandboxClaims.

```
--env=CL2_BURST_SIZE=300
--env=CL2_TOTAL_BURSTS=1
--env=CL2_WARMPOOL_SIZE=600
--machine-type=e2-standard-8
- "--sandbox-claim-concurrent-workers=150"
- "--sandbox-concurrent-workers=150"
- "--sandbox-warm-pool-concurrent-workers=150"
- "--sandbox-template-concurrent-workers=150"
- "--kube-api-qps=1000"
- "--kube-api-burst=1500"
env:
       - name: GOGC
         value: "off"
       resources:
         requests:
           cpu: "2"
           memory: "4Gi"
         limits:
           cpu: "4"
           memory: "8Gi"
```

The Findings:

The API Bottleneck: The unoptimized baseline generated massive API server thrashing on warmpool- pods, specifically ~15,000 .Update() calls and ~8,600 409 Conflict errors.

The Fix (This PR): By switching the Warmpool's status update mechanism to Server-Side Apply (.Patch()), we successfully offloaded conflict resolution to the API server and leveraged native workqueue batching.

The Result: The Warmpool controller's status tracking for the entire 900-pod lifecycle (600 creation + 300 replenishment) was condensed into just ~183 highly efficient PATCH calls with 0 conflicts.

Finding: With the warmpool optimized, the logs proved that the remaining 409 Conflicts are isolated entirely to the sandbox claim controller's `tryAdoptPodFromPool` method (where concurrent workers sort the pool and collide while trying to .Update() the exact same candidates[0] pod).