### PR TITLE
fix: verify pod ownership before operating on annotated pods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ clients/python/agentic-sandbox-client/VERSION
 tmp/
 temp/
 .tmp/
+
+# Python .venv (generated during 'make test-e2e')
+.venv
+
+# E2E test artifacts (generated during 'make test-e2e')
+test/e2e/artifacts/
+test/e2e/extensions/artifacts/

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -49,6 +49,43 @@ const (
 	sandboxControllerFieldOwner = "sandbox-controller"
 )
 
+// resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
+type resourceOwnership int
+
+const (
+	// resourceOwnedBySandbox indicates the resource's controllerRef points to this Sandbox.
+	resourceOwnedBySandbox resourceOwnership = iota
+	// resourceUnowned indicates the resource has no controllerRef.
+	resourceUnowned
+	// resourceOwnedByOther indicates the resource's controllerRef points to a different controller.
+	resourceOwnedByOther
+)
+
+// checkOwnership determines whether a Kubernetes resource is owned by the given Sandbox,
+// has no controller, or is owned by a different controller.
+// It returns both the ownership classification and the controller reference (if any),
+// so callers can log owner details without redundant GetControllerOf calls.
+func checkOwnership(obj client.Object, sandbox *sandboxv1alpha1.Sandbox) (resourceOwnership, *metav1.OwnerReference) {
+	controllerRef := metav1.GetControllerOf(obj)
+	if controllerRef == nil {
+		return resourceUnowned, nil
+	}
+	if controllerRef.UID == sandbox.UID {
+		return resourceOwnedBySandbox, controllerRef
+	}
+	return resourceOwnedByOther, controllerRef
+}
+
+// resolvePodName returns the name of the pod associated with the given Sandbox.
+// If the sandbox has adopted a warm pool pod, the pod name is tracked in the
+// agents.x-k8s.io/pod-name annotation and may differ from sandbox.Name.
+func resolvePodName(sandbox *sandboxv1alpha1.Sandbox) string {
+	if name, ok := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; ok && name != "" {
+		return name
+	}
+	return sandbox.Name
+}
+
 var (
 	// Scheme for use by sandbox controllers. Registers required types for client.
 	Scheme = runtime.NewScheme()
@@ -291,6 +328,48 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		}
 	} else {
 		log.Info("Found Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
+
+		ownership, controllerRef := checkOwnership(service, sandbox)
+		switch ownership {
+		case resourceOwnedByOther:
+			log.Info("Refusing to use service: service is owned by a different controller",
+				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
+				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
+			return nil, fmt.Errorf("service %q is owned by %s/%s (UID: %s), not by sandbox %q",
+				service.Name, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
+
+		case resourceUnowned:
+			// ClusterIP is immutable — refuse adoption if the service is not headless.
+			if service.Spec.ClusterIP != corev1.ClusterIPNone && service.Spec.ClusterIP != "" {
+				log.Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
+					"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
+					"Service.ClusterIP", service.Spec.ClusterIP)
+				return nil, fmt.Errorf("cannot adopt service %q: ClusterIP is %q (expected %q, field is immutable)",
+					service.Name, service.Spec.ClusterIP, corev1.ClusterIPNone)
+			}
+
+			log.Info("Adopting unowned service", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
+
+			// Enforce intended labels and selector to prevent traffic hijack.
+			if service.Labels == nil {
+				service.Labels = make(map[string]string)
+			}
+			service.Labels[sandboxLabel] = nameHash
+			service.Spec.Selector = map[string]string{
+				sandboxLabel: nameHash,
+			}
+
+			if err := ctrl.SetControllerReference(sandbox, service, r.Scheme); err != nil {
+				return nil, fmt.Errorf("SetControllerReference for Service failed: %w", err)
+			}
+			if err := r.Update(ctx, service); err != nil {
+				return nil, fmt.Errorf("failed to update service with owner reference: %w", err)
+			}
+
+		case resourceOwnedBySandbox:
+			// Already owned by this sandbox — no action needed.
+		}
+
 		setServiceStatus(sandbox, service)
 		return service, nil
 	}
@@ -360,11 +439,9 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 
 	// Determine the pod name to look up
-	podName := sandbox.Name
-	var trackedPodName string
-	var podNameAnnotationExists bool
-	if trackedPodName, podNameAnnotationExists = sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; podNameAnnotationExists && trackedPodName != "" {
-		podName = trackedPodName
+	podName := resolvePodName(sandbox)
+	_, podNameAnnotationExists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]
+	if podName != sandbox.Name {
 		log.Info("Using tracked pod name from sandbox annotation", "podName", podName)
 	}
 
@@ -382,23 +459,32 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		pod = nil
 	}
 
-	// 1. PATH: Logic for deleting Pod when replicas is 0
 	if *sandbox.Spec.Replicas == 0 {
 		if pod != nil {
-			if pod.DeletionTimestamp.IsZero() {
-				log.Info("Deleting Pod because .Spec.Replicas is 0", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
-				if err := r.Delete(ctx, pod); err != nil {
-					return nil, fmt.Errorf("failed to delete pod: %w", err)
+			ownership, controllerRef := checkOwnership(pod, sandbox)
+			switch ownership {
+			case resourceOwnedBySandbox:
+				if pod.DeletionTimestamp.IsZero() {
+					log.Info("Deleting Pod because .Spec.Replicas is 0", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+					if err := r.Delete(ctx, pod); err != nil {
+						return nil, fmt.Errorf("failed to delete pod: %w", err)
+					}
+				} else {
+					log.Info("Pod is already being deleted", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 				}
-			} else {
-				log.Info("Pod is already being deleted", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+			case resourceUnowned:
+				log.Info("Refusing to delete pod: pod has no controllerRef pointing to this sandbox",
+					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
+			case resourceOwnedByOther:
+				log.Info("Refusing to delete pod: pod is owned by a different controller",
+					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
+					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 			}
 		}
 
 		// Remove the pod name annotation from the sandbox if it exists
 		if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists {
 			log.Info("Removing pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
-			// Create a patch to update only the annotations
 			patch := client.MergeFrom(sandbox.DeepCopy())
 			delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
 
@@ -448,34 +534,46 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			})
 		}
 
-		if pod.Labels == nil {
-			pod.Labels = make(map[string]string)
-		}
-		changed := false
-		if pod.Labels[sandboxLabel] != nameHash {
-			pod.Labels[sandboxLabel] = nameHash
-			changed = true
-		}
-		// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
-		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
-			if pod.Labels[k] != v {
-				pod.Labels[k] = v
-				changed = true
-			}
-		}
+		ownership, controllerRef := checkOwnership(pod, sandbox)
+		switch ownership {
+		case resourceOwnedByOther:
+			log.Info("Refusing to adopt pod: pod is owned by a different controller",
+				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
+				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 
-		// Set controller reference if the pod is not controlled by anything.
-		if controllerRef := metav1.GetControllerOf(pod); controllerRef == nil {
+			if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists {
+				log.Info("Removing pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
+				patch := client.MergeFrom(sandbox.DeepCopy())
+				delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
+				if err := r.Patch(ctx, sandbox, patch); err != nil {
+					return nil, fmt.Errorf("failed to remove pod name annotation: %w", err)
+				}
+			}
+
+			return nil, fmt.Errorf("pod %q is owned by %s/%s (UID: %s), not by sandbox %q",
+				pod.Name, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
+
+		case resourceUnowned:
 			if err := ctrl.SetControllerReference(sandbox, pod, r.Scheme); err != nil {
 				return nil, fmt.Errorf("SetControllerReference for Pod failed: %w", err)
 			}
-			changed = true
+
+		case resourceOwnedBySandbox:
+			// No additional action needed — label applied below.
 		}
 
-		if changed {
-			if err := r.Update(ctx, pod); err != nil {
-				return nil, fmt.Errorf("failed to update pod: %w", err)
-			}
+		// Apply label for both podUnowned and podOwnedBySandbox cases.
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+		}
+		pod.Labels[sandboxLabel] = nameHash
+		// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
+		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+			pod.Labels[k] = v
+		}
+
+		if err := r.Update(ctx, pod); err != nil {
+			return nil, fmt.Errorf("failed to update pod: %w", err)
 		}
 
 		if err := ensurePodNameAnnotation(pod.Name); err != nil {
@@ -487,7 +585,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		return pod, nil
 	}
 
-	// 3. PATH: Create new Pod
+	// Create new Pod
 	log.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
 	labels := map[string]string{
 		sandboxLabel: nameHash,
@@ -557,6 +655,27 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 		pvcName := pvcTemplate.Name + "-" + sandbox.Name
 		err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: sandbox.Namespace}, pvc)
 		if err == nil {
+			ownership, controllerRef := checkOwnership(pvc, sandbox)
+			switch ownership {
+			case resourceOwnedByOther:
+				log.Info("Refusing to use PVC: PVC is owned by a different controller",
+					"PVC.Name", pvcName, "Sandbox.Name", sandbox.Name,
+					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
+				return fmt.Errorf("PVC %q is owned by %s/%s (UID: %s), not by sandbox %q",
+					pvcName, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
+
+			case resourceUnowned:
+				log.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
+				if err := ctrl.SetControllerReference(sandbox, pvc, r.Scheme); err != nil {
+					return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
+				}
+				if err := r.Update(ctx, pvc); err != nil {
+					return fmt.Errorf("failed to update PVC with owner reference: %w", err)
+				}
+
+			case resourceOwnedBySandbox:
+				// Already owned by this sandbox — no action needed.
+			}
 			continue
 		}
 
@@ -566,6 +685,9 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 		}
 
 		pvcLabels := maps.Clone(pvcTemplate.Labels)
+		if pvcLabels == nil {
+			pvcLabels = make(map[string]string)
+		}
 		pvcLabels[sandboxLabel] = nameHash
 
 		log.Info("Creating a new PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
@@ -591,25 +713,54 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 
 // handles sandbox expiry by deleting child resources and the sandbox itself if needed
 func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) (bool, error) {
+	log := log.FromContext(ctx)
 	var allErrors error
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      sandbox.Name,
-			Namespace: sandbox.Namespace,
-		},
-	}
-	if err := r.Delete(ctx, pod); err != nil && !k8serrors.IsNotFound(err) {
-		allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete pod: %w", err))
+
+	// Delete pod only if owned by this sandbox
+	podName := resolvePodName(sandbox)
+	pod := &corev1.Pod{}
+	if err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: sandbox.Namespace}, pod); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			allErrors = errors.Join(allErrors, fmt.Errorf("failed to get pod: %w", err))
+		}
+	} else {
+		ownership, controllerRef := checkOwnership(pod, sandbox)
+		switch ownership {
+		case resourceOwnedBySandbox:
+			if err := r.Delete(ctx, pod); err != nil && !k8serrors.IsNotFound(err) {
+				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete pod: %w", err))
+			}
+		case resourceUnowned:
+			log.Info("Skipping pod deletion during expiry: pod has no controllerRef pointing to this sandbox",
+				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
+		case resourceOwnedByOther:
+			log.Info("Skipping pod deletion during expiry: pod is owned by a different controller",
+				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
+				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
+		}
 	}
 
-	service := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      sandbox.Name,
-			Namespace: sandbox.Namespace,
-		},
-	}
-	if err := r.Delete(ctx, service); err != nil && !k8serrors.IsNotFound(err) {
-		allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete service: %w", err))
+	// Delete service only if owned by this sandbox
+	service := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, service); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			allErrors = errors.Join(allErrors, fmt.Errorf("failed to get service: %w", err))
+		}
+	} else {
+		ownership, controllerRef := checkOwnership(service, sandbox)
+		switch ownership {
+		case resourceOwnedBySandbox:
+			if err := r.Delete(ctx, service); err != nil && !k8serrors.IsNotFound(err) {
+				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete service: %w", err))
+			}
+		case resourceUnowned:
+			log.Info("Skipping service deletion during expiry: service has no controllerRef pointing to this sandbox",
+				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
+		case resourceOwnedByOther:
+			log.Info("Skipping service deletion during expiry: service is owned by a different controller",
+				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
+				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
+		}
 	}
 
 	if sandbox.Spec.ShutdownPolicy != nil && *sandbox.Spec.ShutdownPolicy == sandboxv1alpha1.ShutdownPolicyDelete {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -45,11 +45,14 @@ func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
 		Build()
 }
 
+const sandboxUID = types.UID("test-sandbox-uid")
+
 func sandboxControllerRef(name string) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion:         "agents.x-k8s.io/v1alpha1",
 		Kind:               "Sandbox",
 		Name:               name,
+		UID:                sandboxUID,
 		Controller:         ptr.To(true),
 		BlockOwnerDeletion: ptr.To(true),
 	}
@@ -203,6 +206,49 @@ func TestComputeReadyCondition(t *testing.T) {
 	}
 }
 
+func TestResolvePodName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		wantPodName string
+	}{
+		{
+			name:        "no annotations",
+			annotations: nil,
+			wantPodName: "my-sandbox",
+		},
+		{
+			name:        "annotation not present",
+			annotations: map[string]string{"other": "value"},
+			wantPodName: "my-sandbox",
+		},
+		{
+			name:        "annotation present but empty",
+			annotations: map[string]string{sandboxv1alpha1.SandboxPodNameAnnotation: ""},
+			wantPodName: "my-sandbox",
+		},
+		{
+			name:        "annotation present with warm pool pod name",
+			annotations: map[string]string{sandboxv1alpha1.SandboxPodNameAnnotation: "warmpool-abc-xyz"},
+			wantPodName: "warmpool-abc-xyz",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandbox := &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-sandbox",
+					Namespace:   "default",
+					Annotations: tc.annotations,
+				},
+			}
+			got := resolvePodName(sandbox)
+			require.Equal(t, tc.wantPodName, got)
+		})
+	}
+}
+
 func TestReconcile(t *testing.T) {
 	sandboxName := "sandbox-name"
 	sandboxNs := "sandbox-ns"
@@ -210,9 +256,11 @@ func TestReconcile(t *testing.T) {
 		name                 string
 		initialObjs          []runtime.Object
 		sandboxSpec          sandboxv1alpha1.SandboxSpec
+		sandboxAnnotations   map[string]string
 		wantStatus           sandboxv1alpha1.SandboxStatus
 		wantObjs             []client.Object
 		wantDeletedObjs      []client.Object
+		wantSurvivingObjs    []client.Object
 		expectSandboxDeleted bool
 	}{
 		{
@@ -422,14 +470,16 @@ func TestReconcile(t *testing.T) {
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      sandboxName,
-						Namespace: sandboxNs,
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 				},
 				&corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      sandboxName,
-						Namespace: sandboxNs,
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 				},
 			},
@@ -465,18 +515,72 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "sandbox expired with delete policy",
+			name: "sandbox expired with retain policy deletes adopted warm pool pod",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      sandboxName,
-						Namespace: sandboxNs,
+						Name:            "warmpool-abc-xyz",
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 				},
 				&corev1.Service{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      sandboxName,
-						Namespace: sandboxNs,
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+				},
+			},
+			sandboxAnnotations: map[string]string{
+				sandboxv1alpha1.SandboxPodNameAnnotation: "warmpool-abc-xyz",
+			},
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+					},
+				},
+				Lifecycle: sandboxv1alpha1.Lifecycle{
+					ShutdownTime:   ptr.To(metav1.NewTime(time.Now().Add(-1 * time.Hour))),
+					ShutdownPolicy: ptr.To(sandboxv1alpha1.ShutdownPolicyRetain),
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "SandboxExpired",
+						Message:            "Sandbox has expired",
+					},
+				},
+			},
+			wantDeletedObjs: []client.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "warmpool-abc-xyz", Namespace: sandboxNs}},
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs}},
+			},
+		},
+		{
+			name: "sandbox expired with delete policy",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 				},
 			},
