### PR TITLE
Add `selector` field to status / scale sub-resources.

### DIFF
--- a/extensions/api/v1alpha1/sandboxwarmpool_types.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_types.go
@@ -43,12 +43,16 @@ type SandboxWarmPoolStatus struct {
 	// ReadyReplicas is the total number of sandboxes in the pool that are in a ready state.
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
+
+	// Selector is the label selector used to find the pods in the pool.
+	// +optional
+	Selector string `json:"selector,omitempty"`
 }
 
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:scope=Namespaced,shortName=swp
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -154,6 +154,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 
 	// Update status replicas
 	warmPool.Status.Replicas = currentReplicas
+	warmPool.Status.Selector = labelSelector.String()
 
 	// Calculate ready replicas
 	readyReplicas := int32(0)

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -184,6 +184,9 @@ func TestReconcilePool(t *testing.T) {
 
 			require.Equal(t, tc.expectedReplicas, count)
 			require.Equal(t, tc.expectedReplicas, warmPool.Status.Replicas)
+
+			expectedSelector := "agents.x-k8s.io/pool=" + poolNameHash
+			require.Equal(t, expectedSelector, warmPool.Status.Selector, "Status.Selector mismatch")
 		})
 	}
 }

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -58,6 +58,8 @@ spec:
               replicas:
                 format: int32
                 type: integer
+              selector:
+                type: string
             type: object
         required:
         - spec
@@ -66,6 +68,7 @@ spec:
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}


### PR DESCRIPTION
Add a new field to track a label selector to filter all pods managed by the warmpool.

The serialized selector will use the `agents.x-k8s.io/pool=<pool-name-hash>` label managed by the warmpool controller. This synthetic label is added to the pod during Pod creation and deleted when the Pod is taken out because of a new claim.

This allows external k8s controllers (e.g. capacity buffers) to track the Pods within a given pool.

Fixes #412 