### PR TITLE
feat: detect Sandbox PodTemplate spec drift; opt-in recreate via Spec.UpdateStrategy

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -110,6 +110,26 @@ type PersistentVolumeClaimTemplate struct {
 	Spec corev1.PersistentVolumeClaimSpec `json:"spec" protobuf:"bytes,3,opt,name=spec"`
 }
 
+// UpdateStrategy describes how the controller should react to drift between
+// `Sandbox.Spec.PodTemplate` and an existing backing Pod's spec.
+// +kubebuilder:validation:Enum=None;Recreate
+type UpdateStrategy string
+
+const (
+	// UpdateStrategyNone is the default. The controller detects drift and may
+	// surface it via logs / status, but does NOT delete or modify the running
+	// Pod. Suits long-running, stateful workloads where deletion is
+	// disruptive.
+	UpdateStrategyNone UpdateStrategy = "None"
+
+	// UpdateStrategyRecreate opts in to automatic Pod recreation: when the
+	// controller observes a drift between the current Sandbox.Spec.PodTemplate
+	// hash and the hash stamped on the Pod at creation, it deletes the Pod so
+	// the next reconcile recreates it from the now-current template. This is
+	// destructive — the running container is killed.
+	UpdateStrategyRecreate UpdateStrategy = "Recreate"
+)
+
 // SandboxSpec defines the desired state of Sandbox.
 type SandboxSpec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
@@ -136,6 +156,16 @@ type SandboxSpec struct {
 	// +kubebuilder:default=1
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// updateStrategy controls how the controller reacts when the running Pod's
+	// spec drifts from `spec.podTemplate`. Default `None` means drift is
+	// detected but the Pod is left alone (suits long-running, stateful
+	// workloads). Set to `Recreate` to opt in to automatic Pod deletion on
+	// drift; the next reconcile will recreate the Pod from the now-current
+	// template. See https://github.com/kubernetes-sigs/agent-sandbox/issues/612.
+	// +kubebuilder:default=None
+	// +optional
+	UpdateStrategy UpdateStrategy `json:"updateStrategy,omitempty"`
 }
 
 // ShutdownPolicy describes the policy for deleting the Sandbox when it expires.

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -376,6 +377,34 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
+// ComputePodTemplateHash returns a stable hash of the given PodTemplate. The
+// hash is computed over the marshalled template (the source-of-truth side, not
+// the materialized Pod spec which Kubernetes may have augmented with admission
+// defaults), so it can be stamped at Pod creation time and compared on every
+// reconcile to detect template drift without false positives from defaulting.
+//
+// The function deep-copies the template and strips SandboxPodTemplateHashLabel
+// from its labels before marshalling. Without this, warm-pool sandboxes (which
+// stamp the hash into the template's pod-template labels at creation, see
+// extensions/controllers/sandboxwarmpool_controller.go) would produce a
+// self-referential hash: the marshalled input would contain a previous hash
+// value, and any change to that label would flip the computed hash, making
+// drift detection report perpetual drift.
+func ComputePodTemplateHash(template sandboxv1alpha1.PodTemplate) (string, error) {
+	canonical := template.DeepCopy()
+	if canonical.ObjectMeta.Labels != nil {
+		delete(canonical.ObjectMeta.Labels, sandboxv1alpha1.SandboxPodTemplateHashLabel)
+		if len(canonical.ObjectMeta.Labels) == 0 {
+			canonical.ObjectMeta.Labels = nil
+		}
+	}
+	specJSON, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal pod template for hashing: %w", err)
+	}
+	return NameHash(string(specJSON)), nil
+}
+
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Service, error) {
 	log := log.FromContext(ctx)
 	service := &corev1.Service{}
@@ -660,8 +689,56 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil, err
 		}
 
