### PR TITLE
Fix: fix prew timeout, build and push operations set to 2 hours

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,5 @@
-timeout: 2700s
+# Timeout set to 7200s (2 hours) to allow sufficient time for build and push operations. 
+timeout: 7200s
 steps:
   # This step runs the python script to build and push the Docker image.
   # We use the gcloud builder because it comes with python and the docker client.


### PR DESCRIPTION
Fix gcp build timeout: 
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-agent-sandbox-push-images/2043897710943145984 
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-agent-sandbox-push-images/2043894167641264128 

<img width="1594" height="856" alt="a7a920ca-e244-43e1-9655-aa3455c9b59f" src="https://github.com/user-attachments/assets/3d406e39-8ea7-4fe8-8481-af034d66df2f" />
