### PR TITLE
add support for tabbed codeblocks

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -208,6 +208,29 @@ figcaption {
 // --------------------------------------------------
 .nav-tabs {
   border-bottom: none !important;
+  gap: 4px;
+
+  .nav-item .nav-link {
+    color: rgba(255, 255, 255, 0.6);
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-bottom: none;
+    border-radius: 0.75rem 0.75rem 0 0;
+    padding: 0.4rem 1rem;
+    text-decoration: none;
+
+    &:hover {
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.3);
+    }
+
+    &.active {
+      color: #fff;
+      background: #111;
+      border-color: rgba(255, 255, 255, 0.15);
+      border-bottom-color: #111;
+    }
+  }
 }
 
 .td-content > ul li,
@@ -219,11 +242,10 @@ figcaption {
   margin: 0;
 }
 
-.tab-pane {
-  border-radius: 0.25rem;
-  padding: 0 16px 16px;
-
-  border: 1px solid #dee2e6;
+.tab-content .tab-pane {
+  border: none !important;
+  background: transparent;
+  margin-bottom: 0;
 
   &:first-of-type.active {
     border-top-left-radius: 0;
@@ -464,6 +486,10 @@ h1.text-center {
     padding: 2rem 1rem;
     border-radius: 1rem;
     border: solid #222;
+}
+
+.td-content .tab-content .highlight pre {
+    border-radius: 0 1rem 1rem 1rem;
 }
 
 .td-content pre > code {

--- a/site/layouts/shortcodes/blocks/tabs.html
+++ b/site/layouts/shortcodes/blocks/tabs.html
@@ -20,31 +20,30 @@
 {{ else }}
   <div id="{{ $id }}" class="tab-pane" role="tabpanel" aria-labelledby="{{ $id }}">
 {{ end }}
-<p>
-	{{- with .content -}}
-		{{- . -}}
-	{{- else -}}
-		{{- if eq $.Page.BundleType "leaf" -}}
-			{{- /* find the file somewhere inside the bundle. Note the use of double asterisk */ -}}
-			{{- with $.Page.Resources.GetMatch (printf "**%s*" .include) -}}
-				{{- if ne .ResourceType "page" -}}
-				{{- /* Assume it is a file that needs code highlighting. */ -}}
-				{{- $codelang := $e.codelang | default ( path.Ext .Name | strings.TrimPrefix ".") -}}
-				{{- highlight .Content $codelang "" -}}
-				{{- else -}}
-					{{- .Content -}}
-				{{- end -}}
+{{- with .content -}}
+	{{- . -}}
+{{- else -}}
+	{{- if eq $.Page.BundleType "leaf" -}}
+		{{- /* find the file somewhere inside the bundle. Note the use of double asterisk */ -}}
+		{{- with $.Page.Resources.GetMatch (printf "**%s*" .include) -}}
+			{{- if ne .ResourceType "page" -}}
+			{{- /* Assume it is a file that needs code highlighting. */ -}}
+			{{- $codelang := $e.codelang | default ( path.Ext .Name | strings.TrimPrefix ".") -}}
+			{{- highlight .Content $codelang "" -}}
+			{{- else -}}
+				{{- .Content -}}
 			{{- end -}}
-		{{- else -}}
-		{{- $path := path.Join $.Page.File.Dir .include -}}
-		{{- $page := site.GetPage "page" $path -}}
-		{{- with $page -}}
-			{{- .Content -}}
-		{{- else -}}
-		{{- errorf "[%s] tabs include not found for path %q" site.Language.Lang $path -}}
 		{{- end -}}
-		{{- end -}}
+	{{- else -}}
+	{{- $path := path.Join $.Page.File.Dir .include -}}
+	{{- $page := site.GetPage "page" $path -}}
+	{{- with $page -}}
+		{{- .Content -}}
+	{{- else -}}
+	{{- errorf "[%s] tabs include not found for path %q" site.Language.Lang $path -}}
 	{{- end -}}
+	{{- end -}}
+{{- end -}}
 </div>
 {{- end -}}
 </div>


### PR DESCRIPTION
Adds support for tabbed codeblocks which allow to showcase code in multiple languates. 


Example usage:

{{< blocks/tabs name="hello-world" >}}
  {{< blocks/tab name="Python" codelang="python" >}}
def main():
    print("Hello, World!")

if __name__ == "__main__":
    main()
  {{< /blocks/tab >}}
  {{< blocks/tab name="Go" codelang="go" >}}
package main

import "fmt"

func main() {
    fmt.Println("Hello, World!")
}
  {{< /blocks/tab >}}
{{< /blocks/tabs >}}


How it looks:
<img width="1394" height="311" alt="image" src="https://github.com/user-attachments/assets/27ea7f42-efd1-427f-adca-826a3eee47a7" />
