### PR TITLE
chore: add a kyverno policy example

### DIFF
--- a/examples/policy/kyverno/.chainsaw-tests/bad-rolebinding.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/bad-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-forbidden-binding
+  namespace: sandbox-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: sandbox-sa
+  namespace: sandbox-ns

--- a/examples/policy/kyverno/.chainsaw-tests/barepod.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/barepod.yaml
@@ -1,0 +1,11 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: bare-pod
+  namespace: sandbox-ns
+spec:
+  serviceAccountName: sandbox-sa
+  containers:
+  - name: my-container
+    image: busybox
+    command: ["/bin/sh", "-c", "sleep 3600"]

--- a/examples/policy/kyverno/.chainsaw-tests/chainsaw-test.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/chainsaw-test.yaml
@@ -37,6 +37,17 @@ spec:
         file: setup-sa.yaml
     - apply:
         file: setup-sandbox.yaml
+    - assert:
+        resource:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              namespace: sandbox-ns
+              ownerReferences:
+              - kind: Sandbox
+            spec:
+              serviceAccountName: sandbox-sa
+        timeout: 30s
     - apply:
         file: bad-rolebinding.yaml
         expect:
@@ -50,8 +61,24 @@ spec:
         file: good-rolebinding.yaml
   - name: step-04
     try:
-    - delete:
-        file: setup-sandbox.yaml
+    - script:
+        timeout: 30s
+        content: |
+          kubectl delete --force --grace-period=0 -f setup-sandbox.yaml --ignore-not-found=true
+          kubectl delete --force --grace-period=0 pod --all -n sandbox-ns --ignore-not-found=true
+    - script:
+        timeout: 30s
+        content: |
+          set -euo pipefail
+          end=$((SECONDS + 30))
+          while [ "$SECONDS" -lt "$end" ]; do
+            if ! kubectl get pods -n sandbox-ns -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.spec.serviceAccountName}{"|"}{range .metadata.ownerReferences[*]}{.kind}{","}{end}{"\n"}{end}' | grep -qE '\|sandbox-sa\|.*Sandbox'; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Timed out waiting for Sandbox-owned pods using sandbox-sa to be deleted" >&2
+          exit 1
     - apply:
         file: barepod.yaml
     - apply:

--- a/examples/policy/kyverno/.chainsaw-tests/chainsaw-test.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/chainsaw-test.yaml
@@ -1,0 +1,58 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: prevent-sandbox-sa-binding
+spec:
+  template: false
+  steps:
+  - name: step-01
+    try:
+    - apply:
+        file: setup-rbac.yaml
+    - apply:
+        file: ../prevent-sandbox-sa-binding.yaml
+    - assert:
+        resource:
+            apiVersion: policies.kyverno.io/v1
+            kind: ValidatingPolicy
+            metadata:
+              name: prevent-sandbox-sa-binding
+            status:
+              conditionStatus:
+                (conditions[?type == 'WebhookConfigured']):
+                - message: Webhook configured.
+                  reason: Succeeded
+                  status: "True"
+                  type: WebhookConfigured
+                (conditions[?type == 'RBACPermissionsGranted']):
+                - message: Policy is ready for reporting.
+                  reason: Succeeded
+                  status: "True"
+                  type: RBACPermissionsGranted
+                ready: true
+        timeout: 10s
+  - name: step-02
+    try:
+    - apply:
+        file: setup-sa.yaml
+    - apply:
+        file: setup-sandbox.yaml
+    - apply:
+        file: bad-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+  - name: step-03
+    try:
+    - apply:
+        file: setup-other-sa.yaml
+    - apply:
+        file: good-rolebinding.yaml
+  - name: step-04
+    try:
+    - delete:
+        file: setup-sandbox.yaml
+    - apply:
+        file: barepod.yaml
+    - apply:
+        file: bad-rolebinding.yaml

--- a/examples/policy/kyverno/.chainsaw-tests/good-rolebinding.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/good-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-allow
+  namespace: test-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: another-sa
+  namespace: test-ns

--- a/examples/policy/kyverno/.chainsaw-tests/setup-other-sa.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/setup-other-sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: another-sa
+  namespace: test-ns

--- a/examples/policy/kyverno/.chainsaw-tests/setup-rbac.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/setup-rbac.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno:rbac
+  labels:
+    rbac.kyverno.io/aggregate-to-reports-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch

--- a/examples/policy/kyverno/.chainsaw-tests/setup-sa.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/setup-sa.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sandbox-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox-sa
+  namespace: sandbox-ns

--- a/examples/policy/kyverno/.chainsaw-tests/setup-sandbox.yaml
+++ b/examples/policy/kyverno/.chainsaw-tests/setup-sandbox.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: sandbox-example
+  namespace: sandbox-ns
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: my-sandbox
+      annotations:
+        test: "yes"
+    spec:
+      serviceAccountName: sandbox-sa
+      containers:
+      - name: my-container
+        image: busybox
+        command: ["/bin/sh", "-c", "sleep 3600"]

--- a/examples/policy/kyverno/README.md
+++ b/examples/policy/kyverno/README.md
@@ -1,0 +1,160 @@
+# User Guide: Protecting Agentic Sandboxes with Kyverno ValidatingPolicy
+
+## 1. Overview
+
+This guide provides step-by-step instructions for configuring a Kyverno
+ValidatingPolicy on a Kubernetes cluster. The goal of this policy is to prevent
+any user or process from granting new permissions to a ServiceAccount that is
+actively being used by a custom Sandbox resource.
+
+This acts as a critical security boundary, preventing accidental or malicious
+privilege escalation for sandboxed environments.
+
+How it works:
+The policy intercepts RoleBinding and ClusterRoleBinding create and update
+requests. If the request targets a ServiceAccount that is referenced by a
+Sandbox-owned Pod, the request is denied.
+
+---
+
+## 2. Prerequisites
+
+Before you begin, ensure you have the following:
+
+- kubectl access to a Kubernetes cluster.
+- Helm v3+ installed.
+- Kyverno installed in the cluster.
+- Agent Sandbox CRDs/controller installed if you want to create real Sandbox
+  resources for manual verification.
+
+Install Kyverno:
+
+```bash
+# 1. Add the Kyverno Helm repository
+helm repo add kyverno https://kyverno.github.io/kyverno/
+
+# 2. Update local Helm repositories
+helm repo update
+
+# 3. Install Kyverno
+helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace
+```
+
+Verify Kyverno is running:
+
+```bash
+kubectl get pods -n kyverno
+```
+
+---
+
+## 3. Configuration Steps
+
+### Step 1: Grant RBAC required by policy reporting checks
+
+This example includes an RBAC grant used by the test flow so the policy can
+report ready conditions.
+
+```bash
+kubectl apply -f .chainsaw-tests/setup-rbac.yaml
+```
+
+### Step 2: Apply the ValidatingPolicy
+
+```bash
+kubectl apply -f prevent-sandbox-sa-binding.yaml
+```
+
+### Step 3: Verify policy readiness
+
+```bash
+kubectl get validatingpolicy prevent-sandbox-sa-binding -o yaml
+```
+
+Look for ready status and successful conditions such as WebhookConfigured and
+RBACPermissionsGranted.
+
+---
+
+## 4. Testing and Verification
+
+### A. Set up the test scenario
+
+```bash
+kubectl apply -f .chainsaw-tests/setup-sa.yaml
+kubectl apply -f .chainsaw-tests/setup-sandbox.yaml
+```
+
+### B. Trigger the policy
+
+```bash
+kubectl apply -f .chainsaw-tests/bad-rolebinding.yaml
+```
+
+### C. Check expected outcome 
+
+The request should be denied by admission.
+```
+Error from server: error when creating "examples/policy/kyverno/.chainsaw-tests/bad-rolebinding.yaml": admission webhook "vpol.validate.kyverno.svc-fail" denied the request: Policy prevent-sandbox-sa-binding failed: Binding denied: one or more subjects reference a ServiceAccount that is actively used by a Sandbox-owned Pod. ServiceAccounts in use by Pods controlled by a Sandbox CR (agents.x-k8s.io) must not be granted additional RBAC bindings to prevent privilege escalation in sandboxed environments.
+```
+
+### Scenario 2: Binding to an unused ServiceAccount (should be allowed)
+
+```bash
+kubectl apply -f .chainsaw-tests/setup-other-sa.yaml
+kubectl apply -f .chainsaw-tests/good-rolebinding.yaml
+```
+
+Expected: RoleBinding is created.
+
+### Scenario 3: ServiceAccount used by a non-Sandbox Pod (should be allowed)
+
+```bash
+kubectl delete -f .chainsaw-tests/setup-sandbox.yaml
+kubectl apply -f .chainsaw-tests/barepod.yaml
+kubectl apply -f .chainsaw-tests/bad-rolebinding.yaml
+```
+
+Expected: RoleBinding is created after Sandbox ownership is removed.
+
+---
+
+## 5. Run Automated Chainsaw Tests
+
+Run the full test suite:
+
+```bash
+chainsaw test --test-dir .chainsaw-tests
+```
+
+The test file is:
+
+- .chainsaw-tests/chainsaw-test.yaml
+
+Step mapping in the test:
+
+- step-01: apply RBAC + policy and assert readiness
+- step-02: assert deny for active Sandbox ServiceAccount
+- step-03: assert allow for unused ServiceAccount
+- step-04: remove Sandbox owner, create bare Pod, then allow binding
+
+---
+
+## 6. Cleanup
+
+```bash
+kubectl delete -f .chainsaw-tests/good-rolebinding.yaml --ignore-not-found
+kubectl delete -f .chainsaw-tests/bad-rolebinding.yaml --ignore-not-found
+kubectl delete -f .chainsaw-tests/barepod.yaml --ignore-not-found
+kubectl delete -f .chainsaw-tests/setup-other-sa.yaml --ignore-not-found
+kubectl delete -f .chainsaw-tests/setup-sandbox.yaml --ignore-not-found
+kubectl delete -f .chainsaw-tests/setup-sa.yaml --ignore-not-found
+kubectl delete -f prevent-sandbox-sa-binding.yaml --ignore-not-found
+kubectl delete -f .chainsaw-tests/setup-rbac.yaml --ignore-not-found
+```
+
+Optional: uninstall Kyverno
+
+```bash
+helm uninstall kyverno -n kyverno
+```

