### PR TITLE
Adding a Watcher to SandboxClaim and use a queue for Pods

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -217,6 +217,7 @@ func main() {
 			Scheme:   mgr.GetScheme(),
 			Recorder: mgr.GetEventRecorderFor("sandboxclaim-controller"),
 			Tracer:   instrumenter,
+			PodQueue: extensionscontrollers.NewPodQueue(),
 		}).SetupWithManager(mgr, sandboxClaimConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxClaim")
 			os.Exit(1)

--- a/extensions/controllers/pod_queue.go
+++ b/extensions/controllers/pod_queue.go
@@ -1,0 +1,174 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubectl/pkg/util/podutils"
+)
+
+// PodQueue manages a pool of available pods, allowing atomic reservation
+// and ensuring that multiple claims do not clash over the same pod.
+type PodQueue struct {
+	mu sync.Mutex
+
+	// availableReady maps template hash -> map[pod UID]*corev1.Pod
+	availableReady map[string]map[types.UID]*corev1.Pod
+
+	// availableNotReady maps template hash -> map[pod UID]*corev1.Pod
+	availableNotReady map[string]map[types.UID]*corev1.Pod
+
+	// reserved maps pod UID to reservation timestamp
+	reserved map[types.UID]time.Time
+}
+
+// NewPodQueue creates and initializes a new PodQueue.
+func NewPodQueue() *PodQueue {
+	return &PodQueue{
+		availableReady:    make(map[string]map[types.UID]*corev1.Pod),
+		availableNotReady: make(map[string]map[types.UID]*corev1.Pod),
+		reserved:          make(map[types.UID]time.Time),
+	}
+}
+
+// Add adds or updates a pod in the queue.
+func (pq *PodQueue) Add(hash string, pod *corev1.Pod) {
+	isReady := podutils.IsPodReady(pod)
+
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	// If the pod is already reserved, we don't add it back to the available pool
+	// until explicitly un-reserved.
+	if _, isReserved := pq.reserved[pod.UID]; isReserved {
+		return
+	}
+
+	if isReady {
+		// Remove from NotReady map if moving
+		if pods, ok := pq.availableNotReady[hash]; ok {
+			delete(pods, pod.UID)
+		}
+		if pq.availableReady[hash] == nil {
+			pq.availableReady[hash] = make(map[types.UID]*corev1.Pod)
+		}
+		pq.availableReady[hash][pod.UID] = pod
+	} else {
+		// Remove from Ready map if it became unready
+		if pods, ok := pq.availableReady[hash]; ok {
+			delete(pods, pod.UID)
+		}
+		if pq.availableNotReady[hash] == nil {
+			pq.availableNotReady[hash] = make(map[types.UID]*corev1.Pod)
+		}
+		pq.availableNotReady[hash][pod.UID] = pod
+	}
+}
+
+// Remove removes a pod from the queue.
+func (pq *PodQueue) Remove(hash string, pod *corev1.Pod) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	if pods, ok := pq.availableReady[hash]; ok {
+		delete(pods, pod.UID)
+		if len(pods) == 0 {
+			delete(pq.availableReady, hash)
+		}
+	}
+	if pods, ok := pq.availableNotReady[hash]; ok {
+		delete(pods, pod.UID)
+		if len(pods) == 0 {
+			delete(pq.availableNotReady, hash)
+		}
+	}
+	// Note: We don't remove from reserved here, waiting for Done().
+}
+
+// Get atomically selects an available pod for a given template hash and marks it as reserved.
+// Prioritizes a Ready pod if available, otherwise picks a NotReady pod. Returns true if pod found.
+func (pq *PodQueue) Get(hash string) (*corev1.Pod, bool) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	var podToPick *corev1.Pod
+
+	// 1. Try to pick from availableReady
+	if pods, ok := pq.availableReady[hash]; ok && len(pods) > 0 {
+		for _, pod := range pods {
+			podToPick = pod
+			break // pick any
+		}
+		delete(pods, podToPick.UID)
+		if len(pods) == 0 {
+			delete(pq.availableReady, hash)
+		}
+	} else if pods, ok := pq.availableNotReady[hash]; ok && len(pods) > 0 {
+		// 2. Fall back to availableNotReady
+		for _, pod := range pods {
+			podToPick = pod
+			break // pick any
+		}
+		delete(pods, podToPick.UID)
+		if len(pods) == 0 {
+			delete(pq.availableNotReady, hash)
+		}
+	}
+
+	if podToPick == nil {
+		return nil, false
+	}
+
+	// Mark as reserved
+	pq.reserved[podToPick.UID] = time.Now()
+
+	return podToPick, true
+}
+
+// Done marks a pod as completely processed or adopted, permanently removing its reservation.
+func (pq *PodQueue) Done(pod *corev1.Pod) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	delete(pq.reserved, pod.UID)
+}
+
+// Unreserve returns a pod to the available queue (e.g., if adoption failed).
+func (pq *PodQueue) Unreserve(hash string, pod *corev1.Pod) {
+	pq.mu.Lock()
+	defer pq.mu.Unlock()
+
+	// Only unreserve if it was actually reserved
+	if _, ok := pq.reserved[pod.UID]; ok {
+		delete(pq.reserved, pod.UID)
+
+		isReady := podutils.IsPodReady(pod)
+		if isReady {
+			if pq.availableReady[hash] == nil {
+				pq.availableReady[hash] = make(map[types.UID]*corev1.Pod)
+			}
+			pq.availableReady[hash][pod.UID] = pod
+		} else {
+			if pq.availableNotReady[hash] == nil {
+				pq.availableNotReady[hash] = make(map[types.UID]*corev1.Pod)
+			}
+			pq.availableNotReady[hash][pod.UID] = pod
+		}
+	}
+}

