### PR TITLE
fix: prevent cross-claim race during warm pool sandbox adoption

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -41,6 +41,11 @@ const (
 	SandboxPropagatedLabelsAnnotation = "agents.x-k8s.io/propagated-labels"
 	// SandboxPropagatedAnnotationsAnnotation is the annotation used to track the annotations explicitly propagated from sandbox spec to pod.
 	SandboxPropagatedAnnotationsAnnotation = "agents.x-k8s.io/propagated-annotations"
+
+	// SandboxClaimedByAnnotation records which SandboxClaim UID has claimed this sandbox.
+	// Protected by MergeFromWithOptimisticLock (resourceVersion CAS).
+	// Set during warm pool adoption.
+	SandboxClaimedByAnnotation = "agents.x-k8s.io/claimed-by"
 )
 
 type PodMetadata struct {

--- a/extensions/controllers/sandboxclaim_adoption_race_test.go
+++ b/extensions/controllers/sandboxclaim_adoption_race_test.go
@@ -1,0 +1,412 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// makeWarmPoolSandbox creates a warm pool sandbox suitable as an adoption candidate.
+// It has the required labels, owner references, and optionally a Ready condition.
+func makeWarmPoolSandbox(name string, poolNameHash, templateHash string, warmPoolUID types.UID, ready bool, annotations map[string]string) *sandboxv1alpha1.Sandbox {
+	conditionStatus := metav1.ConditionFalse
+	if ready {
+		conditionStatus = metav1.ConditionTrue
+	}
+	replicas := int32(1)
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	return &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute)),
+			Annotations:       annotations,
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: templateHash,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+				Kind:       "SandboxWarmPool",
+				Name:       "pool",
+				UID:        warmPoolUID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: &replicas,
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "pause"}},
+				},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1alpha1.SandboxConditionReady),
+				Status: conditionStatus,
+				Reason: "DependenciesReady",
+			}},
+		},
+	}
+}
+
+// TestAdoptedSandboxGetsClaimedByAnnotation verifies that adopting a warm pool
+// sandbox writes the claimed-by annotation with the claim's UID.
+// Regression test for #127, #478.
+func TestAdoptedSandboxGetsClaimedByAnnotation(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tpl", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "pause"}},
+				},
+			},
+		},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash("pool")
+	templateHash := sandboxcontrollers.NameHash("tpl")
+	warmPoolUID := types.UID("pool-uid")
+
+	sandbox := makeWarmPoolSandbox("pool-sb-0", poolNameHash, templateHash, warmPoolUID, true, nil)
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adopt-claim",
+			Namespace: "default",
+			UID:       "adopt-claim-uid-123",
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, sandbox, claim).
+		WithStatusSubresource(&sandboxv1alpha1.Sandbox{}, &extensionsv1alpha1.SandboxClaim{}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:                  fakeClient,
+		Scheme:                  scheme,
+		Tracer:                  asmetrics.NewNoOp(),
+		MaxConcurrentReconciles: 1,
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "adopt-claim", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// Fetch the sandbox after reconciliation
+	var updated sandboxv1alpha1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "pool-sb-0", Namespace: "default",
+	}, &updated))
+
+	// Verify the sandbox was adopted (warm pool labels removed, claim is controller)
+	_, hasWarmPoolLabel := updated.Labels[warmPoolSandboxLabel]
+	require.False(t, hasWarmPoolLabel,
+		"warm pool label should be removed after adoption")
+
+	controllerRef := metav1.GetControllerOf(&updated)
+	require.NotNil(t, controllerRef,
+		"adopted sandbox must have a controller owner reference")
+	require.Equal(t, claim.UID, controllerRef.UID,
+		"adopted sandbox must be owned by the claim")
+
+	claimedBy, hasClaimed := updated.Annotations[sandboxv1alpha1.SandboxClaimedByAnnotation]
+	require.True(t, hasClaimed,
+		"adopted sandbox must have the %s annotation — "+
+			"the controller should write it during adoption to prevent cross-claim races",
+		sandboxv1alpha1.SandboxClaimedByAnnotation)
+	require.Equal(t, string(claim.UID), claimedBy,
+		"claimed-by annotation must match the adopting claim's UID")
+}
+
+// TestSinglePreClaimedSandboxIsSkipped verifies that a sandbox with a
+// claimed-by annotation from another claim is skipped; the claim cold-starts.
+// Regression test for #127, #478.
+func TestSinglePreClaimedSandboxIsSkipped(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tpl", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "pause"}},
+				},
+			},
+		},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash("pool")
+	templateHash := sandboxcontrollers.NameHash("tpl")
+	warmPoolUID := types.UID("pool-uid")
+
+	// Pre-annotated sandbox: claimed by a different UID
+	preClaimed := makeWarmPoolSandbox(
+		"pre-claimed-sb", poolNameHash, templateHash, warmPoolUID, true,
+		map[string]string{sandboxv1alpha1.SandboxClaimedByAnnotation: "some-other-uid"},
+	)
+
+	// The claim that owns the reservation must exist in the cluster
+	// so the candidate filter treats the annotation as a live reservation.
+	otherClaim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-claim",
+			Namespace: "default",
+			UID:       "some-other-uid",
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"},
+		},
+	}
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skip-claim",
+			Namespace: "default",
+			UID:       "skip-claim-uid-456",
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, preClaimed, otherClaim, claim).
+		WithStatusSubresource(&sandboxv1alpha1.Sandbox{}, &extensionsv1alpha1.SandboxClaim{}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:                  fakeClient,
+		Scheme:                  scheme,
+		Tracer:                  asmetrics.NewNoOp(),
+		MaxConcurrentReconciles: 1,
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "skip-claim", Namespace: "default"},
+	})
+	require.NoError(t, err)
+
+	// Verify the pre-claimed sandbox was NOT adopted.
+	var sb sandboxv1alpha1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "pre-claimed-sb", Namespace: "default",
+	}, &sb))
+
+	// Warm pool labels must still be present (not removed by adoption).
+	_, hasWarmPoolLabel := sb.Labels[warmPoolSandboxLabel]
+	require.True(t, hasWarmPoolLabel,
+		"pre-claimed sandbox must retain its warm pool label — it should not have been adopted")
+
+	_, hasTemplateHash := sb.Labels[sandboxTemplateRefHash]
+	require.True(t, hasTemplateHash,
+		"pre-claimed sandbox must retain its template hash label — it should not have been adopted")
+
+	// Owner reference must still point to SandboxWarmPool, not SandboxClaim.
+	controllerRef := metav1.GetControllerOf(&sb)
+	require.NotNil(t, controllerRef,
+		"pre-claimed sandbox must still have a controller owner")
+	require.Equal(t, "SandboxWarmPool", controllerRef.Kind,
+		"pre-claimed sandbox owner must still be SandboxWarmPool, not SandboxClaim")
+
+	// The annotation must be unchanged.
+	require.Equal(t, "some-other-uid", sb.Annotations[sandboxv1alpha1.SandboxClaimedByAnnotation],
+		"pre-claimed sandbox annotation must be untouched")
+
+	// Verify the claim cold-started: a new sandbox with the claim's name exists.
+	var coldStartSandbox sandboxv1alpha1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name: "skip-claim", Namespace: "default",
+	}, &coldStartSandbox),
+		"claim should have cold-started and created a sandbox named after itself")
+
+	coldRef := metav1.GetControllerOf(&coldStartSandbox)
+	require.NotNil(t, coldRef, "cold-started sandbox must have a controller owner")
+	require.Equal(t, claim.UID, coldRef.UID,
+		"cold-started sandbox must be owned by the claim")
+}
+
+// TestMultipleClaimsRespectReservations verifies that claims skip sandboxes
+// with a claimed-by annotation. 4 of 5 are reserved; none may be adopted.
+// Regression test for #127, #478.
+func TestMultipleClaimsRespectReservations(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tpl", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "pause"}},
+				},
+			},
+		},
+	}
+
+	warmPoolUID := types.UID("pool-uid")
+	poolNameHash := sandboxcontrollers.NameHash("pool")
+	templateHash := sandboxcontrollers.NameHash("tpl")
+
+	objs := []client.Object{template}
+
+	// Create 5 pool sandboxes: 4 reserved, 1 free
+	for i := 0; i < 5; i++ {
+		replicas := int32(1)
+		annotations := map[string]string{}
+		if i < 4 {
+			annotations[sandboxv1alpha1.SandboxClaimedByAnnotation] = fmt.Sprintf("other-claim-uid-%d", i)
+		}
+		sb := &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              fmt.Sprintf("pool-sb-%d", i),
+				Namespace:         "default",
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Duration(i) * time.Second)),
+				Annotations:       annotations,
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   poolNameHash,
+					sandboxTemplateRefHash: templateHash,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+					Kind:       "SandboxWarmPool",
+					Name:       "pool",
+					UID:        warmPoolUID,
+					Controller: ptr.To(true),
+				}},
+			},
+			Spec: sandboxv1alpha1.SandboxSpec{
+				Replicas: &replicas,
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c", Image: "pause"}},
+					},
+				},
+			},
+			Status: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(sandboxv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+					Reason: "DependenciesReady",
+				}},
+			},
+		}
+		objs = append(objs, sb)
+	}
+
+	// Create stub claims for the reserved UIDs so the candidate
+	// filter treats the annotations as live reservations.
+	for i := 0; i < 4; i++ {
+		stub := &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("other-claim-%d", i),
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("other-claim-uid-%d", i)),
+			},
+			Spec: extensionsv1alpha1.SandboxClaimSpec{
+				TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"},
+			},
+		}
+		objs = append(objs, stub)
+	}
+
+	// Create 3 claims
+	for i := 0; i < 3; i++ {
+		c := &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("claim-%d", i),
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("test-claim-uid-%d", i)),
+			},
+			Spec: extensionsv1alpha1.SandboxClaimSpec{
+				TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "tpl"},
+			},
+		}
+		objs = append(objs, c)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&sandboxv1alpha1.Sandbox{}, &extensionsv1alpha1.SandboxClaim{}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:                  fakeClient,
+		Scheme:                  scheme,
+		Tracer:                  asmetrics.NewNoOp(),
+		MaxConcurrentReconciles: 1,
+	}
+
+	// Reconcile each claim sequentially
+	for i := 0; i < 3; i++ {
+		_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      fmt.Sprintf("claim-%d", i),
+				Namespace: "default",
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	// Check: no claim should have adopted a reserved sandbox (pool-sb-0 through pool-sb-3)
+	var sandboxList sandboxv1alpha1.SandboxList
+	require.NoError(t, fakeClient.List(context.Background(), &sandboxList))
+
+	for _, sb := range sandboxList.Items {
+		ownerRef := metav1.GetControllerOf(&sb)
+		if ownerRef == nil || ownerRef.Kind != "SandboxClaim" {
+			continue
+		}
+		// Check if this was a reserved sandbox
+		for i := 0; i < 4; i++ {
+			if sb.Name == fmt.Sprintf("pool-sb-%d", i) {
+				t.Errorf("claim %s adopted reserved sandbox %s (annotation %s=%s) — "+
+					"the controller must skip sandboxes with a claimed-by annotation",
+					ownerRef.Name, sb.Name, sandboxv1alpha1.SandboxClaimedByAnnotation,
+					fmt.Sprintf("other-claim-uid-%d", i))
+			}
+		}
+		t.Logf("claim %s → sandbox %s", ownerRef.Name, sb.Name)
+	}
+}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -501,21 +501,31 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 
 		logger.Info("Attempting sandbox adoption", "sandbox candidate", adopted.Name, "warm pool", poolName, "claim", claim.Name)
 
