### PR TITLE
Throw a graceful error when the template doesn't exist.

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/__init__.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/__init__.py
@@ -16,6 +16,7 @@ from .sandbox_client import SandboxClient
 from .exceptions import (
     SandboxError,
     SandboxNotFoundError,
+    SandboxTemplateNotFoundError,
     SandboxNotReadyError,
     SandboxPortForwardError,
     SandboxRequestError,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -31,7 +31,7 @@ from .constants import (
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
 )
-from .exceptions import SandboxMetadataError, SandboxNotFoundError
+from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError
 
 
 class AsyncK8sHelper:
@@ -137,7 +137,16 @@ class AsyncK8sHelper:
                         )
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         claim_object = event["object"]
-                        sandbox_status = claim_object.get("status", {}).get("sandbox", {})
+                        status = claim_object.get("status", {})
+                        
+                        for cond in status.get("conditions", []):
+                            if cond.get("type") == "Ready" and cond.get("status") == "False":
+                                if cond.get("reason") == "TemplateNotFound":
+                                    raise SandboxTemplateNotFoundError(
+                                        f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
+                                    )
+
+                        sandbox_status = status.get("sandbox", {})
                         # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
                         name = sandbox_status.get("name", "") or sandbox_status.get("Name", "")
                         if name:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -137,14 +137,17 @@ class AsyncK8sHelper:
                         )
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         claim_object = event["object"]
-                        status = claim_object.get("status", {})
+                        status = claim_object.get("status") or {}
                         
                         for cond in status.get("conditions", []):
-                            if cond.get("type") == "Ready" and cond.get("status") == "False":
-                                if cond.get("reason") == "TemplateNotFound":
-                                    raise SandboxTemplateNotFoundError(
-                                        f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
-                                    )
+                            if (
+                                cond.get("type") == "Ready"
+                                and cond.get("status") == "False"
+                                and cond.get("reason") == "TemplateNotFound"
+                            ):
+                                raise SandboxTemplateNotFoundError(
+                                    f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
+                                )
 
                         sandbox_status = status.get("sandbox", {})
                         # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
@@ -180,7 +183,7 @@ class AsyncK8sHelper:
                         continue
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         sandbox_object = event["object"]
-                        status = sandbox_object.get("status", {})
+                        status = sandbox_object.get("status") or {}
                         conditions = status.get("conditions", [])
                         for cond in conditions:
                             if cond.get("type") == "Ready" and cond.get("status") == "True":
@@ -274,7 +277,7 @@ class AsyncK8sHelper:
                         continue
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         gateway_object = event["object"]
-                        status = gateway_object.get("status", {})
+                        status = gateway_object.get("status") or {}
                         addresses = status.get("addresses", [])
                         if addresses:
                             ip_address = addresses[0].get("value")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/exceptions.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/exceptions.py
@@ -27,6 +27,10 @@ class SandboxNotFoundError(SandboxError):
     """Raised when the sandbox or sandbox claim cannot be found or was deleted."""
 
 
+class SandboxTemplateNotFoundError(SandboxError):
+    """Raised when the requested sandbox template does not exist."""
+
+
 class SandboxPortForwardError(SandboxError):
     """Raised when the port-forward process crashes."""
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -16,7 +16,7 @@ import logging
 import time
 from typing import List
 from kubernetes import client, config, watch
-from .exceptions import SandboxMetadataError, SandboxNotFoundError
+from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError
 
 # Constants for API Groups and Resources
 CLAIM_API_GROUP = "extensions.agents.x-k8s.io"
@@ -106,8 +106,17 @@ class K8sHelper:
                         f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
                 if event["type"] in ["ADDED", "MODIFIED"]:
                     claim_object = event['object']
-                    sandbox_status = claim_object.get(
-                        'status', {}).get('sandbox', {})
+                    status = claim_object.get('status', {})
+                    
+                    for cond in status.get('conditions', []):
+                        if cond.get('type') == 'Ready' and cond.get('status') == 'False':
+                            if cond.get('reason') == 'TemplateNotFound':
+                                w.stop()
+                                raise SandboxTemplateNotFoundError(
+                                    f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
+                                )
+
+                    sandbox_status = status.get('sandbox', {})
                     # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
                     name = sandbox_status.get('name', '') or sandbox_status.get('Name', '')
                     if name:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -106,15 +106,18 @@ class K8sHelper:
                         f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
                 if event["type"] in ["ADDED", "MODIFIED"]:
                     claim_object = event['object']
-                    status = claim_object.get('status', {})
+                    status = claim_object.get('status') or {}
                     
                     for cond in status.get('conditions', []):
-                        if cond.get('type') == 'Ready' and cond.get('status') == 'False':
-                            if cond.get('reason') == 'TemplateNotFound':
-                                w.stop()
-                                raise SandboxTemplateNotFoundError(
-                                    f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
-                                )
+                        if (
+                            cond.get('type') == 'Ready'
+                            and cond.get('status') == 'False'
+                            and cond.get('reason') == 'TemplateNotFound'
+                        ):
+                            w.stop()
+                            raise SandboxTemplateNotFoundError(
+                                f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
+                            )
 
                     sandbox_status = status.get('sandbox', {})
                     # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
@@ -147,7 +150,7 @@ class K8sHelper:
                     continue
                 if event["type"] in ["ADDED", "MODIFIED"]:
                     sandbox_object = event['object']
