### PR TITLE
feat: add claim_labels support to SandboxClient

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -40,15 +40,19 @@ class K8sHelper:
         self.custom_objects_api = client.CustomObjectsApi()
         self.core_v1_api = client.CoreV1Api()
 
-    def create_sandbox_claim(self, name: str, template: str, namespace: str, annotations: dict | None = None):
+    def create_sandbox_claim(self, name: str, template: str, namespace: str, annotations: dict | None = None, labels: dict | None = None):
         """Creates a SandboxClaim custom resource."""
+        metadata = {
+            "name": name,
+            "annotations": annotations or {},
+        }
+        if labels:
+            metadata["labels"] = labels
+
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",
             "kind": "SandboxClaim",
-            "metadata": {
-                "name": name,
-                "annotations": annotations or {}
-            },
+            "metadata": metadata,
             "spec": {
                 "sandboxTemplateRef": {
                     "name": template

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -19,6 +19,7 @@ file I/O) via the Sandbox resource handle.
 
 import json
 import os
+import re
 import uuid
 import sys
 import subprocess
@@ -79,7 +80,7 @@ class SandboxClient(Generic[T]):
         # Deletes all the sandboxes on program termination
         atexit.register(self.delete_all)
 
-    def create_sandbox(self, template: str, namespace: str = "default", sandbox_ready_timeout: int = 180) -> T:
+    def create_sandbox(self, template: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None) -> T:
         """Provisions new Sandbox claim and returns a Sandbox handle which tracks 
            the underlying infrastructure.
         
@@ -92,10 +93,13 @@ class SandboxClient(Generic[T]):
         if not template:
             raise ValueError("Template name cannot be empty.")
 
+        if labels:
+            self._validate_labels(labels)
+
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
         
         try:
-            self._create_claim(claim_name, template, namespace)
+            self._create_claim(claim_name, template, namespace, labels=labels)
             # Resolve the sandbox id from the sandbox claim object.
             # In case of warmpool, sandbox id is not the same as claim name.
             start_time = time.monotonic()
@@ -240,9 +244,55 @@ class SandboxClient(Generic[T]):
                     f"Cleanup failed for {claim_name} in namespace {ns}: {e}"
                 )
 
-    
+    # Kubernetes label validation: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+    _LABEL_NAME_RE = re.compile(r'^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$|^[A-Za-z0-9]$')
+    _LABEL_PREFIX_RE = re.compile(r'^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$')
+    _LABEL_NAME_MAX_LENGTH = 63
+    _LABEL_PREFIX_MAX_LENGTH = 253
+
+    @staticmethod
+    def _validate_label_name(name: str, context: str):
+        """Validates a label name segment (key or value) against k8s constraints."""
+        if len(name) > SandboxClient._LABEL_NAME_MAX_LENGTH:
+            raise ValueError(
+                f"Label {context} '{name}' exceeds max length of {SandboxClient._LABEL_NAME_MAX_LENGTH} characters."
+            )
+        if not SandboxClient._LABEL_NAME_RE.match(name):
+            raise ValueError(
+                f"Label {context} '{name}' contains invalid characters. "
+                f"Must start and end with alphanumeric, and contain only [-A-Za-z0-9_.]."
+            )
+
+    @staticmethod
+    def _validate_labels(labels: dict[str, str]):
+        """Validates label keys and values against Kubernetes constraints."""
+        for key, value in labels.items():
+            if not key:
+                raise ValueError("Label key cannot be empty.")
+
+            # Keys can have an optional prefix: "prefix/name"
+            if '/' in key:
+                prefix, name = key.split('/', 1)
+                if not prefix or len(prefix) > SandboxClient._LABEL_PREFIX_MAX_LENGTH:
+                    raise ValueError(
+                        f"Label key prefix '{prefix}' is invalid or exceeds {SandboxClient._LABEL_PREFIX_MAX_LENGTH} characters."
+                    )
+                if not SandboxClient._LABEL_PREFIX_RE.match(prefix):
+                    raise ValueError(
+                        f"Label key prefix '{prefix}' must be a valid DNS subdomain."
+                    )
+                if not name:
+                    raise ValueError(f"Label key '{key}' has an empty name after prefix.")
+                SandboxClient._validate_label_name(name, f"key name in '{key}'")
+            else:
+                SandboxClient._validate_label_name(key, f"key '{key}'")
+
+            # Values can be empty, but if non-empty must match the same name constraints
+            if value:
+                SandboxClient._validate_label_name(value, f"value '{value}' for key '{key}'")
+
     @trace_span("create_claim")
-    def _create_claim(self, claim_name: str, template_name: str, namespace: str):
+    def _create_claim(self, claim_name: str, template_name: str, namespace: str, labels: dict[str, str] | None = None):
         """Creates the SandboxClaim custom resource in the Kubernetes cluster."""
         span = trace.get_current_span()
         if span.is_recording():
@@ -254,7 +304,7 @@ class SandboxClient(Generic[T]):
             if trace_context_str:
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
-        self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations)
+        self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations=annotations, labels=labels)
 
     @trace_span("wait_for_sandbox_ready")
     def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from k8s_agent_sandbox.k8s_helper import K8sHelper
+
+
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
+
+    def test_labels_and_annotations_coexist_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim", "test-template", "test-namespace",
+            annotations={"opentelemetry.io/trace-context": "trace-data"},
+            labels={"agent": "code-agent", "team": "platform"},
+        )
+
+        mock_api.create_namespaced_custom_object.assert_called_once()
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["metadata"]["annotations"], {"opentelemetry.io/trace-context": "trace-data"})
+        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent", "team": "platform"})
+
+    def test_labels_only_no_annotations(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim", "test-template", "test-namespace",
+            labels={"agent": "code-agent"},
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["metadata"]["annotations"], {})
+        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent"})
+
+    def test_no_labels_no_annotations(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim("test-claim", "test-template", "test-namespace")
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["metadata"]["annotations"], {})
+        self.assertNotIn("labels", body["metadata"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -46,7 +46,7 @@ class TestSandboxClient(unittest.TestCase):
             
             sandbox = self.client.create_sandbox("test-template", "test-namespace")
             
-            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace")
+            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace", labels=None)
             self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
             mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
             self.assertEqual(sandbox, mock_sandbox_instance)
@@ -169,6 +169,39 @@ class TestSandboxClient(unittest.TestCase):
             mock_delete.assert_any_call("claim1", namespace="ns1")
             mock_delete.assert_any_call("claim2", namespace="ns2")
 
+    @patch('uuid.uuid4')
+    def test_create_sandbox_with_labels(self, mock_uuid):
+        mock_uuid.return_value.hex = '1234abcd'
+        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+
+        mock_sandbox_instance = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        labels = {"agent": "code-agent", "team": "platform"}
+
+        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+             patch.object(self.client, '_wait_for_sandbox_ready'):
+
+            self.client.create_sandbox("test-template", "test-namespace", labels=labels)
+
+            mock_create_claim.assert_called_once_with(
+                "sandbox-claim-1234abcd", "test-template", "test-namespace",
+                labels={"agent": "code-agent", "team": "platform"},
+            )
+
+    def test_create_claim_with_labels(self):
+        self.client.tracing_manager = MagicMock()
+        self.client.tracing_manager.get_trace_context_json.return_value = "trace-data"
+
+        labels = {"agent": "code-agent"}
+        self.client._create_claim("test-claim", "test-template", "test-namespace", labels=labels)
+
+        self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
+            "test-claim", "test-template", "test-namespace",
+            annotations={"opentelemetry.io/trace-context": "trace-data"},
+            labels={"agent": "code-agent"},
+        )
+
     def test_create_claim(self):
         self.client.tracing_manager = MagicMock()
         self.client.tracing_manager.get_trace_context_json.return_value = "trace-data"
@@ -176,9 +209,52 @@ class TestSandboxClient(unittest.TestCase):
         self.client._create_claim("test-claim", "test-template", "test-namespace")
         
         self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
-            "test-claim", "test-template", "test-namespace", 
-            {"opentelemetry.io/trace-context": "trace-data"}
+            "test-claim", "test-template", "test-namespace",
+            annotations={"opentelemetry.io/trace-context": "trace-data"},
+            labels=None
         )
+
+    def test_validate_labels_rejects_invalid_value(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-template", labels={"agent": "invalid value!"})
+        self.assertIn("invalid characters", str(ctx.exception))
+
+    def test_validate_labels_rejects_too_long_value(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-template", labels={"agent": "a" * 64})
+        self.assertIn("exceeds max length", str(ctx.exception))
+
+    def test_validate_labels_rejects_empty_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-template", labels={"": "value"})
+        self.assertIn("Label key cannot be empty", str(ctx.exception))
+
+    def test_validate_labels_rejects_invalid_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-template", labels={"bad key!": "value"})
+        self.assertIn("invalid characters", str(ctx.exception))
+
+    def test_validate_labels_rejects_too_long_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-template", labels={"a" * 64: "value"})
+        self.assertIn("exceeds max length", str(ctx.exception))
+
+    def test_validate_labels_accepts_prefixed_key(self):
+        SandboxClient._validate_labels({"app.kubernetes.io/name": "my-app"})
+
+    def test_validate_labels_rejects_invalid_prefix(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-template", labels={"BAD PREFIX/name": "value"})
+        self.assertIn("valid DNS subdomain", str(ctx.exception))
+
+    def test_validate_labels_accepts_single_char_prefix(self):
+        SandboxClient._validate_labels({"a/name": "value"})
+
+    def test_validate_labels_accepts_empty_value(self):
+        SandboxClient._validate_labels({"key": ""})
+
+    def test_validate_labels_accepts_valid(self):
+        SandboxClient._validate_labels({"agent": "code-agent", "team": "platform-123"})
 
     def test_wait_for_sandbox_ready(self):
         self.client._wait_for_sandbox_ready("sandbox-id", "test-namespace", 45)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Adds an optional `labels` parameter to `SandboxClient.create_sandbox()` so consumers can attach custom Kubernetes labels to `SandboxClaim` resources.

This enables per-agent capacity gating: consumers label claims with an agent identifier, then use `label_selector` on `list_namespaced_custom_object` to count active claims per agent and enforce capacity limits — without listing all claims in the namespace.

Without this, consumers must override `_create_claim()` (a private method), coupling them to internal implementation details.

**Changes:**

- `k8s_helper.py`: Add `labels` keyword param to `create_sandbox_claim()`, conditionally include in manifest metadata (omitted when empty)
- `sandbox_client.py`: Add `labels` param to `create_sandbox()`, client-side validation of label keys and values against k8s constraints (regex matching `apimachinery/pkg/util/validation`), thread through `_create_claim()` using keyword args
- `test/unit/test_sandboxclient.py`: Label flow tests + 10 validation tests (invalid key/value, too-long key/value, empty key, prefixed key, single-char prefix, invalid prefix, empty value, valid labels)
- `test/unit/test_k8s_helper.py`: Manifest body tests (labels+annotations coexistence, labels-only, no-labels)

**Which issue(s) this PR fixes:**

N/A

**Special notes for your reviewer:**

- Fully backwards-compatible. `labels` defaults to `None`, so existing callers are unaffected.
- Client-side label validation matches k8s spec constraints. The `kubernetes` Python client has no built-in validation utils, so custom regex is used (consistent with the Go `apimachinery` validation patterns). The API server remains authoritative.
- Labels field is omitted from the manifest when empty (not set to `{}`).

All 36 unit tests pass.

**Does this PR introduce a user-facing change?:**

Yes — new optional `labels` parameter on `SandboxClient.create_sandbox()`