-		// Remove warm pool labels so the sandbox no longer appears in warm pool queries
+		// Reserve via optimistic-lock annotation patch before ownership transfer.
+		claimUID := string(claim.UID)
+		patch := client.MergeFromWithOptions(adopted.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		if adopted.Annotations == nil {
+			adopted.Annotations = make(map[string]string)
+		}
+		adopted.Annotations[v1alpha1.SandboxClaimedByAnnotation] = claimUID
+		if err := r.Patch(ctx, adopted, patch); err != nil {
+			if k8errors.IsConflict(err) || k8errors.IsNotFound(err) {
+				asmetrics.AdoptionConflictsTotal.WithLabelValues(claim.Namespace).Inc()
+				continue
+			}
+			logger.Error(err, "Failed to patch claimed-by annotation", "sandbox candidate", adopted.Name, "claim", claim.Name)
+			return nil, err
+		}
+
 		delete(adopted.Labels, warmPoolSandboxLabel)
 		delete(adopted.Labels, sandboxTemplateRefHash)
 		delete(adopted.Labels, v1alpha1.SandboxPodTemplateHashLabel)
 
-		// Transfer ownership from SandboxWarmPool to SandboxClaim
 		adopted.OwnerReferences = nil
 		if err := controllerutil.SetControllerReference(claim, adopted, r.Scheme); err != nil {
 			return nil, fmt.Errorf("failed to set controller reference on adopted sandbox: %w", err)
 		}
 
-		// Propagate trace context from claim
-		if adopted.Annotations == nil {
-			adopted.Annotations = make(map[string]string)
-		}
 		// Ensure the adopted sandbox records its pod name before it can be observed Ready.
 		if podName := adopted.Annotations[v1alpha1.SandboxPodNameAnnotation]; podName != adopted.Name {
 			if podName != "" {
@@ -523,6 +533,8 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			}
 			adopted.Annotations[v1alpha1.SandboxPodNameAnnotation] = adopted.Name
 		}
+
+		// Propagate trace context from claim
 		if traceContext, ok := claim.Annotations[asmetrics.TraceContextAnnotation]; ok {
 			adopted.Annotations[asmetrics.TraceContextAnnotation] = traceContext
 		}
@@ -539,11 +551,9 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			return nil, err
 		}
 
