### PR TITLE
fix(python-client): harden tracing, uploads, and execution response handling

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -59,18 +59,17 @@ class AsyncK8sHelper:
 
     async def create_sandbox_claim(
         self,
-        name: str,
         template: str,
         namespace: str,
         annotations: dict | None = None,
         labels: dict | None = None,
         lifecycle: dict | None = None,
-    ):
-        """Creates a SandboxClaim custom resource."""
+    ) -> str:
+        """Creates a SandboxClaim and returns its generated name."""
         await self._ensure_initialized()
 
         metadata = {
-            "name": name,
+            "generateName": "sandbox-claim-",
             "annotations": annotations or {},
         }
         if labels:
@@ -91,15 +90,18 @@ class AsyncK8sHelper:
             "spec": spec,
         }
         logger.info(
-            f"Creating SandboxClaim '{name}' in namespace '{namespace}' using template '{template}'..."
+            f"Creating SandboxClaim in namespace '{namespace}' using template '{template}'..."
         )
-        await self.custom_objects_api.create_namespaced_custom_object(
+        created = await self.custom_objects_api.create_namespaced_custom_object(
             group=CLAIM_API_GROUP,
             version=CLAIM_API_VERSION,
             namespace=namespace,
             plural=CLAIM_PLURAL_NAME,
             body=manifest,
         )
+        name = created["metadata"]["name"]
+        logger.info(f"SandboxClaim '{name}' created.")
+        return name
 
     async def resolve_sandbox_name(self, claim_name: str, namespace: str, timeout: int) -> str:
         """Resolves the actual Sandbox name from the SandboxClaim status.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -23,7 +23,6 @@ import asyncio
 import logging
 import re
 import time
-import uuid
 from typing import Generic, TypeVar
 
 from .async_k8s_helper import AsyncK8sHelper
@@ -31,7 +30,7 @@ from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
 from .utils import construct_sandbox_claim_lifecycle_spec
 from .models import SandboxConnectionConfig, SandboxTracerConfig
-from .trace_manager import async_trace_span, create_tracer_manager, initialize_tracer, trace
+from .trace_manager import async_trace_span, create_tracer_manager, create_tracer_provider, trace
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +73,10 @@ class AsyncSandboxClient(Generic[T]):
         self.connection_config = connection_config
 
         self.tracer_config = tracer_config or SandboxTracerConfig()
-        if self.tracer_config.enable_tracing:
-            initialize_tracer(self.tracer_config.trace_service_name)
-        self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
+        if self.tracer_config.enable_tracing and self.tracer_config.tracer_provider is None:
+            self.tracer_config.tracer_provider = create_tracer_provider(self.tracer_config.trace_service_name)
+        self.tracing_manager, self.tracer = create_tracer_manager(
+            self.tracer_config, self.tracer_config.tracer_provider)
 
         self.k8s_helper = AsyncK8sHelper()
 
@@ -139,10 +139,8 @@ class AsyncSandboxClient(Generic[T]):
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
-        claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
-
         try:
-            await self._create_claim(claim_name, template, namespace, labels=labels, lifecycle=lifecycle)
+            claim_name = await self._create_claim(template, namespace, labels=labels, lifecycle=lifecycle)
             start_time = time.monotonic()
             sandbox_id = await self.k8s_helper.resolve_sandbox_name(
                 claim_name, namespace, sandbox_ready_timeout
@@ -312,12 +310,22 @@ class AsyncSandboxClient(Generic[T]):
     @async_trace_span("create_claim")
     async def _create_claim(
         self,
-        claim_name: str,
         template_name: str,
         namespace: str,
         labels: dict[str, str] | None = None,
         lifecycle: dict | None = None,
-    ):
+    ) -> str:
+        """Creates the SandboxClaim and returns its generated name."""
+        annotations = {}
+        if self.tracing_manager:
+            trace_context_str = self.tracing_manager.get_trace_context_json()
+            if trace_context_str:
+                annotations["opentelemetry.io/trace-context"] = trace_context_str
+
+        claim_name = await self.k8s_helper.create_sandbox_claim(
+            template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle
+        )
+
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.claim.name", claim_name)
@@ -325,15 +333,7 @@ class AsyncSandboxClient(Generic[T]):
                 span.set_attribute("sandbox.lifecycle.shutdown_time", lifecycle["shutdownTime"])
                 span.set_attribute("sandbox.lifecycle.shutdown_policy", lifecycle["shutdownPolicy"])
 
-        annotations = {}
-        if self.tracing_manager:
-            trace_context_str = self.tracing_manager.get_trace_context_json()
-            if trace_context_str:
-                annotations["opentelemetry.io/trace-context"] = trace_context_str
-
-        await self.k8s_helper.create_sandbox_claim(
-            claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle
-        )
+        return claim_name
 
     @async_trace_span("wait_for_sandbox_ready")
     async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
@@ -31,7 +31,7 @@ class CommandExecutor:
 
     @trace_span("run")
     def run(self, command: str, timeout: int = 60) -> ExecutionResult:
-        """Executes a command. Rejects responses larger than 16 MB."""
+        """Executes a command. Rejects responses exceeding ``MAX_EXECUTION_RESPONSE_SIZE``."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.command", command)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
@@ -17,6 +17,9 @@ from k8s_agent_sandbox.connector import SandboxConnector
 from k8s_agent_sandbox.models import ExecutionResult
 from k8s_agent_sandbox.trace_manager import trace_span, trace
 
