### PR TITLE
feat: make warm pool adoption retry count configurable in SandboxClaim

### DIFF
--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -141,6 +141,14 @@ type SandboxClaimSpec struct {
 	// +optional
 	AdditionalPodMetadata sandboxv1alpha1.PodMetadata `json:"additionalPodMetadata,omitempty"`
 
+	// warmpoolMaxRetries is the number of retry attempts when adopting a sandbox
+	// from the warm pool fails due to conflicts or not-found errors.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=10
+	// +kubebuilder:default=3
+	// +optional
+	WarmPoolMaxRetries *int32 `json:"warmpoolMaxRetries,omitempty"`
+
 	// env is a list of environment variables to inject into the sandbox
 	// +listType=atomic
 	// +optional

--- a/extensions/api/v1alpha1/zz_generated.deepcopy.go
+++ b/extensions/api/v1alpha1/zz_generated.deepcopy.go
@@ -153,6 +153,11 @@ func (in *SandboxClaimSpec) DeepCopyInto(out *SandboxClaimSpec) {
 		**out = **in
 	}
 	in.AdditionalPodMetadata.DeepCopyInto(&out.AdditionalPodMetadata)
+	if in.WarmPoolMaxRetries != nil {
+		in, out := &in.WarmPoolMaxRetries, &out.WarmPoolMaxRetries
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]EnvVar, len(*in))

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -57,6 +57,10 @@ import (
 const ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
 const immediateRequeueDelay = time.Millisecond
 
+// DefaultWarmPoolAdoptionRetries is the default number of retry attempts when adopting
+// a sandbox from the warm pool fails due to conflicts or not-found errors.
+const DefaultWarmPoolAdoptionRetries = 3
+
 // ErrTemplateNotFound is a sentinel error indicating a SandboxTemplate was not found.
 var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
 
@@ -76,6 +80,14 @@ func getWarmPoolPolicy(claim *extensionsv1alpha1.SandboxClaim) extensionsv1alpha
 		return *claim.Spec.WarmPool
 	}
 	return extensionsv1alpha1.WarmPoolPolicyDefault
+}
+
+// getWarmPoolMaxRetries returns the maximum number of retry attempts for warm pool adoption.
+func getWarmPoolMaxRetries(claim *extensionsv1alpha1.SandboxClaim) int {
+	if claim.Spec.WarmPoolMaxRetries != nil {
+		return int(*claim.Spec.WarmPoolMaxRetries)
+	}
+	return DefaultWarmPoolAdoptionRetries
 }
 
 // observedTimeEntry stores the first observed timestamp and the UID of the SandboxClaim.
@@ -627,9 +639,10 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*v1alpha1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+	maxRetries := getWarmPoolMaxRetries(claim)
 
 	// Keep trying until we successfully adopt a sandbox, or run out of candidates
-	for range 3 {
+	for range maxRetries {
 		adopted, adoptedKey, err := r.getCandidate(ctx, claim, templateHash)
 		if err != nil {
 			return nil, err

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1902,6 +1902,164 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		})
 	}
 }
