### PR TITLE
Fix for Duplicate Sandbox Adoption

### DIFF
--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -25,6 +25,9 @@ import (
 const (
 	// ClaimExpiredReason is the reason used in conditions/events when a claim expires.
 	ClaimExpiredReason = "ClaimExpired"
+
+	// AssignedSandboxNameLabel is the label key applied to the claim to identify the adopted Sandbox name.
+	AssignedSandboxNameLabel = "agents.x-k8s.io/sandbox-name"
 )
 
 // WarmPoolPolicy describes the policy for using warm pools.

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -648,90 +648,31 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 
 			logger.Info("Attempting sandbox adoption", "sandbox candidate", adopted.Name, "warm pool", poolName, "claim", claim.Name)
 
-			// Take a snapshot of the pod BEFORE we mutate it to generate a clean JSON Patch.
-			originalAdopted := adopted.DeepCopy()
-
-			// Remove warm pool labels so the sandbox no longer appears in warm pool queries
-			delete(adopted.Labels, warmPoolSandboxLabel)
-			delete(adopted.Labels, sandboxTemplateRefHash)
-			delete(adopted.Labels, v1alpha1.SandboxPodTemplateHashLabel)
-
-			// Transfer ownership from SandboxWarmPool to SandboxClaim
-			adopted.OwnerReferences = nil
-			if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
+			// Update claim to record adoption (optimistic lock)
+			if claim.Labels == nil {
+				claim.Labels = make(map[string]string)
+			}
+			claim.Labels[extensionsv1alpha1.AssignedSandboxNameLabel] = adopted.Name
+			if err := r.Update(ctx, claim); err != nil {
 				r.WarmSandboxQueue.Add(templateHash, adoptedKey)
-				return false, fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
-			}
-
-			// Propagate trace context from claim
-			if adopted.Annotations == nil {
-				adopted.Annotations = make(map[string]string)
-			}
-
-			// Ensure the adopted sandbox records its pod name before it can be observed Ready.
-			if podName := adopted.Annotations[v1alpha1.SandboxPodNameAnnotation]; podName != adopted.Name {
-				if podName != "" {
-					logger.Info("Correcting adopted sandbox pod-name annotation", "sandbox", adopted.Name, "oldPodName", podName, "newPodName", adopted.Name)
-				}
-				adopted.Annotations[v1alpha1.SandboxPodNameAnnotation] = adopted.Name
-			}
-
-			if traceContext, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
-				adopted.Annotations[asmetrics.TraceContextAnnotation] = traceContext
-			}
-
-			// Propagate claim identity labels for discovery and NetworkPolicy targeting.
-			// Fork extension: also write SandboxIDLabel onto the top-level Sandbox metadata
-			// (KEP-0174 only propagates to pod template labels; platform's informer reads
-			// Sandbox.metadata.labels).
-			adopted.Labels = ensureClaimIdentityLabels(adopted.Labels, claim)
-			adopted.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(adopted.Spec.PodTemplate.ObjectMeta.Labels, claim)
-
-			// Fetch the template to construct the mergedMeta that reconcileActive will build.
-			template, templateErr := r.getTemplate(ctx, claim)
-			if templateErr == nil && template != nil {
-				var mergedMeta v1alpha1.PodMetadata
-				template.Spec.PodTemplate.ObjectMeta.DeepCopyInto(&mergedMeta)
-
-				if mergedMeta.Labels == nil {
-					mergedMeta.Labels = make(map[string]string)
-				}
-				mergedMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
-				mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
-
-				if err := mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
-					// Adoption hasn't been patched yet. Put the sandbox back to avoid draining the pool!
-					r.WarmSandboxQueue.Add(templateHash, adoptedKey)
-					logger.Error(err, "Failed to merge pod metadata for adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+				if k8errors.IsConflict(err) {
+					// Conflict means someone else updated the claim. We fail and retry.
 					return false, err
 				}
-
-				// Force an exact match
-				adopted.Spec.PodTemplate.ObjectMeta = mergedMeta
-			} else {
-				// Fallback (just in case template is somehow missing)
-				adopted.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = templateHash
-
-				if err := mergePodMetadata(&adopted.Spec.PodTemplate.ObjectMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
-					r.WarmSandboxQueue.Add(templateHash, adoptedKey)
-					logger.Error(err, "Failed to merge pod metadata for fallback adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
-					return false, err
-				}
+				logger.Error(err, "Failed to update claim for adoption", "claim", claim.Name, "sandbox", adopted.Name)
+				return false, err
 			}
 
-			if err := r.Patch(ctx, adopted, client.MergeFrom(originalAdopted)); err != nil {
+			// Call helper to complete adoption (patch sandbox)
+			if err := r.completeAdoption(ctx, claim, adopted); err != nil {
 				if k8errors.IsNotFound(err) {
 					return false, nil
 				}
-
 				r.WarmSandboxQueue.Add(templateHash, adoptedKey)
-
 				if k8errors.IsConflict(err) {
-					// Patch conflicts are not expected here in the common case, but they can still legitimately occur.
 					return false, nil
 				}
-
-				logger.Error(err, "Failed to patch adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+				logger.Error(err, "Failed to complete adoption for candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
 				return false, err
 			}
 
@@ -761,6 +702,74 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 
 	logger.Info("Failed to adopt sandbox after max retries", "claim", claim.Name)
 	return nil, nil
+}
+
+func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim, adopted *v1alpha1.Sandbox) error {
+	// Take a snapshot of the pod BEFORE we mutate it to generate a clean JSON Patch.
+	originalAdopted := adopted.DeepCopy()
+
+	// Remove warm pool labels so the sandbox no longer appears in warm pool queries
+	delete(adopted.Labels, warmPoolSandboxLabel)
+	delete(adopted.Labels, sandboxTemplateRefHash)
+	delete(adopted.Labels, v1alpha1.SandboxPodTemplateHashLabel)
+
+	// Transfer ownership from SandboxWarmPool to SandboxClaim
+	adopted.OwnerReferences = nil
+	if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
+		return fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
+	}
+
+	// Propagate trace context from claim
+	if adopted.Annotations == nil {
+		adopted.Annotations = make(map[string]string)
+	}
+
+	// Ensure the adopted sandbox records its pod name before it can be observed Ready.
+	if podName := adopted.Annotations[v1alpha1.SandboxPodNameAnnotation]; podName != adopted.Name {
+		adopted.Annotations[v1alpha1.SandboxPodNameAnnotation] = adopted.Name
+	}
+
+	if traceContext, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
+		adopted.Annotations[asmetrics.TraceContextAnnotation] = traceContext
+	}
+
+	// Propagate claim identity labels for discovery and NetworkPolicy targeting.
+	adopted.Labels = ensureClaimIdentityLabels(adopted.Labels, claim)
+	adopted.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(adopted.Spec.PodTemplate.ObjectMeta.Labels, claim)
+
+	// Fetch the template to construct the mergedMeta that reconcileActive will build.
+	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+	template, templateErr := r.getTemplate(ctx, claim)
+	if templateErr == nil && template != nil {
+		var mergedMeta v1alpha1.PodMetadata
+		template.Spec.PodTemplate.ObjectMeta.DeepCopyInto(&mergedMeta)
+
+		if mergedMeta.Labels == nil {
+			mergedMeta.Labels = make(map[string]string)
+		}
+		mergedMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
+		mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
+
+		if err := mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
+			return err
+		}
+
+		// Force an exact match
+		adopted.Spec.PodTemplate.ObjectMeta = mergedMeta
+	} else {
+		// Fallback (just in case template is somehow missing)
+		adopted.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = templateHash
+
+		if err := mergePodMetadata(&adopted.Spec.PodTemplate.ObjectMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
+			return err
+		}
+	}
+
+	if err := r.Patch(ctx, adopted, client.MergeFrom(originalAdopted)); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // isSandboxReady checks if a sandbox has Ready=True condition.
@@ -1051,6 +1060,48 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			}
 		} else if !k8errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get sandbox %q from status: %w", statusName, err)