-		// TODO - Do we enfore (change) spec if a pod exists ?
-		// r.Patch(ctx, pod, client.Apply, client.ForceOwnership, client.FieldOwner("sandbox-controller"))
+		// Drift check: if the pod was stamped with a SandboxPodTemplateHashLabel
+		// at creation time and the current template hashes differently, the
+		// Sandbox.Spec.PodTemplate has changed since the pod was made. Whether
+		// we react to the drift depends on Sandbox.Spec.UpdateStrategy:
+		//
+		//   - UpdateStrategyNone (default): drift is logged at V(1) but the
+		//     Pod is left alone. Long-running, stateful workloads stay running
+		//     even when the template is updated; the new template takes effect
+		//     on the next natural Pod recreate (delete, eviction, node drain).
+		//   - UpdateStrategyRecreate: the Pod is deleted; the next reconcile
+		//     loop creates a fresh Pod from the now-current template. This is
+		//     destructive — the running container is killed.
+		//
+		// See https://github.com/kubernetes-sigs/agent-sandbox/issues/612 for
+		// the design discussion: opt-in is the consensus default to avoid
+		// surprise disruption of in-flight sandbox operations.
+		//
+		// Pods missing the hash label predate this controller version (legacy
+		// / warm pool adoption from older versions); skip drift in that case
+		// regardless of strategy to avoid churn during a rolling controller
+		// upgrade.
+		//
+		// Only consider drift on pods owned by this sandbox — adoption from
+		// warm pool already replaced the template hash label as part of the
+		// hand-off, so anything still labelled with a stale hash is genuine
+		// drift, not adoption transition state.
+		if ownership == resourceOwnedBySandbox {
+			if stampedHash, hasHash := pod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel]; hasHash {
+				currentHash, hashErr := ComputePodTemplateHash(sandbox.Spec.PodTemplate)
+				if hashErr != nil {
+					return nil, fmt.Errorf("failed to compute pod template hash: %w", hashErr)
+				}
+				if currentHash != stampedHash {
+					switch sandbox.Spec.UpdateStrategy {
+					case sandboxv1alpha1.UpdateStrategyRecreate:
+						log.Info("Recreating Pod because Sandbox.Spec.PodTemplate hash drifted (updateStrategy=Recreate)",
+							"Pod.Name", pod.Name, "stampedHash", stampedHash, "currentHash", currentHash)
+						if err := r.Delete(ctx, pod); err != nil && !k8serrors.IsNotFound(err) {
+							return nil, fmt.Errorf("failed to delete drifted pod: %w", err)
+						}
+						// Treat as no-pod for this reconcile; next loop creates.
+						return nil, nil
+					default:
+						log.V(1).Info("Sandbox.Spec.PodTemplate has drifted from running Pod; updateStrategy=None, leaving Pod untouched",
+							"Pod.Name", pod.Name, "stampedHash", stampedHash, "currentHash", currentHash)
+					}
+				}
+			}
+		}
+
 		return pod, nil
 	}
 
@@ -673,9 +750,26 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		// SandboxPodTemplateHashLabel is controller-owned (stamped below from
+		// the freshly-computed hash) and must not be tracked as a
+		// template-propagated label. Otherwise updatePodMetadata would later
+		// strip it from the Pod when a template no longer carries it,
+		// breaking drift detection on warm-pool-adopted Pods.
+		if k == sandboxv1alpha1.SandboxPodTemplateHashLabel {
+			continue
+		}
 		labels[k] = v
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
+
+	// Stamp the pod-template hash AFTER copying template labels so a stale
+	// SandboxPodTemplateHashLabel in the template (warm pool sandboxes stamp
+	// it there at creation time) cannot overwrite the freshly-computed value.
+	templateHash, err := ComputePodTemplateHash(sandbox.Spec.PodTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compute pod template hash: %w", err)
+	}
+	labels[sandboxv1alpha1.SandboxPodTemplateHashLabel] = templateHash
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -884,8 +884,23 @@ func TestReconcile(t *testing.T) {
 					t.Fatalf("unexpected sandbox status (-want,+got):\n%s", diff)
 				}
 			}
+			// Inject the SandboxPodTemplateHashLabel into want-Pod fixtures so
+			// each test case doesn't have to hardcode it. The hash is derived
+			// from sandboxSpec.PodTemplate, which is what the controller stamps
+			// on creation. Test cases that exercise spec drift will set the
+			// label explicitly to a different value.
+			templateHash, err := ComputePodTemplateHash(tc.sandboxSpec.PodTemplate)
+			require.NoError(t, err)
 			// Validate the other objects from the "cluster" (fake client)
 			for _, obj := range tc.wantObjs {
+				if pod, ok := obj.(*corev1.Pod); ok {
+					if pod.Labels == nil {
+						pod.Labels = map[string]string{}
+					}
+					if _, has := pod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel]; !has {
+						pod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel] = templateHash
+					}
+				}
 				liveObj := obj.DeepCopyObject().(client.Object)
 				err = r.Get(t.Context(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, liveObj)
 				require.NoError(t, err)
@@ -1503,6 +1518,30 @@ func TestReconcilePod(t *testing.T) {
 				Scheme:        Scheme,
 				Tracer:        asmetrics.NewNoOp(),
 				ClusterDomain: "cluster.local",
+			}
+
+			// Inject the SandboxPodTemplateHashLabel into want-Pod fixtures
+			// when the controller will create the pod fresh (no pre-existing
+			// pod in initialObjs). For the existing-pod update path, legacy
+			// pods don't get the label retroactively, so don't inject.
+			if tc.wantPod != nil {
+				preExistingPod := false
+				for _, obj := range tc.initialObjs {
+					if existing, ok := obj.(*corev1.Pod); ok && existing.Name == tc.wantPod.Name && existing.Namespace == tc.wantPod.Namespace {
+						preExistingPod = true
+						break
+					}
+				}
+				if !preExistingPod {
+					templateHash, hashErr := ComputePodTemplateHash(sandbox.Spec.PodTemplate)
+					require.NoError(t, hashErr)
+					if tc.wantPod.Labels == nil {
+						tc.wantPod.Labels = map[string]string{}
+					}
+					if _, has := tc.wantPod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel]; !has {
+						tc.wantPod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel] = templateHash
+					}
+				}
 			}
 
 			pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
