### PR TITLE
fix: preserve pod template annotations during warm adoption

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -424,6 +424,9 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
 		changed := false
 		if pod.Labels[sandboxLabel] != nameHash {
 			pod.Labels[sandboxLabel] = nameHash
@@ -433,6 +436,12 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 			if pod.Labels[k] != v {
 				pod.Labels[k] = v
+				changed = true
+			}
+		}
+		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+			if pod.Annotations[k] != v {
+				pod.Annotations[k] = v
 				changed = true
 			}
 		}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -613,6 +613,9 @@ func TestReconcilePod(t *testing.T) {
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						"custom-label":                      "label-val",
 					},
+					Annotations: map[string]string{
+						"custom-annotation": "anno-val",
+					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.PodSpec{
@@ -685,7 +688,7 @@ func TestReconcilePod(t *testing.T) {
 			wantPod: nil,
 		},
 		{
-			name: "adopts existing pod via annotation - pod gets label and owner reference",
+			name: "adopts existing pod via annotation - pod gets metadata and owner reference",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -713,6 +716,11 @@ func TestReconcilePod(t *testing.T) {
 				Spec: sandboxv1alpha1.SandboxSpec{
 					Replicas: ptr.To(int32(1)),
 					PodTemplate: sandboxv1alpha1.PodTemplate{
+						ObjectMeta: sandboxv1alpha1.PodMetadata{
+							Annotations: map[string]string{
+								"io.codewire.sh/workspace": "true",
+							},
+						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
@@ -730,6 +738,9 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "2",
 					Labels: map[string]string{
 						sandboxLabel: nameHash,
+					},
+					Annotations: map[string]string{
+						"io.codewire.sh/workspace": "true",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
@@ -782,6 +793,9 @@ func TestReconcilePod(t *testing.T) {
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation": "anno-val",
 					},
 					// Should still have the original controller reference
 					OwnerReferences: []metav1.OwnerReference{

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -339,8 +339,31 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1alpha1.S
 	}
 }
 
+func mergeTemplatePodMetadata(target *v1alpha1.PodMetadata, template v1alpha1.PodMetadata) {
+	if len(template.Labels) > 0 {
+		if target.Labels == nil {
+			target.Labels = make(map[string]string, len(template.Labels))
+		}
+		for k, v := range template.Labels {
+			if _, exists := target.Labels[k]; !exists {
+				target.Labels[k] = v
+			}
+		}
+	}
+	if len(template.Annotations) > 0 {
+		if target.Annotations == nil {
+			target.Annotations = make(map[string]string, len(template.Annotations))
+		}
+		for k, v := range template.Annotations {
+			if _, exists := target.Annotations[k]; !exists {
+				target.Annotations[k] = v
+			}
+		}
+	}
+}
+
 // adoptSandboxFromCandidates picks the best candidate and transfers ownership to the claim.
-func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, candidates []*v1alpha1.Sandbox) (*v1alpha1.Sandbox, error) {
+func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, template *extensionsv1alpha1.SandboxTemplate, candidates []*v1alpha1.Sandbox) (*v1alpha1.Sandbox, error) {
 	log := log.FromContext(ctx)
 
 	// Sort: ready sandboxes first, then by creation time (oldest first)
@@ -399,6 +422,10 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 		}
 		if tc, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
 			adopted.Annotations[asmetrics.TraceContextAnnotation] = tc
+		}
+
+		if template != nil {
+			mergeTemplatePodMetadata(&adopted.Spec.PodTemplate.ObjectMeta, template.Spec.PodTemplate.ObjectMeta)
 		}
 
 		// Add sandbox ID label to pod template for NetworkPolicy targeting
@@ -605,7 +632,12 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 
 	// Try to adopt from warm pool
 	if len(adoptionCandidates) > 0 {
-		adopted, err := r.adoptSandboxFromCandidates(ctx, claim, adoptionCandidates)
+		var template *extensionsv1alpha1.SandboxTemplate
+		template, err := r.getTemplate(ctx, claim)
+		if err != nil && !k8errors.IsNotFound(err) {
+			return nil, err
+		}
+		adopted, err := r.adoptSandboxFromCandidates(ctx, claim, template, adoptionCandidates)
 		if err != nil {
 			return nil, err
 		}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1114,6 +1114,108 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 	}
 }
 
+func TestSandboxClaimAdoptionPreservesPodTemplateAnnotations(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				ObjectMeta: sandboxv1alpha1.PodMetadata{
+					Annotations: map[string]string{
+						"io.codewire.sh/workspace": "true",
+						"test-annotation":          "template",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "workspace", Image: "workspace:latest"},
+						{Name: "codewire-sidecar", Image: "sidecar:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	warmSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-sb",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   sandboxcontrollers.NameHash("test-pool"),
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+					Kind:       "SandboxWarmPool",
+					Name:       "test-pool",
+					UID:        "pool-uid",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				ObjectMeta: sandboxv1alpha1.PodMetadata{
+					Annotations: map[string]string{
+						"io.codewire.sh/workspace": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "workspace", Image: "workspace:latest"},
+						{Name: "codewire-sidecar", Image: "sidecar:latest"},
+					},
+				},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, claim, warmSandbox).
+		WithStatusSubresource(claim).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+		Tracer:   asmetrics.NewNoOp(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	var adopted sandboxv1alpha1.Sandbox
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "warm-sb", Namespace: "default"}, &adopted); err != nil {
+		t.Fatalf("failed to get adopted sandbox: %v", err)
+	}
+
+	if got := adopted.Spec.PodTemplate.ObjectMeta.Annotations["io.codewire.sh/workspace"]; got != "true" {
+		t.Fatalf("expected adopted workspace annotation to survive, got %q", got)
+	}
+	if got := adopted.Spec.PodTemplate.ObjectMeta.Annotations["test-annotation"]; got != "template" {
+		t.Fatalf("expected template annotation to be restored on adoption, got %q", got)
+	}
+}
+
 func TestRecordCreationLatencyMetric(t *testing.T) {
 	pastTime := metav1.Time{Time: time.Now().Add(-10 * time.Second)}
 


### PR DESCRIPTION
## Summary
- preserve template pod annotations when adopting a warm-pool Sandbox
- propagate pod template annotations onto an existing adopted Pod
- add regression coverage for annotation preservation during warm adoption

## Context
This fixes a regression in the warm-pool adoption path that came out of the #375 split, most directly the adoption work in #396, and was later touched again by #437.

Warm-pool Sandboxes and their backing Pods retain pod template annotations like , but an adopted Sandbox could lose  during claim adoption. When an adopted Pod was then created or refreshed from that Sandbox, it came up without the workspace annotation.

That breaks downstream consumers that rely on PodTemplate annotations surviving warm adoption, including Docker socket enablement in isol8 workspaces.

## Why separate from other open PRs
This is not new metadata propagation behavior. It is a regression fix for the existing warm adoption path, so it is kept separate from broader metadata propagation and claim-label work.

## Testing
- ok  	sigs.k8s.io/agent-sandbox/extensions/controllers	0.136s
ok  	sigs.k8s.io/agent-sandbox/controllers	0.070s