### PR TITLE
Fix:  Enable goleak and fix memory leaks in extensions/controllers

### DIFF
--- a/extensions/controllers/queue/simple_sandbox_queue.go
+++ b/extensions/controllers/queue/simple_sandbox_queue.go
@@ -45,16 +45,8 @@ func NewSimpleSandboxQueue() *SimpleSandboxQueue {
 
 // Add pushes an item to the specific template's queue.
 func (s *SimpleSandboxQueue) Add(templateHash string, item SandboxKey) {
-	for {
-		q, _ := s.queues.LoadOrStore(templateHash, newSynchronizedQueue())
-		q.(*synchronizedQueue).Push(item)
-
-		// If the queue entry was concurrently removed while pushing,
-		// retry so the item lands in the current live queue.
-		if current, ok := s.queues.Load(templateHash); ok && current == q {
-			return
-		}
-	}
+	q, _ := s.queues.LoadOrStore(templateHash, newSynchronizedQueue())
+	q.(*synchronizedQueue).Push(item)
 }
 
 // Get pops an item from the specific template's queue.
@@ -71,14 +63,6 @@ func (s *SimpleSandboxQueue) RemoveItem(templateHash string, item SandboxKey) {
 	if q, ok := s.queues.Load(templateHash); ok {
 		sq := q.(*synchronizedQueue)
 		sq.Remove(item)
-
-		sq.mu.Lock()
-		empty := len(sq.items) == 0
-		sq.mu.Unlock()
-
-		if empty {
-			s.queues.CompareAndDelete(templateHash, sq)
-		}
 	}
 }
 

--- a/extensions/controllers/queue/simple_sandbox_queue.go
+++ b/extensions/controllers/queue/simple_sandbox_queue.go
@@ -45,8 +45,16 @@ func NewSimpleSandboxQueue() *SimpleSandboxQueue {
 
 // Add pushes an item to the specific template's queue.
 func (s *SimpleSandboxQueue) Add(templateHash string, item SandboxKey) {
-	q, _ := s.queues.LoadOrStore(templateHash, newSynchronizedQueue())
-	q.(*synchronizedQueue).Push(item)
+	for {
+		q, _ := s.queues.LoadOrStore(templateHash, newSynchronizedQueue())
+		q.(*synchronizedQueue).Push(item)
+
+		// If the queue entry was concurrently removed while pushing,
+		// retry so the item lands in the current live queue.
+		if current, ok := s.queues.Load(templateHash); ok && current == q {
+			return
+		}
+	}
 }
 
 // Get pops an item from the specific template's queue.
@@ -61,7 +69,16 @@ func (s *SimpleSandboxQueue) Get(templateHash string) (SandboxKey, bool) {
 // RemoveItem deletes a specific sandbox from a template's queue.
 func (s *SimpleSandboxQueue) RemoveItem(templateHash string, item SandboxKey) {
 	if q, ok := s.queues.Load(templateHash); ok {
-		q.(*synchronizedQueue).Remove(item)
+		sq := q.(*synchronizedQueue)
+		sq.Remove(item)
+
+		sq.mu.Lock()
+		empty := len(sq.items) == 0
+		sq.mu.Unlock()
+
+		if empty {
+			s.queues.CompareAndDelete(templateHash, sq)
+		}
 	}
 }
 
@@ -78,8 +95,12 @@ func (q *synchronizedQueue) Remove(key SandboxKey) {
 
 	for i, k := range q.items {
 		if k == key {
-			// Delete from slice
-			q.items = append(q.items[:i], q.items[i+1:]...)
+			// Shift left and clear the tail slot so removed keys don't linger.
+			// Same pattern as Pop()
+			last := len(q.items) - 1
+			copy(q.items[i:], q.items[i+1:])
+			q.items[last] = SandboxKey{}
+			q.items = q.items[:last]
 			break
 		}
 	}

--- a/extensions/controllers/queue/simple_sandbox_queue_test.go
+++ b/extensions/controllers/queue/simple_sandbox_queue_test.go
@@ -64,7 +64,7 @@ func TestSimpleSandboxQueue_RemoveItem_GhostPodFix(t *testing.T) {
 	// Ensure RemoveItem does not retain stale references in backing array tail.
 	rawQueue, ok := q.queues.Load(hash)
 	if !ok {
-		t.Errorf("Expected queue for %q to exist", hash)
+		t.Fatalf("Expected queue for %q to exist", hash)
 	}
 	sq := rawQueue.(*synchronizedQueue)
 	if cap(sq.items) > len(sq.items) {
@@ -89,8 +89,8 @@ func TestSimpleSandboxQueue_RemoveItem_GhostPodFix(t *testing.T) {
 	}
 
 	// Queue should now be empty
-	_, empty := q.Get(hash)
-	if empty {
+	_, hasItem := q.Get(hash)
+	if hasItem {
 		t.Errorf("Expected queue to be empty after Ghost Pod removal")
 	}
 }
@@ -129,20 +129,5 @@ func TestSimpleSandboxQueue_RemoveQueue_MemoryLeakFix(t *testing.T) {
 	_, ok := q.Get(hash)
 	if ok {
 		t.Errorf("Expected queue to be completely removed, but it still existed")
-	}
-
-	// Also verify item-by-item removal cleans up empty queues in sync.Map.
-	hash2 := "template-hash-item-by-item-delete"
-	key2 := SandboxKey{Namespace: "default", Name: "sb-2"}
-
-	q.Add(hash2, key1)
-	q.Add(hash2, key2)
-	q.RemoveItem(hash2, key1)
-	if _, exists := q.queues.Load(hash2); !exists {
-		t.Errorf("Expected queue for %q to still exist while items remain", hash2)
-	}
-	q.RemoveItem(hash2, key2)
-	if _, exists := q.queues.Load(hash2); exists {
-		t.Errorf("Expected empty queue for %q to be removed from sync.Map", hash2)
 	}
 }

--- a/extensions/controllers/queue/simple_sandbox_queue_test.go
+++ b/extensions/controllers/queue/simple_sandbox_queue_test.go
@@ -61,6 +61,21 @@ func TestSimpleSandboxQueue_RemoveItem_GhostPodFix(t *testing.T) {
 	// Simulate the Kubelet deleting the middle pod (Ghost Pod scenario)
 	q.RemoveItem(hash, key2)
 
+	// Ensure RemoveItem does not retain stale references in backing array tail.
+	rawQueue, ok := q.queues.Load(hash)
+	if !ok {
+		t.Errorf("Expected queue for %q to exist", hash)
+	}
+	sq := rawQueue.(*synchronizedQueue)
+	if cap(sq.items) > len(sq.items) {
+		backing := sq.items[:cap(sq.items)]
+		for i := len(sq.items); i < len(backing); i++ {
+			if backing[i] != (SandboxKey{}) {
+				t.Errorf("Expected backing array slot %d to be cleared, found %+v", i, backing[i])
+			}
+		}
+	}
+
 	// First pop should still be key1
 	got1, _ := q.Get(hash)
 	if got1 != key1 {
@@ -74,8 +89,8 @@ func TestSimpleSandboxQueue_RemoveItem_GhostPodFix(t *testing.T) {
 	}
 
 	// Queue should now be empty
-	_, ok := q.Get(hash)
-	if ok {
+	_, empty := q.Get(hash)
+	if empty {
 		t.Errorf("Expected queue to be empty after Ghost Pod removal")
 	}
 }
@@ -114,5 +129,20 @@ func TestSimpleSandboxQueue_RemoveQueue_MemoryLeakFix(t *testing.T) {
 	_, ok := q.Get(hash)
 	if ok {
 		t.Errorf("Expected queue to be completely removed, but it still existed")
+	}
+
+	// Also verify item-by-item removal cleans up empty queues in sync.Map.
+	hash2 := "template-hash-item-by-item-delete"
+	key2 := SandboxKey{Namespace: "default", Name: "sb-2"}
+
+	q.Add(hash2, key1)
+	q.Add(hash2, key2)
+	q.RemoveItem(hash2, key1)
+	if _, exists := q.queues.Load(hash2); !exists {
+		t.Errorf("Expected queue for %q to still exist while items remain", hash2)
+	}
+	q.RemoveItem(hash2, key2)
+	if _, exists := q.queues.Load(hash2); exists {
+		t.Errorf("Expected empty queue for %q to be removed from sync.Map", hash2)
 	}
 }

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1287,6 +1287,11 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	// Do not record creation metric if we have already seen the ready state.
 	oldReady := meta.FindStatusCondition(oldStatus.Conditions, string(v1alpha1.SandboxConditionReady))
 	if oldReady != nil && oldReady.Status == metav1.ConditionTrue {
+		// Already Ready before this reconcile; drain any entry re-added by a post-Ready UpdateFunc.
+		key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+		if entry, ok := r.observedTimes.Load(key); ok && entry.uid == claim.UID {
+			r.observedTimes.Delete(key)
+		}
 		return
 	}
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2903,36 +2903,224 @@ func TestGetOrRecordObservedTime(t *testing.T) {
 }
 
 func TestSandboxClaimReconcileCleanup(t *testing.T) {
-	scheme := newScheme(t)
-
-	claim := &extensionsv1alpha1.SandboxClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "uid-1"},
+	newReconcilerFor := func(t *testing.T, objs ...client.Object) *SandboxClaimReconciler {
+		t.Helper()
+		scheme := newScheme(t)
+		fc := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(objs...).
+			WithStatusSubresource(&extensionsv1alpha1.SandboxClaim{}).
+			Build()
+		return &SandboxClaimReconciler{
+			Client:           fc,
+			Scheme:           scheme,
+			WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+			Recorder:         events.NewFakeRecorder(10),
+			Tracer:           asmetrics.NewNoOp(),
+		}
 	}
 
-	// Create a fake client without the claim, so it returns NotFound
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
-
-	reconciler := &SandboxClaimReconciler{
-		Client: client,
-		Scheme: scheme,
+	makeReadyClaim := func(name string) *extensionsv1alpha1.SandboxClaim {
+		return &extensionsv1alpha1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(name),
+				Annotations: map[string]string{
+					asmetrics.ObservabilityAnnotation: time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano),
+				},
+			},
+			Spec: extensionsv1alpha1.SandboxClaimSpec{
+				TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+			},
+			Status: extensionsv1alpha1.SandboxClaimStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(sandboxv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+					Reason: "Ready",
+				}},
+			},
+		}
 	}
 
-	key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-	// Pre-populate map
-	reconciler.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: claim.UID})
+	ctrlBool := true
+	makeOwnedReadySandbox := func(cl *extensionsv1alpha1.SandboxClaim) *sandboxv1alpha1.Sandbox {
+		return &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cl.Name,
+				Namespace: cl.Namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+					Kind:       "SandboxClaim",
+					Name:       cl.Name,
+					UID:        cl.UID,
+					Controller: &ctrlBool,
+				}},
+			},
+			Status: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(sandboxv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+					Reason: "Ready",
+				}},
+			},
+		}
+	}
 
