### PR TITLE
fix: clear stale pod-name annotation instead of hard error

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -376,8 +376,12 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil, fmt.Errorf("pod get failed: %w", err)
 		}
 		if podNameAnnotationExists {
-			log.Error(err, "Pod not found")
-			return nil, fmt.Errorf("pod in annotation get failed: %w", err)
+			log.Info("Tracked pod not found, clearing stale annotation", "podName", podName)
+			patch := client.MergeFrom(sandbox.DeepCopy())
+			delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
+			if patchErr := r.Patch(ctx, sandbox, patch); patchErr != nil {
+				return nil, fmt.Errorf("failed to clear stale pod name annotation: %w", patchErr)
+			}
 		}
 		pod = nil
 	}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -818,33 +818,8 @@ func TestReconcilePod(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:        "error when annotated pod does not exist",
-			initialObjs: []runtime.Object{},
-			sandbox: &sandboxv1alpha1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      sandboxName,
-					Namespace: sandboxNs,
-					Annotations: map[string]string{
-						sandboxv1alpha1.SandboxPodNameAnnotation: "non-existent-pod",
-					},
-				},
-				Spec: sandboxv1alpha1.SandboxSpec{
-					Replicas: ptr.To(int32(1)),
-					PodTemplate: sandboxv1alpha1.PodTemplate{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "test-container",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantPod:   nil,
-			expectErr: true,
-		},
+		// "clears stale annotation" test is a standalone test below (TestReconcilePodClearsStaleAnnotation)
+		// because the returned pod has an initialized annotations map that differs from the stored pod.
 		{
 			name: "remove pod name annotation when replicas is 0",
 			initialObjs: []runtime.Object{
@@ -976,4 +951,47 @@ func TestSandboxExpiry(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcilePodClearsStaleAnnotation(t *testing.T) {
+	sandboxName := "sandbox-name"
+	sandboxNs := "sandbox-ns"
+	nameHash := NameHash(sandboxName)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: sandboxNs,
+			Annotations: map[string]string{
+				sandboxv1alpha1.SandboxPodNameAnnotation: "non-existent-pod",
+			},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+		},
+	}
+
+	r := SandboxReconciler{
+		Client: newFakeClient(sandbox),
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, pod, "should have created a new pod after clearing stale annotation")
+	require.Equal(t, sandboxName, pod.Name)
+	require.Equal(t, nameHash, pod.Labels[sandboxLabel])
+
+	// Verify the stale annotation was replaced with the new pod name
+	liveSandbox := &sandboxv1alpha1.Sandbox{}
+	err = r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, liveSandbox)
+	require.NoError(t, err)
+	require.Equal(t, sandboxName, liveSandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation],
+		"annotation should track the newly created pod, not the stale one")
 }


### PR DESCRIPTION
## Summary

When the pod tracked by `agents.x-k8s.io/pod-name` annotation doesn't exist, clear the stale annotation and fall through to pod creation instead of returning a hard error.

## Problem

The `ensurePodNameAnnotation` function (commit 32cddd3) records the backing pod's name on the Sandbox CR. This is used for stable pod tracking across reconciliations. However, when the annotated pod is deleted (warm pool rotation, eviction, image pull failure), `reconcilePod` returns a hard error:

```go
if podNameAnnotationExists {
    log.Error(err, "Pod not found")
    return nil, fmt.Errorf("pod in annotation get failed: %w", err)
}
```

The controller never reaches PATH 3 (create pod). The Sandbox is stuck in a reconcile error loop and the warm pool never becomes ready.

## Fix

When the annotated pod isn't found, clear the stale annotation and let `pod = nil` fall through to pod creation:

```go
if podNameAnnotationExists {
    log.Info("Tracked pod not found, clearing stale annotation", "podName", podName)
    patch := client.MergeFrom(sandbox.DeepCopy())
    delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
    if patchErr := r.Patch(ctx, sandbox, patch); patchErr != nil {
        return nil, fmt.Errorf("failed to clear stale pod name annotation: %w", patchErr)
    }
}
```

The subsequent `ensurePodNameAnnotation` call after pod creation re-sets the annotation to track the new pod.

## Test plan

- [x] `TestReconcilePodClearsStaleAnnotation` — sandbox with stale annotation pointing to non-existent pod creates a new pod and updates the annotation
- [x] Updated table test to remove the old hard-error expectation
- [x] All existing reconcilePod tests pass (no behavior change for valid annotations)