### PR TITLE
fix: fix broken links and mermaid diagram on doc website

### DIFF
--- a/site/content/docs/getting_started/_index.md
+++ b/site/content/docs/getting_started/_index.md
@@ -6,4 +6,4 @@ description: >
   How to get started with Agent Sandbox
 ---
 
-{{% include-file file="additional/README.md" %}}
+{{< include-file file="additional/README.md" >}}

--- a/site/layouts/shortcodes/include-file.html
+++ b/site/layouts/shortcodes/include-file.html
@@ -13,4 +13,10 @@
 {{- $content = replaceRE `\]\(\.\.\/\.\./(README|INSTALL)\.md(#[^)]+)?\)` "](/docs/getting_started/$2)" $content -}}
 {{- $content = replaceRE `src="site/assets/` `src="/assets/` $content -}}
 
-{{- $content | markdownify -}}
+{{/* Rewrite remaining relative links to point to the GitHub repo */}}
+{{- $ghBase := "https://github.com/kubernetes-sigs/agent-sandbox/blob/main/" -}}
+{{- $ghTree := "https://github.com/kubernetes-sigs/agent-sandbox/tree/main/" -}}
+{{- $content = replaceRE `\]\(([a-zA-Z][a-zA-Z0-9_/.+-]*)/\)` (printf "](%s$1/)" $ghTree) $content -}}
+{{- $content = replaceRE `\]\(([a-zA-Z][a-zA-Z0-9_/.+-]*\.[a-zA-Z0-9]+)\)` (printf "](%s$1)" $ghBase) $content -}}
+
+{{- $content | .Page.RenderString -}}


### PR DESCRIPTION
Replace `markdownify` with `.Page.RenderString` in the include-file shortcode to properly render fenced code blocks (including mermaid diagrams). Switch the getting_started page from `{{% %}}` to `{{< >}}` shortcode syntax to prevent double markdown processing that caused HTML double-escaping.

Add regex rewrites to convert remaining relative repo links (examples/, roadmap.md, docs/configuration.md, etc.) to their corresponding GitHub URLs.