-	req := reconcile.Request{
-		NamespacedName: key,
-	}
-	_, err := reconciler.Reconcile(context.Background(), req)
-	if err != nil {
-		t.Fatalf("Reconcile failed: %v", err)
+	reconcileAll := func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim) {
+		t.Helper()
+		for _, cl := range claims {
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: cl.Name, Namespace: cl.Namespace}}
+			if _, err := r.Reconcile(context.Background(), req); err != nil {
+				t.Fatalf("Reconcile(%s): %v", cl.Name, err)
+			}
+		}
 	}
 
-	_, ok := reconciler.observedTimes.Load(key)
-	if ok {
-		t.Error("Entry should be deleted by Reconcile when object is not found")
+	testCases := []struct {
+		name        string
+		build       func(t *testing.T) (*SandboxClaimReconciler, []*extensionsv1alpha1.SandboxClaim)
+		action      func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim)
+		wantEntries int
+	}{
+		{
+			// Reconcile on a missing claim removes the observedTimes entry via the NotFound fallback.
+			name: "NotFound reconcile removes stale entry",
+			build: func(t *testing.T) (*SandboxClaimReconciler, []*extensionsv1alpha1.SandboxClaim) {
+				cl := makeReadyClaim("stale-claim")
+				r := newReconcilerFor(t)
+				key := types.NamespacedName{Name: cl.Name, Namespace: cl.Namespace}
+				r.observedTimes.Store(key, observedTimeEntry{timestamp: time.Now(), uid: cl.UID})
+				return r, []*extensionsv1alpha1.SandboxClaim{cl}
+			},
+			action: func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim) {
+				reconcileAll(t, r, claims)
+			},
+			wantEntries: 0,
+		},
+		{
+			// CreateFunc adds an entry; recordControllerStartupLatency removes it on the first
+			// Not-Ready → Ready transition detected by recordCreationLatencyMetric.
+			name: "new claim transitioning to Ready cleans its entry",
+			build: func(t *testing.T) (*SandboxClaimReconciler, []*extensionsv1alpha1.SandboxClaim) {
+				cl := &extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "new-claim", Namespace: "default", UID: "new-claim"},
+					Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"}},
+				}
+				r := newReconcilerFor(t, cl, makeOwnedReadySandbox(cl))
+				return r, []*extensionsv1alpha1.SandboxClaim{cl}
+			},
+			action: func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim) {
+				pred := r.getTimingPredicate()
+				for _, cl := range claims {
+					pred.Create(event.CreateEvent{Object: cl})
+				}
+				reconcileAll(t, r, claims)
+			},
+			wantEntries: 0,
+		},
+		{
+			// Simulates a controller restart where the informer replays UpdateFunc for existing,
+			// already-Ready claims. The reconciler must correctly clean up the observed time entries.
+			name: "already-Ready claims are cleaned up after restart simulation",
+			build: func(t *testing.T) (*SandboxClaimReconciler, []*extensionsv1alpha1.SandboxClaim) {
+				const n = 10
+				objs := make([]client.Object, 0, n*2)
+				claims := make([]*extensionsv1alpha1.SandboxClaim, n)
+				for i := range n {
+					cl := makeReadyClaim(fmt.Sprintf("ready-claim-%d", i))
+					claims[i] = cl
+					objs = append(objs, cl, makeOwnedReadySandbox(cl))
+				}
+				return newReconcilerFor(t, objs...), claims
+			},
+			action: func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim) {
+				pred := r.getTimingPredicate()
+				for _, cl := range claims {
+					pred.Update(event.UpdateEvent{ObjectOld: cl, ObjectNew: cl})
+				}
+				reconcileAll(t, r, claims)
+			},
+			wantEntries: 0,
+		},
+		{
+
+			// Simulates an update for already ready claim.
+			// The reconciler must correctly clean up the observed time entries.
+			name: "post-Ready UpdateFunc re-creates entry that is then cleaned on next reconcile",
+			build: func(t *testing.T) (*SandboxClaimReconciler, []*extensionsv1alpha1.SandboxClaim) {
+				cl := &extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "post-ready-claim", Namespace: "default", UID: "post-ready"},
+					Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"}},
+				}
+				r := newReconcilerFor(t, cl, makeOwnedReadySandbox(cl))
+				return r, []*extensionsv1alpha1.SandboxClaim{cl}
+			},
+			action: func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim) {
+				pred := r.getTimingPredicate()
+				// Step 1: CreateFunc → entry added
+				for _, cl := range claims {
+					pred.Create(event.CreateEvent{Object: cl})
+				}
+				// Step 2: First reconcile → Not-Ready → Ready transition → entry cleaned.
+				reconcileAll(t, r, claims)
+				// Step 3: Post-Ready UpdateFunc
+				for _, cl := range claims {
+					pred.Update(event.UpdateEvent{ObjectOld: cl, ObjectNew: cl})
+				}
+				// Step 4: Reconcile with old=Ready, new=Ready
+				reconcileAll(t, r, claims)
+			},
+			wantEntries: 0,
+		},
+		{
+			// DeleteFunc is the sole cleanup path for entries that accumulated after a restart.
+			// Firing it for each claim fully drains the map.
+			name: "DeleteFunc drains entries accumulated after restart simulation",
+			build: func(t *testing.T) (*SandboxClaimReconciler, []*extensionsv1alpha1.SandboxClaim) {
+				const n = 10
+				objs := make([]client.Object, 0, n*2)
+				claims := make([]*extensionsv1alpha1.SandboxClaim, n)
+				for i := range n {
+					cl := makeReadyClaim(fmt.Sprintf("rescue-claim-%d", i))
+					claims[i] = cl
+					objs = append(objs, cl, makeOwnedReadySandbox(cl))
+				}
+				return newReconcilerFor(t, objs...), claims
+			},
+			action: func(t *testing.T, r *SandboxClaimReconciler, claims []*extensionsv1alpha1.SandboxClaim) {
+				pred := r.getTimingPredicate()
+				for _, cl := range claims {
+					pred.Update(event.UpdateEvent{ObjectOld: cl, ObjectNew: cl})
+				}
+				reconcileAll(t, r, claims)
+				for _, cl := range claims {
+					pred.Delete(event.DeleteEvent{Object: cl})
+				}
+			},
+			wantEntries: 0,
+		},
 	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, claims := tc.build(t)
