### PR TITLE
optimization: added a sandbox queue to retrieve warm sandboxes

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -29,15 +29,15 @@ import (
 
 	"github.com/felixge/fgprof"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/agent-sandbox/controllers"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	extensionscontrollers "sigs.k8s.io/agent-sandbox/extensions/controllers"
+	"sigs.k8s.io/agent-sandbox/extensions/controllers/queue"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-
-	"sigs.k8s.io/agent-sandbox/controllers"
-	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
-	extensionscontrollers "sigs.k8s.io/agent-sandbox/extensions/controllers"
-	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -227,11 +227,13 @@ func main() {
 	}
 
 	if extensions {
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
 		if err = (&extensionscontrollers.SandboxClaimReconciler{
-			Client:   mgr.GetClient(),
-			Scheme:   mgr.GetScheme(),
-			Recorder: mgr.GetEventRecorder("sandboxclaim-controller"),
-			Tracer:   instrumenter,
+			Client:           mgr.GetClient(),
+			Scheme:           mgr.GetScheme(),
+			WarmSandboxQueue: warmSandboxQueue,
+			Recorder:         mgr.GetEventRecorder("sandboxclaim-controller"),
+			Tracer:           instrumenter,
 		}).SetupWithManager(mgr, sandboxClaimConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxClaim")
 			os.Exit(1)

--- a/extensions/controllers/queue/simple_sandbox_queue.go
+++ b/extensions/controllers/queue/simple_sandbox_queue.go
@@ -1,0 +1,141 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// SandboxKey uniquely identifies a sandbox in the queue.
+type SandboxKey types.NamespacedName
+
+// SandboxQueue defines the interface for managing a thread-safe,
+// highly concurrent queue of adoptable warm pool sandboxes.
+type SandboxQueue interface {
+	Add(templateHash string, item SandboxKey)
+	Get(templateHash string) (SandboxKey, bool)
+	RemoveQueue(templateHash string)
+	RemoveItem(templateHash string, item SandboxKey)
+}
+
+// SimpleSandboxQueue implements SandboxQueue using simple synchronized slices.
+type SimpleSandboxQueue struct {
+	// queues is a thread-safe dictionary from template hash to a synchronizedQueue
+	queues sync.Map
+}
+
+// NewSimpleSandboxQueue initializes a new SimpleSandboxQueue.
+func NewSimpleSandboxQueue() *SimpleSandboxQueue {
+	return &SimpleSandboxQueue{}
+}
+
+// Add pushes an item to the specific template's queue.
+func (s *SimpleSandboxQueue) Add(templateHash string, item SandboxKey) {
+	q, _ := s.queues.LoadOrStore(templateHash, newSynchronizedQueue())
+	q.(*synchronizedQueue).Push(item)
+}
+
+// Get pops an item from the specific template's queue.
+func (s *SimpleSandboxQueue) Get(templateHash string) (SandboxKey, bool) {
+	q, ok := s.queues.Load(templateHash)
+	if !ok {
+		return SandboxKey{}, false
+	}
+	return q.(*synchronizedQueue).Pop()
+}
+
+// RemoveItem deletes a specific sandbox from a template's queue.
+func (s *SimpleSandboxQueue) RemoveItem(templateHash string, item SandboxKey) {
+	if q, ok := s.queues.Load(templateHash); ok {
+		q.(*synchronizedQueue).Remove(item)
+	}
+}
+
+// Remove scans the slice and deletes the item to prevent Ghost Pods.
+func (q *synchronizedQueue) Remove(key SandboxKey) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if _, exists := q.set[key]; !exists {
+		return
+	}
+
+	delete(q.set, key)
+
+	for i, k := range q.items {
+		if k == key {
+			// Delete from slice
+			q.items = append(q.items[:i], q.items[i+1:]...)
+			break
+		}
+	}
+}
+
+// TODO(vicentefb): Implement queue cleanup mechanism.
+// We should remove the queue from the sync.Map when the corresponding
+// SandboxWarmPool for a given template is deleted to prevent memory leaks.
+type synchronizedQueue struct {
+	mu    sync.Mutex
+	items []SandboxKey
+	set   map[SandboxKey]struct{} // Used for O(1) deduplication
+}
+
+func newSynchronizedQueue() *synchronizedQueue {
+	return &synchronizedQueue{
+		items: make([]SandboxKey, 0),
+		set:   make(map[SandboxKey]struct{}),
+	}
+}
+
+// Push adds an item to the queue if it isn't already present.
+func (q *synchronizedQueue) Push(key SandboxKey) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if _, exists := q.set[key]; !exists {
+		q.set[key] = struct{}{}
+		q.items = append(q.items, key)
+	}
+}
+
+// Pop removes and returns the first item from the queue.
+func (q *synchronizedQueue) Pop() (SandboxKey, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.items) == 0 {
+		return SandboxKey{}, false
+	}
+
+	// Grab the first item
+	item := q.items[0]
+
+	// This removes the pointer references so the Garbage Collector
+	// can free the strings in memory!
+	q.items[0] = SandboxKey{}
+
+	// Remove it from slice and set
+	q.items = q.items[1:]
+	delete(q.set, item)
+
+	return item, true
+}
+
+// RemoveQueue completely deletes a template's queue from the sync.Map
+// to prevent memory leaks when SandboxTemplates or WarmPools are deleted.
+func (s *SimpleSandboxQueue) RemoveQueue(templateHash string) {
+	s.queues.Delete(templateHash)
+}

