### PR TITLE
Implement Suspended state via Status conditions

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -25,17 +25,33 @@ type ConditionType string
 func (c ConditionType) String() string { return string(c) }
 
 const (
+	// SandboxConditionSuspended indicates the sandbox is administratively suspended.
+	SandboxConditionSuspended ConditionType = "Suspended"
+	// SandboxReasonSuspendedPodTerminated indicates that the pod has been terminated.
+	SandboxReasonSuspendedPodTerminated = "PodTerminated"
+	// SandboxReasonSuspendedPodNotTerminated indicates the pod has not been terminated yet.
+	SandboxReasonSuspendedPodNotTerminated = "PodNotTerminated"
+
 	// SandboxConditionReady indicates readiness for Sandbox.
 	SandboxConditionReady ConditionType = "Ready"
+	// SandboxReasonDependenciesReady indicates the sandbox is fully operational.
+	SandboxReasonDependenciesReady = "DependenciesReady"
+	// SandboxReasonDependenciesNotReady indicates the Sandbox is expected to be running
+	// but its underlying dependencies are not fully provisioned or ready yet.
+	SandboxReasonDependenciesNotReady = "DependenciesNotReady"
+	// SandboxReasonSuspended indicates the Sandbox has been administratively suspended
+	// (i.e., intentional action by the user to suspend the Sandbox).
+	SandboxReasonSuspended = "SandboxSuspended"
+
 	// SandboxConditionFinished indicates the backing Pod reached a terminal phase.
 	SandboxConditionFinished ConditionType = "Finished"
-
-	// SandboxReasonExpired indicates expired state for Sandbox.
-	SandboxReasonExpired = "SandboxExpired"
 	// SandboxReasonPodSucceeded indicates the backing Pod completed successfully.
 	SandboxReasonPodSucceeded = "PodSucceeded"
 	// SandboxReasonPodFailed indicates the backing Pod completed unsuccessfully.
 	SandboxReasonPodFailed = "PodFailed"
+
+	// SandboxReasonExpired indicates expired state for Sandbox.
+	SandboxReasonExpired = "SandboxExpired"
 
 	// SandboxPodNameAnnotation is the annotation used to track the pod name adopted from a warm pool.
 	SandboxPodNameAnnotation = "agents.x-k8s.io/pod-name"

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -253,17 +253,61 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	svc, err := r.reconcileService(ctx, sandbox, nameHash)
 	allErrors = errors.Join(allErrors, err)
 
-	// compute and set overall Ready condition
-	readyCondition := r.computeReadyCondition(sandbox, allErrors, svc, pod)
-	meta.SetStatusCondition(&sandbox.Status.Conditions, readyCondition)
+	// compute and set overall conditions
+	conditions := r.computeConditions(sandbox, allErrors, svc, pod)
+	hasFinished := false
+	for _, condition := range conditions {
+		meta.SetStatusCondition(&sandbox.Status.Conditions, condition)
+		if condition.Type == string(sandboxv1alpha1.SandboxConditionFinished) {
+			hasFinished = true
+		}
+	}
 
-	if finishedCondition := r.computeFinishedCondition(sandbox, pod); finishedCondition != nil {
-		meta.SetStatusCondition(&sandbox.Status.Conditions, *finishedCondition)
-	} else {
+	if !hasFinished {
 		meta.RemoveStatusCondition(&sandbox.Status.Conditions, string(sandboxv1alpha1.SandboxConditionFinished))
 	}
 
 	return allErrors
+}
+
+func (r *SandboxReconciler) computeConditions(sandbox *sandboxv1alpha1.Sandbox, err error, svc *corev1.Service, pod *corev1.Pod) []metav1.Condition {
+	var conditions []metav1.Condition
+
+	if suspended := r.computeSuspendedCondition(sandbox, pod); suspended != nil {
+		conditions = append(conditions, *suspended)
+	}
+
+	if finished := r.computeFinishedCondition(sandbox, pod); finished != nil {
+		conditions = append(conditions, *finished)
+	}
+
+	conditions = append(conditions, r.computeReadyCondition(sandbox, err, svc, pod))
+
+	return conditions
+}
+
+func (r *SandboxReconciler) computeSuspendedCondition(sandbox *sandboxv1alpha1.Sandbox, pod *corev1.Pod) *metav1.Condition {
+	replicaCountZero := sandbox.Spec.Replicas != nil && *sandbox.Spec.Replicas == 0
+	if !replicaCountZero {
+		return nil
+	}
+
+	suspended := metav1.Condition{
+		Type:               string(sandboxv1alpha1.SandboxConditionSuspended),
+		ObservedGeneration: sandbox.Generation,
+	}
+	if pod == nil {
+		// Mark Suspended condition as True
+		suspended.Status = metav1.ConditionTrue
+		suspended.Reason = sandboxv1alpha1.SandboxReasonSuspendedPodTerminated
+		suspended.Message = "Pod has been terminated. Sandbox is not operational."
+	} else {
+		suspended.Status = metav1.ConditionFalse
+		suspended.Reason = sandboxv1alpha1.SandboxReasonSuspendedPodNotTerminated
+		suspended.Message = "Pod has not been terminated. Sandbox is operational."
+	}
+
+	return &suspended
 }
 
 func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1alpha1.Sandbox, err error, svc *corev1.Service, pod *corev1.Pod) metav1.Condition {
@@ -272,12 +316,23 @@ func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1alpha1.Sandb
 		ObservedGeneration: sandbox.Generation,
 		Message:            "",
 		Status:             metav1.ConditionFalse,
-		Reason:             "DependenciesNotReady",
+		Reason:             sandboxv1alpha1.SandboxReasonDependenciesNotReady,
 	}
 
 	if err != nil {
 		readyCondition.Reason = "ReconcilerError"
 		readyCondition.Message = "Error seen: " + err.Error()
+		return readyCondition
+	}
+
+	replicaCountZero := sandbox.Spec.Replicas != nil && *sandbox.Spec.Replicas == 0
+	if replicaCountZero {
+		readyCondition.Reason = sandboxv1alpha1.SandboxReasonSuspended
+		if pod != nil {
+			readyCondition.Message = "Sandbox is suspending"
+		} else {
+			readyCondition.Message = "Sandbox is suspended"
+		}
 		return readyCondition
 	}
 
