### PR TITLE
warm pool: template content hash for spec-drift detection

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -396,6 +396,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 		// Remove warm pool labels so the sandbox no longer appears in warm pool queries
 		delete(adopted.Labels, warmPoolSandboxLabel)
 		delete(adopted.Labels, sandboxTemplateRefHash)
+		delete(adopted.Labels, templateContentHashLabel)
 
 		// Transfer ownership from SandboxWarmPool to SandboxClaim
 		adopted.OwnerReferences = nil
@@ -614,6 +615,27 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			continue
 		}
 		adoptionCandidates = append(adoptionCandidates, sb)
+	}
+
+	// Filter adoption candidates by template content hash to avoid adopting
+	// sandboxes created from a stale template spec.
+	if len(adoptionCandidates) > 0 {
+		template, err := r.getTemplate(ctx, claim)
+		if err == nil && template != nil {
+			contentHash := templateContentHash(template)
+			var filtered []*v1alpha1.Sandbox
+			for _, c := range adoptionCandidates {
+				if ch := c.Labels[templateContentHashLabel]; ch != "" && ch != contentHash {
+					logger.Info("skipping stale adoption candidate (content hash mismatch)",
+						"sandbox", c.Name,
+						"sandboxHash", ch,
+						"currentHash", contentHash)
+					continue
+				}
+				filtered = append(filtered, c)
+			}
+			adoptionCandidates = filtered
+		}
 	}
 
 	// Try to adopt from warm pool

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1309,6 +1309,217 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 	})
 }
 
+func TestSandboxClaimAdoptionSkipsStaleContentHash(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "new-image:v2"}},
+				},
+			},
+		},
+	}
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hash-claim", Namespace: "default",
+			UID: "hash-claim-uid",
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+		},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	currentHash := templateContentHash(template)
+
+	// Stale sandbox: content hash from old template version.
+	staleSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "stale-sb", Namespace: "default",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+			Labels: map[string]string{
+				warmPoolSandboxLabel:     poolNameHash,
+				sandboxTemplateRefHash:   sandboxcontrollers.NameHash("test-template"),
+				templateContentHashLabel: "oldold00",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1", Kind: "SandboxWarmPool",
+				Name: "test-pool", UID: "wp-uid", Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "old-image:v1"}}},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}},
+		},
+	}
+
+	// Fresh sandbox: content hash matches current template.
+	freshSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fresh-sb", Namespace: "default",
+			CreationTimestamp: metav1.Now(),
+			Labels: map[string]string{
+				warmPoolSandboxLabel:     poolNameHash,
+				sandboxTemplateRefHash:   sandboxcontrollers.NameHash("test-template"),
+				templateContentHashLabel: currentHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1", Kind: "SandboxWarmPool",
+				Name: "test-pool", UID: "wp-uid", Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "new-image:v2"}}},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}},
+		},
+	}
+
+	reconciler := &SandboxClaimReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(template, claim, staleSandbox, freshSandbox).
+			WithStatusSubresource(claim).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		Tracer:   asmetrics.NewNoOp(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "hash-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	// Should have adopted the fresh sandbox, not the stale one.
+	var adopted sandboxv1alpha1.Sandbox
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "fresh-sb", Namespace: "default"}, &adopted)
+	if err != nil {
+		t.Fatalf("failed to get fresh sandbox: %v", err)
+	}
+	controllerRef := metav1.GetControllerOf(&adopted)
+	if controllerRef == nil || controllerRef.UID != claim.UID {
+		t.Fatalf("expected fresh-sb to be adopted by claim, got controller %v", controllerRef)
+	}
+
+	// Stale sandbox should still be owned by warm pool (not adopted).
+	var stale sandboxv1alpha1.Sandbox
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "stale-sb", Namespace: "default"}, &stale)
+	if err != nil {
+		t.Fatalf("failed to get stale sandbox: %v", err)
+	}
+	staleRef := metav1.GetControllerOf(&stale)
+	if staleRef != nil && staleRef.UID == claim.UID {
+		t.Fatal("stale sandbox should not have been adopted by claim")
+	}
+}
+
+func TestSandboxClaimAdoptionRemovesContentHashLabel(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "label-claim", Namespace: "default", UID: "label-claim-uid",
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+		},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	contentHash := templateContentHash(template)
+
+	poolSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pool-sb", Namespace: "default",
+			CreationTimestamp: metav1.Now(),
+			Labels: map[string]string{
+				warmPoolSandboxLabel:     poolNameHash,
+				sandboxTemplateRefHash:   sandboxcontrollers.NameHash("test-template"),
+				templateContentHashLabel: contentHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1", Kind: "SandboxWarmPool",
+				Name: "test-pool", UID: "wp-uid", Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}},
+		},
+	}
+
+	reconciler := &SandboxClaimReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(template, claim, poolSandbox).
+			WithStatusSubresource(claim).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		Tracer:   asmetrics.NewNoOp(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "label-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	var adopted sandboxv1alpha1.Sandbox
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "pool-sb", Namespace: "default"}, &adopted)
+	if err != nil {
+		t.Fatalf("failed to get adopted sandbox: %v", err)
+	}
+
+	// All warm pool labels should be removed after adoption.
+	if _, exists := adopted.Labels[warmPoolSandboxLabel]; exists {
+		t.Error("warmPoolSandboxLabel should be removed after adoption")
+	}
+	if _, exists := adopted.Labels[sandboxTemplateRefHash]; exists {
+		t.Error("sandboxTemplateRefHash should be removed after adoption")
+	}
+	if _, exists := adopted.Labels[templateContentHashLabel]; exists {
+		t.Error("templateContentHashLabel should be removed after adoption")
+	}
+}
+
 func newScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	if err := sandboxv1alpha1.AddToScheme(scheme); err != nil {

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -16,6 +16,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -39,9 +41,24 @@ import (
 )
 
 const (
-	sandboxTemplateRefHash = "agents.x-k8s.io/sandbox-template-ref-hash"
-	warmPoolSandboxLabel   = "agents.x-k8s.io/warm-pool-sandbox"
+	sandboxTemplateRefHash       = "agents.x-k8s.io/sandbox-template-ref-hash"
+	warmPoolSandboxLabel         = "agents.x-k8s.io/warm-pool-sandbox"
+	templateContentHashLabel     = "agents.x-k8s.io/template-content-hash"
 )
+
+// templateContentHash computes a SHA-256 hash over the JSON-serialized
+// SandboxTemplate spec, returning the first 8 hex chars. This captures
+// everything the template defines and is used to detect spec drift between
+// warm pool sandboxes and the current template.
+func templateContentHash(template *extensionsv1alpha1.SandboxTemplate) string {
+	data, err := json.Marshal(template.Spec)
+	if err != nil {
+		// Spec is always serializable; this should never happen.
+		return "00000000"
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])[:8]
+}
 
 // SandboxWarmPoolReconciler reconciles a SandboxWarmPool object
 type SandboxWarmPoolReconciler struct {
@@ -142,6 +159,37 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 				"controller", controllerRef.Name,
 				"controllerKind", controllerRef.Kind)
 		}
