### PR TITLE
feat(sandboxclaim): exempt safe-to-evict annotation from additionalPodMetadata domain validation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -558,7 +558,7 @@ _Appears in:_
 | `sandboxTemplateRef` _[SandboxTemplateRef](#sandboxtemplateref)_ | sandboxTemplateRef defines the name of the SandboxTemplate to be used for creating a Sandbox. |  | Required: \{\} <br /> |
 | `lifecycle` _[Lifecycle](#lifecycle)_ | lifecycle defines when and how the SandboxClaim should be shut down. |  | Optional: \{\} <br /> |
 | `warmpool` _[WarmPoolPolicy](#warmpoolpolicy)_ | warmpool specifies the warm pool policy for sandbox adoption.<br />- "none": Do not use any warm pool, always create fresh sandboxes<br />- "default": Use default behavior, select from all matching warm pools (default)<br />- A warm pool name: Select only from the specified warm pool (e.g., "fast-pool", "secure-pool") | default | Optional: \{\} <br /> |
-| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted. |  | Optional: \{\} <br /> |
+| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Annotations in restricted system domains are rejected, except cluster-autoscaler.kubernetes.io/safe-to-evict. |  | Optional: \{\} <br /> |
 | `env` _[EnvVar](#envvar) array_ | env is a list of environment variables to inject into the sandbox |  | Optional: \{\} <br /> |
 
 
@@ -925,7 +925,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `warmPoolRef` _[SandboxWarmPoolRef](#sandboxwarmpoolref)_ | warmPoolRef targets the specific pre-warmed infrastructure pool to check out from. |  | Required: \{\} <br /> |
 | `lifecycle` _[Lifecycle](#lifecycle)_ | lifecycle defines when and how the SandboxClaim should be shut down. |  | Optional: \{\} <br /> |
-| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted. |  | Optional: \{\} <br /> |
+| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Annotations in restricted system domains are rejected, except cluster-autoscaler.kubernetes.io/safe-to-evict. |  | Optional: \{\} <br /> |
 | `env` _[EnvVar](#envvar) array_ | env is a list of environment variables to inject into the sandbox.<br />Please note adding this field means the Sandbox will always be cold-started from the<br />template of the warmpool. |  | Optional: \{\} <br /> |
 | `volumeClaimTemplates` _[PersistentVolumeClaimTemplate](#persistentvolumeclaimtemplate) array_ | volumeClaimTemplates is a list of persistent volume claims to be created for the sandbox.<br />Specifying this field forces a cold start because warm pool pods will not have these volumes. |  | Optional: \{\} <br /> |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -558,7 +558,7 @@ _Appears in:_
 | `sandboxTemplateRef` _[SandboxTemplateRef](#sandboxtemplateref)_ | sandboxTemplateRef defines the name of the SandboxTemplate to be used for creating a Sandbox. |  | Required: \{\} <br /> |
 | `lifecycle` _[Lifecycle](#lifecycle)_ | lifecycle defines when and how the SandboxClaim should be shut down. |  | Optional: \{\} <br /> |
 | `warmpool` _[WarmPoolPolicy](#warmpoolpolicy)_ | warmpool specifies the warm pool policy for sandbox adoption.<br />- "none": Do not use any warm pool, always create fresh sandboxes<br />- "default": Use default behavior, select from all matching warm pools (default)<br />- A warm pool name: Select only from the specified warm pool (e.g., "fast-pool", "secure-pool") | default | Optional: \{\} <br /> |
-| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns. |  | Optional: \{\} <br /> |
+| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted. |  | Optional: \{\} <br /> |
 | `env` _[EnvVar](#envvar) array_ | env is a list of environment variables to inject into the sandbox |  | Optional: \{\} <br /> |
 
 
@@ -925,7 +925,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `warmPoolRef` _[SandboxWarmPoolRef](#sandboxwarmpoolref)_ | warmPoolRef targets the specific pre-warmed infrastructure pool to check out from. |  | Required: \{\} <br /> |
 | `lifecycle` _[Lifecycle](#lifecycle)_ | lifecycle defines when and how the SandboxClaim should be shut down. |  | Optional: \{\} <br /> |
-| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns. |  | Optional: \{\} <br /> |
+| `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted. |  | Optional: \{\} <br /> |
 | `env` _[EnvVar](#envvar) array_ | env is a list of environment variables to inject into the sandbox.<br />Please note adding this field means the Sandbox will always be cold-started from the<br />template of the warmpool. |  | Optional: \{\} <br /> |
 | `volumeClaimTemplates` _[PersistentVolumeClaimTemplate](#persistentvolumeclaimtemplate) array_ | volumeClaimTemplates is a list of persistent volume claims to be created for the sandbox.<br />Specifying this field forces a cold start because warm pool pods will not have these volumes. |  | Optional: \{\} <br /> |
 

--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -146,6 +146,7 @@ type SandboxClaimSpec struct {
 
 	// additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.
 	// Label values are limited to 63 characters and must match Kubernetes label value patterns.
+	// Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted.
 	// +optional
 	AdditionalPodMetadata sandboxv1alpha1.PodMetadata `json:"additionalPodMetadata,omitempty"`
 

--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -146,7 +146,7 @@ type SandboxClaimSpec struct {
 
 	// additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.
 	// Label values are limited to 63 characters and must match Kubernetes label value patterns.
-	// Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted.
+	// Annotations in restricted system domains are rejected, except cluster-autoscaler.kubernetes.io/safe-to-evict.
 	// +optional
 	AdditionalPodMetadata sandboxv1alpha1.PodMetadata `json:"additionalPodMetadata,omitempty"`
 

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -117,6 +117,7 @@ type SandboxClaimSpec struct {
 
 	// additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.
 	// Label values are limited to 63 characters and must match Kubernetes label value patterns.
+	// Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted.
 	// +optional
 	AdditionalPodMetadata sandboxv1beta1.PodMetadata `json:"additionalPodMetadata,omitempty"`
 

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -117,7 +117,7 @@ type SandboxClaimSpec struct {
 
 	// additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.
 	// Label values are limited to 63 characters and must match Kubernetes label value patterns.
-	// Restricted system domains are rejected outright, but cluster-autoscaler.kubernetes.io/safe-to-evict is exempted.
+	// Annotations in restricted system domains are rejected, except cluster-autoscaler.kubernetes.io/safe-to-evict.
 	// +optional
 	AdditionalPodMetadata sandboxv1beta1.PodMetadata `json:"additionalPodMetadata,omitempty"`
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -87,6 +87,9 @@ var errAdoptionTriggeredRetry = errors.New("triggered adoption completion, retry
 const adoptionCacheLagRequeueDelay = 50 * time.Millisecond
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
+var exemptedMetadataKeys = []string{
+	"cluster-autoscaler.kubernetes.io/safe-to-evict",
+}
 
 var ErrCrossNamespaceAdoption = errors.New("cross-namespace adoption forbidden")
 
@@ -1160,7 +1163,7 @@ func (r *SandboxClaimReconciler) validateAdditionalPodMetadata(claimMeta *v1beta
 			}
 		} else {
 			// For annotations, we use the blocklist
-			if isRestrictedDomain(domain) {
+			if isRestrictedDomain(domain) && !slices.Contains(exemptedMetadataKeys, key) {
 				return fmt.Errorf("restricted system domain: %q is not allowed in AdditionalPodMetadata", key)
 			}
 		}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -87,9 +87,8 @@ var errAdoptionTriggeredRetry = errors.New("triggered adoption completion, retry
 const adoptionCacheLagRequeueDelay = 50 * time.Millisecond
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
-var exemptedMetadataKeys = []string{
-	"cluster-autoscaler.kubernetes.io/safe-to-evict",
-}
+var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
+var validAutoscalerSafeToEvictValues = []string{"true", "false", "on-completion"}
 
 var ErrCrossNamespaceAdoption = errors.New("cross-namespace adoption forbidden")
 
@@ -1012,8 +1011,8 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	// Remove the warm pool's default eviction annotation so the adopted sandbox
 	// is protected from autoscaler scale-downs now that it hosts active state.
 	// Custom template-specified overrides (e.g. "false") are explicitly kept.
-	if adopted.Spec.PodTemplate.ObjectMeta.Annotations != nil && adopted.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation] == "true" {
-		delete(adopted.Spec.PodTemplate.ObjectMeta.Annotations, warmPoolEvictionAnnotation)
+	if adopted.Spec.PodTemplate.ObjectMeta.Annotations != nil && adopted.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation] == "true" {
+		delete(adopted.Spec.PodTemplate.ObjectMeta.Annotations, autoscalerSafeToEvictAnnotation)
 	}
 
 	// Transfer ownership from SandboxWarmPool to SandboxClaim
@@ -1163,8 +1162,13 @@ func (r *SandboxClaimReconciler) validateAdditionalPodMetadata(claimMeta *v1beta
 			}
 		} else {
 			// For annotations, we use the blocklist
-			if isRestrictedDomain(domain) && !slices.Contains(exemptedMetadataKeys, key) {
-				return fmt.Errorf("restricted system domain: %q is not allowed in AdditionalPodMetadata", key)
+			if isRestrictedDomain(domain) {
+				if !slices.Contains(exemptedMetadataKeys, key) {
+					return fmt.Errorf("restricted system domain: %q is not allowed in AdditionalPodMetadata", key)
+				}
+				if key == autoscalerSafeToEvictAnnotation && !slices.Contains(validAutoscalerSafeToEvictValues, value) {
+					return fmt.Errorf("invalid value %q for annotation %q: must be 'true', 'false', or 'on-completion'", value, key)
+				}
 			}
 		}
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -88,7 +88,6 @@ const adoptionCacheLagRequeueDelay = 50 * time.Millisecond
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
-var validAutoscalerSafeToEvictValues = []string{"true", "false", "on-completion"}
 
 var ErrCrossNamespaceAdoption = errors.New("cross-namespace adoption forbidden")
 
@@ -1165,9 +1164,6 @@ func (r *SandboxClaimReconciler) validateAdditionalPodMetadata(claimMeta *v1beta
 			if isRestrictedDomain(domain) {
 				if !slices.Contains(exemptedMetadataKeys, key) {
 					return fmt.Errorf("restricted system domain: %q is not allowed in AdditionalPodMetadata", key)
-				}
-				if key == autoscalerSafeToEvictAnnotation && !slices.Contains(validAutoscalerSafeToEvictValues, value) {
-					return fmt.Errorf("invalid value %q for annotation %q: must be 'true', 'false', or 'on-completion'", value, key)
 				}
 			}
 		}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -792,6 +792,28 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "claim with safe-to-evict annotation is accepted",
+			claimToReconcile: &extensionsv1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-safe-to-evict", Namespace: "default", UID: "uid-safe-to-evict"},
+				Spec: extensionsv1beta1.SandboxClaimSpec{
+					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"},
+					AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
+						Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
+					},
+				},
+			},
+			existingObjects: []client.Object{template, warmPool},
+			expectSandbox:   true,
+			expectedCondition: metav1.Condition{
+				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "SandboxNotReady", Message: "Sandbox is not ready",
+			},
+			validateSandbox: func(t *testing.T, sandbox *sandboxv1beta1.Sandbox, _ *extensionsv1beta1.SandboxTemplate) {
+				if val, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]; !ok || val != "false" {
+					t.Errorf("expected cluster-autoscaler.kubernetes.io/safe-to-evict to be propagated, got %q", val)
+				}
+			},
+		},
+		{
 			name: "claim with spoofed router app label is rejected",
 			claimToReconcile: &extensionsv1beta1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim-spoofed-app-label", Namespace: "default", UID: "uid-spoofed-app-label"},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -814,6 +814,49 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "claim with safe-to-evict on-completion annotation is accepted",
+			claimToReconcile: &extensionsv1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-safe-to-evict-completion", Namespace: "default", UID: "uid-safe-to-evict-completion"},
+				Spec: extensionsv1beta1.SandboxClaimSpec{
+					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"},
+					AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
+						Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "on-completion"},
+					},
+				},
+			},
+			existingObjects: []client.Object{template, warmPool},
+			expectSandbox:   true,
+			expectedCondition: metav1.Condition{
+				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "SandboxNotReady", Message: "Sandbox is not ready",
+			},
+			validateSandbox: func(t *testing.T, sandbox *sandboxv1beta1.Sandbox, _ *extensionsv1beta1.SandboxTemplate) {
+				if val, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]; !ok || val != "on-completion" {
+					t.Errorf("expected cluster-autoscaler.kubernetes.io/safe-to-evict to be propagated, got %q", val)
+				}
+			},
+		},
+		{
+			name: "claim with invalid safe-to-evict annotation value is rejected",
+			claimToReconcile: &extensionsv1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-invalid-safe-to-evict", Namespace: "default", UID: "uid-invalid-safe-to-evict"},
+				Spec: extensionsv1beta1.SandboxClaimSpec{
+					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"},
+					AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
+						Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "True"},
+					},
+				},
+			},
+			existingObjects: []client.Object{template, warmPool},
+			expectSandbox:   false,
+			expectError:     false,
+			expectedCondition: metav1.Condition{
+				Type:    string(sandboxv1beta1.SandboxConditionReady),
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidMetadata",
+				Message: "invalid additionalPodMetadata: failed to validate annotation \"cluster-autoscaler.kubernetes.io/safe-to-evict\": invalid value \"True\" for annotation \"cluster-autoscaler.kubernetes.io/safe-to-evict\": must be 'true', 'false', or 'on-completion'",
+			},
+		},
+		{
 			name: "claim with spoofed router app label is rejected",
 			claimToReconcile: &extensionsv1beta1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim-spoofed-app-label", Namespace: "default", UID: "uid-spoofed-app-label"},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -836,27 +836,6 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "claim with invalid safe-to-evict annotation value is rejected",
-			claimToReconcile: &extensionsv1beta1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim-invalid-safe-to-evict", Namespace: "default", UID: "uid-invalid-safe-to-evict"},
-				Spec: extensionsv1beta1.SandboxClaimSpec{
-					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"},
-					AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
-						Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "True"},
-					},
-				},
-			},
-			existingObjects: []client.Object{template, warmPool},
-			expectSandbox:   false,
-			expectError:     false,
-			expectedCondition: metav1.Condition{
-				Type:    string(sandboxv1beta1.SandboxConditionReady),
-				Status:  metav1.ConditionFalse,
-				Reason:  "InvalidMetadata",
-				Message: "invalid additionalPodMetadata: failed to validate annotation \"cluster-autoscaler.kubernetes.io/safe-to-evict\": invalid value \"True\" for annotation \"cluster-autoscaler.kubernetes.io/safe-to-evict\": must be 'true', 'false', or 'on-completion'",
-			},
-		},
-		{
 			name: "claim with spoofed router app label is rejected",
 			claimToReconcile: &extensionsv1beta1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim-spoofed-app-label", Namespace: "default", UID: "uid-spoofed-app-label"},
@@ -2242,6 +2221,32 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectedAdoptedSandbox: "pool-sb-1",
 			expectedPodAnnotations: map[string]string{
 				autoscalerSafeToEvictAnnotation: "false",
+			},
+			expectNewSandboxCreated: false,
+		},
+		{
+			name: "preserves claim eviction annotation true when adopting sandbox",
+			existingObjects: []client.Object{
+				template,
+				func() client.Object {
+					cCopy := claim.DeepCopy()
+					if cCopy.Spec.AdditionalPodMetadata.Annotations == nil {
+						cCopy.Spec.AdditionalPodMetadata.Annotations = make(map[string]string)
+					}
+					cCopy.Spec.AdditionalPodMetadata.Annotations[autoscalerSafeToEvictAnnotation] = "true"
+					return cCopy
+				}(),
+				func() client.Object {
+					sb := createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true)
+					sb.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation] = "true"
+					return sb
+				}(),
+				createWarmPoolSandbox("pool-sb-2", metav1.Time{Time: metav1.Now().Add(-30 * time.Minute)}, true),
+			},
+			expectSandboxAdoption:  true,
+			expectedAdoptedSandbox: "pool-sb-1",
+			expectedPodAnnotations: map[string]string{
+				autoscalerSafeToEvictAnnotation: "true",
 			},
 			expectNewSandboxCreated: false,
 		},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1945,7 +1945,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
 				ObjectMeta: sandboxv1beta1.PodMetadata{
 					Annotations: map[string]string{
-						warmPoolEvictionAnnotation: "true",
+						autoscalerSafeToEvictAnnotation: "true",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -2166,13 +2166,13 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					if tCopy.Spec.PodTemplate.ObjectMeta.Annotations == nil {
 						tCopy.Spec.PodTemplate.ObjectMeta.Annotations = make(map[string]string)
 					}
-					tCopy.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation] = "false"
+					tCopy.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation] = "false"
 					return tCopy
 				}(),
 				claim,
 				func() client.Object {
 					sb := createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true)
-					sb.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation] = "false"
+					sb.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation] = "false"
 					return sb
 				}(),
 				createWarmPoolSandbox("pool-sb-2", metav1.Time{Time: metav1.Now().Add(-30 * time.Minute)}, true),
@@ -2180,7 +2180,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectSandboxAdoption:  true,
 			expectedAdoptedSandbox: "pool-sb-1",
 			expectedPodAnnotations: map[string]string{
-				warmPoolEvictionAnnotation: "false",
+				autoscalerSafeToEvictAnnotation: "false",
 			},
 			expectNewSandboxCreated: false,
 		},
@@ -2190,7 +2190,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				claim,
 				func() client.Object {
 					sb := createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true)
-					sb.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation] = "false"
+					sb.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation] = "false"
 					return sb
 				}(),
 				createWarmPoolSandbox("pool-sb-2", metav1.Time{Time: metav1.Now().Add(-30 * time.Minute)}, true),
@@ -2198,7 +2198,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectSandboxAdoption:  true,
 			expectedAdoptedSandbox: "pool-sb-1",
 			expectedPodAnnotations: map[string]string{
-				warmPoolEvictionAnnotation: "false",
+				autoscalerSafeToEvictAnnotation: "false",
 			},
 			expectNewSandboxCreated: false,
 		},
@@ -2362,7 +2362,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 						}
 					}
 				} else {
-					if _, exists := adoptedSandbox.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation]; exists {
+					if _, exists := adoptedSandbox.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation]; exists {
 						t.Errorf("expected eviction annotation to be removed from adopted sandbox")
 					}
 				}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -814,28 +814,6 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "claim with safe-to-evict on-completion annotation is accepted",
-			claimToReconcile: &extensionsv1beta1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim-safe-to-evict-completion", Namespace: "default", UID: "uid-safe-to-evict-completion"},
-				Spec: extensionsv1beta1.SandboxClaimSpec{
-					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"},
-					AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
-						Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "on-completion"},
-					},
-				},
-			},
-			existingObjects: []client.Object{template, warmPool},
-			expectSandbox:   true,
-			expectedCondition: metav1.Condition{
-				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "SandboxNotReady", Message: "Sandbox is not ready",
-			},
-			validateSandbox: func(t *testing.T, sandbox *sandboxv1beta1.Sandbox, _ *extensionsv1beta1.SandboxTemplate) {
-				if val, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"]; !ok || val != "on-completion" {
-					t.Errorf("expected cluster-autoscaler.kubernetes.io/safe-to-evict to be propagated, got %q", val)
-				}
-			},
-		},
-		{
 			name: "claim with spoofed router app label is rejected",
 			claimToReconcile: &extensionsv1beta1.SandboxClaim{
 				ObjectMeta: metav1.ObjectMeta{Name: "claim-spoofed-app-label", Namespace: "default", UID: "uid-spoofed-app-label"},

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -48,7 +48,7 @@ const (
 	sandboxTemplateRefHash          = sandboxv1beta1.SandboxTemplateRefHashLabel
 	warmPoolSandboxLabel            = sandboxv1beta1.SandboxWarmPoolLabel
 	sandboxCreateDeleteMaxBatchSize = 300
-	warmPoolEvictionAnnotation      = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	autoscalerSafeToEvictAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 	// sandboxWarmPoolLabelIndex is the cache field index over the warmPoolSandboxLabel
 	// value on warm sandboxes, so reconcilePool's member lookup is O(pool members) instead
 	// of O(sandboxes-in-namespace).
@@ -413,12 +413,12 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(
 
 	// Respect the template's custom eviction annotation if explicitly specified.
 	// Only apply the default eviction behavior if the annotation is not defined.
-	if _, exists := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation]; !exists {
+	if _, exists := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation]; !exists {
 		if r.EnableWarmPoolEviction {
 			if sandbox.Spec.PodTemplate.ObjectMeta.Annotations == nil {
 				sandbox.Spec.PodTemplate.ObjectMeta.Annotations = make(map[string]string)
 			}
-			sandbox.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation] = "true"
+			sandbox.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation] = "true"
 		}
 	}
 

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -501,7 +501,7 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 
 			// Verify pod template annotations
 			require.Equal(t, "from-podtemplate", sb.Spec.PodTemplate.ObjectMeta.Annotations["pod-annotation"])
-			require.Equal(t, "true", sb.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation])
+			require.Equal(t, "true", sb.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation])
 		}
 	})
 }
@@ -1609,7 +1609,7 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			name:             "controller true respects explicit template value false",
 			controllerEnable: true,
 			templateAnnotations: map[string]string{
-				warmPoolEvictionAnnotation: "false",
+				autoscalerSafeToEvictAnnotation: "false",
 			},
 			expectedEvictionVal: "false",
 		},
@@ -1617,7 +1617,7 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			name:             "controller false respects explicit template value false",
 			controllerEnable: false,
 			templateAnnotations: map[string]string{
-				warmPoolEvictionAnnotation: "false",
+				autoscalerSafeToEvictAnnotation: "false",
 			},
 			expectedEvictionVal: "false",
 		},
@@ -1625,7 +1625,7 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			name:             "controller true respects explicit template value true",
 			controllerEnable: true,
 			templateAnnotations: map[string]string{
-				warmPoolEvictionAnnotation: "true",
+				autoscalerSafeToEvictAnnotation: "true",
 			},
 			expectedEvictionVal: "true",
 		},
@@ -1633,7 +1633,7 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			name:             "controller false respects explicit template value true",
 			controllerEnable: false,
 			templateAnnotations: map[string]string{
-				warmPoolEvictionAnnotation: "true",
+				autoscalerSafeToEvictAnnotation: "true",
 			},
 			expectedEvictionVal: "true",
 		},
@@ -1676,7 +1676,7 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			require.Len(t, list.Items, 1)
 
 			sb := list.Items[0]
-			val, exists := sb.Spec.PodTemplate.ObjectMeta.Annotations[warmPoolEvictionAnnotation]
+			val, exists := sb.Spec.PodTemplate.ObjectMeta.Annotations[autoscalerSafeToEvictAnnotation]
 			if tc.expectedEvictionVal != "" {
 				require.True(t, exists, "expected eviction annotation to exist")
 				require.Equal(t, tc.expectedEvictionVal, val)


### PR DESCRIPTION
This PR implements the proposal in [#435](https://github.com/kubernetes-sigs/agent-sandbox/issues/435) to adopt the `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation for claimed sandboxes. This allows cluster scale-down to wait for sandbox completion rather than immediately evicting active workloads.

Rather than introducing new typed fields or complex eviction policies in the `SandboxClaim` API (which would bloat the CRD schema and create conflicting precedence rules), this implementation exempts the operational `safe-to-evict` annotation from the restricted-domain validations of `additionalPodMetadata`. Since this annotation is an operational hint for the autoscaler rather than a tenant security risk, it is safe from privilege escalation.

### Changes:
* **Validation Logic:** Exempt `cluster-autoscaler.kubernetes.io/safe-to-evict` from the restricted-domain annotation check in `additionalPodMetadata` validation.
* **Verification:** Added test assertions to verify that the `safe-to-evict` annotation is successfully accepted in the metadata template while other restricted-domain annotations continue to be blocked.
