### PR TITLE
override podsnapshot api version

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 # Constants for API Groups and Resources
 GATEWAY_API_GROUP = "gateway.networking.k8s.io"
 GATEWAY_API_VERSION = "v1"
@@ -29,7 +31,7 @@ POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
 PODSNAPSHOT_POD_NAME_LABEL = "podsnapshot.gke.io/pod-name"
 
 PODSNAPSHOT_API_GROUP = "podsnapshot.gke.io"
-PODSNAPSHOT_API_VERSION = "v1alpha1"
+PODSNAPSHOT_API_VERSION = os.environ.get("PODSNAPSHOT_API_VERSION", "v1alpha1")
 PODSNAPSHOT_PLURAL = "podsnapshots"
 PODSNAPSHOTMANUALTRIGGER_PLURAL = "podsnapshotmanualtriggers"
 PODSNAPSHOTMANUALTRIGGER_API_KIND = "PodSnapshotManualTrigger"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/podsnapshot_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/podsnapshot_client.py
@@ -32,8 +32,11 @@ class PodSnapshotSandboxClient(SandboxClient[SandboxWithSnapshotSupport]):
 
     def __init__(
         self,
-        *args, **kwargs,
+        *args,
+        podsnapshot_api_version: str | None = None,
+        **kwargs,
     ):
+        self.podsnapshot_api_version = podsnapshot_api_version or PODSNAPSHOT_API_VERSION
         super().__init__(*args, **kwargs)
 
         self.snapshot_crd_installed = self._check_snapshot_crd_installed()
@@ -49,7 +52,7 @@ class PodSnapshotSandboxClient(SandboxClient[SandboxWithSnapshotSupport]):
         try:
             resource_list = self.k8s_helper.custom_objects_api.get_api_resources(
                 group=PODSNAPSHOT_API_GROUP,
-                version=PODSNAPSHOT_API_VERSION,
+                version=self.podsnapshot_api_version,
             )
             if not resource_list or not resource_list.resources:
                 return False

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -47,11 +47,13 @@ class ResumeResponse(BaseModel):
 
 class SandboxWithSnapshotSupport(Sandbox):
     def __init__(self, *args, **kwargs):
+        podsnapshot_api_version = kwargs.pop("podsnapshot_api_version", None)
         super().__init__(*args, **kwargs)
         self._snapshots = SnapshotEngine(
             namespace=self.namespace,
             k8s_helper=self.k8s_helper,
             get_pod_name_func=self.get_pod_name,
+            api_version=podsnapshot_api_version,
         )
 
     @property

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -91,11 +91,13 @@ class SnapshotEngine:
         namespace: str,
         k8s_helper,
         get_pod_name_func: Callable[[], str],
+        api_version: str | None = None,
     ):
         self.namespace = namespace
         self.k8s_helper = k8s_helper
         self.get_pod_name_func = get_pod_name_func
         self.created_manual_triggers = []
