### PR TITLE
tests: print object state after waiting for predicate

### DIFF
--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -40,6 +40,7 @@ import (
 	sandboxextensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -298,6 +299,7 @@ func (cl *ClusterClient) WaitForObject(ctx context.Context, obj client.Object, p
 	watchFilter := WatchFilter{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 
 	var lastNotMatching []predicates.ObjectPredicate
+	var lastObject *unstructured.Unstructured
 	done, err := Watch(ctx, cl, gvr, watchFilter, func(event watch.Event, obj *unstructured.Unstructured) (bool, error) {
 		if event.Type == watch.Deleted {
 			return false, fmt.Errorf("object was deleted while waiting for predicates to be satisfied")
@@ -314,8 +316,22 @@ func (cl *ClusterClient) WaitForObject(ctx context.Context, obj client.Object, p
 		}
 
 		lastNotMatching = notMatching
+		lastObject = obj.DeepCopy()
+
 		return len(notMatching) == 0, nil
 	})
+
+	if lastObject == nil {
+		cl.Logf("no matching object observed")
+	} else {
+		y, err := yaml.Marshal(lastObject)
+		if err != nil {
+			cl.Errorf("failed to marshal last object state: %v", err)
+		} else {
+			cl.Logf("last object state: %v", string(y))
+		}
+	}
+
 	if err != nil {
 		return err
 	}

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -57,7 +57,7 @@ func TestSandboxReplicas(t *testing.T) {
 			},
 		}),
 	}
-	require.NoError(t, tc.WaitForObject(t.Context(), sandboxObj, p...))
+	tc.MustWaitForObject(sandboxObj, p...)
 	// Assert Pod and Service objects exist
 	pod := &corev1.Pod{}
 	pod.Name = "my-sandbox"
@@ -92,7 +92,7 @@ func TestSandboxReplicas(t *testing.T) {
 			},
 		}),
 	}
-	require.NoError(t, tc.WaitForObject(t.Context(), sandboxObj, p...))
+	tc.MustWaitForObject(sandboxObj, p...)
 	// Verify Pod is deleted but Service still exists
 	require.NoError(t, tc.WaitForObjectNotFound(t.Context(), pod))
 	tc.MustMatchPredicates(service, predicates.NotDeleted())


### PR DESCRIPTION
Because it's a test, we print the object state on success as well as failure.