@@ -303,13 +358,7 @@ func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1alpha1.Sandb
 			}
 		}
 	} else {
-		if sandbox.Spec.Replicas != nil && *sandbox.Spec.Replicas == 0 {
-			message = "Pod does not exist, replicas is 0"
-			// This is intended behaviour. So marking it ready.
-			podReady = true
-		} else {
-			message = "Pod does not exist"
-		}
+		message = "Pod does not exist"
 	}
 
 	// svcRequired: true if the sandbox explicitly requests a service or if a
@@ -336,7 +385,7 @@ func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1alpha1.Sandb
 	readyCondition.Message = message
 	if podReady && svcReady {
 		readyCondition.Status = metav1.ConditionTrue
-		readyCondition.Reason = "DependenciesReady"
+		readyCondition.Reason = sandboxv1alpha1.SandboxReasonDependenciesReady
 	}
 
 	return readyCondition
@@ -1074,7 +1123,7 @@ func setSandboxExpiredCondition(sandbox *sandboxv1alpha1.Sandbox) {
 // sandboxMarkedExpired checks if the sandbox is already marked as expired.
 func sandboxMarkedExpired(sandbox *sandboxv1alpha1.Sandbox) bool {
 	cond := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1alpha1.SandboxConditionReady))
-	return cond != nil && cond.Reason == sandboxv1alpha1.SandboxReasonExpired
+	return cond != nil && (cond.Reason == sandboxv1alpha1.SandboxReasonExpired)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -47,25 +47,6 @@ func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
 		Build()
 }
 
-type alreadyExistsOnPodCreateClient struct {
-	client.WithWatch
-	pod *corev1.Pod
-}
-
-func (c *alreadyExistsOnPodCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	if _, ok := obj.(*corev1.Pod); ok {
-		if c.pod != nil {
-			pod := c.pod.DeepCopy()
-			if err := c.WithWatch.Create(ctx, pod); err != nil && !k8serrors.IsAlreadyExists(err) {
-				return err
-			}
-			c.pod = nil
-		}
-		return k8serrors.NewAlreadyExists(corev1.Resource("pods"), obj.GetName())
-	}
-	return c.WithWatch.Create(ctx, obj, opts...)
-}
-
 const sandboxUID = types.UID("test-sandbox-uid")
 
 func sandboxControllerRef(name string) metav1.OwnerReference {
@@ -79,51 +60,79 @@ func sandboxControllerRef(name string) metav1.OwnerReference {
 	}
 }
 
-func TestComputeReadyCondition(t *testing.T) {
+func TestComputeConditions(t *testing.T) {
 	r := &SandboxReconciler{}
 
+	gen := int64(1)
+	sbWithRepl := func(replicas int32) *sandboxv1alpha1.Sandbox {
+		return &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Generation: gen},
+			Spec:       sandboxv1alpha1.SandboxSpec{Replicas: new(replicas)},
+		}
+	}
+
+	sbWithReplAndSvcReq := func(replicas int32) *sandboxv1alpha1.Sandbox {
+		sb := sbWithRepl(replicas)
+		sb.Spec.Service = new(true)
+		return sb
+	}
+
 	testCases := []struct {
-		name           string
-		sandbox        *sandboxv1alpha1.Sandbox
-		err            error
-		svc            *corev1.Service
-		pod            *corev1.Pod
-		expectedStatus metav1.ConditionStatus
-		expectedReason string
+		name               string
+		sandbox            *sandboxv1alpha1.Sandbox
+		err                error
+		svc                *corev1.Service
+		pod                *corev1.Pod
+		expectedConditions []metav1.Condition
 	}{
 		{
-			name: "all ready",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
+			name:    "1. Provisioning - No dependencies",
+			sandbox: sbWithReplAndSvcReq(1),
+			svc:     nil,
+			pod:     nil,
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod does not exist; Service does not exist"},
 			},
-			err: nil,
-			svc: &corev1.Service{},
+		},
+		{
+			name:    "2. Provisioning - Partial dependencies (missing Pod)",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
+			pod:     nil,
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod does not exist; Service Exists"},
+			},
+		},
+		{
+			name:    "3. Pod Pending",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
+			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
+			},
+		},
+		{
+			name:    "4. Pod Running but not Ready",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase:  corev1.PodRunning,
 					PodIPs: []corev1.PodIP{{IP: "10.244.0.1"}},
 					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionTrue,
-						},
+						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
 					},
 				},
 			},
