### PR TITLE
fix: correct warm pool sandbox deletion when policy is retain

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -58,6 +58,9 @@ var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
 // ErrInvalidMetadata is a sentinel error indicating additionalPodMetadata was invalid.
 var ErrInvalidMetadata = errors.New("invalid additionalPodMetadata")
 
+// ErrSandboxNotOwned indicates the Sandbox exists but is not controlled by this claim.
+var ErrSandboxNotOwned = errors.New("sandbox not owned by this claim")
+
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 
 // getWarmPoolPolicy returns the effective warm pool policy for a claim.
@@ -215,7 +218,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Suppress expected user errors (like missing templates) to avoid crash loops
-	if errors.Is(reconcileErr, ErrTemplateNotFound) || errors.Is(reconcileErr, ErrInvalidMetadata) {
+	if errors.Is(reconcileErr, ErrTemplateNotFound) || errors.Is(reconcileErr, ErrInvalidMetadata) || errors.Is(reconcileErr, ErrSandboxNotOwned) {
 		logger.V(1).Info("Sandboxclaim suppressed error(s) encountered", "error", reconcileErr, "request", req.NamespacedName)
 		return result, nil
 	}
@@ -313,24 +316,33 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 func (r *SandboxClaimReconciler) reconcileExpired(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*v1alpha1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	logger.V(1).Info("Reconciling Expired claim", "claim", claim.Name)
-	sandbox := &v1alpha1.Sandbox{}
 
-	// Check if Sandbox exists
-	if err := r.Get(ctx, client.ObjectKeyFromObject(claim), sandbox); err != nil {
+	// Fall back to claim.Name when status is unset.
+	statusName := claim.Name
+	if claim.Status.SandboxStatus.Name != "" {
+		statusName = claim.Status.SandboxStatus.Name
+	}
+
+	sandbox := &v1alpha1.Sandbox{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err != nil {
 		if k8errors.IsNotFound(err) {
 			return nil, nil // Sandbox is gone, life is good.
 		}
 		return nil, err
 	}
 
+	// Verify ownership before delete action
+	if !metav1.IsControlledBy(sandbox, claim) {
+		logger.Info("Skipping deletion: Sandbox is not controlled by this claim", "sandbox", sandbox.Name, "claim", claim.Name)
+		return nil, fmt.Errorf("%w: sandbox %q is not owned by claim %q", ErrSandboxNotOwned, sandbox.Name, claim.Name)
+	}
 	// Sandbox exists, delete it.
 	if sandbox.DeletionTimestamp.IsZero() {
-		logger.Info("Deleting Sandbox because Claim expired (Policy=Retain)", "Sandbox", sandbox.Name, "claim", claim.Name)
+		logger.Info("Deleting Sandbox because Claim expired (Policy=Retain)", "sandbox", sandbox.Name, "claim", claim.Name)
 		if err := r.Delete(ctx, sandbox); err != nil {
 			return sandbox, fmt.Errorf("failed to delete expired sandbox: %w", err)
 		}
 	}
-
 	return sandbox, nil
 }
 
@@ -382,6 +394,15 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1alpha1
 				Status:             metav1.ConditionFalse,
 				Reason:             reason,
 				Message:            err.Error(),
+				ObservedGeneration: claim.Generation,
+			}
+		}
+		if errors.Is(err, ErrSandboxNotOwned) {
+			return metav1.Condition{
+				Type:               string(v1alpha1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             extensionsv1alpha1.ClaimExpiredReason,
+				Message:            fmt.Sprintf("Claim expired. %v; deletion skipped.", err),
 				ObservedGeneration: claim.Generation,
 			}
 		}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -921,12 +921,15 @@ func TestSandboxClaimCleanupPolicy(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                 string
-		claim                *extensionsv1alpha1.SandboxClaim
-		sandboxIsExpired     bool
-		expectClaimDeleted   bool
-		expectSandboxDeleted bool
-		expectStatus         string
+		name                       string
+		claim                      *extensionsv1alpha1.SandboxClaim
+		sandboxIsExpired           bool
+		isWarmPool                 bool
+		sandboxNotOwned            bool // sandbox exists at statusName but belongs to a different owner
+		expectClaimDeleted         bool
+		expectSandboxDeleted       bool
+		expectSandboxStatusCleared bool // SandboxStatus.Name and PodIPs must be empty
+		expectStatus               string
 	}{
 		{
 			name:                 "Policy=Retain -> Should Retain Claim but DELETE Sandbox",
@@ -935,6 +938,24 @@ func TestSandboxClaimCleanupPolicy(t *testing.T) {
 			expectClaimDeleted:   false,
 			expectSandboxDeleted: true, // Controller explicitly deletes Sandbox here.
 			expectStatus:         extensionsv1alpha1.ClaimExpiredReason,
+		},
+		{
+			name:                 "Policy=Retain (Sandbox from Warm Pool) -> Should Retain Claim but DELETE Sandbox",
+			claim:                createClaim("retain-claim-warm-pool", extensionsv1alpha1.ShutdownPolicyRetain),
+			sandboxIsExpired:     false,
+			isWarmPool:           true,
+			expectClaimDeleted:   false,
+			expectSandboxDeleted: true, // Controller explicitly deletes Sandbox here.
+			expectStatus:         extensionsv1alpha1.ClaimExpiredReason,
+		},
+		{
+			name:                       "Policy=Retain, Sandbox not owned by claim -> skip deletion, SandboxStatus cleared",
+			claim:                      createClaim("retain-claim-unowned", extensionsv1alpha1.ShutdownPolicyRetain),
+			sandboxNotOwned:            true,
+			expectClaimDeleted:         false,
+			expectSandboxDeleted:       false,
+			expectSandboxStatusCleared: true,
+			expectStatus:               extensionsv1alpha1.ClaimExpiredReason,
 		},
 		{
 			name:               "Policy=Delete && Sandbox Expired -> Should Delete Claim",
@@ -979,6 +1000,22 @@ func TestSandboxClaimCleanupPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newScheme(t)
 			sandbox := createSandbox(tc.claim.Name, tc.sandboxIsExpired)
+
+			// Hack: Simulate warmPool adopted sandbox
+			if tc.isWarmPool {
+				sandbox.Name = "warm-pool-sandbox-adopted"
+				tc.claim.Status.SandboxStatus.Name = sandbox.Name
+			}
+
+			// Simulate a sandbox that exists at statusName but belongs to a different owner.
+			if tc.sandboxNotOwned {
+				sandbox.Name = "foreign-sandbox"
+				sandbox.OwnerReferences = []metav1.OwnerReference{
+					{APIVersion: "extensions.agents.x-k8s.io/v1alpha1", Kind: "SandboxClaim", Name: "other-claim", UID: "other-uid", Controller: func() *bool { b := true; return &b }()},
+				}
+				tc.claim.Status.SandboxStatus.Name = sandbox.Name
+			}
+
 			client := fake.NewClientBuilder().WithScheme(scheme).
 				WithObjects(template, tc.claim, sandbox).
 				WithStatusSubresource(tc.claim).Build()
@@ -1018,11 +1055,22 @@ func TestSandboxClaimCleanupPolicy(t *testing.T) {
 				if !foundReason {
 					t.Errorf("Expected status reason %q, but not found", tc.expectStatus)
 				}
+
+				if tc.expectSandboxStatusCleared {
+					if fetchedClaim.Status.SandboxStatus.Name != "" {
+						t.Errorf("expected SandboxStatus.Name to be empty, got %q", fetchedClaim.Status.SandboxStatus.Name)
+					}
+					if fetchedClaim.Status.SandboxStatus.PodIPs != nil {
+						t.Errorf("expected SandboxStatus.PodIPs to be nil, got %v", fetchedClaim.Status.SandboxStatus.PodIPs)
+					}
+				}
 			}
 
 			// 2. Verify Sandbox
 			var fetchedSandbox sandboxv1alpha1.Sandbox
-			err = client.Get(context.Background(), req.NamespacedName, &fetchedSandbox)
+
+			// The Sandbox might now have different name than the claim!
+			err = client.Get(context.Background(), types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, &fetchedSandbox)
 
 			if tc.expectSandboxDeleted {
 				if !k8errors.IsNotFound(err) {


### PR DESCRIPTION
# Fix: delete warm-pool-adopted Sandboxes when SandboxClaim expires with Policy=Retain

## Problem

`SandboxClaimReconciler.reconcileExpired` looks up the Sandbox to delete using `client.ObjectKeyFromObject(claim)`, i.e. `{claim.Namespace, claim.Name}`. This works for Sandboxes created directly from a claim (they are named after the claim), but fails for Sandboxes adopted from a `SandboxWarmPool`.

Adopted Sandboxes keep the name the warm pool gave (e.g. `basic-warmpool-a1b2c3`). When the claim expires under `ShutdownPolicy=Retain`, the controller's lookup by `claim.Name` returns `NotFound`, the function returns `nil, nil`

Ofc, GC does not save us here: as the sandbox is still referenced with the claim. Once we delete the claim, everything is good.

## Fix

Look up the Sandbox by `claim.Status.SandboxStatus.Name` when populated. This field is maintained by `computeAndSetStatus` to track the actual Sandbox name (direct or adopted). Fall back to `claim.Name` when status is unset, which preserves existing behavior for direct-created Sandboxes whose names are equal to the claim name anyway.

```go
	statusName := claim.Name
	if claim.Status.SandboxStatus.Name != "" {
		statusName = claim.Status.SandboxStatus.Name
	}

	sandbox := &v1alpha1.Sandbox{}
	if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err != nil { ... }
```

I also add a verfication to ensure the ownership between claim & sandbox before deletion using `!metav1.IsControlledBy(sandbox, claim)`

## Tests

- **Added Warm-Pool Scenario**: Expanded `TestSandboxClaimCleanupPolicy` by adding a new test case (`isWarmPool: true`) to specifically simulate an adopted warm-pool sandbox.
- **Fixed Assertions for Adopted Sandboxes**: Decoupled the test verification logic by ensuring the test explicitly looks up the `Sandbox` using its actual initialized name (which can differ from the claim).