### PR TITLE
feat: recreate Pod on Sandbox PodTemplate spec drift

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -340,11 +340,15 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
-// computePodTemplateHash computes a hash of the sandbox's PodTemplate spec.
+// computePodTemplateHash computes a hash of the sandbox's PodTemplate.Spec.
+// It intentionally excludes PodTemplate.ObjectMeta (labels/annotations) since
+// those may be modified by other controllers (e.g., SandboxClaim) without
+// requiring pod recreation. Only changes to the actual PodSpec should trigger
+// a recreate.
 func computePodTemplateHash(sandbox *sandboxv1alpha1.Sandbox) (string, error) {
-	specJSON, err := json.Marshal(sandbox.Spec.PodTemplate)
+	specJSON, err := json.Marshal(sandbox.Spec.PodTemplate.Spec)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal pod template for hashing: %w", err)
+		return "", fmt.Errorf("failed to marshal pod template spec for hashing: %w", err)
 	}
 	return NameHash(string(specJSON)), nil
 }

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -47,6 +48,7 @@ import (
 const (
 	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
 	sandboxControllerFieldOwner = "sandbox-controller"
+	podTemplateHashLabel        = "agents.x-k8s.io/pod-template-hash"
 )
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
@@ -338,6 +340,15 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
+// computePodTemplateHash computes a hash of the sandbox's PodTemplate spec.
+func computePodTemplateHash(sandbox *sandboxv1alpha1.Sandbox) (string, error) {
+	specJSON, err := json.Marshal(sandbox.Spec.PodTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal pod template for hashing: %w", err)
+	}
+	return NameHash(string(specJSON)), nil
+}
+
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Service, error) {
 	log := log.FromContext(ctx)
 	service := &corev1.Service{}
@@ -542,6 +553,12 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		return nil
 	}
 
