### PR TITLE
make analytics-tool a proper section under guides (#633)

### DIFF
--- a/site/content/docs/guides/analytics-tool/overview.md
+++ b/site/content/docs/guides/analytics-tool/overview.md
@@ -1,0 +1,7 @@
+---
+title: "Overview"
+weight: 1
+description: >
+  This guide shows how to create your own analytics tool and invoke it in your agent workflow.
+---
+{{% include-file file="additional/examples/analytics-tool/README.md" %}}


### PR DESCRIPTION
## Fixes #633

## Title 
make analytics-tool a proper section under guides

## Description

The Analytics Tool guide was appearing as a top-level document instead of being nested under the Guides section. This was happening because the guides/analytics-tool/ directory only contained a single _index.md, which Hugo treated as a standalone page rather than a section.

## Changes
 Converted analytics-tool into a proper Hugo section:
- Added a new _index.md to define the section
- Moved existing content into overview.md