### PR TITLE
feat(python-sdk): add SandboxInClusterConnectionConfig to bypass router

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -9,14 +9,16 @@ Router, while maintaining a convenient **Developer Mode** for local testing.
 
 ## Architecture
 
-The client operates in three modes:
+The client operates in four modes:
 
 1.  **Production (Gateway Mode):** Traffic flows from the Client -> Cloud Load Balancer (Gateway)
     -> Router Service -> Sandbox Pod. This supports high-scale deployments.
 2.  **Development (Tunnel Mode):** Traffic flows from Localhost -> `kubectl port-forward` -> Router
     Service -> Sandbox Pod. This requires no public IP and works on Kind/Minikube.
-3.  **Advanced / Internal Mode**: The client connects directly to a provided api_url, bypassing
-    discovery. This is useful for in-cluster communication or when connecting through a custom domain.
+3.  **In-Cluster Mode:** The client connects **directly to the sandbox pod** (via pod IP or cluster
+    DNS), bypassing the router. Intended for workloads running inside the cluster.
+4.  **Advanced / Internal Mode:** The client connects directly to a provided `api_url`, bypassing
+    discovery. This is useful when connecting through a custom domain or a manually specified router URL.
 
 ## Prerequisites
 
@@ -100,7 +102,7 @@ Before using the client, you must deploy the `sandbox-router`. This is a one-tim
         If you are using [tracing with GCP](GCP.md#tracing-with-open-telemetry-and-google-cloud-trace),
         install with the optional tracing dependencies:
 
-        ```
+        ```bash
         pip install -e ".[tracing]"
         ```
 
@@ -150,7 +152,44 @@ finally:
     sandbox.terminate()
 ```
 
-### 3. Advanced / Internal Mode
+### 3. In-Cluster Mode (Direct Pod Connection)
+
+Use this when the client runs **inside the cluster** (for example, another pod in the same cluster).
+The client connects **directly to the sandbox runtime pod**, bypassing the sandbox router.
+
+The **default** is **cluster DNS** (`use_pod_ip=False`). Omit the argument or pass `use_pod_ip=False`
+to use it; set `use_pod_ip=True` only when you want the pod IP path.
+
+**Option A: Direct Pod IP** — `SandboxInClusterConnectionConfig(use_pod_ip=True)`
+
+- Uses the pod IP from the Sandbox status for **low-latency**, direct connections without relying on
+  cluster DNS resolution.
+
+**Option B: Cluster DNS** — `SandboxInClusterConnectionConfig(use_pod_ip=False)`
+
+- Uses a stable DNS-style endpoint (typically `http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}`).
+  Prefer this when you want **stable DNS-based routing** across pod lifecycle events.
+
+```python
+from k8s_agent_sandbox import SandboxClient
+from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
+
+# Choose one connection_config (default = cluster DNS):
+#   SandboxInClusterConnectionConfig()  # same as use_pod_ip=False
+# Option A — direct pod IP (low latency):
+#   SandboxInClusterConnectionConfig(use_pod_ip=True)
+connection_config = SandboxInClusterConnectionConfig()
+
+client = SandboxClient(connection_config=connection_config)
+
+sandbox = client.create_sandbox(template="python-sandbox-template", namespace="default")
+try:
+    print(sandbox.commands.run("echo 'Hello from in-cluster!'").stdout)
+finally:
+    sandbox.terminate()
+```
+
+### 4. Advanced / Internal Mode
 
 Use `SandboxDirectConnectionConfig` to bypass discovery entirely. Useful for:
 
@@ -174,7 +213,7 @@ finally:
     sandbox.terminate()
 ```
 
-### 4. Custom Ports
+### 5. Custom Ports
 
 If your sandbox runtime listens on a port other than 8888 (e.g., a Node.js app on 3000), specify `server_port`.
 
@@ -186,10 +225,10 @@ client = SandboxClient(
     connection_config=SandboxLocalTunnelConnectionConfig(server_port=3000)
 )
 
-sandbox = client.create_sandbox(template="node-sandbox-template", namespace="default").
+sandbox = client.create_sandbox(template="node-sandbox-template", namespace="default")
 ```
 
-### 5. Async Client
+### 6. Async Client
 
 For async applications (FastAPI, aiohttp, async agent orchestrators), use the `AsyncSandboxClient`.
 Install the async extras first:
@@ -199,18 +238,16 @@ pip install k8s-agent-sandbox[async]
 ```
 
 The async client requires an explicit connection config — `LocalTunnel` mode is not supported
-because it relies on a synchronous `kubectl port-forward` subprocess. Use `DirectConnection` or
-`GatewayConnection` instead.
+because it relies on a synchronous `kubectl port-forward` subprocess. Use `GatewayConnection`,
+`DirectConnection`, or `SandboxInClusterConnectionConfig` instead.
 
 ```python
 import asyncio
 from k8s_agent_sandbox import AsyncSandboxClient
-from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
 
 async def main():
-    config = SandboxDirectConnectionConfig(
-        api_url="http://sandbox-router-svc.default.svc.cluster.local:8080"
-    )
+    config = SandboxInClusterConnectionConfig()  # default: cluster DNS
 
     async with AsyncSandboxClient(connection_config=config) as client:
         sandbox = await client.create_sandbox(
@@ -229,12 +266,12 @@ A test script is included to verify the full lifecycle (Creation -> Execution ->
 
 ### Run in Dev Mode:
 
-```
+```bash
 python test_client.py --namespace default
 ```
 
 ### Run in Production Mode:
 
-```
+```bash
 python test_client.py --gateway-name external-http-gateway
 ```

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -193,7 +193,7 @@ finally:
 
 Use `SandboxDirectConnectionConfig` to bypass discovery entirely. Useful for:
 
-- **Internal Agents:** Running inside the cluster (connect via K8s DNS).
+- **Internal Agents:** Running inside the cluster (e.g. router Service DNS).
 - **Custom Domains:** Connecting via HTTPS (e.g., `https://sandbox.example.com`).
 
 ```python
@@ -237,9 +237,35 @@ Install the async extras first:
 pip install k8s-agent-sandbox[async]
 ```
 
-The async client requires an explicit connection config — `LocalTunnel` mode is not supported
-because it relies on a synchronous `kubectl port-forward` subprocess. Use `GatewayConnection`,
-`DirectConnection`, or `SandboxInClusterConnectionConfig` instead.
+The async client requires an explicit connection config — `SandboxLocalTunnelConnectionConfig`
+is not supported because it relies on a synchronous `kubectl port-forward` subprocess. Use
+`SandboxGatewayConnectionConfig`, `SandboxDirectConnectionConfig`, or
+`SandboxInClusterConnectionConfig` instead.
+
+**Direct connection (explicit URL, e.g. router service):**
+
+```python
+import asyncio
+from k8s_agent_sandbox import AsyncSandboxClient
+from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+
+async def main():
+    config = SandboxDirectConnectionConfig(
+        api_url="http://sandbox-router-svc.default.svc.cluster.local:8080"
+    )
+
+    async with AsyncSandboxClient(connection_config=config) as client:
+        sandbox = await client.create_sandbox(
+            template="python-sandbox-template",
+            namespace="default",
+        )
+        result = await sandbox.commands.run("echo 'Hello from async!'")
+        print(result.stdout)
+
+asyncio.run(main())
+```
+
+**In-cluster (direct to sandbox pod; default: cluster DNS):**
 
 ```python
 import asyncio

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -73,6 +73,10 @@ class AsyncSandboxConnector:
                     f".svc.cluster.local:{connection_config.server_port}"
                 )
 
+        self._inject_router_headers = not isinstance(
+            connection_config, SandboxInClusterConnectionConfig
+        )
+
         transport = httpx.AsyncHTTPTransport(retries=3)
         self.client = httpx.AsyncClient(
             transport=transport, timeout=httpx.Timeout(60.0)
@@ -98,15 +102,12 @@ class AsyncSandboxConnector:
 
         return self._base_url
 
-    def _should_inject_router_headers(self) -> bool:
-        return not isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-
     async def send_request(self, method: str, endpoint: str, **kwargs) -> httpx.Response:
         base_url = await self._resolve_base_url()
         url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
         headers = kwargs.pop("headers", {}).copy()
-        if self._should_inject_router_headers():
+        if self._inject_router_headers:
             headers["X-Sandbox-ID"] = self.id
             headers["X-Sandbox-Namespace"] = self.namespace
             headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
@@ -156,4 +157,6 @@ class AsyncSandboxConnector:
 
     async def close(self):
         await self.client.aclose()
-        self._base_url = None
+        # Only clear volatile URLs (Gateway). Direct and InCluster URLs are stable.
+        if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
+            self._base_url = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -147,6 +147,11 @@ class AsyncSandboxConnector:
                 return response
             except httpx.HTTPStatusError as e:
                 logger.error(f"Request to sandbox failed: {e}")
+                # Clear cached URLs that may have gone stale.
+                if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
+                    self._base_url = None
+                self._pod_ip_resolved = False
+                self._cached_pod_ip_url = None
                 raise SandboxRequestError(
                     f"Failed to communicate with the sandbox at {url}.",
                     status_code=e.response.status_code,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -55,7 +55,8 @@ class AsyncSandboxConnector:
         if isinstance(connection_config, SandboxLocalTunnelConnectionConfig):
             raise ValueError(
                 "AsyncSandboxConnector does not support SandboxLocalTunnelConnectionConfig. "
-                "Use SandboxDirectConnectionConfig or SandboxGatewayConnectionConfig instead. "
+                "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, "
+                "or SandboxInClusterConnectionConfig instead. "
                 "For local development, use the synchronous SandboxClient."
             )
 
@@ -93,9 +94,9 @@ class AsyncSandboxConnector:
                 if self._pod_ip_resolved:
                     return self._cached_pod_ip_url or self._dns_url
                 pod_ip = await self._get_pod_ip()
-                self._pod_ip_resolved = True
                 if pod_ip:
                     self._cached_pod_ip_url = f"http://{pod_ip}:{self._server_port}"
+                    self._pod_ip_resolved = True
                     return self._cached_pod_ip_url
             return self._dns_url
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import logging
+from typing import Callable, Awaitable
 
 import httpx
 
@@ -49,7 +50,7 @@ class AsyncSandboxConnector:
         namespace: str,
         connection_config: SandboxConnectionConfig,
         k8s_helper: AsyncK8sHelper,
-        pod_ip: str | None = None,
+        get_pod_ip: Callable[[], Awaitable[str | None]] | None = None,
     ):
         if isinstance(connection_config, SandboxLocalTunnelConnectionConfig):
             raise ValueError(
@@ -62,16 +63,20 @@ class AsyncSandboxConnector:
         self.namespace = namespace
         self.connection_config = connection_config
         self.k8s_helper = k8s_helper
+        self._get_pod_ip = get_pod_ip
 
         self._base_url: str | None = None
+        self._pod_ip_resolved = False
+        self._cached_pod_ip_url: str | None = None
         if isinstance(connection_config, SandboxInClusterConnectionConfig):
-            if pod_ip:
-                self._base_url = f"http://{pod_ip}:{connection_config.server_port}"
-            else:
-                self._base_url = (
-                    f"http://{sandbox_id}.{namespace}"
-                    f".svc.cluster.local:{connection_config.server_port}"
-                )
+            self._dns_url = (
+                f"http://{sandbox_id}.{namespace}"
+                f".svc.cluster.local:{connection_config.server_port}"
+            )
+            self._server_port = connection_config.server_port
+        else:
+            self._dns_url = None
+            self._server_port = None
 
         self._inject_router_headers = not isinstance(
             connection_config, SandboxInClusterConnectionConfig
@@ -83,6 +88,17 @@ class AsyncSandboxConnector:
         )
 
     async def _resolve_base_url(self) -> str:
+        if isinstance(self.connection_config, SandboxInClusterConnectionConfig):
+            if self._get_pod_ip:
+                if self._pod_ip_resolved:
+                    return self._cached_pod_ip_url or self._dns_url
+                pod_ip = await self._get_pod_ip()
+                self._pod_ip_resolved = True
+                if pod_ip:
+                    self._cached_pod_ip_url = f"http://{pod_ip}:{self._server_port}"
+                    return self._cached_pod_ip_url
+            return self._dns_url
+
         if self._base_url:
             return self._base_url
 
@@ -138,10 +154,11 @@ class AsyncSandboxConnector:
                 ) from e
             except httpx.HTTPError as e:
                 logger.error(f"Request to sandbox failed: {e}")
-                # Only clear the cached URL for Gateway config — the IP may have changed.
-                # Direct and InCluster URLs are stable and must not be cleared.
+                # Clear cached URLs that may have gone stale.
                 if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
                     self._base_url = None
+                self._pod_ip_resolved = False
+                self._cached_pod_ip_url = None
                 raise SandboxRequestError(
                     f"Failed to communicate with the sandbox at {url}.",
                     status_code=None,
@@ -157,6 +174,7 @@ class AsyncSandboxConnector:
 
     async def close(self):
         await self.client.aclose()
-        # Only clear volatile URLs (Gateway). Direct and InCluster URLs are stable.
         if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
             self._base_url = None
+        self._pod_ip_resolved = False
+        self._cached_pod_ip_url = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -25,6 +25,7 @@ from .models import (
     SandboxConnectionConfig,
     SandboxDirectConnectionConfig,
     SandboxGatewayConnectionConfig,
+    SandboxInClusterConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
 )
 
@@ -37,8 +38,8 @@ class AsyncSandboxConnector:
     """
     Async connector for communicating with a Sandbox over HTTP using httpx.
 
-    Supports DirectConnection and GatewayConnection modes. LocalTunnel mode
-    is not supported because it relies on a long-running subprocess; use the
+    Supports DirectConnection, GatewayConnection, and InCluster modes. LocalTunnel
+    mode is not supported because it relies on a long-running subprocess; use the
     sync SandboxConnector for local development.
     """
 
@@ -48,6 +49,7 @@ class AsyncSandboxConnector:
         namespace: str,
         connection_config: SandboxConnectionConfig,
         k8s_helper: AsyncK8sHelper,
+        pod_ip: str | None = None,
     ):
         if isinstance(connection_config, SandboxLocalTunnelConnectionConfig):
             raise ValueError(
@@ -62,6 +64,15 @@ class AsyncSandboxConnector:
         self.k8s_helper = k8s_helper
 
         self._base_url: str | None = None
+        if isinstance(connection_config, SandboxInClusterConnectionConfig):
+            if pod_ip:
+                self._base_url = f"http://{pod_ip}:{connection_config.server_port}"
+            else:
+                self._base_url = (
+                    f"http://{sandbox_id}.{namespace}"
+                    f".svc.cluster.local:{connection_config.server_port}"
+                )
+
         transport = httpx.AsyncHTTPTransport(retries=3)
         self.client = httpx.AsyncClient(
             transport=transport, timeout=httpx.Timeout(60.0)
@@ -87,14 +98,18 @@ class AsyncSandboxConnector:
 
         return self._base_url
 
+    def _should_inject_router_headers(self) -> bool:
+        return not isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+
     async def send_request(self, method: str, endpoint: str, **kwargs) -> httpx.Response:
         base_url = await self._resolve_base_url()
         url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
         headers = kwargs.pop("headers", {}).copy()
-        headers["X-Sandbox-ID"] = self.id
-        headers["X-Sandbox-Namespace"] = self.namespace
-        headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
+        if self._should_inject_router_headers():
+            headers["X-Sandbox-ID"] = self.id
+            headers["X-Sandbox-Namespace"] = self.namespace
+            headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
 
         last_response: httpx.Response | None = None
         for attempt in range(MAX_RETRIES + 1):
@@ -122,7 +137,10 @@ class AsyncSandboxConnector:
                 ) from e
             except httpx.HTTPError as e:
                 logger.error(f"Request to sandbox failed: {e}")
-                self._base_url = None
+                # Only clear the cached URL for Gateway config — the IP may have changed.
+                # Direct and InCluster URLs are stable and must not be cleared.
+                if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
+                    self._base_url = None
                 raise SandboxRequestError(
                     f"Failed to communicate with the sandbox at {url}.",
                     status_code=None,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -158,8 +158,12 @@ class AsyncK8sHelper:
             finally:
                 await w.close()
 
-    async def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int):
-        """Waits for the Sandbox custom resource to have a 'Ready' status."""
+    async def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int) -> str | None:
+        """Waits for the Sandbox custom resource to have a 'Ready' status.
+
+        Returns the first pod IP from the sandbox status when ready, or None if
+        no IPs are present (e.g. on older controllers that don't populate podIPs).
+        """
         await self._ensure_initialized()
 
         deadline = time.monotonic() + timeout
@@ -188,7 +192,8 @@ class AsyncK8sHelper:
                         for cond in conditions:
                             if cond.get("type") == "Ready" and cond.get("status") == "True":
                                 logger.info(f"Sandbox {name} is ready.")
-                                return
+                                pod_ips = status.get("podIPs", [])
+                                return pod_ips[0] if pod_ips else None
                     elif event["type"] == "DELETED":
                         logger.error(f"Sandbox {name} was deleted before becoming ready.")
                         raise SandboxNotFoundError(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -45,6 +45,7 @@ class AsyncSandbox:
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         k8s_helper: AsyncK8sHelper | None = None,
+        pod_ip: str | None = None,
     ):
         if connection_config is None:
             raise ValueError(
@@ -64,6 +65,7 @@ class AsyncSandbox:
             namespace=self.namespace,
             connection_config=self.connection_config,
             k8s_helper=self.k8s_helper,
+            pod_ip=pod_ip,
         )
 
         self.tracer_config = tracer_config or SandboxTracerConfig()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -19,7 +19,7 @@ from .async_k8s_helper import AsyncK8sHelper
 from .commands.async_command_executor import AsyncCommandExecutor
 from .constants import POD_NAME_ANNOTATION
 from .files.async_filesystem import AsyncFilesystem
-from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxTracerConfig
 from .trace_manager import create_tracer_manager
 
 
@@ -45,7 +45,7 @@ class AsyncSandbox:
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         k8s_helper: AsyncK8sHelper | None = None,
-        pod_ip: str | None = None,
+        use_pod_ip: bool = False,
     ):
         if connection_config is None:
             raise ValueError(
@@ -65,7 +65,7 @@ class AsyncSandbox:
             namespace=self.namespace,
             connection_config=self.connection_config,
             k8s_helper=self.k8s_helper,
-            pod_ip=pod_ip,
+            get_pod_ip=self.get_pod_ip if use_pod_ip else None,
         )
 
         self.tracer_config = tracer_config or SandboxTracerConfig()
@@ -81,7 +81,6 @@ class AsyncSandbox:
 
         self._is_closed = False
         self._pod_name = None
-        self._pod_ip = pod_ip
 
     async def get_pod_name(self) -> str:
         """Fetches the Sandbox object from Kubernetes and retrieves its current pod name."""
@@ -98,15 +97,13 @@ class AsyncSandbox:
     async def get_pod_ip(self) -> str | None:
         """Fetches the first pod IP from the Sandbox status.
 
+        Always queries the K8s API for the latest IP — the pod IP can change
+        after a pod restart (e.g. when spec.replicas is scaled to 0 and back).
         Returns None if the controller does not populate podIPs.
         """
-        if self._pod_ip is not None:
-            return self._pod_ip
-
         sandbox_object = await self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get("status", {}).get("podIPs", [])
-        self._pod_ip = pod_ips[0] if pod_ips else None
-        return self._pod_ip
+        return pod_ips[0] if pod_ips else None
 
     @property
     def commands(self) -> AsyncCommandExecutor | None:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -19,7 +19,7 @@ from .async_k8s_helper import AsyncK8sHelper
 from .commands.async_command_executor import AsyncCommandExecutor
 from .constants import POD_NAME_ANNOTATION
 from .files.async_filesystem import AsyncFilesystem
-from .models import SandboxConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
 from .trace_manager import create_tracer_manager
 
 
@@ -81,6 +81,7 @@ class AsyncSandbox:
 
         self._is_closed = False
         self._pod_name = None
+        self._pod_ip = pod_ip
 
     async def get_pod_name(self) -> str:
         """Fetches the Sandbox object from Kubernetes and retrieves its current pod name."""
@@ -93,6 +94,19 @@ class AsyncSandbox:
         pod_name = annotations.get(POD_NAME_ANNOTATION)
         self._pod_name = pod_name if pod_name is not None else self.sandbox_id
         return self._pod_name
+
+    async def get_pod_ip(self) -> str | None:
+        """Fetches the first pod IP from the Sandbox status.
+
+        Returns None if the controller does not populate podIPs.
+        """
+        if self._pod_ip is not None:
+            return self._pod_ip
+
+        sandbox_object = await self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
+        pod_ips = sandbox_object.get("status", {}).get("podIPs", [])
+        self._pod_ip = pod_ips[0] if pod_ips else None
+        return self._pod_ip
 
     @property
     def commands(self) -> AsyncCommandExecutor | None:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -19,7 +19,7 @@ from .async_k8s_helper import AsyncK8sHelper
 from .commands.async_command_executor import AsyncCommandExecutor
 from .constants import POD_NAME_ANNOTATION
 from .files.async_filesystem import AsyncFilesystem
-from .models import SandboxConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
 from .trace_manager import create_tracer_manager
 
 
@@ -45,12 +45,12 @@ class AsyncSandbox:
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         k8s_helper: AsyncK8sHelper | None = None,
-        use_pod_ip: bool = False,
     ):
         if connection_config is None:
             raise ValueError(
                 "connection_config is required for AsyncSandbox. "
-                "Use SandboxDirectConnectionConfig or SandboxGatewayConnectionConfig."
+                "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, "
+                "or SandboxInClusterConnectionConfig."
             )
 
         self.claim_name = claim_name
@@ -60,6 +60,10 @@ class AsyncSandbox:
 
         self.k8s_helper = k8s_helper or AsyncK8sHelper()
 
+        use_pod_ip = (
+            isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+            and self.connection_config.use_pod_ip
+        )
         self.connector = AsyncSandboxConnector(
             sandbox_id=self.sandbox_id,
             namespace=self.namespace,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -154,10 +154,6 @@ class AsyncSandboxClient(Generic[T]):
                 raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
             await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
-            use_pod_ip = (
-                isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-                and self.connection_config.use_pod_ip
-            )
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
                 sandbox_id=sandbox_id,
@@ -165,7 +161,6 @@ class AsyncSandboxClient(Generic[T]):
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
                 k8s_helper=self.k8s_helper,
-                use_pod_ip=use_pod_ip,
             )
         except (Exception, asyncio.CancelledError):
             await asyncio.shield(self._delete_claim(claim_name, namespace))
@@ -214,10 +209,6 @@ class AsyncSandboxClient(Generic[T]):
             async with self._lock:
                 self._active_connection_sandboxes.pop(key, None)
 
-        use_pod_ip = (
-            isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-            and self.connection_config.use_pod_ip
-        )
         new_handle = self.sandbox_class(
             claim_name=claim_name,
             sandbox_id=sandbox_id,
@@ -225,7 +216,6 @@ class AsyncSandboxClient(Generic[T]):
             connection_config=self.connection_config,
             tracer_config=self.tracer_config,
             k8s_helper=self.k8s_helper,
-            use_pod_ip=use_pod_ip,
         )
 
         async with self._lock:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -30,7 +30,7 @@ from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
 from .utils import construct_sandbox_claim_lifecycle_spec
-from .models import SandboxConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
 from .trace_manager import async_trace_span, create_tracer_manager, initialize_tracer, trace
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,8 @@ class AsyncSandboxClient(Generic[T]):
         if connection_config is None:
             raise ValueError(
                 "connection_config is required for AsyncSandboxClient. "
-                "Use SandboxDirectConnectionConfig or SandboxGatewayConnectionConfig. "
+                "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, or "
+                "SandboxInClusterConnectionConfig. "
                 "For local development with kubectl port-forward, use the synchronous SandboxClient."
             )
 
@@ -151,8 +152,12 @@ class AsyncSandboxClient(Generic[T]):
             remaining_timeout = max(0, int(sandbox_ready_timeout - elapsed_time))
             if remaining_timeout <= 0:
                 raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
-            await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
+            pod_ip = await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
+            use_pod_ip = (
+                isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+                and self.connection_config.use_pod_ip
+            )
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
                 sandbox_id=sandbox_id,
@@ -160,6 +165,7 @@ class AsyncSandboxClient(Generic[T]):
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
                 k8s_helper=self.k8s_helper,
+                pod_ip=pod_ip if use_pod_ip else None,
             )
         except (Exception, asyncio.CancelledError):
             await asyncio.shield(self._delete_claim(claim_name, namespace))
@@ -208,6 +214,8 @@ class AsyncSandboxClient(Generic[T]):
             async with self._lock:
                 self._active_connection_sandboxes.pop(key, None)
 
+        # pod_ip is intentionally omitted — we don't have it here without an extra
+        # K8s API call, and the stable cluster DNS is always available in-cluster.
         new_handle = self.sandbox_class(
             claim_name=claim_name,
             sandbox_id=sandbox_id,
@@ -336,8 +344,8 @@ class AsyncSandboxClient(Generic[T]):
         )
 
     @async_trace_span("wait_for_sandbox_ready")
-    async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
-        await self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
+    async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int) -> str | None:
+        return await self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @async_trace_span("delete_claim")
     async def _delete_claim(self, claim_name: str, namespace: str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -152,12 +152,16 @@ class AsyncSandboxClient(Generic[T]):
             remaining_timeout = max(0, int(sandbox_ready_timeout - elapsed_time))
             if remaining_timeout <= 0:
                 raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
-            pod_ip = await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
+            await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
-            use_pod_ip = (
-                isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-                and self.connection_config.use_pod_ip
-            )
+            # Resolve pod IP if requested — must happen after sandbox is Ready
+            pod_ip = None
+            if (isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+                    and self.connection_config.use_pod_ip):
+                sandbox_obj = await self.k8s_helper.get_sandbox(sandbox_id, namespace) or {}
+                pod_ips = sandbox_obj.get("status", {}).get("podIPs", [])
+                pod_ip = pod_ips[0] if pod_ips else None
+
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
                 sandbox_id=sandbox_id,
@@ -165,7 +169,7 @@ class AsyncSandboxClient(Generic[T]):
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
                 k8s_helper=self.k8s_helper,
-                pod_ip=pod_ip if use_pod_ip else None,
+                pod_ip=pod_ip,
             )
         except (Exception, asyncio.CancelledError):
             await asyncio.shield(self._delete_claim(claim_name, namespace))
@@ -214,8 +218,6 @@ class AsyncSandboxClient(Generic[T]):
             async with self._lock:
                 self._active_connection_sandboxes.pop(key, None)
 
-        # pod_ip is intentionally omitted — we don't have it here without an extra
-        # K8s API call, and the stable cluster DNS is always available in-cluster.
         new_handle = self.sandbox_class(
             claim_name=claim_name,
             sandbox_id=sandbox_id,
@@ -344,8 +346,8 @@ class AsyncSandboxClient(Generic[T]):
         )
 
     @async_trace_span("wait_for_sandbox_ready")
-    async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int) -> str | None:
-        return await self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
+    async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
+        await self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @async_trace_span("delete_claim")
     async def _delete_claim(self, claim_name: str, namespace: str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -214,6 +214,10 @@ class AsyncSandboxClient(Generic[T]):
             async with self._lock:
                 self._active_connection_sandboxes.pop(key, None)
 
+        use_pod_ip = (
+            isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+            and self.connection_config.use_pod_ip
+        )
         new_handle = self.sandbox_class(
             claim_name=claim_name,
             sandbox_id=sandbox_id,
@@ -221,6 +225,7 @@ class AsyncSandboxClient(Generic[T]):
             connection_config=self.connection_config,
             tracer_config=self.tracer_config,
             k8s_helper=self.k8s_helper,
+            use_pod_ip=use_pod_ip,
         )
 
         async with self._lock:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -154,14 +154,10 @@ class AsyncSandboxClient(Generic[T]):
                 raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
             await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
-            # Resolve pod IP if requested — must happen after sandbox is Ready
-            pod_ip = None
-            if (isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-                    and self.connection_config.use_pod_ip):
-                sandbox_obj = await self.k8s_helper.get_sandbox(sandbox_id, namespace) or {}
-                pod_ips = sandbox_obj.get("status", {}).get("podIPs", [])
-                pod_ip = pod_ips[0] if pod_ips else None
-
+            use_pod_ip = (
+                isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+                and self.connection_config.use_pod_ip
+            )
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
                 sandbox_id=sandbox_id,
@@ -169,7 +165,7 @@ class AsyncSandboxClient(Generic[T]):
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
                 k8s_helper=self.k8s_helper,
-                pod_ip=pod_ip,
+                use_pod_ip=use_pod_ip,
             )
         except (Exception, asyncio.CancelledError):
             await asyncio.shield(self._delete_claim(claim_name, namespace))

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -224,7 +224,7 @@ class SandboxConnector:
         self.namespace = namespace
         self.connection_config = connection_config
         self.k8s_helper = k8s_helper
-        self.pod_ip = pod_ip
+        self._pod_ip = pod_ip
 
         # Connection strategy initialization
         self.strategy = self._connection_strategy()
@@ -249,7 +249,7 @@ class SandboxConnector:
         elif isinstance(self.connection_config, SandboxLocalTunnelConnectionConfig):
             return LocalTunnelConnectionStrategy(self.id, self.namespace, self.connection_config)
         elif isinstance(self.connection_config, SandboxInClusterConnectionConfig):
-            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config, self.pod_ip)
+            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config, self._pod_ip)
         else:
             raise ValueError("Unknown connection configuration type")
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -24,7 +24,8 @@ from .models import (
     SandboxConnectionConfig,
     SandboxDirectConnectionConfig,
     SandboxGatewayConnectionConfig,
-    SandboxLocalTunnelConnectionConfig
+    SandboxInClusterConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
 )
 from .k8s_helper import K8sHelper
 from .exceptions import (
@@ -51,6 +52,14 @@ class ConnectionStrategy(ABC):
     def verify_connection(self):
         """Checks if the connection is healthy. Raises SandboxPortForwardError if not."""
         pass
+
+    def should_inject_router_headers(self) -> bool:
+        """Returns True if X-Sandbox-* router headers should be attached to requests.
+
+        Defaults to True. InClusterConnectionStrategy overrides to False because
+        requests go directly to the sandbox pod, which does not use those headers.
+        """
+        return True
 
 class DirectConnectionStrategy(ConnectionStrategy):
     def __init__(self, config: SandboxDirectConnectionConfig):
@@ -168,6 +177,38 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                 f"Stderr: {stderr.decode(errors='replace')}"
             )
 
+class InClusterConnectionStrategy(ConnectionStrategy):
+    """Provides direct in-cluster connectivity to a sandbox pod, bypassing the router.
+
+    Requires the SDK to run inside the same Kubernetes cluster as the sandbox.
+    Router-specific request headers are not injected.
+    """
+
+    def __init__(
+        self,
+        sandbox_id: str,
+        namespace: str,
+        config: SandboxInClusterConnectionConfig,
+    ):
+        self.sandbox_id = sandbox_id
+        self.namespace = namespace
+        self.config = config
+
+    def connect(self) -> str:
+        return (
+            f"http://{self.sandbox_id}.{self.namespace}"
+            f".svc.cluster.local:{self.config.server_port}"
+        )
+
+    def verify_connection(self):
+        pass
+
+    def close(self):
+        pass
+
+    def should_inject_router_headers(self) -> bool:
+        return False
+
 class SandboxConnector:
     """
     Manages the connection to the Sandbox, including auto-discovery and port-forwarding.
@@ -207,6 +248,8 @@ class SandboxConnector:
             return GatewayConnectionStrategy(self.connection_config, self.k8s_helper)
         elif isinstance(self.connection_config, SandboxLocalTunnelConnectionConfig):
             return LocalTunnelConnectionStrategy(self.id, self.namespace, self.connection_config)
+        elif isinstance(self.connection_config, SandboxInClusterConnectionConfig):
+            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config)
         else:
             raise ValueError("Unknown connection configuration type")
 
@@ -231,9 +274,10 @@ class SandboxConnector:
             url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
             headers = kwargs.get("headers", {}).copy()
-            headers["X-Sandbox-ID"] = self.id
-            headers["X-Sandbox-Namespace"] = self.namespace
-            headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
+            if self.strategy.should_inject_router_headers():
+                headers["X-Sandbox-ID"] = self.id
+                headers["X-Sandbox-Namespace"] = self.namespace
+                headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
             kwargs["headers"] = headers
 
             # Send the request

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -53,9 +53,10 @@ class ConnectionStrategy(ABC):
         """Checks if the connection is healthy. Raises SandboxPortForwardError if not."""
         pass
 
+    @abstractmethod
     def should_inject_router_headers(self) -> bool:
         """Returns True if X-Sandbox-* router headers should be injected into requests."""
-        return True
+        pass
 
 class DirectConnectionStrategy(ConnectionStrategy):
     def __init__(self, config: SandboxDirectConnectionConfig):
@@ -69,6 +70,9 @@ class DirectConnectionStrategy(ConnectionStrategy):
 
     def verify_connection(self):
         pass
+
+    def should_inject_router_headers(self) -> bool:
+        return True
 
 class GatewayConnectionStrategy(ConnectionStrategy):
     def __init__(self, config: SandboxGatewayConnectionConfig, k8s_helper: K8sHelper):
@@ -93,6 +97,9 @@ class GatewayConnectionStrategy(ConnectionStrategy):
 
     def verify_connection(self):
         pass
+
+    def should_inject_router_headers(self) -> bool:
+        return True
 
 class LocalTunnelConnectionStrategy(ConnectionStrategy):
     def __init__(self, sandbox_id: str, namespace: str, config: SandboxLocalTunnelConnectionConfig):
@@ -172,6 +179,9 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                 f"Kubectl Port-Forward crashed!\n"
                 f"Stderr: {stderr.decode(errors='replace')}"
             )
+
+    def should_inject_router_headers(self) -> bool:
+        return True
 
 class InClusterConnectionStrategy(ConnectionStrategy):
     """Provides direct in-cluster connectivity to a sandbox pod, bypassing the router.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -185,11 +185,15 @@ class InClusterConnectionStrategy(ConnectionStrategy):
         sandbox_id: str,
         namespace: str,
         config: SandboxInClusterConnectionConfig,
+        pod_ip: str | None = None,
     ):
-        self._base_url = (
-            f"http://{sandbox_id}.{namespace}"
-            f".svc.cluster.local:{config.server_port}"
-        )
+        if pod_ip:
+            self._base_url = f"http://{pod_ip}:{config.server_port}"
+        else:
+            self._base_url = (
+                f"http://{sandbox_id}.{namespace}"
+                f".svc.cluster.local:{config.server_port}"
+            )
 
     def connect(self) -> str:
         return self._base_url
@@ -213,13 +217,15 @@ class SandboxConnector:
         namespace: str,
         connection_config: SandboxConnectionConfig,
         k8s_helper: K8sHelper,
+        pod_ip: str | None = None,
     ):
         # Parameter initialization
         self.id = sandbox_id
         self.namespace = namespace
         self.connection_config = connection_config
         self.k8s_helper = k8s_helper
-        
+        self.pod_ip = pod_ip
+
         # Connection strategy initialization
         self.strategy = self._connection_strategy()
         
@@ -243,7 +249,7 @@ class SandboxConnector:
         elif isinstance(self.connection_config, SandboxLocalTunnelConnectionConfig):
             return LocalTunnelConnectionStrategy(self.id, self.namespace, self.connection_config)
         elif isinstance(self.connection_config, SandboxInClusterConnectionConfig):
-            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config)
+            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config, self.pod_ip)
         else:
             raise ValueError("Unknown connection configuration type")
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -16,6 +16,7 @@ import logging
 import socket
 import subprocess
 import time
+from typing import Callable
 import requests
 from abc import ABC, abstractmethod
 from requests.adapters import HTTPAdapter
@@ -195,24 +196,34 @@ class InClusterConnectionStrategy(ConnectionStrategy):
         sandbox_id: str,
         namespace: str,
         config: SandboxInClusterConnectionConfig,
-        pod_ip: str | None = None,
+        get_pod_ip: Callable[[], str | None] | None = None,
     ):
-        if pod_ip:
-            self._base_url = f"http://{pod_ip}:{config.server_port}"
-        else:
-            self._base_url = (
-                f"http://{sandbox_id}.{namespace}"
-                f".svc.cluster.local:{config.server_port}"
-            )
+        self._dns_url = (
+            f"http://{sandbox_id}.{namespace}"
+            f".svc.cluster.local:{config.server_port}"
+        )
+        self._get_pod_ip = get_pod_ip
+        self._server_port = config.server_port
+        self._resolved = False
+        self._cached_pod_ip_url: str | None = None
 
     def connect(self) -> str:
-        return self._base_url
+        if self._get_pod_ip:
+            if self._resolved:
+                return self._cached_pod_ip_url or self._dns_url
+            pod_ip = self._get_pod_ip()
+            self._resolved = True
+            if pod_ip:
+                self._cached_pod_ip_url = f"http://{pod_ip}:{self._server_port}"
+                return self._cached_pod_ip_url
+        return self._dns_url
 
     def verify_connection(self):
         pass
 
     def close(self):
-        pass
+        self._resolved = False
+        self._cached_pod_ip_url = None
 
     def should_inject_router_headers(self) -> bool:
         return False
@@ -227,14 +238,14 @@ class SandboxConnector:
         namespace: str,
         connection_config: SandboxConnectionConfig,
         k8s_helper: K8sHelper,
-        pod_ip: str | None = None,
+        get_pod_ip: Callable[[], str | None] | None = None,
     ):
         # Parameter initialization
         self.id = sandbox_id
         self.namespace = namespace
         self.connection_config = connection_config
         self.k8s_helper = k8s_helper
-        self._pod_ip = pod_ip
+        self._get_pod_ip = get_pod_ip
 
         # Connection strategy initialization
         self.strategy = self._connection_strategy()
@@ -259,7 +270,7 @@ class SandboxConnector:
         elif isinstance(self.connection_config, SandboxLocalTunnelConnectionConfig):
             return LocalTunnelConnectionStrategy(self.id, self.namespace, self.connection_config)
         elif isinstance(self.connection_config, SandboxInClusterConnectionConfig):
-            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config, self._pod_ip)
+            return InClusterConnectionStrategy(self.id, self.namespace, self.connection_config, self._get_pod_ip)
         else:
             raise ValueError("Unknown connection configuration type")
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -212,9 +212,9 @@ class InClusterConnectionStrategy(ConnectionStrategy):
             if self._resolved:
                 return self._cached_pod_ip_url or self._dns_url
             pod_ip = self._get_pod_ip()
-            self._resolved = True
             if pod_ip:
                 self._cached_pod_ip_url = f"http://{pod_ip}:{self._server_port}"
+                self._resolved = True
                 return self._cached_pod_ip_url
         return self._dns_url
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -54,11 +54,7 @@ class ConnectionStrategy(ABC):
         pass
 
     def should_inject_router_headers(self) -> bool:
-        """Returns True if X-Sandbox-* router headers should be attached to requests.
-
-        Defaults to True. InClusterConnectionStrategy overrides to False because
-        requests go directly to the sandbox pod, which does not use those headers.
-        """
+        """Returns True if X-Sandbox-* router headers should be injected into requests."""
         return True
 
 class DirectConnectionStrategy(ConnectionStrategy):
@@ -190,15 +186,13 @@ class InClusterConnectionStrategy(ConnectionStrategy):
         namespace: str,
         config: SandboxInClusterConnectionConfig,
     ):
-        self.sandbox_id = sandbox_id
-        self.namespace = namespace
-        self.config = config
+        self._base_url = (
+            f"http://{sandbox_id}.{namespace}"
+            f".svc.cluster.local:{config.server_port}"
+        )
 
     def connect(self) -> str:
-        return (
-            f"http://{self.sandbox_id}.{self.namespace}"
-            f".svc.cluster.local:{self.config.server_port}"
-        )
+        return self._base_url
 
     def verify_connection(self):
         pass

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -128,8 +128,12 @@ class K8sHelper:
                         w.stop()
                         return name
 
-    def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int):
-        """Waits for the Sandbox custom resource to have a 'Ready' status."""
+    def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int) -> str | None:
+        """Waits for the Sandbox custom resource to have a 'Ready' status.
+
+        Returns the first pod IP from the sandbox status when ready, or None if
+        no IPs are present (e.g. on older controllers that don't populate podIPs).
+        """
         deadline = time.monotonic() + timeout
         logging.info(f"Watching for Sandbox {name} to become ready...")
         while True:
@@ -156,7 +160,8 @@ class K8sHelper:
                         if cond.get('type') == 'Ready' and cond.get('status') == 'True':
                             logging.info(f"Sandbox {name} is ready.")
                             w.stop()
-                            return
+                            pod_ips = status.get('podIPs', [])
+                            return pod_ips[0] if pod_ips else None
                 elif event["type"] == "DELETED":
                     logging.error(f"Sandbox {name} was deleted before becoming ready.")
                     w.stop()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -45,7 +45,21 @@ class SandboxLocalTunnelConnectionConfig(BaseModel):
     port_forward_ready_timeout: int = 30  # Timeout in seconds to wait for port-forward to be ready.
     server_port: int = 8888  # Port the sandbox container listens on.
 
-SandboxConnectionConfig = Union[SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, SandboxLocalTunnelConnectionConfig]
+class SandboxInClusterConnectionConfig(BaseModel):
+    """Configuration for direct in-cluster connection to the sandbox pod via K8s DNS.
+
+    Constructs the URL as http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}
+    and bypasses the router entirely. No external config is required beyond what
+    the Sandbox already knows (id, namespace, port).
+    """
+    server_port: int = 8888  # Port the sandbox container listens on.
+
+SandboxConnectionConfig = Union[
+    SandboxDirectConnectionConfig,
+    SandboxGatewayConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
+    SandboxInClusterConnectionConfig,
+]
 
 class SandboxTracerConfig(BaseModel):
     """Configuration for tracer level information"""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -46,13 +46,16 @@ class SandboxLocalTunnelConnectionConfig(BaseModel):
     server_port: int = 8888  # Port the sandbox container listens on.
 
 class SandboxInClusterConnectionConfig(BaseModel):
-    """Configuration for direct in-cluster connection to the sandbox pod via K8s DNS.
+    """Configuration for direct in-cluster connection to the sandbox pod, bypassing the router.
 
-    Constructs the URL as http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}
-    and bypasses the router entirely. No external config is required beyond what
-    the Sandbox already knows (id, namespace, port).
+    By default, connects via stable K8s DNS:
+        http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}
+
+    When use_pod_ip=True, connects directly to the pod IP from the Sandbox status,
+    avoiding DNS resolution at the cost of needing a K8s API call to retrieve the IP.
     """
     server_port: int = 8888  # Port the sandbox container listens on.
+    use_pod_ip: bool = False  # If True, connect via pod IP instead of cluster DNS.
 
 SandboxConnectionConfig = Union[
     SandboxDirectConnectionConfig,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -45,13 +45,14 @@ class Sandbox:
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         k8s_helper: K8sHelper | None = None,
+        pod_ip: str | None = None,
     ):
         # Sandbox Related Configuration
         self.claim_name = claim_name
         self.sandbox_id = sandbox_id
         self.namespace = namespace
         self.connection_config = connection_config or SandboxLocalTunnelConnectionConfig()
-        
+
         # Sandbox Management downstream dependency
         self.k8s_helper = k8s_helper or K8sHelper()
 
@@ -60,7 +61,8 @@ class Sandbox:
             sandbox_id=self.sandbox_id, # Pass the base sandbox id to connect to.
             namespace=self.namespace,
             connection_config=self.connection_config,
-            k8s_helper=self.k8s_helper
+            k8s_helper=self.k8s_helper,
+            pod_ip=pod_ip,
         )
 
         # Tracer initialization

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -19,9 +19,10 @@ from .trace_manager import create_tracer_manager, trace_span, trace
 from .commands.command_executor import CommandExecutor
 from .files.filesystem import Filesystem
 from .models import (
-    SandboxConnectionConfig, 
-    SandboxLocalTunnelConnectionConfig, 
-    SandboxTracerConfig
+    SandboxConnectionConfig,
+    SandboxInClusterConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
+    SandboxTracerConfig,
 )
 from .k8s_helper import K8sHelper
 from .connector import SandboxConnector
@@ -45,7 +46,6 @@ class Sandbox:
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         k8s_helper: K8sHelper | None = None,
-        pod_ip: str | None = None,
     ):
         # Sandbox Related Configuration
         self.claim_name = claim_name
@@ -56,13 +56,19 @@ class Sandbox:
         # Sandbox Management downstream dependency
         self.k8s_helper = k8s_helper or K8sHelper()
 
+        # Resolve pod IP if requested before establishing connection
+        self._pod_ip = None
+        if (isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+                and self.connection_config.use_pod_ip):
+            self.get_pod_ip()
+
         # Establish Sandbox Connection
         self.connector = SandboxConnector(
-            sandbox_id=self.sandbox_id, # Pass the base sandbox id to connect to.
+            sandbox_id=self.sandbox_id,
             namespace=self.namespace,
             connection_config=self.connection_config,
             k8s_helper=self.k8s_helper,
-            pod_ip=pod_ip,
+            pod_ip=self._pod_ip,
         )
 
         # Tracer initialization
@@ -82,13 +88,26 @@ class Sandbox:
         """Fetches the Sandbox object from Kubernetes and retrieves its current pod name."""
         if self._pod_name is not None:
             return self._pod_name
-            
+
         sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         metadata = sandbox_object.get('metadata') or {}
         annotations = metadata.get('annotations') or {}
         pod_name = annotations.get(POD_NAME_ANNOTATION)
         self._pod_name = pod_name if pod_name is not None else self.sandbox_id
         return self._pod_name
+
+    def get_pod_ip(self) -> str | None:
+        """Fetches the first pod IP from the Sandbox status.
+
+        Returns None if the controller does not populate podIPs.
+        """
+        if self._pod_ip is not None:
+            return self._pod_ip
+
+        sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
+        pod_ips = sandbox_object.get('status', {}).get('podIPs', [])
+        self._pod_ip = pod_ips[0] if pod_ips else None
+        return self._pod_ip
 
     def status(self) -> tuple[str, str]:
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -56,19 +56,17 @@ class Sandbox:
         # Sandbox Management downstream dependency
         self.k8s_helper = k8s_helper or K8sHelper()
 
-        # Resolve pod IP if requested before establishing connection
-        self._pod_ip = None
-        if (isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-                and self.connection_config.use_pod_ip):
-            self.get_pod_ip()
-
         # Establish Sandbox Connection
+        use_pod_ip = (
+            isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+            and self.connection_config.use_pod_ip
+        )
         self.connector = SandboxConnector(
             sandbox_id=self.sandbox_id,
             namespace=self.namespace,
             connection_config=self.connection_config,
             k8s_helper=self.k8s_helper,
-            pod_ip=self._pod_ip,
+            get_pod_ip=self.get_pod_ip if use_pod_ip else None,
         )
 
         # Tracer initialization
@@ -99,15 +97,13 @@ class Sandbox:
     def get_pod_ip(self) -> str | None:
         """Fetches the first pod IP from the Sandbox status.
 
+        Always queries the K8s API for the latest IP — the pod IP can change
+        after a pod restart (e.g. when spec.replicas is scaled to 0 and back).
         Returns None if the controller does not populate podIPs.
         """
-        if self._pod_ip is not None:
-            return self._pod_ip
-
         sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get('status', {}).get('podIPs', [])
-        self._pod_ip = pod_ips[0] if pod_ips else None
-        return self._pod_ip
+        return pod_ips[0] if pod_ips else None
 
     def status(self) -> tuple[str, str]:
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -32,9 +32,8 @@ from .trace_manager import (
 from .sandbox import Sandbox
 from .models import (
     SandboxConnectionConfig,
-    SandboxInClusterConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
-    SandboxTracerConfig
+    SandboxTracerConfig,
 )
 from .k8s_helper import K8sHelper
 from .utils import construct_sandbox_claim_lifecycle_spec
@@ -121,12 +120,8 @@ class SandboxClient(Generic[T]):
             remaining_timeout = max(0, int(sandbox_ready_timeout - elapsed_time))
             if remaining_timeout <= 0:
                 raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
-            pod_ip = self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
+            self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
-            use_pod_ip = (
-                isinstance(self.connection_config, SandboxInClusterConnectionConfig)
-                and self.connection_config.use_pod_ip
-            )
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
                 sandbox_id=sandbox_id,
@@ -134,7 +129,6 @@ class SandboxClient(Generic[T]):
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
                 k8s_helper=self.k8s_helper,
-                pod_ip=pod_ip if use_pod_ip else None,
             )
         except Exception:
             # If creation or waiting fails, ensure we don't leave an orphaned claim
@@ -178,9 +172,7 @@ class SandboxClient(Generic[T]):
         if existing:
             self._active_connection_sandboxes.pop(key, None)
 
-        # Re-attach: Create a fresh handle for the existing ID.
-        # pod_ip is intentionally omitted — we don't have it here without an extra
-        # K8s API call, and the stable cluster DNS is always available in-cluster.
+        # Re-attach: Create a fresh handle for the existing ID
         new_handle = self.sandbox_class(
             claim_name=claim_name,
             sandbox_id=sandbox_id,
@@ -328,12 +320,9 @@ class SandboxClient(Generic[T]):
         self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle)
 
     @trace_span("wait_for_sandbox_ready")
-    def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int) -> str | None:
-        """Waits for the Sandbox custom resource to have a 'Ready' status.
-
-        Returns the first pod IP if available, or None.
-        """
-        return self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
+    def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
+        """Waits for the Sandbox custom resource to have a 'Ready' status."""
+        self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @trace_span("delete_claim")
     def _delete_claim(self, claim_name: str, namespace: str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -31,8 +31,9 @@ from .trace_manager import (
 )
 from .sandbox import Sandbox
 from .models import (
-    SandboxConnectionConfig, 
-    SandboxLocalTunnelConnectionConfig, 
+    SandboxConnectionConfig,
+    SandboxInClusterConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
     SandboxTracerConfig
 )
 from .k8s_helper import K8sHelper
@@ -120,15 +121,20 @@ class SandboxClient(Generic[T]):
             remaining_timeout = max(0, int(sandbox_ready_timeout - elapsed_time))
             if remaining_timeout <= 0:
                 raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
-            self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
-            
+            pod_ip = self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
+
+            use_pod_ip = (
+                isinstance(self.connection_config, SandboxInClusterConnectionConfig)
+                and self.connection_config.use_pod_ip
+            )
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
                 sandbox_id=sandbox_id,
                 namespace=namespace,
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
-                k8s_helper=self.k8s_helper
+                k8s_helper=self.k8s_helper,
+                pod_ip=pod_ip if use_pod_ip else None,
             )
         except Exception:
             # If creation or waiting fails, ensure we don't leave an orphaned claim
@@ -320,9 +326,12 @@ class SandboxClient(Generic[T]):
         self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle)
 
     @trace_span("wait_for_sandbox_ready")
-    def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
-        """Waits for the Sandbox custom resource to have a 'Ready' status."""
-        self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
+    def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int) -> str | None:
+        """Waits for the Sandbox custom resource to have a 'Ready' status.
+
+        Returns the first pod IP if available, or None.
+        """
+        return self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @trace_span("delete_claim")
     def _delete_claim(self, claim_name: str, namespace: str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -178,7 +178,9 @@ class SandboxClient(Generic[T]):
         if existing:
             self._active_connection_sandboxes.pop(key, None)
 
-        # Re-attach: Create a fresh handle for the existing ID
+        # Re-attach: Create a fresh handle for the existing ID.
+        # pod_ip is intentionally omitted — we don't have it here without an extra
+        # K8s API call, and the stable cluster DNS is always available in-cluster.
         new_handle = self.sandbox_class(
             claim_name=claim_name,
             sandbox_id=sandbox_id,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -102,16 +102,16 @@ class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
                 }
             }
         }
-        
+
         async def mock_stream(*args, **kwargs):
             yield mock_event
-            
+
         mock_watch.stream = mock_stream
         mock_watch_class.return_value = mock_watch
-        
+
         with self.assertRaises(SandboxTemplateNotFoundError) as context:
             await self.helper.resolve_sandbox_name("test-claim", "default", timeout=5)
-            
+
         self.assertIn("Template 'non-existent-template' not found", str(context.exception))
 
     @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
@@ -124,17 +124,68 @@ class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
                 "metadata": {"name": "test-claim"}
             }
         }
-        
+
         async def mock_stream(*args, **kwargs):
             yield mock_event
-            
+
         mock_watch.stream = mock_stream
         mock_watch_class.return_value = mock_watch
-        
+
         with self.assertRaises(SandboxMetadataError) as context:
             await self.helper.resolve_sandbox_name("test-claim", "default", timeout=5)
-            
+
         self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
+
+
+class TestAsyncK8sHelperWaitForSandboxReady(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.helper = AsyncK8sHelper()
+        self.helper._initialized = True
+        self.helper.custom_objects_api = MagicMock()
+
+    async def test_returns_first_pod_ip_when_ready(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                        "podIPs": ["10.244.0.5", "fd00::5"],
+                    }
+                },
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            result = await self.helper.wait_for_sandbox_ready("my-sandbox", "default", timeout=10)
+
+        self.assertEqual(result, "10.244.0.5")
+
+    async def test_returns_none_when_no_pod_ips(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "status": {
+                        "conditions": [{"type": "Ready", "status": "True"}],
+                    }
+                },
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            result = await self.helper.wait_for_sandbox_ready("my-sandbox", "default", timeout=10)
+
+        self.assertIsNone(result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -31,6 +31,7 @@ from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
 from k8s_agent_sandbox.exceptions import SandboxRequestError
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
+    SandboxInClusterConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
 )
 
@@ -269,6 +270,53 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         self.assertIn("connection_config is required", str(ctx.exception))
 
 
+class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        patcher = patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
+        self.MockAsyncK8sHelper = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    async def test_in_cluster_config_accepted(self):
+        config = SandboxInClusterConnectionConfig()
+        client = AsyncSandboxClient(connection_config=config)
+        self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
+
+    async def test_pod_ip_passed_to_sandbox_when_use_pod_ip_true(self):
+        config = SandboxInClusterConnectionConfig(use_pod_ip=True)
+        client = AsyncSandboxClient(connection_config=config)
+        mock_k8s_helper = client.k8s_helper
+        mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
+
+        mock_sandbox_class = MagicMock()
+        mock_sandbox_class.return_value = MagicMock()
+        client.sandbox_class = mock_sandbox_class
+
+        with patch.object(client, "_create_claim", new_callable=AsyncMock), \
+             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock, return_value="10.244.0.5"):
+            await client.create_sandbox("my-template")
+
+        call_kwargs = mock_sandbox_class.call_args.kwargs
+        self.assertEqual(call_kwargs["pod_ip"], "10.244.0.5")
+
+    async def test_pod_ip_not_passed_when_use_pod_ip_false(self):
+        config = SandboxInClusterConnectionConfig(use_pod_ip=False)
+        client = AsyncSandboxClient(connection_config=config)
+        mock_k8s_helper = client.k8s_helper
+        mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
+
+        mock_sandbox_class = MagicMock()
+        mock_sandbox_class.return_value = MagicMock()
+        client.sandbox_class = mock_sandbox_class
+
+        with patch.object(client, "_create_claim", new_callable=AsyncMock), \
+             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock, return_value="10.244.0.5"):
+            await client.create_sandbox("my-template")
+
+        call_kwargs = mock_sandbox_class.call_args.kwargs
+        self.assertIsNone(call_kwargs["pod_ip"])
+
+
 class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
 
     async def test_rejects_local_tunnel_config(self):
@@ -280,6 +328,47 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
                 k8s_helper=MagicMock(),
             )
         self.assertIn("does not support SandboxLocalTunnelConnectionConfig", str(ctx.exception))
+
+    async def test_in_cluster_uses_dns_by_default(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        self.assertEqual(connector._base_url, "http://my-sandbox.dev.svc.cluster.local:8888")
+
+    async def test_in_cluster_uses_pod_ip_when_provided(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+            pod_ip="10.244.0.5",
+        )
+        self.assertEqual(connector._base_url, "http://10.244.0.5:8888")
+
+    async def test_in_cluster_does_not_inject_router_headers(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        self.assertFalse(connector._should_inject_router_headers())
+
+    async def test_direct_injects_router_headers(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        self.assertTrue(connector._should_inject_router_headers())
 
 
 class AsyncSandboxHandler(BaseHTTPRequestHandler):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -358,7 +358,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
             connection_config=config,
             k8s_helper=MagicMock(),
         )
-        self.assertFalse(connector._should_inject_router_headers())
+        self.assertFalse(connector._inject_router_headers)
 
     async def test_direct_injects_router_headers(self):
         config = SandboxDirectConnectionConfig(api_url="http://router")
@@ -368,7 +368,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
             connection_config=config,
             k8s_helper=MagicMock(),
         )
-        self.assertTrue(connector._should_inject_router_headers())
+        self.assertTrue(connector._inject_router_headers)
 
 
 class AsyncSandboxHandler(BaseHTTPRequestHandler):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -282,7 +282,8 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         client = AsyncSandboxClient(connection_config=config)
         self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
 
-    async def test_use_pod_ip_passed_when_true(self):
+    async def test_use_pod_ip_not_passed_as_kwarg(self):
+        """AsyncSandbox derives use_pod_ip from connection_config internally."""
         config = SandboxInClusterConnectionConfig(use_pod_ip=True)
         client = AsyncSandboxClient(connection_config=config)
         mock_k8s_helper = client.k8s_helper
@@ -297,24 +298,8 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
             await client.create_sandbox("my-template")
 
         call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertTrue(call_kwargs["use_pod_ip"])
-
-    async def test_use_pod_ip_false_when_not_set(self):
-        config = SandboxInClusterConnectionConfig(use_pod_ip=False)
-        client = AsyncSandboxClient(connection_config=config)
-        mock_k8s_helper = client.k8s_helper
-        mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
-
-        mock_sandbox_class = MagicMock()
-        mock_sandbox_class.return_value = MagicMock()
-        client.sandbox_class = mock_sandbox_class
-
-        with patch.object(client, "_create_claim", new_callable=AsyncMock), \
-             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
-            await client.create_sandbox("my-template")
-
-        call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertFalse(call_kwargs.get("use_pod_ip", False))
+        self.assertNotIn("use_pod_ip", call_kwargs,
+                        "use_pod_ip should not be passed; AsyncSandbox derives it from connection_config")
 
 
 class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
@@ -502,7 +487,7 @@ class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
 
 
 class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
-    """Tests for Bug Fix #1: get_sandbox() must pass use_pod_ip parameter."""
+    """Tests that use_pod_ip is NOT passed as a kwarg — AsyncSandbox derives it internally."""
 
     def setUp(self):
         patcher = patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
@@ -515,8 +500,8 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
 
-    async def test_create_sandbox_passes_use_pod_ip_true(self):
-        """Verify create_sandbox passes use_pod_ip=True when configured."""
+    async def test_create_sandbox_does_not_pass_use_pod_ip(self):
+        """AsyncSandbox derives use_pod_ip from connection_config internally."""
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
         self.mock_k8s_helper.wait_for_sandbox_ready = AsyncMock(return_value="10.244.0.5")
 
@@ -526,13 +511,13 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
         with patch.object(self.client, "_create_claim", new_callable=AsyncMock):
             await self.client.create_sandbox("test-template", "default")
 
-        # Verify use_pod_ip=True was passed
         call_kwargs = self.mock_sandbox_class.call_args.kwargs
-        self.assertTrue(call_kwargs.get("use_pod_ip"),
-                       "create_sandbox should pass use_pod_ip=True when configured")
+        self.assertNotIn("use_pod_ip", call_kwargs,
+                        "use_pod_ip should not be passed; AsyncSandbox derives it from connection_config")
+        self.assertEqual(call_kwargs["connection_config"], self.config)
 
-    async def test_get_sandbox_passes_use_pod_ip_true(self):
-        """Verify get_sandbox passes use_pod_ip=True when reconnecting (Bug Fix #1)."""
+    async def test_get_sandbox_does_not_pass_use_pod_ip(self):
+        """get_sandbox should not pass use_pod_ip — AsyncSandbox derives it."""
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
         self.mock_k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
 
@@ -541,29 +526,13 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
 
         await self.client.get_sandbox("test-claim", "default")
 
-        # Verify use_pod_ip=True was passed (this was the bug)
         call_kwargs = self.mock_sandbox_class.call_args.kwargs
-        self.assertTrue(call_kwargs.get("use_pod_ip"),
-                       "get_sandbox should pass use_pod_ip=True when configured")
+        self.assertNotIn("use_pod_ip", call_kwargs,
+                        "use_pod_ip should not be passed; AsyncSandbox derives it from connection_config")
+        self.assertEqual(call_kwargs["connection_config"], self.config)
 
-    async def test_get_sandbox_passes_use_pod_ip_false_when_disabled(self):
-        """Verify get_sandbox passes use_pod_ip=False when use_pod_ip is disabled."""
-        config_no_pod_ip = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=False)
-        client = AsyncSandboxClient(connection_config=config_no_pod_ip)
-        client.k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
-        client.k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
-
-        mock_sandbox = MagicMock()
-        client.sandbox_class = MagicMock(return_value=mock_sandbox)
-
-        await client.get_sandbox("test-claim", "default")
-
-        call_kwargs = client.sandbox_class.call_args.kwargs
-        self.assertFalse(call_kwargs.get("use_pod_ip"),
-                        "get_sandbox should pass use_pod_ip=False when disabled")
-
-    async def test_get_sandbox_with_non_incluster_config(self):
-        """Verify get_sandbox passes use_pod_ip=False for non-InCluster configs."""
+    async def test_get_sandbox_passes_connection_config_for_non_incluster(self):
+        """Verify connection_config is passed through for non-InCluster configs."""
         config = SandboxDirectConnectionConfig(api_url="http://test", server_port=8888)
         client = AsyncSandboxClient(connection_config=config)
         client.k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
@@ -575,8 +544,8 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
         await client.get_sandbox("test-claim", "default")
 
         call_kwargs = client.sandbox_class.call_args.kwargs
-        self.assertFalse(call_kwargs.get("use_pod_ip"),
-                        "get_sandbox should pass use_pod_ip=False for non-InCluster configs")
+        self.assertNotIn("use_pod_ip", call_kwargs)
+        self.assertEqual(call_kwargs["connection_config"], config)
 
 
 class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -282,14 +282,11 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         client = AsyncSandboxClient(connection_config=config)
         self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
 
-    async def test_pod_ip_resolved_when_use_pod_ip_true(self):
+    async def test_use_pod_ip_passed_when_true(self):
         config = SandboxInClusterConnectionConfig(use_pod_ip=True)
         client = AsyncSandboxClient(connection_config=config)
         mock_k8s_helper = client.k8s_helper
         mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
-        mock_k8s_helper.get_sandbox = AsyncMock(return_value={
-            "status": {"podIPs": ["10.244.0.5"]}
-        })
 
         mock_sandbox_class = MagicMock()
         mock_sandbox_class.return_value = MagicMock()
@@ -300,9 +297,9 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
             await client.create_sandbox("my-template")
 
         call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertEqual(call_kwargs["pod_ip"], "10.244.0.5")
+        self.assertTrue(call_kwargs["use_pod_ip"])
 
-    async def test_pod_ip_none_when_use_pod_ip_false(self):
+    async def test_use_pod_ip_false_when_not_set(self):
         config = SandboxInClusterConnectionConfig(use_pod_ip=False)
         client = AsyncSandboxClient(connection_config=config)
         mock_k8s_helper = client.k8s_helper
@@ -317,7 +314,7 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
             await client.create_sandbox("my-template")
 
         call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertIsNone(call_kwargs.get("pod_ip"))
+        self.assertFalse(call_kwargs.get("use_pod_ip", False))
 
 
 class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
@@ -332,7 +329,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
             )
         self.assertIn("does not support SandboxLocalTunnelConnectionConfig", str(ctx.exception))
 
-    async def test_in_cluster_uses_dns_by_default(self):
+    async def test_in_cluster_resolves_dns_by_default(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)
         connector = AsyncSandboxConnector(
             sandbox_id="my-sandbox",
@@ -340,18 +337,20 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
             connection_config=config,
             k8s_helper=MagicMock(),
         )
-        self.assertEqual(connector._base_url, "http://my-sandbox.dev.svc.cluster.local:8888")
+        url = await connector._resolve_base_url()
+        self.assertEqual(url, "http://my-sandbox.dev.svc.cluster.local:8888")
 
-    async def test_in_cluster_uses_pod_ip_when_provided(self):
+    async def test_in_cluster_resolves_pod_ip_via_callable(self):
         config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
         connector = AsyncSandboxConnector(
             sandbox_id="my-sandbox",
             namespace="dev",
             connection_config=config,
             k8s_helper=MagicMock(),
-            pod_ip="10.244.0.5",
+            get_pod_ip=AsyncMock(return_value="10.244.0.5"),
         )
-        self.assertEqual(connector._base_url, "http://10.244.0.5:8888")
+        url = await connector._resolve_base_url()
+        self.assertEqual(url, "http://10.244.0.5:8888")
 
     async def test_in_cluster_does_not_inject_router_headers(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -501,5 +501,220 @@ class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
             await connector.close()
 
 
+class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
+    """Tests for Bug Fix #1: get_sandbox() must pass use_pod_ip parameter."""
+
+    def setUp(self):
+        patcher = patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
+        self.MockAsyncK8sHelper = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        self.client = AsyncSandboxClient(connection_config=self.config)
+        self.mock_k8s_helper = self.client.k8s_helper
+        self.mock_sandbox_class = MagicMock()
+        self.client.sandbox_class = self.mock_sandbox_class
+
+    async def test_create_sandbox_passes_use_pod_ip_true(self):
+        """Verify create_sandbox passes use_pod_ip=True when configured."""
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
+        self.mock_k8s_helper.wait_for_sandbox_ready = AsyncMock(return_value="10.244.0.5")
+
+        mock_sandbox = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock):
+            await self.client.create_sandbox("test-template", "default")
+
+        # Verify use_pod_ip=True was passed
+        call_kwargs = self.mock_sandbox_class.call_args.kwargs
+        self.assertTrue(call_kwargs.get("use_pod_ip"),
+                       "create_sandbox should pass use_pod_ip=True when configured")
+
+    async def test_get_sandbox_passes_use_pod_ip_true(self):
+        """Verify get_sandbox passes use_pod_ip=True when reconnecting (Bug Fix #1)."""
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
+        self.mock_k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
+
+        mock_sandbox = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox
+
+        await self.client.get_sandbox("test-claim", "default")
+
+        # Verify use_pod_ip=True was passed (this was the bug)
+        call_kwargs = self.mock_sandbox_class.call_args.kwargs
+        self.assertTrue(call_kwargs.get("use_pod_ip"),
+                       "get_sandbox should pass use_pod_ip=True when configured")
+
+    async def test_get_sandbox_passes_use_pod_ip_false_when_disabled(self):
+        """Verify get_sandbox passes use_pod_ip=False when use_pod_ip is disabled."""
+        config_no_pod_ip = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=False)
+        client = AsyncSandboxClient(connection_config=config_no_pod_ip)
+        client.k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
+        client.k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
+
+        mock_sandbox = MagicMock()
+        client.sandbox_class = MagicMock(return_value=mock_sandbox)
+
+        await client.get_sandbox("test-claim", "default")
+
+        call_kwargs = client.sandbox_class.call_args.kwargs
+        self.assertFalse(call_kwargs.get("use_pod_ip"),
+                        "get_sandbox should pass use_pod_ip=False when disabled")
+
+    async def test_get_sandbox_with_non_incluster_config(self):
+        """Verify get_sandbox passes use_pod_ip=False for non-InCluster configs."""
+        config = SandboxDirectConnectionConfig(api_url="http://test", server_port=8888)
+        client = AsyncSandboxClient(connection_config=config)
+        client.k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
+        client.k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
+
+        mock_sandbox = MagicMock()
+        client.sandbox_class = MagicMock(return_value=mock_sandbox)
+
+        await client.get_sandbox("test-claim", "default")
+
+        call_kwargs = client.sandbox_class.call_args.kwargs
+        self.assertFalse(call_kwargs.get("use_pod_ip"),
+                        "get_sandbox should pass use_pod_ip=False for non-InCluster configs")
+
+
+class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
+    """Tests for Bug Fix #2: Cache invalidation on HTTPStatusError."""
+
+    async def test_http_status_error_clears_pod_ip_cache(self):
+        """Verify HTTPStatusError (4xx/5xx) clears pod IP cache (Bug Fix #2)."""
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+
+        # Mock get_pod_ip to track how many times it's called
+        call_count = [0]
+        async def mock_get_pod_ip():
+            call_count[0] += 1
+            return "10.244.0.5"
+
+        connector = AsyncSandboxConnector(
+            sandbox_id="test-sandbox",
+            namespace="default",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+            get_pod_ip=mock_get_pod_ip,
+        )
+
+        # Mock httpx client to return 404 on first request
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404 Not Found",
+            request=MagicMock(),
+            response=mock_response
+        )
+
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            # First request should fail with 404
+            with self.assertRaises(SandboxRequestError):
+                await connector.send_request("GET", "test")
+
+            # Verify cache was cleared (pod_ip_resolved reset)
+            self.assertFalse(connector._pod_ip_resolved,
+                           "HTTPStatusError should clear pod_ip_resolved flag")
+            self.assertIsNone(connector._cached_pod_ip_url,
+                            "HTTPStatusError should clear cached pod IP URL")
+
+            # Second request should re-resolve pod IP (call count increases)
+            initial_count = call_count[0]
+            mock_response.status_code = 200
+            mock_response.raise_for_status.side_effect = None
+            connector.client.request = AsyncMock(return_value=mock_response)
+
+            await connector.send_request("GET", "test")
+
+            self.assertEqual(call_count[0], initial_count + 1,
+                           "After cache invalidation, pod IP should be re-resolved")
+        finally:
+            await connector.close()
+
+    async def test_http_error_clears_pod_ip_cache(self):
+        """Verify HTTPError (connection failures) also clears pod IP cache."""
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+
+        async def mock_get_pod_ip():
+            return "10.244.0.5"
+
+        connector = AsyncSandboxConnector(
+            sandbox_id="test-sandbox",
+            namespace="default",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+            get_pod_ip=mock_get_pod_ip,
+        )
+
+        # Mock httpx client to raise connection error
+        connector.client.request = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        try:
+            with self.assertRaises(SandboxRequestError):
+                await connector.send_request("GET", "test")
+
+            # Verify cache was cleared
+            self.assertFalse(connector._pod_ip_resolved,
+                           "HTTPError should clear pod_ip_resolved flag")
+            self.assertIsNone(connector._cached_pod_ip_url,
+                            "HTTPError should clear cached pod IP URL")
+        finally:
+            await connector.close()
+
+    async def test_gateway_cache_cleared_on_status_error(self):
+        """Verify HTTPStatusError clears gateway base_url cache."""
+        from k8s_agent_sandbox.models import SandboxGatewayConnectionConfig
+
+        config = SandboxGatewayConnectionConfig(
+            gateway_name="test-gw",
+            gateway_namespace="default",
+        )
+
+        mock_k8s = MagicMock()
+        mock_k8s.wait_for_gateway_ip = AsyncMock(return_value="34.56.78.90")
+
+        connector = AsyncSandboxConnector(
+            sandbox_id="test-sandbox",
+            namespace="default",
+            connection_config=config,
+            k8s_helper=mock_k8s,
+        )
+
+        # First request to establish base_url
+        mock_response_ok = MagicMock()
+        mock_response_ok.status_code = 200
+        mock_response_ok.raise_for_status = MagicMock()
+        connector.client.request = AsyncMock(return_value=mock_response_ok)
+
+        await connector.send_request("GET", "health")
+        self.assertIsNotNone(connector._base_url, "base_url should be cached")
+
+        # Now return 503 error
+        mock_response_error = MagicMock()
+        mock_response_error.status_code = 503
+        mock_response_error.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=mock_response_error
+        )
+        connector.client.request = AsyncMock(return_value=mock_response_error)
+
+        try:
+            with self.assertRaises(SandboxRequestError):
+                await connector.send_request("GET", "test")
+
+            # Verify gateway cache was cleared
+            self.assertIsNone(connector._base_url,
+                            "HTTPStatusError should clear gateway base_url cache")
+        finally:
+            await connector.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -282,24 +282,27 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         client = AsyncSandboxClient(connection_config=config)
         self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
 
-    async def test_pod_ip_passed_to_sandbox_when_use_pod_ip_true(self):
+    async def test_pod_ip_resolved_when_use_pod_ip_true(self):
         config = SandboxInClusterConnectionConfig(use_pod_ip=True)
         client = AsyncSandboxClient(connection_config=config)
         mock_k8s_helper = client.k8s_helper
         mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
+        mock_k8s_helper.get_sandbox = AsyncMock(return_value={
+            "status": {"podIPs": ["10.244.0.5"]}
+        })
 
         mock_sandbox_class = MagicMock()
         mock_sandbox_class.return_value = MagicMock()
         client.sandbox_class = mock_sandbox_class
 
         with patch.object(client, "_create_claim", new_callable=AsyncMock), \
-             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock, return_value="10.244.0.5"):
+             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
             await client.create_sandbox("my-template")
 
         call_kwargs = mock_sandbox_class.call_args.kwargs
         self.assertEqual(call_kwargs["pod_ip"], "10.244.0.5")
 
-    async def test_pod_ip_not_passed_when_use_pod_ip_false(self):
+    async def test_pod_ip_none_when_use_pod_ip_false(self):
         config = SandboxInClusterConnectionConfig(use_pod_ip=False)
         client = AsyncSandboxClient(connection_config=config)
         mock_k8s_helper = client.k8s_helper
@@ -310,11 +313,11 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         client.sandbox_class = mock_sandbox_class
 
         with patch.object(client, "_create_claim", new_callable=AsyncMock), \
-             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock, return_value="10.244.0.5"):
+             patch.object(client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
             await client.create_sandbox("my-template")
 
         call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertIsNone(call_kwargs["pod_ip"])
+        self.assertIsNone(call_kwargs.get("pod_ip"))
 
 
 class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -137,7 +137,7 @@ class TestSandboxConnectorStrategySelection(unittest.TestCase):
         self.assertIsInstance(connector.strategy, DirectConnectionStrategy)
 
     def test_raises_on_unknown_config_type(self):
-        with self.assertRaises((ValueError, Exception)):
+        with self.assertRaises(ValueError):
             SandboxConnector(
                 sandbox_id="sb",
                 namespace="ns",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -1,0 +1,179 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+import requests
+
+from k8s_agent_sandbox.connector import (
+    DirectConnectionStrategy,
+    GatewayConnectionStrategy,
+    LocalTunnelConnectionStrategy,
+    InClusterConnectionStrategy,
+    SandboxConnector,
+)
+from k8s_agent_sandbox.models import (
+    SandboxDirectConnectionConfig,
+    SandboxGatewayConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
+    SandboxInClusterConnectionConfig,
+)
+
+
+class TestInClusterConnectionStrategy(unittest.TestCase):
+    """Unit tests for InClusterConnectionStrategy."""
+
+    def setUp(self):
+        self.config = SandboxInClusterConnectionConfig(server_port=8888)
+        self.strategy = InClusterConnectionStrategy(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            config=self.config,
+        )
+
+    def test_connect_returns_correct_dns_url(self):
+        url = self.strategy.connect()
+        self.assertEqual(url, "http://my-sandbox.dev.svc.cluster.local:8888")
+
+    def test_connect_uses_custom_port(self):
+        config = SandboxInClusterConnectionConfig(server_port=9000)
+        strategy = InClusterConnectionStrategy("sb", "ns", config)
+        self.assertEqual(strategy.connect(), "http://sb.ns.svc.cluster.local:9000")
+
+    def test_connect_is_idempotent(self):
+        self.assertEqual(self.strategy.connect(), self.strategy.connect())
+
+    def test_does_not_inject_router_headers(self):
+        self.assertFalse(self.strategy.should_inject_router_headers())
+
+    def test_verify_connection_does_not_raise(self):
+        self.strategy.verify_connection()
+
+    def test_close_does_not_raise(self):
+        self.strategy.close()
+
+
+class TestExistingStrategiesDefaultHeaderInjection(unittest.TestCase):
+    """Regression: existing strategies must still inject router headers by default."""
+
+    def test_direct_injects_headers(self):
+        s = DirectConnectionStrategy(SandboxDirectConnectionConfig(api_url="http://x"))
+        self.assertTrue(s.should_inject_router_headers())
+
+    def test_gateway_injects_headers(self):
+        s = GatewayConnectionStrategy(
+            SandboxGatewayConnectionConfig(gateway_name="gw"),
+            k8s_helper=MagicMock(),
+        )
+        self.assertTrue(s.should_inject_router_headers())
+
+    def test_local_tunnel_injects_headers(self):
+        s = LocalTunnelConnectionStrategy(
+            sandbox_id="s", namespace="ns",
+            config=SandboxLocalTunnelConnectionConfig(),
+        )
+        self.assertTrue(s.should_inject_router_headers())
+
+
+class TestSandboxConnectorStrategySelection(unittest.TestCase):
+    def _make_connector(self, config):
+        return SandboxConnector(
+            sandbox_id="sb",
+            namespace="ns",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+
+    def test_selects_in_cluster_strategy(self):
+        config = SandboxInClusterConnectionConfig()
+        connector = self._make_connector(config)
+        self.assertIsInstance(connector.strategy, InClusterConnectionStrategy)
+
+    def test_selects_direct_strategy(self):
+        config = SandboxDirectConnectionConfig(api_url="http://x")
+        connector = self._make_connector(config)
+        self.assertIsInstance(connector.strategy, DirectConnectionStrategy)
+
+    def test_raises_on_unknown_config_type(self):
+        with self.assertRaises((ValueError, Exception)):
+            SandboxConnector(
+                sandbox_id="sb",
+                namespace="ns",
+                connection_config=object(),
+                k8s_helper=MagicMock(),
+            )
+
+
+class TestSandboxConnectorHeaderInjection(unittest.TestCase):
+    def _make_connector_with_strategy(self, strategy, config):
+        connector = SandboxConnector(
+            sandbox_id="my-sb",
+            namespace="my-ns",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        connector.strategy = strategy
+        mock_session = MagicMock()
+        connector.session = mock_session
+        return connector, mock_session
+
+    def _mock_ok_response(self):
+        mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.raise_for_status.return_value = None
+        return mock_resp
+
+    def test_router_headers_NOT_sent_for_in_cluster(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        strategy = InClusterConnectionStrategy("my-sb", "my-ns", config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute")
+
+        call_args, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-ID", sent_headers)
+        self.assertNotIn("X-Sandbox-Namespace", sent_headers)
+        self.assertNotIn("X-Sandbox-Port", sent_headers)
+
+    def test_router_headers_ARE_sent_for_direct(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute")
+
+        call_args, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertIn("X-Sandbox-ID", sent_headers)
+        self.assertIn("X-Sandbox-Namespace", sent_headers)
+        self.assertIn("X-Sandbox-Port", sent_headers)
+
+    def test_in_cluster_url_is_pod_dns(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        strategy = InClusterConnectionStrategy("my-sb", "my-ns", config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("POST", "execute")
+
+        call_args, call_kwargs = mock_session.request.call_args
+        url = call_args[1]
+        self.assertEqual(url, "http://my-sb.my-ns.svc.cluster.local:8888/execute")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -64,20 +64,35 @@ class TestInClusterConnectionStrategy(unittest.TestCase):
     def test_close_does_not_raise(self):
         self.strategy.close()
 
-    def test_connect_uses_pod_ip_when_provided(self):
+    def test_connect_uses_pod_ip_when_callable_provided(self):
         config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
-        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, pod_ip="10.244.0.5")
+        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, get_pod_ip=lambda: "10.244.0.5")
         self.assertEqual(strategy.connect(), "http://10.244.0.5:8888")
 
-    def test_connect_uses_dns_when_pod_ip_not_provided(self):
+    def test_connect_falls_back_to_dns_when_callable_returns_none(self):
         config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
-        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, pod_ip=None)
+        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, get_pod_ip=lambda: None)
+        self.assertEqual(strategy.connect(), "http://my-sandbox.dev.svc.cluster.local:8888")
+
+    def test_connect_uses_dns_when_no_callable(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, get_pod_ip=None)
         self.assertEqual(strategy.connect(), "http://my-sandbox.dev.svc.cluster.local:8888")
 
     def test_connect_pod_ip_uses_custom_port(self):
         config = SandboxInClusterConnectionConfig(server_port=9000)
-        strategy = InClusterConnectionStrategy("sb", "ns", config, pod_ip="192.168.1.1")
+        strategy = InClusterConnectionStrategy("sb", "ns", config, get_pod_ip=lambda: "192.168.1.1")
         self.assertEqual(strategy.connect(), "http://192.168.1.1:9000")
+
+    def test_connect_caches_pod_ip_until_close(self):
+        """Pod IP is cached across connect() calls; close() invalidates the cache."""
+        ips = iter(["10.0.0.1", "10.0.0.2"])
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        strategy = InClusterConnectionStrategy("sb", "ns", config, get_pod_ip=lambda: next(ips))
+        self.assertEqual(strategy.connect(), "http://10.0.0.1:8888")
+        self.assertEqual(strategy.connect(), "http://10.0.0.1:8888")  # cached
+        strategy.close()  # invalidates cache
+        self.assertEqual(strategy.connect(), "http://10.0.0.2:8888")  # fresh resolve
 
 
 class TestExistingStrategiesDefaultHeaderInjection(unittest.TestCase):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -64,6 +64,21 @@ class TestInClusterConnectionStrategy(unittest.TestCase):
     def test_close_does_not_raise(self):
         self.strategy.close()
 
+    def test_connect_uses_pod_ip_when_provided(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, pod_ip="10.244.0.5")
+        self.assertEqual(strategy.connect(), "http://10.244.0.5:8888")
+
+    def test_connect_uses_dns_when_pod_ip_not_provided(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, pod_ip=None)
+        self.assertEqual(strategy.connect(), "http://my-sandbox.dev.svc.cluster.local:8888")
+
+    def test_connect_pod_ip_uses_custom_port(self):
+        config = SandboxInClusterConnectionConfig(server_port=9000)
+        strategy = InClusterConnectionStrategy("sb", "ns", config, pod_ip="192.168.1.1")
+        self.assertEqual(strategy.connect(), "http://192.168.1.1:9000")
+
 
 class TestExistingStrategiesDefaultHeaderInjection(unittest.TestCase):
     """Regression: existing strategies must still inject router headers by default."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -103,7 +103,7 @@ class TestSandbox(unittest.TestCase):
             namespace="custom-ns",
             connection_config=mock_connection_config,
             k8s_helper=mock_k8s_helper_instance,
-            pod_ip=None,
+            pod_ip=None,  # no use_pod_ip on this config
         )
 
         mock_create_tracer_manager.assert_called_once_with(mock_tracer_config)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -103,7 +103,7 @@ class TestSandbox(unittest.TestCase):
             namespace="custom-ns",
             connection_config=mock_connection_config,
             k8s_helper=mock_k8s_helper_instance,
-            pod_ip=None,  # no use_pod_ip on this config
+            get_pod_ip=None,  # no use_pod_ip on this config
         )
 
         mock_create_tracer_manager.assert_called_once_with(mock_tracer_config)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -102,7 +102,8 @@ class TestSandbox(unittest.TestCase):
             sandbox_id="custom-id",
             namespace="custom-ns",
             connection_config=mock_connection_config,
-            k8s_helper=mock_k8s_helper_instance
+            k8s_helper=mock_k8s_helper_instance,
+            pod_ip=None,
         )
 
         mock_create_tracer_manager.assert_called_once_with(mock_tracer_config)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -618,41 +618,26 @@ class TestSandboxClientInClusterConfig(unittest.TestCase):
         sc = SandboxClient(connection_config=config)
         self.assertEqual(sc.connection_config.server_port, 8888)
 
-    @patch('uuid.uuid4')
-    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
-    def test_sandbox_created_with_in_cluster_config(self, MockK8sHelper, mock_uuid):
-        mock_uuid.return_value.hex = 'aabbccdd'
-        in_cluster_config = SandboxInClusterConnectionConfig()
-        client = SandboxClient(connection_config=in_cluster_config)
-        client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
+    def _create_sandbox_with_in_cluster_config(self, namespace='default'):
+        with patch('k8s_agent_sandbox.sandbox_client.K8sHelper'), \
+             patch('uuid.uuid4') as mock_uuid:
+            mock_uuid.return_value.hex = 'aabbccdd'
+            client = SandboxClient(connection_config=SandboxInClusterConnectionConfig())
+            client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
+            mock_sandbox_class = MagicMock()
+            mock_sandbox_class.return_value = MagicMock()
+            client.sandbox_class = mock_sandbox_class
+            with patch.object(client, '_create_claim'), \
+                 patch.object(client, '_wait_for_sandbox_ready'):
+                client.create_sandbox('my-template', namespace=namespace)
+            return mock_sandbox_class.call_args.kwargs
 
-        mock_sandbox_class = MagicMock()
-        mock_sandbox_class.return_value = MagicMock()
-        client.sandbox_class = mock_sandbox_class
-
-        with patch.object(client, '_create_claim'), \
-             patch.object(client, '_wait_for_sandbox_ready'):
-            client.create_sandbox('my-template')
-
-        call_kwargs = mock_sandbox_class.call_args.kwargs
+    def test_sandbox_created_with_in_cluster_config(self):
+        call_kwargs = self._create_sandbox_with_in_cluster_config()
         self.assertIsInstance(call_kwargs['connection_config'], SandboxInClusterConnectionConfig)
 
-    @patch('uuid.uuid4')
-    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
-    def test_sandbox_namespace_passed_correctly(self, MockK8sHelper, mock_uuid):
-        mock_uuid.return_value.hex = 'aabbccdd'
-        client = SandboxClient(connection_config=SandboxInClusterConnectionConfig())
-        client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
-
-        mock_sandbox_class = MagicMock()
-        mock_sandbox_class.return_value = MagicMock()
-        client.sandbox_class = mock_sandbox_class
-
-        with patch.object(client, '_create_claim'), \
-             patch.object(client, '_wait_for_sandbox_ready'):
-            client.create_sandbox('my-template', namespace='prod')
-
-        call_kwargs = mock_sandbox_class.call_args.kwargs
+    def test_sandbox_namespace_passed_correctly(self):
+        call_kwargs = self._create_sandbox_with_in_cluster_config(namespace='prod')
         self.assertEqual(call_kwargs['namespace'], 'prod')
 
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -542,6 +542,39 @@ class TestK8sHelperWatchNoneEvents(unittest.TestCase):
         self.helper.custom_objects_api = MagicMock()
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_sandbox_ready_returns_pod_ip(self, mock_watch_cls):
+        """wait_for_sandbox_ready returns the first pod IP when present."""
+        mock_watch = MagicMock()
+        mock_watch_cls.return_value = mock_watch
+        mock_watch.stream.return_value = [{
+            "type": "MODIFIED",
+            "object": {
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "podIPs": ["10.244.0.5", "fd00::5"],
+                },
+            },
+        }]
+        result = self.helper.wait_for_sandbox_ready("test-sandbox", "default", timeout=10)
+        self.assertEqual(result, "10.244.0.5")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_sandbox_ready_returns_none_when_no_pod_ips(self, mock_watch_cls):
+        """wait_for_sandbox_ready returns None when podIPs is absent."""
+        mock_watch = MagicMock()
+        mock_watch_cls.return_value = mock_watch
+        mock_watch.stream.return_value = [{
+            "type": "MODIFIED",
+            "object": {
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                },
+            },
+        }]
+        result = self.helper.wait_for_sandbox_ready("test-sandbox", "default", timeout=10)
+        self.assertIsNone(result)
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
     def test_wait_for_sandbox_ready_skips_none_events(self, mock_watch_cls):
         """None events from the watch stream should be skipped, not crash."""
         mock_watch = MagicMock()
@@ -639,6 +672,45 @@ class TestSandboxClientInClusterConfig(unittest.TestCase):
     def test_sandbox_namespace_passed_correctly(self):
         call_kwargs = self._create_sandbox_with_in_cluster_config(namespace='prod')
         self.assertEqual(call_kwargs['namespace'], 'prod')
+
+    def _create_sandbox_with_pod_ip_config(self, pod_ip_from_ready):
+        with patch('k8s_agent_sandbox.sandbox_client.K8sHelper'), \
+             patch('uuid.uuid4') as mock_uuid:
+            mock_uuid.return_value.hex = 'aabbccdd'
+            config = SandboxInClusterConnectionConfig(use_pod_ip=True)
+            client = SandboxClient(connection_config=config)
+            client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
+            mock_sandbox_class = MagicMock()
+            mock_sandbox_class.return_value = MagicMock()
+            client.sandbox_class = mock_sandbox_class
+            with patch.object(client, '_create_claim'), \
+                 patch.object(client, '_wait_for_sandbox_ready', return_value=pod_ip_from_ready):
+                client.create_sandbox('my-template')
+            return mock_sandbox_class.call_args.kwargs
+
+    def test_pod_ip_passed_to_sandbox_when_use_pod_ip_true(self):
+        call_kwargs = self._create_sandbox_with_pod_ip_config(pod_ip_from_ready='10.244.0.5')
+        self.assertEqual(call_kwargs['pod_ip'], '10.244.0.5')
+
+    def test_pod_ip_is_none_when_not_returned(self):
+        call_kwargs = self._create_sandbox_with_pod_ip_config(pod_ip_from_ready=None)
+        self.assertIsNone(call_kwargs['pod_ip'])
+
+    def test_pod_ip_not_passed_when_use_pod_ip_false(self):
+        with patch('k8s_agent_sandbox.sandbox_client.K8sHelper'), \
+             patch('uuid.uuid4') as mock_uuid:
+            mock_uuid.return_value.hex = 'aabbccdd'
+            config = SandboxInClusterConnectionConfig(use_pod_ip=False)
+            client = SandboxClient(connection_config=config)
+            client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
+            mock_sandbox_class = MagicMock()
+            mock_sandbox_class.return_value = MagicMock()
+            client.sandbox_class = mock_sandbox_class
+            with patch.object(client, '_create_claim'), \
+                 patch.object(client, '_wait_for_sandbox_ready', return_value='10.244.0.5'):
+                client.create_sandbox('my-template')
+            call_kwargs = mock_sandbox_class.call_args.kwargs
+        self.assertIsNone(call_kwargs['pod_ip'])
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -26,7 +26,11 @@ from urllib3.util.retry import Retry
 from kubernetes import config as k8s_config
 from k8s_agent_sandbox.sandbox_client import SandboxClient
 from k8s_agent_sandbox.connector import SandboxConnector
-from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+from k8s_agent_sandbox.models import (
+    SandboxDirectConnectionConfig,
+    SandboxInClusterConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
+)
 from k8s_agent_sandbox.constants import POD_NAME_ANNOTATION
 from k8s_agent_sandbox.exceptions import (
     SandboxPortForwardError,
@@ -586,6 +590,70 @@ class TestK8sHelperWatchNoneEvents(unittest.TestCase):
 
         ip = self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=10)
         self.assertEqual(ip, "10.0.0.1")
+
+
+class TestSandboxClientInClusterConfig(unittest.TestCase):
+    """Tests that SandboxClient stores and propagates SandboxInClusterConnectionConfig."""
+
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_in_cluster_config_stored(self, _):
+        config = SandboxInClusterConnectionConfig()
+        sc = SandboxClient(connection_config=config)
+        self.assertIsInstance(sc.connection_config, SandboxInClusterConnectionConfig)
+
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_default_config_is_local_tunnel(self, _):
+        sc = SandboxClient()
+        self.assertIsInstance(sc.connection_config, SandboxLocalTunnelConnectionConfig)
+
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_in_cluster_config_custom_port(self, _):
+        config = SandboxInClusterConnectionConfig(server_port=9000)
+        sc = SandboxClient(connection_config=config)
+        self.assertEqual(sc.connection_config.server_port, 9000)
+
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_in_cluster_config_default_port(self, _):
+        config = SandboxInClusterConnectionConfig()
+        sc = SandboxClient(connection_config=config)
+        self.assertEqual(sc.connection_config.server_port, 8888)
+
+    @patch('uuid.uuid4')
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_sandbox_created_with_in_cluster_config(self, MockK8sHelper, mock_uuid):
+        mock_uuid.return_value.hex = 'aabbccdd'
+        in_cluster_config = SandboxInClusterConnectionConfig()
+        client = SandboxClient(connection_config=in_cluster_config)
+        client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
+
+        mock_sandbox_class = MagicMock()
+        mock_sandbox_class.return_value = MagicMock()
+        client.sandbox_class = mock_sandbox_class
+
+        with patch.object(client, '_create_claim'), \
+             patch.object(client, '_wait_for_sandbox_ready'):
+            client.create_sandbox('my-template')
+
+        call_kwargs = mock_sandbox_class.call_args.kwargs
+        self.assertIsInstance(call_kwargs['connection_config'], SandboxInClusterConnectionConfig)
+
+    @patch('uuid.uuid4')
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_sandbox_namespace_passed_correctly(self, MockK8sHelper, mock_uuid):
+        mock_uuid.return_value.hex = 'aabbccdd'
+        client = SandboxClient(connection_config=SandboxInClusterConnectionConfig())
+        client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
+
+        mock_sandbox_class = MagicMock()
+        mock_sandbox_class.return_value = MagicMock()
+        client.sandbox_class = mock_sandbox_class
+
+        with patch.object(client, '_create_claim'), \
+             patch.object(client, '_wait_for_sandbox_ready'):
+            client.create_sandbox('my-template', namespace='prod')
+
+        call_kwargs = mock_sandbox_class.call_args.kwargs
+        self.assertEqual(call_kwargs['namespace'], 'prod')
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -673,44 +673,10 @@ class TestSandboxClientInClusterConfig(unittest.TestCase):
         call_kwargs = self._create_sandbox_with_in_cluster_config(namespace='prod')
         self.assertEqual(call_kwargs['namespace'], 'prod')
 
-    def _create_sandbox_with_pod_ip_config(self, pod_ip_from_ready):
-        with patch('k8s_agent_sandbox.sandbox_client.K8sHelper'), \
-             patch('uuid.uuid4') as mock_uuid:
-            mock_uuid.return_value.hex = 'aabbccdd'
-            config = SandboxInClusterConnectionConfig(use_pod_ip=True)
-            client = SandboxClient(connection_config=config)
-            client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
-            mock_sandbox_class = MagicMock()
-            mock_sandbox_class.return_value = MagicMock()
-            client.sandbox_class = mock_sandbox_class
-            with patch.object(client, '_create_claim'), \
-                 patch.object(client, '_wait_for_sandbox_ready', return_value=pod_ip_from_ready):
-                client.create_sandbox('my-template')
-            return mock_sandbox_class.call_args.kwargs
-
-    def test_pod_ip_passed_to_sandbox_when_use_pod_ip_true(self):
-        call_kwargs = self._create_sandbox_with_pod_ip_config(pod_ip_from_ready='10.244.0.5')
-        self.assertEqual(call_kwargs['pod_ip'], '10.244.0.5')
-
-    def test_pod_ip_is_none_when_not_returned(self):
-        call_kwargs = self._create_sandbox_with_pod_ip_config(pod_ip_from_ready=None)
-        self.assertIsNone(call_kwargs['pod_ip'])
-
-    def test_pod_ip_not_passed_when_use_pod_ip_false(self):
-        with patch('k8s_agent_sandbox.sandbox_client.K8sHelper'), \
-             patch('uuid.uuid4') as mock_uuid:
-            mock_uuid.return_value.hex = 'aabbccdd'
-            config = SandboxInClusterConnectionConfig(use_pod_ip=False)
-            client = SandboxClient(connection_config=config)
-            client.k8s_helper.resolve_sandbox_name.return_value = 'my-sandbox'
-            mock_sandbox_class = MagicMock()
-            mock_sandbox_class.return_value = MagicMock()
-            client.sandbox_class = mock_sandbox_class
-            with patch.object(client, '_create_claim'), \
-                 patch.object(client, '_wait_for_sandbox_ready', return_value='10.244.0.5'):
-                client.create_sandbox('my-template')
-            call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertIsNone(call_kwargs['pod_ip'])
+    def test_client_does_not_pass_pod_ip(self):
+        """SandboxClient no longer threads pod_ip — Sandbox resolves it internally."""
+        call_kwargs = self._create_sandbox_with_in_cluster_config()
+        self.assertNotIn('pod_ip', call_kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Adds `SandboxInClusterConnectionConfig` to `models.py` for direct in-cluster connectivity to sandbox pods, bypassing the sandbox router entirely
- Constructs the pod URL as `http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}` by default (stable across pod restarts)
- Adds `use_pod_ip=True` option to connect directly via pod IP from the Sandbox status instead of DNS (pod IP is guaranteed present when `Ready=True`)
- `InClusterConnectionStrategy` in `connector.py` suppresses router-specific headers (`X-Sandbox-ID`, `X-Sandbox-Namespace`, `X-Sandbox-Port`) since requests go directly to the pod
- `should_inject_router_headers` is now an `@abstractmethod` on `ConnectionStrategy`, with explicit overrides on all four strategy subclasses
- Pod IP resolution lives in `Sandbox.get_pod_ip()` / `AsyncSandbox.get_pod_ip()` — always queries the K8s API for the latest IP (no caching at this layer, since the pod IP can change after a restart). The connector layer (`InClusterConnectionStrategy` / `AsyncSandboxConnector`) caches the resolved pod IP URL and invalidates on connection errors or `close()`
- Ports all of the above to the async client (`AsyncSandboxConnector`, `AsyncSandbox`, `AsyncSandboxClient`)

## Usage

**DNS-based (default, stable across pod restarts):**
```python
from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
from k8s_agent_sandbox import SandboxClient

client = SandboxClient(connection_config=SandboxInClusterConnectionConfig())
sandbox = client.create_sandbox(template="my-template")
result = sandbox.commands.run("echo hello")
```

**Pod IP (avoids DNS resolution):**
```python
client = SandboxClient(connection_config=SandboxInClusterConnectionConfig(use_pod_ip=True))
sandbox = client.create_sandbox(template="my-template")  # connects via pod IP
```

**Async client:**
```python
from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient

async with AsyncSandboxClient(connection_config=SandboxInClusterConnectionConfig()) as client:
    sandbox = await client.create_sandbox(template="my-template")
    result = await sandbox.commands.run("echo hello")
```

## Test Plan

- [x] Unit tests: `cd clients/python/agentic-sandbox-client && pytest k8s_agent_sandbox/test/ sandbox-router/test_sandbox_router.py` — 152 passed
  - `TestInClusterConnectionStrategy` — DNS URL construction, pod IP override, header suppression, idempotency
  - `TestExistingStrategiesDefaultHeaderInjection` — regression: existing strategies unaffected
  - `TestSandboxConnectorStrategySelection` — in-cluster strategy selected for `SandboxInClusterConnectionConfig`
  - `TestSandboxConnectorHeaderInjection` — router headers suppressed for in-cluster, present otherwise
  - `TestSandboxClientInClusterConfig` — config stored correctly, client does not thread `pod_ip`
  - `TestSandboxClient` — regression: existing factory behaviour unaffected
  - `TestAsyncSandboxClientInCluster` — async client accepts in-cluster config, pod IP derived from connection_config
  - `TestAsyncSandboxClientInClusterUsePodIP` — use_pod_ip not passed as kwarg, derived internally by AsyncSandbox
  - `TestAsyncConnector` — in-cluster DNS and pod IP URL construction, header suppression
  - `TestAsyncConnectorCacheInvalidation` — pod IP cache cleared on HTTPStatusError, HTTPError, and gateway errors
  - `TestAsyncK8sHelperWaitForSandboxReady` — returns first pod IP or `None`