### PR TITLE
fix: skip warm pool sandboxes without a backing pod

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -2478,6 +2478,12 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	if !utils.MatchesGroupKind(controllerRef, extensionsv1beta1.GroupVersion.Group, extensionsv1beta1.SandboxWarmPoolKind) {
 		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
 	}
+
+	// PodIPs is the adoption boundary: without it, the backing Pod is missing
+	// or not networked yet. Not-Ready sandboxes with PodIPs are still useful.
+	if len(candidate.Status.PodIPs) == 0 {
+		return fmt.Errorf("sandbox has no assigned pod IPs yet")
+	}
 	return nil
 }
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -935,8 +935,11 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 
 		// PodIPs is the adoption boundary: without it, the backing Pod is missing
 		// or not networked yet. Keep the candidate in the queue so it can be
-		// retried once networking completes.
+		// retried once networking completes. Normalize NodeName from the latest
+		// Sandbox status before requeueing so a stale queue key does not erase
+		// placement information used by pickSmart.
 		if len(adopted.Status.PodIPs) == 0 {
+			adoptedKey.NodeName = adopted.Status.NodeName
 			skipped = append(skipped, adoptedKey)
 			continue
 		}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -2511,6 +2511,12 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	if !utils.MatchesGroupKind(controllerRef, extensionsv1beta1.GroupVersion.Group, extensionsv1beta1.SandboxWarmPoolKind) {
 		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
 	}
+
+	// PodIPs is the adoption boundary: without it, the backing Pod is missing
+	// or not networked yet. Not-Ready sandboxes with PodIPs are still useful.
+	if len(candidate.Status.PodIPs) == 0 {
+		return fmt.Errorf("sandbox has no assigned pod IPs yet")
+	}
 	return nil
 }
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -59,7 +59,12 @@ import (
 )
 
 const ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
-const immediateRequeueDelay = time.Millisecond
+
+const (
+	immediateRequeueDelay      = time.Millisecond
+	warmCandidateGracePeriod   = 2 * time.Second
+	warmCandidateRetryInterval = 500 * time.Millisecond
+)
 
 // ErrTemplateNotFound is a sentinel error indicating a SandboxTemplate was not found.
 var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
@@ -77,6 +82,15 @@ var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 // locked adoption writes; the Ready condition surfaces it as the benign
 // AdoptionConflict reason instead of ReconcilerError.
 var errAdoptionConflict = errors.New("adoption write conflict")
+
+type warmCandidatesPendingError struct {
+	pendingCandidates int
+	retryAfter        time.Duration
+}
+
+func (e *warmCandidatesPendingError) Error() string {
+	return fmt.Sprintf("%d warm pool candidate(s) are awaiting observed Pod IPs", e.pendingCandidates)
+}
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
@@ -277,6 +291,20 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	} else {
 		// Ensure Sandbox exists and is configured.
 		sandbox, reconcileErr = r.reconcileActive(ctx, claim)
+	}
+
+	// Pending warm candidates are expected transient state, not a claim failure.
+	// Return before status calculation so the grace period does not publish a
+	// misleading SandboxMissing or ReconcilerError condition.
+	var pendingWarmCandidates *warmCandidatesPendingError
+	if errors.As(reconcileErr, &pendingWarmCandidates) {
+		logger.V(4).Info("Waiting for warm pool candidates to report Pod IPs",
+			"claim", claim.Name,
+			"warmPool", claim.Spec.WarmPoolRef.Name,
+			"pendingCandidates", pendingWarmCandidates.pendingCandidates,
+			"retryAfter", pendingWarmCandidates.retryAfter,
+		)
+		return ctrl.Result{RequeueAfter: pendingWarmCandidates.retryAfter}, nil
 	}
 
 	// Update Status & Events
@@ -825,7 +853,7 @@ func ensureClaimIdentityLabels(labels map[string]string, claim *extensionsv1beta
 	return labels
 }
 
-func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, queue.SandboxKey, error) {
+func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, queue.SandboxKey, int, error) {
 	logger := log.FromContext(ctx)
 
 	namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(claim.Namespace, claim.Spec.WarmPoolRef.Name)
@@ -834,6 +862,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	var fallbackSandbox *v1beta1.Sandbox
 	var fallbackKey queue.SandboxKey
 	var adoptingFallback bool
+	var pendingNetworkCandidates int
 
 	// Instantly returns unused keys the moment we find a valid/ready candidate!
 	defer func() {
@@ -905,9 +934,9 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			// No more candidates in our namespace. If we found an unready fallback sandbox, return it.
 			if fallbackSandbox != nil {
 				adoptingFallback = true
-				return fallbackSandbox, fallbackKey, nil
+				return fallbackSandbox, fallbackKey, pendingNetworkCandidates, nil
 			}
-			return nil, queue.SandboxKey{}, nil
+			return nil, queue.SandboxKey{}, pendingNetworkCandidates, nil
 		}
 
 		adopted := &v1beta1.Sandbox{}
@@ -920,7 +949,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			}
 			// For real errors, put the key back in line and error out
 			r.WarmSandboxQueue.Add(namespacedWarmPoolName, adoptedKey)
-			return nil, queue.SandboxKey{}, err
+			return nil, queue.SandboxKey{}, pendingNetworkCandidates, err
 		}
 
 		if err := verifySandboxCandidate(adopted, claim); err != nil {
@@ -933,15 +962,16 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			continue
 		}
 
-		// PodIPs is the adoption boundary: without it, the backing Pod is missing
-		// or not networked yet. Keep the candidate in the queue so it can be
-		// retried once networking completes. Normalize NodeName from the latest
-		// Sandbox status before requeueing so a stale queue key does not erase
-		// placement information used by pickSmart.
+		// Missing cached PodIPs means the controller has not observed a networked
+		// backing Pod for this candidate. Non-empty cached PodIPs narrow but cannot
+		// eliminate every concurrent Pod-deletion race. Keep pending candidates in
+		// the queue for a bounded claim-side retry. Normalize NodeName from the
+		// latest Sandbox status so a stale key does not erase placement information.
 		if len(adopted.Status.PodIPs) == 0 {
 			if adopted.Status.NodeName != "" {
 				adoptedKey.NodeName = adopted.Status.NodeName
 			}
+			pendingNetworkCandidates++
 			skipped = append(skipped, adoptedKey)
 			continue
 		}
@@ -949,7 +979,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 		// Candidate is valid! Now check if it is Ready
 		if isSandboxReady(adopted) {
 			// Found a Ready sandbox! Adopt it immediately.
-			return adopted, adoptedKey, nil
+			return adopted, adoptedKey, pendingNetworkCandidates, nil
 		}
 
 		// Sandbox is valid but NOT Ready.
@@ -964,19 +994,23 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	}
 }
 
-func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, error) {
+func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, int, error) {
 	logger := log.FromContext(ctx)
 	namespacedWarmPoolNameForQueue := queue.GetNamespacedWarmPoolName(claim.Namespace, claim.Spec.WarmPoolRef.Name)
 
 	// Keep trying until we successfully adopt a sandbox, or run out of candidates
 	for range 3 {
-		adopted, adoptedKey, err := r.getCandidate(ctx, claim)
+		adopted, adoptedKey, pendingNetworkCandidates, err := r.getCandidate(ctx, claim)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if adopted == nil {
-			logger.Info("Failed to adopt any sandbox after checking all candidates", "claim", claim.Name)
-			return nil, nil // Warm pool is truly empty, fall completely to cold start
+			if pendingNetworkCandidates > 0 {
+				logger.V(4).Info("No network-ready warm sandbox after checking candidates", "claim", claim.Name, "pendingCandidates", pendingNetworkCandidates)
+				return nil, pendingNetworkCandidates, nil
+			}
+			logger.V(4).Info("No warm sandbox candidates available", "claim", claim.Name)
+			return nil, 0, nil // Warm pool is truly empty, fall completely to cold start
 		}
 
 		// Wrap the API logic in a closure
@@ -1052,16 +1086,16 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 		}()
 
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if success {
-			return adopted, nil
+			return adopted, 0, nil
 		}
 	}
 
 	logger.Info("Failed to adopt sandbox after max retries", "claim", claim.Name)
