### PR TITLE
feat: add client-go metrics for request failures, latency, and rate limiting

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	//+kubebuilder:scaffold:imports
 )
@@ -224,6 +225,9 @@ func main() {
 
 	// Register the custom Sandbox metric collector globally.
 	asmetrics.RegisterSandboxCollector(mgr.GetClient(), mgr.GetLogger().WithName("sandbox-collector"))
+
+	// Register client-go metrics for API server interaction observability.
+	asmetrics.MustRegisterClientGoMetrics(crmetrics.Registry)
 
 	if err = (&controllers.SandboxReconciler{
 		Client:        mgr.GetClient(),

--- a/internal/metrics/client_go_adapter.go
+++ b/internal/metrics/client_go_adapter.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+)
+
+// Client-go metrics adapter wrapping prometheus metrics.
+
+var (
+	// HTTP request counter: tracks total requests by status code.
+	// Use: rate(...{status_code=~"5.."}[5m]) / rate(...[5m]) for failure ratio.
+	k8sClientHTTPRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "agent_sandbox_k8s_client_http_requests_total",
+			Help: "Total number of Kubernetes API client HTTP requests by status code.",
+		},
+		[]string{"status_code"},
+	)
+
+	// HTTP request duration histogram: tracks API latency by endpoint.
+	// Use: histogram_quantile(0.99, rate(..._bucket[5m])) for P99 alerting.
+	k8sClientHTTPRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "agent_sandbox_k8s_client_http_request_duration_seconds",
+			Help:    "Kubernetes API client HTTP request duration in seconds by endpoint.",
+			Buckets: []float64{0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 5.0, 10.0, 30.0},
+		},
+		[]string{"endpoint"},
+	)
+
+	// Rate limiter duration histogram: tracks client-side throttling delay by endpoint.
+	// Use: rate(..._sum[5m]) to detect frequent rate limiting.
+	k8sClientRateLimiterDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "agent_sandbox_k8s_client_rate_limiter_duration_seconds",
+			Help:    "Kubernetes API client rate limiter wait duration in seconds by endpoint.",
+			Buckets: []float64{0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 5.0, 10.0, 30.0},
+		},
+		[]string{"endpoint"},
+	)
+)
+
+// clientGoHTTPMetricAdapter implements client-go LatencyMetric and ResultMetric interfaces.
+type clientGoHTTPMetricAdapter struct {
+	count           *prometheus.CounterVec
+	duration        *prometheus.HistogramVec
+	resultDelegate  clientmetrics.ResultMetric  // chained to preserve controller-runtime's rest_client_requests_total
+	latencyDelegate clientmetrics.LatencyMetric // chained to preserve any pre-existing latency observers
+}
+
+// Increment implements metrics.ResultMetric.
+func (a *clientGoHTTPMetricAdapter) Increment(ctx context.Context, code, method, host string) {
+	a.count.WithLabelValues(code).Inc()
+	if a.resultDelegate != nil {
+		a.resultDelegate.Increment(ctx, code, method, host)
+	}
+}
+
+// Observe implements metrics.LatencyMetric.
+func (a *clientGoHTTPMetricAdapter) Observe(ctx context.Context, method string, u url.URL, d time.Duration) {
+	a.duration.WithLabelValues(u.EscapedPath()).Observe(d.Seconds())
+	if a.latencyDelegate != nil {
+		a.latencyDelegate.Observe(ctx, method, u, d)
+	}
+}
+
+// clientGoRateLimiterMetricAdapter implements client-go LatencyMetric for rate limiter delays.
+type clientGoRateLimiterMetricAdapter struct {
+	duration *prometheus.HistogramVec
+	delegate clientmetrics.LatencyMetric // chained to preserve any pre-existing rate limiter observers
+}
+
+// Observe implements metrics.LatencyMetric.
+func (a *clientGoRateLimiterMetricAdapter) Observe(ctx context.Context, method string, u url.URL, d time.Duration) {
+	a.duration.WithLabelValues(u.EscapedPath()).Observe(d.Seconds())
+	if a.delegate != nil {
+		a.delegate.Observe(ctx, method, u, d)
+	}
+}
+
+// Interface assertions.
+var (
+	_ clientmetrics.LatencyMetric = (*clientGoHTTPMetricAdapter)(nil)
+	_ clientmetrics.ResultMetric  = (*clientGoHTTPMetricAdapter)(nil)
+	_ clientmetrics.LatencyMetric = (*clientGoRateLimiterMetricAdapter)(nil)
+)
+
+// MustRegisterClientGoMetrics registers client-go metrics adapters with the global
+// client-go metrics registry and the provided prometheus registerer.
+func MustRegisterClientGoMetrics(registerer prometheus.Registerer) {
+	// Capture existing global adapters so we can chain calls and preserve
+	// any previously-installed metrics/instrumentation.
+	existingResult := clientmetrics.RequestResult
+	existingLatency := clientmetrics.RequestLatency
+	existingRateLimiter := clientmetrics.RateLimiterLatency
+
+	httpAdapter := &clientGoHTTPMetricAdapter{
+		count:           k8sClientHTTPRequestsTotal,
+		duration:        k8sClientHTTPRequestDuration,
+		resultDelegate:  existingResult,
+		latencyDelegate: existingLatency,
+	}
+	rateLimiterAdapter := &clientGoRateLimiterMetricAdapter{
+		duration: k8sClientRateLimiterDuration,
+		delegate: existingRateLimiter,
+	}
+
+	// Directly assign the global variables to work around controller-runtime's
+	// single-registration limitation (clientmetrics.Register uses sync.Once).
+	clientmetrics.RequestLatency = httpAdapter
+	clientmetrics.RequestResult = httpAdapter
+	clientmetrics.RateLimiterLatency = rateLimiterAdapter
+
+	// Register prometheus metrics with the provided registerer.
+	registerer.MustRegister(k8sClientHTTPRequestsTotal)
+	registerer.MustRegister(k8sClientHTTPRequestDuration)
+	registerer.MustRegister(k8sClientRateLimiterDuration)
+}

