### PR TITLE
feat: add PodIP field to SandboxClaim status

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -166,6 +166,10 @@ type SandboxStatus struct {
 	// LabelSelector is the label selector for pods.
 	// +optional
 	LabelSelector string `json:"selector,omitempty"`
+
+	// PodIP is the IP address of the sandbox pod.
+	// +optional
+	PodIP string `json:"podIP,omitempty"`
 }
 
 // +genclient

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -179,9 +179,11 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	if pod == nil {
 		sandbox.Status.Replicas = 0
 		sandbox.Status.LabelSelector = ""
+		sandbox.Status.PodIP = ""
 	} else {
 		sandbox.Status.Replicas = 1
 		sandbox.Status.LabelSelector = fmt.Sprintf("%s=%s", sandboxLabel, NameHash(sandbox.Name))
+		sandbox.Status.PodIP = pod.Status.PodIP
 	}
 
 	// Reconcile Service

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -495,6 +495,68 @@ func TestReconcile(t *testing.T) {
 			},
 			expectSandboxDeleted: true,
 		},
+		{
+			name: "sandbox status includes PodIP from running pod",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						PodIP: "10.0.0.42",
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector:  map[string]string{"agents.x-k8s.io/sandbox-name-hash": "ab179450"},
+						ClusterIP: "None",
+					},
+				},
+			},
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Service:       sandboxName,
+				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
+				Replicas:      1,
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				PodIP:         "10.0.0.42",
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             "DependenciesReady",
+						Message:            "Pod is Ready; Service Exists",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -89,6 +89,11 @@ type SandboxStatus struct {
 	// SandboxName is the name of the Sandbox created from this claim
 	// +optional
 	Name string `json:"Name,omitempty"`
+
+	// PodIP is the IP address of the sandbox pod, for direct connectivity.
+	// Populated from the Sandbox status.
+	// +optional
+	PodIP string `json:"podIP,omitempty"`
 }
 
 // +genclient

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -329,6 +329,7 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1alpha1.S
 
 	if sandbox != nil {
 		claim.Status.SandboxStatus.Name = sandbox.Name
+		claim.Status.SandboxStatus.PodIP = sandbox.Status.PodIP
 	}
 }
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1231,6 +1231,64 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
+func TestComputeAndSetStatusPodIP(t *testing.T) {
+	scheme := newScheme(t)
+	_ = scheme
+
+	readySandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb", Namespace: "default"},
+		Status: sandboxv1alpha1.SandboxStatus{
+			PodIP: "10.0.0.42",
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}},
+		},
+	}
+
+	notReadySandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb", Namespace: "default"},
+		Status: sandboxv1alpha1.SandboxStatus{
+			PodIP: "",
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "NotReady",
+			}},
+		},
+	}
+
+	t.Run("copies PodIP from sandbox status", func(t *testing.T) {
+		claim := &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+		}
+		r := &SandboxClaimReconciler{}
+		r.computeAndSetStatus(claim, readySandbox, nil, false)
+		if claim.Status.SandboxStatus.PodIP != "10.0.0.42" {
+			t.Errorf("expected PodIP %q, got %q", "10.0.0.42", claim.Status.SandboxStatus.PodIP)
+		}
+	})
+
+	t.Run("PodIP empty when sandbox not ready", func(t *testing.T) {
+		claim := &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+		}
+		r := &SandboxClaimReconciler{}
+		r.computeAndSetStatus(claim, notReadySandbox, nil, false)
+		if claim.Status.SandboxStatus.PodIP != "" {
+			t.Errorf("expected empty PodIP, got %q", claim.Status.SandboxStatus.PodIP)
+		}
+	})
+
+	t.Run("PodIP empty when sandbox is nil", func(t *testing.T) {
+		claim := &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"},
+		}
+		r := &SandboxClaimReconciler{}
+		r.computeAndSetStatus(claim, nil, nil, false)
+		if claim.Status.SandboxStatus.PodIP != "" {
+			t.Errorf("expected empty PodIP, got %q", claim.Status.SandboxStatus.PodIP)
+		}
+	})
+}
+
 func ignoreTimestamp(_, _ metav1.Time) bool {
 	return true
 }

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3977,6 +3977,8 @@ spec:
                   - type
                   type: object
                 type: array
+              podIP:
+                type: string
               replicas:
                 format: int32
                 type: integer

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -92,6 +92,8 @@ spec:
                 properties:
                   Name:
                     type: string
+                  podIP:
+                    type: string
                 type: object
             type: object
         required:


### PR DESCRIPTION
## Summary
- Add `PodIP` field to `SandboxStatus` in `SandboxClaim` for direct SDK connectivity
- Regenerated CRD manifest via `controller-gen`

## Test plan
- [x] `go build ./...` passes
- [x] CRD regeneration produces clean diff (only `podIP` field added)
- [x] Verify in a live cluster that claim status shows pod IP

Split from #375 (2/5)