-	return nil, nil
+	return nil, 0, nil
 }
 
 func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, adopted *v1beta1.Sandbox) error {
@@ -1782,6 +1816,17 @@ func (r *SandboxClaimReconciler) migrateLegacyAssignedSandboxLabel(ctx context.C
 	return r.Patch(ctx, claim, patch)
 }
 
+func warmCandidateRetryAfter(claim *extensionsv1beta1.SandboxClaim, now time.Time) (time.Duration, bool) {
+	if claim.CreationTimestamp.IsZero() {
+		return 0, false
+	}
+	remaining := claim.CreationTimestamp.Add(warmCandidateGracePeriod).Sub(now)
+	if remaining <= 0 {
+		return 0, false
+	}
+	return min(warmCandidateRetryInterval, remaining), true
+}
+
 func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, _ *extensionsv1beta1.SandboxTemplate) (*v1beta1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	logger.V(1).Info("Executing getOrCreateSandbox", "claim", claim.Name)
@@ -1954,12 +1999,27 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	}
 
 	// Go to the custom queue instead of standard r.List()
-	adopted, err := r.adoptSandboxFromCandidates(ctx, claim)
+	adopted, pendingNetworkCandidates, err := r.adoptSandboxFromCandidates(ctx, claim)
 	if err != nil {
 		return nil, err
 	}
 	if adopted != nil {
 		return adopted, nil
+	}
+	if pendingNetworkCandidates > 0 {
+		if retryAfter, ok := warmCandidateRetryAfter(claim, time.Now()); ok {
+			return nil, &warmCandidatesPendingError{
+				pendingCandidates: pendingNetworkCandidates,
+				retryAfter:        retryAfter,
+			}
+		}
+		logger.Info("Warm pool candidates did not report Pod IPs within the grace period; falling back to cold creation",
+			"claim", claim.Name,
+			"warmPool", claim.Spec.WarmPoolRef.Name,
+			"pendingCandidates", pendingNetworkCandidates,
+			"gracePeriod", warmCandidateGracePeriod,
+			"reason", "warm_candidates_network_pending",
+		)
 	}
 
 	// No warm pool sandbox available; caller decides whether to create

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -933,6 +933,14 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			continue
 		}
 
+		// PodIPs is the adoption boundary: without it, the backing Pod is missing
+		// or not networked yet. Keep the candidate in the queue so it can be
+		// retried once networking completes.
+		if len(adopted.Status.PodIPs) == 0 {
+			skipped = append(skipped, adoptedKey)
+			continue
+		}
+
 		// Candidate is valid! Now check if it is Ready
 		if isSandboxReady(adopted) {
 			// Found a Ready sandbox! Adopt it immediately.
@@ -2489,6 +2497,10 @@ func verifySandboxCandidate(candidate *v1beta1.Sandbox, claim *extensionsv1beta1
 	return nil
 }
 
+// isAdoptable evaluates static ownership and validity only.
+// Transient runtime conditions (e.g., waiting for PodIPs or image pulling)
+// MUST NOT be checked here; failures in isAdoptable trigger permanent queue
+// eviction and premature claim unassignments. Transient checks belong in getCandidate.
 func isAdoptable(candidate *v1beta1.Sandbox) error {
 	if !candidate.DeletionTimestamp.IsZero() {
 		return fmt.Errorf("sandbox is deleted")
@@ -2510,12 +2522,6 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	// group version after an upgrade. Match on group+kind, not version.
 	if !utils.MatchesGroupKind(controllerRef, extensionsv1beta1.GroupVersion.Group, extensionsv1beta1.SandboxWarmPoolKind) {
 		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
-	}
-
-	// PodIPs is the adoption boundary: without it, the backing Pod is missing
-	// or not networked yet. Not-Ready sandboxes with PodIPs are still useful.
-	if len(candidate.Status.PodIPs) == 0 {
-		return fmt.Errorf("sandbox has no assigned pod IPs yet")
 	}
 	return nil
 }

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -933,6 +933,14 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			continue
 		}
 
+		// PodIPs is the adoption boundary: without it, the backing Pod is missing
+		// or not networked yet. Keep the candidate in the queue so it can be
+		// retried once networking completes.
+		if len(adopted.Status.PodIPs) == 0 {
+			skipped = append(skipped, adoptedKey)
+			continue
+		}
+
 		// Candidate is valid! Now check if it is Ready
 		if isSandboxReady(adopted) {
 			// Found a Ready sandbox! Adopt it immediately.
@@ -2456,6 +2464,10 @@ func verifySandboxCandidate(candidate *v1beta1.Sandbox, claim *extensionsv1beta1
 	return nil
 }
 
+// isAdoptable evaluates static ownership and validity only.
+// Transient runtime conditions (e.g., waiting for PodIPs or image pulling)
+// MUST NOT be checked here; failures in isAdoptable trigger permanent queue
+// eviction and premature claim unassignments. Transient checks belong in getCandidate.
 func isAdoptable(candidate *v1beta1.Sandbox) error {
 	if !candidate.DeletionTimestamp.IsZero() {
 		return fmt.Errorf("sandbox is deleted")
@@ -2477,12 +2489,6 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	// group version after an upgrade. Match on group+kind, not version.
 	if !utils.MatchesGroupKind(controllerRef, extensionsv1beta1.GroupVersion.Group, extensionsv1beta1.SandboxWarmPoolKind) {
 		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
-	}
-
-	// PodIPs is the adoption boundary: without it, the backing Pod is missing
-	// or not networked yet. Not-Ready sandboxes with PodIPs are still useful.
-	if len(candidate.Status.PodIPs) == 0 {
-		return fmt.Errorf("sandbox has no assigned pod IPs yet")
 	}
 	return nil
 }

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -61,7 +61,10 @@ import (
 const ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
 
 const (
-	immediateRequeueDelay      = time.Millisecond
+	immediateRequeueDelay = time.Millisecond
+	// warmCandidateGracePeriod gives a newly created claim two seconds for a
+	// warm candidate to receive a Pod IP. This covers short IPAM delays without
+	// allowing an unavailable warm pool to postpone cold creation indefinitely.
 	warmCandidateGracePeriod   = 2 * time.Second
 	warmCandidateRetryInterval = 500 * time.Millisecond
 )

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -939,7 +939,9 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 		// Sandbox status before requeueing so a stale queue key does not erase
 		// placement information used by pickSmart.
 		if len(adopted.Status.PodIPs) == 0 {
-			adoptedKey.NodeName = adopted.Status.NodeName
+			if adopted.Status.NodeName != "" {
+				adoptedKey.NodeName = adopted.Status.NodeName
+			}
 			skipped = append(skipped, adoptedKey)
 			continue
 		}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -59,7 +59,12 @@ import (
 )
 
 const ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
-const immediateRequeueDelay = time.Millisecond
+
+const (
+	immediateRequeueDelay      = time.Millisecond
+	warmCandidateGracePeriod   = 2 * time.Second
+	warmCandidateRetryInterval = 500 * time.Millisecond
+)
 
 // ErrTemplateNotFound is a sentinel error indicating a SandboxTemplate was not found.
 var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
@@ -77,6 +82,15 @@ var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 // locked adoption writes; the Ready condition surfaces it as the benign
 // AdoptionConflict reason instead of ReconcilerError.
 var errAdoptionConflict = errors.New("adoption write conflict")
+
+type warmCandidatesPendingError struct {
+	pendingCandidates int
+	retryAfter        time.Duration
+}
+
+func (e *warmCandidatesPendingError) Error() string {
+	return fmt.Sprintf("%d warm pool candidate(s) are awaiting observed Pod IPs", e.pendingCandidates)
+}
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
@@ -277,6 +291,20 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	} else {
 		// Ensure Sandbox exists and is configured.
 		sandbox, reconcileErr = r.reconcileActive(ctx, claim)
+	}
+
+	// Pending warm candidates are expected transient state, not a claim failure.
+	// Return before status calculation so the grace period does not publish a
+	// misleading SandboxMissing or ReconcilerError condition.
+	var pendingWarmCandidates *warmCandidatesPendingError
+	if errors.As(reconcileErr, &pendingWarmCandidates) {
+		logger.V(4).Info("Waiting for warm pool candidates to report Pod IPs",
+			"claim", claim.Name,
+			"warmPool", claim.Spec.WarmPoolRef.Name,
+			"pendingCandidates", pendingWarmCandidates.pendingCandidates,
+			"retryAfter", pendingWarmCandidates.retryAfter,
+		)
+		return ctrl.Result{RequeueAfter: pendingWarmCandidates.retryAfter}, nil
 	}
 
 	// Update Status & Events
@@ -825,7 +853,7 @@ func ensureClaimIdentityLabels(labels map[string]string, claim *extensionsv1beta
 	return labels
 }
 
-func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, queue.SandboxKey, error) {
+func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, queue.SandboxKey, int, error) {
 	logger := log.FromContext(ctx)
 
 	namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(claim.Namespace, claim.Spec.WarmPoolRef.Name)
@@ -834,6 +862,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	var fallbackSandbox *v1beta1.Sandbox
 	var fallbackKey queue.SandboxKey
 	var adoptingFallback bool
+	var pendingNetworkCandidates int
 
 	// Instantly returns unused keys the moment we find a valid/ready candidate!
 	defer func() {
@@ -905,9 +934,9 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			// No more candidates in our namespace. If we found an unready fallback sandbox, return it.
 			if fallbackSandbox != nil {
 				adoptingFallback = true
-				return fallbackSandbox, fallbackKey, nil
+				return fallbackSandbox, fallbackKey, pendingNetworkCandidates, nil
 			}
-			return nil, queue.SandboxKey{}, nil
+			return nil, queue.SandboxKey{}, pendingNetworkCandidates, nil
 		}
 
 		adopted := &v1beta1.Sandbox{}
@@ -920,7 +949,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			}
 			// For real errors, put the key back in line and error out
 			r.WarmSandboxQueue.Add(namespacedWarmPoolName, adoptedKey)
-			return nil, queue.SandboxKey{}, err
+			return nil, queue.SandboxKey{}, pendingNetworkCandidates, err
 		}
 
 		if err := verifySandboxCandidate(adopted, claim); err != nil {
@@ -933,15 +962,16 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			continue
 		}
 
-		// PodIPs is the adoption boundary: without it, the backing Pod is missing
-		// or not networked yet. Keep the candidate in the queue so it can be
-		// retried once networking completes. Normalize NodeName from the latest
-		// Sandbox status before requeueing so a stale queue key does not erase
-		// placement information used by pickSmart.
+		// Missing cached PodIPs means the controller has not observed a networked
+		// backing Pod for this candidate. Non-empty cached PodIPs narrow but cannot
+		// eliminate every concurrent Pod-deletion race. Keep pending candidates in
+		// the queue for a bounded claim-side retry. Normalize NodeName from the
+		// latest Sandbox status so a stale key does not erase placement information.
 		if len(adopted.Status.PodIPs) == 0 {
 			if adopted.Status.NodeName != "" {
 				adoptedKey.NodeName = adopted.Status.NodeName
 			}
+			pendingNetworkCandidates++
 			skipped = append(skipped, adoptedKey)
 			continue
 		}
@@ -949,7 +979,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 		// Candidate is valid! Now check if it is Ready
 		if isSandboxReady(adopted) {
 			// Found a Ready sandbox! Adopt it immediately.
-			return adopted, adoptedKey, nil
+			return adopted, adoptedKey, pendingNetworkCandidates, nil
 		}
 
 		// Sandbox is valid but NOT Ready.
@@ -964,19 +994,23 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	}
 }
 
