### PR TITLE
optimization: replace .Update() with .Patch() for sandbox updateStatus

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
-	"reflect"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -308,18 +308,24 @@ func podIPsFromStatus(podIPs []corev1.PodIP) []string {
 }
 
 func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1alpha1.SandboxStatus, sandbox *sandboxv1alpha1.Sandbox) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	if reflect.DeepEqual(oldStatus, &sandbox.Status) {
+	if equality.Semantic.DeepEqual(oldStatus, &sandbox.Status) {
 		return nil
 	}
 
-	if err := r.Status().Update(ctx, sandbox); err != nil {
-		log.Error(err, "Failed to update sandbox status")
+	oldSandbox := sandbox.DeepCopy()
+	oldSandbox.Status = *oldStatus
+
+	sandbox.SetGroupVersionKind(sandboxv1alpha1.GroupVersion.WithKind("Sandbox"))
+
+	patch := client.MergeFrom(oldSandbox)
+
+	if err := r.Status().Patch(ctx, sandbox, patch); err != nil {
+		logger.Error(err, "Failed to patch sandbox status")
 		return err
 	}
 
-	// Surface error
 	return nil
 }
 


### PR DESCRIPTION
In an effort to reduce "Operation cannot be fulfilled..." conflicts at scale, this PR switches to patching to the status of Sandbox resource status.

Tests from main without this change indicate:

526 operation cannot be fulfilled conflicts from sandboxclaim (protoPayload.resourceName="pods/sandboxclaim-" OR protoPayload.resourceName="sandboxclaims/")

With this change, it decreased to ~16 conflicts. 

Test parameters:

```
# BURST_SIZE * TOTAL_BURSTS = Total sandbox claims created
BURST_SIZE=300
QPS=300
TOTAL_BURSTS=5
WARMPOOL_SIZE=600
RUNTIME_CLASS="" # Change to "gvisor" if your cluster supports it
```

Deployment args:

```
        args:
        - "--leader-elect=true"
        - "--extensions"
        - "--enable-tracing=true"
        - --zap-log-level=debug
        - --zap-encoder=json
        - --enable-pprof-debug
        - --kube-api-qps=1000
        - --kube-api-burst=2000
        - --sandbox-concurrent-workers=400
        - --sandbox-claim-concurrent-workers=400
        - --sandbox-warm-pool-concurrent-workers=1
```