+# Maximum response size for command execution (16 MB).
+MAX_EXECUTION_RESPONSE_SIZE = 16 * 1024 * 1024
+
 class CommandExecutor:
     """
     Handles execution of commands within the sandbox.
@@ -28,6 +31,7 @@ class CommandExecutor:
 
     @trace_span("run")
     def run(self, command: str, timeout: int = 60) -> ExecutionResult:
+        """Executes a command. Rejects responses larger than 16 MB."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.command", command)
@@ -35,6 +39,12 @@ class CommandExecutor:
         payload = {"command": command}
         response = self.connector.send_request(
             "POST", "execute", json=payload, timeout=timeout)
+
+        body = response.content
+        if len(body) > MAX_EXECUTION_RESPONSE_SIZE:
+            raise RuntimeError(
+                f"Execution response exceeds {MAX_EXECUTION_RESPONSE_SIZE} byte limit"
+            )
 
         try:
             response_data = response.json()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/filesystem.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/filesystem.py
@@ -41,6 +41,10 @@ class Filesystem:
             content = content.encode('utf-8')
 
         filename = os.path.basename(path)
+        if filename != path:
+            raise ValueError(
+                f"path must be a plain filename without directories, got {path!r}"
+            )
         files_payload = {'file': (filename, content)}
         self.connector.send_request("POST", "upload",
                       files=files_payload, timeout=timeout)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -42,10 +42,10 @@ class K8sHelper:
         self.custom_objects_api = client.CustomObjectsApi()
         self.core_v1_api = client.CoreV1Api()
 
-    def create_sandbox_claim(self, name: str, template: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None):
-        """Creates a SandboxClaim custom resource."""
+    def create_sandbox_claim(self, template: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None) -> str:
+        """Creates a SandboxClaim and returns its generated name."""
         metadata = {
-            "name": name,
+            "generateName": "sandbox-claim-",
             "annotations": annotations or {},
         }
         if labels:
@@ -65,14 +65,17 @@ class K8sHelper:
             "metadata": metadata,
             "spec": spec,
         }