-func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, error) {
+func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*v1beta1.Sandbox, int, error) {
 	logger := log.FromContext(ctx)
 	namespacedWarmPoolNameForQueue := queue.GetNamespacedWarmPoolName(claim.Namespace, claim.Spec.WarmPoolRef.Name)
 
 	// Keep trying until we successfully adopt a sandbox, or run out of candidates
 	for range 3 {
-		adopted, adoptedKey, err := r.getCandidate(ctx, claim)
+		adopted, adoptedKey, pendingNetworkCandidates, err := r.getCandidate(ctx, claim)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 		if adopted == nil {
-			logger.Info("Failed to adopt any sandbox after checking all candidates", "claim", claim.Name)
-			return nil, nil // Warm pool is truly empty, fall completely to cold start
+			if pendingNetworkCandidates > 0 {
+				logger.V(4).Info("No network-ready warm sandbox after checking candidates", "claim", claim.Name, "pendingCandidates", pendingNetworkCandidates)
+				return nil, pendingNetworkCandidates, nil
+			}
+			logger.V(4).Info("No warm sandbox candidates available", "claim", claim.Name)
+			return nil, 0, nil // Warm pool is truly empty, fall completely to cold start
 		}
 
 		// Wrap the API logic in a closure
@@ -1052,16 +1086,16 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 		}()
 
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		if success {
-			return adopted, nil
+			return adopted, 0, nil
 		}
 	}
 
 	logger.Info("Failed to adopt sandbox after max retries", "claim", claim.Name)
-	return nil, nil
+	return nil, 0, nil
 }
 
 func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, adopted *v1beta1.Sandbox) error {
@@ -1782,6 +1816,17 @@ func (r *SandboxClaimReconciler) migrateLegacyAssignedSandboxLabel(ctx context.C
 	return r.Patch(ctx, claim, patch)
 }
 
+func warmCandidateRetryAfter(claim *extensionsv1beta1.SandboxClaim, now time.Time) (time.Duration, bool) {
+	if claim.CreationTimestamp.IsZero() {
+		return 0, false
+	}
+	remaining := claim.CreationTimestamp.Add(warmCandidateGracePeriod).Sub(now)
+	if remaining <= 0 {
+		return 0, false
+	}
+	return min(warmCandidateRetryInterval, remaining), true
+}
+
 func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, _ *extensionsv1beta1.SandboxTemplate) (*v1beta1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	logger.V(1).Info("Executing getOrCreateSandbox", "claim", claim.Name)
@@ -1938,12 +1983,27 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	}
 
 	// Go to the custom queue instead of standard r.List()
-	adopted, err := r.adoptSandboxFromCandidates(ctx, claim)
+	adopted, pendingNetworkCandidates, err := r.adoptSandboxFromCandidates(ctx, claim)
 	if err != nil {
 		return nil, err
 	}
 	if adopted != nil {
 		return adopted, nil
+	}
+	if pendingNetworkCandidates > 0 {
+		if retryAfter, ok := warmCandidateRetryAfter(claim, time.Now()); ok {
+			return nil, &warmCandidatesPendingError{
+				pendingCandidates: pendingNetworkCandidates,
+				retryAfter:        retryAfter,
+			}
+		}
+		logger.Info("Warm pool candidates did not report Pod IPs within the grace period; falling back to cold creation",
+			"claim", claim.Name,
+			"warmPool", claim.Spec.WarmPoolRef.Name,
+			"pendingCandidates", pendingNetworkCandidates,
+			"gracePeriod", warmCandidateGracePeriod,
+			"reason", "warm_candidates_network_pending",
+		)
 	}
 
 	// No warm pool sandbox available; caller decides whether to create

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2506,8 +2506,10 @@ func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T)
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
 		Spec: extensionsv1beta1.SandboxTemplateSpec{
-			PodTemplate: sandboxv1beta1.PodTemplate{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+				},
 			},
 		},
 	}
@@ -2544,8 +2546,10 @@ func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T)
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
 			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
