### PR TITLE
feat: propagate podTemplate annotations from Sandbox to Pod

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -451,6 +451,9 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
 		}
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+		}
 		changed := false
 		if pod.Labels[sandboxLabel] != nameHash {
 			pod.Labels[sandboxLabel] = nameHash
@@ -460,6 +463,12 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 			if pod.Labels[k] != v {
 				pod.Labels[k] = v
+				changed = true
+			}
+		}
+		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+			if pod.Annotations[k] != v {
+				pod.Annotations[k] = v
 				changed = true
 			}
 		}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -620,6 +620,9 @@ func TestReconcilePod(t *testing.T) {
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						"custom-label":                      "label-val",
 					},
+					Annotations: map[string]string{
+						"custom-annotation": "anno-val",
+					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.PodSpec{
@@ -699,7 +702,7 @@ func TestReconcilePod(t *testing.T) {
 			wantPod: nil,
 		},
 		{
-			name: "adopts existing pod via annotation - pod gets label and owner reference",
+			name: "adopts existing pod via annotation - pod gets metadata and owner reference",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -727,6 +730,11 @@ func TestReconcilePod(t *testing.T) {
 				Spec: sandboxv1alpha1.SandboxSpec{
 					Replicas: ptr.To(int32(1)),
 					PodTemplate: sandboxv1alpha1.PodTemplate{
+						ObjectMeta: sandboxv1alpha1.PodMetadata{
+							Annotations: map[string]string{
+								"example.com/workspace": "true",
+							},
+						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
@@ -744,6 +752,9 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "2",
 					Labels: map[string]string{
 						sandboxLabel: nameHash,
+					},
+					Annotations: map[string]string{
+						"example.com/workspace": "true",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
@@ -796,6 +807,9 @@ func TestReconcilePod(t *testing.T) {
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation": "anno-val",
 					},
 					// Should still have the original controller reference
 					OwnerReferences: []metav1.OwnerReference{


### PR DESCRIPTION
## Summary

Extend the existing label-sync loop in `reconcilePod` to also propagate annotations from `Sandbox.Spec.PodTemplate.ObjectMeta.Annotations` to the running Pod. This is a no-restart, in-place metadata update.

Split out from #459 per maintainer request to keep the annotation propagation discussion separate from the workspaceResources feature.

## Why in-place propagation is the right model for Sandbox

justinsb raised a good question in #459 about whether in-place propagation sets a precedent for Deployments/StatefulSets. It doesn't, because the lifecycle models are fundamentally different:

- **Deployments/StatefulSets** manage replica sets. PodTemplate changes trigger rolling updates — new Pods replace old ones. That's deliberate: stateless workloads benefit from gradual rollout, canary detection, and rollback.
- **Sandbox is 1:1** — one CR, one Pod. There is no replica set, no rolling update, no rollout strategy. The Pod *is* the Sandbox. When the Sandbox spec changes, the only sensible thing is to update the Pod in place.

Kubernetes already supports this:
- Labels and annotations are mutable on Pods (always have been)
- `InPlacePodVerticalScaling` (GA path since KEP-1287) makes container resources mutable too

The existing `reconcilePod` already syncs labels this way. This PR adds annotations to the same loop — no new pattern, just extending existing behavior to another mutable field.

This does not change behavior for Deployments, StatefulSets, or any other workload controller.

## Test plan

- [x] Existing label propagation tests still pass
- [x] New test: annotations from Sandbox podTemplate are synced to Pod
- [x] New test: adopted pod gets annotations from Sandbox
- [x] Pods with existing annotations preserve them (additive merge)

## Files

- `controllers/sandbox_controller.go` — extend reconcilePod annotation sync
- `controllers/sandbox_controller_test.go` — test coverage