### PR TITLE
perf: inline trace annotation to eliminate double-reconcile

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -116,7 +116,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	// Initialize trace ID for active resources missing an ID
+	// Initialize trace ID for active resources missing an ID (inline, no re-reconcile)
 	tc := r.Tracer.GetTraceContext(ctx)
 	if tc != "" && (sandbox.Annotations == nil || sandbox.Annotations[asmetrics.TraceContextAnnotation] == "") {
 		patch := client.MergeFrom(sandbox.DeepCopy())
@@ -128,8 +128,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err := r.Patch(ctx, sandbox, patch); err != nil {
 			return ctrl.Result{}, err
 		}
-		// Return to ensure the next loop uses the persisted ID
-		return ctrl.Result{}, nil
+		// Continue reconciliation in the same cycle instead of returning
 	}
 
 	if sandbox.Spec.Replicas == nil {

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -88,7 +88,8 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Initialize trace ID for active resources missing an ID
+	// Initialize trace ID for active resources missing an ID — inline patch,
+	// no early return, to avoid forcing a second reconcile cycle.
 	tc := r.Tracer.GetTraceContext(ctx)
 	if tc != "" && (claim.Annotations == nil || claim.Annotations[asmetrics.TraceContextAnnotation] == "") {
 		patch := client.MergeFrom(claim.DeepCopy())
@@ -99,7 +100,6 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err := r.Patch(ctx, claim, patch); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
 	}
 
 	originalClaimStatus := claim.Status.DeepCopy()


### PR DESCRIPTION
## Summary
- Remove the early return after patching the trace annotation in both `SandboxReconciler` and `SandboxClaimReconciler`
- The reconciler now continues in the same cycle instead of triggering a second reconciliation
- Reduces reconcile count per resource from 2 to 1 on first sync

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./controllers/... -count=1` passes
- [ ] Verify in a live cluster that sandbox creation no longer shows two reconcile cycles

Split from #375 (1/5)