### PR TITLE
tests: fix timing flake in TestSandboxShutdownTime

### DIFF
--- a/test/e2e/shutdown_test.go
+++ b/test/e2e/shutdown_test.go
@@ -68,8 +68,9 @@ func TestSandboxShutdownTime(t *testing.T) {
 	service.Namespace = ns.Name
 	tc.MustExist(service)
 
-	// Set a shutdown time that ends shortly
-	shutdown := metav1.NewTime(time.Now().Add(10 * time.Second))
+	// Set a shutdown time that ends shortly, truncated to second-level precision (RFC3339) to match
+	// the Kubernetes API's storage behavior.
+	shutdown := metav1.NewTime(time.Now().Add(10 * time.Second)).Rfc3339Copy()
 	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1alpha1.Sandbox) {
 		obj.Spec.ShutdownTime = &shutdown
 	})


### PR DESCRIPTION
This fix resolves a time mismatch where the test compared nanosecond-precise local time against the second-precision value stored in the API server. By using [Rfc3339Copy()](https://github.com/kubernetes/apimachinery/blob/72d71eac265e06713c6d83d7034aac609450243f/pkg/apis/meta/v1/time.go#L94), the test's assertion now correctly matches the second-level expiration logic.

Example of a failing test:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_agent-sandbox/471/presubmit-agent-sandbox-e2e-test/2036476219532251136