### PR TITLE
Change ClaimStartupLatency to use an WebhookAnnotation for creation timestamp

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1062,6 +1062,11 @@ func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, 
 		logger.Error(err, "Failed to parse webhook first seen time", "value", webhookSeenTimeStr)
 		return
 	}
+	duration := time.Since(webhookSeenTime)
+	if duration < 0 {
+		logger.Error(errors.New("negative duration"), "Webhook seen time is in the future", "duration", duration, "webhookSeenTime", webhookSeenTime)
+		return
+	}
 	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, claim.Spec.TemplateRef.Name)
 }
 
@@ -1081,7 +1086,7 @@ func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Cont
 	}
 }
 
-// recordSandboxCreationLatency records the sandbox creation latency for cold launches.
+// recordSandboxCreationLatency records the sandbox creation latency.
 func (r *SandboxClaimReconciler) recordSandboxCreationLatency(claim *extensionsv1alpha1.SandboxClaim, sandbox *v1alpha1.Sandbox, launchType string) {
 	if sandbox == nil || sandbox.CreationTimestamp.IsZero() {
 		return

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -985,6 +985,11 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 			r.observedTimes.LoadOrStore(key, time.Now())
 			return true
 		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			key := types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()}
+			r.observedTimes.Delete(key)
+			return true
+		},
 	}
 }
 
@@ -1064,14 +1069,15 @@ func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, 
 func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, launchType string) {
 	logger := log.FromContext(ctx)
 	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
+		key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+		defer r.observedTimes.Delete(key)
+
 		observedTime, err := time.Parse(time.RFC3339Nano, observedTimeString)
 		if err != nil {
 			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)
 			return
 		}
 		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, claim.Spec.TemplateRef.Name)
-		// Clean up map entry after success
-		r.observedTimes.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 	}
 }
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -50,8 +50,6 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
-const ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
-
 // ErrTemplateNotFound is a sentinel error indicating a SandboxTemplate was not found.
 var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
 
@@ -121,7 +119,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Initialize trace ID and observation time for active resources missing them.
 	// Inline patch, no early return, to avoid forcing a second reconcile cycle.
 	traceContext := r.Tracer.GetTraceContext(ctx)
-	needObservabilityPatch := claim.Annotations[ObservabilityAnnotation] == ""
+	needObservabilityPatch := claim.Annotations[asmetrics.ObservabilityAnnotation] == ""
 	needTraceContextPatch := traceContext != "" && (claim.Annotations[asmetrics.TraceContextAnnotation] == "")
 
 	if needObservabilityPatch || needTraceContextPatch {
@@ -132,10 +130,10 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if needObservabilityPatch {
 			key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
 			if val, ok := r.observedTimes.Load(key); ok {
-				claim.Annotations[ObservabilityAnnotation] = val.(time.Time).Format(time.RFC3339Nano)
+				claim.Annotations[asmetrics.ObservabilityAnnotation] = val.(time.Time).Format(time.RFC3339Nano)
 			} else {
 				now := time.Now()
-				claim.Annotations[ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
+				claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
 				r.observedTimes.Store(key, now)
 			}
 		}
@@ -1071,12 +1069,20 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	}
 	logger.V(1).Info("SandboxClaim is marked as Ready", "claim", claim.Name, "sandbox", sandboxName, "duration", time.Since(claim.CreationTimestamp.Time))
 
-	// SandboxClaim doesn't react to TemplateRef updates currently, so we don't need to handle the
-	// startup latency when the TemplateRef is updated.
-	asmetrics.RecordClaimStartupLatency(claim.CreationTimestamp.Time, launchType, claim.Spec.TemplateRef.Name)
+	webhookSeenTimeStr := claim.Annotations[asmetrics.WebhookAnnotation]
+	if webhookSeenTimeStr == "" {
+		logger.V(1).Info("Webhook first seen annotation missing, skipping ClaimStartupLatency metric", "claim", claim.Name)
+	} else {
+		webhookSeenTime, err := time.Parse(time.RFC3339Nano, webhookSeenTimeStr)
+		if err != nil {
+			logger.Error(err, "Failed to parse webhook first seen time", "value", webhookSeenTimeStr)
+		} else {
+			asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, claim.Spec.TemplateRef.Name)
+		}
+	}
 
 	// Record controller startup latency
