### PR TITLE
feat: Add `--version` flag and `agent_sandbox_build_info` Prometheus metric 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@ FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 # Declare TARGETARCH to make it available in this build stage
 ARG TARGETARCH
 
+# Version info injected via build args (e.g. docker build --buildarg GIT_VERSION=...)
+ARG GIT_VERSION=unknown
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+
 WORKDIR /workspace
 
 # Download dependencies first to leverage layer caching
@@ -19,7 +24,9 @@ COPY extensions/ ./extensions/
 COPY internal/ ./internal/
 
 # Build the binary with optimizations
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /agent-sandbox-controller ./cmd/agent-sandbox-controller
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+    -ldflags="-s -w -X sigs.k8s.io/agent-sandbox/internal/version.gitVersion=${GIT_VERSION} -X sigs.k8s.io/agent-sandbox/internal/version.gitSHA=${GIT_SHA} -X sigs.k8s.io/agent-sandbox/internal/version.buildDate=${BUILD_DATE}" \
+    -o /agent-sandbox-controller ./cmd/agent-sandbox-controller
 
 
 # The controller image

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,19 @@ all: fix-go-generate build lint-go lint-api test-unit toc-verify
 fix-go-generate:
 	dev/tools/fix-go-generate
 
+VERSION_PKG := sigs.k8s.io/agent-sandbox/internal/version
+
+GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+GIT_SHA     ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE  ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+LD_FLAGS := -s -w -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
+	-X $(VERSION_PKG).gitSHA=$(GIT_SHA) \
+	-X $(VERSION_PKG).buildDate=$(BUILD_DATE)
+
 .PHONY: build
 build:
-	go build -o bin/manager cmd/agent-sandbox-controller/main.go
+	go build -ldflags "$(LD_FLAGS)" -o bin/manager cmd/agent-sandbox-controller/main.go
 
 KIND_CLUSTER=agent-sandbox
 

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -34,6 +35,7 @@ import (
 	extensionscontrollers "sigs.k8s.io/agent-sandbox/extensions/controllers"
 	"sigs.k8s.io/agent-sandbox/extensions/controllers/queue"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
+	"sigs.k8s.io/agent-sandbox/internal/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -63,6 +65,8 @@ func main() {
 	var sandboxClaimConcurrentWorkers int
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
+	var printVersion bool
+	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -94,6 +98,11 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if printVersion {
+		fmt.Println(version.Print("agent-sandbox-controller"))
+		os.Exit(0)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -20,6 +20,19 @@ import subprocess
 from shared import utils
 
 
+def _get_version_build_args():
+    """Returns build args for version info injection into Go binaries."""
+    import datetime
+    git_version = utils.git_describe()
+    git_sha = utils.git_sha()
+    build_date = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return [
+        f"--build-arg=GIT_VERSION={git_version}",
+        f"--build-arg=GIT_SHA={git_sha}",
+        f"--build-arg=BUILD_DATE={build_date}",
+    ]
+
+
 def create_buildx_builder_if_not_exists():
     builder_name = "agent-sandbox-builder"
     try:
@@ -59,6 +72,8 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
         os.path.basename(dockerfile_path),
         ".",
     ])
+    # Inject version info into Go binaries
+    build_cmd.extend(_get_version_build_args())
     subprocess.run(build_cmd, cwd=srcdir, check=True)
     print(f"pushed image {image_name}")
 

--- a/dev/tools/shared/utils.py
+++ b/dev/tools/shared/utils.py
@@ -24,6 +24,12 @@ def git_describe():
         ["git", "describe", "--always", "--dirty"], text=True).strip()
 
 
+def git_sha():
+    """Gets the short git SHA for HEAD."""
+    return subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+
+
 def get_image_tag():
     """Gets the image tag from the IMAGE_TAG environment variable, falling back to a
     generated value based on the date and git commit."""

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/agent-sandbox/internal/version"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -106,6 +107,25 @@ var (
 		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template"},
 		nil,
 	)