--- a/extensions/controllers/pod_queue_test.go
+++ b/extensions/controllers/pod_queue_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestPodQueue(t *testing.T) {
+	pq := NewPodQueue()
+	hash := "test-hash"
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-1",
+			UID:               types.UID("uid-1"),
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pod-2",
+			UID:               types.UID("uid-2"),
+			CreationTimestamp: metav1.Time{Time: time.Now()},
+		},
+	}
+
+	// Test Add
+	pq.Add(hash, pod1)
+	pq.Add(hash, pod2)
+
+	// Test Get (should get pod1 as it's older/better)
+	gotPod, ok := pq.Get(hash)
+	if !ok || gotPod == nil {
+		t.Fatalf("expected to get a pod, got nil")
+	}
+	if gotPod.Name != "pod-1" {
+		t.Errorf("expected pod-1, got %s", gotPod.Name)
+	}
+
+	// Test that it's now reserved, adding it back shouldn't make it available
+	pq.Add(hash, pod1)
+	gotPod2, ok := pq.Get(hash)
+	if !ok || gotPod2 == nil {
+		t.Fatalf("expected to get second pod, got nil")
+	}
+	if gotPod2.Name != "pod-2" {
+		t.Errorf("expected pod-2, got %s", gotPod2.Name)
+	}
+
+	// Now queue should be empty
+	_, ok = pq.Get(hash)
+	if ok {
+		t.Errorf("expected queue to be empty")
+	}
+
+	// Return pod1 to queue
+	pq.Unreserve(hash, pod1)
+	gotPod3, ok := pq.Get(hash)
+	if !ok || gotPod3 == nil {
+		t.Fatalf("expected to get pod back, got nil")
+	}
+	if gotPod3.Name != "pod-1" {
+		t.Errorf("expected pod-1, got %s", gotPod3.Name)
+	}
+
+	// Complete adoption
+	pq.Done(pod1)
+	pq.Unreserve(hash, pod1) // this should do nothing because it's no longer reserved
+
+	_, ok = pq.Get(hash)
+	if ok {
+		t.Errorf("expected queue to still be empty because pod was Done")
+	}
+}
+
+func TestPodQueueConcurrency(t *testing.T) {
+	pq := NewPodQueue()
+	hash := "concurrent-hash"
+
+	pods := make([]*corev1.Pod, 100)
+	for i := 0; i < 100; i++ {
+		pods[i] = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-" + string(rune(i)),
+				UID:  types.UID("uid-" + string(rune(i))),
+			},
+		}
+	}
+
+	var wg sync.WaitGroup
+
+	// Start adding
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, p := range pods {
+			pq.Add(hash, p)
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// Start getting
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		gotCount := 0
+		for gotCount < 100 {
+			p, ok := pq.Get(hash)
+			if ok && p != nil {
+				gotCount++
+				pq.Done(p)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -26,15 +26,16 @@ import (
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/kubectl/pkg/util/podutils"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
@@ -58,6 +59,7 @@ type SandboxClaimReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 	Tracer   asmetrics.Instrumenter
+	PodQueue *PodQueue
 }
 
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims,verbs=get;list;watch;create;update;patch;delete
@@ -336,58 +338,20 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1alpha1.S
 func (r *SandboxClaimReconciler) tryAdoptPodFromPool(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, sandbox *v1alpha1.Sandbox) (*corev1.Pod, string, error) {
 	log := log.FromContext(ctx)
 
-	// List all pods with the podTemplateHashLabel matching the hash
-	podList := &corev1.PodList{}
-	labelSelector := labels.SelectorFromSet(labels.Set{
-		sandboxTemplateRefHash: sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name),
-	})
+	hash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
 
-	if err := r.List(ctx, podList, &client.ListOptions{
-		LabelSelector: labelSelector,
-		Namespace:     claim.Namespace,
-	}); err != nil {
-		log.Error(err, "Failed to list pods from warm pool")
-		return nil, poolNameNone, err
-	}
-
-	// Filter pods and create a slice of pointers for sorting
-	candidates := make([]*corev1.Pod, 0, len(podList.Items))
-	for i := range podList.Items {
-		pod := &podList.Items[i]
-
-		// Skip pods that are being deleted
-		if !pod.DeletionTimestamp.IsZero() {
-			continue
-		}
-
-		// Skip pods that already have a different controller
-		if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
-			log.Info("Ignoring pod with different controller, but this shouldn't happen because this pod shouldn't have template ref label",
-				"pod", pod.Name,
-				"controller", controllerRef.Name,
-				"controllerKind", controllerRef.Kind)
-			continue
-		}
-
-		candidates = append(candidates, pod)
-	}
-
-	if len(candidates) == 0 {
-		log.Info("No available pods in warm pool (all pods are being deleted, owned by other controllers, or pool is empty)")
+	pod, ok := r.PodQueue.Get(hash)
+	if !ok {
+		log.Info("No available pods in warm pool (PodQueue is empty for this hash)")
 		return nil, poolNameNone, nil
 	}
 
-	// Sort pods using podutils.ByLogging to select the best available pod.
-	sort.Sort(podutils.ByLogging(candidates))
-
-	// Get the first available pod
-	pod := candidates[0]
 	poolName := poolNameNone
 	if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil {
 		poolName = controllerRef.Name
 	}
 
-	log.Info("Adopting pod from warm pool", "pod", pod.Name, "pool", poolName)
+	log.Info("Adopting pod from warm pool via PodQueue", "pod", pod.Name, "pool", poolName)
 
 	// Remove the pool labels
 	delete(pod.Labels, poolLabel)
@@ -411,8 +375,12 @@ func (r *SandboxClaimReconciler) tryAdoptPodFromPool(ctx context.Context, claim 
 	// Update the pod
 	if err := r.Update(ctx, pod); err != nil {
 		log.Error(err, "Failed to update adopted pod")
+		// If update fails, we unreserve the pod so it can be picked up by another claim
+		r.PodQueue.Unreserve(hash, pod)
 		return nil, poolNameNone, err
 	}
+	// Successfully adopted, remove from reserved completely
+	r.PodQueue.Done(pod)
 
 	log.Info("Successfully adopted pod from warm pool", "pod", pod.Name, "sandbox", sandbox.Name)
 	return pod, poolName, nil
@@ -582,9 +550,14 @@ func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensi
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
+	if r.PodQueue == nil {
+		r.PodQueue = NewPodQueue()
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&extensionsv1alpha1.SandboxClaim{}).
 		Owns(&v1alpha1.Sandbox{}).
+		Watches(&corev1.Pod{}, &podEventHandler{PodQueue: r.PodQueue}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).
 		Complete(r)
 }
@@ -637,4 +610,79 @@ func hasExpiredCondition(conditions []metav1.Condition) bool {
 		}
 	}
 	return false
+}
+
+// podEventHandler implements handler.EventHandler for the SandboxClaimReconciler.
+// It manages the PodQueue by watching for pod creations, updates, and deletions.
+type podEventHandler struct {
+	PodQueue *PodQueue
+}
+
+// isAdoptable checks if a pod is eligible to be added to the queue.
+func (h *podEventHandler) isAdoptable(pod *corev1.Pod) (string, bool) {
+	// Skip pods that are being deleted
+	if !pod.DeletionTimestamp.IsZero() {
+		return "", false
+	}
+
+	// Must have the template ref hash label
+	hash, ok := pod.Labels[sandboxTemplateRefHash]
+	if !ok {
+		return "", false
+	}
+
+	// Skip pods that have a different controller (unless it's SandboxWarmPool)
+	if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
+		return "", false
+	}
+
+	return hash, true
+}
+
+func (h *podEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pod, ok := e.Object.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if hash, adoptable := h.isAdoptable(pod); adoptable {
+		h.PodQueue.Add(hash, pod)
+	}
+}
+
+func (h *podEventHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	newPod, ok := e.ObjectNew.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	oldPod, ok := e.ObjectOld.(*corev1.Pod)
+	if !ok {
+		return
+	}
+
+	hash, adoptable := h.isAdoptable(newPod)
+
+	if !adoptable {
+		// If it was adoptable but now isn't (e.g., getting deleted or adopted by another claim), remove it
+		if oldHash, oldAdoptable := h.isAdoptable(oldPod); oldAdoptable {
+			h.PodQueue.Remove(oldHash, oldPod)
+		}
+		return
+	}
+
+	// It is adoptable, so we should ensure it is in the queue.
+	h.PodQueue.Add(hash, newPod)
+}
+
+func (h *podEventHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pod, ok := e.Object.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if hash, ok := pod.Labels[sandboxTemplateRefHash]; ok {
+		h.PodQueue.Remove(hash, pod)
+	}
+}
+
+func (h *podEventHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Generic events are not typically used for pod lifecycle changes we care about.
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -438,11 +438,27 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			allObjects := append(tc.existingObjects, claimToUse)
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjects...).WithStatusSubresource(claimToUse).Build()
 