-		// Update uses optimistic concurrency (resourceVersion) so concurrent
-		// claims racing to adopt the same sandbox will conflict and retry.
 		if err := r.Update(ctx, adopted); err != nil {
 			if k8errors.IsConflict(err) || k8errors.IsNotFound(err) {
-				// Another worker adopted this sandbox while we were processing; try next candidate.
+				asmetrics.AdoptionConflictsTotal.WithLabelValues(claim.Namespace).Inc()
 				continue
 			}
 			logger.Error(err, "Failed to update adoption candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
@@ -795,6 +805,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 
 	policy := getWarmPoolPolicy(claim)
 	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+
 	var adoptionCandidates []*v1alpha1.Sandbox
 
 	for i := range allSandboxes.Items {
@@ -832,6 +843,13 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			if sb.Labels[warmPoolSandboxLabel] != specificPoolHash {
 				continue
 			}
+		}
+
+		// Skip sandboxes already claimed by a different SandboxClaim.
+		// Allow sandboxes claimed by THIS claim through so a partially-
+		// completed adoption can be resumed after controller restart.
+		if claimedBy, ok := sb.Annotations[v1alpha1.SandboxClaimedByAnnotation]; ok && claimedBy != "" && claimedBy != string(claim.UID) {
+			continue
 		}
 
 		adoptionCandidates = append(adoptionCandidates, sb)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1276,6 +1276,117 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 	}
 }
 
