### PR TITLE
examples: add Azure OpenAI coding agent with Agent Sandbox

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**aio-sandbox**](./aio-sandbox): An example of running All-in-One (AIO) Sandbox using agent-sandbox.
 - [**chrome-sandbox**](./chrome-sandbox): An example of running a Chrome browser in a sandbox.
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
+- [**copilot-cli-sandbox**](./copilot-cli-sandbox): A coding agent using Azure OpenAI and Agent Sandbox for sandboxed code execution.
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
 - [**hello-world-sandbox**](./hello-world-sandbox): A simple "Hello World" sandbox example.

--- a/examples/copilot-cli-sandbox/README.md
+++ b/examples/copilot-cli-sandbox/README.md
@@ -1,0 +1,172 @@
+# Coding Agent with Azure OpenAI and Agent Sandbox
+
+## Overview
+
+This example implements an interactive coding agent that uses [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) (or any OpenAI-compatible API) to generate Python code and executes it inside an Agent Sandbox pod.
+
+The agent follows the same generate → execute → auto-fix loop as the [LangChain example](../langchain/), but uses the OpenAI Python SDK directly — no framework dependencies required.
+
+```
+┌──────────┐    task     ┌───────────────┐   code    ┌─────────────────┐
+│   User   │ ──────────> │  coding_agent │ ───────── │  Azure OpenAI   │
+│  (CLI)   │ <────────── │   .py         │ <──────── │  (GPT-4o)       │
+└──────────┘   result    │               │           └─────────────────┘
+                         │   write+run   │
+                         │       │       │
+                         │       ▼       │
+                         │  ┌─────────┐  │
+                         │  │ Sandbox │  │
+                         │  │  Pod    │  │
+                         │  └─────────┘  │
+                         └───────────────┘
+```
+
+### How it works
+
+1. User enters a coding task
+2. Agent calls Azure OpenAI to generate Python code
+3. Agent writes the code into a Sandbox pod and executes it via the [Python SDK](../../clients/python/agentic-sandbox-client/)
+4. If execution fails, the error is fed back to the LLM for auto-fix (up to 3 attempts)
+5. Results are printed to the user
+
+## Prerequisites
+
+1. **A running Kubernetes cluster** with the Agent Sandbox controller and extensions installed.
+   See the [Installation Guide](../../README.md#installation).
+
+2. **The sandbox-router deployed.** Follow the [sandbox-router setup instructions](../../clients/python/agentic-sandbox-client/sandbox-router/README.md).
+
+3. **An Azure OpenAI resource** (or any OpenAI-compatible API key).
+   See the [Azure OpenAI quickstart](https://learn.microsoft.com/azure/ai-services/openai/quickstart) for setup.
+
+4. **Python 3.10+** and **kubectl** configured to access your cluster.
+
+## Setup
+
+### 1. Install the Extensions CRDs
+
+The `SandboxTemplate` resource requires the extensions CRDs:
+
+```shell
+# Replace "vX.Y.Z" with a release tag
+export VERSION="vX.Y.Z"
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/extensions.yaml
+```
+
+### 2. Create the SandboxTemplate
+
+```shell
+kubectl apply -f sandbox-template.yaml
+```
+
+### 3. Install Python dependencies
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 4. Set your API credentials
+
+**Azure OpenAI:**
+
+```shell
+export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
+export AZURE_OPENAI_API_KEY="<your-key>"
+export AZURE_OPENAI_DEPLOYMENT="gpt-4o"  # your deployment name
+```
+
+**Or standard OpenAI / GitHub Models:**
+
+```shell
+export OPENAI_API_KEY="<your-key>"
+export OPENAI_MODEL="gpt-4o"
+# Optional: export OPENAI_BASE_URL="https://models.inference.ai.azure.com"
+```
+
+**Or GitHub Models with your GitHub token (free):**
+
+```shell
+export OPENAI_API_KEY=$(gh auth token)
+export OPENAI_BASE_URL="https://models.inference.ai.azure.com"
+export OPENAI_MODEL="gpt-4o"
+```
+
+## Usage
+
+```shell
+python coding_agent.py
+```
+
+Example session:
+
+```
+Connecting to sandbox (template=python-sandbox-template, ns=default)...
+Sandbox ready!
+============================================================
+Agent Sandbox — Coding Agent (Azure OpenAI)
+============================================================
+Give me a coding task and I'll generate Python code,
+execute it in a sandboxed environment, and show results.
+Type 'exit' or 'quit' to stop.
+============================================================
+
+You: calculate the first 20 fibonacci numbers
+
+[1/2] Generating code...
+----------------------------------------
+def fibonacci(n):
+    fib = [0, 1]
+    for i in range(2, n):
+        fib.append(fib[-1] + fib[-2])
+    return fib[:n]
+
+result = fibonacci(20)
+for i, num in enumerate(result):
+    print(f"F({i}) = {num}")
+----------------------------------------
+
+[2/2] Executing in sandbox...
+
+✅ Execution succeeded:
+F(0) = 0
+F(1) = 1
+F(2) = 1
+...
+F(19) = 4181
+```
+
+## Configuration
+
+| Environment Variable | Description | Default |
+|---|---|---|
+| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI endpoint URL | — |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key | — |
+| `AZURE_OPENAI_DEPLOYMENT` | Azure OpenAI deployment name | `gpt-4o` |
+| `AZURE_OPENAI_API_VERSION` | Azure OpenAI API version | `2024-12-01-preview` |
+| `OPENAI_API_KEY` | OpenAI API key (used if Azure not set) | — |
+| `OPENAI_MODEL` | OpenAI model name | `gpt-4o` |
+| `OPENAI_BASE_URL` | Custom OpenAI-compatible endpoint | — |
+| `SANDBOX_TEMPLATE` | Name of the SandboxTemplate | `python-sandbox-template` |
+| `SANDBOX_NAMESPACE` | Kubernetes namespace | `default` |
+
+## How this compares to other examples
+
+| | This example | [LangChain](../langchain/) | [ADK](../code-interpreter-agent-on-adk/) |
+|---|---|---|---|
+| **LLM** | Azure OpenAI / OpenAI API | Self-hosted (codegen-350M) | Gemini |
+| **Framework** | None (openai SDK only) | LangGraph | Google ADK |
+| **Dependencies** | `openai`, `k8s-agent-sandbox` | transformers, torch, langgraph | google-adk |
+| **GPU required** | No | Yes (or slow CPU) | No |
+| **Setup time** | ~2 min | ~15 min (model download) | ~5 min |
+
+## Cleanup
+
+```shell
+# Delete the sandbox template
+kubectl delete sandboxtemplate python-sandbox-template
+
+# Deactivate virtual environment
+deactivate
+```

--- a/examples/copilot-cli-sandbox/coding_agent.py
+++ b/examples/copilot-cli-sandbox/coding_agent.py
@@ -1,0 +1,202 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Coding agent that uses Azure OpenAI (or any OpenAI-compatible API) to generate
+Python code and executes it inside an Agent Sandbox pod.
+
+The agent loop:
+1. Takes a task from the user
+2. Calls the LLM to generate Python code
+3. Writes the code into a Sandbox and executes it
+4. If execution fails, feeds the error back to the LLM for auto-fix
+5. Repeats up to MAX_FIX_ATTEMPTS times
+"""
+
+import os
+import sys
+
+from openai import AzureOpenAI, OpenAI
+from k8s_agent_sandbox import SandboxClient
+
+MAX_FIX_ATTEMPTS = 3
+
+SYSTEM_PROMPT = """You are an expert Python programmer. When given a task, \
+generate clean, self-contained Python code that solves it.
+
+Rules:
+- Output ONLY executable Python code — no markdown fences, no explanations.
+- The code must be completely self-contained with no external dependencies \
+beyond the Python standard library.
+- Include proper error handling.
+- Print informative output so the user can see the results."""
+
+FIX_PROMPT_TEMPLATE = """The following Python code failed with an error.
+Fix the code so it runs successfully.
+
+Output ONLY the corrected Python code — no markdown fences, no explanations.
+
+Original task: {task}
+
+Failed code:
+{code}
+
+Error:
+{error}"""
+
+
+def create_client():
+    """Create an OpenAI client, auto-detecting Azure vs standard endpoints."""
+    azure_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+    if azure_endpoint:
+        return AzureOpenAI(
+            azure_endpoint=azure_endpoint,
+            api_key=os.environ.get("AZURE_OPENAI_API_KEY"),
+            api_version=os.environ.get(
+                "AZURE_OPENAI_API_VERSION", "2024-12-01-preview"),
+        )
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        base_url = os.environ.get("OPENAI_BASE_URL")
+        return OpenAI(api_key=api_key, base_url=base_url)
+
+    print("Error: Set AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY "
+          "or OPENAI_API_KEY.")
+    sys.exit(1)
+
+
+def generate_code(client, model: str, task: str) -> str:
+    """Ask the LLM to generate Python code for a task."""
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": task},
+        ],
+        temperature=0.2,
+    )
+    code = response.choices[0].message.content.strip()
+    # Strip markdown fences if the model includes them anyway
+    if code.startswith("```python"):
+        code = code[len("```python"):].strip()
+    if code.startswith("```"):
+        code = code[3:].strip()
+    if code.endswith("```"):
+        code = code[:-3].strip()
+    return code
+
+
+def fix_code(client, model: str, task: str, code: str, error: str) -> str:
+    """Ask the LLM to fix code that failed."""
+    prompt = FIX_PROMPT_TEMPLATE.format(task=task, code=code, error=error)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.2,
+    )
+    fixed = response.choices[0].message.content.strip()
+    if fixed.startswith("```python"):
+        fixed = fixed[len("```python"):].strip()
+    if fixed.startswith("```"):
+        fixed = fixed[3:].strip()
+    if fixed.endswith("```"):
+        fixed = fixed[:-3].strip()
+    return fixed
+
+
+def execute_in_sandbox(sandbox: SandboxClient, code: str):
+    """Write code to the sandbox and execute it. Returns (stdout, success)."""
+    sandbox.write("task.py", code)
+    result = sandbox.run("python3 task.py", timeout=60)
+    success = result.exit_code == 0
+    output = result.stdout if success else (result.stderr or result.stdout)
+    return output, success
+
+
+def run_agent_loop(client, model: str, sandbox: SandboxClient):
+    """Interactive loop: user gives tasks, agent generates and executes code."""
+    print("=" * 60)
+    print("Agent Sandbox — Coding Agent (Azure OpenAI)")
+    print("=" * 60)
+    print("Give me a coding task and I'll generate Python code,")
+    print("execute it in a sandboxed environment, and show results.")
+    print("Type 'exit' or 'quit' to stop.")
+    print("=" * 60)
+
+    while True:
+        try:
+            task = input("\nYou: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nGoodbye!")
+            break
+
+        if not task:
+            continue
+        if task.lower() in ("exit", "quit"):
+            print("Goodbye!")
+            break
+
+        # Generate
+        print("\n[1/2] Generating code...")
+        code = generate_code(client, model, task)
+        print("-" * 40)
+        print(code)
+        print("-" * 40)
+
+        # Execute + auto-fix loop
+        for attempt in range(1, MAX_FIX_ATTEMPTS + 1):
+            step = "2/2" if attempt == 1 else f"fix {attempt-1}/{MAX_FIX_ATTEMPTS}"
+            print(f"\n[{step}] Executing in sandbox...")
+            output, success = execute_in_sandbox(sandbox, code)
+
+            if success:
+                print("\n✅ Execution succeeded:")
+                print(output)
+                break
+
+            print(f"\n❌ Execution failed (attempt {attempt}):")
+            print(output)
+
+            if attempt < MAX_FIX_ATTEMPTS:
+                print(f"\n[fix] Asking LLM to fix the code...")
+                code = fix_code(client, model, task, code, output)
+                print("-" * 40)
+                print(code)
+                print("-" * 40)
+        else:
+            print(f"\n⛔ Failed after {MAX_FIX_ATTEMPTS} attempts.")
+
+
+def main():
+    model = os.environ.get("AZURE_OPENAI_DEPLOYMENT",
+                           os.environ.get("OPENAI_MODEL", "gpt-4o"))
+    template = os.environ.get("SANDBOX_TEMPLATE", "python-sandbox-template")
+    namespace = os.environ.get("SANDBOX_NAMESPACE", "default")
+
+    client = create_client()
+
+    print(f"Connecting to sandbox (template={template}, ns={namespace})...")
+    with SandboxClient(
+        template_name=template,
+        namespace=namespace,
+    ) as sandbox:
+        print("Sandbox ready!")
+        run_agent_loop(client, model, sandbox)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/copilot-cli-sandbox/requirements.txt
+++ b/examples/copilot-cli-sandbox/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+k8s-agent-sandbox

--- a/examples/copilot-cli-sandbox/sandbox-template.yaml
+++ b/examples/copilot-cli-sandbox/sandbox-template.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: python-sandbox-template
+  namespace: default
+spec:
+  podTemplate:
+    spec:
+      containers:
+      - name: python-runtime
+        image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/python-runtime-sandbox:latest-main
+        ports:
+        - containerPort: 8888
+        readinessProbe:
+          httpGet:
+            path: "/"
+            port: 8888
+          initialDelaySeconds: 0
+          periodSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: "/"
+            port: 8888
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+            ephemeral-storage: "512Mi"
+      restartPolicy: "OnFailure"


### PR DESCRIPTION
## What this PR does

Adds a coding agent example that uses **Azure OpenAI** (or any OpenAI-compatible API) to generate Python code and execute it inside an Agent Sandbox pod. This is the first example in the repo using Azure AI services.

### Architecture

```
User → coding_agent.py → Azure OpenAI (generate code)
                        → SandboxClient (write + execute in pod)
                        → auto-fix loop on failure (up to 3 attempts)
```

### How it compares to existing examples

| | This example | langchain/ | code-interpreter-agent-on-adk/ |
|---|---|---|---|
| **LLM** | Azure OpenAI / OpenAI API | Self-hosted codegen-350M | Gemini |
| **Framework** | None (openai SDK only) | LangGraph | Google ADK |
| **GPU required** | No | Yes (or slow CPU) | No |
| **Dependencies** | `openai`, `k8s-agent-sandbox` | transformers, torch, langgraph | google-adk |

### Files

| File | Description |
|------|-------------|
| `coding_agent.py` | Interactive CLI agent with generate → execute → auto-fix loop |
| `sandbox-template.yaml` | Python runtime SandboxTemplate |
| `requirements.txt` | `openai`, `k8s-agent-sandbox` |
| `README.md` | Architecture, setup, configuration, usage example |
| `examples/README.md` | Updated index |

### Design choices

- Uses the `k8s_agent_sandbox.SandboxClient` Python SDK (same pattern as the ADK example)
- Supports Azure OpenAI, standard OpenAI, and GitHub Models via environment variables
- No framework dependency — just the `openai` SDK for maximum simplicity
- Follows the same auto-fix loop pattern as `langchain/coding_agent.py`