+		}
+	}
+
+	// Check if a previously adopted sandbox is recorded in claim labels
+	if claim.Labels != nil {
+		if sbName := claim.Labels[extensionsv1alpha1.AssignedSandboxNameLabel]; sbName != "" {
+			logger.V(1).Info("Checking labels for sandbox name", "label", sbName, "claim", claim.Name)
+			sandbox := &v1alpha1.Sandbox{}
+			if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
+				if metav1.IsControlledBy(sandbox, claim) {
+					logger.Info("Found existing adopted sandbox from labels", "sandbox", sbName, "claim", claim.Name)
+					return sandbox, nil
+				}
+
+				controllerRef := metav1.GetControllerOf(sandbox)
+				if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
+					// Still in warm pool. Try to complete adoption!
+					logger.Info("Sandbox found by label still in warm pool, trying to complete adoption", "sandbox", sbName, "claim", claim.Name)
+
+					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
+						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
+							logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
+						} else {
+							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
+						}
+					} else {
+						// If succeeded, return error to retry so next reconcile sees it controlled by us!
+						return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sbName)
+					}
+				}
+
+				logger.Info("Sandbox recorded in label belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
+			} else if k8errors.IsNotFound(err) {
+				logger.Info("Sandbox recorded in label not found, removing stale label", "sandbox", sbName, "claim", claim.Name)
+				patch := client.MergeFrom(claim.DeepCopy())
+				delete(claim.Labels, extensionsv1alpha1.AssignedSandboxNameLabel)
+				if err := r.Patch(ctx, claim, patch); err != nil {
+					return nil, fmt.Errorf("failed to remove stale sandbox label: %w", err)
+				}
+			} else {
+				return nil, fmt.Errorf("failed to get sandbox %q from labels: %w", sbName, err)
+			}
 		}
 	}
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -3080,5 +3081,175 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 		t.Fatal("FATAL: Cross-namespace sandbox was successfully verified! The namespace check is missing.")
 	} else if !errors.Is(err, ErrCrossNamespaceAdoption) {
 		t.Errorf("Expected ErrCrossNamespaceAdoption, but got a different error: %v", err)
+	}
+}
+
+// TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag verifies that during informer cache lag,
+// the assigned sandbox label on the claim is used to identify the previously adopted Sandbox,
+// preventing duplicate adoptions from the warm pool.
+func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
+	scheme := newScheme(t)
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Labels: map[string]string{
+				"agents.x-k8s.io/sandbox-name": "adopted-sb",
+			},
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+		},
+	}
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	adoptedSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adopted-sb",
+			Namespace: "default",
+			UID:       "adopted-sb-uid",
+			Labels: map[string]string{
+				extensionsv1alpha1.SandboxIDLabel: "claim-uid-123",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        "warmpool-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				ObjectMeta: sandboxv1alpha1.PodMetadata{
+					Labels: map[string]string{
+						extensionsv1alpha1.SandboxIDLabel: "claim-uid-123",
+					},
+				},
+			},
+		},
+	}
+
+	// Another sandbox in the warm pool that we want to make sure doesn't get adopted
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	extraSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pool-sb-extra",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, claim, adoptedSandbox, extraSandbox).
+		WithStatusSubresource(claim).
+		Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	if isAdoptable(extraSandbox) == nil {
+		hash := extraSandbox.Labels[sandboxTemplateRefHash]
+		key := queue.SandboxKey{Namespace: extraSandbox.Namespace, Name: extraSandbox.Name}
+		warmSandboxQueue.Add(hash, key)
+	}
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: warmSandboxQueue,
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+
+	// Run reconcile
+	_, err := reconciler.Reconcile(context.Background(), req)
+	expectedErr := "triggered adoption completion for \"adopted-sb\": retrying"
+	if err == nil {
+		t.Fatal("Expected reconcile to fail with cache lag error, but it succeeded")
+	} else if err.Error() != expectedErr {
+		t.Errorf("Expected error %q, got: %q", expectedErr, err.Error())
+	}
+
+	// Verify that the claim status was NOT updated with the sandbox name (due to error)
+	updatedClaim := &extensionsv1alpha1.SandboxClaim{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+		t.Fatalf("failed to get claim: %v", err)
+	}
+
+	if updatedClaim.Status.SandboxStatus.Name == "adopted-sb" {
+		t.Error("expected claim status to NOT be updated with 'adopted-sb' during cache lag")
+	}
+
+	// Verify that the extra warm sandbox was NOT adopted (it should still have its warm pool labels)
+	var extra sandboxv1alpha1.Sandbox
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-extra", Namespace: "default"}, &extra); err != nil {
+		t.Fatalf("failed to get extra warm sandbox: %v", err)
+	}
+	if _, ok := extra.Labels[warmPoolSandboxLabel]; !ok {
+		t.Error("expected extra warm sandbox to still have warm pool label, meaning it was not incorrectly adopted during cache lag")
+	}
+
+	// Simulate the cache catching up!
+	// Fetch the adopted sandbox object, add the SandboxClaim owner reference, and update it in fakeClient.
+	var adopted sandboxv1alpha1.Sandbox
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "adopted-sb", Namespace: "default"}, &adopted); err != nil {
+		t.Fatalf("failed to get adopted sandbox: %v", err)
+	}
+	adopted.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+		Kind:       "SandboxClaim",
+		Name:       "test-claim",
+		UID:        "claim-uid-123",
+		Controller: ptr.To(true), // nolint:modernize
+	}}
+	if err := fakeClient.Update(context.Background(), &adopted); err != nil {
+		t.Fatalf("failed to update adopted sandbox with claim owner ref: %v", err)
+	}
+
+	// Run reconcile AGAIN
+	_, err = reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected second Reconcile to succeed after cache caught up, but failed: %v", err)
+	}
+
+	// Verify that the claim status WAS updated this time!
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+		t.Fatalf("failed to get claim: %v", err)
+	}
+	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
+		t.Errorf("expected claim status to be updated with 'adopted-sb' on 2nd pass, got %q", updatedClaim.Status.SandboxStatus.Name)
+	}
+
+	// Verify that the extra warm sandbox was STILL NOT adopted (it should still have its warm pool labels)
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-extra", Namespace: "default"}, &extra); err != nil {
+		t.Fatalf("failed to get extra warm sandbox: %v", err)
+	}
+	if _, ok := extra.Labels[warmPoolSandboxLabel]; !ok {
+		t.Error("expected extra warm sandbox to still have warm pool label after 2nd pass (should not have been adopted)")
 	}
 }