-                    status = sandbox_object.get('status', {})
+                    status = sandbox_object.get('status') or {}
                     conditions = status.get('conditions', [])
                     for cond in conditions:
                         if cond.get('type') == 'Ready' and cond.get('status') == 'True':
@@ -230,7 +233,7 @@ class K8sHelper:
                     continue
                 if event["type"] in ["ADDED", "MODIFIED"]:
                     gateway_object = event['object']
-                    status = gateway_object.get('status', {})
+                    status = gateway_object.get('status') or {}
                     addresses = status.get('addresses', [])
                     if addresses:
                         ip_address = addresses[0].get('value')

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 pytest.importorskip("kubernetes_asyncio")
 
 from k8s_agent_sandbox.async_k8s_helper import AsyncK8sHelper
+from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
 
 
 class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
@@ -72,6 +73,68 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["metadata"]["labels"], {"agent": "test"})
         self.assertEqual(body["metadata"]["annotations"], {"key": "val"})
 
+
+class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.helper = AsyncK8sHelper()
+        self.helper._initialized = True
+        self.helper.custom_objects_api = MagicMock()
+        self.helper.core_v1_api = MagicMock()
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
+    async def test_async_resolve_sandbox_name_template_not_found(self, mock_watch_class):
+        mock_watch = MagicMock()
+        mock_watch.close = AsyncMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "False",
+                            "reason": "TemplateNotFound",
+                            "message": "Template 'non-existent-template' not found"
+                        }
+                    ]
+                }
+            }
+        }
+        
+        async def mock_stream(*args, **kwargs):
+            yield mock_event
+            
+        mock_watch.stream = mock_stream
+        mock_watch_class.return_value = mock_watch
+        
+        with self.assertRaises(SandboxTemplateNotFoundError) as context:
+            await self.helper.resolve_sandbox_name("test-claim", "default", timeout=5)
+            
+        self.assertIn("Template 'non-existent-template' not found", str(context.exception))
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
+    async def test_async_resolve_sandbox_name_deleted_event(self, mock_watch_class):
+        mock_watch = MagicMock()
+        mock_watch.close = AsyncMock()
+        mock_event = {
+            "type": "DELETED",
+            "object": {
+                "metadata": {"name": "test-claim"}
+            }
+        }
+        
+        async def mock_stream(*args, **kwargs):
+            yield mock_event
+            
+        mock_watch.stream = mock_stream
+        mock_watch_class.return_value = mock_watch
+        
+        with self.assertRaises(SandboxMetadataError) as context:
+            await self.helper.resolve_sandbox_name("test-claim", "default", timeout=5)
+            
+        self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -16,6 +16,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from k8s_agent_sandbox.k8s_helper import K8sHelper
+from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
 
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
@@ -90,6 +91,61 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertNotIn("lifecycle", body["spec"])
+
+
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperResolveSandboxName(unittest.TestCase):
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_resolve_sandbox_name_template_not_found(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "False",
+                            "reason": "TemplateNotFound",
+                            "message": "Template 'non-existent-template' not found"
+                        }
+                    ]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+
+        with self.assertRaises(SandboxTemplateNotFoundError) as context:
+            helper.resolve_sandbox_name("test-claim", "default", timeout=5)
+
+        self.assertIn("Template 'non-existent-template' not found", str(context.exception))
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_resolve_sandbox_name_deleted_event(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "DELETED",
+            "object": {
+                "metadata": {"name": "test-claim"}
+            }
+        }
+        
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+        
+        helper = K8sHelper()
+        
+        with self.assertRaises(SandboxMetadataError) as context:
+            helper.resolve_sandbox_name("test-claim", "default", timeout=5)
+            
+        self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/test_client.py
+++ b/clients/python/agentic-sandbox-client/test_client.py
@@ -17,7 +17,7 @@ import time
 import logging
 from unittest.mock import MagicMock
 from pydantic import ValidationError
-from k8s_agent_sandbox import SandboxClient
+from k8s_agent_sandbox import SandboxClient, SandboxTemplateNotFoundError
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
     SandboxGatewayConnectionConfig,
@@ -142,7 +142,21 @@ def run_sandbox_tests(sandbox: Sandbox):
     print("--- Pydantic Validation Tests Passed ---")
 
 
+def test_wrong_template_name(client: SandboxClient, namespace: str):
+    print("\n--- Testing Wrong Template Name ---")
+    wrong_template = "this-template-does-not-exist-123"
+    print(f"Attempting to create sandbox with non-existent template '{wrong_template}'...")
+    try:
+        client.create_sandbox(wrong_template, namespace=namespace)
+        raise AssertionError("Expected SandboxTemplateNotFoundError was not raised")
+    except SandboxTemplateNotFoundError as e:
+        print(f"Caught expected SandboxTemplateNotFoundError: {e}")
+    print("--- Wrong Template Name Test Passed! ---")
+
+
 def run_client_tests(client: SandboxClient, template_name: str, namespace: str):
+    test_wrong_template_name(client, namespace)
+
     print(f"Creating sandbox with template '{template_name}' in namespace '{namespace}'...")
     sandbox = client.create_sandbox(template_name, namespace=namespace)
     print(f"Sandbox created with claim name: {sandbox.claim_name}")


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/agent-sandbox/issues/558