+	}
+
+	// Compute the current template content hash to detect spec drift.
+	currentContentHash := ""
+	if template, err := r.getTemplate(ctx, warmPool); err == nil {
+		currentContentHash = templateContentHash(template)
+	} else if !k8serrors.IsNotFound(err) {
+		log.Error(err, "Failed to get template for content hash")
+		allErrors = errors.Join(allErrors, err)
+	}
+
+	// Delete sandboxes whose template content hash doesn't match the
+	// current template spec (stale from a prior template version).
+	if currentContentHash != "" {
+		var freshSandboxes []sandboxv1alpha1.Sandbox
+		for _, sb := range activeSandboxes {
+			sbHash := sb.Labels[templateContentHashLabel]
+			if sbHash != "" && sbHash != currentContentHash {
+				log.Info("Deleting stale warm pool sandbox (template content hash mismatch)",
+					"sandbox", sb.Name,
+					"sandboxHash", sbHash,
+					"currentHash", currentContentHash)
+				if err := r.Delete(ctx, &sb); err != nil {
+					log.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
+					allErrors = errors.Join(allErrors, err)
+				}
+				continue
+			}
+			freshSandboxes = append(freshSandboxes, sb)
+		}
+		activeSandboxes = freshSandboxes
 	}
 
 	const warmPoolReadinessGracePeriod = 5 * time.Minute
@@ -245,10 +293,14 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 		return err
 	}
 
+	// Compute template content hash for spec-drift detection.
+	contentHash := templateContentHash(template)
+
 	// Build labels for the Sandbox CR
 	sandboxLabels := map[string]string{
-		warmPoolSandboxLabel:   poolNameHash,
-		sandboxTemplateRefHash: sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name),
+		warmPoolSandboxLabel:     poolNameHash,
+		sandboxTemplateRefHash:   sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name),
+		templateContentHashLabel: contentHash,
 	}
 
 	// Copy template pod labels into sandbox pod template
@@ -258,6 +310,7 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	}
 	// Propagate template ref hash to pod template for NetworkPolicy targeting
 	podLabels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name)
+	podLabels[templateContentHashLabel] = contentHash
 
 	podAnnotations := make(map[string]string)
 	for k, v := range template.Spec.PodTemplate.ObjectMeta.Annotations {

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -525,6 +525,149 @@ func TestReconcilePoolReadyReplicas(t *testing.T) {
 	}
 }
 