+
+	buildVersionInfo = version.Get()
+
+	// BuildInfo exposes agent-sandbox-controller build metadata as a constant gauge.
+	BuildInfo = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "agent_sandbox_build_info",
+			Help: "Agent sandbox controller build metadata exposed as labels with a constant value of 1.",
+			ConstLabels: prometheus.Labels{
+				"git_version": buildVersionInfo.GitVersion,
+				"git_commit":  buildVersionInfo.GitSHA,
+				"build_date":  buildVersionInfo.BuildDate,
+				"go_version":  buildVersionInfo.GoVersion,
+				"compiler":    buildVersionInfo.Compiler,
+				"platform":    buildVersionInfo.Platform,
+			},
+		},
+		func() float64 { return 1 },
+	)
 )
 
 // Init registers custom metrics with the global controller-runtime registry.
@@ -114,6 +134,7 @@ func init() {
 	metrics.Registry.MustRegister(ClaimControllerStartupLatency)
 	metrics.Registry.MustRegister(SandboxCreationLatency)
 	metrics.Registry.MustRegister(SandboxClaimCreationTotal)
+	metrics.Registry.MustRegister(BuildInfo)
 }
 
 // RecordClaimStartupLatency records the duration since the provided start time.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -16,10 +16,12 @@
 package metrics
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"sigs.k8s.io/agent-sandbox/internal/version"
 )
 
 func TestClaimLatencyRecording(t *testing.T) {
@@ -87,5 +89,17 @@ func TestSandboxClaimCreationRecording(t *testing.T) {
 				t.Errorf("Expected 1 observation")
 			}
 		})