-        logging.info(f"Creating SandboxClaim '{name}' in namespace '{namespace}' using template '{template}'...")
-        self.custom_objects_api.create_namespaced_custom_object(
+        logging.info(f"Creating SandboxClaim in namespace '{namespace}' using template '{template}'...")
+        created = self.custom_objects_api.create_namespaced_custom_object(
             group=CLAIM_API_GROUP,
             version=CLAIM_API_VERSION,
             namespace=namespace,
             plural=CLAIM_PLURAL_NAME,
             body=manifest
         )
+        name = created["metadata"]["name"]
+        logging.info(f"SandboxClaim '{name}' created.")
+        return name
     
     def resolve_sandbox_name(self, claim_name: str, namespace: str, timeout: int) -> str:
         """Resolves the actual Sandbox name from the SandboxClaim status.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -49,6 +49,8 @@ SandboxConnectionConfig = Union[SandboxDirectConnectionConfig, SandboxGatewayCon
 
 class SandboxTracerConfig(BaseModel):
     """Configuration for tracer level information"""
+    model_config = {"arbitrary_types_allowed": True}
     enable_tracing: bool = False  # Whether to enable OpenTelemetry tracing.
     trace_service_name: str = "sandbox-client"  # Service name used for traces.
+    tracer_provider: object = None  # Optional TracerProvider instance.
     

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -49,6 +49,7 @@ SandboxConnectionConfig = Union[SandboxDirectConnectionConfig, SandboxGatewayCon
 
 class SandboxTracerConfig(BaseModel):
     """Configuration for tracer level information"""
+    # Required because tracer_provider accepts a TracerProvider instance.
     model_config = {"arbitrary_types_allowed": True}
     enable_tracing: bool = False  # Whether to enable OpenTelemetry tracing.
     trace_service_name: str = "sandbox-client"  # Service name used for traces.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -66,7 +66,8 @@ class Sandbox:
         # Tracer initialization
         self.tracer_config = tracer_config or SandboxTracerConfig()
         self.trace_service_name = self.tracer_config.trace_service_name
-        self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
+        self.tracing_manager, self.tracer = create_tracer_manager(
+            self.tracer_config, self.tracer_config.tracer_provider)
 
         # Initialisation of namespaced engines
         self._commands = CommandExecutor(self.connector, self.tracer, self.trace_service_name)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -18,7 +18,6 @@ file I/O) via the Sandbox resource handle.
 """
 
 import re
-import uuid
 import sys
 import time
 import atexit
@@ -27,7 +26,7 @@ from typing import List, Dict, Tuple, TypeVar, Generic, Type
 
 # Import all tracing components from the trace_manager module
 from .trace_manager import (
-    create_tracer_manager, initialize_tracer, trace_span, trace
+    create_tracer_manager, create_tracer_provider, trace_span, trace
 )
 from .sandbox import Sandbox
 from .models import (
@@ -63,9 +62,10 @@ class SandboxClient(Generic[T]):
         
         # Tracer configuration
         self.tracer_config = tracer_config or SandboxTracerConfig()
-        if self.tracer_config.enable_tracing:
-            initialize_tracer(self.tracer_config.trace_service_name)
-        self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
+        if self.tracer_config.enable_tracing and self.tracer_config.tracer_provider is None:
+            self.tracer_config.tracer_provider = create_tracer_provider(self.tracer_config.trace_service_name)
+        self.tracing_manager, self.tracer = create_tracer_manager(
+            self.tracer_config, self.tracer_config.tracer_provider)
 
         # Downstream Kubernetes Configuration
         self.k8s_helper = K8sHelper()
@@ -106,10 +106,8 @@ class SandboxClient(Generic[T]):
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
-        claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
-        
         try:
-            self._create_claim(claim_name, template, namespace, labels=labels, lifecycle=lifecycle)
+            claim_name = self._create_claim(template, namespace, labels=labels, lifecycle=lifecycle)
             # Resolve the sandbox id from the sandbox claim object.
             # In case of warmpool, sandbox id is not the same as claim name.
             start_time = time.monotonic()
@@ -302,8 +300,16 @@ class SandboxClient(Generic[T]):
                 SandboxClient._validate_label_name(value, f"value '{value}' for key '{key}'")
 
     @trace_span("create_claim")
-    def _create_claim(self, claim_name: str, template_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None):
-        """Creates the SandboxClaim custom resource in the Kubernetes cluster."""
+    def _create_claim(self, template_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None) -> str:
+        """Creates the SandboxClaim and returns its generated name."""
+        annotations = {}
+        if self.tracing_manager:
+            trace_context_str = self.tracing_manager.get_trace_context_json()
+            if trace_context_str:
+                annotations["opentelemetry.io/trace-context"] = trace_context_str
+
+        claim_name = self.k8s_helper.create_sandbox_claim(template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle)
+
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.claim.name", claim_name)
@@ -311,13 +317,7 @@ class SandboxClient(Generic[T]):
                 span.set_attribute("sandbox.lifecycle.shutdown_time", lifecycle["shutdownTime"])
                 span.set_attribute("sandbox.lifecycle.shutdown_policy", lifecycle["shutdownPolicy"])
 
-        annotations = {}
-        if self.tracing_manager:
-            trace_context_str = self.tracing_manager.get_trace_context_json()
-            if trace_context_str:
-                annotations["opentelemetry.io/trace-context"] = trace_context_str
-
-        self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle)
+        return claim_name
 
     @trace_span("wait_for_sandbox_ready")
     def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -28,7 +28,9 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.helper = AsyncK8sHelper()
         self.helper._initialized = True
         self.helper.custom_objects_api = MagicMock()
-        self.helper.custom_objects_api.create_namespaced_custom_object = AsyncMock()
+        self.helper.custom_objects_api.create_namespaced_custom_object = AsyncMock(
+            return_value={"metadata": {"name": "sandbox-claim-gen12"}}
+        )
         self.helper.core_v1_api = MagicMock()
 
     async def test_lifecycle_included_in_manifest(self):
@@ -37,7 +39,7 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
             "shutdownPolicy": "Delete",
         }
         await self.helper.create_sandbox_claim(
-            "test-claim", "test-template", "test-namespace", lifecycle=lifecycle
+            "test-template", "test-namespace", lifecycle=lifecycle
         )
 
         call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
