### PR TITLE
Re-Implement worker thread collision avoidance for warm pool adoption

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -47,9 +47,10 @@ var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
 // SandboxClaimReconciler reconciles a SandboxClaim object
 type SandboxClaimReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Tracer   asmetrics.Instrumenter
+	Scheme                  *runtime.Scheme
+	Recorder                record.EventRecorder
+	Tracer                  asmetrics.Instrumenter
+	MaxConcurrentReconciles int
 }
 
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims,verbs=get;list;watch;create;update;patch;delete
@@ -352,71 +353,88 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 		return candidates[i].CreationTimestamp.Before(&candidates[j].CreationTimestamp)
 	})
 
-	var readyCandidates []*v1alpha1.Sandbox
-	for _, c := range candidates {
-		if isSandboxReady(c) {
-			readyCandidates = append(readyCandidates, c)
-		}
-	}
-	if len(readyCandidates) == 0 {
-		log.Info("No ready warm pool candidates, falling through to cold start",
-			"totalCandidates", len(candidates))
+	if len(candidates) == 0 {
+		log.Info("No warm pool candidates available, falling through to cold start")
 		return nil, nil
 	}
 
-	adopted := readyCandidates[0]
-	log.Info("Adopting sandbox from warm pool", "sandbox", adopted.Name)
+	// Determine the search range for collision avoidance.
+	n := len(candidates)
+	workerCount := r.MaxConcurrentReconciles
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+	searchWindow := min(n, workerCount)
 
-	// Remove warm pool labels so the sandbox no longer appears in warm pool queries
-	delete(adopted.Labels, warmPoolSandboxLabel)
-	delete(adopted.Labels, sandboxTemplateRefHash)
+	// Compute a starting index deterministic to this specific Claim UID.
+	hashValue := sandboxcontrollers.GetNumericHash(string(claim.UID))
+	startIndex := int(hashValue % uint32(searchWindow))
 
-	// Extract pool name from owner reference before clearing
-	poolName := "none"
-	if controllerRef := metav1.GetControllerOf(adopted); controllerRef != nil {
-		poolName = controllerRef.Name
+	// Iterate through the entire list starting from the hashed offset.
+	for i := 0; i < n; i++ {
+		currIndex := (startIndex + i) % n
+		adopted := candidates[currIndex]
+
+		// Extract pool name from owner reference before clearing
+		poolName := "none"
+		if controllerRef := metav1.GetControllerOf(adopted); controllerRef != nil {
+			poolName = controllerRef.Name
+		}
+
+		log.Info(fmt.Sprintf("Attempting sandbox adoption: sandbox=%s, pool=%s", adopted.Name, poolName))
+
+		// Remove warm pool labels so the sandbox no longer appears in warm pool queries
+		delete(adopted.Labels, warmPoolSandboxLabel)
+		delete(adopted.Labels, sandboxTemplateRefHash)
+
+		// Transfer ownership from SandboxWarmPool to SandboxClaim
+		adopted.OwnerReferences = nil
+		if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
+			return nil, fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
+		}
+
+		// Propagate trace context from claim
+		if adopted.Annotations == nil {
+			adopted.Annotations = make(map[string]string)
+		}
+		if tc, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
+			adopted.Annotations[asmetrics.TraceContextAnnotation] = tc
+		}
+
+		// Add sandbox ID label to pod template for NetworkPolicy targeting
+		if adopted.Spec.PodTemplate.ObjectMeta.Labels == nil {
+			adopted.Spec.PodTemplate.ObjectMeta.Labels = make(map[string]string)
+		}
+		adopted.Spec.PodTemplate.ObjectMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
+
+		// Update uses optimistic concurrency (resourceVersion) so concurrent
+		// claims racing to adopt the same sandbox will conflict and retry.
+		if err := r.Update(ctx, adopted); err != nil {
+			if k8errors.IsConflict(err) || k8errors.IsNotFound(err) {
+				// Another worker adopted this sandbox while we were processing; try next candidate.
+				continue
+			}
+			log.Error(err, "Failed to update adopted sandbox")
+			return nil, err
+		}
+
+		log.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
+
+		if r.Recorder != nil {
+			r.Recorder.Event(claim, corev1.EventTypeNormal, "SandboxAdopted", fmt.Sprintf("Adopted warm pool Sandbox %q", adopted.Name))
+		}
+
+		podCondition := "not_ready"
+		if isSandboxReady(adopted) {
+			podCondition = "ready"
+		}
+		asmetrics.RecordSandboxClaimCreation(claim.Namespace, claim.Spec.TemplateRef.Name, asmetrics.LaunchTypeWarm, poolName, podCondition)
+
+		return adopted, nil
 	}
 