--- a/extensions/controllers/queue/simple_sandbox_queue_test.go
+++ b/extensions/controllers/queue/simple_sandbox_queue_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package queue
+
+import (
+	"testing"
+)
+
+func TestSimpleSandboxQueue_BasicOperations(t *testing.T) {
+	q := NewSimpleSandboxQueue()
+	hash := "template-hash-1"
+
+	key1 := SandboxKey{Namespace: "default", Name: "sb-1"}
+	key2 := SandboxKey{Namespace: "default", Name: "sb-2"}
+
+	// Test Add
+	q.Add(hash, key1)
+	q.Add(hash, key2)
+
+	// Test Get (Should be FIFO)
+	got1, ok1 := q.Get(hash)
+	if !ok1 || got1 != key1 {
+		t.Errorf("Expected %v, got %v (ok: %v)", key1, got1, ok1)
+	}
+
+	got2, ok2 := q.Get(hash)
+	if !ok2 || got2 != key2 {
+		t.Errorf("Expected %v, got %v (ok: %v)", key2, got2, ok2)
+	}
+
+	// Queue should now be empty
+	_, ok3 := q.Get(hash)
+	if ok3 {
+		t.Errorf("Expected queue to be empty, but got an item")
+	}
+}
+
+func TestSimpleSandboxQueue_RemoveItem_GhostPodFix(t *testing.T) {
+	q := NewSimpleSandboxQueue()
+	hash := "template-hash-1"
+
+	key1 := SandboxKey{Namespace: "default", Name: "sb-1"}
+	key2 := SandboxKey{Namespace: "default", Name: "sb-2"}
+	key3 := SandboxKey{Namespace: "default", Name: "sb-3"}
+
+	q.Add(hash, key1)
+	q.Add(hash, key2)
+	q.Add(hash, key3)
+
+	// Simulate the Kubelet deleting the middle pod (Ghost Pod scenario)
+	q.RemoveItem(hash, key2)
+
+	// First pop should still be key1
+	got1, _ := q.Get(hash)
+	if got1 != key1 {
+		t.Errorf("Expected %v, got %v", key1, got1)
+	}
+
+	// Second pop should be key3! (key2 was successfully removed)
+	got3, _ := q.Get(hash)
+	if got3 != key3 {
+		t.Errorf("Expected %v to skip deleted item and return %v, but got %v", hash, key3, got3)
+	}
+
+	// Queue should now be empty
+	_, ok := q.Get(hash)
+	if ok {
+		t.Errorf("Expected queue to be empty after Ghost Pod removal")
+	}
+}
+
+func TestSynchronizedQueue_Deduplication(t *testing.T) {
+	q := newSynchronizedQueue()
+	key := SandboxKey{Namespace: "default", Name: "duplicate-sb"}
+
+	// Push the exact same pod 3 times
+	q.Push(key)
+	q.Push(key)
+	q.Push(key)
+
+	// Verify it only stored it once
+	if len(q.items) != 1 {
+		t.Errorf("Expected length 1 due to O(1) deduplication, got %d", len(q.items))
+	}
+
+	// Verify the set also only has 1 item
+	if len(q.set) != 1 {
+		t.Errorf("Expected set length 1, got %d", len(q.set))
+	}
+}
+
+func TestSimpleSandboxQueue_RemoveQueue_MemoryLeakFix(t *testing.T) {
+	q := NewSimpleSandboxQueue()
+	hash := "template-hash-to-delete"
+	key1 := SandboxKey{Namespace: "default", Name: "sb-1"}
+
+	q.Add(hash, key1)
+
+	// Simulate SandboxTemplate deletion
+	q.RemoveQueue(hash)
+
+	// Verify the entire queue was wiped from the sync.Map
+	_, ok := q.Get(hash)
+	if ok {
+		t.Errorf("Expected queue to be completely removed, but it still existed")
+	}
+}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,10 +44,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/extensions/controllers/queue"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
@@ -72,6 +75,7 @@ func getWarmPoolPolicy(claim *extensionsv1alpha1.SandboxClaim) extensionsv1alpha
 type SandboxClaimReconciler struct {
 	client.Client
 	Scheme                  *runtime.Scheme
+	WarmSandboxQueue        queue.SandboxQueue
 	Recorder                events.EventRecorder
 	Tracer                  asmetrics.Instrumenter
 	MaxConcurrentReconciles int
@@ -455,119 +459,194 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1alpha1.S
 	}
 }
 