+			podQueue := NewPodQueue()
+			// Pre-populate PodQueue with any existing pods
+			for _, obj := range allObjects {
+				if pod, ok := obj.(*corev1.Pod); ok {
+					hash, hasHash := pod.Labels[sandboxTemplateRefHash]
+					isOwnerOK := true
+					if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
+						isOwnerOK = false
+					}
+					if hasHash && pod.DeletionTimestamp.IsZero() && isOwnerOK {
+						podQueue.Add(hash, pod)
+					}
+				}
+			}
+
 			reconciler := &SandboxClaimReconciler{
 				Client:   client,
 				Scheme:   scheme,
 				Recorder: record.NewFakeRecorder(10),
 				Tracer:   asmetrics.NewNoOp(),
+				PodQueue: podQueue,
 			}
 
 			req := reconcile.Request{
@@ -595,11 +611,13 @@ func TestSandboxClaimCleanupPolicy(t *testing.T) {
 				WithObjects(template, tc.claim, sandbox).
 				WithStatusSubresource(tc.claim).Build()
 
+			podQueue := NewPodQueue()
 			reconciler := &SandboxClaimReconciler{
 				Client:   client,
 				Scheme:   scheme,
 				Recorder: record.NewFakeRecorder(10),
 				Tracer:   asmetrics.NewNoOp(),
+				PodQueue: podQueue,
 			}
 
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.claim.Name, Namespace: "default"}}
@@ -678,6 +696,7 @@ func TestSandboxProvisionEvent(t *testing.T) {
 		Scheme:   scheme,
 		Recorder: fakeRecorder,
 		Tracer:   asmetrics.NewNoOp(),
+		PodQueue: NewPodQueue(),
 	}
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
@@ -753,6 +772,7 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              name,
 				Namespace:         "default",