-			PodTemplate: sandboxv1beta1.PodTemplate{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+				},
 			},
 		},
 		Status: sandboxv1beta1.SandboxStatus{

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -55,6 +55,10 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
+// testNetworkedPodIP is a placeholder Pod IP used by warm-pool sandbox
+// fixtures to mark "backing Pod exists and is networked".
+const testNetworkedPodIP = "10.244.0.5"
+
 func TestSandboxClaimReconcile(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
@@ -1979,6 +1983,8 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 						Reason: "DependenciesReady",
 					},
 				},
+				// PodIPs marks that the backing Pod exists and is networked.
+				PodIPs: []string{testNetworkedPodIP},
 			},
 		}
 	}
@@ -2021,6 +2027,14 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		now := metav1.Now()
 		sb.DeletionTimestamp = &now
 		sb.Finalizers = []string{"test-finalizer"}
+		return sb
+	}
+
+	// createRotatingSandbox simulates a warm-pool sandbox whose backing Pod has
+	// been deleted or is not networked yet while its queue entry is still present.
+	createRotatingSandbox := func(name string, creationTime metav1.Time) *sandboxv1beta1.Sandbox {
+		sb := createWarmPoolSandbox(name, creationTime, false)
+		sb.Status.PodIPs = nil
 		return sb
 	}
 
@@ -2116,6 +2130,29 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 			expectSandboxAdoption:   true,
 			expectedAdoptedSandbox:  "not-ready-1",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name: "skips warm pool sandboxes with no backing pod and falls through to cold creation",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				createRotatingSandbox("rotating-sb-1", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}),
+				createRotatingSandbox("rotating-sb-2", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}),
+			},
+			expectSandboxAdoption:   false,
+			expectNewSandboxCreated: true,
+		},
+		{
+			name: "adopts not-ready sandbox with backing pod, skipping rotating sandboxes without pods",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				createRotatingSandbox("rotating-sb", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}),
+				createWarmPoolSandbox("not-ready-with-pod", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, false),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "not-ready-with-pod",
 			expectNewSandboxCreated: false,
 		},
 		{
@@ -2334,16 +2371,18 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			// 1. Initialize the Queue
 			warmSandboxQueue := queue.NewSimpleSandboxQueue()
 
-			// 2. Seed the Queue with the existing objects from the test case
+			// 2. Seed stale queue entries too; production can retain keys after
+			//    a sandbox stops being adoptable, and pop-side validation must
+			//    reject them.
 			for _, obj := range tc.existingObjects {
 				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok {
-					// Only add valid, adoptable sandboxes to the queue
-					if isAdoptable(sb) == nil {
-						warmPoolName := getWarmPoolName(sb)
-						namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(sb.Namespace, warmPoolName)
-						key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name, NodeName: sb.Status.NodeName}
-						warmSandboxQueue.Add(namespacedWarmPoolName, key)
+					warmPoolName := getWarmPoolName(sb)
+					if warmPoolName == "" {
+						continue
 					}
+					namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(sb.Namespace, warmPoolName)
+					key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name, NodeName: sb.Status.NodeName}
+					warmSandboxQueue.Add(namespacedWarmPoolName, key)
 				}
 			}
 
@@ -3986,6 +4025,9 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
+		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
+		},
 	}
 
 	// 2. Invalid Sandbox (Different Namespace, but identical hash)
@@ -4003,6 +4045,9 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				Name:       "test-warmpool",
 				Controller: ptr.To(true), // nolint:modernize
 			}},
+		},
+		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 		},
 	}
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2588,7 +2588,7 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 	ctx := context.Background()
 	warmPoolUID := types.UID("warmpool-uid-123")
 	poolName := "test-pool"
-	key := queue.SandboxKey{Namespace: "default", Name: "rotating-sb"}
+	key := queue.SandboxKey{Namespace: "default", Name: "rotating-sb", NodeName: "node-a"}
 	rotatingSandbox := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.Name,
@@ -2605,7 +2605,7 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
-		Status: sandboxv1beta1.SandboxStatus{NodeName: "node-a", PodIPs: nil},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: nil},
 	}
 	claim := &extensionsv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: key.Namespace, UID: types.UID("claim-uid")},
@@ -2627,7 +2627,7 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 
 	requeued, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
 	require.True(t, ok, "unnetworked candidate should be returned to the queue")
-	require.Equal(t, queue.SandboxKey{Namespace: key.Namespace, Name: key.Name, NodeName: rotatingSandbox.Status.NodeName}, requeued)
+	require.Equal(t, key, requeued)
 }
 
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -54,6 +54,10 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
+// testNetworkedPodIP is a placeholder Pod IP used by warm-pool sandbox
+// fixtures to mark "backing Pod exists and is networked".
+const testNetworkedPodIP = "10.244.0.5"
+
 func TestSandboxClaimReconcile(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
@@ -1978,6 +1982,8 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 						Reason: "DependenciesReady",
 					},
 				},
+				// PodIPs marks that the backing Pod exists and is networked.
+				PodIPs: []string{testNetworkedPodIP},
 			},
 		}
 	}
@@ -2020,6 +2026,14 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		now := metav1.Now()
 		sb.DeletionTimestamp = &now
 		sb.Finalizers = []string{"test-finalizer"}
+		return sb
+	}
+
+	// createRotatingSandbox simulates a warm-pool sandbox whose backing Pod has
+	// been deleted or is not networked yet while its queue entry is still present.
+	createRotatingSandbox := func(name string, creationTime metav1.Time) *sandboxv1beta1.Sandbox {
+		sb := createWarmPoolSandbox(name, creationTime, false)
+		sb.Status.PodIPs = nil
 		return sb
 	}
 
@@ -2115,6 +2129,29 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 			expectSandboxAdoption:   true,
 			expectedAdoptedSandbox:  "not-ready-1",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name: "skips warm pool sandboxes with no backing pod and falls through to cold creation",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				createRotatingSandbox("rotating-sb-1", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}),
+				createRotatingSandbox("rotating-sb-2", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}),
+			},
+			expectSandboxAdoption:   false,
+			expectNewSandboxCreated: true,
+		},
+		{
+			name: "adopts not-ready sandbox with backing pod, skipping rotating sandboxes without pods",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				createRotatingSandbox("rotating-sb", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}),
+				createWarmPoolSandbox("not-ready-with-pod", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, false),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "not-ready-with-pod",
 			expectNewSandboxCreated: false,
 		},
 		{
@@ -2333,16 +2370,18 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			// 1. Initialize the Queue
 			warmSandboxQueue := queue.NewSimpleSandboxQueue()
 
-			// 2. Seed the Queue with the existing objects from the test case
+			// 2. Seed stale queue entries too; production can retain keys after
+			//    a sandbox stops being adoptable, and pop-side validation must
+			//    reject them.
 			for _, obj := range tc.existingObjects {
 				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok {
-					// Only add valid, adoptable sandboxes to the queue
-					if isAdoptable(sb) == nil {
-						warmPoolName := getWarmPoolName(sb)
-						namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(sb.Namespace, warmPoolName)
-						key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name, NodeName: sb.Status.NodeName}
-						warmSandboxQueue.Add(namespacedWarmPoolName, key)
+					warmPoolName := getWarmPoolName(sb)
+					if warmPoolName == "" {
+						continue
 					}
+					namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(sb.Namespace, warmPoolName)
+					key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name, NodeName: sb.Status.NodeName}
+					warmSandboxQueue.Add(namespacedWarmPoolName, key)
 				}
 			}
 
@@ -3902,6 +3941,9 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
+		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
+		},
 	}
 
 	// 2. Invalid Sandbox (Different Namespace, but identical hash)
@@ -3919,6 +3961,9 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				Name:       "test-warmpool",
 				Controller: ptr.To(true), // nolint:modernize
 			}},
+		},
+		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 		},
 	}
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3338,6 +3338,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 				Conditions: []metav1.Condition{{
 					Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 				}},
+				PodIPs: []string{testNetworkedPodIP},
 			},
 		}
 
@@ -4205,6 +4206,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			},
 		}},
 		},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: []string{testNetworkedPodIP}},
 	}
 
 	// Another sandbox in the warm pool that we want to make sure doesn't get adopted