+	// Compute the expected pod template hash for drift detection
+	expectedHash, hashErr := computePodTemplateHash(sandbox)
+	if hashErr != nil {
+		log.Error(hashErr, "Failed to compute pod template hash")
+	}
+
 	// 2. PATH: Existing Pod found (e.g., adopted from WarmPool or already exists)
 	if pod != nil {
 		log.Info("Found Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
@@ -581,6 +598,29 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			// No additional action needed — label applied below.
 		}
 
+		// Check for pod template drift and recreate if needed
+		if hashErr == nil && expectedHash != "" && pod.DeletionTimestamp.IsZero() {
+			podHash := pod.Labels[podTemplateHashLabel]
+			if podHash != "" && podHash != expectedHash {
+				log.Info("Pod template spec has drifted, deleting pod to trigger recreation",
+					"Pod.Name", pod.Name,
+					"OldHash", podHash,
+					"NewHash", expectedHash)
+				if err := r.Delete(ctx, pod); err != nil && !k8serrors.IsNotFound(err) {
+					return nil, fmt.Errorf("failed to delete drifted pod: %w", err)
+				}
+				// Remove pod name annotation so the sandbox tracks the new pod name
+				if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists {
+					patch := client.MergeFrom(sandbox.DeepCopy())
+					delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
+					if err := r.Patch(ctx, sandbox, patch); err != nil {
+						log.Error(err, "Failed to remove pod name annotation during drift deletion")
+					}
+				}
+				return nil, nil
+			}
+		}
+
 		// Apply label for both podUnowned and podOwnedBySandbox cases.
 		if pod.Labels == nil {
 			pod.Labels = make(map[string]string)
@@ -589,6 +629,10 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 			pod.Labels[k] = v
+		}
+		// Set the pod template hash label
+		if expectedHash != "" {
+			pod.Labels[podTemplateHashLabel] = expectedHash
 		}
 
 		if err := r.Update(ctx, pod); err != nil {
@@ -611,6 +655,9 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		labels[k] = v
+	}
+	if expectedHash != "" {
+		labels[podTemplateHashLabel] = expectedHash
 	}
 	annotations := map[string]string{}
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -326,7 +326,7 @@ func TestReconcile(t *testing.T) {
 						ResourceVersion: "1",
 						Labels: map[string]string{
 							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
-							"agents.x-k8s.io/pod-template-hash": "bba517df",
+							"agents.x-k8s.io/pod-template-hash": "7e531891",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -422,7 +422,7 @@ func TestReconcile(t *testing.T) {
 						ResourceVersion: "1",
 						Labels: map[string]string{
 							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
-							"agents.x-k8s.io/pod-template-hash": "21481b6f",
+							"agents.x-k8s.io/pod-template-hash": "7e531891",
 							"custom-label":                      "label-val",
 						},
 						Annotations: map[string]string{
@@ -957,7 +957,7 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "2",
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
-						"agents.x-k8s.io/pod-template-hash": "21481b6f",
+						"agents.x-k8s.io/pod-template-hash": "7e531891",
 						"custom-label":                      "label-val",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
@@ -984,7 +984,7 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "1",
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
-						"agents.x-k8s.io/pod-template-hash": "21481b6f",
+						"agents.x-k8s.io/pod-template-hash": "7e531891",
 						"custom-label":                      "label-val",
 					},
 					Annotations: map[string]string{
@@ -1088,7 +1088,7 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "2",
 					Labels: map[string]string{
 						sandboxLabel:         nameHash,
-						podTemplateHashLabel: "bba517df",
+						podTemplateHashLabel: "7e531891",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -326,6 +326,7 @@ func TestReconcile(t *testing.T) {
 						ResourceVersion: "1",
 						Labels: map[string]string{
 							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/pod-template-hash": "bba517df",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -421,6 +422,7 @@ func TestReconcile(t *testing.T) {
 						ResourceVersion: "1",
 						Labels: map[string]string{
 							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/pod-template-hash": "21481b6f",
 							"custom-label":                      "label-val",
 						},
 						Annotations: map[string]string{
@@ -955,6 +957,7 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "2",
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"agents.x-k8s.io/pod-template-hash": "21481b6f",
 						"custom-label":                      "label-val",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
@@ -981,6 +984,7 @@ func TestReconcilePod(t *testing.T) {
 					ResourceVersion: "1",
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"agents.x-k8s.io/pod-template-hash": "21481b6f",
 						"custom-label":                      "label-val",
 					},
 					Annotations: map[string]string{
@@ -1083,7 +1087,8 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxLabel:         nameHash,
+						podTemplateHashLabel: "bba517df",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
@@ -1337,6 +1342,54 @@ func TestReconcilePod(t *testing.T) {
 			expectErr:              false,
 			wantSandboxAnnotations: map[string]string{"other-annotation": "other-value"},
 			wantPodSurvives:        "annotated-pod-name",
+		},
+		{
+			name: "deletes pod when template spec drifts",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel:         nameHash,
+							podTemplateHashLabel: "stale-hash-value",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "old-container",
+							},
+						},
+					},
+				},
+			},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: sandboxName,
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: ptr.To(int32(1)),
+					PodTemplate: sandboxv1alpha1.PodTemplate{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "new-container",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPod: nil,
+			expectErr: false,
 		},
 	}
 

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1388,7 +1388,7 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
-			wantPod: nil,
+			wantPod:   nil,
 			expectErr: false,
 		},
 	}


### PR DESCRIPTION
 ## Summary

  - Detect when `spec.podTemplate.spec` changes by comparing a hash label (`agents.x-k8s.io/pod-template-hash`) on the existing Pod against the computed hash of the current Sandbox spec
  - Delete the stale Pod to trigger a recreation with the updated spec, preserving PVCs (owned by the Sandbox CR)
  - Set the hash label on both newly created and adopted/updated Pods for future drift detection

  ## What was the problem?

  When `spec.podTemplate.spec` on a Sandbox was updated (e.g., changing the container image or resource limits), the running Pod kept its old spec. The controller's `reconcilePod` only ensured labels and ownerReferences on an
  existing Pod, but never checked for spec drift.

  ## How was this addressed?

  Added `computePodTemplateHash` to the sandbox controller (consistent with the WarmPool controller's approach). In `reconcilePod`, when an existing Pod is found, its hash label is compared to the expected hash. If they differ,
  the stale Pod is deleted and the sandbox tracks the new Pod name for the next reconcile cycle.

  ## Related

  - Fixes #581
  - #323 — WarmPool rollout on template updates (existing reference implementation)