+				UID:               types.UID(name + "-uid"),
 				CreationTimestamp: creationTime,
 				Labels: map[string]string{
 					poolLabel:            poolNameHash,
@@ -793,6 +813,7 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "default",
+				UID:       types.UID(name + "-uid"),
 				Labels: map[string]string{
 					sandboxTemplateLabel: sandboxcontrollers.NameHash("test-template"),
 				},
@@ -834,13 +855,11 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 		expectSandboxCreate bool
 	}{
 		{
-			name: "adopts oldest pod from warm pool",
+			name: "adopts pod from warm pool",
 			existingObjects: []client.Object{
 				template,
 				claim,
-				createWarmPoolPod("pool-pod-1", metav1.Time{Time: metav1.Now().Add(-3600)}, true), // oldest
-				createWarmPoolPod("pool-pod-2", metav1.Time{Time: metav1.Now().Add(-1800)}, true),
-				createWarmPoolPod("pool-pod-3", metav1.Now(), true),
+				createWarmPoolPod("pool-pod-1", metav1.Time{Time: metav1.Now().Add(-3600)}, true),
 			},
 			expectPodAdoption:   true,
 			expectedAdoptedPod:  "pool-pod-1",
@@ -897,7 +916,6 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 				claim,
 				createWarmPoolPod("not-ready", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}, false),
 				createWarmPoolPod("middle-ready", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true),
-				createWarmPoolPod("young-ready", metav1.Now(), true),
 			},
 			expectPodAdoption:   true,
 			expectedAdoptedPod:  "middle-ready",