@@ -4230,6 +4232,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},
+			PodIPs: []string{testNetworkedPodIP},
 		},
 	}
 
@@ -5217,6 +5220,7 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 				sandboxTemplateRefHash: templateHash,
 			},
 		},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: []string{testNetworkedPodIP}},
 	}
 
 	// 3. Verify it is rejected
@@ -5327,6 +5331,7 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 			},
 			Status: sandboxv1beta1.SandboxStatus{
 				NodeName: nodeName,
+				PodIPs:   []string{testNetworkedPodIP},
 				Conditions: []metav1.Condition{
 					{
 						Type:   string(sandboxv1beta1.SandboxConditionReady),
@@ -5610,6 +5615,7 @@ func TestCreateSandboxClaimVolumeClaimTemplatesSuccess(t *testing.T) {
 							Type:   string(sandboxv1beta1.SandboxConditionReady),
 							Status: metav1.ConditionTrue,
 						}},
+						PodIPs: []string{testNetworkedPodIP},
 					},
 				}
 				existingObjects = append(existingObjects, readyWarmSandbox)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1925,6 +1925,8 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 		},
 	}
+	claimPastWarmCandidateGracePeriod := claim.DeepCopy()
+	claimPastWarmCandidateGracePeriod.CreationTimestamp = metav1.NewTime(time.Now().Add(-warmCandidateGracePeriod - time.Second))
 
 	warmPoolUID := types.UID("warmpool-uid-123")
 	poolNameHash := sandboxcontrollers.NameHash("test-pool")
@@ -2133,10 +2135,10 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: false,
 		},
 		{
-			name: "skips warm pool sandboxes with no backing pod and falls through to cold creation",
+			name: "falls through to cold creation after grace expires when warm candidates lack PodIPs",
 			existingObjects: []client.Object{
 				template,
-				claim,
+				claimPastWarmCandidateGracePeriod,
 				createRotatingSandbox("rotating-sb-1", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}),
 				createRotatingSandbox("rotating-sb-2", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}),
 			},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3254,6 +3254,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 				Conditions: []metav1.Condition{{
 					Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 				}},
+				PodIPs: []string{testNetworkedPodIP},
 			},
 		}
 
@@ -4042,6 +4043,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			},
 		}},
 		},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: []string{testNetworkedPodIP}},
 	}
 
 	// Another sandbox in the warm pool that we want to make sure doesn't get adopted
@@ -4067,6 +4069,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},
+			PodIPs: []string{testNetworkedPodIP},
 		},
 	}
 
@@ -5054,6 +5057,7 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 				sandboxTemplateRefHash: templateHash,
 			},
 		},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: []string{testNetworkedPodIP}},
 	}
 
 	// 3. Verify it is rejected
@@ -5164,6 +5168,7 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 			},
 			Status: sandboxv1beta1.SandboxStatus{
 				NodeName: nodeName,
+				PodIPs:   []string{testNetworkedPodIP},
 				Conditions: []metav1.Condition{
 					{
 						Type:   string(sandboxv1beta1.SandboxConditionReady),
@@ -5447,6 +5452,7 @@ func TestCreateSandboxClaimVolumeClaimTemplatesSuccess(t *testing.T) {
 							Type:   string(sandboxv1beta1.SandboxConditionReady),
 							Status: metav1.ConditionTrue,
 						}},
+						PodIPs: []string{testNetworkedPodIP},
 					},
 				}
 				existingObjects = append(existingObjects, readyWarmSandbox)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2505,8 +2505,10 @@ func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T)
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
 		Spec: extensionsv1beta1.SandboxTemplateSpec{
-			PodTemplate: sandboxv1beta1.PodTemplate{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+				},
 			},
 		},
 	}
@@ -2543,8 +2545,10 @@ func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T)
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
 			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
-			PodTemplate: sandboxv1beta1.PodTemplate{
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+				},
 			},
 		},
 		Status: sandboxv1beta1.SandboxStatus{

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1924,6 +1924,8 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 		},
 	}
+	claimPastWarmCandidateGracePeriod := claim.DeepCopy()
+	claimPastWarmCandidateGracePeriod.CreationTimestamp = metav1.NewTime(time.Now().Add(-warmCandidateGracePeriod - time.Second))
 
 	warmPoolUID := types.UID("warmpool-uid-123")
 	poolNameHash := sandboxcontrollers.NameHash("test-pool")
@@ -2132,10 +2134,10 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: false,
 		},
 		{
-			name: "skips warm pool sandboxes with no backing pod and falls through to cold creation",
+			name: "falls through to cold creation after grace expires when warm candidates lack PodIPs",
 			existingObjects: []client.Object{
 				template,
-				claim,
+				claimPastWarmCandidateGracePeriod,
 				createRotatingSandbox("rotating-sb-1", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}),
 				createRotatingSandbox("rotating-sb-2", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}),
 			},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2495,6 +2495,139 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		})
 	}
 }
+
+func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T) {
+	scheme := newScheme(t)
+	ctx := context.Background()
+	warmPoolUID := types.UID("warmpool-uid-123")
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			},
+		},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: warmPoolUID},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       types.UID("claim-uid"),
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "rotating-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPool.Name}},
+	}
+	rotatingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rotating-sb",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash(template.Name),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       warmPool.Name,
+				UID:        warmPoolUID,
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			},
+		},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionFalse,
+				Reason: "PodRecreating",
+			}},
+			PodIPs: nil,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, rotatingSandbox).
+		WithStatusSubresource(claim).
+		Build()
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	_, err := reconciler.getOrCreateSandbox(ctx, claim, template)
+	require.Error(t, err, "completing an in-progress assignment should ask reconcile to retry")
+
+	var updatedClaim extensionsv1beta1.SandboxClaim
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, &updatedClaim))
+	require.Equal(t, rotatingSandbox.Name, updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+
+	var updatedSandbox sandboxv1beta1.Sandbox
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rotatingSandbox.Name, Namespace: rotatingSandbox.Namespace}, &updatedSandbox))
+	require.True(t, metav1.IsControlledBy(&updatedSandbox, claim))
+}
+
+func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
+	scheme := newScheme(t)
+	ctx := context.Background()
+	warmPoolUID := types.UID("warmpool-uid-123")
+	poolName := "test-pool"
+	key := queue.SandboxKey{Namespace: "default", Name: "rotating-sb"}
+	rotatingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   sandboxcontrollers.NameHash(poolName),
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       poolName,
+				UID:        warmPoolUID,
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: nil},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: key.Namespace, UID: types.UID("claim-uid")},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: poolName}},
+	}
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	warmSandboxQueue.Add(poolName, key)
+	reconciler := &SandboxClaimReconciler{
+		Client:           fake.NewClientBuilder().WithScheme(scheme).WithObjects(rotatingSandbox).Build(),
+		Scheme:           scheme,
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	candidate, _, err := reconciler.getCandidate(ctx, claim)
+	require.NoError(t, err)
+	require.Nil(t, candidate)
+
+	requeued, ok := warmSandboxQueue.Get(poolName)
+	require.True(t, ok, "unnetworked candidate should be returned to the queue")
+	require.Equal(t, key, requeued)
+}
+
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
 	q := queue.NewSimpleSandboxQueue()
 	handler := &sandboxEventHandler{sandboxQueue: q}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2605,14 +2605,15 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
-		Status: sandboxv1beta1.SandboxStatus{PodIPs: nil},
+		Status: sandboxv1beta1.SandboxStatus{NodeName: "node-a", PodIPs: nil},
 	}
 	claim := &extensionsv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: key.Namespace, UID: types.UID("claim-uid")},
 		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: poolName}},
 	}
 	warmSandboxQueue := queue.NewSimpleSandboxQueue()
