### PR TITLE
feat: set service ports when containerPort is set

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
@@ -47,9 +48,11 @@ import (
 )
 
 const (
-	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
-	sandboxControllerFieldOwner = "sandbox-controller"
-	immediateRequeueDelay       = time.Millisecond
+	sandboxLabel = "agents.x-k8s.io/sandbox-name-hash"
+	// SandboxExposePortsAnnotation enables auto-populating Service ports from container ports when set to "true".
+	SandboxExposePortsAnnotation = "agents.x-k8s.io/auto-expose-ports"
+	sandboxControllerFieldOwner  = "sandbox-controller"
+	immediateRequeueDelay        = time.Millisecond
 )
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
@@ -463,6 +466,15 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 				needsUpdate = true
 			}
 
+			var desiredPorts []corev1.ServicePort
+			if shouldAutoExposePorts(sandbox) {
+				desiredPorts = buildServicePorts(&sandbox.Spec.PodTemplate.Spec)
+			}
+			if !reflect.DeepEqual(service.Spec.Ports, desiredPorts) {
+				service.Spec.Ports = desiredPorts
+				needsUpdate = true
+			}
+
 			if needsUpdate {
 				log.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
 				if err := r.Patch(ctx, service, patch); err != nil {
@@ -492,6 +504,14 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			},
 		},
 	}
+
+	if shouldAutoExposePorts(sandbox) {
+		ports := buildServicePorts(&sandbox.Spec.PodTemplate.Spec)
+		if len(ports) > 0 {
+			service.Spec.Ports = ports
+		}
+	}
+
 	service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 	if err := ctrl.SetControllerReference(sandbox, service, r.Scheme); err != nil {
 		log.Error(err, "Failed to set controller reference")
@@ -527,6 +547,79 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 func (r *SandboxReconciler) setServiceStatus(sandbox *sandboxv1alpha1.Sandbox, service *corev1.Service) {
 	sandbox.Status.Service = service.Name
 	sandbox.Status.ServiceFQDN = service.Name + "." + service.Namespace + ".svc." + r.ClusterDomain
+}
+
+func buildServicePorts(podSpec *corev1.PodSpec) []corev1.ServicePort {
+	if podSpec == nil {
+		return nil
+	}
+
+	seen := map[string]struct{}{}
+	seenNames := map[string]struct{}{}
+	var ports []corev1.ServicePort
+
+	for _, container := range podSpec.Containers {
+		for _, containerPort := range container.Ports {
+			if containerPort.ContainerPort <= 0 {
+				continue
+			}
+
+			protocol := containerPort.Protocol
+			if protocol == "" {
+				protocol = corev1.ProtocolTCP
+			}
+
+			key := fmt.Sprintf("%d/%s", containerPort.ContainerPort, protocol)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+
+			port := corev1.ServicePort{
+				Port:       containerPort.ContainerPort,
+				Protocol:   protocol,
+				TargetPort: intstr.FromInt32(containerPort.ContainerPort),
+			}
+
+			name := containerPort.Name
+			if name == "" {
+				name = fmt.Sprintf("port-%d-%s", containerPort.ContainerPort, strings.ToLower(string(protocol)))
+			}
+			if _, exists := seenNames[name]; exists {
+				name = uniqueServicePortName(name, containerPort.ContainerPort, protocol)
+			}
+			port.Name = name
+			seenNames[name] = struct{}{}
+
+			ports = append(ports, port)
+			seen[key] = struct{}{}
+		}
+	}
+
+	return ports
+}
+
+// ServicePort.Name is validated as a DNS_LABEL (max 63 chars) in Kubernetes 1.32+.
+const maxServicePortNameLength = 63
+
+func shouldAutoExposePorts(sandbox *sandboxv1alpha1.Sandbox) bool {
+	if sandbox == nil {
+		return false
+	}
+	value, ok := sandbox.Annotations[SandboxExposePortsAnnotation]
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(value, "true")
+}
+
+func uniqueServicePortName(base string, port int32, protocol corev1.Protocol) string {
+	protocolLower := strings.ToLower(string(protocol))
+	suffix := fmt.Sprintf("-%d-%s", port, protocolLower)
+	maxBase := maxServicePortNameLength - len(suffix)
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+	return base + suffix
 }
 
 func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Pod, error) {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -300,9 +301,9 @@ func TestReconcile(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		initialObjs          []runtime.Object
-		sandboxSpec          sandboxv1alpha1.SandboxSpec
 		sandboxAnnotations   map[string]string
 		reconcileCount       int
+		sandboxSpec          sandboxv1alpha1.SandboxSpec
 		wantStatus           sandboxv1alpha1.SandboxStatus
 		wantObjs             []client.Object
 		wantDeletedObjs      []client.Object
@@ -852,6 +853,161 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "SandboxExpired",
 						Message:            "Sandbox has expired",
+					},
+				},
+			},
+		},
+		{
+			name: "sandbox spec with container ports creates service ports",
+			sandboxAnnotations: map[string]string{
+				SandboxExposePortsAnnotation: "true",
+			},
+			sandboxSpec: sandboxv1alpha1.SandboxSpec{
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "main",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+									},
+									{
+										Name:          "metrics",
+										ContainerPort: 9090,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "duplicate",
+										ContainerPort: 8080,
+									},
+								},
+							},
+							{
+								Name: "sidecar",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "admin",
+										ContainerPort: 9000,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "http",
+										ContainerPort: 9091,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStatus: sandboxv1alpha1.SandboxStatus{
+				Service:       sandboxName,
+				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
+				Replicas:      1,
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "DependenciesNotReady",
+						Message:            "Pod exists with phase: ; Service Exists",
+					},
+				},
+			},
+			wantObjs: []client.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "main",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "http",
+										ContainerPort: 8080,
+									},
+									{
+										Name:          "metrics",
+										ContainerPort: 9090,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "duplicate",
+										ContainerPort: 8080,
+									},
+								},
+							},
+							{
+								Name: "sidecar",
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "admin",
+										ContainerPort: 9000,
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										Name:          "http",
+										ContainerPort: 9091,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+							},
+						},
+					},
+				},
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						ClusterIP: "None",
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       8080,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(8080),
+							},
+							{
+								Name:       "metrics",
+								Port:       9090,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(9090),
+							},
+							{
+								Name:       "admin",
+								Port:       9000,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(9000),
+							},
+							{
+								Name:       "http-9091-tcp",
+								Port:       9091,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(9091),
+							},
+						},
 					},
 				},
 			},