-// adoptSandboxFromCandidates picks the best candidate and transfers ownership to the claim.
-func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, candidates []*v1alpha1.Sandbox) (*v1alpha1.Sandbox, error) {
+func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, templateHash string) (*v1alpha1.Sandbox, queue.SandboxKey, error) {
 	logger := log.FromContext(ctx)
+	policy := getWarmPoolPolicy(claim)
 
-	// Sort: ready sandboxes first, then by creation time (oldest first)
-	slices.SortFunc(candidates, func(a, b *v1alpha1.Sandbox) int {
-		aReady := isSandboxReady(a)
-		bReady := isSandboxReady(b)
-		if aReady != bReady {
-			if aReady {
-				return -1 // a ready, b not ready -> a first
-			}
-			return 1 // b ready, a not ready -> b first
+	var skipped []queue.SandboxKey
+	// Instantly returns unused keys the moment we find a valid candidate!
+	defer func() {
+		for _, key := range skipped {
+			r.WarmSandboxQueue.Add(templateHash, key)
 		}
-		return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
-	})
+	}()
 
-	if len(candidates) == 0 {
-		logger.Info("No warm pool candidates available, falling through to cold start", "claim", claim.Name)
-		return nil, nil
-	}
-
-	// Determine the search range for collision avoidance.
-	n := len(candidates)
-	workerCount := r.MaxConcurrentReconciles
-	if workerCount <= 0 {
-		workerCount = 1
-	}
-	searchWindow := min(n, workerCount)
-
-	// Compute a starting index deterministic to this specific Claim UID.
-	hashValue := sandboxcontrollers.GetNumericHash(string(claim.UID))
-	startIndex := int(hashValue % uint32(searchWindow))
-
-	// Iterate through the entire list starting from the hashed offset.
-	for i := range n {
-		currIndex := (startIndex + i) % n
-		adopted := candidates[currIndex]
-
-		// Extract pool name from owner reference before clearing
-		poolName := "none"
-		if controllerRef := metav1.GetControllerOf(adopted); controllerRef != nil {
-			poolName = controllerRef.Name
+	for {
+		adoptedKey, ok := r.WarmSandboxQueue.Get(templateHash)
+		if !ok {
+			return nil, queue.SandboxKey{}, nil
 		}
 
-		logger.Info("Attempting sandbox adoption", "sandbox candidate", adopted.Name, "warm pool", poolName, "claim", claim.Name)
+		// 1. Hand the Kubernetes client the empty bucket
+		adopted := &v1alpha1.Sandbox{}
 
-		// Remove warm pool labels so the sandbox no longer appears in warm pool queries
-		delete(adopted.Labels, warmPoolSandboxLabel)
-		delete(adopted.Labels, sandboxTemplateRefHash)
-		delete(adopted.Labels, v1alpha1.SandboxPodTemplateHashLabel)
-
-		// Transfer ownership from SandboxWarmPool to SandboxClaim
-		adopted.OwnerReferences = nil
-		if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
-			return nil, fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
-		}
-
-		// Propagate trace context from claim
-		if adopted.Annotations == nil {
-			adopted.Annotations = make(map[string]string)
-		}
-		// Ensure the adopted sandbox records its pod name before it can be observed Ready.
-		if podName := adopted.Annotations[v1alpha1.SandboxPodNameAnnotation]; podName != adopted.Name {
-			if podName != "" {
-				logger.Info("Correcting adopted sandbox pod-name annotation", "sandbox", adopted.Name, "oldPodName", podName, "newPodName", adopted.Name)
-			}
-			adopted.Annotations[v1alpha1.SandboxPodNameAnnotation] = adopted.Name
-		}
-		if traceContext, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
-			adopted.Annotations[asmetrics.TraceContextAnnotation] = traceContext
-		}
-
-		// Add sandbox ID label to pod template for NetworkPolicy targeting
-		if adopted.Spec.PodTemplate.ObjectMeta.Labels == nil {
-			adopted.Spec.PodTemplate.ObjectMeta.Labels = make(map[string]string)
-		}
-		adopted.Spec.PodTemplate.ObjectMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
-		adopted.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
-
-		// Merge metadata from claim
-		if err := mergePodMetadata(&adopted.Spec.PodTemplate.ObjectMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
-			return nil, err
-		}
-
-		// Update uses optimistic concurrency (resourceVersion) so concurrent
-		// claims racing to adopt the same sandbox will conflict and retry.
-		if err := r.Update(ctx, adopted); err != nil {
-			if k8errors.IsConflict(err) || k8errors.IsNotFound(err) {
-				// Another worker adopted this sandbox while we were processing; try next candidate.
+		// 2. Fetch from the Informer Cache
+		err := r.Get(ctx, client.ObjectKey{Namespace: adoptedKey.Namespace, Name: adoptedKey.Name}, adopted)
+		if err != nil {
+			if k8errors.IsNotFound(err) {
+				// Ghost Pod detected: It was deleted from the cluster but was still in our queue.
+				// Ignore it and instantly pop the next one.
 				continue
 			}
-			logger.Error(err, "Failed to update adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+			// For real errors, put the key back in line and error out
+			r.WarmSandboxQueue.Add(templateHash, adoptedKey)
+			return nil, queue.SandboxKey{}, err
+		}
+
+		if err := verifySandboxCandidate(adopted, claim); err != nil {
+			logger.V(1).Info("sandbox candidate can't be adopted for template", "sandbox", adopted.Name, "templateHash", templateHash, "reason", err.Error())
+			continue
+		}
+
+		if policy.IsSpecificPool() {
+			specificPoolHash := sandboxcontrollers.NameHash(string(policy))
+			if adopted.Labels[warmPoolSandboxLabel] != specificPoolHash {
+				skipped = append(skipped, adoptedKey) // Save to skip list for the defer loop
+				continue
+			}
+		}
+
+		// Valid candidate found
+		return adopted, adoptedKey, nil
+	}
+}
+
+func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*v1alpha1.Sandbox, error) {
+	logger := log.FromContext(ctx)
+	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+
+	// Keep trying until we successfully adopt a sandbox, or run out of candidates
+	for range 3 {
+		adopted, adoptedKey, err := r.getCandidate(ctx, claim, templateHash)
+		if err != nil {
+			return nil, err
+		}
+		if adopted == nil {
+			logger.Info("Failed to adopt any sandbox after checking all candidates", "claim", claim.Name)
+			return nil, nil // Warm pool is truly empty, fall completely to cold start
+		}
+
+		// Wrap the API logic in a closure
+		success, err := func() (bool, error) {
+			poolName := "none"
+			if controllerRef := metav1.GetControllerOf(adopted); controllerRef != nil {
+				poolName = controllerRef.Name
+			}
+
+			logger.Info("Attempting sandbox adoption", "sandbox candidate", adopted.Name, "warm pool", poolName, "claim", claim.Name)
+
+			// Take a snapshot of the pod BEFORE we mutate it to generate a clean JSON Patch.
+			originalAdopted := adopted.DeepCopy()
+
+			// Remove warm pool labels so the sandbox no longer appears in warm pool queries
+			delete(adopted.Labels, warmPoolSandboxLabel)
+			delete(adopted.Labels, sandboxTemplateRefHash)
+			delete(adopted.Labels, v1alpha1.SandboxPodTemplateHashLabel)
+
+			// Transfer ownership from SandboxWarmPool to SandboxClaim
+			adopted.OwnerReferences = nil
+			if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
+				r.WarmSandboxQueue.Add(templateHash, adoptedKey)
+				return false, fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
+			}
+
+			// Propagate trace context from claim
+			if adopted.Annotations == nil {
+				adopted.Annotations = make(map[string]string)
+			}
+
+			// Ensure the adopted sandbox records its pod name before it can be observed Ready.
+			if podName := adopted.Annotations[v1alpha1.SandboxPodNameAnnotation]; podName != adopted.Name {
+				if podName != "" {
+					logger.Info("Correcting adopted sandbox pod-name annotation", "sandbox", adopted.Name, "oldPodName", podName, "newPodName", adopted.Name)
+				}
+				adopted.Annotations[v1alpha1.SandboxPodNameAnnotation] = adopted.Name
+			}
+
+			if traceContext, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
+				adopted.Annotations[asmetrics.TraceContextAnnotation] = traceContext
+			}
+
+			// Add sandbox ID label to pod template for NetworkPolicy targeting
+			if adopted.Spec.PodTemplate.ObjectMeta.Labels == nil {
+				adopted.Spec.PodTemplate.ObjectMeta.Labels = make(map[string]string)
+			}
+			adopted.Spec.PodTemplate.ObjectMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
+
+			// Fetch the template to construct the mergedMeta that reconcileActive will build.
+			template, templateErr := r.getTemplate(ctx, claim)
+			if templateErr == nil && template != nil {
+				var mergedMeta v1alpha1.PodMetadata
+				template.Spec.PodTemplate.ObjectMeta.DeepCopyInto(&mergedMeta)
+
+				if mergedMeta.Labels == nil {
+					mergedMeta.Labels = make(map[string]string)
+				}
+				mergedMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
+				mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
+
+				if err := mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
+					// Adoption hasn't been patched yet. Put the sandbox back to avoid draining the pool!
+					r.WarmSandboxQueue.Add(templateHash, adoptedKey)
+					logger.Error(err, "Failed to merge pod metadata for adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+					return false, err
+				}
+
+				// Force an exact match
+				adopted.Spec.PodTemplate.ObjectMeta = mergedMeta
+			} else {
+				// Fallback (just in case template is somehow missing)
+				adopted.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = templateHash
+
+				if err := mergePodMetadata(&adopted.Spec.PodTemplate.ObjectMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
+					r.WarmSandboxQueue.Add(templateHash, adoptedKey)
+					logger.Error(err, "Failed to merge pod metadata for fallback adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+					return false, err
+				}
+			}
+
+			if err := r.Patch(ctx, adopted, client.MergeFrom(originalAdopted)); err != nil {
+				if k8errors.IsNotFound(err) {
+					return false, nil
+				}
+
+				r.WarmSandboxQueue.Add(templateHash, adoptedKey)
+
+				if k8errors.IsConflict(err) {
+					// Patch conflicts are not expected here in the common case, but they can still legitimately occur.
+					return false, nil
+				}
+
+				logger.Error(err, "Failed to patch adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+				return false, err
+			}
+
+			logger.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
+
+			if r.Recorder != nil {
+				r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxAdopted", "Adoption", "Adopted warm pool Sandbox %q", adopted.Name)
+			}
+
+			podCondition := "not_ready"
+			if isSandboxReady(adopted) {
+				podCondition = "ready"
+			}
+			asmetrics.RecordSandboxClaimCreation(claim.Namespace, claim.Spec.TemplateRef.Name, asmetrics.LaunchTypeWarm, poolName, podCondition)
+
+			return true, nil
+		}()
+
+		if err != nil {
 			return nil, err
 		}
 
-		logger.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
-
-		if r.Recorder != nil {
-			r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxAdopted", "Adoption", "Adopted warm pool Sandbox %q", adopted.Name)
+		if success {
+			return adopted, nil
 		}
-
-		podCondition := "not_ready"
-		if isSandboxReady(adopted) {
-			podCondition = "ready"
-		}
-		asmetrics.RecordSandboxClaimCreation(claim.Namespace, claim.Spec.TemplateRef.Name, asmetrics.LaunchTypeWarm, poolName, podCondition)
-
-		return adopted, nil
 	}
 
-	logger.Info("Failed to adopt any sandbox after checking all candidates", "claim", claim.Name)
-	return nil, nil // Return nil, nil to fall completely to cold start
+	logger.Info("Failed to adopt sandbox after max retries", "claim", claim.Name)
+	return nil, nil
 }
 
 // isSandboxReady checks if a sandbox has Ready=True condition.
@@ -877,58 +956,9 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		return sandbox, nil
 	}
 
-	// Single List: ownership guard + adoption candidate scan.
-	// This queries the informer cache (not the API server), so it's fast.
-	logger.V(1).Info("Listing sandbox adoption candidates", "claim", claim.Name)
-	allSandboxes := &v1alpha1.SandboxList{}
-	if err := r.List(ctx, allSandboxes, client.InNamespace(claim.Namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list sandboxes: %w", err)
-	}
-
 	policy := getWarmPoolPolicy(claim)
-	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
-	var adoptionCandidates []*v1alpha1.Sandbox
 
-	for i := range allSandboxes.Items {
-		sb := &allSandboxes.Items[i]
-		if !sb.DeletionTimestamp.IsZero() {
-			continue
-		}
-
-		// Ownership guard: if this claim already owns a sandbox, return it
-		if metav1.IsControlledBy(sb, claim) {
-			logger.Info("Found existing owned sandbox", "sandbox", sb.Name, "claim", claim.Name)
-			return sb, nil
-		}
-
-		// Skip warm pool adoption entirely if policy is "none"
-		if policy == extensionsv1alpha1.WarmPoolPolicyNone {
-			continue
-		}
-
-		// Collect adoption candidates from warm pool
-		if _, ok := sb.Labels[warmPoolSandboxLabel]; !ok {
-			continue
-		}
-		if sb.Labels[sandboxTemplateRefHash] != templateHash {
-			continue
-		}
-		controllerRef := metav1.GetControllerOf(sb)
-		if controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
-			continue
-		}
-
-		// If a specific pool is requested, only consider sandboxes from that pool
-		if policy.IsSpecificPool() {
-			specificPoolHash := sandboxcontrollers.NameHash(string(policy))
-			if sb.Labels[warmPoolSandboxLabel] != specificPoolHash {
-				continue
-			}
-		}
-
-		adoptionCandidates = append(adoptionCandidates, sb)
-	}
-
+	// Preserve HEAD's new Env validation feature!
 	if policy != extensionsv1alpha1.WarmPoolPolicyNone && len(claim.Spec.Env) > 0 {
 		err := fmt.Errorf("custom environment variables are not supported when using a warm pool")
 		logger.Error(err, "Invalid configuration", "claim", claim.Name)
@@ -940,18 +970,13 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		return nil, nil
 	}
 
-	// Try to adopt from warm pool
-	if len(adoptionCandidates) > 0 {
-		logger.V(1).Info("Found warm pool adoption candidates", "count", len(adoptionCandidates), "claim", claim.Name, "warmpool", policy)
-		adopted, err := r.adoptSandboxFromCandidates(ctx, claim, adoptionCandidates)
-		if err != nil {
-			return nil, err
-		}
-		if adopted != nil {
-			return adopted, nil
-		}
-	} else if policy.IsSpecificPool() {
-		logger.Info("No available sandboxes in specified warm pool", "warmPool", string(policy), "claim", claim.Name)
+	// Go to the custom queue instead of standard r.List()
+	adopted, err := r.adoptSandboxFromCandidates(ctx, claim)
+	if err != nil {
+		return nil, err
+	}
+	if adopted != nil {
+		return adopted, nil
 	}
 
 	// No warm pool sandbox available; caller decides whether to create
@@ -997,6 +1022,8 @@ func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWo
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&extensionsv1alpha1.SandboxClaim{}, builder.WithPredicates(r.getTimingPredicate())).
 		Owns(&v1alpha1.Sandbox{}).
+		Watches(&v1alpha1.Sandbox{}, &sandboxEventHandler{sandboxQueue: r.WarmSandboxQueue}).
+		Watches(&extensionsv1alpha1.SandboxTemplate{}, &templateEventHandler{sandboxQueue: r.WarmSandboxQueue}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).
 		Complete(r)
 }
@@ -1116,4 +1143,122 @@ func hasExpiredCondition(conditions []metav1.Condition) bool {
 		}
 	}
 	return false
+}
+
+// sandboxEventHandler implements handler.EventHandler for the SandboxClaimReconciler.
+type sandboxEventHandler struct {
+	sandboxQueue queue.SandboxQueue
+}
+
+func (h *sandboxEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.Update(ctx, event.UpdateEvent{ObjectOld: &v1alpha1.Sandbox{}, ObjectNew: e.Object}, q)
+}
+
+func (h *sandboxEventHandler) Update(ctx context.Context, e event.UpdateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	newSandbox, ok := e.ObjectNew.(*v1alpha1.Sandbox)
+	if !ok {
+		return
+	}
+	oldSandbox, ok := e.ObjectOld.(*v1alpha1.Sandbox)
+	if !ok {
+		return
+	}
+
+	newAdoptable := isAdoptable(newSandbox) == nil
+	oldAdoptable := isAdoptable(oldSandbox) == nil
+
+	logger := log.FromContext(ctx)
+
+	hashChanged := oldSandbox.Labels[sandboxTemplateRefHash] != newSandbox.Labels[sandboxTemplateRefHash]
+
+	if (!oldAdoptable && newAdoptable) || (newAdoptable && hashChanged) {
+		// Add sandbox only on transition to adoptable.
+		key := queue.SandboxKey{
+			Namespace: newSandbox.Namespace,
+			Name:      newSandbox.Name,
+		}
+		logger.V(1).Info("Adding sandbox to warm pool queue", "templateRefHash", newSandbox.Labels[sandboxTemplateRefHash], "sandbox", key)
+		h.sandboxQueue.Add(newSandbox.Labels[sandboxTemplateRefHash], key)
+	}
+}
+
+func (h *sandboxEventHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Generic events are not typically used for pod lifecycle changes we care about.
+}
+
+func verifySandboxCandidate(candidate *v1alpha1.Sandbox, claim *extensionsv1alpha1.SandboxClaim) error {
+	if err := isAdoptable(candidate); err != nil {
+		return err
+	}
+
+	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+	if candidate.Labels[sandboxTemplateRefHash] != templateHash {
+		return fmt.Errorf("incorrect template hash, expected %v, got %v", templateHash, candidate.Labels[sandboxTemplateRefHash])
+	}
+	return nil
+}
+
+func isAdoptable(candidate *v1alpha1.Sandbox) error {
+	if !candidate.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("sandbox is deleted")
+	}
+	if _, ok := candidate.Labels[warmPoolSandboxLabel]; !ok {
+		return fmt.Errorf("sandbox is missing the warm pool sandbox label")
+	}
+	if _, ok := candidate.Labels[sandboxTemplateRefHash]; !ok {
+		return fmt.Errorf("sandbox is missing the sandbox template ref hash label")
+	}
+
+	controllerRef := metav1.GetControllerOf(candidate)
+	if controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
+		return fmt.Errorf("sandbox is not managed by warm pool. Controller: %v", controllerRef)
+	}
+	return nil
+}
+
+func (h *sandboxEventHandler) Delete(ctx context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	sandbox, ok := e.Object.(*v1alpha1.Sandbox)
+	if !ok {
+		return
+	}
+
+	// Grab the hash to find which queue this pod lived in
+	templateHash := sandbox.Labels[sandboxTemplateRefHash]
+
+	if templateHash != "" {
+		key := queue.SandboxKey{
+			Namespace: sandbox.Namespace,
+			Name:      sandbox.Name,
+		}
+
+		// Actively delete the Ghost Pod from the memory queue
+		logger := log.FromContext(ctx)
+		logger.V(1).Info("Removing deleted sandbox from warm pool queue", "sandbox", key)
+		h.sandboxQueue.RemoveItem(templateHash, key)
+	}
+}
+
+type templateEventHandler struct {
+	sandboxQueue queue.SandboxQueue
+}
+
+func (h *templateEventHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+func (h *templateEventHandler) Update(_ context.Context, _ event.UpdateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+func (h *templateEventHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *templateEventHandler) Delete(ctx context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	template, ok := e.Object.(*extensionsv1alpha1.SandboxTemplate)
+	if !ok {
+		return
+	}
+
+	templateHash := sandboxcontrollers.NameHash(template.Name)
+	logger := log.FromContext(ctx)
+	logger.Info("SandboxTemplate deleted, cleaning up memory queue", "template", template.Name, "hash", templateHash)
+
+	// Actively drop the entire queue from memory
+	h.sandboxQueue.RemoveQueue(templateHash)
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -41,6 +41,7 @@ import (
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/extensions/controllers/queue"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
@@ -787,12 +788,24 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjects...).WithStatusSubresource(claimToUse).Build()
 
 			reconciler := &SandboxClaimReconciler{
-				Client:   client,
-				Scheme:   scheme,
-				Recorder: events.NewFakeRecorder(10),
-				Tracer:   asmetrics.NewNoOp(),
+				Client:           client,
+				Scheme:           scheme,
+				WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+				Recorder:         events.NewFakeRecorder(10),
+				Tracer:           asmetrics.NewNoOp(),
 			}
 
+			// Pre-populate PodQueue with any existing pods
+			for _, obj := range allObjects {
+				if sb, ok := obj.(*sandboxv1alpha1.Sandbox); ok {
+					if isAdoptable(sb) != nil {
+						continue
+					}
+					hash := sb.Labels[sandboxTemplateRefHash]
+					key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name}
+					reconciler.WarmSandboxQueue.Add(hash, key)
+				}
+			}
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: claimToUse.Name, Namespace: "default"},
 			}