+
+			tc.action(t, r, claims)
+
+			gotEntries := countObservedTimesEntries(r)
+			if gotEntries != tc.wantEntries {
+				t.Errorf("observedTimes has %d entries, want %d", gotEntries, tc.wantEntries)
+			}
+		})
+	}
+}
+
+// countObservedTimesEntries returns the number of live entries in the observedTimes map.
+func countObservedTimesEntries(r *SandboxClaimReconciler) int {
+	count := 0
+	r.observedTimes.inner.Range(func(_, _ any) bool { count++; return true })
+	return count
 }
 
 // seedQueueForTest acts as a mock Informer, pre-loading the test queue with adoptable sandboxes.

--- a/extensions/controllers/testmain_test.go
+++ b/extensions/controllers/testmain_test.go
@@ -1,0 +1,25 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	go.uber.org/goleak v1.3.0
 	k8s.io/api v0.35.4
 	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4


### PR DESCRIPTION
## Description

This PR is the first in a series to address #636 by introducing memory-leaks detection & solve, starting with the `extensions/controllers` package. 


### Code Changes

**1. Goroutine Leak Detection (Testing Framework)**
* Added `uber.org/goleak` to `go.mod`.
* Integrated `goleak.VerifyTestMain(m)` into `TestMain` for the `extensions/controllers` package to strictly catch any orphaned goroutines during test runs (currently None).

**2. Controller Memory Retention Fixes (`SandboxClaimReconciler`)**
* Fixed an unbounded map growth issue in `recordCreationLatencyMetric` where `observedTimes` tracking entries were retained indefinitely for already-Ready claims when an `Update` event triggered. 
* Expanded the `TestSandboxClaimReconcileCleanup` test suite to cover all `observedTimes` cleanup flows (stale entry creation, post-ready updates, and deletion drains).


**3. Queue Memory Retention Fixes (`SimpleSandboxQueue`)**
* **Tail Slice Retention Fix:** `Remove` now properly zeroes out the slice tail slot, ensuring the GC can correctly free stale `SandboxKey` string references.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Ran `go test ./extensions/controllers/... -count=1` locally to ensure the package passes with `goleak` enabled (validating no goroutine leaks).
- [x] Verified that the newly introduced leak-detection tests in `simple_sandbox_queue_test.go` correctly identify the memory retention bugs.
- [x] Verified `SandboxClaimReconcileCleanup` tests cover all states for `observedTimes` map cleanup.