@@ -1699,6 +1855,26 @@ func TestReconcileService(t *testing.T) {
 		},
 		Spec: sandboxv1alpha1.SandboxSpec{
 			Replicas: new(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "main",
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: 8080,
+								},
+								{
+									Name:          "metrics",
+									ContainerPort: 9090,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -1907,6 +2083,421 @@ func TestReconcileService(t *testing.T) {
 			},
 			wantStatusService:     sandboxName,
 			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "adopts unowned service with matching labels and selector",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+				},
+			},
+		},
+		{
+			name:    "creates service without ports when annotation missing",
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+				},
+			},
+		},
+		{
+			name: "creates service with ports when annotation enabled",
+			sandbox: func() *sandboxv1alpha1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Annotations = map[string]string{
+					SandboxExposePortsAnnotation: "true",
+				}
+				return sb
+			}(),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       8080,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(8080),
+						},
+						{
+							Name:       "metrics",
+							Port:       9090,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(9090),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "creates service with unique port names when container port names collide",
+			sandbox: func() *sandboxv1alpha1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Annotations = map[string]string{
+					SandboxExposePortsAnnotation: "true",
+				}
+				sb.Spec.PodTemplate.Spec.Containers = []corev1.Container{
+					{
+						Name: "main",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								ContainerPort: 8080,
+							},
+						},
+					},
+					{
+						Name: "sidecar",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								ContainerPort: 9091,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+					},
+				}
+				return sb
+			}(),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       8080,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(8080),
+						},
+						{
+							Name:       "http-9091-tcp",
+							Port:       9091,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(9091),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "adds ports to existing owned service when annotation enabled",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							sandboxLabel: nameHash,
+						},
+					},
+				},
+			},
+			sandbox: func() *sandboxv1alpha1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Annotations = map[string]string{
+					SandboxExposePortsAnnotation: "true",
+				}
+				return sb
+			}(),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       8080,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(8080),
+						},
+						{
+							Name:       "metrics",
+							Port:       9090,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(9090),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "removes ports from existing owned service when annotation disabled",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "old-port",
+								Port:       9999,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(9999),
+							},
+						},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+				},
+			},
+		},
+		{
+			name: "updates ports on existing owned service when container ports change",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name:       "http",
+								Port:       8080,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(8080),
+							},
+							{
+								Name:       "metrics",
+								Port:       9090,
+								Protocol:   corev1.ProtocolTCP,
+								TargetPort: intstr.FromInt32(9090),
+							},
+						},
+					},
+				},
+			},
+			sandbox: func() *sandboxv1alpha1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Annotations = map[string]string{
+					SandboxExposePortsAnnotation: "true",
+				}
+				sb.Spec.PodTemplate.Spec.Containers = []corev1.Container{
+					{
+						Name: "main",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								ContainerPort: 8080,
+							},
+							{
+								Name:          "grpc",
+								ContainerPort: 50051,
+							},
+						},
+					},
+				}
+				return sb
+			}(),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       8080,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(8080),
+						},
+						{
+							Name:       "grpc",
+							Port:       50051,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(50051),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "creates service with generated port names when container ports have no name",
+			sandbox: func() *sandboxv1alpha1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Annotations = map[string]string{
+					SandboxExposePortsAnnotation: "true",
+				}
+				sb.Spec.PodTemplate.Spec.Containers = []corev1.Container{
+					{
+						Name: "main",
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 8080,
+							},
+							{
+								ContainerPort: 9090,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+					},
+				}
+				return sb
+			}(),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "port-8080-tcp",
+							Port:       8080,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(8080),
+						},
+						{
+							Name:       "port-9090-tcp",
+							Port:       9090,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromInt32(9090),
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
related to https://github.com/kubernetes-sigs/agent-sandbox/issues/154

Populate headless Services with port definitions when the sandbox pod template declares container ports.
Deduplicate ports per protocol, default to TCP when unspecified, and reuse container port names in the Service spec.

services like:

```shell
bin % kubectl -n test-abc get svc
NAME                TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
sandbox-clusterip   ClusterIP   None         <none>        80/TCP    1s
```
Some details:
1. I added uniqueness handling for service port names. When duplicate containerPort.Name values appear across containers, the controller now generates a unique service port name (`e.g. <name>-<port>-<protocol>`) to avoid collisions.
2. I added a simple opt-in switch via annotation (`agents.x-k8s.io/auto-expose-ports: "true"`). When unset/false, the controller creates the headless Service without ports; when true, it auto-populates ports from the pod template. 