### PR TITLE
Update SDK client to accept the warmpool policy

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -65,6 +65,7 @@ class AsyncK8sHelper:
         annotations: dict | None = None,
         labels: dict | None = None,
         lifecycle: dict | None = None,
+        warmpool: str | None = None,
     ):
         """Creates a SandboxClaim custom resource."""
         await self._ensure_initialized()
@@ -83,6 +84,8 @@ class AsyncK8sHelper:
         }
         if lifecycle:
             spec["lifecycle"] = lifecycle
+        if warmpool:
+            spec["warmpool"] = warmpool
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -110,6 +110,7 @@ class AsyncSandboxClient(Generic[T]):
         namespace: str = "default",
         sandbox_ready_timeout: int = 180,
         labels: dict[str, str] | None = None,
+        warmpool: str | None = None,
         *,
         shutdown_after_seconds: int | None = None,
     ) -> T:
@@ -143,7 +144,7 @@ class AsyncSandboxClient(Generic[T]):
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
 
         try:
-            await self._create_claim(claim_name, template, namespace, labels=labels, lifecycle=lifecycle)
+            await self._create_claim(claim_name, template, namespace, labels=labels, lifecycle=lifecycle, warmpool=warmpool)
             start_time = time.monotonic()
             sandbox_id = await self.k8s_helper.resolve_sandbox_name(
                 claim_name, namespace, sandbox_ready_timeout
@@ -318,6 +319,7 @@ class AsyncSandboxClient(Generic[T]):
         namespace: str,
         labels: dict[str, str] | None = None,
         lifecycle: dict | None = None,
+        warmpool: str | None = None,
     ):
         span = trace.get_current_span()
         if span.is_recording():
@@ -333,7 +335,7 @@ class AsyncSandboxClient(Generic[T]):
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
         await self.k8s_helper.create_sandbox_claim(
-            claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle
+            claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle, warmpool=warmpool
         )
 
     @async_trace_span("wait_for_sandbox_ready")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -121,6 +121,7 @@ class AsyncSandboxClient(Generic[T]):
             namespace: Kubernetes namespace for the claim.
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
             labels: Optional Kubernetes labels to attach to the claim.
+            warmpool: Optional warm pool policy for sandbox adoption (e.g. "default", "none", or custom).
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -40,7 +40,7 @@ class K8sHelper:
         self.custom_objects_api = client.CustomObjectsApi()
         self.core_v1_api = client.CoreV1Api()
 
-    def create_sandbox_claim(self, name: str, template: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None):
+    def create_sandbox_claim(self, name: str, template: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None, warmpool: str | None = None):
         """Creates a SandboxClaim custom resource."""
         metadata = {
             "name": name,
@@ -56,6 +56,8 @@ class K8sHelper:
         }
         if lifecycle:
             spec["lifecycle"] = lifecycle
+        if warmpool:
+            spec["warmpool"] = warmpool
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -100,6 +100,7 @@ class SandboxClient(Generic[T]):
             namespace: Kubernetes namespace for the claim.
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
             labels: Optional Kubernetes labels to attach to the claim.
+            warmpool: Optional warm pool policy for sandbox adoption (e.g. "default", "none", or custom).
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -91,7 +91,7 @@ class SandboxClient(Generic[T]):
         if cleanup:
             atexit.register(self.delete_all)
 