+// TestSandboxClaimResumesPartialAdoption verifies that a claim can resume its
+// own half-finished adoption. If the controller crashes between setting the
+// claimed-by annotation and completing the ownership transfer, the next
+// reconcile must not skip the sandbox — it must complete the adoption.
+func TestSandboxClaimResumesPartialAdoption(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	claimUID := types.UID("claim-uid-partial")
+	warmPoolUID := types.UID("warmpool-uid")
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+
+	// Claim with no status (adoption never completed)
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-claim", Namespace: "default", UID: claimUID},
+		Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	// Sandbox with claimed-by annotation set to this claim's UID, but still
+	// owned by the warm pool (ownership transfer never completed).
+	partialSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "pool-sb-partial",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			Annotations: map[string]string{
+				sandboxv1alpha1.SandboxClaimedByAnnotation: string(claimUID),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        warmPoolUID,
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1alpha1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, claim, partialSandbox).
+		WithStatusSubresource(claim).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:   fakeClient,
+		Scheme:   scheme,
+		Recorder: events.NewFakeRecorder(10),
+		Tracer:   asmetrics.NewNoOp(),
+	}
+
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "partial-claim", Namespace: "default"}}
+
+	_, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	// Verify the sandbox was adopted (ownership transferred to claim)
+	var sb sandboxv1alpha1.Sandbox
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "pool-sb-partial", Namespace: "default"}, &sb); err != nil {
+		t.Fatalf("failed to get sandbox: %v", err)
+	}
+
+	controllerRef := metav1.GetControllerOf(&sb)
+	if controllerRef == nil || controllerRef.UID != claimUID {
+		t.Errorf("expected sandbox to be owned by claim %s, got %v", claimUID, controllerRef)
+	}
+
+	if _, exists := sb.Labels[warmPoolSandboxLabel]; exists {
+		t.Error("expected warm pool label to be removed after adoption")
+	}
+
+	// Verify no cold-start sandbox was created (claim should have adopted, not created new)
+	var coldStart sandboxv1alpha1.Sandbox
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: "partial-claim", Namespace: "default"}, &coldStart)
+	if err == nil {
+		t.Error("expected no cold-start sandbox to be created — claim should have resumed partial adoption")
+	}
+}
+
 func TestRecordCreationLatencyMetric(t *testing.T) {
 	ctx := context.Background()
 	pastTime := metav1.Time{Time: time.Now().Add(-10 * time.Second)}
@@ -1863,6 +1974,224 @@ func TestSandboxClaimWarmPoolPolicy(t *testing.T) {
 			t.Error("expected warm pool label to be removed from adopted sandbox")
 		}
 	})