-			expectedStatus: metav1.ConditionTrue,
-			expectedReason: "DependenciesReady",
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Running but not Ready; Service Exists"},
+			},
 		},
 		{
-			name: "pod ready but no IP yet",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
-			},
-			err: nil,
-			svc: &corev1.Service{},
+			name:    "5. Pod ready but no IP yet",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
@@ -135,118 +144,96 @@ func TestComputeReadyCondition(t *testing.T) {
 					},
 				},
 			},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "DependenciesNotReady",
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Ready but has no podIPs yet; Service Exists"},
+			},
 		},
 		{
-			name: "error",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
-			},
-			err:            errors.New("test error"),
-			svc:            &corev1.Service{},
-			pod:            &corev1.Pod{},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "ReconcilerError",
-		},
-		{
-			name: "pod not ready",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
-			},
-			err: nil,
-			svc: &corev1.Service{},
+			name:    "6. Suspended by user - Pod still terminating",
+			sandbox: sbWithRepl(0),
+			svc:     &corev1.Service{},
 			pod: &corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
-						{
-							Type:   corev1.PodReady,
-							Status: corev1.ConditionFalse,
-						},
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 					},
 				},
 			},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "DependenciesNotReady",
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodNotTerminated", Message: "Pod has not been terminated. Sandbox is operational."},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "SandboxSuspended", Message: "Sandbox is suspending"},
+			},
 		},
 		{
-			name: "pod running but not ready",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
+			name:    "7. Fully suspended - Pod deleted",
+			sandbox: sbWithRepl(0),
+			svc:     &corev1.Service{},
+			pod:     nil,
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "True", ObservedGeneration: gen, Reason: "PodTerminated", Message: "Pod has been terminated. Sandbox is not operational."},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "SandboxSuspended", Message: "Sandbox is suspended"},
 			},
-			err: nil,
-			svc: &corev1.Service{},
-			pod: &corev1.Pod{
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				},
-			},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "DependenciesNotReady",
 		},
 		{
-			name: "pod pending",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
+			name:    "8. Resuming - Pod missing",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
+			pod:     nil,
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod does not exist; Service Exists"},
 			},
-			err: nil,
-			svc: &corev1.Service{},
-			pod: &corev1.Pod{
-				Status: corev1.PodStatus{
-					Phase: corev1.PodPending,
-				},
-			},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "DependenciesNotReady",
 		},
 		{
-			name: "service not ready",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
+			name:    "9. Unresponsive - Pod Status Unknown",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
+			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}},
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Unknown; Service Exists"},
 			},
-			err: nil,
-			svc: nil,
-			pod: &corev1.Pod{
-				Status: corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				},
-			},
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "DependenciesNotReady",
 		},
 		{
-			name: "all not ready",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
-				},
+			name:    "10. Pod Failed",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
+			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}},
+			expectedConditions: []metav1.Condition{
+				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodFailed", Message: "Pod failed"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Failed; Service Exists"},
 			},
-			err:            nil,
-			svc:            nil,
-			pod:            nil,
-			expectedStatus: metav1.ConditionFalse,
-			expectedReason: "DependenciesNotReady",
+		},
+		{
+			name:    "11. Pod Succeeded",
+			sandbox: sbWithRepl(1),
+			svc:     &corev1.Service{},
+			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
+			expectedConditions: []metav1.Condition{
+				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodSucceeded", Message: "Pod completed successfully"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Succeeded; Service Exists"},
+			},
+		},
+		{
+			name:    "12. Reconciler error takes precedence",
+			sandbox: sbWithRepl(1),
+			err:     errors.New("something went wrong"),
+			svc:     nil,
+			pod:     nil,
+			expectedConditions: []metav1.Condition{
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: something went wrong"},
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			condition := r.computeReadyCondition(tc.sandbox, tc.err, tc.svc, tc.pod)
-			require.Equal(t, sandboxv1alpha1.SandboxConditionReady.String(), condition.Type)
-			require.Equal(t, tc.sandbox.Generation, condition.ObservedGeneration)
-			require.Equal(t, tc.expectedStatus, condition.Status)
-			require.Equal(t, tc.expectedReason, condition.Reason)
+			conditions := r.computeConditions(tc.sandbox, tc.err, tc.svc, tc.pod)
+			opts := []cmp.Option{
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+			}
+			if diff := cmp.Diff(tc.expectedConditions, conditions, opts...); diff != "" {
+				t.Fatalf("unexpected conditions (-want,+got):\n%s", diff)
+			}
 		})
 	}
 }
