### PR TITLE
fix: recover sandbox when tracked pod is deleted externally 

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -452,6 +452,21 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 	return service, nil
 }
 
+// clearPodNameAnnotation removes the pod name annotation from the sandbox if it exists.
+func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) error {
+	if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; !exists {
+		return nil
+	}
+	log := log.FromContext(ctx)
+	patch := client.MergeFrom(sandbox.DeepCopy())
+	delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
+	if err := r.Patch(ctx, sandbox, patch); err != nil {
+		return fmt.Errorf("failed to clear pod name annotation: %w", err)
+	}
+	log.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
+	return nil
+}
+
 // setServiceStatus updates the sandbox status with the service name and FQDN.
 func (r *SandboxReconciler) setServiceStatus(sandbox *sandboxv1alpha1.Sandbox, service *corev1.Service) {
 	sandbox.Status.Service = service.Name
@@ -498,8 +513,10 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil, fmt.Errorf("pod get failed: %w", err)
 		}
 		if podNameAnnotationExists {
-			log.Error(err, "Pod not found")
-			return nil, fmt.Errorf("pod in annotation get failed: %w", err)
+			log.Info("Pod referenced by annotation not found, clearing annotation to recover state", "podName", podName)
+			if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
+				return nil, err
+			}
 		}
 		pod = nil
 	}
@@ -528,14 +545,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		}
 
 		// Remove the pod name annotation from the sandbox if it exists
-		if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists {
-			log.Info("Removing pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
-			patch := client.MergeFrom(sandbox.DeepCopy())
-			delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
-
-			if err := r.Patch(ctx, sandbox, patch); err != nil {
-				return nil, fmt.Errorf("failed to remove pod name annotation: %w", err)
-			}
+		if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
+			return nil, err
 		}
 
 		return nil, nil
@@ -586,13 +597,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 
-			if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; exists {
-				log.Info("Removing pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
-				patch := client.MergeFrom(sandbox.DeepCopy())
-				delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
-				if err := r.Patch(ctx, sandbox, patch); err != nil {
-					return nil, fmt.Errorf("failed to remove pod name annotation: %w", err)
-				}
+			if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
+				return nil, err
 			}
 
 			return nil, fmt.Errorf("pod %q is owned by %s/%s (UID: %s), not by sandbox %q",

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1140,12 +1140,13 @@ func TestReconcilePod(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:        "error when annotated pod does not exist",
+			name:        "annotated pod missing with replicas=1: clears annotation and recreates pod",
 			initialObjs: []runtime.Object{},
 			sandbox: &sandboxv1alpha1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandboxName,
 					Namespace: sandboxNs,
+					UID:       sandboxUID,
 					Annotations: map[string]string{
 						sandboxv1alpha1.SandboxPodNameAnnotation: "non-existent-pod",
 					},
@@ -1153,6 +1154,11 @@ func TestReconcilePod(t *testing.T) {
 				Spec: sandboxv1alpha1.SandboxSpec{
 					Replicas: new(int32(1)),
 					PodTemplate: sandboxv1alpha1.PodTemplate{
+						ObjectMeta: sandboxv1alpha1.PodMetadata{
+							Annotations: map[string]string{
+								"agents.x-k8s.io/template": "default",
+							},
+						},
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
@@ -1163,8 +1169,55 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/template":               "default",
+						"agents.x-k8s.io/propagated-annotations": "agents.x-k8s.io/template",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+			expectErr: false,
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1alpha1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name:        "annotated pod missing with replicas=0: clears annotation and does not recreate pod",
+			initialObjs: []runtime.Object{},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "non-existent-pod",
+						"other-annotation":                       "keep-me",
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: new(int32),
+				},
+			},
 			wantPod:   nil,
-			expectErr: true,
+			expectErr: false,
+			wantSandboxAnnotations: map[string]string{
+				"other-annotation": "keep-me",
+			},
 		},
 		{
 			name: "refuses to delete annotated pod owned by a different controller",


### PR DESCRIPTION
Fixes: #611 

### Approach                                                                                                                                                                                                                           
When the annotated pod returns "Not Found", clear the stale annotation and fall through to the normal pod creation path. If `replicas == 0`, skip recreation as usual. 

### Changes                                                                                                                                                                                                               
  - `reconcilePod`: on "Not Found" for an annotated pod, clear the annotation and  recreate instead of returning a terminal error.         
 
  - Extract the repeated annotation-clearing pattern (3 call sites) into a `clearPodNameAnnotation()` helper.          
                                                                                                                                                                                       
  - Update tests to reflect the new recovery behavior. 
  The previous test `"error when annotated pod does not exist"` had `expectErr: true`, it's unclear whether this was intentional design or an oversight, but the resulting UX requires users to manually delete and recreate the entire Sandbox just to recover from a pod crash or node failure.
 