### PR TITLE
fixed broken icon links on README and site

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -132,6 +132,9 @@ module:
   - disableWatch: false
     source: assets
     target: assets
+  - disableWatch: false
+    source: assets
+    target: static/assets
   - disableWatch: true
     source: ../
     target: assets/additional

--- a/site/layouts/shortcodes/include-file.html
+++ b/site/layouts/shortcodes/include-file.html
@@ -11,5 +11,6 @@
 {{/* Fix all relative README.md and INSTALL.md links */}}
 {{- $content = replaceRE `\]\((\./)?README\.md(#[^)]+)?\)` (printf "](%s$1)" (strings.TrimSuffix "/" $sectionPath)) $content -}}
 {{- $content = replaceRE `\]\(\.\.\/\.\./(README|INSTALL)\.md(#[^)]+)?\)` "](/docs/getting_started/$2)" $content -}}
+{{- $content = replaceRE `src="site/assets/` `src="/assets/` $content -}}
 
 {{- $content | markdownify -}}


### PR DESCRIPTION
When logo (or other artifacts with relative links) are referenced in the repo (e.g. README), they end up breaking on the website getting started page.

<img width="825" height="547" alt="image" src="https://github.com/user-attachments/assets/d8cefa63-4a38-4f05-bc2d-efa724ce02fe" />

This PR address this issue for assets - rewriting `site/assets/` URLs