@@ -502,6 +606,135 @@ func TestReconcile(t *testing.T) {
 			},
 			expectSandboxDeleted: true,
 		},
+		{
+			name: "sandbox expired skips deletion of pod owned by different controller",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "Deployment",
+								Name:               "other-deployment",
+								UID:                "other-uid",
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+				},
+			},
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+				Lifecycle: sandboxv1alpha1.Lifecycle{
+					ShutdownTime:   ptr.To(metav1.NewTime(time.Now().Add(-1 * time.Hour))),
+					ShutdownPolicy: ptr.To(sandboxv1alpha1.ShutdownPolicyRetain),
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "SandboxExpired",
+						Message:            "Sandbox has expired",
+					},
+				},
+			},
+			// Pod should NOT be deleted (owned by other), Service SHOULD be deleted (owned by sandbox)
+			wantDeletedObjs: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs}},
+			},
+			wantSurvivingObjs: []client.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs}},
+			},
+		},
+		{
+			name: "sandbox expired skips deletion of unowned pod",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNs,
+						// No owner references
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+				},
+			},
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+				Lifecycle: sandboxv1alpha1.Lifecycle{
+					ShutdownTime:   ptr.To(metav1.NewTime(time.Now().Add(-1 * time.Hour))),
+					ShutdownPolicy: ptr.To(sandboxv1alpha1.ShutdownPolicyRetain),
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "SandboxExpired",
+						Message:            "Sandbox has expired",
+					},
+				},
+			},
+			wantDeletedObjs: []client.Object{
+				&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs}},
+			},
+			wantSurvivingObjs: []client.Object{
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs}},
+			},
+		},
+		{
+			name: "sandbox expired with no matching pod or service",
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+				Lifecycle: sandboxv1alpha1.Lifecycle{
+					ShutdownTime:   ptr.To(metav1.NewTime(time.Now().Add(-1 * time.Hour))),
+					ShutdownPolicy: ptr.To(sandboxv1alpha1.ShutdownPolicyRetain),
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "SandboxExpired",
+						Message:            "Sandbox has expired",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -509,8 +742,12 @@ func TestReconcile(t *testing.T) {
 			sb := &sandboxv1alpha1.Sandbox{}
 			sb.Name = sandboxName
 			sb.Namespace = sandboxNs
+			sb.UID = sandboxUID
 			sb.Generation = 1
 			sb.Spec = tc.sandboxSpec
+			if tc.sandboxAnnotations != nil {
+				sb.Annotations = tc.sandboxAnnotations
+			}
 			r := SandboxReconciler{
 				Client: newFakeClient(append(tc.initialObjs, sb)...),
 				Scheme: Scheme,
@@ -550,6 +787,12 @@ func TestReconcile(t *testing.T) {
 				err = r.Get(t.Context(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, liveObj)
 				require.True(t, k8serrors.IsNotFound(err))
 			}
+			for _, obj := range tc.wantSurvivingObjs {
+				liveObj := obj.DeepCopyObject().(client.Object)
+				err = r.Get(t.Context(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, liveObj)
+				require.NoError(t, err, "expected object %q/%q to survive but it was deleted or not found",
+					obj.GetNamespace(), obj.GetName())
+			}
 		})
 	}
 }
@@ -562,6 +805,7 @@ func TestReconcilePod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sandboxName,
 			Namespace: sandboxNs,
+			UID:       sandboxUID,
 		},
 		Spec: sandboxv1alpha1.SandboxSpec{
 			Replicas: ptr.To(int32(1)),
@@ -591,6 +835,7 @@ func TestReconcilePod(t *testing.T) {
 		wantPod                *corev1.Pod
 		expectErr              bool
 		wantSandboxAnnotations map[string]string
+		wantPodSurvives        string // if set, verify this pod still exists after reconcile
 	}{
 		{
 			name: "updates label and owner reference if Pod already exists",
@@ -671,6 +916,7 @@ func TestReconcilePod(t *testing.T) {
 						Name:            sandboxName,
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 				},
 			},
@@ -678,6 +924,7 @@ func TestReconcilePod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandboxName,
 					Namespace: sandboxNs,
+					UID:       sandboxUID,
 				},
 				Spec: sandboxv1alpha1.SandboxSpec{
 					Replicas: ptr.To(int32(0)),
@@ -720,6 +967,7 @@ func TestReconcilePod(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandboxName,
 					Namespace: sandboxNs,
+					UID:       sandboxUID,
 					Annotations: map[string]string{
 						sandboxv1alpha1.SandboxPodNameAnnotation: "adopted-pod-name",
 					},
@@ -758,7 +1006,7 @@ func TestReconcilePod(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "does not change controller if Pod already has a different controller",
+			name: "refuses to modify pod owned by a different controller",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -786,37 +1034,9 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
-			sandbox: sandboxObj,
-			// The pod should still have the original controller reference
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            sandboxName,
-					Namespace:       sandboxNs,
-					ResourceVersion: "2",
-					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
-						"custom-label":                      "label-val",
-					},
-					// Should still have the original controller reference
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "apps/v1",
-							Kind:               "Deployment",
-							Name:               "some-other-controller",
-							UID:                "some-other-uid",
-							Controller:         ptr.To(true),
-							BlockOwnerDeletion: ptr.To(true),
-						},
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "foo",
-						},
-					},
-				},
-			},
+			sandbox:   sandboxObj,
+			wantPod:   nil,
+			expectErr: true,
 		},
 		{
 			name:        "error when annotated pod does not exist",
@@ -846,7 +1066,159 @@ func TestReconcilePod(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "remove pod name annotation when replicas is 0",
+			name: "refuses to delete annotated pod owned by a different controller",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "victim-pod",
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "Deployment",
+								Name:               "other-deployment",
+								UID:                "other-uid",
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "victim-pod",
+						"other-annotation":                       "keep-me",
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+			},
+			wantPod:                nil,
+			expectErr:              false,
+			wantSandboxAnnotations: map[string]string{"other-annotation": "keep-me"},
+			wantPodSurvives:        "victim-pod",
+		},
+		{
+			name: "refuses to delete annotated pod with no controller reference",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "unowned-pod",
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "unowned-pod",
+						"other-annotation":                       "keep-me",
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+			},
+			wantPod:                nil,
+			expectErr:              false,
+			wantSandboxAnnotations: map[string]string{"other-annotation": "keep-me"},
+			wantPodSurvives:        "unowned-pod",
+		},
+		{
+			name: "deletes annotated pod owned by this sandbox",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "owned-pod",
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "owned-pod",
+						"other-annotation":                       "keep-me",
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: ptr.To(int32(0)),
+				},
+			},
+			wantPod:                nil,
+			expectErr:              false,
+			wantSandboxAnnotations: map[string]string{"other-annotation": "keep-me"},
+		},
+		{
+			name: "refuses to adopt annotated pod owned by a different controller",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "foreign-pod",
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "Deployment",
+								Name:               "other-deployment",
+								UID:                "other-uid",
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "foreign-pod",
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: ptr.To(int32(1)),
+					PodTemplate: sandboxv1alpha1.PodTemplate{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test-container"}},
+						},
+					},
+				},
+			},
+			wantPod:                nil,
+			expectErr:              true,
+			wantSandboxAnnotations: map[string]string{},
+		},
+		{
+			name: "refuses to delete unowned annotated pod and removes annotation when replicas is 0",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -872,6 +1244,7 @@ func TestReconcilePod(t *testing.T) {
 			wantPod:                nil,
 			expectErr:              false,
 			wantSandboxAnnotations: map[string]string{"other-annotation": "other-value"},
+			wantPodSurvives:        "annotated-pod-name",
 		},
 	}
 
