### PR TITLE
doc: SandboxWarmPool creates Sandbox in Architecture Diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ flowchart LR
     Pod --> Runtime
 
     %% Warm pool
-    WarmPool -->|pre-warmed pods| Pod
+    WarmPool -->|creates| Sandbox
 ```
 
 ## Installation


### PR DESCRIPTION
https://github.com/kubernetes-sigs/agent-sandbox/pull/395 changes the `SandboxWarmPool` controller to create `Sandbox` instead of just `Pod`. The [Architecture Diagram](https://github.com/kubernetes-sigs/agent-sandbox#architecture-diagram) still shows that `SandboxWarmPool` controller creates `Pod`. 