-	if observedTimeString := claim.Annotations[ObservabilityAnnotation]; observedTimeString != "" {
+	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
 		observedTime, err := time.Parse(time.RFC3339Nano, observedTimeString)
 		if err != nil {
 			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1033,6 +1033,63 @@ func (r *SandboxClaimReconciler) cleanupLegacyNetworkPolicy(ctx context.Context,
 	return nil
 }
 
+// getLaunchType determines the launch type based on the sandbox state.
+func getLaunchType(sandbox *v1alpha1.Sandbox) string {
+	if sandbox == nil {
+		return asmetrics.LaunchTypeUnknown
+	}
+	if sandbox.Annotations[v1alpha1.SandboxPodNameAnnotation] != "" {
+		return asmetrics.LaunchTypeWarm
+	}
+	return asmetrics.LaunchTypeCold
+}
+
+// recordClaimStartupLatency records the startup latency based on webhook annotation.
+func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, launchType string) {
+	logger := log.FromContext(ctx)
+	webhookSeenTimeStr := claim.Annotations[asmetrics.WebhookAnnotation]
+	if webhookSeenTimeStr == "" {
+		logger.V(1).Info("Webhook first seen annotation missing, skipping ClaimStartupLatency metric", "claim", claim.Name)
+		return
+	}
+	webhookSeenTime, err := time.Parse(time.RFC3339Nano, webhookSeenTimeStr)
+	if err != nil {
+		logger.Error(err, "Failed to parse webhook first seen time", "value", webhookSeenTimeStr)
+		return
+	}
+	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, claim.Spec.TemplateRef.Name)
+}
+
+// recordControllerStartupLatency records the controller startup latency based on observed time.
+func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, launchType string) {
+	logger := log.FromContext(ctx)
+	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
+		observedTime, err := time.Parse(time.RFC3339Nano, observedTimeString)
+		if err != nil {
+			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)
+			return
+		}
+		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, claim.Spec.TemplateRef.Name)
+		// Clean up map entry after success
+		r.observedTimes.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
+	}
+}
+
+// recordSandboxCreationLatency records the sandbox creation latency for cold launches.
+func (r *SandboxClaimReconciler) recordSandboxCreationLatency(claim *extensionsv1alpha1.SandboxClaim, sandbox *v1alpha1.Sandbox, launchType string) {
+	if sandbox == nil || sandbox.CreationTimestamp.IsZero() {
+		return
+	}
+	sandboxReady := meta.FindStatusCondition(sandbox.Status.Conditions, string(v1alpha1.SandboxConditionReady))
+	if sandboxReady == nil || sandboxReady.Status != metav1.ConditionTrue || sandboxReady.LastTransitionTime.IsZero() {
+		return
+	}
+	latency := sandboxReady.LastTransitionTime.Sub(sandbox.CreationTimestamp.Time)
+	if latency >= 0 {
+		asmetrics.RecordSandboxCreationLatency(latency, sandbox.Namespace, launchType, claim.Spec.TemplateRef.Name)
+	}
+}
+
 // recordCreationLatencyMetric detects and records transitions to Ready state.
 func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	ctx context.Context,
@@ -1054,14 +1111,7 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 		return
 	}
 