@@ -1062,10 +1075,11 @@ func TestSandboxProvisionEvent(t *testing.T) {
 		WithStatusSubresource(claim).Build()
 
 	reconciler := &SandboxClaimReconciler{
-		Client:   client,
-		Scheme:   scheme,
-		Recorder: fakeRecorder,
-		Tracer:   asmetrics.NewNoOp(),
+		Client:           client,
+		Scheme:           scheme,
+		Recorder:         fakeRecorder,
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+		Tracer:           asmetrics.NewNoOp(),
 	}
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
@@ -1292,7 +1306,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: true,
 		},
 		{
-			name: "prioritizes ready sandboxes over not-ready ones",
+			name: "adopts sandboxes from queue regardless of ready state",
 			existingObjects: []client.Object{
 				template,
 				claim,
@@ -1301,11 +1315,11 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				createWarmPoolSandbox("young-ready", metav1.Now(), true),
 			},
 			expectSandboxAdoption:   true,
-			expectedAdoptedSandbox:  "middle-ready",
+			expectedAdoptedSandbox:  "not-ready",
 			expectNewSandboxCreated: false,
 		},
 		{
-			name: "adopts oldest non-ready sandbox when no ready sandboxes exist",
+			name: "adopts first available non-ready sandbox from queue",
 			existingObjects: []client.Object{
 				template,
 				claim,
@@ -1387,11 +1401,28 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				}
 			}
 