@@ -2273,4 +2312,230 @@ func TestSetServiceStatusCustomDomain(t *testing.T) {
 			require.Equal(t, tc.wantFQDN, sandbox.Status.ServiceFQDN)
 		})
 	}
+}
+
+// TestReconcilePodDriftRecreate covers the pod-template-hash drift detection
+// added by reconcilePod: drift is reacted to per Sandbox.Spec.UpdateStrategy.
+// Recreate deletes the Pod (next reconcile recreates from the current
+// template); None logs but leaves the Pod alone (issue #612 default). Pods
+// missing the hash label predate this controller version and are never
+// recreated regardless of strategy, so a rolling upgrade doesn't churn.
+func TestReconcilePodDriftRecreate(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+	)
+	makeSandbox := func(strategy sandboxv1alpha1.UpdateStrategy) *sandboxv1alpha1.Sandbox {
+		return &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs, UID: sandboxUID},
+			Spec: sandboxv1alpha1.SandboxSpec{
+				Replicas: new(int32(1)),
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+				UpdateStrategy: strategy,
+			},
+		}
+	}
+	currentHash, err := ComputePodTemplateHash(makeSandbox("").Spec.PodTemplate)
+	require.NoError(t, err)
+
+	makePod := func(hashLabel string) *corev1.Pod {
+		labels := map[string]string{sandboxLabel: nameHash}
+		if hashLabel != "" {
+			labels[sandboxv1alpha1.SandboxPodTemplateHashLabel] = hashLabel
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            sandboxName,
+				Namespace:       sandboxNs,
+				ResourceVersion: "1",
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		strategy    sandboxv1alpha1.UpdateStrategy
+		stampedHash string // "" = no hash label (legacy)
+		wantDeleted bool
+	}{
+		{
+			name:        "recreates Pod when hash drifts and strategy=Recreate",
+			strategy:    sandboxv1alpha1.UpdateStrategyRecreate,
+			stampedHash: "stale-hash-doesnt-match",
+			wantDeleted: true,
+		},
+		{
+			name:        "keeps drifted Pod when strategy=None (default)",
+			strategy:    sandboxv1alpha1.UpdateStrategyNone,
+			stampedHash: "stale-hash-doesnt-match",
+			wantDeleted: false,
+		},
+		{
+			name:        "keeps drifted Pod when strategy is unset (treated as None)",
+			strategy:    "", // zero value: drift is detected but Pod is not touched
+			stampedHash: "stale-hash-doesnt-match",
+			wantDeleted: false,
+		},
+		{
+			name:        "keeps Pod when hash matches current PodTemplate (strategy=Recreate)",
+			strategy:    sandboxv1alpha1.UpdateStrategyRecreate,
+			stampedHash: currentHash,
+			wantDeleted: false,
+		},
+		{
+			name:        "keeps Pod when hash label is absent regardless of strategy",
+			strategy:    sandboxv1alpha1.UpdateStrategyRecreate,
+			stampedHash: "",
+			wantDeleted: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := makePod(tc.stampedHash)
+			sb := makeSandbox(tc.strategy)
+			r := SandboxReconciler{
+				Client:        newFakeClient(pod, sb),
+				Scheme:        Scheme,
+				Tracer:        asmetrics.NewNoOp(),
+				ClusterDomain: "cluster.local",
+			}
+
+			gotPod, reconcileErr := r.reconcilePod(t.Context(), sb, nameHash)
+			require.NoError(t, reconcileErr)
+
+			livePod := &corev1.Pod{}
+			getErr := r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, livePod)
+			if tc.wantDeleted {
+				require.Nil(t, gotPod, "reconcilePod should return nil after deleting drifted pod")
+				require.True(t, k8serrors.IsNotFound(getErr), "drifted pod should be deleted but live pod still exists")
+			} else {
+				require.NoError(t, getErr, "non-drifted / not-recreated pod should still exist")
+				require.NotNil(t, gotPod, "reconcilePod should return existing pod when no recreate")
+			}
+		})
+	}
+}
+
+// TestComputePodTemplateHashIgnoresStampedLabel pins the fix for the warm-pool
+// self-reference bug Copilot flagged: a SandboxTemplate / Sandbox spec that
+// already carries SandboxPodTemplateHashLabel in its PodTemplate.ObjectMeta.Labels
+// (warm pool sandboxes stamp it there at creation time) must hash to the same
+// value as one that doesn't. Otherwise the stamped-on-Pod hash and the
+// recomputed hash disagree forever and drift detection always fires.
+func TestComputePodTemplateHashIgnoresStampedLabel(t *testing.T) {
+	clean := sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "workspace", Image: "img"}}},
+		ObjectMeta: sandboxv1alpha1.PodMetadata{
+			Labels: map[string]string{"app": "test"},
+		},
+	}
+	stamped := sandboxv1alpha1.PodTemplate{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "workspace", Image: "img"}}},
+		ObjectMeta: sandboxv1alpha1.PodMetadata{
+			Labels: map[string]string{
+				"app": "test",
+				sandboxv1alpha1.SandboxPodTemplateHashLabel: "some-prior-hash-value",
+			},
+		},
+	}
+
+	cleanHash, err := ComputePodTemplateHash(clean)
+	require.NoError(t, err)
+	stampedHash, err := ComputePodTemplateHash(stamped)
+	require.NoError(t, err)
+	require.Equal(t, cleanHash, stampedHash, "the stamped hash label must not influence the computed hash")
+
+	// The original input must NOT be mutated by the hash function.
+	require.Equal(t, "some-prior-hash-value", stamped.ObjectMeta.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel])
+}
+
+// TestReconcilePodCreateStampsControllerHashOverTemplateLabel pins the fix for
+// the second bug Copilot flagged: when sandbox.Spec.PodTemplate.ObjectMeta.Labels
+// contains a stale SandboxPodTemplateHashLabel value (warm pool template), the
+// controller must stamp the freshly-computed hash on the new Pod, not the
+// stale value coming from the template's own labels.
+func TestReconcilePodCreateStampsControllerHashOverTemplateLabel(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+	)
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs, UID: sandboxUID},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: new(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				ObjectMeta: sandboxv1alpha1.PodMetadata{
+					Labels: map[string]string{
+						sandboxv1alpha1.SandboxPodTemplateHashLabel: "stale-template-hash",
+					},
+				},
+			},
+		},
+	}
+	wantHash, err := ComputePodTemplateHash(sandbox.Spec.PodTemplate)
+	require.NoError(t, err)
+	require.NotEqual(t, "stale-template-hash", wantHash, "test setup precondition: hash function strips the stamped label, so wantHash must differ")
+
+	r := SandboxReconciler{
+		Client:        newFakeClient(sandbox),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+	pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+	require.Equal(t, wantHash, pod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel],
+		"Pod must be stamped with the freshly-computed hash, not the stale value from template labels")
+	// SandboxPodTemplateHashLabel must NOT be tracked as a template-propagated label.
+	require.NotContains(t, pod.Annotations[sandboxv1alpha1.SandboxPropagatedLabelsAnnotation],
+		sandboxv1alpha1.SandboxPodTemplateHashLabel,
+		"the controller-owned hash label must not appear in propagated-labels")
+}
+
+// TestReconcilePodStampsTemplateHashOnCreate verifies that newly-created Pods
+// get the SandboxPodTemplateHashLabel set to the current PodTemplate hash, so
+// future reconciles can detect drift.
+func TestReconcilePodStampsTemplateHashOnCreate(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+	)
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs, UID: sandboxUID},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: new(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+		},
+	}
+	wantHash, err := ComputePodTemplateHash(sandbox.Spec.PodTemplate)
+	require.NoError(t, err)
+
+	r := SandboxReconciler{
+		Client:        newFakeClient(sandbox),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+	require.Equal(t, wantHash, pod.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel])
 }

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -16,7 +16,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -286,12 +285,10 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 }
 
 // computePodTemplateHash computes a hash of the sandbox template's Spec.PodTemplate.