--- a/examples/policy/kyverno/prevent-sandbox-sa-binding.yaml
+++ b/examples/policy/kyverno/prevent-sandbox-sa-binding.yaml
@@ -1,0 +1,47 @@
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/description: Prevents RoleBindings and ClusterRoleBindings
+      from being granted to ServiceAccounts that are actively used by Pods controlled
+      by a Sandbox CR (agents.x-k8s.io), blocking privilege escalation in sandboxed
+      environments.
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/title: Prevent Active Sandbox ServiceAccount Binding
+  name: prevent-sandbox-sa-binding
+spec:
+  evaluation:
+    background:
+      enabled: true
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - rolebindings
+      - clusterrolebindings
+  validationActions:
+  - Deny
+  validations:
+  - expression: |-
+      !object.subjects.exists(subject,
+        subject.kind == 'ServiceAccount' &&
+        subject.?namespace.orValue('') != '' &&
+        resource.List('v1', 'pods', subject.namespace).items.orValue([]).exists(pod,
+          pod.spec.?serviceAccountName.orValue('') == subject.name &&
+          pod.metadata.?ownerReferences.orValue([]).exists(owner,
+            owner.kind == 'Sandbox' &&
+            owner.apiVersion.startsWith('agents.x-k8s.io/')
+          )
+        )
+      )
+    messageExpression: '''Binding denied: one or more subjects reference a ServiceAccount
+      that is actively used by a Sandbox-owned Pod. ServiceAccounts in use by Pods
+      controlled by a Sandbox CR (agents.x-k8s.io) must not be granted additional
+      RBAC bindings to prevent privilege escalation in sandboxed environments.'''


### PR DESCRIPTION
## Summary

This PR adds a Kyverno-based policy example to prevent RBAC privilege escalation for Sandbox workloads.

Specifically, it introduces a ValidatingPolicy that denies creation/update of RoleBinding and ClusterRoleBinding objects when they reference a ServiceAccount currently used by a Sandbox-owned Pod.

## Behavior Covered
- Deny binding to ServiceAccounts actively used by Sandbox-owned Pods.
- Allow binding to unused ServiceAccounts.
- Allow binding when the ServiceAccount is used only by a non-Sandbox Pod.

## Testing
- Added automated Chainsaw scenarios in `.chainsaw` subfolder.
- Manual verification steps and expected outcomes are documented in `README.md`.