### PR TITLE
Add action label for resolving reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,15 @@ This is a community-driven effort, and we welcome collaboration!
 
 ### AI-Assisted Code Reviews (Experimental)
 
-To help improve our review velocity, we are currently experimenting with AI-assisted code reviews, starting with GitHub Copilot as our automated first-pass reviewer.
+To help improve our review velocity, we are currently experimenting with AI-assisted code reviews, starting with GitHub Copilot as our automated first-pass reviewer. Here is the workflow:
+
+1. Copilot will be assigned as the first reviewer of all open PRs (skipping the ones without CLA signed)
+1. After Copilot reviews are posted, the PR will be labeled `action-required: resolve-copilot-comments`
+   * **⚠️ Important Contribution Note:** If you receive a code suggestion from Copilot in your PR, please don't directly apply suggestions via the GitHub UI. It will set Copilot as co-author and break the Kubernetes CLA requirements. For more information, read our [Contributing Guidelines](CONTRIBUTING.md). 
+1. After all of Copilot reviews are marked resolved, the PR will be labeled `ready-for-review`
+1. Maintainers will review `ready-for-review` PRs and provide final approval 
 
 We actively welcome your feedback on the quality, relevance, and helpfulness of these automated reviews! As we iterate on this process, we also plan to evaluate and test different AI review tools to find the best fit for our project's workflow.
-
-**⚠️ Important Contribution Note:** If you receive a code suggestion from Copilot in your PR, please read our [Contributing Guidelines](CONTRIBUTING.md) carefully on how to apply it. Directly committing suggestions via the GitHub UI will break the Kubernetes CLA requirements.
 
 ### Contact Us
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ This is a community-driven effort, and we welcome collaboration!
 
 To help improve our review velocity, we are currently experimenting with AI-assisted code reviews, starting with GitHub Copilot as our automated first-pass reviewer. Here is the workflow:
 
-1. Copilot will be assigned as the first reviewer of all open PRs (skipping the ones without CLA signed)
+1. Copilot will be assigned as the first reviewer of all open PRs (skipping PRs without a signed CLA)
 1. After Copilot reviews are posted, the PR will be labeled `action-required: resolve-copilot-comments`
    * **⚠️ Important Contribution Note:** If you receive a code suggestion from Copilot in your PR, please don't directly apply suggestions via the GitHub UI. It will set Copilot as co-author and break the Kubernetes CLA requirements. For more information, read our [Contributing Guidelines](CONTRIBUTING.md). 
 1. After all of Copilot reviews are marked resolved, the PR will be labeled `ready-for-review`

--- a/dev/tools/ai-label
+++ b/dev/tools/ai-label
@@ -50,7 +50,9 @@ check_copilot_resolved() {
     }' | jq "[.data.node.reviewThreads.nodes[] | select(.comments.nodes[0].author.login == \"$BOT_NAME\" and .isResolved == false)] | length"
 }
 
-echo "--- Scanning for Copilot-Active PRs: $(date) ---"
+echo "--- Scanning for $LIMIT Copilot-Active PRs: $(date) ---"
+
+PENDING_LABEL="action-required: resolve-copilot-comments"
 
 ACTIVE_PRS=$(gh pr list --limit "$LIMIT" --json number,labels,reviews,reviewRequests \
   --jq '.[] | select(
@@ -65,9 +67,16 @@ for PR in $ACTIVE_PRS; do
   UNRESOLVED=$(check_copilot_resolved "$PR")
   
   if [ "$UNRESOLVED" -eq 0 ]; then
-    echo "✅ PR #$PR: All Copilot comments resolved. Ready for Human Review. Adding label..."
-    gh pr edit "$PR" --add-label "ready-for-review"
+    echo "✅ PR #$PR: All Copilot comments resolved. Ready for Human Review. Updating label..."
+    gh pr edit "$PR" --add-label "ready-for-review" --remove-label "$PENDING_LABEL"
   else
-    echo "⏳ PR #$PR: Still has $UNRESOLVED unresolved Copilot comments. Skipping."
+    # Check current labels to avoid repeatedly applying the pending label on every cron run
+    CURRENT_LABELS=$(gh pr view "$PR" --json labels --jq '.labels[].name')
+    if ! echo "$CURRENT_LABELS" | grep -q "^${PENDING_LABEL}$"; then
+      echo "⏳ PR #$PR: Still has $UNRESOLVED unresolved Copilot comments. Adding pending label..."
+      gh pr edit "$PR" --add-label "$PENDING_LABEL"
+    else
+      echo "⏳ PR #$PR: Still has $UNRESOLVED unresolved Copilot comments. Skipping."
+    fi
   fi
 done

--- a/dev/tools/ai-label
+++ b/dev/tools/ai-label
@@ -70,13 +70,8 @@ for PR in $ACTIVE_PRS; do
     echo "✅ PR #$PR: All Copilot comments resolved. Ready for Human Review. Updating label..."
     gh pr edit "$PR" --add-label "ready-for-review" --remove-label "$PENDING_LABEL"
   else
-    # Check current labels to avoid repeatedly applying the pending label on every cron run
-    CURRENT_LABELS=$(gh pr view "$PR" --json labels --jq '.labels[].name')
-    if ! echo "$CURRENT_LABELS" | grep -q "^${PENDING_LABEL}$"; then
-      echo "⏳ PR #$PR: Still has $UNRESOLVED unresolved Copilot comments. Adding pending label..."
-      gh pr edit "$PR" --add-label "$PENDING_LABEL"
-    else
-      echo "⏳ PR #$PR: Still has $UNRESOLVED unresolved Copilot comments. Skipping."
-    fi
+    echo "⏳ PR #$PR: Still has $UNRESOLVED unresolved Copilot comments. Ensuring pending label is set..."
+    # 'gh pr edit' is idempotent; it's safe to run even if the label is already present
+    gh pr edit "$PR" --add-label "$PENDING_LABEL"
   fi
 done


### PR DESCRIPTION
PRs with Copilot reviews will have the `action-required: resolve-copilot-comments` label, which will be removed after all Copilot review comments are addressed. 