### PR TITLE
Fix stale observedTimes entries for ControllerStartupLatency

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -110,6 +110,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	claim := &extensionsv1alpha1.SandboxClaim{}
 	if err := r.Get(ctx, req.NamespacedName, claim); err != nil {
 		if k8errors.IsNotFound(err) {
+			// Fallback cleanup to prevent memory leaks if the delete predicate was missed or a stale request is processed.
 			r.observedTimes.Delete(req.NamespacedName)
 			logger.V(1).Info("SandboxClaim not found, ignoring", "request", req.NamespacedName)
 			return ctrl.Result{}, nil
@@ -133,39 +134,8 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Initialize trace ID and observation time for active resources missing them.
-	// Inline patch, no early return, to avoid forcing a second reconcile cycle.
-	traceContext := r.Tracer.GetTraceContext(ctx)
-	needObservabilityPatch := claim.Annotations[asmetrics.ObservabilityAnnotation] == ""
-	needTraceContextPatch := traceContext != "" && (claim.Annotations[asmetrics.TraceContextAnnotation] == "")
-
-	if needObservabilityPatch || needTraceContextPatch {
-		patch := client.MergeFrom(claim.DeepCopy())
-		if claim.Annotations == nil {
-			claim.Annotations = make(map[string]string)
-		}
-		if needObservabilityPatch {
-			key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-			if actualObservedTimeEntry, ok := r.observedTimes.Load(key); ok {
-				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
-				if observedEntry.uid == claim.UID {
-					claim.Annotations[asmetrics.ObservabilityAnnotation] = observedEntry.timestamp.Format(time.RFC3339Nano)
-				} else {
-					now := time.Now()
-					claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
-					r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
-				}
-			} else {
-				now := time.Now()
-				claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
-				r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
-			}
-		}
-		if needTraceContextPatch {
-			claim.Annotations[asmetrics.TraceContextAnnotation] = traceContext
-		}
-		if err := r.Patch(ctx, claim, patch); err != nil {
-			return ctrl.Result{}, err
-		}
+	if err := r.initializeAnnotations(ctx, claim); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	originalClaimStatus := claim.Status.DeepCopy()
@@ -243,6 +213,44 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	logger.V(1).Info("End of Reconcile loop SandboxClaim", "result", result, "error", reconcileErr, "request", req.NamespacedName)
 	return result, reconcileErr
+}
+
+// initializeAnnotations initializes trace ID and observation time for active resources missing them.
+func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) error {
+	traceContext := r.Tracer.GetTraceContext(ctx)
+	needObservabilityPatch := claim.Annotations[asmetrics.ObservabilityAnnotation] == ""
+	needTraceContextPatch := traceContext != "" && (claim.Annotations[asmetrics.TraceContextAnnotation] == "")
+
+	if needObservabilityPatch || needTraceContextPatch {
+		patch := client.MergeFrom(claim.DeepCopy())
+		if claim.Annotations == nil {
+			claim.Annotations = make(map[string]string)
+		}
+		if needObservabilityPatch {
+			key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+			if actualObservedTimeEntry, ok := r.observedTimes.Load(key); ok {
+				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
+				if observedEntry.uid == claim.UID {
+					claim.Annotations[asmetrics.ObservabilityAnnotation] = observedEntry.timestamp.Format(time.RFC3339Nano)
+				} else {
+					now := time.Now()
+					claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
+					r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
+				}
+			} else {
+				now := time.Now()
+				claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
+			}
+		}
+		if needTraceContextPatch {
+			claim.Annotations[asmetrics.TraceContextAnnotation] = traceContext
+		}
+		if err := r.Patch(ctx, claim, patch); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // checkExpiration calculates if the claim is expired and how much time is left.

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -234,8 +234,8 @@ func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, clai
 
 			// Use the cached timestamp if the claim UID matches.
 			if ok {
-				entry := actualObservedTimeEntry.(observedTimeEntry)
-				if entry.uid == claim.UID {
+				entry, typeOk := actualObservedTimeEntry.(observedTimeEntry)
+				if typeOk && entry.uid == claim.UID {
 					timestamp = entry.timestamp
 				}
 			}
@@ -1054,8 +1054,8 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 			actualObservedTimeEntry, loaded := r.observedTimes.LoadOrStore(key, observedTimeEntry{timestamp: time.Now(), uid: e.Object.GetUID()})
 			if loaded {
 				// sync.Map returns any, so we need to type assert to observedTimeEntry
-				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
-				if observedEntry.uid != e.Object.GetUID() {
+				observedEntry, typeOk := actualObservedTimeEntry.(observedTimeEntry)
+				if !typeOk || observedEntry.uid != e.Object.GetUID() {
 					r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: e.Object.GetUID()})
 				}
 			}
@@ -1065,8 +1065,8 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 			key := types.NamespacedName{Name: e.ObjectNew.GetName(), Namespace: e.ObjectNew.GetNamespace()}
 			actualObservedTimeEntry, loaded := r.observedTimes.LoadOrStore(key, observedTimeEntry{timestamp: time.Now(), uid: e.ObjectNew.GetUID()})
 			if loaded {
-				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
-				if observedEntry.uid != e.ObjectNew.GetUID() {
+				observedEntry, typeOk := actualObservedTimeEntry.(observedTimeEntry)
+				if !typeOk || observedEntry.uid != e.ObjectNew.GetUID() {
 					r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: e.ObjectNew.GetUID()})
 				}
 			}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -80,6 +80,32 @@ type observedTimeEntry struct {
 	uid       types.UID
 }
 
+// observedTimeMap is a type-safe wrapper around sync.Map that only stores observedTimeEntry values.
+type observedTimeMap struct {
+	inner sync.Map
+}
+
+func (m *observedTimeMap) Load(key types.NamespacedName) (observedTimeEntry, bool) {
+	val, ok := m.inner.Load(key)
+	if !ok {
+		return observedTimeEntry{}, false
+	}
+	return val.(observedTimeEntry), true
+}
+
+func (m *observedTimeMap) Store(key types.NamespacedName, entry observedTimeEntry) {
+	m.inner.Store(key, entry)
+}
+
+func (m *observedTimeMap) Delete(key types.NamespacedName) {
+	m.inner.Delete(key)
+}
+
+func (m *observedTimeMap) LoadOrStore(key types.NamespacedName, entry observedTimeEntry) (observedTimeEntry, bool) {
+	actual, loaded := m.inner.LoadOrStore(key, entry)
+	return actual.(observedTimeEntry), loaded
+}
+
 // SandboxClaimReconciler reconciles a SandboxClaim object.
 type SandboxClaimReconciler struct {
 	client.Client
@@ -88,7 +114,7 @@ type SandboxClaimReconciler struct {
 	Recorder                events.EventRecorder
 	Tracer                  asmetrics.Instrumenter
 	MaxConcurrentReconciles int
-	observedTimes           sync.Map
+	observedTimes           observedTimeMap
 }
 
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims,verbs=get;list;watch;create;update;patch;delete
@@ -1036,8 +1062,8 @@ func (r *SandboxClaimReconciler) getOrRecordObservedTime(obj client.Object) time
 	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
 
 	// Fast path: Entry already exists and UID matches
-	if val, ok := r.observedTimes.Load(key); ok {
-		if entry, typeOk := val.(observedTimeEntry); typeOk && entry.uid == obj.GetUID() {
+	if entry, ok := r.observedTimes.Load(key); ok {
+		if entry.uid == obj.GetUID() {
 			return entry.timestamp
 		}
 	}
@@ -1047,13 +1073,12 @@ func (r *SandboxClaimReconciler) getOrRecordObservedTime(obj client.Object) time
 	actual, loaded := r.observedTimes.LoadOrStore(key, newEntry)
 	if loaded {
 		// Handle concurrent insertion: check if we need to overwrite due to UID mismatch
-		entry, typeOk := actual.(observedTimeEntry)
-		if !typeOk || entry.uid != obj.GetUID() {
+		if actual.uid != obj.GetUID() {
 			r.observedTimes.Store(key, newEntry)
 			return newEntry.timestamp
 		}
 		// UID matches, return the loaded timestamp
-		return entry.timestamp
+		return actual.timestamp
 	}
 	return newEntry.timestamp
 }

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -228,20 +228,24 @@ func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, clai
 		}
 		if needObservabilityPatch {
 			key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-			if actualObservedTimeEntry, ok := r.observedTimes.Load(key); ok {
-				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
-				if observedEntry.uid == claim.UID {
-					claim.Annotations[asmetrics.ObservabilityAnnotation] = observedEntry.timestamp.Format(time.RFC3339Nano)
-				} else {
-					now := time.Now()
-					claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
-					r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
+			actualObservedTimeEntry, ok := r.observedTimes.Load(key)
+
+			var timestamp time.Time
+
+			// Use the cached timestamp if the claim UID matches.
+			if ok {
+				entry := actualObservedTimeEntry.(observedTimeEntry)
+				if entry.uid == claim.UID {
+					timestamp = entry.timestamp
 				}
-			} else {
-				now := time.Now()
-				claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
-				r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
 			}
+
+			// If entry not found or UID mismatch, create a new timestamp and cache it
+			if timestamp.IsZero() {
+				timestamp = time.Now()
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: timestamp, uid: claim.UID})
+			}
+			claim.Annotations[asmetrics.ObservabilityAnnotation] = timestamp.Format(time.RFC3339Nano)
 		}
 		if needTraceContextPatch {
 			claim.Annotations[asmetrics.TraceContextAnnotation] = traceContext

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -227,24 +227,7 @@ func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, clai
 			claim.Annotations = make(map[string]string)
 		}
 		if needObservabilityPatch {
-			key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-			actualObservedTimeEntry, ok := r.observedTimes.Load(key)
-
-			var timestamp time.Time
-
-			// Use the cached timestamp if the claim UID matches.
-			if ok {
-				entry, typeOk := actualObservedTimeEntry.(observedTimeEntry)
-				if typeOk && entry.uid == claim.UID {
-					timestamp = entry.timestamp
-				}
-			}
-
-			// If entry not found or UID mismatch, create a new timestamp and cache it
-			if timestamp.IsZero() {
-				timestamp = time.Now()
-				r.observedTimes.Store(key, observedTimeEntry{timestamp: timestamp, uid: claim.UID})
-			}
+			timestamp := r.getOrRecordObservedTime(claim)
 			claim.Annotations[asmetrics.ObservabilityAnnotation] = timestamp.Format(time.RFC3339Nano)
 		}
 		if needTraceContextPatch {
@@ -1047,29 +1030,44 @@ func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensi
 	return template, nil
 }
 
+// getOrRecordObservedTime stores the first time an object is seen by the controller in an in-memory
+// map observedTimes for latency tracking. It returns the resolved timestamp for the object.
+func (r *SandboxClaimReconciler) getOrRecordObservedTime(obj client.Object) time.Time {
+	key := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
+
+	// Fast path: Entry already exists and UID matches
+	if val, ok := r.observedTimes.Load(key); ok {
+		if entry, typeOk := val.(observedTimeEntry); typeOk && entry.uid == obj.GetUID() {
+			return entry.timestamp
+		}
+	}
+
+	// Slow path: Entry missing or UID mismatched
+	newEntry := observedTimeEntry{timestamp: time.Now(), uid: obj.GetUID()}
+	actual, loaded := r.observedTimes.LoadOrStore(key, newEntry)
+	if loaded {
+		// Handle concurrent insertion: check if we need to overwrite due to UID mismatch
+		entry, typeOk := actual.(observedTimeEntry)
+		if !typeOk || entry.uid != obj.GetUID() {
+			r.observedTimes.Store(key, newEntry)
+			return newEntry.timestamp
+		}
+		// UID matches, return the loaded timestamp
+		return entry.timestamp
+	}
+	return newEntry.timestamp
+}
+
+// getTimingPredicate returns a predicate that stores the first time an object is seen by the
+// controller, and cleans up the in-memory map entry when the object is deleted.
 func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			key := types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()}
-			actualObservedTimeEntry, loaded := r.observedTimes.LoadOrStore(key, observedTimeEntry{timestamp: time.Now(), uid: e.Object.GetUID()})
-			if loaded {
-				// sync.Map returns any, so we need to type assert to observedTimeEntry
-				observedEntry, typeOk := actualObservedTimeEntry.(observedTimeEntry)
-				if !typeOk || observedEntry.uid != e.Object.GetUID() {
-					r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: e.Object.GetUID()})
-				}
-			}
+			r.getOrRecordObservedTime(e.Object)
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			key := types.NamespacedName{Name: e.ObjectNew.GetName(), Namespace: e.ObjectNew.GetNamespace()}
-			actualObservedTimeEntry, loaded := r.observedTimes.LoadOrStore(key, observedTimeEntry{timestamp: time.Now(), uid: e.ObjectNew.GetUID()})
-			if loaded {
-				observedEntry, typeOk := actualObservedTimeEntry.(observedTimeEntry)
-				if !typeOk || observedEntry.uid != e.ObjectNew.GetUID() {
-					r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: e.ObjectNew.GetUID()})
-				}
-			}
+			r.getOrRecordObservedTime(e.ObjectNew)
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -72,6 +72,14 @@ func getWarmPoolPolicy(claim *extensionsv1alpha1.SandboxClaim) extensionsv1alpha
 	return extensionsv1alpha1.WarmPoolPolicyDefault
 }
 