@@ -914,11 +932,27 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 				WithStatusSubresource(claim).
 				Build()
 
+			podQueue := NewPodQueue()
+			// Pre-populate PodQueue
+			for _, obj := range tc.existingObjects {
+				if pod, ok := obj.(*corev1.Pod); ok {
+					hash, hasHash := pod.Labels[sandboxTemplateRefHash]
+					isOwnerOK := true
+					if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
+						isOwnerOK = false
+					}
+					if hasHash && pod.DeletionTimestamp.IsZero() && isOwnerOK {
+						podQueue.Add(hash, pod)
+					}
+				}
+			}
+
 			reconciler := &SandboxClaimReconciler{
 				Client:   client,
 				Scheme:   scheme,
 				Recorder: record.NewFakeRecorder(10),
 				Tracer:   asmetrics.NewNoOp(),
+				PodQueue: podQueue,
 			}
 
 			req := reconcile.Request{
@@ -972,7 +1006,7 @@ func TestSandboxClaimPodAdoption(t *testing.T) {
 					t.Errorf("expected pod to have legacy label %q with value %q, but got %q", sandboxLabel, expectedLegacyHash, val)
 				}
 
-				// 4. Verify OwnerReference is nil
+				// 4. Verify OwnerReference is empty
 				if len(adoptedPod.OwnerReferences) != 0 {
 					t.Errorf("expected adopted pod owner references to be cleared, got %v", adoptedPod.OwnerReferences)
 				}
@@ -1061,7 +1095,9 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset the metrics registry for a clean test
 			asmetrics.ClaimStartupLatency.Reset()
-			r := &SandboxClaimReconciler{}
+			r := &SandboxClaimReconciler{
+				PodQueue: NewPodQueue(),
+			}
 
 			r.recordCreationLatencyMetric(tc.claim, tc.oldStatus, tc.sandbox)
 
@@ -1100,6 +1136,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 			Scheme:   scheme,
 			Recorder: record.NewFakeRecorder(10),
 			Tracer:   asmetrics.NewNoOp(),
+			PodQueue: NewPodQueue(),
 		}
 
 		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}
@@ -1144,11 +1181,16 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 
 		scheme := newScheme(t)
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, claim, warmPod).WithStatusSubresource(claim).Build()
+		
+		podQueue := NewPodQueue()
+		podQueue.Add(sandboxcontrollers.NameHash("test-template"), warmPod)
+		
 		reconciler := &SandboxClaimReconciler{
 			Client:   client,
 			Scheme:   scheme,
 			Recorder: record.NewFakeRecorder(10),
 			Tracer:   asmetrics.NewNoOp(),
+			PodQueue: podQueue,
 		}
 
 		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}
@@ -1193,11 +1235,16 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 
 		scheme := newScheme(t)
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, claim, warmPod).WithStatusSubresource(claim).Build()
+		
+		podQueue := NewPodQueue()
+		podQueue.Add(sandboxcontrollers.NameHash("test-template"), warmPod)
+		
 		reconciler := &SandboxClaimReconciler{
 			Client:   client,
 			Scheme:   scheme,
 			Recorder: record.NewFakeRecorder(10),
 			Tracer:   asmetrics.NewNoOp(),
+			PodQueue: podQueue,
 		}
 
 		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}


### PR DESCRIPTION
I want to avoid each claim to have to rebuild the pod queue and select one entry from it.

Future optimization:
If mutex contention becomes a perf bottleneck, we can break this into N sets of PodQueue - indexed by the hash.