### PR TITLE
fix(python): add backward compatibility for SandboxClaim status.sandbox.Name

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -90,7 +90,8 @@ class K8sHelper:
                 claim_object = event['object']
                 sandbox_status = claim_object.get(
                     'status', {}).get('sandbox', {})
-                name = sandbox_status.get('name', '')
+                # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
+                name = sandbox_status.get('name', '') or sandbox_status.get('Name', '')
                 if name:
                     logging.info(
                         f"Resolved sandbox name '{name}' from claim status")


### PR DESCRIPTION
Adds backward compatibility for `status.sandbox.name` in the Python client.
                                                                                                                                                                                   
PR #440 renamed the field from `Name` to `name` but the change isn't released yet. Older controllers still return `Name`, breaking things for users (#505).                                                                                                                                                                         
                                                                                                                                                                                   
The code review bot in #440 actually recommended adding a fallback to check both fields, but it didn't make it into the final PR. This adds that fallback - it's just one line and lets the Python client work with any controller version.
                                                                                                                                                                                   
Fixes #505