+}
+
+// TestCrossClaimAdoptionRace is a regression test for #127 and #478.
+// With N concurrent claims and <N warm pool sandboxes, each sandbox must be
+// adopted by exactly one claim and no claim should end up owning more than
+// one sandbox. The race manifests when concurrent reconcilers read the same
+// candidate list from the informer cache.
+//
+// NOTE: This test uses fake.Client which serializes writes in-memory. It
+// validates the reconcile flow and adoption invariants but does not exercise
+// real API server concurrency. See test/e2e/extensions/adoption_race_test.go
+// for integration coverage against a live cluster.
+func TestCrossClaimAdoptionRace(t *testing.T) {
+	const (
+		numClaims    = 10
+		numSandboxes = 3 // Intentionally less than numClaims to force contention
+	)
+
+	scheme := newScheme(t)
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "race-template",
+			Namespace: "default",
+		},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	warmPoolUID := types.UID("warmpool-uid")
+	poolNameHash := sandboxcontrollers.NameHash("race-pool")
+	templateHash := sandboxcontrollers.NameHash("race-template")
+
+	// Create warm pool sandboxes
+	var sandboxes []client.Object
+	for i := range numSandboxes {
+		name := fmt.Sprintf("pool-sb-%d", i)
+		replicas := int32(1)
+		sb := &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "default",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Duration(numSandboxes-i) * time.Hour)},
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   poolNameHash,
+					sandboxTemplateRefHash: templateHash,
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+					Kind:       "SandboxWarmPool",
+					Name:       "race-pool",
+					UID:        warmPoolUID,
+					Controller: ptr.To(true),
+				}},
+			},
+			Spec: sandboxv1alpha1.SandboxSpec{
+				Replicas: &replicas,
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "c", Image: "img"}},
+					},
+				},
+			},
+			Status: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(sandboxv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+					Reason: "Ready",
+				}},
+			},
+		}
+		sandboxes = append(sandboxes, sb)
+	}
+
+	// Create N concurrent claims
+	var claims []client.Object
+	for i := range numClaims {
+		claim := &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("claim-%d", i),
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("claim-uid-%d", i)),
+			},
+			Spec: extensionsv1alpha1.SandboxClaimSpec{
+				TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+					Name: "race-template",
+				},
+			},
+		}
+		claims = append(claims, claim)
+	}
+
+	allObjects := []client.Object{template}
+	allObjects = append(allObjects, sandboxes...)
+	allObjects = append(allObjects, claims...)
+
+	statusSubresources := make([]client.Object, len(claims))
+	copy(statusSubresources, claims)
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(allObjects...).
+		WithStatusSubresource(statusSubresources...).
+		Build()
+
+	// Run all claims' reconciliations concurrently to maximize contention.
+	var wg sync.WaitGroup
+	reconcileErrors := make([]error, numClaims)
+
+	for i := range numClaims {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			reconciler := &SandboxClaimReconciler{
+				Client:                  fakeClient,
+				Scheme:                  scheme,
+				Recorder:                events.NewFakeRecorder(10),
+				Tracer:                  asmetrics.NewNoOp(),
+				MaxConcurrentReconciles: numClaims,
+			}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      fmt.Sprintf("claim-%d", idx),
+					Namespace: "default",
+				},
+			}
+			_, reconcileErrors[idx] = reconciler.Reconcile(context.Background(), req)
+		}(i)
+	}
+	wg.Wait()
+
+	// Collect adoption results: for each sandbox, which claim(s) adopted it
+	ctx := context.Background()
+	sandboxOwners := make(map[string]string)    // sandbox name -> claim UID
+	claimSandboxes := make(map[string][]string) // claim UID -> sandbox names
+
+	for i := range numSandboxes {
+		name := fmt.Sprintf("pool-sb-%d", i)
+		var sb sandboxv1alpha1.Sandbox
+		if err := fakeClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, &sb); err != nil {
+			t.Fatalf("failed to get sandbox %s: %v", name, err)
+		}
+
+		controllerRef := metav1.GetControllerOf(&sb)
+		if controllerRef != nil && controllerRef.Kind == "SandboxClaim" {
+			ownerUID := string(controllerRef.UID)
+			sandboxOwners[name] = ownerUID
+			claimSandboxes[ownerUID] = append(claimSandboxes[ownerUID], name)
+		}
+	}
+
+	// Also check for cold-start sandboxes created by claims
+	for i := range numClaims {
+		claimName := fmt.Sprintf("claim-%d", i)
+		claimUID := fmt.Sprintf("claim-uid-%d", i)
+		var sb sandboxv1alpha1.Sandbox
+		// Cold-start sandboxes use the claim name
+		if err := fakeClient.Get(ctx, types.NamespacedName{Name: claimName, Namespace: "default"}, &sb); err == nil {
+			controllerRef := metav1.GetControllerOf(&sb)
+			if controllerRef != nil && controllerRef.Kind == "SandboxClaim" {
+				claimSandboxes[claimUID] = append(claimSandboxes[claimUID], claimName)
+			}
+		}
+	}
+
+	// Invariant 1: No claim adopted more than one warm pool sandbox.
+	// sandboxOwners is sandbox→owner (unique by construction); check the
+	// reverse map owner→sandboxes for multi-adoption.
+	ownerToSandboxes := make(map[string][]string)
+	for sbName, ownerUID := range sandboxOwners {
+		t.Logf("Sandbox %s adopted by claim %s", sbName, ownerUID)
+		ownerToSandboxes[ownerUID] = append(ownerToSandboxes[ownerUID], sbName)
+	}
+	for ownerUID, sbs := range ownerToSandboxes {
+		if len(sbs) > 1 {
+			t.Errorf("claim %s adopted multiple warm pool sandboxes %v — cross-claim race detected", ownerUID, sbs)
+		}
+	}
+
+	// Invariant 2: No claim owns more than one sandbox (warm pool + cold start combined)
+	for claimUID, sandboxNames := range claimSandboxes {
+		if len(sandboxNames) > 1 {
+			t.Errorf("claim %s owns multiple sandboxes %v — 1:1 invariant violated (double-adoption bug)", claimUID, sandboxNames)
+		}
+	}
+
+	// Invariant 3: At most numSandboxes claims adopted from the warm pool
+	warmAdoptions := len(sandboxOwners)
+	if warmAdoptions > numSandboxes {
+		t.Errorf("expected at most %d warm adoptions, got %d — cross-claim race detected", numSandboxes, warmAdoptions)
+	}
+
+	// Invariant 4: The claimed-by annotation matches the owning claim on adopted sandboxes
+	for sbName, ownerUID := range sandboxOwners {
+		var sb sandboxv1alpha1.Sandbox
+		if err := fakeClient.Get(ctx, types.NamespacedName{Name: sbName, Namespace: "default"}, &sb); err != nil {
+			t.Fatalf("failed to re-read sandbox %s: %v", sbName, err)
+		}
+		if claimedBy := sb.Annotations[sandboxv1alpha1.SandboxClaimedByAnnotation]; claimedBy != ownerUID {
+			t.Errorf("sandbox %s: claimed-by annotation %q does not match controller owner %q", sbName, claimedBy, ownerUID)
+		}
+	}
+
+	t.Logf("Result: %d warm adoptions, %d total claims, %d reconcile errors",
+		warmAdoptions, numClaims, func() int {
+			n := 0
+			for _, e := range reconcileErrors {
+				if e != nil {
+					n++
+				}
+			}
+			return n
+		}())
 }
 
 func TestSandboxClaimPredicates(t *testing.T) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -87,6 +87,18 @@ var (
 		[]string{"namespace", "sandbox_template", "launch_type", "warmpool_name", "pod_condition"},
 	)
 
+	// AdoptionConflictsTotal counts optimistic locking conflicts during warm pool adoption.
+	// High values indicate thundering herd contention on the API server.
+	// Labels:
+	// - namespace: the namespace of the claim
+	AdoptionConflictsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "agent_sandbox_adoption_conflicts_total",
+			Help: "Total number of optimistic locking conflicts during warm pool sandbox adoption.",
+		},
+		[]string{"namespace"},
+	)
+
 	// AgentSandboxesDesc describes the agent_sandboxes metric point-in-time counts.
 	// Labels:
 	// - namespace: the namespace of the sandbox
@@ -108,6 +120,7 @@ func init() {
 	metrics.Registry.MustRegister(ClaimControllerStartupLatency)
 	metrics.Registry.MustRegister(SandboxCreationLatency)
 	metrics.Registry.MustRegister(SandboxClaimCreationTotal)
+	metrics.Registry.MustRegister(AdoptionConflictsTotal)
 }
 
 // RecordClaimStartupLatency records the duration since the provided start time.