-	warmSandboxQueue.Add(poolName, key)
+	namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(key.Namespace, poolName)
+	warmSandboxQueue.Add(namespacedWarmPoolName, key)
 	reconciler := &SandboxClaimReconciler{
 		Client:           fake.NewClientBuilder().WithScheme(scheme).WithObjects(rotatingSandbox).Build(),
 		Scheme:           scheme,
@@ -2624,9 +2625,9 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, candidate)
 
-	requeued, ok := warmSandboxQueue.Get(poolName)
+	requeued, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
 	require.True(t, ok, "unnetworked candidate should be returned to the queue")
-	require.Equal(t, key, requeued)
+	require.Equal(t, queue.SandboxKey{Namespace: key.Namespace, Name: key.Name, NodeName: rotatingSandbox.Status.NodeName}, requeued)
 }
 
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2575,8 +2575,9 @@ func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T)
 		Tracer:           asmetrics.NewNoOp(),
 	}
 
-	_, err := reconciler.getOrCreateSandbox(ctx, claim, template)
-	require.Error(t, err, "completing an in-progress assignment should ask reconcile to retry")
+	assigned, err := reconciler.getOrCreateSandbox(ctx, claim, template)
+	require.NoError(t, err)
+	require.Equal(t, rotatingSandbox.Name, assigned.Name)
 
 	var updatedClaim extensionsv1beta1.SandboxClaim
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, &updatedClaim))
@@ -2625,13 +2626,165 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 		Tracer:           asmetrics.NewNoOp(),
 	}
 
-	candidate, _, err := reconciler.getCandidate(ctx, claim)
+	candidate, _, pendingNetworkCandidates, err := reconciler.getCandidate(ctx, claim)
 	require.NoError(t, err)
 	require.Nil(t, candidate)
+	require.Equal(t, 1, pendingNetworkCandidates)
 
 	requeued, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
 	require.True(t, ok, "unnetworked candidate should be returned to the queue")
 	require.Equal(t, key, requeued)
+}
+
+func newWarmCandidateGraceFixture(t *testing.T, claimCreated time.Time, withCandidate bool) (client.Client, *SandboxClaimReconciler, reconcile.Request, *sandboxv1beta1.Sandbox) {
+	t.Helper()
+	scheme := newScheme(t)
+	poolName := "test-pool"
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+			PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "workspace", Image: "workspace:latest"}},
+			}},
+		}},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName, Namespace: "default", UID: "pool-uid"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-claim",
+			Namespace:         "default",
+			UID:               "claim-uid",
+			CreationTimestamp: metav1.NewTime(claimCreated),
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: poolName}},
+	}
+	objects := []client.Object{template, warmPool, claim}
+	var candidate *sandboxv1beta1.Sandbox
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	if withCandidate {
+		candidate = &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pending-sandbox",
+				Namespace: "default",
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   sandboxcontrollers.NameHash(poolName),
+					sandboxTemplateRefHash: sandboxcontrollers.NameHash(template.Name),
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: extensionsv1beta1.GroupVersion.String(),
+					Kind:       extensionsv1beta1.SandboxWarmPoolKind,
+					Name:       poolName,
+					UID:        warmPool.UID,
+					Controller: new(true),
+				}},
+			},
+			Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: template.Spec.PodTemplate,
+			}},
+			Status: sandboxv1beta1.SandboxStatus{NodeName: "node-a"},
+		}
+		objects = append(objects, candidate)
+		warmSandboxQueue.Add(
+			queue.GetNamespacedWarmPoolName(candidate.Namespace, poolName),
+			queue.SandboxKey{Namespace: candidate.Namespace, Name: candidate.Name, NodeName: candidate.Status.NodeName},
+		)
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(claim).
+		Build()
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+	return fakeClient, reconciler, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(claim)}, candidate
+}
+
+func TestSandboxClaimWarmCandidateGrace(t *testing.T) {
+	tests := []struct {
+		name          string
+		claimCreated  time.Time
+		withCandidate bool
+		wantRequeue   bool
+		wantCold      bool
+	}{
+		{
+			name:          "pending candidate briefly requeues",
+			claimCreated:  time.Now(),
+			withCandidate: true,
+			wantRequeue:   true,
+		},
+		{
+			name:         "truly empty pool cold starts immediately",
+			claimCreated: time.Now(),
+			wantCold:     true,
+		},
+		{
+			name:          "pending candidate past deadline cold starts",
+			claimCreated:  time.Now().Add(-warmCandidateGracePeriod - time.Second),
+			withCandidate: true,
+			wantCold:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient, reconciler, req, _ := newWarmCandidateGraceFixture(t, tc.claimCreated, tc.withCandidate)
+			result, err := reconciler.Reconcile(context.Background(), req)
+			require.NoError(t, err)
+			if tc.wantRequeue {
+				require.Greater(t, result.RequeueAfter, time.Duration(0))
+				require.LessOrEqual(t, result.RequeueAfter, warmCandidateRetryInterval)
+			} else {
+				require.Zero(t, result.RequeueAfter)
+			}
+
+			var coldSandbox sandboxv1beta1.Sandbox
+			err = fakeClient.Get(context.Background(), req.NamespacedName, &coldSandbox)
+			if tc.wantCold {
+				require.NoError(t, err)
+				require.True(t, metav1.IsControlledBy(&coldSandbox, &extensionsv1beta1.SandboxClaim{ObjectMeta: metav1.ObjectMeta{UID: "claim-uid"}}))
+			} else {
+				require.True(t, k8errors.IsNotFound(err), "cold sandbox should not be created during grace")
+				var updatedClaim extensionsv1beta1.SandboxClaim
+				require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &updatedClaim))
+				require.Empty(t, updatedClaim.Status.Conditions, "grace retry should not publish a failure condition")
+			}
+		})
+	}
+}
+
+func TestSandboxClaimAdoptsCandidateThatBecomesNetworkReadyDuringGrace(t *testing.T) {
+	fakeClient, reconciler, req, candidate := newWarmCandidateGraceFixture(t, time.Now(), true)
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.Greater(t, result.RequeueAfter, time.Duration(0))
+
+	var networked sandboxv1beta1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), &networked))
+	networked.Status.PodIPs = []string{"10.0.0.8"}
+	networked.Status.Conditions = []metav1.Condition{{
+		Type:   string(sandboxv1beta1.SandboxConditionReady),
+		Status: metav1.ConditionTrue,
+		Reason: "Ready",
+	}}
+	require.NoError(t, fakeClient.Update(context.Background(), &networked))
+
+	_, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	var adopted sandboxv1beta1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), &adopted))
+	var claim extensionsv1beta1.SandboxClaim
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &claim))
+	require.True(t, metav1.IsControlledBy(&adopted, &claim))
+	require.Equal(t, candidate.Name, claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
 }
 
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
@@ -2751,6 +2904,7 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},
@@ -4866,6 +5020,7 @@ func TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus(t *testing.T) {
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},
@@ -6122,6 +6277,7 @@ func TestReconcilePropagatesAnnotationPatchError(t *testing.T) {
 			}},
 		},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type:   string(sandboxv1beta1.SandboxConditionReady),
 				Status: metav1.ConditionTrue,
@@ -6661,6 +6817,7 @@ func TestSandboxClaimAdoptionConflictRetriedInPass(t *testing.T) {
 			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 		}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type:   string(sandboxv1beta1.SandboxConditionReady),
 				Status: metav1.ConditionTrue,
@@ -6762,6 +6919,7 @@ func newPoolCandidateSandbox(name string) *sandboxv1beta1.Sandbox {
 			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 		}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type:   string(sandboxv1beta1.SandboxConditionReady),
 				Status: metav1.ConditionTrue,

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -55,10 +55,6 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
-// testNetworkedPodIP is a placeholder Pod IP used by warm-pool sandbox
-// fixtures to mark "backing Pod exists and is networked".
-const testNetworkedPodIP = "10.244.0.5"
-
 func TestSandboxClaimReconcile(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
@@ -1893,6 +1889,10 @@ func TestCreateSandboxPropagatesVolumeClaimTemplates(t *testing.T) {
 		t.Errorf("expected storage %s, got %s", expectedStorage.String(), actualStorage.String())
 	}
 }