+// observedTimeEntry stores the first observed timestamp and the UID of the SandboxClaim.
+// We store the UID to protect against stale data when a claim is deleted and a new one
+// is created with the same name.
+type observedTimeEntry struct {
+	timestamp time.Time
+	uid       types.UID
+}
+
 // SandboxClaimReconciler reconciles a SandboxClaim object.
 type SandboxClaimReconciler struct {
 	client.Client
@@ -102,6 +110,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	claim := &extensionsv1alpha1.SandboxClaim{}
 	if err := r.Get(ctx, req.NamespacedName, claim); err != nil {
 		if k8errors.IsNotFound(err) {
+			r.observedTimes.Delete(req.NamespacedName)
 			logger.V(1).Info("SandboxClaim not found, ignoring", "request", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
@@ -136,12 +145,19 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		if needObservabilityPatch {
 			key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-			if val, ok := r.observedTimes.Load(key); ok {
-				claim.Annotations[asmetrics.ObservabilityAnnotation] = val.(time.Time).Format(time.RFC3339Nano)
+			if actualObservedTimeEntry, ok := r.observedTimes.Load(key); ok {
+				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
+				if observedEntry.uid == claim.UID {
+					claim.Annotations[asmetrics.ObservabilityAnnotation] = observedEntry.timestamp.Format(time.RFC3339Nano)
+				} else {
+					now := time.Now()
+					claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
+					r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
+				}
 			} else {
 				now := time.Now()
 				claim.Annotations[asmetrics.ObservabilityAnnotation] = now.Format(time.RFC3339Nano)
-				r.observedTimes.Store(key, now)
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: now, uid: claim.UID})
 			}
 		}
 		if needTraceContextPatch {
@@ -1023,16 +1039,30 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			key := types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()}
-			r.observedTimes.LoadOrStore(key, time.Now())
+			actualObservedTimeEntry, loaded := r.observedTimes.LoadOrStore(key, observedTimeEntry{timestamp: time.Now(), uid: e.Object.GetUID()})
+			if loaded {
+				// sync.Map returns any, so we need to type assert to observedTimeEntry
+				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
+				if observedEntry.uid != e.Object.GetUID() {
+					r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: e.Object.GetUID()})
+				}
+			}
 			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			key := types.NamespacedName{Name: e.ObjectNew.GetName(), Namespace: e.ObjectNew.GetNamespace()}
-			r.observedTimes.LoadOrStore(key, time.Now())
+			actualObservedTimeEntry, loaded := r.observedTimes.LoadOrStore(key, observedTimeEntry{timestamp: time.Now(), uid: e.ObjectNew.GetUID()})
+			if loaded {
+				observedEntry := actualObservedTimeEntry.(observedTimeEntry)
+				if observedEntry.uid != e.ObjectNew.GetUID() {
+					r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: e.ObjectNew.GetUID()})
+				}
+			}
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			key := types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()}
+			// Remove SandboxClaims from in memory map when SandboxClaims are deleted. No-op if key is not in map.
 			r.observedTimes.Delete(key)
 			return true
 		},

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1097,8 +1097,10 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			key := types.NamespacedName{Name: e.Object.GetName(), Namespace: e.Object.GetNamespace()}
-			// Remove SandboxClaims from in memory map when SandboxClaims are deleted. No-op if key is not in map.
-			r.observedTimes.Delete(key)
+			entry, ok := r.observedTimes.Load(key)
+			if ok && entry.uid == e.Object.GetUID() {
+				r.observedTimes.Delete(key)
+			}
 			return true
 		},
 	}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2408,7 +2408,7 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 	})
 }
 
