### PR TITLE
Implement suspend and resume with GKE extension Pod snapshots.

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -13,15 +13,37 @@
 # limitations under the License.
 
 import logging
-from .snapshot_engine import SnapshotEngine
+from kubernetes.client import ApiException
+from .snapshot_engine import SnapshotEngine, SnapshotResponse
 from k8s_agent_sandbox.sandbox import Sandbox
-from .utils import check_pod_restored_from_snapshot, RestoreCheckResult
+from k8s_agent_sandbox.constants import SANDBOX_API_GROUP, SANDBOX_API_VERSION, SANDBOX_PLURAL_NAME
+from .utils import (
+    check_pod_restored_from_snapshot,
+    RestoreCheckResult,
+    wait_for_pod_termination,
+    wait_for_pod_ready,
+)
 from pydantic import BaseModel
 
-SNAPSHOT_SUCCESS_CODE = 0
-SNAPSHOT_ERROR_CODE = 1
+SUCCESS_CODE = 0
+ERROR_CODE = 1
 
 logger = logging.getLogger(__name__)
+
+class SuspendResponse(BaseModel):
+    """Result of a suspend operation."""
+    success: bool
+    snapshot_response: SnapshotResponse | None = None
+    error_reason: str = ""
+    error_code: int = 0
+
+class ResumeResponse(BaseModel):
+    """Result of a resume operation."""
+    success: bool
+    restored_from_snapshot: bool | None = None
+    snapshot_uid: str | None = None
+    error_reason: str = ""
+    error_code: int = 0
 
 class SandboxWithSnapshotSupport(Sandbox):
     def __init__(self, *args, **kwargs):
@@ -51,7 +73,7 @@ class SandboxWithSnapshotSupport(Sandbox):
             return RestoreCheckResult(
                 success=False,
                 error_reason="Snapshot UID cannot be empty.",
-                error_code=SNAPSHOT_ERROR_CODE,
+                error_code=ERROR_CODE,
             )
 
         pod_name = self.get_pod_name()