-	launchType := asmetrics.LaunchTypeCold
-	// This is unlikely to happen; here for completeness only.
-	if sandbox == nil {
-		launchType = asmetrics.LaunchTypeUnknown
-	} else if sandbox.Annotations[v1alpha1.SandboxPodNameAnnotation] != "" {
-		// Existence of the SandboxPodNameAnnotation implies the pod was adopted from a warm pool.
-		launchType = asmetrics.LaunchTypeWarm
-	}
+	launchType := getLaunchType(sandbox)
 
 	sandboxName := "none"
 	if sandbox != nil {
@@ -1069,42 +1119,9 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	}
 	logger.V(1).Info("SandboxClaim is marked as Ready", "claim", claim.Name, "sandbox", sandboxName, "duration", time.Since(claim.CreationTimestamp.Time))
 
-	webhookSeenTimeStr := claim.Annotations[asmetrics.WebhookAnnotation]
-	if webhookSeenTimeStr == "" {
-		logger.V(1).Info("Webhook first seen annotation missing, skipping ClaimStartupLatency metric", "claim", claim.Name)
-	} else {
-		webhookSeenTime, err := time.Parse(time.RFC3339Nano, webhookSeenTimeStr)
-		if err != nil {
-			logger.Error(err, "Failed to parse webhook first seen time", "value", webhookSeenTimeStr)
-		} else {
-			asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, claim.Spec.TemplateRef.Name)
-		}
-	}
-
-	// Record controller startup latency
-	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
-		observedTime, err := time.Parse(time.RFC3339Nano, observedTimeString)
-		if err != nil {
-			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)
-		} else {
-			asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, claim.Spec.TemplateRef.Name)
-			// Clean up map entry after success
-			r.observedTimes.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
-		}
-	}
-
-	// For cold launches, also record the time from Sandbox creation to Ready state to capture controller overhead.
-	if sandbox == nil || sandbox.CreationTimestamp.IsZero() {
-		return
-	}
-	sandboxReady := meta.FindStatusCondition(sandbox.Status.Conditions, string(v1alpha1.SandboxConditionReady))
-	if sandboxReady == nil || sandboxReady.Status != metav1.ConditionTrue || sandboxReady.LastTransitionTime.IsZero() {
-		return
-	}
-	latency := sandboxReady.LastTransitionTime.Sub(sandbox.CreationTimestamp.Time)
-	if latency >= 0 {
-		asmetrics.RecordSandboxCreationLatency(latency, sandbox.Namespace, launchType, claim.Spec.TemplateRef.Name)
-	}
+	r.recordClaimStartupLatency(ctx, claim, launchType)
+	r.recordControllerStartupLatency(ctx, claim, launchType)
+	r.recordSandboxCreationLatency(claim, sandbox, launchType)
 }
 
 // isSandboxExpired checks the Sandbox status condition set by the Core Controller.

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1568,16 +1568,34 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 		setupReconciler                func(r *SandboxClaimReconciler)
 	}{
 		{
-			name: "records success on first ready transition",
+			name: "records success on first ready transition (with webhook annotation)",
 			claim: &extensionsv1alpha1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "new-ready", CreationTimestamp: pastTime},
-				Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "new-ready",
+					CreationTimestamp: pastTime,
+					Annotations: map[string]string{
+						asmetrics.WebhookAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
+					},
+				},
+				Spec: extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},
 				Status: extensionsv1alpha1.SandboxClaimStatus{
 					Conditions: []metav1.Condition{{Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue}},
 				},
 			},
 			oldStatus:            &extensionsv1alpha1.SandboxClaimStatus{},
 			expectedObservations: 1,