@@ -303,6 +290,7 @@ func TestReconcile(t *testing.T) {
 		sandboxSpec          sandboxv1alpha1.SandboxSpec
 		sandboxAnnotations   map[string]string
 		reconcileCount       int
+		deletionTimestamp    *metav1.Time
 		wantStatus           sandboxv1alpha1.SandboxStatus
 		wantObjs             []client.Object
 		wantDeletedObjs      []client.Object
@@ -332,7 +320,7 @@ func TestReconcile(t *testing.T) {
 						Type:               "Ready",
 						Status:             "False",
 						ObservedGeneration: 1,
-						Reason:             "DependenciesNotReady",
+						Reason:             sandboxv1alpha1.SandboxReasonDependenciesNotReady,
 						Message:            "Pod exists with phase: ",
 					},
 				},
@@ -382,10 +370,10 @@ func TestReconcile(t *testing.T) {
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
 					{
-						Type:               "Ready",
-						Status:             "False",
+						Type:               string(sandboxv1alpha1.SandboxConditionReady),
+						Status:             metav1.ConditionFalse,
 						ObservedGeneration: 1,
-						Reason:             "DependenciesNotReady",
+						Reason:             sandboxv1alpha1.SandboxReasonDependenciesNotReady,
 						Message:            "Pod exists with phase: ; Service Exists",
 					},
 				},
@@ -478,10 +466,10 @@ func TestReconcile(t *testing.T) {
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
 					{
-						Type:               "Ready",
-						Status:             "False",
+						Type:               string(sandboxv1alpha1.SandboxConditionReady),
+						Status:             metav1.ConditionFalse,
 						ObservedGeneration: 1,
-						Reason:             "DependenciesNotReady",
+						Reason:             sandboxv1alpha1.SandboxReasonDependenciesNotReady,
 						Message:            "Pod exists with phase: ; Service Exists",
 					},
 				},
@@ -607,7 +595,7 @@ func TestReconcile(t *testing.T) {
 						Type:               "Ready",
 						Status:             "True",
 						ObservedGeneration: 1,
-						Reason:             "DependenciesReady",
+						Reason:             sandboxv1alpha1.SandboxReasonDependenciesReady,
 						Message:            "Pod is Ready; Service Exists",
 					},
 				},
@@ -672,7 +660,7 @@ func TestReconcile(t *testing.T) {
 						Type:               "Ready",
 						Status:             "True",
 						ObservedGeneration: 1,
-						Reason:             "DependenciesReady",
+						Reason:             sandboxv1alpha1.SandboxReasonDependenciesReady,
 						Message:            "Pod is Ready",
 					},
 				},
@@ -715,10 +703,10 @@ func TestReconcile(t *testing.T) {
 			wantStatus: sandboxv1alpha1.SandboxStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               "Ready",
+						Type:               string(sandboxv1alpha1.SandboxConditionReady),
 						Status:             "False",
 						ObservedGeneration: 1,
-						Reason:             "SandboxExpired",
+						Reason:             sandboxv1alpha1.SandboxReasonExpired,
 						Message:            "Sandbox has expired",
 					},
 				},