--- a/internal/metrics/client_go_adapter_test.go
+++ b/internal/metrics/client_go_adapter_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestClientGoHTTPAdapter_Increment(t *testing.T) {
+	k8sClientHTTPRequestsTotal.Reset()
+
+	adapter := &clientGoHTTPMetricAdapter{
+		count:    k8sClientHTTPRequestsTotal,
+		duration: k8sClientHTTPRequestDuration,
+	}
+
+	adapter.Increment(context.Background(), "200", "GET", "/api/v1/pods")
+	adapter.Increment(context.Background(), "500", "GET", "/api/v1/pods")
+
+	if got := testutil.CollectAndCount(k8sClientHTTPRequestsTotal); got != 2 {
+		t.Errorf("Expected 2 status_code metrics, got %d", got)
+	}
+}
+
+func TestClientGoHTTPAdapter_Observe(t *testing.T) {
+	k8sClientHTTPRequestDuration.Reset()
+
+	adapter := &clientGoHTTPMetricAdapter{
+		count:    k8sClientHTTPRequestsTotal,
+		duration: k8sClientHTTPRequestDuration,
+	}
+
+	u := url.URL{Path: "/api/v1/pods"}
+	adapter.Observe(context.Background(), "GET", u, 500*time.Millisecond)
+
+	if got := testutil.CollectAndCount(k8sClientHTTPRequestDuration); got != 1 {
+		t.Errorf("Expected 1 duration metric, got %d", got)
+	}
+}
+
+func TestClientGoRateLimiterAdapter_Observe(t *testing.T) {
+	k8sClientRateLimiterDuration.Reset()
+
+	adapter := &clientGoRateLimiterMetricAdapter{
+		duration: k8sClientRateLimiterDuration,
+	}
+
+	u := url.URL{Path: "/api/v1/pods"}
+	adapter.Observe(context.Background(), "GET", u, 1*time.Second)
+
+	if got := testutil.CollectAndCount(k8sClientRateLimiterDuration); got != 1 {
+		t.Errorf("Expected 1 rate limiter metric, got %d", got)
+	}
+}
+
+func TestMustRegisterClientGoMetrics(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	MustRegisterClientGoMetrics(registry)
+
+	// Reset and record data so GatherAndCount can verify the metrics are registered.
+	k8sClientHTTPRequestsTotal.Reset()
+	k8sClientHTTPRequestDuration.Reset()
+	k8sClientRateLimiterDuration.Reset()
+	k8sClientHTTPRequestsTotal.WithLabelValues("200").Inc()
+	k8sClientHTTPRequestDuration.WithLabelValues("/api/v1/pods").Observe(0.5)
+	k8sClientRateLimiterDuration.WithLabelValues("/api/v1/pods").Observe(0.5)
+
+	// Verify all three metrics are registered in the provided registry.
+	if got, err := testutil.GatherAndCount(registry, "agent_sandbox_k8s_client_http_requests_total"); err != nil {
+		t.Fatal(err)
+	} else if got != 1 {
+		t.Errorf("Expected 1 registered metric for k8s_client_http_requests_total, got %d", got)
+	}
+	if got, err := testutil.GatherAndCount(registry, "agent_sandbox_k8s_client_http_request_duration_seconds"); err != nil {
+		t.Fatal(err)
+	} else if got != 1 {
+		t.Errorf("Expected 1 registered metric for k8s_client_http_request_duration_seconds, got %d", got)
+	}
+	if got, err := testutil.GatherAndCount(registry, "agent_sandbox_k8s_client_rate_limiter_duration_seconds"); err != nil {
+		t.Fatal(err)
+	} else if got != 1 {
+		t.Errorf("Expected 1 registered metric for k8s_client_rate_limiter_duration_seconds, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
  This project currently has only business-level metrics (claim latency, sandbox creation, etc.) with zero visibility into Kubernetes API client health. This PR addresses three blind spots by adding client-go metrics:                                                  
   
  1. **Request failure rate** — The API server returns 4xx/5xx errors without any monitoring, making it impossible to distinguish control logic failures from infrastructure issues                                                                                        
  2. **Slow API responses** — There is no insight into which endpoints are slow or what their P99 latency looks like, so debugging latency issues relies on guesswork                                                                                                    
  3. **Frequent rate limiting** — The `kube-api-qps`/`kube-api-burst` configuration operates without feedback, so client-side throttling goes undetected                                                                                                                   
                                                                                                                                                                                                                                                                           
  Three new metrics:                                                                                                                                                                                                                                                       
  - `agent_sandbox_k8s_client_http_requests_total` (CounterVec, `status_code`)                                                                                                                                                                                             
  - `agent_sandbox_k8s_client_http_request_duration_seconds` (HistogramVec, `endpoint`)                                                                                                                                                                                    
  - `agent_sandbox_k8s_client_rate_limiter_duration_seconds` (HistogramVec, `endpoint`)                                                                                                                                                                                    
                                                                                                                                                                                                                                                                           
  **Also preserves controller-runtime's existing `rest_client_requests_total` metric by chaining through a delegate adapter.**  