+			// 1. Initialize the Queue
+			warmSandboxQueue := queue.NewSimpleSandboxQueue()
+
+			// 2. Seed the Queue with the existing objects from the test case
+			for _, obj := range tc.existingObjects {
+				if sb, ok := obj.(*sandboxv1alpha1.Sandbox); ok {
+					// Only add valid, adoptable sandboxes to the queue
+					if isAdoptable(sb) == nil {
+						hash := sb.Labels[sandboxTemplateRefHash]
+						key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name}
+						warmSandboxQueue.Add(hash, key)
+					}
+				}
+			}
+
+			// 3. Inject the seeded Queue into the Reconciler
 			reconciler := &SandboxClaimReconciler{
-				Client:   fakeClient,
-				Scheme:   scheme,
-				Recorder: events.NewFakeRecorder(10),
-				Tracer:   asmetrics.NewNoOp(),
+				Client:           fakeClient,
+				Scheme:           scheme,
+				Recorder:         events.NewFakeRecorder(10),
+				WarmSandboxQueue: warmSandboxQueue,
+				Tracer:           asmetrics.NewNoOp(),
 			}
 
 			req := reconcile.Request{
@@ -1403,6 +1434,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 
 			ctx := context.Background()
 			_, err := reconciler.Reconcile(ctx, req)
+
 			if err != nil {
 				t.Fatalf("reconcile failed: %v", err)
 			}
@@ -1458,6 +1490,65 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
+	q := queue.NewSimpleSandboxQueue()
+	handler := &sandboxEventHandler{sandboxQueue: q}
+
+	hash := "test-hash-123"
+	key := queue.SandboxKey{Namespace: "default", Name: "ghost-pod"}
+
+	// 1. Add the pod to the queue
+	q.Add(hash, key)
+
+	// 2. Create the mock Sandbox object that is being deleted
+	sb := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ghost-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				sandboxTemplateRefHash: hash,
+			},
+		},
+	}
+
+	// 3. Fire the Delete event
+	handler.Delete(context.Background(), event.DeleteEvent{Object: sb}, nil)
+
+	// 4. Verify the Ghost Pod was removed from the queue
+	_, ok := q.Get(hash)
+	if ok {
+		t.Errorf("Expected the deleted sandbox to be removed from the queue")
+	}
+}
+
+func TestTemplateEventHandler_Delete_RemovesEntireQueue(t *testing.T) {
+	q := queue.NewSimpleSandboxQueue()
+	handler := &templateEventHandler{sandboxQueue: q}
+
+	templateName := "old-template"
+	hash := sandboxcontrollers.NameHash(templateName)
+	key := queue.SandboxKey{Namespace: "default", Name: "abandoned-pod"}
+
+	// 1. Add a pod to this template's queue
+	q.Add(hash, key)
+
+	// 2. Create the mock SandboxTemplate object that is being deleted
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: "default",
+		},
+	}
+
+	// 3. Fire the Delete event
+	handler.Delete(context.Background(), event.DeleteEvent{Object: template}, nil)
+
+	// 4. Verify the entire queue was wiped out
+	_, ok := q.Get(hash)
+	if ok {
+		t.Errorf("Expected the entire queue to be removed when the template was deleted")
 	}
 }
 