@@ -60,7 +82,7 @@ class SandboxWithSnapshotSupport(Sandbox):
             return RestoreCheckResult(
                 success=False,
                 error_reason="Pod name not found. Ensure sandbox is created.",
-                error_code=SNAPSHOT_ERROR_CODE,
+                error_code=ERROR_CODE,
             )
 
         return check_pod_restored_from_snapshot(
@@ -68,6 +90,214 @@ class SandboxWithSnapshotSupport(Sandbox):
             namespace=self.namespace,
             pod_name=pod_name,
             snapshot_uid=snapshot_uid,
+        )
+
+    def is_suspended(self) -> bool:
+        """
+        Checks if the sandbox is currently suspended by inspecting the Sandbox CR.
+        A sandbox is considered suspended if its spec.replicas is 0 and it has no podIPs assigned.
+        """
+        try:
+            sandbox_cr = self.k8s_helper.custom_objects_api.get_namespaced_custom_object(
+                group=SANDBOX_API_GROUP,
+                version=SANDBOX_API_VERSION,
+                namespace=self.namespace,
+                plural=SANDBOX_PLURAL_NAME,
+                name=self.sandbox_id
+            )
+            spec_replicas = sandbox_cr.get("spec", {}).get("replicas", 1)
+            pod_ips = sandbox_cr.get("status", {}).get("podIPs")
+            
+            is_spec_suspended = spec_replicas == 0
+            
+            # TODO: Replace this with Suspended status when it's available
+            if is_spec_suspended and pod_ips:
+                logger.info(f"Sandbox '{self.sandbox_id}' is in the process of suspending (spec.replicas=0 but podIPs still present).")
+            elif not is_spec_suspended and not pod_ips:
+                logger.info(f"Sandbox '{self.sandbox_id}' is in the process of resuming/starting (spec.replicas={spec_replicas} but no podIPs assigned).")
+                
+            return is_spec_suspended
+        except Exception as e:
+            logger.error(f"Failed to check if Sandbox '{self.sandbox_id}' is suspended: {e}")
+            return False
+
+    def _set_replicas(self, replicas: int):
+        self.k8s_helper.custom_objects_api.patch_namespaced_custom_object(
+            group=SANDBOX_API_GROUP,
+            version=SANDBOX_API_VERSION,
+            namespace=self.namespace,
+            plural=SANDBOX_PLURAL_NAME,
+            name=self.sandbox_id,
+            body={"spec": {"replicas": replicas}}
+        )
+
+    def _get_latest_snapshot_uid(self) -> str | None:
+        if self.snapshots:
+            list_result = self.snapshots.list()
+            if not list_result.success:
+                raise RuntimeError(f"Snapshot list request failed: {list_result.error_reason}")
+            if list_result.snapshots:
+                return list_result.snapshots[0].snapshot_uid
+        return None
+
+    def suspend(self, snapshot_before_suspend: bool = True, wait_timeout: int = 180) -> SuspendResponse:
+        """
+        Suspends the sandbox.
+
+        Args:
+            snapshot_before_suspend: Whether to take a snapshot of the sandbox before suspending it. Defaults to True.
+            wait_timeout: The maximum time in seconds to wait for termination. Defaults to 180.
+
+        Returns:
+            SuspendResponse: An object containing the success status, potential snapshot response, and any error details.
+        """
+        if self.is_suspended():
+            logger.info(f"Sandbox '{self.sandbox_id}' is already suspended.")
+            return SuspendResponse(
+                success=True,
+                snapshot_response=None,
+                error_reason="",
+                error_code=SUCCESS_CODE
+            )
+
+        snapshot_response = None
+        if snapshot_before_suspend and self.snapshots:
+            # Generate a unique trigger name for this suspend action
+            trigger_name = f"suspend-{self.sandbox_id}"
+            snapshot_response = self.snapshots.create(trigger_name)
+            if not snapshot_response.success:
+                logger.error(f"Snapshot before suspend failed: {snapshot_response.error_reason}")
+                return SuspendResponse(
+                    success=False,
+                    snapshot_response=snapshot_response,
+                    error_reason=f"Snapshot failed: {snapshot_response.error_reason}",
+                    error_code=ERROR_CODE
+                )
+
+        pod_name_to_wait = self.get_pod_name()
+        pod_uid_to_wait = None
+        if pod_name_to_wait:
+            try:
+                pod = self.k8s_helper.core_v1_api.read_namespaced_pod(pod_name_to_wait, self.namespace)
+                pod_uid_to_wait = pod.metadata.uid
+            except ApiException as e:
+                if e.status != 404:
+                    logger.error(f"Error getting pod UID before suspend: {e}")
+
+        try:
+            self._set_replicas(0)
+            logger.info(f"Sandbox '{self.sandbox_id}' suspended (scaled down to 0 replicas).")
+        except Exception as e:
+            logger.error(f"Failed to suspend Sandbox '{self.sandbox_id}': {e}")
+            return SuspendResponse(
+                success=False,
+                snapshot_response=snapshot_response,
+                error_reason=f"Failed to scale down sandbox: {e}",
+                error_code=ERROR_CODE
+            )
+
+        if wait_for_pod_termination(self.k8s_helper, self.namespace, pod_name_to_wait, pod_uid_to_wait, wait_timeout):
+            logger.info(f"Sandbox '{self.sandbox_id}' pod successfully terminated.")
+            return SuspendResponse(
+                success=True,
+                snapshot_response=snapshot_response,
+                error_reason="",
+                error_code=SUCCESS_CODE
+            )
+        
+        logger.warning(f"Timed out waiting for Sandbox '{self.sandbox_id}' pod to terminate.")
+        return SuspendResponse(
+            success=False,
+            snapshot_response=snapshot_response,
+            error_reason="Timed out waiting for pod to terminate.",
+            error_code=ERROR_CODE
+        )
+
+    def resume(self, wait_timeout: int = 180) -> ResumeResponse:
+        """
+        Resumes the sandbox from the latest available snapshot.
+
+        Args:
+            wait_timeout: The maximum time in seconds to wait for the pod to become ready. Defaults to 180.
+
+        Returns:
+            ResumeResponse: An object containing the success status, restoration details, and any error information.
+        """
+        if not self.is_suspended():
+            logger.info(f"Sandbox '{self.sandbox_id}' is already running (not suspended).")
+            return ResumeResponse(
+                success=True,
+                restored_from_snapshot=False,
+                snapshot_uid=None,
+                error_reason="",
+                error_code=SUCCESS_CODE
+            )
+
+        # Capture the snapshot UID before patching replicas to guarantee we verify
+        # against the exact state the controller will see.
+        try:
+            latest_snapshot_uid = self._get_latest_snapshot_uid()
+        except Exception as e:
+            logger.error(f"Failed to get latest snapshot UID before resuming: {e}")
+            return ResumeResponse(
+                success=False,
+                restored_from_snapshot=False,
+                snapshot_uid=None,
+                error_reason=f"Failed to get latest snapshot UID: {e}",
+                error_code=ERROR_CODE
+            )
+
+        try:
+            self._set_replicas(1)
+            logger.info(f"Sandbox '{self.sandbox_id}' resumed (scaled up to 1 replica).")
+        except Exception as e:
+            logger.error(f"Failed to resume Sandbox '{self.sandbox_id}': {e}")
+            return ResumeResponse(
+                success=False,
+                restored_from_snapshot=False,
+                snapshot_uid=None,
+                error_reason=f"Failed to patch replicas: {e}",
+                error_code=ERROR_CODE
+            )
+
+        if wait_for_pod_ready(self.k8s_helper, self.namespace, self.get_pod_name, wait_timeout):
+            if not latest_snapshot_uid:
+                logger.info(f"No previous snapshots found for Sandbox '{self.sandbox_id}'. Skipping restore verification.")
+                return ResumeResponse(
+                    success=True,
+                    restored_from_snapshot=False,
+                    snapshot_uid=None,
+                    error_reason="",
+                    error_code=SUCCESS_CODE
+                )
+
+            restore_check = self.is_restored_from_snapshot(latest_snapshot_uid)
+            if restore_check.success:
+                logger.info(f"Sandbox '{self.sandbox_id}' successfully restored from snapshot '{latest_snapshot_uid}'.")
+                return ResumeResponse(
+                    success=True,
+                    restored_from_snapshot=True,
+                    snapshot_uid=latest_snapshot_uid,
+                    error_reason="",
+                    error_code=SUCCESS_CODE
+                )
+            else:
+                logger.error(f"Sandbox '{self.sandbox_id}' was not restored from snapshot '{latest_snapshot_uid}': {restore_check.error_reason}")
+                return ResumeResponse(
+                    success=False,
+                    restored_from_snapshot=False,
+                    snapshot_uid=latest_snapshot_uid,
+                    error_reason=f"Pod ready but not restored from snapshot: {restore_check.error_reason}",
+                    error_code=ERROR_CODE
+                )
+        
+        logger.warning(f"Timed out waiting for Sandbox '{self.sandbox_id}' pod to become ready.")
+        return ResumeResponse(
+            success=False,
+            restored_from_snapshot=False,
+            snapshot_uid=latest_snapshot_uid,
+            error_reason="Timed out waiting for pod to become ready.",
+            error_code=ERROR_CODE
         )
     
     def terminate(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -386,6 +386,7 @@ class SnapshotEngine:
         snapshot_uid: str | None = None,
         scope: str | None = None,
         labels: dict | None = None,
+        timeout: int = 180,
     ) -> DeleteSnapshotResult:
         """Helper method to execute deletion of snapshots."""
         snapshots_to_delete = []
@@ -455,6 +456,7 @@ class SnapshotEngine:
                     namespace=self.namespace,
                     snapshot_uid=uid,
                     resource_version=resource_version,
+                    timeout=timeout,
                 ):
                     deleted_snapshots.append(uid)
                 else:
@@ -497,14 +499,15 @@ class SnapshotEngine:
             error_code=SNAPSHOT_SUCCESS_CODE,
         )
 
