### PR TITLE
fix: reconcile selector and sandbox label drift for sandbox-owned Services

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -386,7 +386,29 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			}
 
 		case resourceOwnedBySandbox:
-			// Already owned by this sandbox — no action needed.
+			desiredSelector := map[string]string{
+				sandboxLabel: nameHash,
+			}
+			needsUpdate := false
+
+			if service.Labels == nil {
+				service.Labels = make(map[string]string)
+			}
+			if service.Labels[sandboxLabel] != nameHash {
+				service.Labels[sandboxLabel] = nameHash
+				needsUpdate = true
+			}
+			if !reflect.DeepEqual(service.Spec.Selector, desiredSelector) {
+				service.Spec.Selector = desiredSelector
+				needsUpdate = true
+			}
+
+			if needsUpdate {
+				log.Info("Reconciling owned service drift", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
+				if err := r.Update(ctx, service); err != nil {
+					return nil, fmt.Errorf("failed to update owned service: %w", err)
+				}
+			}
 		}
 
 		setServiceStatus(sandbox, service)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -389,6 +389,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			desiredSelector := map[string]string{
 				sandboxLabel: nameHash,
 			}
+			patch := client.MergeFrom(service.DeepCopy())
 			needsUpdate := false
 
 			if service.Labels == nil {
@@ -404,11 +405,12 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			}
 
 			if needsUpdate {
-				log.Info("Reconciling owned service drift", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
-				if err := r.Update(ctx, service); err != nil {
-					return nil, fmt.Errorf("failed to update owned service: %w", err)
+				log.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
+				if err := r.Patch(ctx, service, patch); err != nil {
+					return nil, fmt.Errorf("failed to patch owned service: %w", err)
 				}
 			}
+
 		}
 
 		setServiceStatus(sandbox, service)

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1460,6 +1460,48 @@ func TestReconcileService(t *testing.T) {
 			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
 		},
 		{
+			name: "repairs selector and label drift on service owned by this sandbox",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"keep": "me",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "something-else",
+						},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"keep":        "me",
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+
+		{
 			name: "refuses to use service owned by a different controller",
 			initialObjs: []runtime.Object{
 				&corev1.Service{

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1486,7 +1486,7 @@ func TestReconcileService(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						"keep":        "me",
+						"keep":       "me",
 						sandboxLabel: nameHash,
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},


### PR DESCRIPTION
Fixes #560 

## Summary

This change makes `reconcileService` repair critical drift on Services that are already owned by the Sandbox.

Previously, the controller repaired unowned Services during adoption, but skipped reconciliation for already-owned Services. As a result, an owned Service could keep a stale selector or lose the sandbox label indefinitely.

With this change, owned Services now reconcile:

- `metadata.labels[agents.x-k8s.io/sandbox-name-hash]`
- `spec.selector`

Unrelated labels are preserved, and the Service is only updated when drift is detected.
