### PR TITLE
Release script fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ temp/
 # E2E test artifacts (generated during 'make test-e2e')
 test/e2e/artifacts/
 test/e2e/extensions/artifacts/
+
+# Running AI review automation scripts in a crontab
+ai-label
+ai-label.log
+ai-review
+ai-review.log

--- a/dev/tools/shared/git_ops.py
+++ b/dev/tools/shared/git_ops.py
@@ -47,7 +47,7 @@ def check_local_repo_state(remote):
     print(f"🛡️  Verifying local repository state...")
 
     # 1. Check for uncommitted changes
-    if run_command(["git", "status", "--porcelain", "--untracked-files=no"], capture_output=True):
+    if run_command(["git", "status", "--porcelain"], capture_output=True):
         print(
             "❌ You have uncommitted changes in agent-sandbox. Please commit or stash them."
         )

--- a/dev/tools/shared/git_ops.py
+++ b/dev/tools/shared/git_ops.py
@@ -47,7 +47,7 @@ def check_local_repo_state(remote):
     print(f"🛡️  Verifying local repository state...")
 
     # 1. Check for uncommitted changes
-    if run_command(["git", "status", "--porcelain"], capture_output=True):
+    if run_command(["git", "status", "--porcelain", "--untracked-files=no"], capture_output=True):
         print(
             "❌ You have uncommitted changes in agent-sandbox. Please commit or stash them."
         )

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -44,29 +44,29 @@ def check_environment():
 
     # Check GitHub CLI (gh)
     try:
-        run_command(["gh", "--version"], capture_output=True)
+        run_command(["gh", "--version", allow_error=True], capture_output=True)
     except Exception:
         print("❌ 'gh' CLI not found. Please install it: https://cli.github.com/")
         sys.exit(1)
 
     try:
-        run_command(["gh", "auth", "status"], capture_output=True)
+        run_command(["gh", "auth", "status", allow_error=True], capture_output=True)
     except Exception:
         print("❌ Not logged in to GitHub. Please run 'gh auth login'.")
         sys.exit(1)
 
     # Check Google Cloud CLI (gcloud)
     try:
-        run_command(["gcloud", "--version"], capture_output=True)
+        run_command(["gcloud", "--version", allow_error=True], capture_output=True)
     except Exception:
         print("❌ 'gcloud' CLI not found. Please install it.")
         sys.exit(1)
 
     try:
-        auth_list = run_command(["gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)"], capture_output=True)
+        auth_list = run_command(["gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)"], capture_output=True, allow_error=True)
         if not auth_list:
-             print("❌ Not logged in to gcloud. Please run 'gcloud auth login'.")
-             sys.exit(1)
+            print("❌ Not logged in to gcloud. Please run 'gcloud auth login'.")
+            sys.exit(1)
     except Exception:
         print("❌ Error checking gcloud auth status. You might need to upgrade gcloud or run 'gcloud auth login'.")
         sys.exit(1)

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -38,6 +38,38 @@ IMAGES_TO_PROMOTE = [
 REMOTE_UPSTREAM = "upstream"
 REMOTE_FORK = "origin"
 
+def check_environment():
+    """Checks if the required tools are installed and authenticated."""
+    print("🔍 Checking environment...")
+
+    # Check GitHub CLI (gh)
+    try:
+        run_command(["gh", "--version"], capture_output=True)
+    except Exception:
+        print("❌ 'gh' CLI not found. Please install it: https://cli.github.com/")
+        sys.exit(1)
+
+    try:
+        run_command(["gh", "auth", "status"], capture_output=True)
+    except Exception:
+        print("❌ Not logged in to GitHub. Please run 'gh auth login'.")
+        sys.exit(1)
+
+    # Check Google Cloud CLI (gcloud)
+    try:
+        run_command(["gcloud", "--version"], capture_output=True)
+    except Exception:
+        print("❌ 'gcloud' CLI not found. Please install it.")
+        sys.exit(1)
+
+    try:
+        auth_list = run_command(["gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)"], capture_output=True)
+        if not auth_list:
+             print("❌ Not logged in to gcloud. Please run 'gcloud auth login'.")
+             sys.exit(1)
+    except Exception:
+        print("❌ Error checking gcloud auth status. You might need to upgrade gcloud or run 'gcloud auth login'.")
+        sys.exit(1)
 
 def get_gh_username():
     """Fetches the authenticated GitHub username."""
@@ -85,7 +117,9 @@ def main():
 
     tag = args.tag
     validate_tag(tag)
-    
+
+    check_environment()
+
     k8s_io_dir = os.path.abspath(args.k8s_io_dir)
 
     gh_user = get_gh_username()
@@ -95,6 +129,7 @@ def main():
 
     # --- Pre-flight Check ---
     check_local_repo_state(REMOTE_UPSTREAM)
+    sys.exit(0)
     check_tag_exists(tag, remote=REMOTE_UPSTREAM)
 
     # --- Step 1: Create and Push Tag ---

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -43,32 +43,23 @@ def check_environment():
     print("🔍 Checking environment...")
 
     # Check GitHub CLI (gh)
-    try:
-        run_command(["gh", "--version", allow_error=True], capture_output=True)
-    except Exception:
-        print("❌ 'gh' CLI not found. Please install it: https://cli.github.com/")
+    # Explicitly check for None because run_command returns None on error when allow_error=True
+    if run_command(["gh", "--version"], capture_output=True, allow_error=True) is None:
+        print("❌ 'gh' CLI not found. Please install it")
         sys.exit(1)
-
-    try:
-        run_command(["gh", "auth", "status", allow_error=True], capture_output=True)
-    except Exception:
+        
+    if run_command(["gh", "auth", "status"], capture_output=True, allow_error=True) is None:
         print("❌ Not logged in to GitHub. Please run 'gh auth login'.")
         sys.exit(1)
 
     # Check Google Cloud CLI (gcloud)
-    try:
-        run_command(["gcloud", "--version", allow_error=True], capture_output=True)
-    except Exception:
-        print("❌ 'gcloud' CLI not found. Please install it.")
-        sys.exit(1)
-
-    try:
-        auth_list = run_command(["gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)"], capture_output=True, allow_error=True)
-        if not auth_list:
-            print("❌ Not logged in to gcloud. Please run 'gcloud auth login'.")
-            sys.exit(1)
-    except Exception:
-        print("❌ Error checking gcloud auth status. You might need to upgrade gcloud or run 'gcloud auth login'.")
+    test_image = f"{STAGING_REPO_BASE}/{IMAGES_TO_PROMOTE[0]}"
+    # Attempt to list tags for one of our staging images to verify authentication/scopes
+    if run_command(["gcloud", "container", "images", "list-tags", test_image, "--limit=1"], 
+                  capture_output=True, allow_error=True) is None:
+        print(f"❌ Failed to access staging registry: {test_image}")
+        print("   Your current gcloud identity may not have the required permissions or scopes.")
+        print("   If you are on CloudTop, please run 'gcloud auth login' to authenticate as yourself.")
         sys.exit(1)
 
 def get_gh_username():

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -52,13 +52,13 @@ def check_environment():
         sys.exit(1)
 
     # Check Google Cloud CLI (gcloud)
-    test_image = f"{STAGING_REPO_BASE}/{IMAGES_TO_PROMOTE[0]}"
     # Attempt to list tags for one of our staging images to verify authentication/scopes
+    test_image = f"{STAGING_REPO_BASE}/{IMAGES_TO_PROMOTE[0]}"
     if run_command(["gcloud", "container", "images", "list-tags", test_image, "--limit=1"], 
                   capture_output=True, allow_error=True) is None:
         print(f"❌ Failed to access staging registry: {test_image}")
         print("   Your current gcloud identity may not have the required permissions or scopes.")
-        print("   If you are on CloudTop, please run 'gcloud auth login' to authenticate as yourself.")
+        print("   Run 'gcloud auth login' to authenticate.")
         sys.exit(1)
 
 def get_gh_username():

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -151,7 +151,7 @@ def main():
         sys.exit(1)
 
     print("🛡️  Checking for uncommitted changes...")
-    status = run_command(["git", "status", "--porcelain", "--untracked-files=no"], cwd=k8s_io_dir, capture_output=True)
+    status = run_command(["git", "status", "--porcelain"], cwd=k8s_io_dir, capture_output=True)
     if status:
         print(f"❌ Your k8s.io repo at {k8s_io_dir} has uncommitted changes.")
         print("   Please stash or commit them before running the release script.")

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -129,7 +129,6 @@ def main():
 
     # --- Pre-flight Check ---
     check_local_repo_state(REMOTE_UPSTREAM)
-    sys.exit(0)
     check_tag_exists(tag, remote=REMOTE_UPSTREAM)
 
     # --- Step 1: Create and Push Tag ---

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -127,7 +127,7 @@ def main():
         sys.exit(1)
 
     print("🛡️  Checking for uncommitted changes...")
-    status = run_command(["git", "status", "--porcelain"], cwd=k8s_io_dir, capture_output=True)
+    status = run_command(["git", "status", "--porcelain", "--untracked-files=no"], cwd=k8s_io_dir, capture_output=True)
     if status:
         print(f"❌ Your k8s.io repo at {k8s_io_dir} has uncommitted changes.")
         print("   Please stash or commit them before running the release script.")

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -43,7 +43,6 @@ def check_environment():
     print("🔍 Checking environment...")
 
     # Check GitHub CLI (gh)
-    # Explicitly check for None because run_command returns None on error when allow_error=True
     if run_command(["gh", "--version"], capture_output=True, allow_error=True) is None:
         print("❌ 'gh' CLI not found. Please install it")
         sys.exit(1)


### PR DESCRIPTION
Addressing some of https://github.com/kubernetes-sigs/agent-sandbox/issues/528

Given that the script can't be re-run after a tag is created, check `gh`, `gcloud` before creating a tag. 

Also ignore untracked files when checking local repo status. It should be relatively safe. 