### PR TITLE
optimization: replace .Update() with .Patch() for claim updateStatus

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -439,11 +439,20 @@ func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *ex
 		return nil
 	}
 
-	if err := r.Status().Update(ctx, claim); err != nil {
-		logger.Error(err, "Failed to update sandboxclaim status")
+	oldClaim := claim.DeepCopy()
+	oldClaim.Status = *oldStatus
+
+	patch := client.MergeFrom(oldClaim)
+
+	if err := r.Status().Patch(ctx, claim, patch); err != nil {
+		logger.Error(err, "Failed to patch sandboxclaim status")
 		return err
 	}
 
+	logger.V(4).Info("Successfully patched sandboxclaim status",
+		"name", claim.Name,
+		"namespace", claim.Namespace,
+		"observedGeneration", claim.Generation)
 	return nil
 }
 


### PR DESCRIPTION
In an effort to reduce "Operation cannot be fulfilled..." conflicts at scale, this PR switches to patching to the status of Sandbox Claim resrouce status. 

Tests from main without this change indicate:

322 operation cannot be fulfilled conflicts from sandboxclaim (protoPayload.resourceName="pods/sandboxclaim-" OR protoPayload.resourceName="sandboxclaims/") 

With this change, 0 conflicts. 

Test paramters: 

```
# BURST_SIZE * TOTAL_BURSTS = Total sandbox claims created
BURST_SIZE=300
QPS=300
TOTAL_BURSTS=5
WARMPOOL_SIZE=600
RUNTIME_CLASS="" # Change to "gvisor" if your cluster supports it
```

Deployment args
```
        args:
        - "--leader-elect=true"
        - "--extensions"
        - "--enable-tracing=true"
        - --zap-log-level=debug
        - --zap-encoder=json
        - --enable-pprof-debug
        - --kube-api-qps=1000
        - --kube-api-burst=2000
        - --sandbox-concurrent-workers=400
        - --sandbox-claim-concurrent-workers=400
        - --sandbox-warm-pool-concurrent-workers=1
```