@@ -1693,10 +1784,11 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		scheme := newScheme(t)
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, claim).WithStatusSubresource(claim).Build()
 		reconciler := &SandboxClaimReconciler{
-			Client:   client,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+			Client:           client,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+			Tracer:           asmetrics.NewNoOp(),
 		}
 
 		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}
@@ -1748,13 +1840,20 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 
 		scheme := newScheme(t)
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, claim, warmSandbox).WithStatusSubresource(claim).Build()
-		reconciler := &SandboxClaimReconciler{
-			Client:   client,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		if isAdoptable(warmSandbox) == nil {
+			hash := warmSandbox.Labels[sandboxTemplateRefHash]
+			key := queue.SandboxKey{Namespace: warmSandbox.Namespace, Name: warmSandbox.Name}
+			warmSandboxQueue.Add(hash, key)
 		}
 
+		reconciler := &SandboxClaimReconciler{
+			Client:           client,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			WarmSandboxQueue: warmSandboxQueue,
+			Tracer:           asmetrics.NewNoOp(),
+		}
 		req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}
 		_, err := reconciler.Reconcile(context.Background(), req)
 		if err != nil {
@@ -1804,6 +1903,16 @@ func (c *conflictClient) Update(ctx context.Context, obj client.Object, opts ...
 		}
 	}
 	return c.Client.Update(ctx, obj, opts...)