--- a/test/e2e/extensions/adoption_race_test.go
+++ b/test/e2e/extensions/adoption_race_test.go
@@ -1,0 +1,338 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestClaimSkipsPreAnnotatedSandbox verifies that a sandbox with a pre-existing
+// claimed-by annotation is not adopted by a new SandboxClaim. The claim should
+// cold-start a fresh sandbox instead.
+func TestClaimSkipsPreAnnotatedSandbox(t *testing.T) {
+	tc := framework.NewTestContext(t)
+
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("skip-preannotated-%d", time.Now().UnixNano())
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+
+	// Create a SandboxTemplate
+	template := &extensionsv1alpha1.SandboxTemplate{}
+	template.Name = "skip-template"
+	template.Namespace = ns.Name
+	template.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:3.10",
+				},
+			},
+		},
+	}
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), template))
+
+	// Create a SandboxWarmPool with 1 replica
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
+	warmPool.Name = "skip-pool"
+	warmPool.Namespace = ns.Name
+	warmPool.Spec.TemplateRef.Name = template.Name
+	warmPool.Spec.Replicas = 1
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), warmPool))
+
+	// Wait for the warm pool sandbox to become ready
+	var poolSandboxName string
+	require.Eventually(t, func() bool {
+		sandboxList := &sandboxv1alpha1.SandboxList{}
+		if err := tc.List(t.Context(), sandboxList, client.InNamespace(ns.Name)); err != nil {
+			return false
+		}
+		for _, sb := range sandboxList.Items {
+			if sb.DeletionTimestamp.IsZero() && metav1.IsControlledBy(&sb, warmPool) {
+				for _, cond := range sb.Status.Conditions {
+					if cond.Type == string(sandboxv1alpha1.SandboxConditionReady) && cond.Status == metav1.ConditionTrue {
+						poolSandboxName = sb.Name
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}, 60*time.Second, 2*time.Second, "warm pool sandbox should become ready")
+
+	// Pre-annotate the sandbox with a claimed-by annotation to simulate a prior reservation
+	poolSandbox := &sandboxv1alpha1.Sandbox{}
+	poolSandbox.Name = poolSandboxName
+	poolSandbox.Namespace = ns.Name
+	framework.MustUpdateObject(tc.ClusterClient, poolSandbox, func(sb *sandboxv1alpha1.Sandbox) {
+		if sb.Annotations == nil {
+			sb.Annotations = make(map[string]string)
+		}
+		sb.Annotations[sandboxv1alpha1.SandboxClaimedByAnnotation] = "some-other-uid"
+	})
+
+	// Create a claim referencing the same template
+	claim := &extensionsv1alpha1.SandboxClaim{}
+	claim.Name = "skip-claim"
+	claim.Namespace = ns.Name
+	claim.Spec.TemplateRef.Name = template.Name
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), claim))
+
+	// Wait for the claim to have a sandbox name in status (either adopted or cold-started)
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: claim.Name, Namespace: ns.Name}, claim); err != nil {
+			return false
+		}
+		return claim.Status.SandboxStatus.Name != ""
+	}, 60*time.Second, 2*time.Second, "claim should get a sandbox name in status")
+
+	// Verify the claim did NOT adopt the reserved sandbox -- it cold-started a new one
+	require.NotEqual(t, poolSandboxName, claim.Status.SandboxStatus.Name,
+		"claim should not adopt the pre-annotated sandbox; expected cold-start")
+
+	// Verify the reserved sandbox still has its warm pool owner reference (not adopted)
+	require.NoError(t, tc.Get(t.Context(), types.NamespacedName{Name: poolSandboxName, Namespace: ns.Name}, poolSandbox))
+	require.True(t, metav1.IsControlledBy(poolSandbox, warmPool),
+		"reserved sandbox should still be controlled by the warm pool")
+}
+
+// TestClaimAdoptionWritesClaimedByAnnotation verifies that when a claim adopts
+// a warm pool sandbox, the adopted sandbox receives a claimed-by annotation
+// set to the adopting claim's UID.
+func TestClaimAdoptionWritesClaimedByAnnotation(t *testing.T) {
+	tc := framework.NewTestContext(t)
+
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("adoption-annotation-%d", time.Now().UnixNano())
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+
+	// Create a SandboxTemplate
+	template := &extensionsv1alpha1.SandboxTemplate{}
+	template.Name = "adopt-template"
+	template.Namespace = ns.Name
+	template.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:3.10",
+				},
+			},
+		},
+	}
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), template))
+
+	// Create a SandboxWarmPool with 1 replica (no pre-annotation)
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
+	warmPool.Name = "adopt-pool"
+	warmPool.Namespace = ns.Name
+	warmPool.Spec.TemplateRef.Name = template.Name
+	warmPool.Spec.Replicas = 1
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), warmPool))
+
+	// Wait for the warm pool sandbox to become ready
+	var poolSandboxName string
+	require.Eventually(t, func() bool {
+		sandboxList := &sandboxv1alpha1.SandboxList{}
+		if err := tc.List(t.Context(), sandboxList, client.InNamespace(ns.Name)); err != nil {
+			return false
+		}
+		for _, sb := range sandboxList.Items {
+			if sb.DeletionTimestamp.IsZero() && metav1.IsControlledBy(&sb, warmPool) {
+				for _, cond := range sb.Status.Conditions {
+					if cond.Type == string(sandboxv1alpha1.SandboxConditionReady) && cond.Status == metav1.ConditionTrue {
+						poolSandboxName = sb.Name
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}, 60*time.Second, 2*time.Second, "warm pool sandbox should become ready")
+
+	// Create a claim to adopt the sandbox
+	claim := &extensionsv1alpha1.SandboxClaim{}
+	claim.Name = "adopt-claim"
+	claim.Namespace = ns.Name
+	claim.Spec.TemplateRef.Name = template.Name
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), claim))
+
+	// Wait for the claim to become ready
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: claim.Name, Namespace: ns.Name}, claim); err != nil {
+			return false
+		}
+		if claim.Status.SandboxStatus.Name == "" {
+			return false
+		}
+		for _, cond := range claim.Status.Conditions {
+			if cond.Type == string(sandboxv1alpha1.SandboxConditionReady) && cond.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}, 60*time.Second, 2*time.Second, "claim should become ready")
+
+	// Verify the claim adopted the warm pool sandbox
+	require.Equal(t, poolSandboxName, claim.Status.SandboxStatus.Name,
+		"claim should adopt the warm pool sandbox")
+
+	// Verify the adopted sandbox has the claimed-by annotation set to the claim's UID
+	adoptedSandbox := &sandboxv1alpha1.Sandbox{}
+	require.NoError(t, tc.Get(t.Context(), types.NamespacedName{
+		Name:      claim.Status.SandboxStatus.Name,
+		Namespace: ns.Name,
+	}, adoptedSandbox))
+
+	require.Contains(t, adoptedSandbox.Annotations, sandboxv1alpha1.SandboxClaimedByAnnotation,
+		"adopted sandbox should have the claimed-by annotation")
+	require.Equal(t, string(claim.UID), adoptedSandbox.Annotations[sandboxv1alpha1.SandboxClaimedByAnnotation],
+		"claimed-by annotation should equal the claim's UID")
+}
+
+// TestMultipleClaimsRespectReservations verifies that when all warm pool
+// sandboxes are pre-annotated with claimed-by values, new claims cold-start
+// instead of adopting any reserved sandbox.
+func TestMultipleClaimsRespectReservations(t *testing.T) {
+	tc := framework.NewTestContext(t)
+
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("multi-reserve-%d", time.Now().UnixNano())
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+
+	// Create a SandboxTemplate
+	template := &extensionsv1alpha1.SandboxTemplate{}
+	template.Name = "multi-template"
+	template.Namespace = ns.Name
+	template.Spec.PodTemplate = sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "pause",
+					Image: "registry.k8s.io/pause:3.10",
+				},
+			},
+		},
+	}
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), template))
+
+	// Create a SandboxWarmPool with 3 replicas
+	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
+	warmPool.Name = "multi-pool"
+	warmPool.Namespace = ns.Name
+	warmPool.Spec.TemplateRef.Name = template.Name
+	warmPool.Spec.Replicas = 3
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), warmPool))
+
+	// Wait for all 3 warm pool sandboxes to become ready
+	var reservedNames []string
+	require.Eventually(t, func() bool {
+		sandboxList := &sandboxv1alpha1.SandboxList{}
+		if err := tc.List(t.Context(), sandboxList, client.InNamespace(ns.Name)); err != nil {
+			return false
+		}
+		var readyNames []string
+		for _, sb := range sandboxList.Items {
+			if sb.DeletionTimestamp.IsZero() && metav1.IsControlledBy(&sb, warmPool) {
+				for _, cond := range sb.Status.Conditions {
+					if cond.Type == string(sandboxv1alpha1.SandboxConditionReady) && cond.Status == metav1.ConditionTrue {
+						readyNames = append(readyNames, sb.Name)
+					}
+				}
+			}
+		}
+		if len(readyNames) == 3 {
+			reservedNames = readyNames
+			return true
+		}
+		return false
+	}, 90*time.Second, 2*time.Second, "all 3 warm pool sandboxes should become ready")
+
+	// Pre-annotate all 3 sandboxes with distinct claimed-by values
+	for i, name := range reservedNames {
+		sb := &sandboxv1alpha1.Sandbox{}
+		sb.Name = name
+		sb.Namespace = ns.Name
+		uid := fmt.Sprintf("reserved-uid-%d", i)
+		framework.MustUpdateObject(tc.ClusterClient, sb, func(s *sandboxv1alpha1.Sandbox) {
+			if s.Annotations == nil {
+				s.Annotations = make(map[string]string)
+			}
+			s.Annotations[sandboxv1alpha1.SandboxClaimedByAnnotation] = uid
+		})
+	}
+
+	// Create 2 claims referencing the same template
+	claim1 := &extensionsv1alpha1.SandboxClaim{}
+	claim1.Name = "multi-claim-1"
+	claim1.Namespace = ns.Name
+	claim1.Spec.TemplateRef.Name = template.Name
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), claim1))
+
+	claim2 := &extensionsv1alpha1.SandboxClaim{}
+	claim2.Name = "multi-claim-2"
+	claim2.Namespace = ns.Name
+	claim2.Spec.TemplateRef.Name = template.Name
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), claim2))
+
+	// Wait for both claims to have sandbox names in status
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: claim1.Name, Namespace: ns.Name}, claim1); err != nil {
+			return false
+		}
+		return claim1.Status.SandboxStatus.Name != ""
+	}, 60*time.Second, 2*time.Second, "claim1 should get a sandbox name in status")
+
+	require.Eventually(t, func() bool {
+		if err := tc.Get(t.Context(), types.NamespacedName{Name: claim2.Name, Namespace: ns.Name}, claim2); err != nil {
+			return false
+		}
+		return claim2.Status.SandboxStatus.Name != ""
+	}, 60*time.Second, 2*time.Second, "claim2 should get a sandbox name in status")
+
+	// Build a set of reserved names for efficient lookup
+	reservedSet := make(map[string]struct{}, len(reservedNames))
+	for _, name := range reservedNames {
+		reservedSet[name] = struct{}{}
+	}
+
+	// Verify both claims cold-started (their sandbox names differ from all reserved names)
+	_, claim1UsedReserved := reservedSet[claim1.Status.SandboxStatus.Name]
+	require.False(t, claim1UsedReserved,
+		"claim1 should not adopt any reserved sandbox; got %s", claim1.Status.SandboxStatus.Name)
+
+	_, claim2UsedReserved := reservedSet[claim2.Status.SandboxStatus.Name]
+	require.False(t, claim2UsedReserved,
+		"claim2 should not adopt any reserved sandbox; got %s", claim2.Status.SandboxStatus.Name)
+
+	// Verify no reserved sandbox had its owner reference changed to a SandboxClaim
+	for _, name := range reservedNames {
+		sb := &sandboxv1alpha1.Sandbox{}
+		require.NoError(t, tc.Get(t.Context(), types.NamespacedName{Name: name, Namespace: ns.Name}, sb))
+		require.True(t, metav1.IsControlledBy(sb, warmPool),
+			"reserved sandbox %s should still be controlled by the warm pool", name)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a cross-claim race condition where concurrent SandboxClaims can adopt the same warm pool sandbox due to informer cache eventual consistency.

- **Annotation CAS** reserves a sandbox via `MergeFromWithOptimisticLock` before the full ownership transfer. Only one claim wins the resourceVersion CAS.
- **Candidate filter** skips sandboxes already claimed by another SandboxClaim, so claims don't waste patches on sandboxes they can't win. A same-UID passthrough allows a claim to resume its own partial adoption after controller restart.
- **Conflict metric** `agent_sandbox_adoption_conflicts_total` surfaces contention,  incrementing on each 409 Conflict during adoption.

Relates to #127, #478 (doesn't close either, but the complete fix including orphan GC and multi-pod remediation is a follow-up).

/kind bug

## How it works
The adoption loop in `adoptSandboxFromCandidates` now writes `agents.x-k8s.io/claimed-by: <claim-UID>` via an optimistic-lock merge patch before proceeding with the ownership transfer. Concurrent claims targeting the same sandbox lose the resourceVersion CAS (409 Conflict) and move to the next candidate.

The candidate filter in `getOrCreateSandbox` skips sandboxes with a `claimed-by` annotation from a different claim. Sandboxes annotated with the current claim's own UID pass through so a partially-completed adoption can resume after a controller restart.

## Issue

Reproduction on Kind (v0.2.1 controller, --sandbox-claim-concurrent-workers=8)

Setup: 5-replica SandboxWarmPool, 20 concurrent SandboxClaims.

The controller logs show multiple sandboxes adopting the same underlying warm pool pod:

```
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-0
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-9
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-19
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-16
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-6
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-1
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-4
Successfully adopted pod from warm pool  pod=pool-pod-a  claim=claim-15    
```

8 different claims all adopted `pool-pod-a`. The 1:1 sandbox-to-pod invariant is broken, one pod is shared across 8 sandboxes. All 5 warm pool pods had the same problem: `pool-pod-b` (3 claims), `pool-pod-c` (2), `pool-pod-d` (4), `pool-pod-e` (3).

None of the 20 claims got status populated. Reconciliation never completed cleanly because each adoption overwrote the previous one's ownership transfer.

With the fix, same setup:
Total assigned: 20, Unique sandboxes: 20, Duplicates: 0
5 warm pool adoptions (one per pod), 15 cold-starts. No pod shared between sandboxes.

## Known gaps (follow-up PR)

- **Strong-read verification**: re-read via APIReader after the annotation patch to get a fresh object pointer
- **Orphan GC**: clear stale `claimed-by` annotations when the claiming SandboxClaim is deleted mid-adoption
- **Multi-pod remediation**: detect and delete extra pods when the 1:1sandbox-to-pod invariant is violated

## Testing

  - [x] `TestAdoptedSandboxGetsClaimedByAnnotation`: annotation written on adoption
  - [x] `TestSinglePreClaimedSandboxIsSkipped`: pre-claimed sandbox skipped
  - [x] `TestMultipleClaimsRespectReservations`: reserved sandboxes respected
  - [x] `TestCrossClaimAdoptionRace`: 10 concurrent claims, 3 warm pool sandboxes
  - [x] `TestSandboxClaimResumesPartialAdoption`: crash recovery via same-UID passthrough
  - [x] 3 e2e integration tests against a live cluster
  - [x] All existing tests pass