### PR TITLE
Run unit test only the python sdk package

### DIFF
--- a/clients/python/agentic-sandbox-client/pyproject.toml
+++ b/clients/python/agentic-sandbox-client/pyproject.toml
@@ -42,3 +42,6 @@ tracing = [
     "opentelemetry-exporter-otlp~=1.39.0",
     "opentelemetry-instrumentation-requests~=0.60b0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["k8s_agent_sandbox"]


### PR DESCRIPTION
Currently, the github action workflow executes all the python unit tests in `client/python/agentic-sandbox-client`. 
Since the github CI is only required to publish the python SDK, it is required to run only the `k8s-agent-sandbox` unit test and ignore other directories ( like `sandbox-router`).

Fixes: #411 