### PR TITLE
Add debug logging to SandboxClaim controller

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -87,7 +87,7 @@ func main() {
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -65,10 +65,12 @@ type SandboxClaimReconciler struct {
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Start of Reconcile loop for SandboxClaim", "request", req.NamespacedName)
 	claim := &extensionsv1alpha1.SandboxClaim{}
 	if err := r.Get(ctx, req.NamespacedName, claim); err != nil {
 		if k8errors.IsNotFound(err) {
+			logger.V(1).Info("SandboxClaim not found, ignoring", "request", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("failed to get sandbox claim %q: %w", req.NamespacedName, err)
@@ -101,6 +103,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Check Expiration
 	// We calculate this upfront to decide the flow.
 	claimExpired, timeLeft := r.checkExpiration(claim)
+	logger.V(1).Info("Expiration check", "isExpired", claimExpired, "timeLeft", timeLeft, "request", req.NamespacedName)
 
 	// Handle "Delete" and "DeleteForeground" policies immediately.
 	// If we delete the claim, we return immediately.
@@ -110,7 +113,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			claim.Spec.Lifecycle.ShutdownPolicy == extensionsv1alpha1.ShutdownPolicyDeleteForeground) {
 
 		policy := claim.Spec.Lifecycle.ShutdownPolicy
-		log.Info("Deleting Claim because time has expired", "shutdownPolicy", policy)
+		logger.Info("Deleting Claim because time has expired", "shutdownPolicy", policy, "claim", claim.Name)
 		if r.Recorder != nil {
 			r.Recorder.Event(claim, corev1.EventTypeNormal, extensionsv1alpha1.ClaimExpiredReason, fmt.Sprintf("Deleting Claim (ShutdownPolicy=%s)", policy))
 		}
@@ -149,10 +152,12 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
-		return ctrl.Result{}, errors.Join(reconcileErr, updateErr)
+		errs := errors.Join(reconcileErr, updateErr)
+		logger.V(1).Info("Sandboxclaim UpdateStatus error encountered", "errors", errs, "request", req.NamespacedName)
+		return ctrl.Result{}, errs
 	}
 
-	r.recordCreationLatencyMetric(claim, originalClaimStatus, sandbox)
+	r.recordCreationLatencyMetric(ctx, claim, originalClaimStatus, sandbox)
 
 	// Determine Result
 	var result ctrl.Result
@@ -162,9 +167,12 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Suppress expected user errors (like missing templates) to avoid crash loops
 	if errors.Is(reconcileErr, ErrTemplateNotFound) {
+		errs := errors.Join(reconcileErr, ErrTemplateNotFound)
+		logger.V(1).Info("Sandboxclaim suppressed error(s) encountered", "errors", errs, "request", req.NamespacedName)
 		return result, nil
 	}
 
+	logger.V(1).Info("End of Reconcile loop SandboxClaim", "result", result, "error", reconcileErr, "request", req.NamespacedName)
 	return result, reconcileErr
 }
 
@@ -187,21 +195,24 @@ func (r *SandboxClaimReconciler) checkExpiration(claim *extensionsv1alpha1.Sandb
 // reconcileActive handles the creation and updates of running sandboxes.
 func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*v1alpha1.Sandbox, error) {
 	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling active claim", "claim", claim.Name)
 
 	// Fast path: try to find existing or adopt from warm pool before template lookup.
 	sandbox, err := r.getOrCreateSandbox(ctx, claim, nil)
+	logger.V(1).Info("getOrCreateSandbox result", "sandboxFound", sandbox != nil, "err", err, "claim", claim.Name)
 	if err != nil {
 		return nil, err
 	}
 	if sandbox != nil {
 		// Found or adopted. Reconcile network policy (best effort, non blocking).
+		logger.V(1).Info("Fast path: sandbox found or adopted, reconciling network policy", "claim", claim.Name)
 		template, templateErr := r.getTemplate(ctx, claim)
 		if templateErr != nil {
-			logger.Error(templateErr, "failed to get template for network policy reconciliation")
+			logger.Error(templateErr, "failed to get template for network policy reconciliation (non-fatal)", "claim", claim.Name)
 		}
 		if template != nil {
 			if npErr := r.reconcileNetworkPolicy(ctx, claim, template); npErr != nil {
-				logger.Error(npErr, "network policy reconcile failed after adoption (non-fatal)")
+				logger.Error(npErr, "network policy reconcile failed after adoption (non-fatal)", "claim", claim.Name)
 			}
 		}
 		return sandbox, nil
@@ -209,6 +220,7 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 
 	// Cold path: no existing sandbox or warm pool candidate.
 	// Need template to create from scratch.
+	logger.V(1).Info("Cold path: no sandbox found, creating from template", "claim", claim.Name)
 	template, templateErr := r.getTemplate(ctx, claim)
 	if templateErr != nil && !k8errors.IsNotFound(templateErr) {
 		return nil, templateErr
@@ -226,7 +238,8 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 
 // reconcileExpired ensures the Sandbox is deleted for Retained claims.
 func (r *SandboxClaimReconciler) reconcileExpired(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*v1alpha1.Sandbox, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Reconciling Expired claim", "claim", claim.Name)
 	sandbox := &v1alpha1.Sandbox{}
 
 	// Check if Sandbox exists
@@ -239,7 +252,7 @@ func (r *SandboxClaimReconciler) reconcileExpired(ctx context.Context, claim *ex
 
 	// Sandbox exists, delete it.
 	if sandbox.DeletionTimestamp.IsZero() {
-		log.Info("Deleting Sandbox because Claim expired (Policy=Retain)", "Sandbox", sandbox.Name)
+		logger.Info("Deleting Sandbox because Claim expired (Policy=Retain)", "Sandbox", sandbox.Name, "claim", claim.Name)
 		if err := r.Delete(ctx, sandbox); err != nil {
 			return sandbox, fmt.Errorf("failed to delete expired sandbox: %w", err)
 		}
@@ -249,7 +262,7 @@ func (r *SandboxClaimReconciler) reconcileExpired(ctx context.Context, claim *ex
 }
 
 func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *extensionsv1alpha1.SandboxClaimStatus, claim *extensionsv1alpha1.SandboxClaim) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	sort.Slice(oldStatus.Conditions, func(i, j int) bool {
 		return oldStatus.Conditions[i].Type < oldStatus.Conditions[j].Type
@@ -263,7 +276,7 @@ func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *ex
 	}
 
 	if err := r.Status().Update(ctx, claim); err != nil {
-		log.Error(err, "Failed to update sandboxclaim status")
+		logger.Error(err, "Failed to update sandboxclaim status")
 		return err
 	}
 
@@ -351,7 +364,7 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1alpha1.S
 
 // adoptSandboxFromCandidates picks the best candidate and transfers ownership to the claim.
 func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, candidates []*v1alpha1.Sandbox) (*v1alpha1.Sandbox, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Sort: ready sandboxes first, then by creation time (oldest first)
 	sort.Slice(candidates, func(i, j int) bool {
@@ -364,7 +377,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 	})
 
 	if len(candidates) == 0 {
-		log.Info("No warm pool candidates available, falling through to cold start")
+		logger.Info("No warm pool candidates available, falling through to cold start", "claim", claim.Name)
 		return nil, nil
 	}
 
@@ -391,7 +404,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			poolName = controllerRef.Name
 		}
 
-		log.Info(fmt.Sprintf("Attempting sandbox adoption: sandbox=%s, pool=%s", adopted.Name, poolName))
+		logger.Info("Attempting sandbox adoption", "sandbox candidate", adopted.Name, "warm pool", poolName, "claim", claim.Name)
 
 		// Remove warm pool labels so the sandbox no longer appears in warm pool queries
 		delete(adopted.Labels, warmPoolSandboxLabel)
@@ -424,11 +437,11 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 				// Another worker adopted this sandbox while we were processing; try next candidate.
 				continue
 			}
-			log.Error(err, "Failed to update adopted sandbox")
+			logger.Error(err, "Failed to update adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
 			return nil, err
 		}
 
-		log.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
+		logger.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
 
 		if r.Recorder != nil {
 			r.Recorder.Event(claim, corev1.EventTypeNormal, "SandboxAdopted", fmt.Sprintf("Adopted warm pool Sandbox %q", adopted.Name))
@@ -443,7 +456,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 		return adopted, nil
 	}
 
-	log.Info("Failed to adopt any sandbox after checking all candidates")
+	logger.Info("Failed to adopt any sandbox after checking all candidates", "claim", claim.Name)
 	return nil, nil // Return nil, nil to fall completely to cold start
 }
 
@@ -529,7 +542,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		return nil, err
 	}
 
-	logger.Info("Created sandbox for claim", "claim", claim.Name)
+	logger.Info("Created sandbox for claim", "claim", claim.Name, "sandbox", sandbox.Name, "isReady", false, "duration", time.Since(claim.CreationTimestamp.Time))
 
 	if r.Recorder != nil {
 		r.Recorder.Event(claim, corev1.EventTypeNormal, "SandboxProvisioned", fmt.Sprintf("Created Sandbox %q", sandbox.Name))
@@ -542,13 +555,15 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 
 func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, _ *extensionsv1alpha1.SandboxTemplate) (*v1alpha1.Sandbox, error) {
 	logger := log.FromContext(ctx)
+	logger.V(1).Info("Executing getOrCreateSandbox", "claim", claim.Name)
 
 	// Check if a previously adopted sandbox is recorded in claim status
 	if statusName := claim.Status.SandboxStatus.Name; statusName != "" {
+		logger.V(1).Info("Checking status for sandbox name", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
 		sandbox := &v1alpha1.Sandbox{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
-				logger.Info("found existing adopted sandbox from status", "name", statusName)
+				logger.Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
 				return sandbox, nil
 			}
 		} else if !k8errors.IsNotFound(err) {
@@ -557,6 +572,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	}
 
 	// Try name-based lookup (sandbox created by createSandbox uses claim.Name)
+	logger.V(1).Info("Trying name-based lookup for sandbox", "claim", claim.Name)
 	sandbox := &v1alpha1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: claim.Namespace,
@@ -582,6 +598,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 
 	// Single List: ownership guard + adoption candidate scan.
 	// This queries the informer cache (not the API server), so it's fast.
+	logger.V(1).Info("Listing sandbox adoption candidates", "claim", claim.Name)
 	allSandboxes := &v1alpha1.SandboxList{}
 	if err := r.List(ctx, allSandboxes, client.InNamespace(claim.Namespace)); err != nil {
 		return nil, fmt.Errorf("failed to list sandboxes: %w", err)
@@ -598,7 +615,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 
 		// Ownership guard: if this claim already owns a sandbox, return it
 		if metav1.IsControlledBy(sb, claim) {
-			logger.Info("found existing owned sandbox", "name", sb.Name)
+			logger.Info("Found existing owned sandbox", "sandbox", sb.Name, "claim", claim.Name)
 			return sb, nil
 		}
 
@@ -723,10 +740,12 @@ func (r *SandboxClaimReconciler) reconcileNetworkPolicy(ctx context.Context, cla
 
 // recordCreationLatencyMetric detects and records transitions to Ready state.
 func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
+	ctx context.Context,
 	claim *extensionsv1alpha1.SandboxClaim,
 	oldStatus *extensionsv1alpha1.SandboxClaimStatus,
 	sandbox *v1alpha1.Sandbox,
 ) {
+	logger := log.FromContext(ctx)
 
 	newStatus := &claim.Status
 	newReady := meta.FindStatusCondition(newStatus.Conditions, string(v1alpha1.SandboxConditionReady))
@@ -748,6 +767,12 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 		// Existence of the SandboxPodNameAnnotation implies the pod was adopted from a warm pool.
 		launchType = asmetrics.LaunchTypeWarm
 	}
+
+	sandboxName := "none"
+	if sandbox != nil {
+		sandboxName = sandbox.Name
+	}
+	logger.V(1).Info("SandboxClaim is marked as Ready", "claim", claim.Name, "sandbox", sandboxName, "duration", time.Since(claim.CreationTimestamp.Time))
 
 	// SandboxClaim doesn't react to TemplateRef updates currently, so we don't need to handle the
 	// startup latency when the TemplateRef is updated.

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1133,6 +1133,7 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 }
 
 func TestRecordCreationLatencyMetric(t *testing.T) {
+	ctx := context.Background()
 	pastTime := metav1.Time{Time: time.Now().Add(-10 * time.Second)}
 
 	testCases := []struct {
@@ -1200,7 +1201,7 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 			asmetrics.ClaimStartupLatency.Reset()
 			r := &SandboxClaimReconciler{}
 
-			r.recordCreationLatencyMetric(tc.claim, tc.oldStatus, tc.sandbox)
+			r.recordCreationLatencyMetric(ctx, tc.claim, tc.oldStatus, tc.sandbox)
 
 			// Verify the metric was observed in the Prometheus registry
 			count := testutil.CollectAndCount(asmetrics.ClaimStartupLatency)


### PR DESCRIPTION
This PR improves observability by adding structured V(1) debug level logs to the SandboxClaim controller.

Because of the additional debug logs, this PR also adds `Development: false` to enable the production Zap logger by default.

To enable debug logs, add the `--zap-log-level=debug` as an argument to the controller.

```
...
      containers:
      - name: agent-sandbox-controller
        image: path/to/agent/sandbox/controller/image:tag
        args:
        - --leader-elect=true
        - --extensions
        - --enable-tracing=true
        - --zap-log-level=debug
...
```

#462 