### PR TITLE
chore: add dependabot configuration for Go modules and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+# TODO: tools.mod in the root directory is NOT tracked by Dependabot because 
+# Dependabot only supports files named exactly 'go.mod'. 
+# Maintainers will need to manually update tools.mod when shared dependencies change.
+# See discussion in PR #629 and #588 for context.
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,31 +49,55 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: "docker"
   directory: "/clients/python/agentic-sandbox-client/sandbox-router"
   schedule:
     interval: "weekly"
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: "docker"
   directory: "/examples/chrome-sandbox"
   schedule:
     interval: "weekly"
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: "docker"
   directory: "/examples/gemini-cu-sandbox"
   schedule:
     interval: "weekly"
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: "docker"
   directory: "/examples/hello-world-sandbox"
   schedule:
     interval: "weekly"
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: "docker"
   directory: "/examples/python-runtime-sandbox"
   schedule:
     interval: "weekly"
+  groups:
+    docker-dependencies:
+      patterns:
+      - "*"
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,85 @@
 version: 2
 updates:
-  # Enable version updates for Go modules
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    gomod-dependencies:
+      patterns:
+      - "*"
 
-  - package-ecosystem: "gomod"
-    directory: "/dev/tools"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+- package-ecosystem: "gomod"
+  directory: "/dev/tools"
+  schedule:
+    interval: "weekly"
+  groups:
+    gomod-dependencies:
+      patterns:
+      - "*"
 
-  - package-ecosystem: "gomod"
-    directory: "/examples/chrome-sandbox"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+- package-ecosystem: "gomod"
+  directory: "/examples/chrome-sandbox"
+  schedule:
+    interval: "weekly"
+  groups:
+    gomod-dependencies:
+      patterns:
+      - "*"
 
-  - package-ecosystem: "gomod"
-    directory: "/site"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+- package-ecosystem: "gomod"
+  directory: "/site"
+  schedule:
+    interval: "weekly"
+  groups:
+    gomod-dependencies:
+      patterns:
+      - "*"
 
-  # Enable version updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+- package-ecosystem: "pip"
+  directory: "/clients/python/agentic-sandbox-client"
+  schedule:
+    interval: "weekly"
+  groups:
+    python-dependencies:
+      patterns:
+      - "*"
+
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "docker"
+  directory: "/clients/python/agentic-sandbox-client/sandbox-router"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "docker"
+  directory: "/examples/chrome-sandbox"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "docker"
+  directory: "/examples/gemini-cu-sandbox"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "docker"
+  directory: "/examples/hello-world-sandbox"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "docker"
+  directory: "/examples/python-runtime-sandbox"
+  schedule:
+    interval: "weekly"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    github-actions:
+      patterns:
+      - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,33 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: daily
-    groups:
-      k8s-libs:
-        patterns:
-          - "k8s.io/api"
-          - "k8s.io/apiextensions-apiserver"
-          - "k8s.io/apimachinery"
-          - "k8s.io/client-go"
-          - "k8s.io/klog/v2"
-          - "k8s.io/utils"
+      interval: "daily"
+    open-pull-requests-limit: 5
 
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "gomod"
+    directory: "/dev/tools"
     schedule:
-      interval: weekly
+      interval: "daily"
+    open-pull-requests-limit: 5
 
-  - package-ecosystem: docker
-    directory: /
+  - package-ecosystem: "gomod"
+    directory: "/examples/chrome-sandbox"
     schedule:
-      interval: weekly
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gomod"
+    directory: "/site"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gomod"
+    directory: "/dev/tools"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gomod"
+    directory: "/examples/chrome-sandbox"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gomod"
+    directory: "/site"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
  This PR adds a .github/dependabot.yml configuration file to enable automated dependency updates via Dependabot. This will help maintain the project's
  security posture by automatically identifying and proposing fixes for outdated or vulnerable dependencies.

  Key Changes
   - Go Modules (gomod): Configured for daily updates across the following directories:
     - Root (/)
     - Development tools (/dev/tools)
     - Chrome sandbox examples (/examples/chrome-sandbox)
     - Documentation/site (/site)
   - GitHub Actions: Configured for weekly updates to ensure CI/CD workflows use the latest stable versions of actions.
   - Pull Request Limit: Set to a maximum of 5 open PRs per ecosystem to prevent overflow.