+// Thin wrapper over the shared sandboxcontrollers.ComputePodTemplateHash so the
+// warm pool controller can pass a *SandboxTemplate directly without converting.
 func computePodTemplateHash(template *extensionsv1alpha1.SandboxTemplate) (string, error) {
-	specJSON, err := json.Marshal(template.Spec.PodTemplate)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal pod template for hashing: %w", err)
-	}
-	return sandboxcontrollers.NameHash(string(specJSON)), nil
+	return sandboxcontrollers.ComputePodTemplateHash(template.Spec.PodTemplate)
 }
 
 // fetchTemplateAndHash fetches the sandbox template and computes its hash.

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3845,6 +3845,12 @@ spec:
               shutdownTime:
                 format: date-time
                 type: string
+              updateStrategy:
+                default: None
+                enum:
+                - None
+                - Recreate
+                type: string
               volumeClaimTemplates:
                 items:
                   properties:


### PR DESCRIPTION
## Summary

Detects drift between `Sandbox.Spec.PodTemplate` and the running Pod via a content hash stamped on the Pod at creation, and reacts according to a new opt-in `Spec.UpdateStrategy` field.

## Why opt-in (issue #612 / #593 history)

#593 (also implementing drift recreate) hit pushback from @aditya-shantanu and @barney-s: a sandbox can be in the middle of an operation, and silently auto-deleting its Pod is disruptive. The team had previously decided against auto-recreation. That conversation moved to #612, where today's consensus settled on:

> `spec.updateStrategy: None | Recreate` — `None` is the default, `Recreate` opts in.

(@kincoy proposed the shape; @janetkuo asked to drop the `InPlace` value because Sandbox API shouldn't compete with the Pod `/resize` subresource / VPA; @kincoy agreed.)

This PR ships exactly that.

- **`UpdateStrategy: None` (default):** drift is detected and logged at V(1); the running Pod is left untouched. The new template takes effect on the next natural Pod recreate (manual delete, eviction, drain). Suits long-running, stateful sandboxes.
- **`UpdateStrategy: Recreate`:** the drifted Pod is deleted; the next reconcile creates a fresh Pod from the now-current template. Destructive — the running container is killed.

## Hash design

- New shared `sandboxcontrollers.ComputePodTemplateHash(PodTemplate) (string, error)` hashes the marshalled template. Hashing the **input** side (template) instead of the materialized Pod spec sidesteps Kubernetes admission defaulting (DNS policy, ServiceAccount mounts, terminationGracePeriod, etc.) cleanly — no `ApplySandboxSecureDefaults`-style normalization needed.
- The hash function strips `SandboxPodTemplateHashLabel` from the marshalled input. Warm pool sandboxes stamp this label into the template's pod-template labels at creation time (`extensions/controllers/sandboxwarmpool_controller.go`); without stripping, the hash would be self-referential and drift would always fire on adopted Pods. Pinned by `TestComputePodTemplateHashIgnoresStampedLabel`.
- The warm-pool controller's existing `computePodTemplateHash` now delegates to the shared helper.

## Pod creation

- `SandboxPodTemplateHashLabel` is stamped on the new Pod **after** the loop that copies template labels, so a stale label value already in the template cannot overwrite the freshly-computed value.
- The hash label is treated as controller-owned and **excluded from `propagated-labels` tracking**, so `updatePodMetadata` never strips it on a subsequent reconcile when a future template doesn't carry it.
- Pinned by `TestReconcilePodCreateStampsControllerHashOverTemplateLabel`.

## Drift check

- Guards on `ownership == resourceOwnedBySandbox`. Warm-pool adoption hand-off (which clears and rewrites the hash label as part of the Patch) is not mistaken for drift.
- Pods missing the hash label predate this controller version and are treated as in-sync regardless of strategy. A rolling controller upgrade doesn't churn existing Pods.

## Tests

- `TestReconcilePodDriftRecreate` — strategy gating: drift + `Recreate` deletes; drift + `None` / unset keeps; matching hash keeps regardless; missing label keeps regardless.
- `TestComputePodTemplateHashIgnoresStampedLabel` — hash is invariant to whether `SandboxPodTemplateHashLabel` is in the input; input not mutated.
- `TestReconcilePodCreateStampsControllerHashOverTemplateLabel` — controller-computed hash always wins over a stale template-label value; hash label is not in `propagated-labels`.
- `TestReconcilePodStampsTemplateHashOnCreate` — basic stamp-on-create.
- `TestReconcile` / `TestReconcilePod` fixtures inject the hash label dynamically so test cases don't hardcode values.

`go test ./controllers/... ./extensions/... -count=1` and `make lint-go` / `make lint-api` clean.

## Coordination

Duplicated work with #593 (@dongjiang1989). Posting a comment there asking whether they want to drive theirs to the consensus shape (in which case I'll close this) or whether to consolidate here. Either way, only one of us should land.

/cc @janetkuo @aditya-shantanu @barney-s @kincoy @dongjiang1989

Refs: #459, #491, #593, #612.