@@ -47,7 +49,7 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
 
     async def test_no_lifecycle_omits_key(self):
         await self.helper.create_sandbox_claim(
-            "test-claim", "test-template", "test-namespace"
+            "test-template", "test-namespace"
         )
 
         call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
@@ -60,7 +62,7 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
             "shutdownPolicy": "Delete",
         }
         await self.helper.create_sandbox_claim(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             annotations={"key": "val"},
             labels={"agent": "test"},
             lifecycle=lifecycle,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -58,13 +58,13 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
-        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock, return_value="sandbox-claim-gen12") as mock_create, \
              patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
 
             sandbox = await self.client.create_sandbox("test-template", "test-namespace")
 
             mock_create.assert_called_once_with(
-                ANY, "test-template", "test-namespace", labels=None, lifecycle=None
+                "test-template", "test-namespace", labels=None, lifecycle=None
             )
             self.assertEqual(sandbox, mock_sandbox_instance)
 
@@ -76,7 +76,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             side_effect=Exception("Timeout")
         )
 
-        with patch.object(self.client, "_create_claim", new_callable=AsyncMock), \
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock, return_value="sandbox-claim-gen12"), \
              patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
 
             with self.assertRaises(Exception) as ctx:
@@ -91,7 +91,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             side_effect=asyncio.CancelledError()
         )
 
-        with patch.object(self.client, "_create_claim", new_callable=AsyncMock), \
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock, return_value="sandbox-claim-gen12"), \
              patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
 
             with self.assertRaises(asyncio.CancelledError):
@@ -215,7 +215,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
-        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock, return_value="sandbox-claim-gen12") as mock_create, \
              patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
 
             await self.client.create_sandbox(
@@ -235,7 +235,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
-        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock, return_value="sandbox-claim-gen12") as mock_create, \
              patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
 
             await self.client.create_sandbox("test-template", "test-namespace")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -29,7 +29,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
         helper = K8sHelper()
         helper.create_sandbox_claim(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels={"agent": "code-agent", "team": "platform"},
         )
@@ -45,7 +45,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
         helper = K8sHelper()
         helper.create_sandbox_claim(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             labels={"agent": "code-agent"},
         )
 
@@ -58,7 +58,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         mock_api_cls.return_value = mock_api
 
         helper = K8sHelper()
-        helper.create_sandbox_claim("test-claim", "test-template", "test-namespace")
+        helper.create_sandbox_claim("test-template", "test-namespace")
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["metadata"]["annotations"], {})
@@ -74,7 +74,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         }
         helper = K8sHelper()
         helper.create_sandbox_claim(
-            "test-claim", "test-template", "test-namespace", lifecycle=lifecycle
+            "test-template", "test-namespace", lifecycle=lifecycle
         )
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
@@ -86,7 +86,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         mock_api_cls.return_value = mock_api
 
         helper = K8sHelper()
-        helper.create_sandbox_claim("test-claim", "test-template", "test-namespace")
+        helper.create_sandbox_claim("test-template", "test-namespace")
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertNotIn("lifecycle", body["spec"])

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -105,7 +105,7 @@ class TestSandbox(unittest.TestCase):
             k8s_helper=mock_k8s_helper_instance
         )
 
-        mock_create_tracer_manager.assert_called_once_with(mock_tracer_config)
+        mock_create_tracer_manager.assert_called_once_with(mock_tracer_config, None)
         mock_command_executor.assert_called_once_with(mock_connector.return_value, mock_tracer, "custom-tracer")
         mock_filesystem.assert_called_once_with(mock_connector.return_value, mock_tracer, "custom-tracer")
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -44,43 +44,39 @@ class TestSandboxClient(unittest.TestCase):
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
 