+	}
+}
+
+func TestBuildInfo(t *testing.T) {
+	expected := strings.TrimSpace(`
+		# HELP agent_sandbox_build_info Agent sandbox controller build metadata exposed as labels with a constant value of 1.
+		# TYPE agent_sandbox_build_info gauge
+		agent_sandbox_build_info{build_date="`+version.Get().BuildDate+`",compiler="`+version.Get().Compiler+`",git_commit="`+version.Get().GitSHA+`",git_version="`+version.Get().GitVersion+`",go_version="`+version.Get().GoVersion+`",platform="`+version.Get().Platform+`"} 1
+	`) + "\n"
+
+	if err := testutil.CollectAndCompare(BuildInfo, strings.NewReader(expected)); err != nil {
+		t.Errorf("BuildInfo metric mismatch: %v", err)
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:revive
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+	"strings"
+	"text/template"
+)
+
+var (
+	// The version of agent-sandbox-controller.
+	gitVersion = "unknown"
+	// Short sha1 from git, output of $(git rev-parse --short HEAD).
+	gitSHA = "unknown"
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ').
+	buildDate = "unknown"
+
+	// Go runtime version used to build agent-sandbox-controller.
+	goVersion = runtime.Version()
+
+	// Go compiler name used to build agent-sandbox (e.g., "gc").
+	goCompiler = runtime.Compiler
+
+	// Operating system and CPU architecture the binary is compiled for.
+	goOS   = runtime.GOOS
+	goArch = runtime.GOARCH
+)
+
+type Info struct {
+	Program    string `json:"program"`
+	GitVersion string `json:"gitVersion"`
+	GitSHA     string `json:"gitSHA"`
+	BuildDate  string `json:"buildDate"`
+	GoVersion  string `json:"goVersion"`
+	Compiler   string `json:"compiler"`
+	Platform   string `json:"platform"`
+}
+
+var versionInfoTmpl = `
+{{.Program}}, version {{.GitVersion}} (revision: {{.GitSHA}})
+  build date:       {{.BuildDate}}
+  go version:       {{.GoVersion}}
+  compiler:         {{.Compiler}}
+  platform:         {{.Platform}}
+`
+
+// Get returns version information populated with build-time values.
+func Get() Info {
+	return Info{
+		GitVersion: gitVersion,
+		GitSHA:     gitSHA,
+		BuildDate:  buildDate,
+		GoVersion:  goVersion,
+		Compiler:   goCompiler,
+		Platform:   goOS + "/" + goArch,
+	}
+}
+
+// String returns a Go-syntax representation of the Info.
+func (info Info) String() string {
+	return fmt.Sprintf("%#v", info)
+}
+
+// Print returns version information.
+func Print(program string) string {
+	m := Get()
+	m.Program = program
+	t := template.Must(template.New("version").Parse(versionInfoTmpl))
+
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "version", m); err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(buf.String())
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:revive
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestInfoDefault(t *testing.T) {
+	info := Info{}
+
+	testCases := []struct {
+		name   string
+		actual string
+		expect string
+	}{
+		{"GitVersion", info.GitVersion, ""},
+		{"GitSHA", info.GitSHA, ""},
+		{"BuildDate", info.BuildDate, ""},
+		{"GoVersion", info.GoVersion, ""},
+		{"Compiler", info.Compiler, ""},
+		{"Platform", info.Platform, ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.actual != tc.expect {
+				t.Errorf("Expected %q, got %q", tc.expect, tc.actual)
+			}
+		})
+	}
+}
+
+func TestInfoString(t *testing.T) {
+	info := Info{
+		GitVersion: "v1.0.0",
+		GitSHA:     "abc123",
+		BuildDate:  "2026-01-01T00:00:00Z",
+		GoVersion:  "go1.22.0",
+		Compiler:   "gc",
+		Platform:   "linux/amd64",
+	}
+
+	s := info.String()
+	testCases := []struct {
+		name   string
+		check  func(string) bool
+		expect string
+	}{
+		{"ContainsTypeName", func(s string) bool { return strings.Contains(s, "version.Info") }, "version.Info"},
+		{"ContainsGitVersion", func(s string) bool { return strings.Contains(s, "GitVersion:") }, "GitVersion:"},
+		{"ContainsGoVersion", func(s string) bool { return strings.Contains(s, "GoVersion:") }, "GoVersion:"},
+		{"ContainsGitSHA", func(s string) bool { return strings.Contains(s, "GitSHA:") }, "GitSHA:"},
+		{"ContainsBuildDate", func(s string) bool { return strings.Contains(s, "BuildDate:") }, "BuildDate:"},
+		{"ContainsCompiler", func(s string) bool { return strings.Contains(s, "Compiler:") }, "Compiler:"},
+		{"ContainsPlatform", func(s string) bool { return strings.Contains(s, "Platform:") }, "Platform:"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !tc.check(s) {
+				t.Errorf("Expected %s in String output, got: %s", tc.expect, s)
+			}
+		})
+	}
+}
+
+func TestInfoPrinted(t *testing.T) {
+	platform := fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
+
+	info := Get()
+
+	testCases := []struct {
+		name   string
+		actual string
+		expect string
+	}{
+		{"GitVersion", info.GitVersion, "unknown"},
+		{"GitSHA", info.GitSHA, "unknown"},
+		{"BuildDate", info.BuildDate, "unknown"},
+		{"GoVersion", info.GoVersion, runtime.Version()},
+		{"Compiler", info.Compiler, runtime.Compiler},
+		{"Platform", info.Platform, platform},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.actual != tc.expect {
+				t.Errorf("Expected %q, got %q", tc.expect, tc.actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary                                                                                                                                                             
  - Add a `--version` CLI flag to print build-time version information (git tag, commit SHA, build date, Go version, platform).                                          
  - Inject version strings via `-ldflags` in the Makefile so the binary carries build metadata at compile time.                                                          
  - Expose build metadata as a Prometheus metric `agent_sandbox_build_info` with labels for `git_version`, `git_commit`, `build_date`, `go_version`, `compiler`, and     
  `platform`, enabling operators to track which controller version is running across the cluster.                                                                        
                                                                                                                                                                         
  ## What changed                                                                                                                                                        
  - `internal/version/version.go` — new package providing `Get()`, `Print()`, and `Info.String()` for version information.
  - `internal/version/version_test.go` — unit tests for the version package.                                                                                             
  - `cmd/agent-sandbox-controller/main.go` — registers `--version` flag; exits early after printing version.                                                             
  - `internal/metrics/metrics.go` — registers `BuildInfo` gauge metric populated from version data.                                                                      
  - `internal/metrics/metrics_test.go` — adds test for `BuildInfo` metric output.                                                                                        
  - `Makefile` — defines `LD_FLAGS` with git-derived version strings and passes them via `-ldflags` during `make build`.