+
+// testNetworkedPodIP is a placeholder Pod IP used by warm-pool sandbox
+// fixtures to mark "backing Pod exists and is networked".
+const testNetworkedPodIP = "10.244.0.5"
 
 func TestSandboxClaimSandboxAdoption(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -54,10 +54,6 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
-// testNetworkedPodIP is a placeholder Pod IP used by warm-pool sandbox
-// fixtures to mark "backing Pod exists and is networked".
-const testNetworkedPodIP = "10.244.0.5"
-
 func TestSandboxClaimReconcile(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
@@ -1892,6 +1888,10 @@ func TestCreateSandboxPropagatesVolumeClaimTemplates(t *testing.T) {
 		t.Errorf("expected storage %s, got %s", expectedStorage.String(), actualStorage.String())
 	}
 }
+
+// testNetworkedPodIP is a placeholder Pod IP used by warm-pool sandbox
+// fixtures to mark "backing Pod exists and is networked".
+const testNetworkedPodIP = "10.244.0.5"
 
 func TestSandboxClaimSandboxAdoption(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2587,7 +2587,7 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 	ctx := context.Background()
 	warmPoolUID := types.UID("warmpool-uid-123")
 	poolName := "test-pool"
-	key := queue.SandboxKey{Namespace: "default", Name: "rotating-sb"}
+	key := queue.SandboxKey{Namespace: "default", Name: "rotating-sb", NodeName: "node-a"}
 	rotatingSandbox := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.Name,
@@ -2604,7 +2604,7 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
-		Status: sandboxv1beta1.SandboxStatus{NodeName: "node-a", PodIPs: nil},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: nil},
 	}
 	claim := &extensionsv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: key.Namespace, UID: types.UID("claim-uid")},
@@ -2626,7 +2626,7 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 
 	requeued, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
 	require.True(t, ok, "unnetworked candidate should be returned to the queue")
-	require.Equal(t, queue.SandboxKey{Namespace: key.Namespace, Name: key.Name, NodeName: rotatingSandbox.Status.NodeName}, requeued)
+	require.Equal(t, key, requeued)
 }
 
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2604,14 +2604,15 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
-		Status: sandboxv1beta1.SandboxStatus{PodIPs: nil},
+		Status: sandboxv1beta1.SandboxStatus{NodeName: "node-a", PodIPs: nil},
 	}
 	claim := &extensionsv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: key.Namespace, UID: types.UID("claim-uid")},
 		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: poolName}},
 	}
 	warmSandboxQueue := queue.NewSimpleSandboxQueue()
-	warmSandboxQueue.Add(poolName, key)
+	namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(key.Namespace, poolName)
+	warmSandboxQueue.Add(namespacedWarmPoolName, key)
 	reconciler := &SandboxClaimReconciler{
 		Client:           fake.NewClientBuilder().WithScheme(scheme).WithObjects(rotatingSandbox).Build(),
 		Scheme:           scheme,
@@ -2623,9 +2624,9 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, candidate)
 
-	requeued, ok := warmSandboxQueue.Get(poolName)
+	requeued, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
 	require.True(t, ok, "unnetworked candidate should be returned to the queue")
-	require.Equal(t, key, requeued)
+	require.Equal(t, queue.SandboxKey{Namespace: key.Namespace, Name: key.Name, NodeName: rotatingSandbox.Status.NodeName}, requeued)
 }
 
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2496,6 +2496,139 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		})
 	}
 }
+
+func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T) {
+	scheme := newScheme(t)
+	ctx := context.Background()
+	warmPoolUID := types.UID("warmpool-uid-123")
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			},
+		},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: warmPoolUID},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       types.UID("claim-uid"),
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "rotating-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPool.Name}},
+	}
+	rotatingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rotating-sb",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash(template.Name),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       warmPool.Name,
+				UID:        warmPoolUID,
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			},
+		},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionFalse,
+				Reason: "PodRecreating",
+			}},
+			PodIPs: nil,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, rotatingSandbox).
+		WithStatusSubresource(claim).
+		Build()
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	_, err := reconciler.getOrCreateSandbox(ctx, claim, template)
+	require.Error(t, err, "completing an in-progress assignment should ask reconcile to retry")
+
+	var updatedClaim extensionsv1beta1.SandboxClaim
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, &updatedClaim))
+	require.Equal(t, rotatingSandbox.Name, updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+
+	var updatedSandbox sandboxv1beta1.Sandbox
+	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: rotatingSandbox.Name, Namespace: rotatingSandbox.Namespace}, &updatedSandbox))
+	require.True(t, metav1.IsControlledBy(&updatedSandbox, claim))
+}
+
+func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
+	scheme := newScheme(t)
+	ctx := context.Background()
+	warmPoolUID := types.UID("warmpool-uid-123")
+	poolName := "test-pool"
+	key := queue.SandboxKey{Namespace: "default", Name: "rotating-sb"}
+	rotatingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   sandboxcontrollers.NameHash(poolName),
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       poolName,
+				UID:        warmPoolUID,
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Status: sandboxv1beta1.SandboxStatus{PodIPs: nil},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: key.Namespace, UID: types.UID("claim-uid")},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: poolName}},
+	}
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	warmSandboxQueue.Add(poolName, key)
+	reconciler := &SandboxClaimReconciler{
+		Client:           fake.NewClientBuilder().WithScheme(scheme).WithObjects(rotatingSandbox).Build(),
+		Scheme:           scheme,
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	candidate, _, err := reconciler.getCandidate(ctx, claim)
+	require.NoError(t, err)
+	require.Nil(t, candidate)
+
+	requeued, ok := warmSandboxQueue.Get(poolName)
+	require.True(t, ok, "unnetworked candidate should be returned to the queue")
+	require.Equal(t, key, requeued)
+}
+
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
 	q := queue.NewSimpleSandboxQueue()
 	handler := &sandboxEventHandler{sandboxQueue: q}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2574,8 +2574,9 @@ func TestSandboxClaimPreservesAssignedWarmPoolSandboxWithoutPodIPs(t *testing.T)
 		Tracer:           asmetrics.NewNoOp(),
 	}
 
-	_, err := reconciler.getOrCreateSandbox(ctx, claim, template)
-	require.Error(t, err, "completing an in-progress assignment should ask reconcile to retry")
+	assigned, err := reconciler.getOrCreateSandbox(ctx, claim, template)
+	require.NoError(t, err)
+	require.Equal(t, rotatingSandbox.Name, assigned.Name)
 
 	var updatedClaim extensionsv1beta1.SandboxClaim
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, &updatedClaim))
@@ -2624,13 +2625,165 @@ func TestGetCandidateRequeuesUnnetworkedWarmPoolSandboxes(t *testing.T) {
 		Tracer:           asmetrics.NewNoOp(),
 	}
 
-	candidate, _, err := reconciler.getCandidate(ctx, claim)
+	candidate, _, pendingNetworkCandidates, err := reconciler.getCandidate(ctx, claim)
 	require.NoError(t, err)
 	require.Nil(t, candidate)
+	require.Equal(t, 1, pendingNetworkCandidates)
 
 	requeued, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
 	require.True(t, ok, "unnetworked candidate should be returned to the queue")
 	require.Equal(t, key, requeued)