-    @patch('uuid.uuid4')
-    def test_create_sandbox_success(self, mock_uuid):
-        mock_uuid.return_value.hex = '1234abcd'
+    def test_create_sandbox_success(self):
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
         self.mock_k8s_helper.get_sandbox.return_value = {
             "metadata": {"annotations": {POD_NAME_ANNOTATION: "custom-pod-name"}}
         }
-        
+
         mock_sandbox_instance = MagicMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
-        
-        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+
+        with patch.object(self.client, '_create_claim', return_value="sandbox-claim-gen12") as mock_create_claim, \
              patch.object(self.client, '_wait_for_sandbox_ready') as mock_wait:
-            
+
             sandbox = self.client.create_sandbox("test-template", "test-namespace")
-            
-            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace", labels=None, lifecycle=None)
-            self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
+
+            mock_create_claim.assert_called_once_with("test-template", "test-namespace", labels=None, lifecycle=None)
+            self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-gen12", "test-namespace", 180)
             mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
             self.assertEqual(sandbox, mock_sandbox_instance)
-            
+
             # Verify the new sandbox is tracked in the registry
             self.assertEqual(len(self.client._active_connection_sandboxes), 1)
-            self.assertEqual(self.client._active_connection_sandboxes[("test-namespace", "sandbox-claim-1234abcd")], mock_sandbox_instance)
+            self.assertEqual(self.client._active_connection_sandboxes[("test-namespace", "sandbox-claim-gen12")], mock_sandbox_instance)
 
-    @patch('uuid.uuid4')
-    def test_create_sandbox_failure_cleanup(self, mock_uuid):
-        mock_uuid.return_value.hex = '1234abcd'
+    def test_create_sandbox_failure_cleanup(self):
         self.mock_k8s_helper.resolve_sandbox_name.side_effect = Exception("Timeout Error")
-        
-        with patch.object(self.client, '_create_claim') as mock_create_claim:
+
+        with patch.object(self.client, '_create_claim', return_value="sandbox-claim-gen12") as mock_create_claim:
             with self.assertRaises(Exception) as context:
                 self.client.create_sandbox("test-template", "test-namespace")
-                
+
             self.assertEqual(str(context.exception), "Timeout Error")
             # Ensure delete_sandbox_claim is called to cleanup orphan claim on failure
-            self.mock_k8s_helper.delete_sandbox_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace")
+            self.mock_k8s_helper.delete_sandbox_claim.assert_called_once_with("sandbox-claim-gen12", "test-namespace")
 
     def test_get_sandbox_existing_active(self):
         mock_sandbox = MagicMock()
@@ -183,9 +179,7 @@ class TestSandboxClient(unittest.TestCase):
             mock_delete.assert_any_call("claim1", namespace="ns1")
             mock_delete.assert_any_call("claim2", namespace="ns2")
 
-    @patch('uuid.uuid4')
-    def test_create_sandbox_with_labels(self, mock_uuid):
-        mock_uuid.return_value.hex = '1234abcd'
+    def test_create_sandbox_with_labels(self):
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
 
         mock_sandbox_instance = MagicMock()
@@ -193,13 +187,13 @@ class TestSandboxClient(unittest.TestCase):
 
         labels = {"agent": "code-agent", "team": "platform"}
 
-        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+        with patch.object(self.client, '_create_claim', return_value="sandbox-claim-gen12") as mock_create_claim, \
              patch.object(self.client, '_wait_for_sandbox_ready'):
 
             self.client.create_sandbox("test-template", "test-namespace", labels=labels)
 
             mock_create_claim.assert_called_once_with(
-                "sandbox-claim-1234abcd", "test-template", "test-namespace",
+                "test-template", "test-namespace",
                 labels={"agent": "code-agent", "team": "platform"},
                 lifecycle=None,
             )
@@ -207,12 +201,14 @@ class TestSandboxClient(unittest.TestCase):
     def test_create_claim_with_labels(self):
         self.client.tracing_manager = MagicMock()
         self.client.tracing_manager.get_trace_context_json.return_value = "trace-data"
+        self.mock_k8s_helper.create_sandbox_claim.return_value = "sandbox-claim-abc12"
 
         labels = {"agent": "code-agent"}
-        self.client._create_claim("test-claim", "test-template", "test-namespace", labels=labels)
+        name = self.client._create_claim("test-template", "test-namespace", labels=labels)
 