+		},
+		{
+			name: "skips recording when webhook annotation is missing",
+			claim: &extensionsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "webhook-missing", CreationTimestamp: pastTime},
+				Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},
+				Status: extensionsv1alpha1.SandboxClaimStatus{
+					Conditions: []metav1.Condition{{Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue}},
+				},
+			},
+			oldStatus:            &extensionsv1alpha1.SandboxClaimStatus{},
+			expectedObservations: 0,
 		},
 		{
 			name: "ignores ready condition = false",
@@ -1607,8 +1625,14 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 		{
 			name: "uses unknown launch type when sandbox is nil",
 			claim: &extensionsv1alpha1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "unknown", CreationTimestamp: pastTime},
-				Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "unknown",
+					CreationTimestamp: pastTime,
+					Annotations: map[string]string{
+						asmetrics.WebhookAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
+					},
+				},
+				Spec: extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},
 				Status: extensionsv1alpha1.SandboxClaimStatus{
 					Conditions: []metav1.Condition{{Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Unknown"}},
 				},
@@ -1625,7 +1649,8 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 					Namespace:         "default",
 					CreationTimestamp: pastTime,
 					Annotations: map[string]string{
-						ObservabilityAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
+						asmetrics.ObservabilityAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
+						asmetrics.WebhookAnnotation:       time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
 					},
 				},
 				Spec: extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1666,6 +1666,26 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 				r.observedTimes.Store(key, time.Now().Add(-5*time.Second))
 			},
 		},
+		{
+			name: "skips claim startup latency if webhook duration is negative but records controller latency",
+			claim: &extensionsv1alpha1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "future-webhook",
+					CreationTimestamp: pastTime,
+					Annotations: map[string]string{
+						asmetrics.WebhookAnnotation:       time.Now().Add(5 * time.Second).Format(time.RFC3339Nano),
+						asmetrics.ObservabilityAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
+					},
+				},
+				Spec: extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"}},
+				Status: extensionsv1alpha1.SandboxClaimStatus{
+					Conditions: []metav1.Condition{{Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue}},
+				},
+			},
+			oldStatus:                      &extensionsv1alpha1.SandboxClaimStatus{},
+			expectedObservations:           0,
+			expectedControllerObservations: 1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -26,6 +26,12 @@ const (
 	LaunchTypeWarm    = "warm"    // Pod from a SandboxWarmPool
 	LaunchTypeCold    = "cold"    // Pod not from a SandboxWarmPool
 	LaunchTypeUnknown = "unknown" // Used when Sandbox is nil during failure
+
+	// ObservabilityAnnotation is the annotation key for the time the controller first observed the claim.
+	ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
+
+	// WebhookAnnotation is the annotation key for the time the webhook first saw the claim.
+	WebhookAnnotation = "agents.x-k8s.io/webhook-first-observed-at"
 )
 
 var (

--- a/test/e2e/extensions/sandboxclaim_metric_test.go
+++ b/test/e2e/extensions/sandboxclaim_metric_test.go
@@ -26,7 +26,7 @@ import (
 
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
-	"sigs.k8s.io/agent-sandbox/extensions/controllers"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
@@ -82,8 +82,8 @@ func TestSandboxClaimObservabilityAnnotation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check for the annotation
-	annoValue, found := updatedClaim.Annotations[controllers.ObservabilityAnnotation]
-	require.True(t, found, "expected annotation %q to be present", controllers.ObservabilityAnnotation)
+	annoValue, found := updatedClaim.Annotations[asmetrics.ObservabilityAnnotation]
+	require.True(t, found, "expected annotation %q to be present", asmetrics.ObservabilityAnnotation)
 
 	// Verify it's a valid RFC3339 timestamp
 	parsedTime, err := time.Parse(time.RFC3339Nano, annoValue)


### PR DESCRIPTION
Modifies the `ClaimStartupLatency` metric to use a new `agents.x-k8s.io/webhook-first-seen-at` annotation for the start time, providing millisecond granularity. This replaces the use of the Kubernetes creation timestamp, which only has second precision, and resulted in inaccurate metrics.

Note that this metric is distinct from `ControllerStartupLatency` which only includes latency after the SandboxClaim has been seen by the agent-sandbox controller.

The actual webhook to add this annotation must be provided by the user or cloud provider. This PR only consumes the annotation.

Note for reviewer:

This PR is broken into two separate commits. The first commit has the functional changes. The second commit is refactoring only.

#245