### PR TITLE
docs: add Go sandbox client documentation to docsite

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -35,9 +35,9 @@ The Sandbox controller handles the full lifecycle out of the box: creation, sche
 
 Agent Sandbox builds on standard Kubernetes primitives and integrates cleanly with existing cluster tooling — RBAC, namespaces, network policies, and resource quotas all apply as usual. The extension CRDs let platform teams define reusable `SandboxTemplate`s so developers can claim sandboxes without needing to know the underlying configuration details.
 
-### Python SDK for programmatic access
+### Client SDKs for programmatic access
 
-A first-class [Python client](./python-client/) lets agents and applications create, query, and manage sandboxes programmatically, enabling fully automated sandbox lifecycles within LLM orchestration frameworks.
+Agent Sandbox provides first-class clients for both [Python](./python-client/) and [Go](./go-client/), so agents and applications can create, query, and manage sandboxes programmatically in the language that best fits their runtime and platform.
 
 ## Core capabilities
 
@@ -49,7 +49,8 @@ A first-class [Python client](./python-client/) lets agents and applications cre
 | **SandboxWarmPool** | Pre-warmed pod pools for near-instant sandbox allocation |
 | **Hibernation & resume** | Pause sandboxes to free compute resources; resume automatically on network activity |
 | **Runtime flexibility** | Works with standard containers, gVisor, Kata Containers, and other OCI-compatible runtimes |
-| **Python SDK** | High-level client library for programmatic sandbox management |
+| **Python SDK** | High-level client library for programmatic sandbox management in Python-based agent runtimes |
+| **Go SDK** | High-level client library for programmatic sandbox management in Go services and controllers |
 | **Scheduled deletion** | Automatic cleanup of sandboxes after a configurable TTL |
 
 ## Where to go next

--- a/site/content/docs/go-client/_index.md
+++ b/site/content/docs/go-client/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Go Client"
+linkTitle: "Go Client"
+weight: 26
+description: >
+  This section describes how to use the Go Client
+aliases:
+  - /docs/go_sdk/
+  - /docs/go_sdk
+---
+{{% include-file file="additional/go-client/README.md" %}}

--- a/site/data/link_replacements.yaml
+++ b/site/data/link_replacements.yaml
@@ -58,7 +58,13 @@ replacements:
     replacement: '](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/GCP.md$1)'
     description: "GCP.md to GitHub"
 
+  # Go client source links - redirect to GitHub
+  - pattern: '\]\(sandbox/options\.go\)'
+    replacement: '](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/options.go)'
+    description: "Go client options.go to GitHub"
+
   # Generic relative README.md links (must come after specific rules)
+
   - pattern: '\]\(README\.md(#[^)]+)?\)'
     replacement: null  # Will be dynamically replaced with current section path
     description: "Generic README links to current section"

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -147,9 +147,14 @@ module:
     target: assets/additional/python-agentic-sandbox-client
     includeFiles: ["README.md"]
   - disableWatch: true
+    source: ../clients/go
+    target: assets/additional/go-client
+    includeFiles: ["README.md"]
+  - disableWatch: true
     source: ../docs
     target: assets/additional/docs
     includeFiles: ["testing.md"]
+
   imports:
     - path: github.com/google/docsy
       disable: false


### PR DESCRIPTION
docs: add Go sandbox client documentation to docsite

- add a new Go client docs page
- mount clients/go/README.md into the docsite
- update the docs index to include both Python and Go clients
- add link replacement for Go client source links

Fixes #634