-	// Transfer ownership from SandboxWarmPool to SandboxClaim
-	adopted.OwnerReferences = nil
-	if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
-		return nil, fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
-	}
-
-	// Propagate trace context from claim
-	if adopted.Annotations == nil {
-		adopted.Annotations = make(map[string]string)
-	}
-	if tc, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
-		adopted.Annotations[asmetrics.TraceContextAnnotation] = tc
-	}
-
-	// Add sandbox ID label to pod template for NetworkPolicy targeting
-	if adopted.Spec.PodTemplate.ObjectMeta.Labels == nil {
-		adopted.Spec.PodTemplate.ObjectMeta.Labels = make(map[string]string)
-	}
-	adopted.Spec.PodTemplate.ObjectMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
-
-	// Update uses optimistic concurrency (resourceVersion) so concurrent
-	// claims racing to adopt the same sandbox will conflict and retry.
-	if err := r.Update(ctx, adopted); err != nil {
-		log.Error(err, "Failed to update adopted sandbox")
-		return nil, err
-	}
-
-	log.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
-
-	if r.Recorder != nil {
-		r.Recorder.Event(claim, corev1.EventTypeNormal, "SandboxAdopted", fmt.Sprintf("Adopted warm pool Sandbox %q", adopted.Name))
-	}
-
-	podCondition := "not_ready"
-	if isSandboxReady(adopted) {
-		podCondition = "ready"
-	}
-	asmetrics.RecordSandboxClaimCreation(claim.Namespace, claim.Spec.TemplateRef.Name, asmetrics.LaunchTypeWarm, poolName, podCondition)
-
-	return adopted, nil
+	log.Info("Failed to adopt any sandbox after checking all candidates")
+	return nil, nil // Return nil, nil to fall completely to cold start
 }
 
 // isSandboxReady checks if a sandbox has Ready=True condition
@@ -619,6 +637,7 @@ func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensi
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
+	r.MaxConcurrentReconciles = concurrentWorkers
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&extensionsv1alpha1.SandboxClaim{}).
 		Owns(&v1alpha1.Sandbox{}).

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -843,6 +843,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		expectSandboxAdoption   bool
 		expectedAdoptedSandbox  string
 		expectNewSandboxCreated bool
+		simulateConflicts       int
 	}{
 		{
 			name: "adopts oldest ready sandbox from warm pool",
@@ -915,26 +916,47 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: false,
 		},
 		{
-			name: "cold starts when all warm pool sandboxes are non-ready",
+			name: "adopts oldest non-ready sandbox when no ready sandboxes exist",
 			existingObjects: []client.Object{
 				template,
 				claim,
 				createWarmPoolSandbox("not-ready-1", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}, false),
 				createWarmPoolSandbox("not-ready-2", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, false),
 			},
-			expectSandboxAdoption:   false,
-			expectNewSandboxCreated: true,
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "not-ready-1",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name: "retries on conflict when adopting sandbox",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true),
+				createWarmPoolSandbox("pool-sb-2", metav1.Now(), true),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "pool-sb-2",
+			expectNewSandboxCreated: false,
+			simulateConflicts:       1, // Fail update on the first sandbox, succeed on the second
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newScheme(t)
-			fakeClient := fake.NewClientBuilder().
+			var fakeClient client.Client = fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(tc.existingObjects...).
 				WithStatusSubresource(claim).
 				Build()
+
+			if tc.simulateConflicts > 0 {
+				fakeClient = &conflictClient{
+					Client:       fakeClient,
+					maxConflicts: tc.simulateConflicts,
+				}
+			}
 
 			reconciler := &SandboxClaimReconciler{
 				Client:   fakeClient,
@@ -1288,4 +1310,20 @@ func newScheme(t *testing.T) *runtime.Scheme {
 
 func ignoreTimestamp(_, _ metav1.Time) bool {
 	return true
+}
+
+type conflictClient struct {
+	client.Client
+	conflictCount int
+	maxConflicts  int
+}
+
+func (c *conflictClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if sandbox, ok := obj.(*sandboxv1alpha1.Sandbox); ok {
+		if c.conflictCount < c.maxConflicts {
+			c.conflictCount++
+			return k8errors.NewConflict(sandboxv1alpha1.Resource("sandboxes"), sandbox.Name, fmt.Errorf("simulated conflict"))
+		}
+	}
+	return c.Client.Update(ctx, obj, opts...)
 }


### PR DESCRIPTION
This pull request restores the deterministic "window" selection logic for SandboxClaim workers when adopting resources from the warm pool. This mechanism was previously introduced in PR #391 but was inadvertently removed during the refactor in PR #395, which transitioned the warm pool to use full Sandbox CRs instead of bare pods.