-    def delete(self, snapshot_uid: str) -> DeleteSnapshotResult:
+    def delete(self, snapshot_uid: str, timeout: int = 180) -> DeleteSnapshotResult:
         """Delete a single snapshot by UID."""
-        return self._execute_deletion(snapshot_uid=snapshot_uid)
+        return self._execute_deletion(snapshot_uid=snapshot_uid, timeout=timeout)
 
     def delete_all(
         self,
         delete_by: Literal["all", "labels"] = "all",
         label_value: dict[str, str] | None = None,
+        timeout: int = 180,
     ) -> DeleteSnapshotResult:
         """Deletes snapshots based on a specific strategy.
 
@@ -516,7 +519,7 @@ class SnapshotEngine:
         match delete_by:
             case "all":
                 logger.info("Deleting every snapshot for this pod...")
-                return self._execute_deletion(scope="global")
+                return self._execute_deletion(scope="global", timeout=timeout)
 
             case "labels":
                 if not isinstance(label_value, dict):
@@ -524,7 +527,7 @@ class SnapshotEngine:
                         "label_value must be a dict when deleting by labels"
                     )
                 logger.info(f"Deleting snapshots matching labels: {label_value}")
-                return self._execute_deletion(labels=label_value)
+                return self._execute_deletion(labels=label_value, timeout=timeout)
 
             case _:
                 raise ValueError(f"Unsupported deletion strategy: {delete_by}")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -19,8 +19,10 @@ from kubernetes.client import ApiException
 
 from k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support import (
     SandboxWithSnapshotSupport,
-    SNAPSHOT_SUCCESS_CODE,
-    SNAPSHOT_ERROR_CODE,
+    SUCCESS_CODE,
+    ERROR_CODE,
+    SuspendResponse,
+    ResumeResponse,
 )
 from k8s_agent_sandbox.constants import (
     PODSNAPSHOT_POD_NAME_LABEL,
@@ -29,11 +31,15 @@ from k8s_agent_sandbox.constants import (
     PODSNAPSHOTMANUALTRIGGER_PLURAL,
     POD_NAME_ANNOTATION,
     PODSNAPSHOT_PLURAL,
+    SANDBOX_API_GROUP,
+    SANDBOX_API_VERSION,
+    SANDBOX_PLURAL_NAME,
 )
 from k8s_agent_sandbox.gke_extensions.snapshots.snapshot_engine import (
     ListSnapshotResult,
     SnapshotDetail,
     DeleteSnapshotResult,
+    SnapshotResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,6 +51,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
     @patch("k8s_agent_sandbox.sandbox.CommandExecutor")
     @patch("k8s_agent_sandbox.sandbox.Filesystem")
     def setUp(self, mock_fs, mock_ce, mock_ctm, mock_conn):
+        logging.info(f"Starting {self._testMethodName}...")
         mock_ctm.return_value = (None, None)
 
         self.mock_k8s_helper = MagicMock()
@@ -60,6 +67,9 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         # Access the underlying engine
         self.engine = self.sandbox.snapshots
         self.engine.get_pod_name_func = self.sandbox.get_pod_name
+
+    def tearDown(self):
+        logging.info(f"Finished {self._testMethodName}.")
 
     @patch("k8s_agent_sandbox.gke_extensions.snapshots.utils.watch.Watch")
     def test_snapshots_create_success(self, mock_watch_cls):
@@ -92,7 +102,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         result = self.engine.create("test-trigger")
 
         self.sandbox.get_pod_name.assert_called_once()
-        self.assertEqual(result.error_code, SNAPSHOT_SUCCESS_CODE)
+        self.assertEqual(result.error_code, SUCCESS_CODE)
         self.assertTrue(result.success)
         self.assertEqual(result.snapshot_uid, "snapshot-uid")
         self.assertEqual(result.snapshot_timestamp, "2023-01-01T00:00:00Z")
@@ -305,8 +315,6 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
 
     def test_is_restored_from_snapshot_success(self):
         """Test successful identification of restore from snapshot."""
-        logging.info("Starting test_is_restored_from_snapshot_success...")
-
         mock_pod = MagicMock()
         mock_condition = MagicMock()
         mock_condition.type = "PodRestored"
@@ -319,25 +327,20 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         result = self.sandbox.is_restored_from_snapshot("test-uid")
 
         self.assertTrue(result.success, result.error_reason)
-        self.assertEqual(result.error_code, SNAPSHOT_SUCCESS_CODE)
+        self.assertEqual(result.error_code, SUCCESS_CODE)
         self.mock_k8s_helper.core_v1_api.read_namespaced_pod.assert_called_once_with(
             "test-pod", "test-ns"
         )
-        logging.info("Finished test_is_restored_from_snapshot_success.")
 
     def test_is_restored_from_snapshot_empty_uid(self):
         """Test is_restored_from_snapshot with empty UID."""
-        logging.info("Starting test_is_restored_from_snapshot_empty_uid...")
         result = self.sandbox.is_restored_from_snapshot("")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Snapshot UID cannot be empty", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_empty_uid.")
 
     def test_is_restored_from_snapshot_pending_or_failed(self):
         """Test is_restored_from_snapshot when PodRestored condition is not True."""
-        logging.info("Starting test_is_restored_from_snapshot_pending_or_failed...")
-
         mock_pod = MagicMock()
         mock_condition = MagicMock()
         mock_condition.type = "PodRestored"
@@ -351,55 +354,44 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         result = self.sandbox.is_restored_from_snapshot("test-uid")
 
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Restore attempted but pending or failed", result.error_reason)
         self.assertIn("status: 'False'", result.error_reason)
         self.assertIn("reason: 'FailedToRestore'", result.error_reason)
         self.assertIn("message: 'Snapshot not found'", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_pending_or_failed.")
 
     def test_is_restored_from_snapshot_no_pod_name(self):
         """Test is_restored_from_snapshot when pod name is missing."""
-        logging.info("Starting test_is_restored_from_snapshot_no_pod_name...")
         self.sandbox.get_pod_name.return_value = None
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Pod name not found", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_no_pod_name.")
 
     def test_is_restored_from_snapshot_no_status(self):
         """Test is_restored_from_snapshot when pod status is None."""
-        logging.info("Starting test_is_restored_from_snapshot_no_status...")
-
         mock_pod = MagicMock()
         mock_pod.status = None
         self.mock_k8s_helper.core_v1_api.read_namespaced_pod.return_value = mock_pod
 
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Pod status or conditions not found", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_no_status.")
 
     def test_is_restored_from_snapshot_no_conditions(self):
         """Test is_restored_from_snapshot when pod has no conditions."""
-        logging.info("Starting test_is_restored_from_snapshot_no_conditions...")
-
         mock_pod = MagicMock()
         mock_pod.status.conditions = None
         self.mock_k8s_helper.core_v1_api.read_namespaced_pod.return_value = mock_pod
 
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Pod status or conditions not found", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_no_conditions.")
 
     def test_is_restored_from_snapshot_wrong_uid(self):
         """Test is_restored_from_snapshot when restored from a different snapshot."""
-        logging.info("Starting test_is_restored_from_snapshot_wrong_uid...")
-
         mock_pod = MagicMock()
         mock_condition = MagicMock()
         mock_condition.type = "PodRestored"
@@ -411,14 +403,11 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
 
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("not restored from the given snapshot", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_wrong_uid.")
 
     def test_is_restored_from_snapshot_not_restored(self):
         """Test is_restored_from_snapshot when not restored from any snapshot."""
-        logging.info("Starting test_is_restored_from_snapshot_not_restored...")
-
         mock_pod = MagicMock()
         mock_condition = MagicMock()
         mock_condition.type = "PodScheduled"
@@ -429,23 +418,19 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
 
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("started as a fresh instance", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_not_restored.")
 
     def test_is_restored_from_snapshot_api_exception(self):
         """Test is_restored_from_snapshot handling ApiException."""
-        logging.info("Starting test_is_restored_from_snapshot_api_exception...")
-
         self.mock_k8s_helper.core_v1_api.read_namespaced_pod.side_effect = ApiException(
             status=500, reason="Internal Server Error"
         )
 
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Failed to check pod restore status", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_api_exception.")
 
     def test_is_restored_from_snapshot_generic_exception(self):
         """