+        self.api_version = api_version or PODSNAPSHOT_API_VERSION
 
     def create(
         self, trigger_name: str, podsnapshot_timeout: int = 180
@@ -117,7 +119,7 @@ class SnapshotEngine:
         trigger_name = f"{safe_trigger_name}-{timestamp}-{suffix}"
 
         manifest = {
-            "apiVersion": f"{PODSNAPSHOT_API_GROUP}/{PODSNAPSHOT_API_VERSION}",
+            "apiVersion": f"{PODSNAPSHOT_API_GROUP}/{self.api_version}",
             "kind": f"{PODSNAPSHOTMANUALTRIGGER_API_KIND}",
             "metadata": {"name": trigger_name, "namespace": self.namespace},
             "spec": {"targetPod": self.get_pod_name_func()},
@@ -127,7 +129,7 @@ class SnapshotEngine:
             pod_snapshot_manual_trigger_cr = (
                 self.k8s_helper.custom_objects_api.create_namespaced_custom_object(
                     group=PODSNAPSHOT_API_GROUP,
-                    version=PODSNAPSHOT_API_VERSION,
+                    version=self.api_version,
                     namespace=self.namespace,
                     plural=PODSNAPSHOTMANUALTRIGGER_PLURAL,
                     body=manifest,
@@ -163,6 +165,7 @@ class SnapshotEngine:
                 trigger_name=trigger_name,
                 podsnapshot_timeout=podsnapshot_timeout,
                 resource_version=resource_version,
+                api_version=self.api_version,
             )
 
             return SnapshotResponse(
@@ -225,7 +228,7 @@ class SnapshotEngine:
                 try:
                     self.k8s_helper.custom_objects_api.delete_namespaced_custom_object(
                         group=PODSNAPSHOT_API_GROUP,
-                        version=PODSNAPSHOT_API_VERSION,
+                        version=self.api_version,
                         namespace=self.namespace,
                         plural=PODSNAPSHOTMANUALTRIGGER_PLURAL,
                         name=trigger_name,
@@ -306,7 +309,7 @@ class SnapshotEngine:
             # Fetch the PodSnapshots using label selector directly
             response = self.k8s_helper.custom_objects_api.list_namespaced_custom_object(
                 group=PODSNAPSHOT_API_GROUP,
-                version=PODSNAPSHOT_API_VERSION,
+                version=self.api_version,
                 namespace=self.namespace,
                 plural=PODSNAPSHOT_PLURAL,
                 label_selector=label_selector,
@@ -435,7 +438,7 @@ class SnapshotEngine:
                 delete_resp = (
                     self.k8s_helper.custom_objects_api.delete_namespaced_custom_object(
                         group=PODSNAPSHOT_API_GROUP,
-                        version=PODSNAPSHOT_API_VERSION,
+                        version=self.api_version,
                         namespace=self.namespace,
                         plural=PODSNAPSHOT_PLURAL,
                         name=uid,
@@ -457,6 +460,7 @@ class SnapshotEngine:
                     snapshot_uid=uid,
                     resource_version=resource_version,
                     timeout=timeout,
+                    api_version=self.api_version,
                 ):
                     deleted_snapshots.append(uid)
                 else:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -668,6 +668,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             snapshot_uid="target-snap",
             resource_version=None,
             timeout=180,
+            api_version=PODSNAPSHOT_API_VERSION,
         )
 
     def test_snapshots_delete_all_invalid_strategy(self):
@@ -725,6 +726,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 snapshot_uid="snap-a",
                 resource_version=None,
                 timeout=180,
+                api_version=PODSNAPSHOT_API_VERSION,
             )
 
     @patch(
@@ -806,6 +808,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         snapshot_uid="snap-1",
                         resource_version=None,
                         timeout=180,
+                        api_version=PODSNAPSHOT_API_VERSION,
                     ),
                     call(
                         k8s_helper=self.mock_k8s_helper,
@@ -813,6 +816,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         snapshot_uid="snap-3",
                         resource_version=None,
                         timeout=180,
+                        api_version=PODSNAPSHOT_API_VERSION,
                     ),
                 ],
                 any_order=True,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/utils.py
@@ -84,6 +84,7 @@ def wait_for_snapshot_to_be_completed(
     trigger_name: str,
     podsnapshot_timeout: int,
     resource_version: str | None = None,
+    api_version: str | None = None,
 ) -> SnapshotResult:
     """
     Waits for the PodSnapshotManualTrigger to be processed and returns SnapshotResult.
@@ -102,7 +103,7 @@ def wait_for_snapshot_to_be_completed(
             func=k8s_helper.custom_objects_api.list_namespaced_custom_object,
             namespace=namespace,
             group=PODSNAPSHOT_API_GROUP,
-            version=PODSNAPSHOT_API_VERSION,
+            version=api_version or PODSNAPSHOT_API_VERSION,
             plural=PODSNAPSHOTMANUALTRIGGER_PLURAL,
             field_selector=f"metadata.name={trigger_name}",
             timeout_seconds=podsnapshot_timeout,
@@ -216,13 +217,14 @@ def wait_for_snapshot_deletion(
     snapshot_uid: str,
     timeout: int = 180,
     resource_version: str | None = None,
+    api_version: str | None = None,
 ) -> bool:
     """Waits for the PodSnapshot to be deleted from the cluster."""
     # Check if already deleted
     try:
         k8s_helper.custom_objects_api.get_namespaced_custom_object(
             group=PODSNAPSHOT_API_GROUP,
-            version=PODSNAPSHOT_API_VERSION,
+            version=api_version or PODSNAPSHOT_API_VERSION,
             namespace=namespace,
             plural=PODSNAPSHOT_PLURAL,
             name=snapshot_uid,
@@ -245,7 +247,7 @@ def wait_for_snapshot_deletion(
             func=k8s_helper.custom_objects_api.list_namespaced_custom_object,
             namespace=namespace,
             group=PODSNAPSHOT_API_GROUP,
-            version=PODSNAPSHOT_API_VERSION,
+            version=api_version or PODSNAPSHOT_API_VERSION,
             plural=PODSNAPSHOT_PLURAL,
             field_selector=f"metadata.name={snapshot_uid}",
             timeout_seconds=timeout,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -77,7 +77,7 @@ class SandboxClient(Generic[T]):
         # Deletes all the sandboxes on program termination
         atexit.register(self.delete_all)
 
-    def create_sandbox(self, template: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None, *, shutdown_after_seconds: int | None = None) -> T:
+    def create_sandbox(self, template: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None, *, shutdown_after_seconds: int | None = None, **kwargs) -> T:
         """Provisions new Sandbox claim and returns a Sandbox handle which tracks 
            the underlying infrastructure.
 
@@ -128,7 +128,8 @@ class SandboxClient(Generic[T]):
                 namespace=namespace,
                 connection_config=self.connection_config,
                 tracer_config=self.tracer_config,
-                k8s_helper=self.k8s_helper
+                k8s_helper=self.k8s_helper,
+                **kwargs
             )
         except Exception:
             # If creation or waiting fails, ensure we don't leave an orphaned claim
@@ -138,7 +139,7 @@ class SandboxClient(Generic[T]):
         self._active_connection_sandboxes[(namespace, claim_name)] = sandbox
         return sandbox
 
-    def get_sandbox(self, claim_name: str, namespace: str = "default", resolve_timeout: int = 30) -> T:
+    def get_sandbox(self, claim_name: str, namespace: str = "default", resolve_timeout: int = 30, **kwargs) -> T:
         """
         Retrieves an existing sandbox handle given a sandbox claim name. 
         If the handle is closed or missing, it re-attaches to the infrastructure.
@@ -179,7 +180,8 @@ class SandboxClient(Generic[T]):
             namespace=namespace,
             connection_config=self.connection_config,
             tracer_config=self.tracer_config,
-            k8s_helper=self.k8s_helper
+            k8s_helper=self.k8s_helper,
+            **kwargs
         )
         
         self._active_connection_sandboxes[key] = new_handle


### PR DESCRIPTION
The current version of the python client is statically fixed to a specific PodSnapshot CRD version.  The PR enables that version to be manually overridden with an environment variable

`export PODSNAPSHOT_API_VERSION=v1`