### PR TITLE
Add PodIP to sandbox and sandbox claim status.

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -170,6 +170,10 @@ type SandboxStatus struct {
 	// selector is the label selector for pods.
 	// +optional
 	LabelSelector string `json:"selector,omitempty"`
+
+	// podIP is the IP address of the underlying pod
+	// +optional
+	PodIP string `json:"podIP,omitempty"`
 }
 
 // +genclient

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -177,9 +177,11 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	if pod == nil {
 		sandbox.Status.Replicas = 0
 		sandbox.Status.LabelSelector = ""
+		sandbox.Status.PodIP = ""
 	} else {
 		sandbox.Status.Replicas = 1
 		sandbox.Status.LabelSelector = fmt.Sprintf("%s=%s", sandboxLabel, NameHash(sandbox.Name))
+		sandbox.Status.PodIP = pod.Status.PodIP
 	}
 
 	// Reconcile Service

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -411,6 +411,73 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "sandbox with existing pod propagates PodIP",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.244.0.5",
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Service:       sandboxName,
+				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
+				Replicas:      1,
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				PodIP:         "10.244.0.5",
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             "DependenciesReady",
+						Message:            "Pod is Ready; Service Exists",
+					},
+				},
+			},
+			wantObjs: []client.Object{
+				// Verifying Service exists (Pod was verified indirectly via state, and owner reference is added in reconcilePod test suite)
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						ClusterIP: "None",
+					},
+				},
+			},
+		},
+		{
 			name: "sandbox expired with retain policy",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{

--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -92,6 +92,10 @@ type SandboxStatus struct {
 	// TODO: change `Name` to `name`
 	// +optional
 	Name string `json:"Name,omitempty"` //nolint:kubeapilinter
+
+	// podIP is the IP address of the underlying pod
+	// +optional
+	PodIP string `json:"podIP,omitempty"`
 }
 
 // +genclient

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -336,6 +336,7 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1alpha1.S
 
 	if sandbox != nil {
 		claim.Status.SandboxStatus.Name = sandbox.Name
+		claim.Status.SandboxStatus.PodIP = sandbox.Status.PodIP
 	}
 }
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -213,6 +213,7 @@ func TestSandboxClaimReconcile(t *testing.T) {
 		Reason:  "SandboxReady",
 		Message: "Sandbox is ready",
 	}}
+	readySandbox.Status.PodIP = "10.244.0.6"
 
 	// Validation Functions
 	validateSandboxHasDefaultAutomountToken := func(t *testing.T, sandbox *sandboxv1alpha1.Sandbox, template *extensionsv1alpha1.SandboxTemplate) {
@@ -251,6 +252,7 @@ func TestSandboxClaimReconcile(t *testing.T) {
 		expectSandbox     bool
 		expectError       bool
 		expectedCondition metav1.Condition
+		expectedPodIP     string
 		validateSandbox   func(t *testing.T, sandbox *sandboxv1alpha1.Sandbox, template *extensionsv1alpha1.SandboxTemplate)
 	}{
 		{
@@ -311,6 +313,7 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "SandboxReady", Message: "Sandbox is ready",
 			},
+			expectedPodIP:   "10.244.0.6",
 			validateSandbox: validateSandboxHasDefaultAutomountToken,
 		},
 		{
@@ -321,6 +324,7 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "SandboxReady", Message: "Sandbox is ready",
 			},
+			expectedPodIP:   "10.244.0.6",
 			validateSandbox: validateSandboxHasDefaultAutomountToken,
 		},
 		{
@@ -490,6 +494,11 @@ func TestSandboxClaimReconcile(t *testing.T) {
 					t.Errorf("expected condition reason %q, got %q", "ReconcilerError", condition.Reason)
 				}
 			} else {
+				if tc.expectedPodIP != "" {
+					if updatedClaim.Status.SandboxStatus.PodIP != tc.expectedPodIP {
+						t.Errorf("expected PodIP %q, got %q", tc.expectedPodIP, updatedClaim.Status.SandboxStatus.PodIP)
+					}
+				}
 				if diff := cmp.Diff(tc.expectedCondition, condition, cmp.Comparer(ignoreTimestamp)); diff != "" {
 					t.Errorf("unexpected condition:\n%s", diff)
 				}

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3977,6 +3977,8 @@ spec:
                   - type
                   type: object
                 type: array
+              podIP:
+                type: string
               replicas:
                 format: int32
                 minimum: 0

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -92,6 +92,8 @@ spec:
                 properties:
                   Name:
                     type: string
+                  podIP:
+                    type: string
                 type: object
             type: object
         required:


### PR DESCRIPTION
### Description

This PR was previously closed: https://github.com/kubernetes-sigs/agent-sandbox/pull/394 . Implemented by @noeljackson. 
It adds back the PodIP to sandbox and sandbox claim status.  

### Motivation

Headless service already provides a stable identity and good for human access but requires discovery which adds latency for Sandbox connection.. Pod ip is for speed and fast access to the sandbox directly essentially by-passing the discovery.  If we provide both options, the consumer can choose it. 

### Tested

1. Unit tested
2. Integration test: 
<img width="998" height="450" alt="Screenshot 2026-03-27 at 2 36 10 PM" src="https://github.com/user-attachments/assets/f27dee31-348d-461b-b590-78a61fc39cf7" />

### Future work

1. Integerate this with the client as the fourth connection strategy
