### PR TITLE
fix: update comment for Selector field in SandboxWarmPoolStatus

### DIFF
--- a/extensions/api/v1alpha1/sandboxwarmpool_types.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_types.go
@@ -44,7 +44,7 @@ type SandboxWarmPoolStatus struct {
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 
-	// Selector is the label selector used to find the pods in the pool.
+	// selector is the label selector used to find the pods in the pool.
 	// +optional
 	Selector string `json:"selector,omitempty"`
 }


### PR DESCRIPTION
To fix for lint-api
```shell
  /home/prow/go/src/github.com/kubernetes-sigs/agent-sandbox/dev/tools/tmp/bin/golangci-kube-api-linter run --config=/home/prow/go/src/github.com/kubernetes-sigs/agent-sandbox/dev/tools/.golangci-kal.yml
../../extensions/api/v1alpha1/sandboxwarmpool_types.go:47:2: commentstart: godoc for field SandboxWarmPoolStatus.Selector should start with 'selector ...' (kubeapilinter)
	// Selector is the label selector used to find the pods in the pool.
	^
1 issues:
* kubeapilinter: 1
Building golangci-ku
```