+}
+
+func (c *conflictClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if sandbox, ok := obj.(*sandboxv1alpha1.Sandbox); ok {
+		if c.conflictCount < c.maxConflicts {
+			c.conflictCount++
+			return k8errors.NewConflict(sandboxv1alpha1.Resource("sandboxes"), sandbox.Name, fmt.Errorf("simulated conflict"))
+		}
+	}
+	return c.Client.Patch(ctx, obj, patch, opts...)
 }
 
 func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
@@ -1896,11 +2005,15 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 			WithStatusSubresource(claimWithNone).
 			Build()
 
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		seedQueueForTest(warmSandboxQueue, existingObjects)
+
 		reconciler := &SandboxClaimReconciler{
-			Client:   fakeClient,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+			Client:           fakeClient,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			Tracer:           asmetrics.NewNoOp(),
+			WarmSandboxQueue: warmSandboxQueue,
 		}
 
 		req := reconcile.Request{
@@ -1952,11 +2065,15 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 			WithStatusSubresource(claimWithSpecificPool).
 			Build()
 
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		seedQueueForTest(warmSandboxQueue, existingObjects)
+
 		reconciler := &SandboxClaimReconciler{
-			Client:   fakeClient,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+			Client:           fakeClient,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			Tracer:           asmetrics.NewNoOp(),
+			WarmSandboxQueue: warmSandboxQueue,
 		}
 
 		req := reconcile.Request{
@@ -2013,11 +2130,15 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 			WithStatusSubresource(claimWithSpecificPool).
 			Build()
 
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		seedQueueForTest(warmSandboxQueue, existingObjects)
+
 		reconciler := &SandboxClaimReconciler{
-			Client:   fakeClient,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+			Client:           fakeClient,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			Tracer:           asmetrics.NewNoOp(),
+			WarmSandboxQueue: warmSandboxQueue,
 		}
 
 		req := reconcile.Request{
@@ -2064,11 +2185,15 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 			WithStatusSubresource(claimWithDefault).
 			Build()
 
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		seedQueueForTest(warmSandboxQueue, existingObjects)
+
 		reconciler := &SandboxClaimReconciler{
-			Client:   fakeClient,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+			Client:           fakeClient,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			Tracer:           asmetrics.NewNoOp(),
+			WarmSandboxQueue: warmSandboxQueue,
 		}
 
 		req := reconcile.Request{
@@ -2114,11 +2239,15 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 			WithStatusSubresource(claimWithNil).
 			Build()
 
+		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		seedQueueForTest(warmSandboxQueue, existingObjects)
+
 		reconciler := &SandboxClaimReconciler{
-			Client:   fakeClient,
-			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
-			Tracer:   asmetrics.NewNoOp(),
+			Client:           fakeClient,
+			Scheme:           scheme,
+			Recorder:         events.NewFakeRecorder(10),
+			Tracer:           asmetrics.NewNoOp(),
+			WarmSandboxQueue: warmSandboxQueue,
 		}
 
 		req := reconcile.Request{
@@ -2230,5 +2359,18 @@ func TestSandboxClaimPredicates(t *testing.T) {
 				t.Errorf("expected time to be stored in observedTimes map for key %v", tc.expectedKey)
 			}
 		})
+	}
+}
+
+// seedQueueForTest acts as a mock Informer, pre-loading the test queue with adoptable sandboxes.
+func seedQueueForTest(q queue.SandboxQueue, objects []client.Object) {
+	for _, obj := range objects {
+		if sb, ok := obj.(*sandboxv1alpha1.Sandbox); ok {
+			if isAdoptable(sb) == nil {
+				hash := sb.Labels[sandboxTemplateRefHash]
+				key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name}
+				q.Add(hash, key)
+			}
+		}
 	}
 }