### PR DESCRIPTION
A race condition in the `SandboxClaim` controller allowed a single claim to adopt multiple sandboxes from the warm pool. This occurred when a sandbox adoption was successful, but the subsequent update to the `SandboxClaim` status failed or was delayed by informer cache lag. (https://github.com/kubernetes-sigs/agent-sandbox/issues/478)

This PR implements a robust multi-layered guard to prevent duplicate adoptions.

### Implementation Details

* Record the adopted sandbox's name in the claim's labels (claim.Labels[AssignedSandboxNameLabel] = adopted.Name).
* Use r.Update(ctx, claim) to persist this change. This acts as an optimistic lock by failing on resource version conflicts.
* This creates a "first-writer-wins" behavior: concurrent threads attempting to claim the same sandbox will fail if another thread has already acquired the lock (by successfully setting the label). This effectively prevents the issue where the same claim could adopt multiple sandboxes.


### Verification Results

A new unit test, `TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag`, has been added to simulate the race condition where a sandbox is adopted but the cache is not yet updated. The test verifies that the reconciler correctly identifies the existing adoption and updates the claim status instead of adopting a second sandbox.

### Test Parameters

The following parameters were used to validate the fix under high-concurrency scenarios:

```bash
# BURST_SIZE * TOTAL_BURSTS = Total sandbox claims created
BURST_SIZE=300
QPS=300
TOTAL_BURSTS=2
WARMPOOL_SIZE=600
RUNTIME_CLASS="" # Change to "gvisor" if your cluster supports it
```

### Deployment Args

The controller was deployed with the following configuration to maximize pressure on the API server and increase the likelihood of race conditions:

```yaml
        args:
        - "--leader-elect=true"
        - "--extensions"
        - "--enable-tracing=true"
        - --zap-log-level=debug
        - --zap-encoder=json
        - --enable-pprof-debug
        - --kube-api-qps=1000
        - --kube-api-burst=2000
        - --sandbox-concurrent-workers=400
        - --sandbox-claim-concurrent-workers=400
        - --sandbox-warm-pool-concurrent-workers=1
```

### Latency Comparison (ms)

The implementation ensures 100% correctness, which introduces expected latency overhead compared to the baseline.

Updates: Please see the latest performance test result at comment https://github.com/kubernetes-sigs/agent-sandbox/pull/559#issuecomment-4318367526.