@@ -455,22 +440,17 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         - Deserialization issues when parsing the API response (e.g. ValueError or TypeError)
         - Threading/Async context errors within the underlying kubernetes client library
         """
-        logging.info("Starting test_is_restored_from_snapshot_generic_exception...")
-
         self.mock_k8s_helper.core_v1_api.read_namespaced_pod.side_effect = ValueError(
             "Deserialization error"
         )
 
         result = self.sandbox.is_restored_from_snapshot("test-uid")
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Unexpected error", result.error_reason)
-        logging.info("Finished test_is_restored_from_snapshot_generic_exception.")
 
     def test_snapshots_list_success(self):
         """Test list snapshots returning properly formatted objects."""
-        logging.info("Starting test_snapshots_list_success...")
-
         mock_response = {
             "items": [
                 {
@@ -644,7 +624,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.sandbox.get_pod_name.return_value = None
         result = self.engine.list()
         self.assertFalse(result.success)
-        self.assertEqual(result.error_code, SNAPSHOT_ERROR_CODE)
+        self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Pod name not found", result.error_reason)
 
     def test_snapshots_list_api_exception(self):
@@ -687,6 +667,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             namespace="test-ns",
             snapshot_uid="target-snap",
             resource_version=None,
+            timeout=180,
         )
 
     def test_snapshots_delete_all_invalid_strategy(self):
@@ -716,7 +697,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                     )
                 ],
                 error_reason="",
-                error_code=SNAPSHOT_SUCCESS_CODE,
+                error_code=SUCCESS_CODE,
             )
             self.mock_k8s_helper.custom_objects_api.delete_namespaced_custom_object.return_value = (
                 {}
@@ -743,6 +724,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 namespace="test-ns",
                 snapshot_uid="snap-a",
                 resource_version=None,
+                timeout=180,
             )
 
     @patch(
@@ -823,12 +805,14 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         namespace="test-ns",
                         snapshot_uid="snap-1",
                         resource_version=None,
+                        timeout=180,
                     ),
                     call(
                         k8s_helper=self.mock_k8s_helper,
                         namespace="test-ns",
                         snapshot_uid="snap-3",
                         resource_version=None,
+                        timeout=180,
                     ),
                 ],
                 any_order=True,
@@ -867,7 +851,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 success=False,
                 snapshots=[],
                 error_reason="Could not connect",
-                error_code=SNAPSHOT_ERROR_CODE,
+                error_code=ERROR_CODE,
             )
             result = self.engine.delete_all()
             self.assertFalse(result.success)
@@ -886,7 +870,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 error_code=0,
             )
             self.engine.delete_all()
-            mock_execute.assert_called_once_with(scope="global")
+            mock_execute.assert_called_once_with(scope="global", timeout=180)
 
     def test_snapshots_delete_all_by_labels(self):
         """Test delete_all calls _execute_deletion with labels."""
@@ -898,7 +882,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 error_code=0,
             )
             self.engine.delete_all(delete_by="labels", label_value={"foo": "bar"})
-            mock_execute.assert_called_once_with(labels={"foo": "bar"})
+            mock_execute.assert_called_once_with(labels={"foo": "bar"}, timeout=180)
 
     def test_snapshots_delete_empty_fails(self):
         """Test delete raises TypeError if snapshot_uid is missing."""
@@ -936,7 +920,225 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
 
             self.assertTrue(result.success)
             self.assertEqual(result.deleted_snapshots, [])
+            
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_success(self, mock_is_suspended, mock_wait):
+        """Test suspend successfully takes a snapshot and scales down."""
+        mock_wait.return_value = True
+        with patch.object(self.engine, 'create') as mock_create:
+            mock_create.return_value = SnapshotResponse(
+                success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
+                snapshot_timestamp="2023-01-01T00:00:00Z", error_reason="", error_code=0
+            )
+            
+            result = self.sandbox.suspend(snapshot_before_suspend=True)
+            
+            self.assertTrue(result.success)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once_with(
+                group=SANDBOX_API_GROUP,
+                version=SANDBOX_API_VERSION,
+                namespace=self.sandbox.namespace,
+                plural=SANDBOX_PLURAL_NAME,
+                name=self.sandbox.sandbox_id,
+                body={"spec": {"replicas": 0}}
+            )
 
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_without_snapshot(self, mock_is_suspended, mock_wait):
+        """Test suspend successfully scales down without taking a snapshot."""
+        mock_wait.return_value = True
+        result = self.sandbox.suspend(snapshot_before_suspend=False)
+        
+        self.assertTrue(result.success)
+        self.assertIsNone(result.snapshot_response)
+        self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once()
+
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_pod_not_there(self, mock_is_suspended):
+        """Scenario 1: What happens if pod is not there when suspending."""
+        # If the pod is not there, the snapshot creation fails.
+        # We simulate the snapshot failure and assert that the scale down does not occur.
+        with patch.object(self.engine, 'create') as mock_create:
+            mock_create.return_value = SnapshotResponse(
+                success=False, trigger_name="test-trigger", snapshot_uid=None,
+                snapshot_timestamp=None, error_reason="Pod not found", error_code=1
+            )
+            
+            result = self.sandbox.suspend(snapshot_before_suspend=True)
+            
+            self.assertFalse(result.success)
+            self.assertIn("Pod not found", result.error_reason)
+            # Ensure we don't scale down the replica state if the snapshot fails
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_not_called()
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_ready')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended')
+    def test_resume_pod_already_exists(self, mock_is_suspended, mock_wait):
+        """Scenario 2: What happens if pod is there before resume call."""
+        mock_wait.return_value = True
+        mock_is_suspended.return_value = True
+        with patch.object(self.engine, 'list') as mock_list:
+            mock_list.return_value = ListSnapshotResult(success=True, snapshots=[], error_reason="", error_code=0)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.return_value = {"status": "patched"}
+            
+            result = self.sandbox.resume()
+            
+            self.assertTrue(result.success)
+            self.assertFalse(result.restored_from_snapshot)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once_with(
+                group=SANDBOX_API_GROUP,
+                version=SANDBOX_API_VERSION,
+                namespace=self.sandbox.namespace,
+                plural=SANDBOX_PLURAL_NAME,
+                name=self.sandbox.sandbox_id,
+                body={"spec": {"replicas": 1}}
+            )
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended')
+    def test_suspend_multiple_calls(self, mock_is_suspended, mock_wait):
+        """Scenario 3: What happens when multiple calls are made to suspend before resuming."""
+        mock_wait.return_value = True
+        mock_is_suspended.side_effect = [False, True]
+        with patch.object(self.engine, 'create') as mock_create:
+            mock_create.return_value = SnapshotResponse(
+                success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
+                snapshot_timestamp="2023-01-01T00:00:00Z", error_reason="", error_code=0
+            )
+            
+            self.sandbox.suspend(snapshot_before_suspend=True)
+            self.sandbox.suspend(snapshot_before_suspend=True)
+            
+            # Suspend APIs are called only
+            # Second suspend returns success early
+            self.assertEqual(mock_create.call_count, 1)
+            self.assertEqual(
+                self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.call_count, 1
+            )
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_ready')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended')
+    def test_resume_not_restored_from_snapshot(self, mock_is_suspended, mock_wait):
+        """Scenario 4: What happens if the pod is not restored from snapshot on resume."""
+        mock_wait.return_value = True
+        mock_is_suspended.return_value = True
+        with patch.object(self.engine, 'list') as mock_list:
+            mock_list.return_value = ListSnapshotResult(
+                success=True, 
+                snapshots=[SnapshotDetail(snapshot_uid="uid-123", source_pod="p", creation_timestamp="ts", status="Ready")], 
+                error_reason="", error_code=0
+            )
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.return_value = {"status": "patched"}
+            
+            mock_pod = MagicMock()
+            mock_condition_ready = MagicMock()
+            mock_condition_ready.type = "Ready"
+            mock_condition_ready.status = "True"
+            mock_pod.status.conditions = [mock_condition_ready]
+            mock_pod.metadata.deletion_timestamp = None
+            self.mock_k8s_helper.core_v1_api.read_namespaced_pod.return_value = mock_pod
+            
+            result = self.sandbox.resume(wait_timeout=2)
+            
+            self.assertFalse(result.success)
+            self.assertFalse(result.restored_from_snapshot)
+            self.assertIn("started as a fresh instance", result.error_reason)
+        
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_api_exception(self, mock_is_suspended):
+        """Test suspend raises exception when custom object patch API call fails."""
+        with patch.object(self.engine, 'create') as mock_create:
+            mock_create.return_value = SnapshotResponse(
+                success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
+                snapshot_timestamp="2023-01-01T00:00:00Z", error_reason="", error_code=0
+            )
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.side_effect = ApiException("Failed")
+            
+            result = self.sandbox.suspend()
+            self.assertFalse(result.success)
+            self.assertIn("Failed", result.error_reason)
+
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_resume_api_exception(self, mock_is_suspended):
+        """Test resume raises exception when custom object patch API call fails."""
+        with patch.object(self.sandbox, '_get_latest_snapshot_uid', return_value='uid-123'):
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.side_effect = ApiException("Failed")
+            
+            result = self.sandbox.resume()
+            self.assertFalse(result.success)
+            self.assertIn("Failed", result.error_reason)
+
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_resume_get_snapshot_uid_failure(self, mock_is_suspended):
+        """Test resume handles failure when retrieving latest snapshot UID."""
+        with patch.object(self.sandbox, '_get_latest_snapshot_uid', side_effect=RuntimeError("List error")):
+            result = self.sandbox.resume()
+            self.assertFalse(result.success)
+            self.assertIn("Failed to get latest snapshot UID: List error", result.error_reason)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_not_called()
+
+    def test_get_latest_snapshot_uid_list_failure(self):
+        """Test _get_latest_snapshot_uid raises RuntimeError when list fails."""
+        with patch.object(self.engine, 'list') as mock_list:
+            mock_list.return_value = ListSnapshotResult(
+                success=False, snapshots=[], error_reason="List failed", error_code=1
+            )
+            with self.assertRaises(RuntimeError) as context:
+                self.sandbox._get_latest_snapshot_uid()
+            self.assertIn("Snapshot list request failed: List failed", str(context.exception))
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_ready')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_resume_timeout(self, mock_is_suspended, mock_wait):
+        """Test resume times out when wait_for_pod_ready expires."""
+        mock_wait.return_value = False
+        with patch.object(self.engine, 'list') as mock_list:
+            mock_list.return_value = ListSnapshotResult(
+                success=True, 
+                snapshots=[SnapshotDetail(snapshot_uid="uid-123", source_pod="p", creation_timestamp="ts", status="Ready")], 
+                error_reason="", error_code=0
+            )
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.return_value = {"status": "patched"}
+            
+            result = self.sandbox.resume(wait_timeout=1)
+            
+            self.assertFalse(result.success)
+            self.assertFalse(result.restored_from_snapshot)
+            self.assertEqual(result.snapshot_uid, "uid-123")
+            self.assertIn("Timed out", result.error_reason)
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_timeout(self, mock_is_suspended, mock_wait):
+        """Test suspend times out when wait_for_pod_termination expires."""
+        mock_wait.return_value = False
+        with patch.object(self.engine, 'create') as mock_create:
+            mock_create.return_value = SnapshotResponse(
+                success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
+                snapshot_timestamp="2023-01-01T00:00:00Z", error_reason="", error_code=0
+            )
+            
+            result = self.sandbox.suspend(wait_timeout=1)
+            
+            self.assertFalse(result.success)
+            self.assertIn("Timed out", result.error_reason)
+
+
+    def test_is_suspended_true(self):
+        self.mock_k8s_helper.custom_objects_api.get_namespaced_custom_object.return_value = {
+            "spec": {"replicas": 0},
+            "status": {}
+        }
+        self.assertTrue(self.sandbox.is_suspended())
+
+    def test_is_suspended_false(self):
+        self.mock_k8s_helper.custom_objects_api.get_namespaced_custom_object.return_value = {
+            "spec": {"replicas": 1},
+            "status": {"podIPs": ["10.0.0.1"]}
+        }
+        self.assertFalse(self.sandbox.is_suspended())
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/utils.py
@@ -214,7 +214,7 @@ def wait_for_snapshot_deletion(
     k8s_helper,
     namespace: str,
     snapshot_uid: str,
-    timeout: int = 60,
+    timeout: int = 180,
     resource_version: str | None = None,
 ) -> bool:
     """Waits for the PodSnapshot to be deleted from the cluster."""
@@ -266,4 +266,55 @@ def wait_for_snapshot_deletion(
         w.stop()
 
     logger.warning(f"Timed out waiting for PodSnapshot '{snapshot_uid}' to be deleted.")
+    return False
+
+
+def wait_for_pod_termination(
+    k8s_helper,
+    namespace: str,
+    pod_name: str,
+    pod_uid: str,
+    timeout: int = 180,
+) -> bool:
+    """Waits until the specified pod is terminated."""
+    logger.info(f"Waiting up to {timeout}s for pod '{pod_name}' (UID: {pod_uid}) to terminate...")
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            pod = k8s_helper.core_v1_api.read_namespaced_pod(pod_name, namespace)
+            if pod.metadata.uid != pod_uid:
+                # A new pod has taken this name; the old one has terminated.
+                return True
+        except ApiException as e:
+            if e.status == 404:
+                return True
+            else:
+                logger.error(f"Error checking pod status: {e}")
+        time.sleep(2)
+    return False
+
+
+def wait_for_pod_ready(
+    k8s_helper,
+    namespace: str,
+    get_pod_name_func,
+    timeout: int = 180,
+) -> bool:
+    """Waits until a newly created pod is ready."""
+    logger.info(f"Waiting up to {timeout}s for pod to become ready...")
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        pod_name = get_pod_name_func()
+        if pod_name:
+            try:
+                pod = k8s_helper.core_v1_api.read_namespaced_pod(pod_name, namespace)
+                if pod.metadata and not pod.metadata.deletion_timestamp:
+                    if pod.status and pod.status.conditions:
+                        for condition in pod.status.conditions:
+                            if condition.type == "Ready" and condition.status == "True":
+                                return True
+            except ApiException as e:
+                if e.status != 404:
+                    logger.error(f"Error checking pod status: {e}")
+        time.sleep(2)
     return False

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -53,6 +53,127 @@ def test_snapshot_response(snapshot_response: SnapshotResponse, snapshot_name: s
     assert snapshot_response.error_code == 0
 
 
+def wait_for_snapshot_ready(sandbox, snapshot_uid: str, max_retries: int = 30, sleep_time: int = 2) -> bool:
+    """Helper to poll until a specific snapshot UID is reported as ready."""
+    for _ in range(max_retries):
+        check_list = sandbox.snapshots.list()
+        if check_list.success and any(s.snapshot_uid == snapshot_uid for s in check_list.snapshots):
+            print(f"Snapshot '{snapshot_uid}' is ready.")
+            return True
+        time.sleep(sleep_time)
+    print(f"Warning: Snapshot '{snapshot_uid}' did not become ready in time.")
+    return False
+
+
+def test_manual_snapshots(client, sandbox, template_name: str, namespace: str) -> tuple[str, str]:
+    """Tests creating manual snapshots and restoring a sandbox from the latest snapshot."""
+    first_snapshot_trigger_name = "test-snapshot-10"
+    second_snapshot_trigger_name = "test-snapshot-20"
+
+    time.sleep(WAIT_TIME_SECONDS)
+    print(
+        f"Creating first manual pod snapshot '{first_snapshot_trigger_name}' after {WAIT_TIME_SECONDS} seconds..."
+    )
+    snapshot_response = sandbox.snapshots.create(first_snapshot_trigger_name)
+    test_snapshot_response(snapshot_response, first_snapshot_trigger_name)
+    first_snapshot_uid = snapshot_response.snapshot_uid
+    print(f"First snapshot UID: {first_snapshot_uid}")
+
+    time.sleep(WAIT_TIME_SECONDS)
+
+    print(
+        f"\nCreating second manual pod snapshot '{second_snapshot_trigger_name}' after {WAIT_TIME_SECONDS} seconds..."
+    )
+    snapshot_response = sandbox.snapshots.create(second_snapshot_trigger_name)
+    test_snapshot_response(snapshot_response, second_snapshot_trigger_name)
+    second_snapshot_uid = snapshot_response.snapshot_uid
+    print(f"Recent snapshot UID: {second_snapshot_uid}")
+
+    # Wait longer for the PodSnapshot controller's cache to recognize the new snapshot as the latest
+    print(f"Waiting for second snapshot '{second_snapshot_uid}' to become ready...")
+    wait_for_snapshot_ready(sandbox, second_snapshot_uid)
+
+    print(
+        f"\nChecking if sandbox was restored from latest snapshot '{second_snapshot_uid}'..."
+    )
+    restored_sandbox = client.create_sandbox(template_name, namespace=namespace)
+    restore_result = restored_sandbox.is_restored_from_snapshot(second_snapshot_uid)
+    assert restore_result.success, restore_result.error_reason
+    print("Pod was restored from the most recent snapshot.")
+
+    return first_snapshot_uid, second_snapshot_uid
+
+
+def test_suspend_resume(sandbox) -> str:
+    """Tests suspending and resuming a sandbox and verifying it restored correctly."""
+    print("\n======= Testing Suspend and Resume =======")
+
+    print(f"\nSuspending sandbox '{sandbox.sandbox_id}'...")
+    suspend_result = sandbox.suspend(snapshot_before_suspend=True)
+    assert suspend_result.success, f"Suspend failed: {suspend_result.error_reason}"
+    assert sandbox.is_suspended(), "Sandbox should be suspended."
+    suspend_third_snapshot_uid = suspend_result.snapshot_response.snapshot_uid if suspend_result.snapshot_response else 'None'
+    print(f"Sandbox suspended. Snapshot UID: {suspend_third_snapshot_uid}")
+
+    print(f"Waiting for suspend snapshot '{suspend_third_snapshot_uid}' to become ready...")
+    wait_for_snapshot_ready(sandbox, suspend_third_snapshot_uid)
+
+    print(f"\nResuming sandbox '{sandbox.sandbox_id}'...")
+    resume_result = sandbox.resume()
+    assert resume_result.success, f"Resume failed: {resume_result.error_reason}"
+    assert resume_result.restored_from_snapshot, "Sandbox should have been restored from snapshot."
+    assert not sandbox.is_suspended(), "Sandbox should not be suspended after resume."
+    print(f"Sandbox resumed. Restored from Snapshot UID: {resume_result.snapshot_uid}")
+    
+    return suspend_third_snapshot_uid
+
+
+def test_list_and_delete(sandbox, first_snapshot_uid: str, second_snapshot_uid: str, suspend_third_snapshot_uid: str):
+    """Tests listing all snapshots and verifying snapshot deletion."""
+    print("\n======= Testing List and Delete =======")
+    print(f"\nListing all snapshots for sandbox '{sandbox.sandbox_id}'...")
+    list_result = sandbox.snapshots.list()
+    assert list_result.success, list_result.error_reason
+
+    for snap in list_result.snapshots:
+        print(
+            f"Snapshot UID: {snap.snapshot_uid}, Source Pod: {snap.source_pod}, Creation Time: {snap.creation_timestamp}"
+        )
+    assert (
+        len(list_result.snapshots) == 3
+    ), f"Expected 3 snapshots, but got {len(list_result.snapshots)}"
+    assert (
+        list_result.snapshots[0].snapshot_uid == suspend_third_snapshot_uid
+    ), f"Expected most recent snapshot UID '{suspend_third_snapshot_uid}', but got '{list_result.snapshots[0].snapshot_uid}'"
+    assert (
+        list_result.snapshots[2].snapshot_uid == first_snapshot_uid
+    ), f"Expected older snapshot UID '{first_snapshot_uid}', but got '{list_result.snapshots[2].snapshot_uid}'"
+
+    print(
+        f"\nDeleting snapshot '{suspend_third_snapshot_uid}' of the sandbox '{sandbox.sandbox_id}'..."
+    )
+    delete_result = sandbox.snapshots.delete(snapshot_uid=suspend_third_snapshot_uid)
+    assert delete_result.success, delete_result.error_reason
+    assert (
+        len(delete_result.deleted_snapshots) == 1
+    ), f"Expected 1 deleted snapshot, but got {len(delete_result.deleted_snapshots)}"
+    assert (
+        delete_result.deleted_snapshots[0] == suspend_third_snapshot_uid
+    ), f"Expected deleted snapshot UID '{suspend_third_snapshot_uid}', but got '{delete_result.deleted_snapshots[0]}''"
+    print(f"Snapshot '{suspend_third_snapshot_uid}' deleted successfully.")
+
+    print(f"\nDeleting all snapshots for sandbox '{sandbox.sandbox_id}'...")
+    delete_result = sandbox.snapshots.delete_all(delete_by="all")
+    assert delete_result.success, delete_result.error_reason
+    assert (
+        len(delete_result.deleted_snapshots) == 2
+    ), f"Expected 2 deleted snapshots, but got {len(delete_result.deleted_snapshots)}"
+    assert (
+        first_snapshot_uid in delete_result.deleted_snapshots and second_snapshot_uid in delete_result.deleted_snapshots
+    ), f"Expected deleted snapshot UIDs to include '{first_snapshot_uid}' and '{second_snapshot_uid}'"
+    print(f"Snapshots deleted successfully.")
+
+
 def main(
     template_name: str,
     api_url: str | None,
@@ -74,12 +195,6 @@ def main(
     except config.ConfigException:
         config.load_kube_config()
 
-    first_snapshot_trigger_name = "test-snapshot-10"
-    second_snapshot_trigger_name = "test-snapshot-20"
-
-    # grouping labels used in PodSnapshotPolicy to group snapshots - tenant-id and user-id
-    grouping_labels = {"tenant-id": "test-tenant", "user-id": "test-user"}
-
     client = None
     try:
         print("\n***** Phase 1: Starting Counter *****")
@@ -98,82 +213,17 @@ def main(
         print("\n======= Testing Pod Snapshot Extension =======")
 
         sandbox = client.create_sandbox(template_name, namespace=namespace)
-
+        
+        first_snapshot_uid, second_snapshot_uid = test_manual_snapshots(
+            client, sandbox, template_name, namespace
+        )
+        suspend_third_snapshot_uid = test_suspend_resume(sandbox)
+        
         time.sleep(WAIT_TIME_SECONDS)
-        print(
-            f"Creating first pod snapshot '{first_snapshot_trigger_name}' after {WAIT_TIME_SECONDS} seconds..."
+        
+        test_list_and_delete(
+            sandbox, first_snapshot_uid, second_snapshot_uid, suspend_third_snapshot_uid
         )
-        snapshot_response = sandbox.snapshots.create(first_snapshot_trigger_name)
-        test_snapshot_response(snapshot_response, first_snapshot_trigger_name)
-        first_snapshot_uid = snapshot_response.snapshot_uid
-        print(f"First snapshot UID: {first_snapshot_uid}")
-
-        time.sleep(WAIT_TIME_SECONDS)
-
-        print(
-            f"\nCreating second pod snapshot '{second_snapshot_trigger_name}' after {WAIT_TIME_SECONDS} seconds..."
-        )
-        snapshot_response = sandbox.snapshots.create(second_snapshot_trigger_name)
-        test_snapshot_response(snapshot_response, second_snapshot_trigger_name)
-        recent_snapshot_uid = snapshot_response.snapshot_uid
-        print(f"Recent snapshot UID: {recent_snapshot_uid}")
-
-        # Wait a moment for the PodSnapshotPolicy controller's cache to recognize the new snapshot as the latest
-        time.sleep(WAIT_TIME_SECONDS)
-
-        print(
-            f"\nChecking if sandbox was restored from snapshot '{recent_snapshot_uid}'..."
-        )
-        restored_sandbox = client.create_sandbox(template_name, namespace=namespace)
-        restore_result = restored_sandbox.is_restored_from_snapshot(recent_snapshot_uid)
-        assert restore_result.success, restore_result.error_reason
-        print("Pod was restored from the most recent snapshot.")
-
-        print(f"\nListing all snapshots for sandbox '{sandbox.sandbox_id}'...")
-        list_result = sandbox.snapshots.list(
-            filter_by={"grouping_labels": grouping_labels}
-        )
-        assert list_result.success, list_result.error_reason
-
-        for snap in list_result.snapshots:
-            print(
-                f"Snapshot UID: {snap.snapshot_uid}, Source Pod: {snap.source_pod}, Creation Time: {snap.creation_timestamp}"
-            )
-        assert (
-            len(list_result.snapshots) == 2
-        ), f"Expected 2 snapshots, but got {len(list_result.snapshots)}"
-        assert (
-            list_result.snapshots[0].snapshot_uid == recent_snapshot_uid
-        ), f"Expected most recent snapshot UID '{recent_snapshot_uid}', but got '{list_result.snapshots[0].snapshot_uid}'"
-        assert (
-            list_result.snapshots[1].snapshot_uid == first_snapshot_uid
-        ), f"Expected older snapshot UID '{first_snapshot_uid}', but got '{list_result.snapshots[1].snapshot_uid}'"
-
-        print(
-            f"\nDeleting snapshot '{recent_snapshot_uid}' of the sandbox '{sandbox.sandbox_id}'..."
-        )
-        delete_result = sandbox.snapshots.delete(snapshot_uid=recent_snapshot_uid)
-        assert delete_result.success, delete_result.error_reason
-        assert (
-            len(delete_result.deleted_snapshots) == 1
-        ), f"Expected 1 deleted snapshot, but got {len(delete_result.deleted_snapshots)}"
-        assert (
-            delete_result.deleted_snapshots[0] == recent_snapshot_uid
-        ), f"Expected deleted snapshot UID '{recent_snapshot_uid}', but got '{delete_result.deleted_snapshots[0]}''"
-        print(f"Snapshot '{recent_snapshot_uid}' deleted successfully.")
-
-        print(f"\nDeleting all snapshots for sandbox '{sandbox.sandbox_id}'...")
-        delete_result = sandbox.snapshots.delete_all(
-            delete_by="labels", filter_value=grouping_labels
-        )
-        assert delete_result.success, delete_result.error_reason
-        assert (
-            len(delete_result.deleted_snapshots) == 1
-        ), f"Expected 1 deleted snapshot, but got {len(delete_result.deleted_snapshots)}"
-        assert (
-            delete_result.deleted_snapshots[0] == first_snapshot_uid
-        ), f"Expected deleted snapshot UID '{first_snapshot_uid}', but got '{delete_result.deleted_snapshots[0]}''"
-        print(f"Snapshot '{first_snapshot_uid}' deleted successfully.")
 
         print("--- Pod Snapshot Test Passed! ---")
 


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/agent-sandbox/issues/530

### Description

This PR provides support for `suspend` and `resume` methods in Pod snapshot extension client. 

1. `sandbox.suspend` - Suspend allows you to take snapshot optionally before terminating the pod.
2. `sandbox.resume` - Resume created a new pod. If snapshots are presents, it picks up the latest snapshot to create a pod or else it creates a fresh pod.

### Testing

1. Unit tests - Added associated unit tests for the class.
2. Integration tests: https://paste.googleplex.com/4744520672608256