--- a/extensions/controllers/sandboxclaim_pod_exclusivity_test.go
+++ b/extensions/controllers/sandboxclaim_pod_exclusivity_test.go
@@ -34,6 +34,7 @@ import (
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/extensions/controllers/queue"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
@@ -123,10 +124,15 @@ func TestWarmPoolPodExclusivity(t *testing.T) {
 	}
 	fc := builder.Build()
 
+	testQueue := queue.NewSimpleSandboxQueue()
+	testQueue.Add(templateHash, queue.SandboxKey{Namespace: "default", Name: "pool-sb-0"})
+	testQueue.Add(templateHash, queue.SandboxKey{Namespace: "default", Name: "pool-sb-1"})
+
 	reconciler := &SandboxClaimReconciler{
 		Client: fc, Scheme: scheme,
-		Recorder: events.NewFakeRecorder(10),
-		Tracer:   asmetrics.NewNoOp(), MaxConcurrentReconciles: 1,
+		WarmSandboxQueue: testQueue,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(), MaxConcurrentReconciles: 1,
 	}
 
 	// Reconcile all 3 claims sequentially


### PR DESCRIPTION
When a warm Sandbox becomes Ready, the Kubelet tells the API server, and the API server eventually pushes that update to your local cache. If a massive burst of Claims arrives and checks the cache before that sync happens, they see zero available sandboxes.

The new WarmSandboxQueue rewires this architecture by acting as an instant, lockable, in-memory pipeline.

Here is how it solves the bottlenecks:
- Bypasses the Cache Sync: `sandboxEventHandler` intercepts the Update events coming straight from the API server's watch stream. The moment a Sandbox becomes "adoptable", it is pushed into the WarmSandboxQueue. The claim controller doesn't have to wait for the cache database to settle; it gets the data instantly.
- Lookup Speed: Instead of forcing the controller to run an expensive `r.List()` to scan over thousands of pods in the cluster, a worker thread just comes up to the queue and asks for the next available pod for given template. It’s an instant pop operation.
- Zero-Collision: The standard k8s workqueue has a built-in locking mechanism. When Worker Thread A pops Sandbox A out of the queue, Sandbox A is temporarily invisible to all other worker threads. Worker Thread B will instantly pop Sandbox B. No more 409 collisions trying to adopt the same pod.



The tests are run based on this framework https://github.com/kubernetes-sigs/agent-sandbox/blob/main/dev/load-test/test-recipes/README-rapid-burst.md

Test paramters: 

in `dev/load-test/test-recipes/run_rapid_burst.sh` 

```
# BURST_SIZE * TOTAL_BURSTS = Total sandbox claims created
BURST_SIZE=300
QPS=300
TOTAL_BURSTS=5
WARMPOOL_SIZE=600
RUNTIME_CLASS="" # Change to "gvisor" if your cluster supports it
```

Deployment args
```
        args:
        - "--leader-elect=true"
        - "--extensions"
        - "--enable-tracing=true"
        - --zap-log-level=debug
        - --zap-encoder=json
        - --enable-pprof-debug
        - --kube-api-qps=1000
        - --kube-api-burst=2000
        - --sandbox-concurrent-workers=400
        - --sandbox-claim-concurrent-workers=400
        - --sandbox-warm-pool-concurrent-workers=1
```

Steps i took to run the test: 

```
./dev/tools/push-images --image-prefix=$REGISTRY/ # build the image either from main branch or dev branch
cd ~/agent-sandbox && make release-manifests TAG=sandboxQueueTest
gcloud container clusters get-credentials <CLUSTER> --region <REGION> --project <PROJECT-ID>
kubectl apply -f release_assets/manifest.yaml
kubectl apply -f release_assets/extensions.yaml
kubectl describe po -n agent-sandbox-system # this is to confirm that the new image was deployed


/agent-sandbox/dev/load-test/test-recipes$ ./run_rapid_burst.sh sandboxQueueTests
```

After the test finishes it will drop the latency results into a folder called `sandboxQueueTest`:

```
ls dev/load-test/test-recipes/tmp/20260420-165242-sandboxQueueTest
 cl2-metadata.json
 clusterloader2-20260420-165242-sandboxQueueTest.log
 generatedConfig_rapid-burst-test.yaml
'GenericPrometheusQuery Agent Sandbox Claim Controller Startup Latency (ms)_rapid-burst-test_2026-04-20T16:57:21Z.json'
'GenericPrometheusQuery Agent Sandbox Claim Startup Latency (ms)_rapid-burst-test_2026-04-20T16:57:21Z.json'
 junit.xml
 PodStartupLatency_SandboxStartupLatency_rapid-burst-test_2026-04-20T16:57:22Z.json
 StatefulPodStartupLatency_SandboxStartupLatency_rapid-burst-test_2026-04-20T16:57:22Z.json
 StatelessPodStartupLatency_SandboxStartupLatency_rapid-burst-test_2026-04-20T16:57:22Z.json
 testoverrides.json
```

The numbers below for the two metrics come from these two json files:

```
- 'GenericPrometheusQuery Agent Sandbox Claim Controller Startup Latency (ms)_rapid-burst-test_2026-04-20T16:57:21Z.json'
- 'GenericPrometheusQuery Agent Sandbox Claim Startup Latency (ms)_rapid-burst-test_2026-04-20T16:57:21Z.json'
```

**Latency Comparison (ms)**

| Metric                     | Baseline (ms) | New Run (ms) | Diff (ms)  | % Change |
| :------------------------- | :------------ | :----------- | :--------- | :------- |
| ControllerStartupLatency50 | 426.630       | 73.171       | -353.459   | -82.85%  |
| ControllerStartupLatency90 | 1122.807      | 202.632      | -920.175   | -81.95%  |
| ControllerStartupLatency99 | 1839.286      | 245.263      | -1594.023  | -86.66%  |
| StartupLatency50           | 1041.360      | 597.584      | -443.776   | -42.61%  |
| StartupLatency90           | 1900.000      | 1017.578     | -882.422   | -46.44%  |
| StartupLatency99           | 2464.706      | 1228.516     | -1236.190  | -50.16%  |



