### PR TITLE
Remove publishing to TestPyPI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
-      - uses: devops-actions/actionlint@v0.1.10
+      - uses: devops-actions/actionlint@467e2ce19b2310e93c9ffa0b50fe31f86b5a7f23 # ratchet:devops-actions/actionlint@v0.1.10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 jobs:
   lint-workflows:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -3,7 +3,7 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
   contents: read
@@ -20,23 +20,23 @@ jobs:
         working-directory: clients/python/agentic-sandbox-client
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
-      with: 
-        fetch-depth: 0  # Important: Fetches all history and tags for setuptools-scm
-    
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
-        
-    - name: Install dependencies (including tests)
-      run: python3 -m pip install ".[test]" 
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # Important: Fetches all history and tags for setuptools-scm
 
-    - name: Run Unit Tests
-      run: python3 -m pytest
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install dependencies (including tests)
+        run: python3 -m pip install ".[test]"
+
+      - name: Run Unit Tests
+        run: python3 -m pytest
 
   build:
     name: Build distribution 📦
@@ -48,37 +48,39 @@ jobs:
         working-directory: clients/python/agentic-sandbox-client
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
-    
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
-      with:
-        python-version: "3.10"
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch full history and tags for setuptools-scm during build
 
-    - name: Install pypa/build
-      run: >-
-        python3 -m pip install build
-        
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-      
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: clients/python/agentic-sandbox-client/dist/
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install pypa/build
+        run: >-
+          python3 -m pip install build
+
+      - name: Build a binary wheel and a source tarball
+        run: python3 -m build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: clients/python/agentic-sandbox-client/dist/
 
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
     needs:
-    - build
+      - build
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/k8s-agent-sandbox
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: read
 
     # Run if it is a push event AND NOT a release candidate
@@ -86,11 +88,11 @@ jobs:
       (github.event_name == 'push' && !contains(github.ref, 'rc'))
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-        
-    - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # ratchet:pypa/gh-action-pypi-publish@release/v1
+      - name: Download all the dists
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # ratchet:pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -68,36 +68,11 @@ jobs:
         name: python-package-distributions
         path: clients/python/agentic-sandbox-client/dist/
 
-  publish-to-testpypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to TestPyPI
-    needs:
-    - build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi 
-      url: https://test.pypi.org/p/k8s-agent-sandbox
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-      contents: read
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-        
-    - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
     needs:
-    - publish-to-testpypi
+    - build
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,12 +20,12 @@ jobs:
         working-directory: clients/python/agentic-sandbox-client
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       with: 
         fetch-depth: 0  # Important: Fetches all history and tags for setuptools-scm
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -93,4 +93,4 @@ jobs:
         path: dist/
         
     - name: Publish distribution 📦 to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # ratchet:pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -48,10 +48,10 @@ jobs:
         working-directory: clients/python/agentic-sandbox-client
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
       with:
         python-version: "3.10"
 
@@ -63,7 +63,7 @@ jobs:
       run: python3 -m build
       
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: clients/python/agentic-sandbox-client/dist/
@@ -87,7 +87,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -57,12 +57,15 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install pypa/build
+      - name: Install pypa/build and twine
         run: >-
-          python3 -m pip install build
+          python3 -m pip install build==1.4.3 twine==6.2.0
 
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
+
+      - name: Check distribution packages
+        run: python3 -m twine check dist/*
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4


### PR DESCRIPTION
Based on the comment - https://github.com/kubernetes-sigs/agent-sandbox/pull/542#issuecomment-4240982135
Removing the step to publish to test pypi since there are unit tests set up now. 

Testing:
Tested workflow on the branch after adding the twine check - https://github.com/shrutiyam-glitch/agent-sandbox/actions/runs/24572632807