### PR TITLE
Add install.sh script for one-line local setup using kind

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,34 @@
+set -e
+
+echo "Installing Agent Sandbox..."
+
+# Check dependencies
+command -v kubectl >/dev/null 2>&1 || {
+  echo "kubectl is required but not installed."
+  exit 1
+}
+
+command -v kind >/dev/null 2>&1 || {
+  echo "kind is required but not installed."
+  exit 1
+}
+
+CLUSTER_NAME="agent-sandbox"
+
+echo "Creating kind cluster: $CLUSTER_NAME"
+kind create cluster --name "$CLUSTER_NAME" || true
+
+echo "Building project..."
+make build
+
+echo "Loading images into kind..."
+./dev/tools/push-images --image-prefix=kind.local/ --kind-cluster-name=$CLUSTER_NAME
+
+echo "Deploying to cluster..."
+./dev/tools/deploy-to-kube --image-prefix=kind.local/
+
+echo ""
+echo "Agent Sandbox installed successfully."
+echo ""
+echo "To verify:"
+echo "kubectl get pods -A"


### PR DESCRIPTION
Fixes #432 

## What this PR does

Adds a simple `install.sh` script to bootstrap a local Agent Sandbox environment using kind. This improves onboarding by allowing users to quickly set up the project without manually running multiple setup commands.

## Implementation details

- Adds `install.sh` at the repository root
- Validates required dependencies (kubectl, kind)
- Creates a local kind cluster
- Builds project binaries
- Loads images into kind
- Deploys the controller using existing dev tooling

## Usage

Users can install Agent Sandbox with:

```bash
curl -LsSf https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/main/install.sh | sh
 ```