@@ -900,27 +1273,494 @@ func TestReconcilePod(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, tc.wantPod, livePod)
 			} else if !tc.expectErr {
-				// When wantPod is nil and no error expected, verify pod doesn't exist
-				livePod := &corev1.Pod{}
-				podName := sandboxName
-				// Check if there's an annotation with a non-empty value
-				if annotatedPod, exists := tc.sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists && annotatedPod != "" {
-					podName = annotatedPod
+				if tc.wantPodSurvives != "" {
+					// Pod should still exist (ownership check blocked deletion)
+					livePod := &corev1.Pod{}
+					err = r.Get(t.Context(), types.NamespacedName{Name: tc.wantPodSurvives, Namespace: sandboxNs}, livePod)
+					require.NoError(t, err, "expected pod %q to survive but it was deleted", tc.wantPodSurvives)
+				} else {
+					// When wantPod is nil and no error expected, verify pod doesn't exist
+					livePod := &corev1.Pod{}
+					podName := sandboxName
+					if annotatedPod, exists := tc.sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists && annotatedPod != "" {
+						podName = annotatedPod
+					}
+					err = r.Get(t.Context(), types.NamespacedName{Name: podName, Namespace: sandboxNs}, livePod)
+					require.True(t, k8serrors.IsNotFound(err))
 				}
-				err = r.Get(t.Context(), types.NamespacedName{Name: podName, Namespace: sandboxNs}, livePod)
-				require.True(t, k8serrors.IsNotFound(err))
 			}
 
-			// Check if sandbox annotations were updated as expected
 			if tc.wantSandboxAnnotations != nil {
-				// Fetch the sandbox to see if annotations were updated
 				liveSandbox := &sandboxv1alpha1.Sandbox{}
 				err = r.Get(t.Context(), types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, liveSandbox)
 				require.NoError(t, err)
-
-				// Check if the annotations match what we expect
-				require.Equal(t, tc.wantSandboxAnnotations, liveSandbox.Annotations)
+				if len(tc.wantSandboxAnnotations) == 0 {
+					require.Empty(t, liveSandbox.Annotations)
+				} else {
+					require.Equal(t, tc.wantSandboxAnnotations, liveSandbox.Annotations)
+				}
 			}
+		})
+	}
+}
+
+func TestReconcileService(t *testing.T) {
+	sandboxName := "sandbox-name"
+	sandboxNs := "sandbox-ns"
+	nameHash := "name-hash"
+	sandboxObj := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: sandboxNs,
+			UID:       sandboxUID,
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+		},
+	}
+
+	testCases := []struct {
+		name                  string
+		initialObjs           []runtime.Object
+		sandbox               *sandboxv1alpha1.Sandbox
+		wantService           *corev1.Service
+		expectErr             bool
+		errContains           string // substring that must appear in the error
+		wantStatusService     string
+		wantStatusServiceFQDN string
+	}{
+		{
+			name:    "creates a new headless service when none exists",
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "uses existing service owned by this sandbox",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+				},
+			},
+			sandbox:               sandboxObj,
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "refuses to use service owned by a different controller",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "Deployment",
+								Name:               "some-other-controller",
+								UID:                "some-other-uid",
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+				},
+			},
+			sandbox:     sandboxObj,
+			wantService: nil,
+			expectErr:   true,
+		},
+		{
+			name: "adopts unowned service and sets controller reference",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "refuses to adopt unowned service with non-headless ClusterIP",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.96.0.100",
+					},
+				},
+			},
+			sandbox:     sandboxObj,
+			wantService: nil,
+			expectErr:   true,
+			errContains: "immutable",
+		},
+		{
+			name: "adopts unowned headless service and overwrites wrong selector",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							"app": "something-else",
+						},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := SandboxReconciler{
+				Client: newFakeClient(append(tc.initialObjs, tc.sandbox)...),
+				Scheme: Scheme,
+				Tracer: asmetrics.NewNoOp(),
+			}
+
+			svc, err := r.reconcileService(t.Context(), tc.sandbox, nameHash)
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Nil(t, svc)
+				if tc.errContains != "" {
+					require.Contains(t, err.Error(), tc.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, svc)
+			}
+
+			// Verify status was set correctly
+			if tc.wantStatusService != "" {
+				require.Equal(t, tc.wantStatusService, tc.sandbox.Status.Service)
+				require.Equal(t, tc.wantStatusServiceFQDN, tc.sandbox.Status.ServiceFQDN)
+			}
+
+			// Verify the live service in the fake client matches expected state
+			if tc.wantService != nil {
+				liveSvc := &corev1.Service{}
+				err = r.Get(t.Context(), types.NamespacedName{
+					Name: sandboxName, Namespace: sandboxNs,
+				}, liveSvc)
+				require.NoError(t, err)
+				if diff := cmp.Diff(tc.wantService, liveSvc, cmpopts.IgnoreFields(metav1.TypeMeta{}, "APIVersion", "Kind")); diff != "" {
+					t.Errorf("live service mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckOwnership(t *testing.T) {
+	sandboxName := "test-sandbox"
+	sandboxUID := types.UID("sandbox-uid-123")
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sandboxName,
+			UID:  sandboxUID,
+		},
+	}
+
+	otherOwnerRef := metav1.OwnerReference{
+		APIVersion:         "apps/v1",
+		Kind:               "Deployment",
+		Name:               "other-controller",
+		UID:                "other-uid",
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+
+	sandboxOwnerRef := metav1.OwnerReference{
+		APIVersion:         "agents.x-k8s.io/v1alpha1",
+		Kind:               "Sandbox",
+		Name:               sandboxName,
+		UID:                sandboxUID,
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
+	}
+
+	testCases := []struct {
+		name              string
+		obj               client.Object
+		wantOwnership     resourceOwnership
+		wantControllerRef *metav1.OwnerReference
+	}{
+		{
+			name: "pod owned by sandbox",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-pod",
+					OwnerReferences: []metav1.OwnerReference{sandboxOwnerRef},
+				},
+			},
+			wantOwnership:     resourceOwnedBySandbox,
+			wantControllerRef: &sandboxOwnerRef,
+		},
+		{
+			name: "pod with no owner",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unowned-pod",
+				},
+			},
+			wantOwnership:     resourceUnowned,
+			wantControllerRef: nil,
+		},
+		{
+			name: "pod owned by different controller",
+			obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "foreign-pod",
+					OwnerReferences: []metav1.OwnerReference{otherOwnerRef},
+				},
+			},
+			wantOwnership:     resourceOwnedByOther,
+			wantControllerRef: &otherOwnerRef,
+		},
+		{
+			name: "service owned by sandbox",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test-service",
+					OwnerReferences: []metav1.OwnerReference{sandboxOwnerRef},
+				},
+			},
+			wantOwnership:     resourceOwnedBySandbox,
+			wantControllerRef: &sandboxOwnerRef,
+		},
+		{
+			name: "service with no owner",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "unowned-service",
+				},
+			},
+			wantOwnership:     resourceUnowned,
+			wantControllerRef: nil,
+		},
+		{
+			name: "service owned by different controller",
+			obj: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "foreign-service",
+					OwnerReferences: []metav1.OwnerReference{otherOwnerRef},
+				},
+			},
+			wantOwnership:     resourceOwnedByOther,
+			wantControllerRef: &otherOwnerRef,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ownership, controllerRef := checkOwnership(tc.obj, sandbox)
+			require.Equal(t, tc.wantOwnership, ownership)
+			require.Equal(t, tc.wantControllerRef, controllerRef)
+		})
+	}
+}
+
+func TestReconcilePVCs(t *testing.T) {
+	sandboxName := "test-sandbox"
+	sandboxNs := "test-ns"
+	sandboxUID := types.UID("sandbox-uid-123")
+	otherUID := types.UID("other-uid-456")
+	pvcTemplateName := "data"
+	pvcName := pvcTemplateName + "-" + sandboxName // "data-test-sandbox"
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: sandboxNs,
+			UID:       sandboxUID,
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			VolumeClaimTemplates: []sandboxv1alpha1.PersistentVolumeClaimTemplate{
+				{
+					EmbeddedObjectMetadata: sandboxv1alpha1.EmbeddedObjectMetadata{Name: pvcTemplateName},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		initialObjs []runtime.Object
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:      "creates new PVC when none exists",
+			expectErr: false,
+		},
+		{
+			name: "uses existing PVC owned by this sandbox",
+			initialObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvcName,
+						Namespace: sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "agents.x-k8s.io/v1alpha1",
+								Kind:               "Sandbox",
+								Name:               sandboxName,
+								UID:                sandboxUID,
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "refuses PVC owned by a different controller",
+			initialObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvcName,
+						Namespace: sandboxNs,
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "Deployment",
+								Name:               "other-controller",
+								UID:                otherUID,
+								Controller:         ptr.To(true),
+								BlockOwnerDeletion: ptr.To(true),
+							},
+						},
+					},
+				},
+			},
+			expectErr:   true,
+			errContains: "is owned by",
+		},
+		{
+			name: "adopts unowned PVC",
+			initialObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvcName,
+						Namespace: sandboxNs,
+						// No owner references.
+					},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := SandboxReconciler{
+				Client: newFakeClient(append(tc.initialObjs, sandbox)...),
+				Scheme: Scheme,
+				Tracer: asmetrics.NewNoOp(),
+			}
+
+			err := r.reconcilePVCs(t.Context(), sandbox, NameHash(sandboxName))
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					require.Contains(t, err.Error(), tc.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify PVC exists and is owned by the sandbox.
+			livePVC := &corev1.PersistentVolumeClaim{}
+			err = r.Get(t.Context(), types.NamespacedName{Name: pvcName, Namespace: sandboxNs}, livePVC)
+			require.NoError(t, err)
+			ownerRef := metav1.GetControllerOf(livePVC)
+			require.NotNil(t, ownerRef, "PVC should have a controller owner reference")
+			require.Equal(t, sandboxUID, ownerRef.UID, "PVC controller reference UID should match sandbox UID")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #265: Privilege escalation via `agents.x-k8s.io/pod-name` annotation.

- Adds `checkPodOwnership()` helper that validates the pod's controllerRef UID against the Sandbox UID before any pod operation
- Pods owned by a different controller are rejected
- Pods with no controllerRef are only adopted (not deleted)
- Only pods with a controllerRef UID matching the requesting Sandbox can be deleted
- Warm pool adoption flow is fully preserved
- Adds 4 new test cases covering all ownership verification scenarios
- Updates 3 existing tests to reflect new security behavior

Follows maintainer guidance from @janetkuo: the annotation cannot be the sole source of truth; controllerRef must always be checked.

## Test Plan

- [x] `make build` succeeds
- [x] `make lint-go` passes
- [x] `make test-unit` passes (12/12 TestReconcilePod subtests)
- [x] Manual attack reproduction on Kind cluster — victim pod survives