-    def create_sandbox(self, template: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None, *, shutdown_after_seconds: int | None = None) -> T:
+    def create_sandbox(self, template: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None, warmpool: str | None = None, *, shutdown_after_seconds: int | None = None) -> T:
         """Provisions new Sandbox claim and returns a Sandbox handle which tracks 
            the underlying infrastructure.
 
@@ -123,7 +123,7 @@ class SandboxClient(Generic[T]):
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
         
         try:
-            self._create_claim(claim_name, template, namespace, labels=labels, lifecycle=lifecycle)
+            self._create_claim(claim_name, template, namespace, labels=labels, lifecycle=lifecycle, warmpool=warmpool)
             # Resolve the sandbox id from the sandbox claim object.
             # In case of warmpool, sandbox id is not the same as claim name.
             start_time = time.monotonic()
@@ -315,7 +315,7 @@ class SandboxClient(Generic[T]):
                 SandboxClient._validate_label_name(value, f"value '{value}' for key '{key}'")
 
     @trace_span("create_claim")
-    def _create_claim(self, claim_name: str, template_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None):
+    def _create_claim(self, claim_name: str, template_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None, warmpool: str | None = None):
         """Creates the SandboxClaim custom resource in the Kubernetes cluster."""
         span = trace.get_current_span()
         if span.is_recording():
@@ -330,7 +330,7 @@ class SandboxClient(Generic[T]):
             if trace_context_str:
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
-        self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle)
+        self.k8s_helper.create_sandbox_claim(claim_name, template_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle, warmpool=warmpool)
 
     @trace_span("wait_for_sandbox_ready")
     def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -73,6 +73,31 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["metadata"]["labels"], {"agent": "test"})
         self.assertEqual(body["metadata"]["annotations"], {"key": "val"})
 
+    async def test_create_claim_with_warmpool_none(self):
+        await self.helper.create_sandbox_claim(
+            "test-claim", "test-template", "test-namespace", warmpool="none"
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertEqual(body["spec"]["warmpool"], "none")
+
+    async def test_create_claim_with_specific_warmpool(self):
+        await self.helper.create_sandbox_claim(
+            "test-claim", "test-template", "test-namespace", warmpool="custom-pool"
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertEqual(body["spec"]["warmpool"], "custom-pool")
+
+    async def test_create_claim_warmpool_omitted(self):
+        await self.helper.create_sandbox_claim("test-claim", "test-template", "test-namespace")
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertNotIn("warmpool", body["spec"])
+
 
 class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -65,7 +65,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             sandbox = await self.client.create_sandbox("test-template", "test-namespace")
 
             mock_create.assert_called_once_with(
-                ANY, "test-template", "test-namespace", labels=None, lifecycle=None
+                ANY, "test-template", "test-namespace", labels=None, lifecycle=None, warmpool=None
             )
             self.assertEqual(sandbox, mock_sandbox_instance)
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -92,6 +92,40 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertNotIn("lifecycle", body["spec"])
 
+    def test_create_claim_with_warmpool_none(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim", "test-template", "test-namespace", warmpool="none"
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["spec"]["warmpool"], "none")
+
+    def test_create_claim_with_specific_warmpool(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim", "test-template", "test-namespace", warmpool="custom-pool"
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["spec"]["warmpool"], "custom-pool")
+
+    def test_create_claim_warmpool_omitted(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim("test-claim", "test-template", "test-namespace")
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertNotIn("warmpool", body["spec"])
+
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -64,7 +64,7 @@ class TestSandboxClient(unittest.TestCase):
             
             sandbox = self.client.create_sandbox("test-template", "test-namespace")
             
-            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace", labels=None, lifecycle=None)
+            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace", labels=None, lifecycle=None, warmpool=None)
             self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
             mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
             self.assertEqual(sandbox, mock_sandbox_instance)
@@ -206,6 +206,7 @@ class TestSandboxClient(unittest.TestCase):
                 "sandbox-claim-1234abcd", "test-template", "test-namespace",
                 labels={"agent": "code-agent", "team": "platform"},
                 lifecycle=None,
+                warmpool=None,
             )
 
     def test_create_claim_with_labels(self):
@@ -220,6 +221,7 @@ class TestSandboxClient(unittest.TestCase):
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels={"agent": "code-agent"},
             lifecycle=None,
+            warmpool=None,
         )
 
     def test_create_claim(self):
@@ -233,6 +235,7 @@ class TestSandboxClient(unittest.TestCase):
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels=None,
             lifecycle=None,
+            warmpool=None,
         )
 
     def test_validate_labels_rejects_invalid_value(self):
@@ -344,6 +347,7 @@ class TestSandboxClient(unittest.TestCase):
             annotations={},
             labels=None,
             lifecycle=lifecycle,
+            warmpool=None,
         )
 
     def test_create_claim_without_lifecycle(self):
@@ -357,6 +361,7 @@ class TestSandboxClient(unittest.TestCase):
             annotations={},
             labels=None,
             lifecycle=None,
+            warmpool=None,
         )
 
     def test_shutdown_after_seconds_validation_zero(self):

--- a/test/e2e/clients/python/test_e2e_python_sdk.py
+++ b/test/e2e/clients/python/test_e2e_python_sdk.py
@@ -139,6 +139,7 @@ def test_python_sdk_router_mode(tc, temp_namespace, sandbox_template, deploy_rou
         sandbox = client.create_sandbox(
             template=sandbox_template,
             namespace=temp_namespace,
+            warmpool="none",
         )
         print("\n--- Running SDK tests without warmpool ---")
         run_sdk_tests(sandbox)
@@ -183,6 +184,7 @@ def test_python_sdk_gateway_mode(
         sandbox = client.create_sandbox(
             template=sandbox_template,
             namespace=temp_namespace,
+            warmpool="none",
         )
         print("\n--- Running SDK tests without warmpool ---")
         run_sdk_tests(sandbox)


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/agent-sandbox/issues/668 

The tests - `test_python_sdk_router_mode` and `test_python_sdk_gateway_mode` were failing intermittently. These tests along with `test_python_sdk_router_mode_warmpool` and `test_python_sdk_gateway_mode` in the `test_e2e_python_sdk.py` are running in parallel in their own namespace. 

However, the sandboxclaims (cold starts) created in `test_python_sdk_router_mode` and `test_python_sdk_gateway_mode` were trying to adopt a sandbox from the warmpool of another namespace. 

Sandboxclaim from local (error message) - 
```
$ kubectl describe sandboxclaim sandbox-claim-2
923d8bc -n  py-sdk-e2e-e7e58312
Name:         sandbox-claim-2923d8bc
Namespace:    py-sdk-e2e-e7e58312
Labels:       <none>
Annotations:  agents.x-k8s.io/controller-first-observed-at: 2026-04-27T21:55:01.217568915Z
API Version:  extensions.agents.x-k8s.io/v1alpha1
Kind:         SandboxClaim
Metadata:
  Creation Timestamp:  2026-04-27T21:55:01Z
  Generation:          1
  Resource Version:    3023687
  UID:                 ec5af28e-3e84-4011-9522-3811c654a1c7
Spec:
  Sandbox Template Ref:
    Name:    python-sdk-test-template
  Warmpool:  default
Status:
  Conditions:
    Last Transition Time:  2026-04-27T21:55:01Z
    Message:               Error seen: failed to set controller reference on adopted sandbox: cross-namespace owner references are disallowed, owner's namespace py-sdk-e2e-e7e58312, obj's namespace py-sdk-e2e-ebe7c26f
    Observed Generation:   1
    Reason:                ReconcilerError
    Status:                False
    Type:                  Ready
  Sandbox:
Events:  <none>
```

This is because `warmpool` field is not specified when it is created in the tests and by default the value is considered as `default`, select from all matching warm pools - https://github.com/kubernetes-sigs/agent-sandbox/pull/212/changes#diff-ea3a24a9296d5acda3ecb58d91abdbe91a62c80434dcf0d4b7ef3407854506e7R16

#700 fixes the case when `warmpool` is `default`. 

Changes made:
Updated the python sdk client to accept `warmpool` parameter for creation of the sandboxclaim. 