+}
+
+func newWarmCandidateGraceFixture(t *testing.T, claimCreated time.Time, withCandidate bool) (client.Client, *SandboxClaimReconciler, reconcile.Request, *sandboxv1beta1.Sandbox) {
+	t.Helper()
+	scheme := newScheme(t)
+	poolName := "test-pool"
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+			PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "workspace", Image: "workspace:latest"}},
+			}},
+		}},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName, Namespace: "default", UID: "pool-uid"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-claim",
+			Namespace:         "default",
+			UID:               "claim-uid",
+			CreationTimestamp: metav1.NewTime(claimCreated),
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: poolName}},
+	}
+	objects := []client.Object{template, warmPool, claim}
+	var candidate *sandboxv1beta1.Sandbox
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	if withCandidate {
+		candidate = &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pending-sandbox",
+				Namespace: "default",
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   sandboxcontrollers.NameHash(poolName),
+					sandboxTemplateRefHash: sandboxcontrollers.NameHash(template.Name),
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: extensionsv1beta1.GroupVersion.String(),
+					Kind:       extensionsv1beta1.SandboxWarmPoolKind,
+					Name:       poolName,
+					UID:        warmPool.UID,
+					Controller: new(true),
+				}},
+			},
+			Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: template.Spec.PodTemplate,
+			}},
+			Status: sandboxv1beta1.SandboxStatus{NodeName: "node-a"},
+		}
+		objects = append(objects, candidate)
+		warmSandboxQueue.Add(
+			queue.GetNamespacedWarmPoolName(candidate.Namespace, poolName),
+			queue.SandboxKey{Namespace: candidate.Namespace, Name: candidate.Name, NodeName: candidate.Status.NodeName},
+		)
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(claim).
+		Build()
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+	return fakeClient, reconciler, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(claim)}, candidate
+}
+
+func TestSandboxClaimWarmCandidateGrace(t *testing.T) {
+	tests := []struct {
+		name          string
+		claimCreated  time.Time
+		withCandidate bool
+		wantRequeue   bool
+		wantCold      bool
+	}{
+		{
+			name:          "pending candidate briefly requeues",
+			claimCreated:  time.Now(),
+			withCandidate: true,
+			wantRequeue:   true,
+		},
+		{
+			name:         "truly empty pool cold starts immediately",
+			claimCreated: time.Now(),
+			wantCold:     true,
+		},
+		{
+			name:          "pending candidate past deadline cold starts",
+			claimCreated:  time.Now().Add(-warmCandidateGracePeriod - time.Second),
+			withCandidate: true,
+			wantCold:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient, reconciler, req, _ := newWarmCandidateGraceFixture(t, tc.claimCreated, tc.withCandidate)
+			result, err := reconciler.Reconcile(context.Background(), req)
+			require.NoError(t, err)
+			if tc.wantRequeue {
+				require.Greater(t, result.RequeueAfter, time.Duration(0))
+				require.LessOrEqual(t, result.RequeueAfter, warmCandidateRetryInterval)
+			} else {
+				require.Zero(t, result.RequeueAfter)
+			}
+
+			var coldSandbox sandboxv1beta1.Sandbox
+			err = fakeClient.Get(context.Background(), req.NamespacedName, &coldSandbox)
+			if tc.wantCold {
+				require.NoError(t, err)
+				require.True(t, metav1.IsControlledBy(&coldSandbox, &extensionsv1beta1.SandboxClaim{ObjectMeta: metav1.ObjectMeta{UID: "claim-uid"}}))
+			} else {
+				require.True(t, k8errors.IsNotFound(err), "cold sandbox should not be created during grace")
+				var updatedClaim extensionsv1beta1.SandboxClaim
+				require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &updatedClaim))
+				require.Empty(t, updatedClaim.Status.Conditions, "grace retry should not publish a failure condition")
+			}
+		})
+	}
+}
+
+func TestSandboxClaimAdoptsCandidateThatBecomesNetworkReadyDuringGrace(t *testing.T) {
+	fakeClient, reconciler, req, candidate := newWarmCandidateGraceFixture(t, time.Now(), true)
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.Greater(t, result.RequeueAfter, time.Duration(0))
+
+	var networked sandboxv1beta1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), &networked))
+	networked.Status.PodIPs = []string{"10.0.0.8"}
+	networked.Status.Conditions = []metav1.Condition{{
+		Type:   string(sandboxv1beta1.SandboxConditionReady),
+		Status: metav1.ConditionTrue,
+		Reason: "Ready",
+	}}
+	require.NoError(t, fakeClient.Update(context.Background(), &networked))
+
+	_, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	var adopted sandboxv1beta1.Sandbox
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), &adopted))
+	var claim extensionsv1beta1.SandboxClaim
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, &claim))
+	require.True(t, metav1.IsControlledBy(&adopted, &claim))
+	require.Equal(t, candidate.Name, claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
 }
 
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
@@ -2750,6 +2903,7 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},
@@ -4703,6 +4857,7 @@ func TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus(t *testing.T) {
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},
@@ -5959,6 +6114,7 @@ func TestReconcilePropagatesAnnotationPatchError(t *testing.T) {
 			}},
 		},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type:   string(sandboxv1beta1.SandboxConditionReady),
 				Status: metav1.ConditionTrue,
@@ -6498,6 +6654,7 @@ func TestSandboxClaimAdoptionConflictRetriedInPass(t *testing.T) {
 			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 		}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type:   string(sandboxv1beta1.SandboxConditionReady),
 				Status: metav1.ConditionTrue,
@@ -6599,6 +6756,7 @@ func newPoolCandidateSandbox(name string) *sandboxv1beta1.Sandbox {
 			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
 		}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type:   string(sandboxv1beta1.SandboxConditionReady),
 				Status: metav1.ConditionTrue,

--- a/extensions/controllers/sandboxclaim_pod_exclusivity_test.go
+++ b/extensions/controllers/sandboxclaim_pod_exclusivity_test.go
@@ -91,6 +91,7 @@ func TestWarmPoolPodExclusivity(t *testing.T) {
 					Reason:             "DependenciesReady",
 					LastTransitionTime: metav1.NewTime(time.Now()),
 				}},
+				PodIPs: []string{testNetworkedPodIP},
 			},
 		}
 	}

--- a/extensions/controllers/sandboxclaim_rawpatch_test.go
+++ b/extensions/controllers/sandboxclaim_rawpatch_test.go
@@ -307,6 +307,7 @@ func warmAdoptionFixtures() (*extensionsv1beta1.SandboxClaim, *extensionsv1beta1
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}}},
 		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{testNetworkedPodIP},
 			Conditions: []metav1.Condition{{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
 			}},


### PR DESCRIPTION
#### What this PR does / why we need it:

During a warm-pool rotation, a Sandbox can remain queued while its backing Pod is being recreated. Adopting that Sandbox before the controller has observed Pod networking leaves the claim bound to unusable capacity.

This PR keeps static ownership and validity checks in `isAdoptable` and treats cached `Status.PodIPs` as a transient selection signal in `getCandidate`:

- Candidates without observed Pod IPs are skipped, requeued, and retain their node-placement metadata.
- If every otherwise-valid candidate is waiting for Pod IPs, a newly-created claim briefly requeues at 500 ms intervals for at most two seconds instead of immediately creating a burst of cold Pods.
- A genuinely empty pool still cold-starts immediately.
- When the grace period expires, reconciliation emits a structured level-0 log with the fixed reason `warm_candidates_network_pending` before falling back to cold creation.
- A candidate that has Pod IPs remains eligible even when it is not Ready, since it can still be more useful than a cold start.
- An already-recorded assignment is completed independently of this selection gate, so a transient empty `PodIPs` status cannot abandon it.

`Status.PodIPs` is cached evidence, not an authoritative Pod-existence check: it narrows the rotation race but cannot eliminate every concurrent deletion window. The bounded retry is intentionally write-free and uses the claim creation timestamp as its deadline, preserving bounded claim startup latency and controller restart safety.

This is a resubmission of #519 with the unused `adoptionStrategy` API removed. Selection strategy should be designed separately once there is a concrete second strategy.

#### Which issue(s) this PR is related to:

Ref #491
Ref #519

#### Testing

- `go test ./extensions/controllers -count=1`
- `make lint-go`
- `make build`
- `TMPDIR=$PWD/dev/tools/tmp make test-unit`

Regression coverage includes pool exhaustion, all-candidates-network-pending, grace expiry, adoption after networking becomes observable, queue preservation, and assigned-sandbox recovery.

#### Release Note

```release-note
SandboxClaims now briefly wait for rotating warm-pool Sandboxes to report Pod networking before falling back to cold creation.
```