### PR TITLE
fix: require PodIP before marking Sandbox Ready

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -218,9 +218,11 @@ func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1alpha1.Sandb
 			message = "Pod is Running but not Ready"
 			for _, condition := range pod.Status.Conditions {
 				if condition.Type == corev1.PodReady {
-					if condition.Status == corev1.ConditionTrue {
+					if condition.Status == corev1.ConditionTrue && pod.Status.PodIP != "" {
 						message = "Pod is Ready"
 						podReady = true
+					} else if condition.Status == corev1.ConditionTrue {
+						message = "Pod is Ready but has no IP"
 					}
 					break
 				}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -79,6 +79,7 @@ func TestComputeReadyCondition(t *testing.T) {
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
+					PodIP: "10.0.0.1",
 					Conditions: []corev1.PodCondition{
 						{
 							Type:   corev1.PodReady,
@@ -89,6 +90,29 @@ func TestComputeReadyCondition(t *testing.T) {
 			},
 			expectedStatus: metav1.ConditionTrue,
 			expectedReason: "DependenciesReady",
+		},
+		{
+			name: "pod ready but no PodIP",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+			},
+			err: nil,
+			svc: &corev1.Service{},
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionFalse,
+			expectedReason: "DependenciesNotReady",
 		},
 		{
 			name: "error",


### PR DESCRIPTION
## Summary
- Add PodIP check to `computeReadyCondition` in the sandbox controller
- Prevents a race where Ready=True but PodIP is empty (the claim controller reads PodIP only after Ready=True)
- Adds "pod ready but no PodIP" test case

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./controllers/... -count=1` passes
- [x] Verify in a live cluster that sandbox does not become Ready until PodIP is assigned

Split from #375 (5/5)