+func TestTemplateContentHash(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		tmpl := createTemplate("default")
+		h1 := templateContentHash(tmpl)
+		h2 := templateContentHash(tmpl)
+		require.Equal(t, h1, h2)
+		require.Len(t, h1, 8)
+	})
+
+	t.Run("changes on spec change", func(t *testing.T) {
+		tmpl1 := createTemplate("default")
+		h1 := templateContentHash(tmpl1)
+
+		tmpl2 := createTemplate("default")
+		tmpl2.Spec.PodTemplate.Spec.Containers[0].Image = "different-image"
+		h2 := templateContentHash(tmpl2)
+
+		require.NotEqual(t, h1, h2)
+	})
+
+	t.Run("ignores metadata changes", func(t *testing.T) {
+		tmpl1 := createTemplate("default")
+		h1 := templateContentHash(tmpl1)
+
+		tmpl2 := createTemplate("default")
+		tmpl2.Name = "different-name"
+		tmpl2.ResourceVersion = "12345"
+		h2 := templateContentHash(tmpl2)
+
+		require.Equal(t, h1, h2)
+	})
+}
+
+func TestReconcilePoolContentHashStamped(t *testing.T) {
+	poolName := "test-pool"
+	poolNamespace := "default"
+	templateName := "test-template"
+	replicas := int32(2)
+
+	template := createTemplate(poolNamespace)
+	scheme := newTestScheme()
+
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+		},
+		Spec: extensionsv1alpha1.SandboxWarmPoolSpec{
+			Replicas: replicas,
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+				Name: templateName,
+			},
+		},
+	}
+
+	r := SandboxWarmPoolReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(template).
+			Build(),
+		Scheme: scheme,
+	}
+
+	ctx := context.Background()
+	err := r.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+
+	list := &sandboxv1alpha1.SandboxList{}
+	err = r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace})
+	require.NoError(t, err)
+	require.Len(t, list.Items, int(replicas))
+
+	expectedHash := templateContentHash(template)
+	for _, sb := range list.Items {
+		require.Equal(t, expectedHash, sb.Labels[templateContentHashLabel],
+			"sandbox %s should have template content hash label", sb.Name)
+		require.Equal(t, expectedHash, sb.Spec.PodTemplate.ObjectMeta.Labels[templateContentHashLabel],
+			"sandbox %s pod template should have content hash label", sb.Name)
+	}
+}
+
+func TestReconcilePoolRotatesStale(t *testing.T) {
+	poolName := "test-pool"
+	poolNamespace := "default"
+	templateName := "test-template"
+	replicas := int32(2)
+
+	template := createTemplate(poolNamespace)
+	scheme := newTestScheme()
+
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+		},
+		Spec: extensionsv1alpha1.SandboxWarmPoolSpec{
+			Replicas: replicas,
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+				Name: templateName,
+			},
+		},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash(poolName)
+
+	// Create sandboxes with an old content hash.
+	createStaleSandbox := func(suffix string) *sandboxv1alpha1.Sandbox {
+		sb := createPoolSandbox(poolName, poolNamespace, poolNameHash, suffix)
+		sb.Labels[templateContentHashLabel] = "oldold00"
+		return sb
+	}
+
+	r := SandboxWarmPoolReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(
+				template,
+				createStaleSandbox("-stale1"),
+				createStaleSandbox("-stale2"),
+			).
+			Build(),
+		Scheme: scheme,
+	}
+
+	ctx := context.Background()
+
+	// First reconcile: deletes stale sandboxes and creates fresh ones.
+	err := r.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+
+	list := &sandboxv1alpha1.SandboxList{}
+	err = r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace})
+	require.NoError(t, err)
+
+	currentHash := templateContentHash(template)
+	for _, sb := range list.Items {
+		if sb.Labels[warmPoolSandboxLabel] == poolNameHash {
+			require.Equal(t, currentHash, sb.Labels[templateContentHashLabel],
+				"sandbox %s should have current content hash after rotation", sb.Name)
+		}
+	}
+}
+
 func TestReconcilePoolGCStuckSandboxes(t *testing.T) {
 	poolName := "test-pool"
 	poolNamespace := "default"


### PR DESCRIPTION
## Summary

- Add `agents.x-k8s.io/template-content-hash` label to warm pool sandboxes, computed as the first 8 hex chars of a SHA-256 hash over the JSON-serialized `SandboxTemplate.Spec`
- **Warm pool controller**: detects and deletes stale sandboxes when the referenced template spec changes (image, resources, network policy, etc.), then re-creates at desired replica count
- **Claim controller**: filters adoption candidates by content hash so claims never adopt sandboxes built from an outdated template spec
- Label is removed during adoption alongside existing warm pool labels

## Motivation

When a `SandboxTemplate` is updated (e.g. new container image, changed resource limits), existing warm pool sandboxes still reflect the old spec. Without this change:

1. The warm pool controller keeps serving stale sandboxes until they're manually cleaned up
2. Claims can adopt sandboxes with an outdated spec, causing unexpected behavior (wrong image, missing env vars, etc.)

This is the controller-side complement to server-side pool revisioning -- both mechanisms are independent and complementary.

## Test plan

- [x] `templateContentHash()` is deterministic, changes on spec changes, ignores metadata
- [x] Created sandboxes are stamped with content hash on both CR and pod template labels
- [x] Stale sandboxes (mismatched content hash) are rotated out and replaced
- [x] Adoption candidates with stale content hash are skipped
- [x] Content hash label is removed during adoption
- [x] All existing warm pool and claim controller tests pass
- [ ] E2E: update a template image, verify old sandboxes are rotated and new claims get fresh sandboxes