@@ -929,8 +917,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name:           "sandbox expired with no matching pod or service",
-			reconcileCount: 2,
+			name: "sandbox expired with no matching pod or service",
 			sandboxSpec: sandboxv1alpha1.SandboxSpec{
 				PodTemplate: sandboxv1alpha1.PodTemplate{
 					Spec: corev1.PodSpec{
@@ -963,6 +950,10 @@ func TestReconcile(t *testing.T) {
 			sb.Namespace = sandboxNs
 			sb.UID = sandboxUID
 			sb.Generation = 1
+			if tc.deletionTimestamp != nil {
+				sb.DeletionTimestamp = tc.deletionTimestamp
+				sb.Finalizers = []string{"test-finalizer"}
+			}
 			sb.Spec = tc.sandboxSpec
 			if tc.sandboxAnnotations != nil {
 				sb.Annotations = tc.sandboxAnnotations
@@ -1058,7 +1049,6 @@ func TestReconcilePod(t *testing.T) {
 	testCases := []struct {
 		name                   string
 		initialObjs            []runtime.Object
-		wrapClient             func(client.WithWatch) client.WithWatch
 		sandbox                *sandboxv1alpha1.Sandbox
 		wantPod                *corev1.Pod
 		expectErr              bool
@@ -1272,196 +1262,6 @@ func TestReconcilePod(t *testing.T) {
 			sandbox:   sandboxObj,
 			wantPod:   nil,
 			expectErr: true,
-		},
-		{
-			name: "refuses pod created by another controller between get and create",
-			wrapClient: func(c client.WithWatch) client.WithWatch {
-				return &alreadyExistsOnPodCreateClient{
-					WithWatch: c,
-					pod: &corev1.Pod{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            sandboxName,
-							Namespace:       sandboxNs,
-							ResourceVersion: "1",
-							OwnerReferences: []metav1.OwnerReference{
-								{
-									APIVersion:         "apps/v1",
-									Kind:               "Deployment",
-									Name:               "some-other-controller",
-									UID:                "some-other-uid",
-									Controller:         new(true),
-									BlockOwnerDeletion: new(true),
-								},
-							},
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "foo",
-								},
-							},
-						},
-					},
-				}
-			},
-			sandbox:   sandboxObj,
-			wantPod:   nil,
-			expectErr: true,
-		},
-		{
-			name: "creates pod with volumeClaimTemplate volumes replacing conflicting pod template volumes",
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      sandboxName,
-					Namespace: sandboxNs,
-					UID:       sandboxUID,
-				},
-				Spec: sandboxv1alpha1.SandboxSpec{
-					Replicas: new(int32(1)),
-					PodTemplate: sandboxv1alpha1.PodTemplate{
-						ObjectMeta: sandboxv1alpha1.PodMetadata{
-							Annotations: map[string]string{
-								"agents.x-k8s.io/template": "default",
-							},
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "test-container",
-									VolumeMounts: []corev1.VolumeMount{
-										{Name: "data", MountPath: "/data"},
-									},
-								},
-							},
-							Volumes: []corev1.Volume{
-								{Name: "data", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-								{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"}}}},
-							},
-						},
-					},
-					VolumeClaimTemplates: []sandboxv1alpha1.PersistentVolumeClaimTemplate{
-						{
-							EmbeddedObjectMetadata: sandboxv1alpha1.EmbeddedObjectMetadata{Name: "data"},
-							Spec: corev1.PersistentVolumeClaimSpec{
-								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-							},
-						},
-					},
-				},
-			},
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            sandboxName,
-					Namespace:       sandboxNs,
-					ResourceVersion: "1",
-					Labels: map[string]string{
-						sandboxLabel: nameHash,
-					},
-					Annotations: map[string]string{
-						"agents.x-k8s.io/template":               "default",
-						"agents.x-k8s.io/propagated-annotations": "agents.x-k8s.io/template",
-					},
-					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-							VolumeMounts: []corev1.VolumeMount{
-								{Name: "data", MountPath: "/data"},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						// config preserved, data replaced by PVC
-						{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"}}}},
-						{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-" + sandboxName}}},
-					},
-				},
-			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1alpha1.SandboxPodNameAnnotation: sandboxName,
-			},
-		},
-		{
-			name:        "annotated pod missing with replicas=1: clears annotation and recreates pod",
-			initialObjs: []runtime.Object{},
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      sandboxName,
-					Namespace: sandboxNs,
-					UID:       sandboxUID,
-					Annotations: map[string]string{
-						sandboxv1alpha1.SandboxPodNameAnnotation: "non-existent-pod",
-					},
-				},
-				Spec: sandboxv1alpha1.SandboxSpec{
-					Replicas: new(int32(1)),
-					PodTemplate: sandboxv1alpha1.PodTemplate{
-						ObjectMeta: sandboxv1alpha1.PodMetadata{
-							Annotations: map[string]string{
-								"agents.x-k8s.io/template": "default",
-							},
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "test-container",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            sandboxName,
-					Namespace:       sandboxNs,
-					ResourceVersion: "1",
-					Labels: map[string]string{
-						sandboxLabel: nameHash,
-					},
-					Annotations: map[string]string{
-						"agents.x-k8s.io/template":               "default",
-						"agents.x-k8s.io/propagated-annotations": "agents.x-k8s.io/template",
-					},
-					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name: "test-container",
-						},
-					},
-				},
-			},
-			expectErr: false,
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1alpha1.SandboxPodNameAnnotation: sandboxName,
-			},
-		},
-		{
-			name:        "annotated pod missing with replicas=0: clears annotation and does not recreate pod",
-			initialObjs: []runtime.Object{},
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      sandboxName,
-					Namespace: sandboxNs,
-					UID:       sandboxUID,
-					Annotations: map[string]string{
-						sandboxv1alpha1.SandboxPodNameAnnotation: "non-existent-pod",
-						"other-annotation":                       "keep-me",
-					},
-				},
-				Spec: sandboxv1alpha1.SandboxSpec{
-					Replicas: new(int32),
-				},
-			},
-			wantPod:   nil,
-			expectErr: false,
-			wantSandboxAnnotations: map[string]string{
-				"other-annotation": "keep-me",
-			},
 		},
 		{
 			name: "refuses to delete annotated pod owned by a different controller",
@@ -1727,13 +1527,8 @@ func TestReconcilePod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sandbox := tc.sandbox.DeepCopy()
 
-			fakeClient := newFakeClient(append(tc.initialObjs, sandbox)...)
-			if tc.wrapClient != nil {
-				fakeClient = tc.wrapClient(fakeClient)
-			}
-
 			r := SandboxReconciler{
-				Client:        fakeClient,
+				Client:        newFakeClient(append(tc.initialObjs, sandbox)...),
 				Scheme:        Scheme,
 				Tracer:        asmetrics.NewNoOp(),
 				ClusterDomain: "cluster.local",
@@ -1745,10 +1540,10 @@ func TestReconcilePod(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+			require.Equal(t, tc.wantPod, pod)
 
 			// Validate the Pod from the "cluster" (fake client)
 			if tc.wantPod != nil {
-				require.NotNil(t, pod, "expected pod to be returned")
 				livePod := &corev1.Pod{}
 				err = r.Get(t.Context(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, livePod)
 				require.NoError(t, err)
@@ -2651,7 +2446,9 @@ func TestSetServiceStatusCustomDomain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &SandboxReconciler{ClusterDomain: tc.clusterDomain}
+			r := &SandboxReconciler{
+				ClusterDomain: tc.clusterDomain,
+			}
 			sandbox := &sandboxv1alpha1.Sandbox{}
 			service := &corev1.Service{}
 			service.Name = "my-svc"

--- a/docs/keps/119-sandbox-suspended-state/README.md
+++ b/docs/keps/119-sandbox-suspended-state/README.md
@@ -1,0 +1,81 @@
+# Sandbox Suspended State with Status Condition
+
+<!-- toc -->
+- [Motivation](#motivation)
+- [Condition Hierarchy](#condition-hierarchy)
+    - [1. <code>Suspended</code>](#1-suspended)
+    - [2. <code>Ready</code> (Root Condition)](#2-ready-root-condition)
+- [Usage Examples](#usage-examples)
+- [Alternatives Considered](#alternatives-considered)
+    - [1. Retaining the Legacy <code>status.phase</code> Field](#1-retaining-the-legacy-statusphase-field)
+    - [2. Utilizing a Single &quot;Ready&quot; Condition](#2-utilizing-a-single-ready-condition)
+<!-- /toc -->
+
+## Motivation
+
+We currently expose a single `Ready` condition for Sandboxes. Because Sandbox acts as an "aggregation" object, a common convention is that `Ready` should be `True` when all child objects (Pod, Service, PVC) are applied to the cluster and are themselves `Ready`. However, relying purely on the `Ready` condition makes it harder to observe certain lifecycle transitions—specifically, when a Sandbox is in the process of scaling down (suspending). While a controller or user can observe that a Sandbox should be suspended from `spec` and verify `status.observedGeneration` to know the controller has acted on the spec, they lack a clear signal indicating whether the scale-down process is actively happening or if it has fully completed without deeply inspecting the child objects.
+
+Adding the `Suspended` condition explicitly solves this visibility gap for scale-down. Additionally, it lays the API groundwork for future enhancements like "soft pause". In a future soft pause scenario, a Sandbox's execution might be paused (e.g., freezing processes via the container runtime) without terminating the underlying Pod. An explicit `Suspended` condition provides a stable, consistent API abstraction to represent this halted state to users and automation, regardless of the underlying technical implementation.
+
+Furthermore, there is a growing need to represent a more diverse and granular status in the Agent Sandbox UI. A richer set of conditions allows the UI to provide clear, user-friendly feedback about the exact stage of a Sandbox's lifecycle, rather than just a simple binary Ready or Not Ready state.
+
+## Condition Hierarchy
+
+The Sandbox state is determined by multiple distinct layers. 
+
+#### 1. `Suspended`
+This condition explicitly tracks the suspension process of the Sandbox.
+* **Behavior:** When `True`, the Sandbox is no longer actively executing workloads due to a suspension request. The `Reason` field specifies *how* it is suspended (e.g., `PodTerminated`, `ProcessesFrozen`). When `False`, it implies the Sandbox is actively in the process of suspending. If not suspending, this condition is omitted.
+* **Ready Impact:** The moment a suspension is requested (e.g. `replicas: 0`), the `Ready` condition immediately transitions to `False` with the reason `SandboxSuspended`. It holds this reason through the entire suspending phase and remains that way once fully suspended.
+
+#### 2. `Ready` (Root Condition)
+The overarching signal for whether all child objects are successfully applied to the cluster and are themselves `Ready`.
+
+---
+
+## Condition Dependency Matrix
+
+The controller evaluates the hierarchy top-down.
+
+| Scenario | `Suspended` | Suspended Reason | Pod Phase | **`Ready` (Root)** | Ready Reason |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Provisioning** | None | None | None | **`False`** | `DependenciesNotReady` |
+| **Pod Starting** | None | None | Pending | **`False`** | `DependenciesNotReady` |
+| **Operational** | None | None | Running & Ready | **`True`** | `DependenciesReady` |
+| **Suspending** | `False` | `PodNotTerminated` | Running / Terminating | **`False`** | `SandboxSuspended` |
+| **Suspended** | `True` | `PodTerminated` | None | **`False`** | `SandboxSuspended` |
+
+## Usage Examples
+
+Standard Kubernetes tooling can now interact with the sandbox state natively:
+
+```bash
+# Block a CI/CD pipeline until the sandbox is fully operational and ready to take traffic
+kubectl wait --for=condition=Ready sandbox/my-env
+
+# Wait until the sandbox has successfully scaled down
+kubectl wait --for=condition=Suspended=True sandbox/my-env
+
+# Determine why a sandbox is not ready (e.g. DependenciesNotReady, SandboxExpired)
+kubectl get sandbox my-env -o custom-columns=READY_REASON:.status.conditions[?(@.type=="Ready")].reason
+
+# View the status of the Suspended condition explicitly
+kubectl get sandbox my-env -o custom-columns=SUSPENDED:.status.conditions[?(@.type=="Suspended")].status
+```
+
+## Alternatives Considered
+
+#### 1. Retaining the Legacy `status.phase` Field
+One option considered was to continue using the single-string `status.phase` field (e.g., `Pending`, `Running`, `Suspended`).
+
+* **Cons:**
+    * **Inability to Represent Concurrent States:** A single string cannot represent multiple facets of the lifecycle simultaneously. For example, if we wanted to represent a Sandbox that is "Hibernated" but also "Updating Network", we would end up with a combinatorial explosion of compound phase strings.
+    * **API Standards:** The Kubernetes API conventions explicitly deprecate the `Phase` pattern for new projects. Adhering to `Conditions` ensures compatibility with modern ecosystem tools like `kubectl wait`.
+    * **Logic Complexity:** As the sandbox evolves, the state machine would require an exponential number of strings to represent every possible combination of infrastructure and application health.
+
+#### 2. Utilizing a Single "Ready" Condition
+We considered using only the `Ready` condition and overloading the `Reason` field to communicate the state of the infrastructure and the Pod.
+
+* **Cons:**
+    * **Lack of Granularity for Future Suspend States:** A single `Ready: False` status cannot granularly distinguish between different types of suspension. Future features like "freeze" (pausing container processes), "hibernate" (snapshotting memory to disk), or traditional "scale-to-zero" would all appear identically as "not ready". Extracting `Suspended` into its own explicitly tracked condition gives us the design space to represent these nuanced operational states in the future.
+    * **Ambiguity in Suspension:** If only a `Ready` condition exists, setting it to `False` during suspension provides no programmatic signal that the network identity (Service) are still safely intact.

--- a/docs/keps/119-sandbox-suspended-state/kep.yaml
+++ b/docs/keps/119-sandbox-suspended-state/kep.yaml
@@ -1,0 +1,10 @@
+title: Agent Sandbox Suspended Condition Status
+kep-number: 2
+authors:
+  - "@SHRUTI6991"
+status: implementable
+creation-date: 2026-03-16
+reviewers:
+  - "@barney-s"
+approvers:
+  - "@janetkuo"

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -83,11 +83,11 @@ func TestSimpleSandbox(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod is Ready; Service Exists",
-					ObservedGeneration: 1,
-					Reason:             "DependenciesReady",
-					Status:             "True",
 					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1alpha1.SandboxReasonDependenciesReady,
+					Message:            "Pod is Ready; Service Exists",
 				},
 			},
 		}),

--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -486,7 +486,13 @@ func (cl *ClusterClient) MustWaitForObject(obj client.Object, p ...predicates.Ob
 func (cl *ClusterClient) WaitForObjectNotFound(ctx context.Context, obj client.Object) error {
 	cl.Helper()
 	// Static 1 minute timeout, this can be adjusted if needed
-	timeoutCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
+	timeout := DefaultTimeout
+	// Namespaces can take a while to clean up due to cascading deletion of resources.
+	if _, isNamespace := obj.(*corev1.Namespace); isNamespace {
+		timeout = 3 * time.Minute
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 
 	defer cancel()
 	start := time.Now()

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -15,7 +15,9 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +32,7 @@ func TestSandboxReplicas(t *testing.T) {
 
 	// Set up a namespace
 	ns := &corev1.Namespace{}
-	ns.Name = "my-sandbox-ns"
+	ns.Name = fmt.Sprintf("my-sandbox-ns-%d", time.Now().UnixNano())
 	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
 	// Create a Sandbox Object
 	sandboxObj := simpleSandbox(ns.Name)
@@ -42,16 +44,16 @@ func TestSandboxReplicas(t *testing.T) {
 	p := []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
 			Service:       "my-sandbox",
-			ServiceFQDN:   "my-sandbox.my-sandbox-ns.svc.cluster.local",
+			ServiceFQDN:   fmt.Sprintf("my-sandbox.%s.svc.cluster.local", ns.Name),
 			Replicas:      1,
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod is Ready; Service Exists",
-					ObservedGeneration: 1,
-					Reason:             "DependenciesReady",
-					Status:             "True",
 					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1alpha1.SandboxReasonDependenciesReady,
+					Message:            "Pod is Ready; Service Exists",
 				},
 			},
 		}),
@@ -60,12 +62,12 @@ func TestSandboxReplicas(t *testing.T) {
 	// Assert Pod and Service objects exist
 	pod := &corev1.Pod{}
 	pod.Name = "my-sandbox"
-	pod.Namespace = "my-sandbox-ns"
+	pod.Namespace = ns.Name
 	tc.MustExist(pod)
 
 	service := &corev1.Service{}
 	service.Name = "my-sandbox"
-	service.Namespace = "my-sandbox-ns"
+	service.Namespace = ns.Name
 	tc.MustExist(service)
 
 	// Set replicas to zero
@@ -77,16 +79,23 @@ func TestSandboxReplicas(t *testing.T) {
 	p = []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1alpha1.SandboxStatus{
 			Service:       "my-sandbox",
-			ServiceFQDN:   "my-sandbox.my-sandbox-ns.svc.cluster.local",
+			ServiceFQDN:   fmt.Sprintf("my-sandbox.%s.svc.cluster.local", ns.Name),
 			Replicas:      0,
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod does not exist, replicas is 0; Service Exists",
-					ObservedGeneration: 2,
-					Reason:             "DependenciesReady",
-					Status:             "True",
 					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
+					Reason:             sandboxv1alpha1.SandboxReasonSuspended,
+					Message:            "Sandbox is suspended",
+				},
+				{
+					Type:               string(sandboxv1alpha1.SandboxConditionSuspended),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 2,
+					Reason:             sandboxv1alpha1.SandboxReasonSuspendedPodTerminated,
+					Message:            "Pod has been terminated. Sandbox is not operational.",
 				},
 			},
 		}),

--- a/test/e2e/shutdown_test.go
+++ b/test/e2e/shutdown_test.go
@@ -49,11 +49,11 @@ func TestSandboxShutdownTime(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod is Ready; Service Exists",
-					ObservedGeneration: 1,
-					Reason:             "DependenciesReady",
-					Status:             "True",
 					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1alpha1.SandboxReasonDependenciesReady,
+					Message:            "Pod is Ready; Service Exists",
 				},
 			},
 		}),
@@ -85,11 +85,11 @@ func TestSandboxShutdownTime(t *testing.T) {
 			Replicas:    0,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Sandbox has expired",
+					Type:               string(sandboxv1alpha1.SandboxConditionReady),
+					Status:             metav1.ConditionFalse,
 					ObservedGeneration: 2,
-					Reason:             "SandboxExpired",
-					Status:             "False",
-					Type:               "Ready",
+					Reason:             sandboxv1alpha1.SandboxReasonExpired,
+					Message:            "Sandbox has expired",
 				},
 			},
 		}),

--- a/test/e2e/volumeclaimtemplate_test.go
+++ b/test/e2e/volumeclaimtemplate_test.go
@@ -84,11 +84,11 @@ func TestSandboxVolumeClaimTemplates(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
-					Message:            "Pod is Ready; Service Exists",
-					ObservedGeneration: 1,
-					Reason:             "DependenciesReady",
-					Status:             "True",
 					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1alpha1.SandboxReasonDependenciesReady,
+					Message:            "Pod is Ready; Service Exists",
 				},
 			},
 		}),


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/agent-sandbox/issues/525

# PR Description

## Title
`feat: introduce Suspended status condition for granular sandbox lifecycle tracking`

## Description
This PR implements explicit `Suspended` condition handling for Sandboxes, moving away from binary `Ready` state tracking. 

Previously, relying entirely on `Ready: True/False` created an observability gap. Users and automated systems couldn't easily tell if a Sandbox was actively scaling down, fully suspended, or failing due to an error without deeply digging into child resources (Pods, Services, PVCs). 

This change introduces a dedicated `Suspended` condition type and establishes a clear top-down condition hierarchy. It also provides the necessary API contract to support future features like process-freezing ("soft pause") or memory snapshotting ("hibernation") without breaking backward compatibility.

## Key Changes
* **New Condition Type**: Introduced the `Suspended` condition (`status.conditions[?(@.type=="Suspended")]`).
* **Condition Hierarchy Logic**: Integrated a top-down evaluation matrix into the Sandbox controller:
  * When a suspension is requested (e.g., scale-to-zero), `Ready` immediately transitions to `False` with the reason `SandboxSuspended`.
  * `Suspended` is set to `False` while the scale-down is in progress (`PodNotTerminated`).
  * `Suspended` transitions to `True` only when the underlying Pod is fully removed (`PodTerminated`).
* **UI & Tooling Support**: Enables granular state rendering for the Agent Sandbox UI and allows native CLI orchestration via `kubectl wait --for=condition=Suspended=True`.

## Condition State Matrix Implemented

| Scenario | `Suspended` Status | Suspended Reason | `Ready` Status | Ready Reason |
| :--- | :--- | :--- | :--- | :--- |
| **Operational** | None | None | **`True`** | `DependenciesReady` |
| **Suspending** | `False` | `PodNotTerminated` | **`False`** | `SandboxSuspended` |
| **Suspended** | `True` | `PodTerminated` | **`False`** | `SandboxSuspended` |
| **Resuming** | None | None | **`False`** | `DependenciesNotReady` |

### Testing Strategy

1. Added new unit test
2. Updated the E2E test to reflect the new status in `replicas_test`.