### PR TITLE
fix: handle SandboxClaim create race for cold-start sandboxes

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -916,6 +916,16 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	}
 
 	if err := r.Create(ctx, sandbox); err != nil {
+		if k8errors.IsAlreadyExists(err) {
+			existing := &v1alpha1.Sandbox{}
+			if getErr := r.Get(ctx, client.ObjectKeyFromObject(sandbox), existing); getErr != nil {
+				return nil, fmt.Errorf("sandbox create raced with existing object and fetch failed: %w", getErr)
+			}
+			if !metav1.IsControlledBy(existing, claim) {
+				return nil, fmt.Errorf("sandbox %q already exists but is not controlled by claim %q", existing.Name, claim.Name)
+			}
+			return existing, nil
+		}
 		err = fmt.Errorf("sandbox create error: %w", err)
 		logger.Error(err, "Error creating sandbox for claim", "claimName", claim.Name)
 		return nil, err

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -1154,6 +1155,55 @@ Loop:
 	}
 	if !foundProvisionEvent {
 		t.Errorf("Expected event %q not found", expectedMsg)
+	}
+}
+
+func TestCreateSandboxReturnsExistingOnAlreadyExists(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "existing-sandbox-claim"
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: types.UID(claimName)},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+		},
+	}
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec:       extensionsv1alpha1.SandboxTemplateSpec{PodTemplate: sandboxv1alpha1.PodTemplate{}},
+	}
+
+	existingSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default"},
+	}
+	if err := controllerutil.SetControllerReference(claim, existingSandbox, scheme); err != nil {
+		t.Fatalf("failed to set owner reference: %v", err)
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, template, existingSandbox).
+		WithStatusSubresource(claim).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client: cl,
+		Scheme: scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	sandbox, err := reconciler.createSandbox(context.Background(), claim, template)
+	if err != nil {
+		t.Fatalf("createSandbox returned error: %v", err)
+	}
+	if sandbox == nil {
+		t.Fatal("expected existing sandbox to be returned")
+	}
+	if sandbox.Name != claimName {
+		t.Fatalf("expected sandbox %q, got %q", claimName, sandbox.Name)
+	}
+	if !metav1.IsControlledBy(sandbox, claim) {
+		t.Fatalf("expected returned sandbox %q to be controlled by claim %q", sandbox.Name, claim.Name)
 	}
 }
 


### PR DESCRIPTION
## Summary
- handle `AlreadyExists` when the claim controller races creating a Sandbox that already exists in the API but is not yet visible through the informer fast path
- fetch and return the existing owned Sandbox instead of failing the reconcile and clearing claim sandbox status
- add a regression test for the create race

## Why
The Python SDK presubmit can time out resolving `status.sandbox.name` for non-warmpool claims. A cold-start Sandbox can be created successfully, but a follow-up reconcile may miss it in cache, retry `Create`, hit `AlreadyExists`, and fail before the claim status is repopulated.

## Testing
- `go test ./extensions/controllers`
- `python3 dev/tools/lint-go`
