### PR TITLE
examples: add Copilot CLI overlay for vscode-sandbox

### DIFF
--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -98,6 +98,44 @@ $ kubectl wait --for=condition=Ready sandbox sandbox-example
 $ kubectl get pods -o jsonpath=$'{range .items[*]}{.metadata.name}: {.spec.runtimeClassName}\n{end}'
 ```
 
+### Use GitHub Copilot CLI instead of Gemini CLI (Optional)
+
+You can swap Gemini CLI for [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli) by using the `copilot-cli` overlay. This replaces the Gemini API key with a GitHub token and installs the `gh copilot` extension.
+
+#### Create a GitHub token secret
+
+The token must include the `copilot` scope. First, refresh your local token to add it:
+
+```shell
+gh auth refresh --scopes copilot
+```
+
+Then create the Kubernetes secret:
+
+```shell
+kubectl create secret generic gh-copilot-token \
+  --from-literal=token=$(gh auth token)
+```
+
+#### Deploy with the Copilot CLI overlay
+
+```shell
+kubectl apply -k overlays/copilot-cli
+```
+
+#### Verify the sandbox is running
+
+```shell
+kubectl wait --for=condition=Ready sandbox sandbox-example
+```
+
+Once connected to VS Code (see [Accessing VSCode](#accessing-vscode) below), open a terminal and use Copilot CLI:
+
+```shell
+gh copilot suggest "write a kubernetes deployment yaml for nginx"
+gh copilot explain "kubectl get pods -o wide"
+```
+
 ## Accessing VSCode
 
 ### 1. Wait for VSCode to Start
@@ -204,4 +242,13 @@ Use the password and connect to vscode.
 
 ## Use gemini-cli
 
-Gemini cli is preinstalled. Open a teminal in vscode and use Gemini cli.
+Gemini cli is preinstalled. Open a terminal in vscode and use Gemini cli.
+
+## Use Copilot CLI
+
+If you deployed with the `copilot-cli` overlay, GitHub Copilot CLI is available in the VS Code terminal:
+
+```shell
+gh copilot suggest "list all pods in the default namespace"
+gh copilot explain "awk '{print $1}' file.txt"
+```

--- a/examples/vscode-sandbox/entrypoint-copilot.sh
+++ b/examples/vscode-sandbox/entrypoint-copilot.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+# Install gh CLI if not present
+if ! command -v gh &> /dev/null; then
+  echo "Installing GitHub CLI..."
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+  apt-get update -qq && apt-get install -y -qq gh
+fi
+
+# Authenticate gh CLI using the mounted GH_TOKEN.
+#
+# NOTE: To use `gh copilot`, the token must include the "copilot" scope.
+# Generate a token with the correct scopes:
+#   gh auth token  (does NOT include copilot scope by default)
+#
+# Instead, create a personal access token at https://github.com/settings/tokens
+# with the "copilot" scope, or run the following on your local machine:
+#   gh auth refresh --scopes copilot
+#   gh auth token
+#
+# Then create the secret:
+#   kubectl create secret generic gh-copilot-token --from-literal=token=<YOUR_TOKEN>
+if [ -n "$GH_TOKEN" ]; then
+  echo "$GH_TOKEN" | gh auth login --with-token
+  echo "GitHub CLI authenticated"
+  gh auth status
+
+  # Install Copilot CLI binary (auto-accept the install prompt)
+  echo "Y" | gh copilot > /dev/null 2>&1 || true
+  echo "Copilot CLI ready"
+else
+  echo "Warning: GH_TOKEN not set, GitHub CLI will not be available"
+fi
+
+# Start code-server
+/usr/bin/code-server --auth=none --bind-addr=0.0.0.0:13337

--- a/examples/vscode-sandbox/overlays/copilot-cli/devcontainer.json
+++ b/examples/vscode-sandbox/overlays/copilot-cli/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "Go, Node.js and Copilot CLI Dev Container",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/features/go:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "lts"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"version": "latest"
+		},
+		"ghcr.io/coder/devcontainer-features/code-server:1": {
+			"port": 13337,
+			"host": "0.0.0.0"
+		}
+	},
+	"postCreateCommand": "gh extension install github/gh-copilot",
+	"appPort": ["13337:13337"]
+}

--- a/examples/vscode-sandbox/overlays/copilot-cli/kustomization.yaml
+++ b/examples/vscode-sandbox/overlays/copilot-cli/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: patch-copilot-cli.yaml
+    target:
+      kind: Sandbox
+      name: sandbox-example

--- a/examples/vscode-sandbox/overlays/copilot-cli/patch-copilot-cli.yaml
+++ b/examples/vscode-sandbox/overlays/copilot-cli/patch-copilot-cli.yaml
@@ -1,0 +1,27 @@
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: sandbox-example
+spec:
+  podTemplate:
+    spec:
+      containers:
+        - name: devcontainer-main
+          image: ghcr.io/coder/envbuilder
+          env:
+            - name: ENVBUILDER_GIT_URL
+              value: "https://github.com/kubernetes-sigs/agent-sandbox.git"
+            - name: ENVBUILDER_DEVCONTAINER_DIR
+              value: "examples/vscode-sandbox"
+            - name: ENVBUILDER_GIT_CLONE_SINGLE_BRANCH
+              value: "true"
+            - name: ENVBUILDER_INIT_SCRIPT
+              value: "examples/vscode-sandbox/entrypoint-copilot.sh"
+            - name: ENVBUILDER_IGNORE_PATHS
+              value: "/var/run,/product_uuid,/product_name,/tokens"
+            # GH_TOKEN is used by gh CLI for authentication
+            - name: GH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gh-copilot-token
+                  key: token


### PR DESCRIPTION
## What this PR does

Adds a kustomize overlay to the existing `vscode-sandbox` example that swaps Gemini CLI for **GitHub Copilot CLI**. This is the GitHub/Azure ecosystem counterpart to the existing Gemini setup.

### How it works

Same pattern as the base vscode-sandbox example:

| | Base (Gemini) | This overlay (Copilot CLI) |
|---|---|---|
| **AI tool** | `@google/gemini-cli` | `gh copilot` (gh extension) |
| **Auth** | `GEMINI_API_KEY` from secret | `GH_TOKEN` from secret |
| **Entrypoint** | `entrypoint.sh` | `entrypoint-copilot.sh` |
| **DevContainer** | Installs gemini-cli via npm | Installs gh CLI + gh-copilot extension |

### Files

| File | Description |
|------|-------------|
| `overlays/copilot-cli/kustomization.yaml` | Kustomize overlay referencing the base |
| `overlays/copilot-cli/patch-copilot-cli.yaml` | Patches env vars, entrypoint, devcontainer dir, and mounts GH_TOKEN |
| `overlays/copilot-cli/devcontainer.json` | DevContainer with gh CLI + copilot extension |
| `entrypoint-copilot.sh` | Authenticates gh CLI via `GH_TOKEN`, installs copilot, starts code-server |
| `README.md` | Updated with Copilot CLI setup and usage |

### Usage

```shell
kubectl create secret generic gh-copilot-token --from-literal=token=$(gh auth token)
kubectl apply -k overlays/copilot-cli
# port-forward and open VS Code, then use:
gh copilot suggest "write a kubernetes deployment for nginx"
```

### Validated
- `kubectl kustomize` builds correctly
- Patch merges cleanly with base sandbox manifest
- Entrypoint handles missing GH_TOKEN gracefully
