### PR TITLE
chore: automatically update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      k8s-libs:
+        patterns:
+          - "k8s.io/api"
+          - "k8s.io/apiextensions-apiserver"
+          - "k8s.io/apimachinery"
+          - "k8s.io/client-go"
+          - "k8s.io/klog/v2"
+          - "k8s.io/utils"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Let's introduce dependabot to take care of some of our dependencies. I am fully aware that not all can be updated automatically, but the goal is to take care only of those which can be. If this won't work, we can disable it or reconfigure.

When this gets merged, dependabot should create PRs with dependency bumps for `go.mod`, `docker` and `github actions`.