+
+func TestSandboxClaimWarmPoolAdoptionRetries(t *testing.T) {
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-template",
+			Namespace: "default",
+		},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}},
+				},
+			},
+		},
+	}
+
+	warmPoolUID := types.UID("warmpool-uid-123")
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	templateHash := sandboxcontrollers.NameHash("test-template")
+
+	createWarmPoolSandbox := func(name string) client.Object {
+		replicas := int32(1)
+		return &sandboxv1alpha1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   poolNameHash,
+					sandboxTemplateRefHash: templateHash,
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+						Kind:       "SandboxWarmPool",
+						Name:       "test-pool",
+						UID:        warmPoolUID,
+						Controller: new(true),
+					},
+				},
+			},
+			Spec: sandboxv1alpha1.SandboxSpec{
+				Replicas: &replicas,
+				PodTemplate: sandboxv1alpha1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test", Image: "test"}},
+					},
+				},
+			},
+			Status: sandboxv1alpha1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{Type: string(sandboxv1alpha1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "DependenciesReady"},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name           string
+		maxRetries     int32
+		sandboxes      []client.Object
+		conflicts      int
+		expectAdoption bool
+	}{
+		{
+			name:           "exhausts retries with fewer candidates than retries",
+			maxRetries:     5,
+			sandboxes:      []client.Object{createWarmPoolSandbox("sb-1"), createWarmPoolSandbox("sb-2"), createWarmPoolSandbox("sb-3")},
+			conflicts:      3,
+			expectAdoption: false,
+		},
+		{
+			name:           "succeeds after conflicts with enough candidates",
+			maxRetries:     5,
+			sandboxes:      []client.Object{createWarmPoolSandbox("sb-1"), createWarmPoolSandbox("sb-2"), createWarmPoolSandbox("sb-3"), createWarmPoolSandbox("sb-4")},
+			conflicts:      3,
+			expectAdoption: true,
+		},
+		{
+			name:           "default retries (3) exhausted with only 2 candidates",
+			maxRetries:     0, // 0 = use default
+			sandboxes:      []client.Object{createWarmPoolSandbox("sb-1"), createWarmPoolSandbox("sb-2")},
+			conflicts:      2,
+			expectAdoption: false,
+		},
+		{
+			name:           "default retries (3) succeeds with 3 candidates",
+			maxRetries:     0, // 0 = use default
+			sandboxes:      []client.Object{createWarmPoolSandbox("sb-1"), createWarmPoolSandbox("sb-2"), createWarmPoolSandbox("sb-3")},
+			conflicts:      2,
+			expectAdoption: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var claim *extensionsv1alpha1.SandboxClaim
+			if tc.maxRetries > 0 {
+				retries := tc.maxRetries
+				claim = &extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+					Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"}, WarmPoolMaxRetries: &retries},
+				}
+			} else {
+				claim = &extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+					Spec:       extensionsv1alpha1.SandboxClaimSpec{TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"}},
+				}
+			}
+
+			objects := []client.Object{template, claim}
+			objects = append(objects, tc.sandboxes...)
+
+			scheme := newScheme(t)
+			fakeClient := &conflictClient{
+				Client:       fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).WithStatusSubresource(claim).Build(),
+				maxConflicts: tc.conflicts,
+			}
+
+			warmSandboxQueue := queue.NewSimpleSandboxQueue()
+			for _, obj := range tc.sandboxes {
+				if sb, ok := obj.(*sandboxv1alpha1.Sandbox); ok {
+					warmSandboxQueue.Add(templateHash, queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name})
+				}
+			}
+
+			reconciler := &SandboxClaimReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				WarmSandboxQueue: warmSandboxQueue,
+				Tracer:           asmetrics.NewNoOp(),
+			}
+
+			ctx := context.Background()
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}})
+			if err != nil {
+				t.Fatalf("reconcile failed: %v", err)
+			}
+
+			if tc.expectAdoption {
+				adopted := false
+				for _, sb := range tc.sandboxes {
+					sandbox := sb.(*sandboxv1alpha1.Sandbox)
+					var updated sandboxv1alpha1.Sandbox
+					if fakeClient.Get(ctx, types.NamespacedName{Name: sandbox.Name, Namespace: "default"}, &updated) == nil {
+						if metav1.IsControlledBy(&updated, claim) {
+							adopted = true
+							break
+						}
+					}
+				}
+				if !adopted {
+					t.Error("expected a sandbox to be adopted from warm pool")
+				}
+			}
+		})
+	}
+}
+
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
 	q := queue.NewSimpleSandboxQueue()
 	handler := &sandboxEventHandler{sandboxQueue: q}

--- a/extensions/examples/sandboxclaim.yaml
+++ b/extensions/examples/sandboxclaim.yaml
@@ -17,3 +17,4 @@ spec:
   # - A warm pool name: Select only from the specified warm pool (e.g., "fast-pool", "secure-pool")
   # If not specified, defaults to "default"
   # warmpool: "default"
+  # warmPoolMaxRetries: 3   # Maximum retry attempts for warm pool adoption (default: 3, range: 1-10)

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -81,6 +81,12 @@ spec:
               warmpool:
                 default: default
                 type: string
+              warmpoolMaxRetries:
+                default: 3
+                format: int32
+                maximum: 10
+                minimum: 1
+                type: integer
             required:
             - sandboxTemplateRef
             type: object


### PR DESCRIPTION
  ## Summary
  - Replace the hardcoded retry count (`3`) in `adoptSandboxFromCandidates` with a configurable `warmpoolMaxRetries` field on `SandboxClaimSpec`
  - Add `getWarmPoolMaxRetries` helper with a default of `3` for backward compatibility
  - Default value of `3` and range of `1-10` enforced via kubebuilder validation

  ## Motivation
  Under high concurrency, multiple claims adopting from the same warm pool can cause patch conflicts. A hardcoded retry count of 3 may not be sufficient in all environments, and adjusting it previously required
   a code change and redeployment.