-func TestSandboxClaimPredicates(t *testing.T) {
+func TestSandboxClaimTimingPredicates(t *testing.T) {
 	r := &SandboxClaimReconciler{}
 	pred := r.getTimingPredicate()
 
@@ -2419,6 +2419,7 @@ func TestSandboxClaimPredicates(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-2"},
 	}
 	key := types.NamespacedName{Name: "test-claim", Namespace: "default"}
+	pastTime := time.Now().Add(-10 * time.Second)
 
 	testCases := []struct {
 		name    string
@@ -2464,7 +2465,7 @@ func TestSandboxClaimPredicates(t *testing.T) {
 		{
 			name: "Update with different UID overwrites",
 			setup: func(r *SandboxClaimReconciler) {
-				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-1"})
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: pastTime, uid: "uid-1"})
 			},
 			trigger: func(p predicate.Predicate) bool {
 				return p.Update(event.UpdateEvent{ObjectNew: claim2, ObjectOld: claim1})
@@ -2477,6 +2478,9 @@ func TestSandboxClaimPredicates(t *testing.T) {
 				entry := val.(observedTimeEntry)
 				if entry.uid != "uid-2" {
 					t.Errorf("Expected UID uid-2 after update, got %s", entry.uid)
+				}
+				if !entry.timestamp.After(pastTime) {
+					t.Error("Expected timestamp to be updated to a newer value")
 				}
 			},
 		},
@@ -2523,6 +2527,94 @@ func TestSandboxClaimPredicates(t *testing.T) {
 				t.Error("expected predicate to return true")
 			}
 			tc.verify(t, r)
+		})
+	}
+}
+
+func TestGetOrRecordObservedTime(t *testing.T) {
+	claim1 := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-1"},
+	}
+	claim2 := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-2"},
+	}
+	pastTime := time.Now().Add(-10 * time.Second)
+
+	testCases := []struct {
+		name               string
+		claimToRecord      *extensionsv1alpha1.SandboxClaim
+		initialKey         types.NamespacedName
+		initialEntry       *observedTimeEntry
+		expectedUID        types.UID
+		expectNewTimestamp bool
+		expectedReturnTime time.Time
+	}{
+		{
+			name:               "New Entry stores time and returns it",
+			claimToRecord:      claim1,
+			expectedUID:        "uid-1",
+			expectNewTimestamp: true,
+		},
+		{
+			name:               "Existing Entry with same UID returns loaded timestamp",
+			claimToRecord:      claim1,
+			initialKey:         types.NamespacedName{Name: claim1.Name, Namespace: claim1.Namespace},
+			initialEntry:       &observedTimeEntry{timestamp: pastTime, uid: "uid-1"},
+			expectedUID:        "uid-1",
+			expectNewTimestamp: false,
+			expectedReturnTime: pastTime,
+		},
+		{
+			name:               "Existing Entry with different UID overwrites and returns new timestamp",
+			claimToRecord:      claim2,
+			initialKey:         types.NamespacedName{Name: claim1.Name, Namespace: claim1.Namespace},
+			initialEntry:       &observedTimeEntry{timestamp: pastTime, uid: claim1.UID},
+			expectedUID:        "uid-2",
+			expectNewTimestamp: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &SandboxClaimReconciler{}
+			if tc.initialEntry != nil {
+				r.observedTimes.Store(tc.initialKey, *tc.initialEntry)
+			}
+
+			res := r.getOrRecordObservedTime(tc.claimToRecord)
+
+			// Verify map state for the recorded claim
+			recordedKey := types.NamespacedName{Name: tc.claimToRecord.Name, Namespace: tc.claimToRecord.Namespace}
+			val, ok := r.observedTimes.Load(recordedKey)
+			if !ok {
+				t.Fatal("Expected entry in map")
+			}
+			entry := val.(observedTimeEntry)
+
+			if entry.uid != tc.expectedUID {
+				t.Errorf("Expected UID %s, got %s", tc.expectedUID, entry.uid)
+			}
+
+			if tc.expectNewTimestamp {
+				// Expect a new timestamp
+				if entry.timestamp.IsZero() {
+					t.Error("Expected timestamp to be set")
+				}
+				if tc.initialEntry != nil && entry.timestamp.Equal(tc.initialEntry.timestamp) {
+					t.Error("Expected a different timestamp than the initial one")
+				}
+				if !res.Equal(entry.timestamp) {
+					t.Error("Expected returned time to match stored time")
+				}
+			} else {
+				// Expect specific timestamp
+				if !entry.timestamp.Equal(tc.expectedReturnTime) {
+					t.Errorf("Expected timestamp %v, got %v", tc.expectedReturnTime, entry.timestamp)
+				}
+				if !res.Equal(tc.expectedReturnTime) {
+					t.Errorf("Expected returned time %v, got %v", tc.expectedReturnTime, res)
+				}
+			}
 		})
 	}
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2433,11 +2433,10 @@ func TestSandboxClaimTimingPredicates(t *testing.T) {
 				return p.Create(event.CreateEvent{Object: claim1})
 			},
 			verify: func(t *testing.T, r *SandboxClaimReconciler) {
-				val, ok := r.observedTimes.Load(key)
+				entry, ok := r.observedTimes.Load(key)
 				if !ok {
 					t.Fatal("Expected entry in map after Create")
 				}
-				entry := val.(observedTimeEntry)
 				if entry.uid != "uid-1" {
 					t.Errorf("Expected UID uid-1, got %s", entry.uid)
 				}
@@ -2452,11 +2451,10 @@ func TestSandboxClaimTimingPredicates(t *testing.T) {
 				return p.Update(event.UpdateEvent{ObjectNew: claim1, ObjectOld: claim1})
 			},
 			verify: func(t *testing.T, r *SandboxClaimReconciler) {
-				val, ok := r.observedTimes.Load(key)
+				entry, ok := r.observedTimes.Load(key)
 				if !ok {
 					t.Fatal("Expected entry in map after Update")
 				}
-				entry := val.(observedTimeEntry)
 				if entry.uid != "uid-1" {
 					t.Errorf("Expected UID uid-1, got %s", entry.uid)
 				}
@@ -2471,11 +2469,10 @@ func TestSandboxClaimTimingPredicates(t *testing.T) {
 				return p.Update(event.UpdateEvent{ObjectNew: claim2, ObjectOld: claim1})
 			},
 			verify: func(t *testing.T, r *SandboxClaimReconciler) {
-				val, ok := r.observedTimes.Load(key)
+				entry, ok := r.observedTimes.Load(key)
 				if !ok {
 					t.Fatal("Expected entry in map after Update with new UID")
 				}
-				entry := val.(observedTimeEntry)
 				if entry.uid != "uid-2" {
 					t.Errorf("Expected UID uid-2 after update, got %s", entry.uid)
 				}
@@ -2485,32 +2482,17 @@ func TestSandboxClaimTimingPredicates(t *testing.T) {
 			},
 		},
 		{
-			name: "Delete with mismatch UID does not delete",
+			name: "Delete removes entry by key",
 			setup: func(r *SandboxClaimReconciler) {
-				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-2"})
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-1"})
 			},
 			trigger: func(p predicate.Predicate) bool {
-				return p.Delete(event.DeleteEvent{Object: claim1}) // claim1 has uid-1
-			},
-			verify: func(t *testing.T, r *SandboxClaimReconciler) {
-				_, ok := r.observedTimes.Load(key)
-				if !ok {
-					t.Error("Entry should NOT be deleted when UID mismatches")
-				}
-			},
-		},
-		{
-			name: "Delete with matching UID deletes",
-			setup: func(r *SandboxClaimReconciler) {
-				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-2"})
-			},
-			trigger: func(p predicate.Predicate) bool {
-				return p.Delete(event.DeleteEvent{Object: claim2}) // claim2 has uid-2
+				return p.Delete(event.DeleteEvent{Object: claim1})
 			},
 			verify: func(t *testing.T, r *SandboxClaimReconciler) {
 				_, ok := r.observedTimes.Load(key)
 				if ok {
-					t.Error("Entry should be deleted when UID matches")
+					t.Error("Entry should be deleted on delete event")
 				}
 			},
 		},
@@ -2518,7 +2500,7 @@ func TestSandboxClaimTimingPredicates(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			r.observedTimes = sync.Map{} // Reset map for each test case
+			r.observedTimes = observedTimeMap{} // Reset map for each test case
 			if tc.setup != nil {
 				tc.setup(r)
 			}
@@ -2585,11 +2567,10 @@ func TestGetOrRecordObservedTime(t *testing.T) {
 
 			// Verify map state for the recorded claim
 			recordedKey := types.NamespacedName{Name: tc.claimToRecord.Name, Namespace: tc.claimToRecord.Namespace}
-			val, ok := r.observedTimes.Load(recordedKey)
+			entry, ok := r.observedTimes.Load(recordedKey)
 			if !ok {
 				t.Fatal("Expected entry in map")
 			}
-			entry := val.(observedTimeEntry)
 
 			if entry.uid != tc.expectedUID {
 				t.Errorf("Expected UID %s, got %s", tc.expectedUID, entry.uid)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1786,6 +1786,7 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "stored-time",
 					Namespace:         "default",
+					UID:               "uid-stored-time",
 					CreationTimestamp: pastTime,
 					Annotations: map[string]string{
 						asmetrics.ObservabilityAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
@@ -1802,7 +1803,7 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 			expectedControllerObservations: 1,
 			setupReconciler: func(r *SandboxClaimReconciler) {
 				key := types.NamespacedName{Name: "stored-time", Namespace: "default"}
-				r.observedTimes.Store(key, time.Now().Add(-5*time.Second))
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now().Add(-5 * time.Second), uid: "uid-stored-time"})
 			},
 		},
 		{
@@ -2411,47 +2412,151 @@ func TestSandboxClaimPredicates(t *testing.T) {
 	r := &SandboxClaimReconciler{}
 	pred := r.getTimingPredicate()
 
+	claim1 := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-1"},
+	}
+	claim2 := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-2"},
+	}
+	key := types.NamespacedName{Name: "test-claim", Namespace: "default"}
+
 	testCases := []struct {
-		name        string
-		trigger     func(p predicate.Predicate) bool
-		expectedKey types.NamespacedName
+		name    string
+		setup   func(r *SandboxClaimReconciler)
+		trigger func(p predicate.Predicate) bool
+		verify  func(t *testing.T, r *SandboxClaimReconciler)
 	}{
 		{
-			name: "CreateFunc stores time",
+			name: "Create stores time and UID",
 			trigger: func(p predicate.Predicate) bool {
-				return p.Create(event.CreateEvent{
-					Object: &extensionsv1alpha1.SandboxClaim{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default"},
-					},
-				})
+				return p.Create(event.CreateEvent{Object: claim1})
 			},
-			expectedKey: types.NamespacedName{Name: "test-claim", Namespace: "default"},
+			verify: func(t *testing.T, r *SandboxClaimReconciler) {
+				val, ok := r.observedTimes.Load(key)
+				if !ok {
+					t.Fatal("Expected entry in map after Create")
+				}
+				entry := val.(observedTimeEntry)
+				if entry.uid != "uid-1" {
+					t.Errorf("Expected UID uid-1, got %s", entry.uid)
+				}
+			},
 		},
 		{
-			name: "UpdateFunc stores time",
-			trigger: func(p predicate.Predicate) bool {
-				return p.Update(event.UpdateEvent{
-					ObjectNew: &extensionsv1alpha1.SandboxClaim{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-claim-update", Namespace: "default"},
-					},
-				})
+			name: "Update with same UID preserves",
+			setup: func(r *SandboxClaimReconciler) {
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-1"})
 			},
-			expectedKey: types.NamespacedName{Name: "test-claim-update", Namespace: "default"},
+			trigger: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{ObjectNew: claim1, ObjectOld: claim1})
+			},
+			verify: func(t *testing.T, r *SandboxClaimReconciler) {
+				val, ok := r.observedTimes.Load(key)
+				if !ok {
+					t.Fatal("Expected entry in map after Update")
+				}
+				entry := val.(observedTimeEntry)
+				if entry.uid != "uid-1" {
+					t.Errorf("Expected UID uid-1, got %s", entry.uid)
+				}
+			},
+		},
+		{
+			name: "Update with different UID overwrites",
+			setup: func(r *SandboxClaimReconciler) {
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-1"})
+			},
+			trigger: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{ObjectNew: claim2, ObjectOld: claim1})
+			},
+			verify: func(t *testing.T, r *SandboxClaimReconciler) {
+				val, ok := r.observedTimes.Load(key)
+				if !ok {
+					t.Fatal("Expected entry in map after Update with new UID")
+				}
+				entry := val.(observedTimeEntry)
+				if entry.uid != "uid-2" {
+					t.Errorf("Expected UID uid-2 after update, got %s", entry.uid)
+				}
+			},
+		},
+		{
+			name: "Delete with mismatch UID does not delete",
+			setup: func(r *SandboxClaimReconciler) {
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-2"})
+			},
+			trigger: func(p predicate.Predicate) bool {
+				return p.Delete(event.DeleteEvent{Object: claim1}) // claim1 has uid-1
+			},
+			verify: func(t *testing.T, r *SandboxClaimReconciler) {
+				_, ok := r.observedTimes.Load(key)
+				if !ok {
+					t.Error("Entry should NOT be deleted when UID mismatches")
+				}
+			},
+		},
+		{
+			name: "Delete with matching UID deletes",
+			setup: func(r *SandboxClaimReconciler) {
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-2"})
+			},
+			trigger: func(p predicate.Predicate) bool {
+				return p.Delete(event.DeleteEvent{Object: claim2}) // claim2 has uid-2
+			},
+			verify: func(t *testing.T, r *SandboxClaimReconciler) {
+				_, ok := r.observedTimes.Load(key)
+				if ok {
+					t.Error("Entry should be deleted when UID matches")
+				}
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r.observedTimes = sync.Map{} // Reset map for each test case
+			if tc.setup != nil {
+				tc.setup(r)
+			}
 			res := tc.trigger(pred)
 			if !res {
 				t.Error("expected predicate to return true")
 			}
-
-			if _, ok := r.observedTimes.Load(tc.expectedKey); !ok {
-				t.Errorf("expected time to be stored in observedTimes map for key %v", tc.expectedKey)
-			}
+			tc.verify(t, r)
 		})
+	}
+}
+
+func TestSandboxClaimReconcileCleanup(t *testing.T) {
+	scheme := newScheme(t)
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-1"},
+	}
+
+	// Create a fake client without the claim, so it returns NotFound
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client: client,
+		Scheme: scheme,
+	}
+
+	key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+	// Pre-populate map
+	reconciler.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: claim.UID})
+
+	req := reconcile.Request{
+		NamespacedName: key,
+	}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	_, ok := reconciler.observedTimes.Load(key)
+	if ok {
+		t.Error("Entry should be deleted by Reconcile when object is not found")
 	}
 }
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -2482,17 +2481,32 @@ func TestSandboxClaimTimingPredicates(t *testing.T) {
 			},
 		},
 		{
-			name: "Delete removes entry by key",
+			name: "Delete with mismatch UID does not delete",
+			setup: func(r *SandboxClaimReconciler) {
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-2"})
+			},
+			trigger: func(p predicate.Predicate) bool {
+				return p.Delete(event.DeleteEvent{Object: claim1}) // claim1 has uid-1
+			},
+			verify: func(t *testing.T, r *SandboxClaimReconciler) {
+				_, ok := r.observedTimes.Load(key)
+				if !ok {
+					t.Error("Entry should NOT be deleted when UID mismatches")
+				}
+			},
+		},
+		{
+			name: "Delete with matching UID deletes",
 			setup: func(r *SandboxClaimReconciler) {
 				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: "uid-1"})
 			},
 			trigger: func(p predicate.Predicate) bool {
-				return p.Delete(event.DeleteEvent{Object: claim1})
+				return p.Delete(event.DeleteEvent{Object: claim1}) // claim1 has uid-1
 			},
 			verify: func(t *testing.T, r *SandboxClaimReconciler) {
 				_, ok := r.observedTimes.Load(key)
 				if ok {
-					t.Error("Entry should be deleted on delete event")
+					t.Error("Entry should be deleted when UID matches")
 				}
 			},
 		},


### PR DESCRIPTION
Reusing SandboxClaim names across multiple test runs caused the `ControllerStartupLatency` metric to get stuck in the largest histogram bucket (reporting 240,000 ms). This was due to stale timestamps being preserved in the controller's in-memory map when a sandbox was deleted and recreated with the same name.

Changes:

* Replaced the simple timestamp storage in `observedTimes` with a struct containing both the timestamp and the claim's `UID`. This maintains idempotency and ensures that the controller can distinguish between different objects that share the same name.
* Updated the `Reconcile` loop and add a `Delete` predicate to remove entries from the `observedTimes` map when a `SandboxClaim` is deleted.
* Added logic to the reconciler to verify the `UID` matches the stored entry before applying the observability annotation.