+        self.assertEqual(name, "sandbox-claim-abc12")
         self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels={"agent": "code-agent"},
             lifecycle=None,
@@ -221,11 +217,13 @@ class TestSandboxClient(unittest.TestCase):
     def test_create_claim(self):
         self.client.tracing_manager = MagicMock()
         self.client.tracing_manager.get_trace_context_json.return_value = "trace-data"
-        
-        self.client._create_claim("test-claim", "test-template", "test-namespace")
-        
+        self.mock_k8s_helper.create_sandbox_claim.return_value = "sandbox-claim-abc12"
+
+        name = self.client._create_claim("test-template", "test-namespace")
+
+        self.assertEqual(name, "sandbox-claim-abc12")
         self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels=None,
             lifecycle=None,
@@ -280,15 +278,13 @@ class TestSandboxClient(unittest.TestCase):
             "sandbox-id", "test-namespace", 45
         )
 
-    @patch('uuid.uuid4')
-    def test_create_sandbox_with_shutdown_after_seconds(self, mock_uuid):
-        mock_uuid.return_value.hex = '1234abcd'
+    def test_create_sandbox_with_shutdown_after_seconds(self):
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
 
         mock_sandbox_instance = MagicMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
-        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+        with patch.object(self.client, '_create_claim', return_value="sandbox-claim-gen12") as mock_create_claim, \
              patch.object(self.client, '_wait_for_sandbox_ready'):
 
             self.client.create_sandbox(
@@ -301,15 +297,13 @@ class TestSandboxClient(unittest.TestCase):
             self.assertEqual(lifecycle["shutdownPolicy"], "Delete")
             self.assertIn("shutdownTime", lifecycle)
 
-    @patch('uuid.uuid4')
-    def test_create_sandbox_without_shutdown_after_seconds(self, mock_uuid):
-        mock_uuid.return_value.hex = '1234abcd'
+    def test_create_sandbox_without_shutdown_after_seconds(self):
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
 
         mock_sandbox_instance = MagicMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
-        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+        with patch.object(self.client, '_create_claim', return_value="sandbox-claim-gen12") as mock_create_claim, \
              patch.object(self.client, '_wait_for_sandbox_ready'):
 
             self.client.create_sandbox("test-template", "test-namespace")
@@ -326,17 +320,19 @@ class TestSandboxClient(unittest.TestCase):
 
         self.client.tracing_manager = MagicMock()
         self.client.tracing_manager.get_trace_context_json.return_value = None
+        self.mock_k8s_helper.create_sandbox_claim.return_value = "sandbox-claim-gen12"
 
         lifecycle = {
             "shutdownTime": "2026-06-15T12:05:00Z",
             "shutdownPolicy": "Delete",
         }
-        self.client._create_claim(
-            "test-claim", "test-template", "test-namespace", lifecycle=lifecycle
+        name = self.client._create_claim(
+            "test-template", "test-namespace", lifecycle=lifecycle
         )
 
+        self.assertEqual(name, "sandbox-claim-gen12")
         self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             annotations={},
             labels=None,
             lifecycle=lifecycle,
@@ -345,11 +341,13 @@ class TestSandboxClient(unittest.TestCase):
     def test_create_claim_without_lifecycle(self):
         self.client.tracing_manager = MagicMock()
         self.client.tracing_manager.get_trace_context_json.return_value = None
+        self.mock_k8s_helper.create_sandbox_claim.return_value = "sandbox-claim-gen12"
 
-        self.client._create_claim("test-claim", "test-template", "test-namespace")
+        name = self.client._create_claim("test-template", "test-namespace")
 
+        self.assertEqual(name, "sandbox-claim-gen12")
         self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
-            "test-claim", "test-template", "test-namespace",
+            "test-template", "test-namespace",
             annotations={},
             labels=None,
             lifecycle=None,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/trace_manager.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/trace_manager.py
@@ -22,7 +22,6 @@ import atexit
 import functools
 import json
 import logging
-import threading
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -106,59 +105,26 @@ except ImportError:
     trace = TraceStub
     context = ContextStub
 
-# --- Global state for the singleton TracerProvider ---
-_TRACER_PROVIDER = None
-_TRACER_PROVIDER_LOCK = threading.Lock()
 
 
-def initialize_tracer(service_name: str):
+def create_tracer_provider(service_name: str) -> "TracerProvider | None":
+    """Creates a TracerProvider with an OTLP/gRPC exporter.
+
+    The endpoint is read from OTEL_EXPORTER_OTLP_ENDPOINT (default: localhost:4317).
+    The caller owns the returned provider and should pass it to SandboxTracerConfig.
     """
-    Initializes the global OpenTelemetry TracerProvider using the singleton pattern.
-
-    This function uses double-checked locking to ensure thread-safe, one-time initialization.
-
-    Behavior:
-    - If OpenTelemetry is not installed, this is a no-op.
-    - If the Provider is already initialized, it verifies that the requested 'service_name'
-      matches the existing global service name. If they differ, a warning is logged
-      indicating that the requested name will be ignored in favor of the existing one.
-    - Configures a BatchSpanProcessor and OTLPSpanExporter for sending traces.
-    """
-    global _TRACER_PROVIDER
-
     if not OPENTELEMETRY_AVAILABLE:
         logging.error(
-            "OpenTelemetry not installed; skipping tracer initialization.")
-        return
+            "OpenTelemetry not installed; cannot create TracerProvider.")
+        return None
 
-    # First check (no lock) for performance.
-    if _TRACER_PROVIDER is not None:
-        try:
-            existing_name = _TRACER_PROVIDER.resource.attributes.get(
-                "service.name")
-            if existing_name and existing_name != service_name:
-                logging.warning(
-                    f"Global TracerProvider already initialized with service name '{existing_name}'. "
-                    f"Ignoring request to initialize with '{service_name}'."
-                )
-        except Exception:
-            # Fallback if accessing attributes fails for any reason
-            pass
-        return
-
-    with _TRACER_PROVIDER_LOCK:
-        # Second check (with lock) to ensure thread safety.
-        if _TRACER_PROVIDER is None:
-            resource = Resource(attributes={"service.name": service_name})
-            _TRACER_PROVIDER = TracerProvider(resource=resource)
-            _TRACER_PROVIDER.add_span_processor(
-                BatchSpanProcessor(OTLPSpanExporter())
-            )
-            trace.set_tracer_provider(_TRACER_PROVIDER)
-            # Ensure shutdown is called only once when the process exits.
-            atexit.register(_TRACER_PROVIDER.shutdown)
-            logging.info(
-                f"Global OpenTelemetry TracerProvider configured for service '{service_name}'.")
+    resource = Resource(attributes={"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter())
+    )
+    atexit.register(provider.shutdown)
+    return provider
 
 
 def trace_span(span_suffix):
@@ -226,9 +192,12 @@ class TracerManager:
     3. Handling the attachment/detachment of the OTel context to the current thread.
     """
 
-    def __init__(self, service_name: str):
+    def __init__(self, service_name: str, provider=None):
         instrumentation_scope_name = service_name.replace('-', '_')
-        self.tracer = trace.get_tracer(instrumentation_scope_name)
+        if provider is not None:
+            self.tracer = provider.get_tracer(instrumentation_scope_name)
+        else:
+            self.tracer = trace.get_tracer(instrumentation_scope_name)
         self.lifecycle_span_name = f"{service_name}.lifecycle"
         self.parent_span = None
         self.context_token = None
@@ -256,10 +225,8 @@ class TracerManager:
         self.propagator.inject(carrier)
         return json.dumps(carrier) if carrier else ""
 
-def create_tracer_manager(config: "SandboxTracerConfig"):
-    """
-    Creates and initializes a TracerManager based on the provided configuration.
-    """
+def create_tracer_manager(config: "SandboxTracerConfig", provider=None):
+    """Creates a TracerManager from config and an optional TracerProvider."""
     if not config.enable_tracing:
         return None, None
 
@@ -267,5 +234,5 @@ def create_tracer_manager(config: "SandboxTracerConfig"):
         logging.error("OpenTelemetry not installed; skipping tracer initialization.")
         return None, None
 
-    manager = TracerManager(service_name=config.trace_service_name)
+    manager = TracerManager(service_name=config.trace_service_name, provider=provider)
     return manager, manager.tracer


### PR DESCRIPTION
Issues surfaced during Go SDK review (#424) that also apply to Python SDK.

- Replace `initialize_tracer()` with `create_tracer_provider()` factory, the SDK no longer calls `trace.set_tracer_provider()`.
- Raise `ValueError` on upload paths with directory separators instead of silently stripping to basename.
- Reject execution responses larger than 16 MB with a clear error.
- Use `generateName` for claim creation instead of manual `uuid.uuid4()` suffix.