### PR TITLE
Update Python SDK for Podsnapshot v1 version 

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -27,7 +27,7 @@ SANDBOX_PLURAL_NAME = "sandboxes"
 
 POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
 PODSNAPSHOT_POD_NAME_ANNOTATION = "podsnapshot.gke.io/origin-pod"
-SANDBOX_TEMPLATE_REF_HASH_LABEL = "agents.x-k8s.io/sandbox-template-ref-hash"
+SANDBOX_NAME_HASH_LABEL = "agents.x-k8s.io/sandbox-name-hash"
 
 PODSNAPSHOT_API_GROUP = "podsnapshot.gke.io"
 PODSNAPSHOT_API_VERSION = "v1"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -26,6 +26,7 @@ SANDBOX_API_VERSION = "v1alpha1"
 SANDBOX_PLURAL_NAME = "sandboxes"
 
 POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
+PODSNAPSHOT_POD_NAME_ANNOTATION = "podsnapshot.gke.io/origin-pod"
 SANDBOX_TEMPLATE_REF_HASH_LABEL = "agents.x-k8s.io/sandbox-template-ref-hash"
 
 PODSNAPSHOT_API_GROUP = "podsnapshot.gke.io"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -26,10 +26,10 @@ SANDBOX_API_VERSION = "v1alpha1"
 SANDBOX_PLURAL_NAME = "sandboxes"
 
 POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
-PODSNAPSHOT_POD_NAME_LABEL = "podsnapshot.gke.io/pod-name"
+SANDBOX_TEMPLATE_REF_HASH_LABEL = "agents.x-k8s.io/sandbox-template-ref-hash"
 
 PODSNAPSHOT_API_GROUP = "podsnapshot.gke.io"
-PODSNAPSHOT_API_VERSION = "v1alpha1"
+PODSNAPSHOT_API_VERSION = "v1"
 PODSNAPSHOT_PLURAL = "podsnapshots"
 PODSNAPSHOTMANUALTRIGGER_PLURAL = "podsnapshotmanualtriggers"
 PODSNAPSHOTMANUALTRIGGER_API_KIND = "PodSnapshotManualTrigger"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
@@ -92,7 +92,7 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
     pip install -e clients/python/agentic-sandbox-client/
     ```
 
-3.  **Pod Snapshot Controller**: The Pod Snapshot controller must be installed in a **GKE standard cluster** running with **gVisor**. 
+3.  **Pod Snapshot Controller**: The Pod Snapshot controller must be installed in a **GKE standard cluster** (version >= 1.35.2-gke.1842000) running with **gVisor**. 
    * For detailed setup instructions, refer to the [GKE Pod Snapshots public documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/pod-snapshots).
    * Ensure a GCS bucket is configured to store the pod snapshot states and that the necessary IAM permissions are applied.
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
@@ -96,7 +96,7 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
    * For detailed setup instructions, refer to the [GKE Pod Snapshots public documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/pod-snapshots).
    * Ensure a GCS bucket is configured to store the pod snapshot states and that the necessary IAM permissions are applied.
 
-4.  **CRDs**: `PodSnapshotStorageConfig`, `PodSnapshotPolicy` CRDs must be applied. As a requirement, the label `agents.x-k8s.io/sandbox-template-ref-hash` must be added to the `PodSnapshotPolicy` grouping rules.
+4.  **CRDs**: `PodSnapshotStorageConfig`, `PodSnapshotPolicy` CRDs must be applied. As a requirement, the label `agents.x-k8s.io/sandbox-name-hash` must be added to the `PodSnapshotPolicy` grouping rules.
 
     Example `PodSnapshotPolicy`:
     ```yaml
@@ -115,13 +115,11 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
         postCheckpoint: resume
       snapshotGroupingRules:
         groupByLabelValue:
-          labels: ["agents.x-k8s.io/sandbox-template-ref-hash", "tenant-id", "user-id"]
+          labels: ["agents.x-k8s.io/sandbox-name-hash", "tenant-id", "user-id"]
           groupRetentionPolicy:
             maxSnapshotCountPerGroup: 3
     ```
     (Note: To run the integration test file successfully, `tenant-id` and `user-id` labels should also be added to the `groupByLabelValue.labels` list in the `PodSnapshotPolicy`.)
-
-    **Snapshot Sharing & Isolation**: By default, snapshots are shared across all sandboxes created from the same template in a namespace (isolated by `agents.x-k8s.io/sandbox-template-ref-hash`). This is intentional and allows for restoring state across different sandbox instances of the same template. To achieve instance-level isolation instead, you can add a unique identifier (e.g., `agents.x-k8s.io/claim-uid`, `user-id`, etc.) to the `PodSnapshotPolicy` grouping rules.
 
 5.  **Sandbox Template**: A `SandboxTemplate` (e.g., `python-counter-template`) with runtime gVisor, appropriate KSA and label that matches that selector label in `PodSnapshotPolicy` must be available in the cluster.
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
@@ -96,7 +96,30 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
    * For detailed setup instructions, refer to the [GKE Pod Snapshots public documentation](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/pod-snapshots).
    * Ensure a GCS bucket is configured to store the pod snapshot states and that the necessary IAM permissions are applied.
 
-4.  **CRDs**: `PodSnapshotStorageConfig`, `PodSnapshotPolicy` CRDs must be applied. `PodSnapshotPolicy` should specify the selector match labels. (Note: For the test file to work, `maxSnapshotCountPerGroup` in `PodSnapshotPolicy` must be set to 2 or more, and the grouping labels must include `tenant-id` and `user-id`.)
+4.  **CRDs**: `PodSnapshotStorageConfig`, `PodSnapshotPolicy` CRDs must be applied. As a requirement, the label `agents.x-k8s.io/sandbox-template-ref-hash` must be added to the `PodSnapshotPolicy` grouping rules.
+
+    Example `PodSnapshotPolicy`:
+    ```yaml
+    apiVersion: podsnapshot.gke.io/v1
+    kind: PodSnapshotPolicy
+    metadata:
+      name: example-psp-workload
+      namespace: sandbox-test
+    spec:
+      storageConfigName: example-pssc-gcs
+      selector:
+        matchLabels:
+          app: agent-sandbox-workload
+      triggerConfig:
+        type: manual
+        postCheckpoint: resume
+      snapshotGroupingRules:
+        groupByLabelValue:
+          labels: ["agents.x-k8s.io/sandbox-template-ref-hash", "tenant-id", "user-id"]
+          groupRetentionPolicy:
+            maxSnapshotCountPerGroup: 3
+    ```
+    (Note: To run the integration test file successfully, `tenant-id` and `user-id` labels should also be added to the `groupByLabelValue.labels` list in the `PodSnapshotPolicy`.)
 
 5.  **Sandbox Template**: A `SandboxTemplate` (e.g., `python-counter-template`) with runtime gVisor, appropriate KSA and label that matches that selector label in `PodSnapshotPolicy` must be available in the cluster.
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
@@ -121,6 +121,8 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
     ```
     (Note: To run the integration test file successfully, `tenant-id` and `user-id` labels should also be added to the `groupByLabelValue.labels` list in the `PodSnapshotPolicy`.)
 
+    **Snapshot Sharing & Isolation**: By default, snapshots are shared across all sandboxes created from the same template in a namespace (isolated by `agents.x-k8s.io/sandbox-template-ref-hash`). This is intentional and allows for restoring state across different sandbox instances of the same template. To achieve instance-level isolation instead, you can add a unique identifier (e.g., `agents.x-k8s.io/claim-uid`, `user-id`, etc.) to the `PodSnapshotPolicy` grouping rules.
+
 5.  **Sandbox Template**: A `SandboxTemplate` (e.g., `python-counter-template`) with runtime gVisor, appropriate KSA and label that matches that selector label in `PodSnapshotPolicy` must be available in the cluster.
 
 ### Running Tests:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -52,7 +52,7 @@ class SandboxWithSnapshotSupport(Sandbox):
             namespace=self.namespace,
             k8s_helper=self.k8s_helper,
             get_pod_name_func=self.get_pod_name,
-            get_sandbox_template_ref_hash_func=self.get_sandbox_template_ref_hash,
+            get_sandbox_name_hash_func=self.get_sandbox_name_hash,
         )
 
     @property

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -52,6 +52,7 @@ class SandboxWithSnapshotSupport(Sandbox):
             namespace=self.namespace,
             k8s_helper=self.k8s_helper,
             get_pod_name_func=self.get_pod_name,
+            get_sandbox_template_ref_hash_func=self.get_sandbox_template_ref_hash,
         )
 
     @property

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from k8s_agent_sandbox.constants import (
     SANDBOX_TEMPLATE_REF_HASH_LABEL,
+    PODSNAPSHOT_POD_NAME_ANNOTATION,
     PODSNAPSHOT_PLURAL,
     PODSNAPSHOT_API_GROUP,
     PODSNAPSHOT_API_VERSION,
@@ -343,8 +344,8 @@ class SnapshotEngine:
                     valid_snapshots.append(
                         SnapshotDetail(
                             snapshot_uid=metadata.get("name"),
-                            source_pod=metadata.get("labels", {}).get(
-                                SANDBOX_TEMPLATE_REF_HASH_LABEL, "Unknown"
+                            source_pod=metadata.get("annotations", {}).get(
+                                PODSNAPSHOT_POD_NAME_ANNOTATION, "Unknown"
                             ),
                             creation_timestamp=metadata.get("creationTimestamp"),
                             status="Ready" if is_ready else "NotReady",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -21,7 +21,7 @@ from kubernetes.client import ApiException
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from k8s_agent_sandbox.constants import (
-    SANDBOX_TEMPLATE_REF_HASH_LABEL,
+    SANDBOX_NAME_HASH_LABEL,
     PODSNAPSHOT_POD_NAME_ANNOTATION,
     PODSNAPSHOT_PLURAL,
     PODSNAPSHOT_API_GROUP,
@@ -92,12 +92,12 @@ class SnapshotEngine:
         namespace: str,
         k8s_helper,
         get_pod_name_func: Callable[[], str],
-        get_sandbox_template_ref_hash_func: Callable[[], str | None],
+        get_sandbox_name_hash_func: Callable[[], str | None],
     ):
         self.namespace = namespace
         self.k8s_helper = k8s_helper
         self.get_pod_name_func = get_pod_name_func
-        self.get_sandbox_template_ref_hash_func = get_sandbox_template_ref_hash_func
+        self.get_sandbox_name_hash_func = get_sandbox_name_hash_func
         self.created_manual_triggers = []
 
     def create(
@@ -296,17 +296,17 @@ class SnapshotEngine:
                 error_code=SNAPSHOT_ERROR_CODE,
             )
 
-        template_ref_hash = self.get_sandbox_template_ref_hash_func()
-        if not template_ref_hash:
-            logger.warning(f"Template reference hash not found for pod {pod_name}.")
+        sandbox_name_hash = self.get_sandbox_name_hash_func()
+        if not sandbox_name_hash:
+            logger.warning(f"Sandbox name hash not found for pod {pod_name}.")
             return ListSnapshotResult(
                 success=False,
                 snapshots=[],
-                error_reason="Template reference hash not found.",
+                error_reason="Sandbox name hash not found.",
                 error_code=SNAPSHOT_ERROR_CODE,
             )
         
-        selectors.append(f"{SANDBOX_TEMPLATE_REF_HASH_LABEL}={template_ref_hash}")
+        selectors.append(f"{SANDBOX_NAME_HASH_LABEL}={sandbox_name_hash}")
 
         if filter_by.grouping_labels:
             for k, v in filter_by.grouping_labels.items():

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -264,7 +264,7 @@ class SnapshotEngine:
         self, filter_by: SnapshotFilter | dict | None = None
     ) -> ListSnapshotResult:
         """
-        Checks for existing snapshots matching the grouping labels associated with the sandboxTemplate across the sandbox instances.
+        Checks for existing snapshots matching the grouping labels associated with the sandbox
         Returns a ListSnapshotResult containing valid snapshots sorted by creation timestamp (newest first).
 
         filter_by: Structure containing filters (status and grouping_labels).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -21,7 +21,7 @@ from kubernetes.client import ApiException
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from k8s_agent_sandbox.constants import (
-    PODSNAPSHOT_POD_NAME_LABEL,
+    SANDBOX_TEMPLATE_REF_HASH_LABEL,
     PODSNAPSHOT_PLURAL,
     PODSNAPSHOT_API_GROUP,
     PODSNAPSHOT_API_VERSION,
@@ -91,10 +91,12 @@ class SnapshotEngine:
         namespace: str,
         k8s_helper,
         get_pod_name_func: Callable[[], str],
+        get_sandbox_template_ref_hash_func: Callable[[], str | None],
     ):
         self.namespace = namespace
         self.k8s_helper = k8s_helper
         self.get_pod_name_func = get_pod_name_func
+        self.get_sandbox_template_ref_hash_func = get_sandbox_template_ref_hash_func
         self.created_manual_triggers = []
 
     def create(
@@ -293,7 +295,17 @@ class SnapshotEngine:
                 error_code=SNAPSHOT_ERROR_CODE,
             )
 
-        selectors.append(f"{PODSNAPSHOT_POD_NAME_LABEL}={pod_name}")
+        template_ref_hash = self.get_sandbox_template_ref_hash_func()
+        if not template_ref_hash:
+            logger.warning(f"Template reference hash not found for pod {pod_name}.")
+            return ListSnapshotResult(
+                success=False,
+                snapshots=[],
+                error_reason="Template reference hash not found.",
+                error_code=SNAPSHOT_ERROR_CODE,
+            )
+        
+        selectors.append(f"{SANDBOX_TEMPLATE_REF_HASH_LABEL}={template_ref_hash}")
 
         if filter_by.grouping_labels:
             for k, v in filter_by.grouping_labels.items():
@@ -332,7 +344,7 @@ class SnapshotEngine:
                         SnapshotDetail(
                             snapshot_uid=metadata.get("name"),
                             source_pod=metadata.get("labels", {}).get(
-                                PODSNAPSHOT_POD_NAME_LABEL, "Unknown"
+                                SANDBOX_TEMPLATE_REF_HASH_LABEL, "Unknown"
                             ),
                             creation_timestamp=metadata.get("creationTimestamp"),
                             status="Ready" if is_ready else "NotReady",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/snapshot_engine.py
@@ -264,7 +264,7 @@ class SnapshotEngine:
         self, filter_by: SnapshotFilter | dict | None = None
     ) -> ListSnapshotResult:
         """
-        Checks for existing snapshots matching the grouping labels associated with the sandbox.
+        Checks for existing snapshots matching the grouping labels associated with the sandboxTemplate across the sandbox instances.
         Returns a ListSnapshotResult containing valid snapshots sorted by creation timestamp (newest first).
 
         filter_by: Structure containing filters (status and grouping_labels).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -26,6 +26,7 @@ from k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support im
 )
 from k8s_agent_sandbox.constants import (
     SANDBOX_TEMPLATE_REF_HASH_LABEL,
+    PODSNAPSHOT_POD_NAME_ANNOTATION,
     PODSNAPSHOT_API_GROUP,
     PODSNAPSHOT_API_VERSION,
     PODSNAPSHOTMANUALTRIGGER_PLURAL,
@@ -462,6 +463,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "uid": "uid-1",
                         "creationTimestamp": "2023-01-02T00:00:00Z",
                         "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -471,6 +473,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "uid": "uid-2",
                         "creationTimestamp": "2023-01-01T00:00:00Z",
                         "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -496,7 +499,9 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.assertEqual(len(result.snapshots), 2)
         # Verify it sorted by creationTimestamp newest first
         self.assertEqual(result.snapshots[0].snapshot_uid, "snap-1")
+        self.assertEqual(result.snapshots[0].source_pod, "test-pod")
         self.assertEqual(result.snapshots[1].snapshot_uid, "snap-2")
+        self.assertEqual(result.snapshots[1].source_pod, "test-pod")
         self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.assert_called_once_with(
             group=PODSNAPSHOT_API_GROUP,
             version=PODSNAPSHOT_API_VERSION,
@@ -580,6 +585,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "uid": "uid-1",
                         "creationTimestamp": None,  # Test Case: None
                         "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -589,6 +595,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "uid": "uid-2",
                         "creationTimestamp": "2023-01-01T00:00:00Z",
                         "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -629,6 +636,14 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Pod name not found", result.error_reason)
+
+    def test_snapshots_list_no_template_hash(self):
+        """Test list snapshots fails when template reference hash is missing."""
+        self.engine.get_sandbox_template_ref_hash_func.return_value = None
+        result = self.engine.list()
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, ERROR_CODE)
+        self.assertIn("Template reference hash not found", result.error_reason)
 
     def test_snapshots_list_api_exception(self):
         self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.side_effect = ApiException(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -25,7 +25,7 @@ from k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support im
     ResumeResponse,
 )
 from k8s_agent_sandbox.constants import (
-    PODSNAPSHOT_POD_NAME_LABEL,
+    SANDBOX_TEMPLATE_REF_HASH_LABEL,
     PODSNAPSHOT_API_GROUP,
     PODSNAPSHOT_API_VERSION,
     PODSNAPSHOTMANUALTRIGGER_PLURAL,
@@ -67,6 +67,9 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         # Access the underlying engine
         self.engine = self.sandbox.snapshots
         self.engine.get_pod_name_func = self.sandbox.get_pod_name
+        
+        # Mock get_sandbox_template_ref_hash_func directly on the engine
+        self.engine.get_sandbox_template_ref_hash_func = MagicMock(return_value="test-template-hash")
 
     def tearDown(self):
         logging.info(f"Finished {self._testMethodName}.")
@@ -458,7 +461,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-1",
                         "uid": "uid-1",
                         "creationTimestamp": "2023-01-02T00:00:00Z",
-                        "labels": {PODSNAPSHOT_POD_NAME_LABEL: "test-pod"},
+                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -467,7 +470,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-2",
                         "uid": "uid-2",
                         "creationTimestamp": "2023-01-01T00:00:00Z",
-                        "labels": {PODSNAPSHOT_POD_NAME_LABEL: "test-pod"},
+                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -499,7 +502,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             version=PODSNAPSHOT_API_VERSION,
             namespace="test-ns",
             plural=PODSNAPSHOT_PLURAL,
-            label_selector=f"{PODSNAPSHOT_POD_NAME_LABEL}=test-pod,test-label=test-value",
+            label_selector=f"{SANDBOX_TEMPLATE_REF_HASH_LABEL}=test-template-hash,test-label=test-value",
         )
 
     def test_snapshots_list_filter_empty(self):
@@ -576,7 +579,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-1",
                         "uid": "uid-1",
                         "creationTimestamp": None,  # Test Case: None
-                        "labels": {PODSNAPSHOT_POD_NAME_LABEL: "test-pod"},
+                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -585,7 +588,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-2",
                         "uid": "uid-2",
                         "creationTimestamp": "2023-01-01T00:00:00Z",
-                        "labels": {PODSNAPSHOT_POD_NAME_LABEL: "test-pod"},
+                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
                 },
@@ -616,7 +619,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             version=PODSNAPSHOT_API_VERSION,
             namespace="test-ns",
             plural=PODSNAPSHOT_PLURAL,
-            label_selector=f"{PODSNAPSHOT_POD_NAME_LABEL}=test-pod",
+            label_selector=f"{SANDBOX_TEMPLATE_REF_HASH_LABEL}=test-template-hash",
         )
 
     def test_snapshots_list_no_pod_name(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -25,7 +25,7 @@ from k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support im
     ResumeResponse,
 )
 from k8s_agent_sandbox.constants import (
-    SANDBOX_TEMPLATE_REF_HASH_LABEL,
+    SANDBOX_NAME_HASH_LABEL,
     PODSNAPSHOT_POD_NAME_ANNOTATION,
     PODSNAPSHOT_API_GROUP,
     PODSNAPSHOT_API_VERSION,
@@ -69,8 +69,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.engine = self.sandbox.snapshots
         self.engine.get_pod_name_func = self.sandbox.get_pod_name
         
-        # Mock get_sandbox_template_ref_hash_func directly on the engine
-        self.engine.get_sandbox_template_ref_hash_func = MagicMock(return_value="test-template-hash")
+        self.engine.get_sandbox_name_hash_func = MagicMock(return_value="test-hash")
 
     def tearDown(self):
         logging.info(f"Finished {self._testMethodName}.")
@@ -462,7 +461,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-1",
                         "uid": "uid-1",
                         "creationTimestamp": "2023-01-02T00:00:00Z",
-                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "labels": {SANDBOX_NAME_HASH_LABEL: "test-hash"},
                         "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
@@ -472,7 +471,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-2",
                         "uid": "uid-2",
                         "creationTimestamp": "2023-01-01T00:00:00Z",
-                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "labels": {SANDBOX_NAME_HASH_LABEL: "test-hash"},
                         "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
@@ -507,7 +506,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             version=PODSNAPSHOT_API_VERSION,
             namespace="test-ns",
             plural=PODSNAPSHOT_PLURAL,
-            label_selector=f"{SANDBOX_TEMPLATE_REF_HASH_LABEL}=test-template-hash,test-label=test-value",
+            label_selector=f"{SANDBOX_NAME_HASH_LABEL}=test-hash,test-label=test-value",
         )
 
     def test_snapshots_list_filter_empty(self):
@@ -584,7 +583,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-1",
                         "uid": "uid-1",
                         "creationTimestamp": None,  # Test Case: None
-                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "labels": {SANDBOX_NAME_HASH_LABEL: "test-hash"},
                         "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
@@ -594,7 +593,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                         "name": "snap-2",
                         "uid": "uid-2",
                         "creationTimestamp": "2023-01-01T00:00:00Z",
-                        "labels": {SANDBOX_TEMPLATE_REF_HASH_LABEL: "test-template-hash"},
+                        "labels": {SANDBOX_NAME_HASH_LABEL: "test-hash"},
                         "annotations": {PODSNAPSHOT_POD_NAME_ANNOTATION: "test-pod"},
                     },
                     "status": {"conditions": [{"type": "Ready", "status": "True"}]},
@@ -626,7 +625,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             version=PODSNAPSHOT_API_VERSION,
             namespace="test-ns",
             plural=PODSNAPSHOT_PLURAL,
-            label_selector=f"{SANDBOX_TEMPLATE_REF_HASH_LABEL}=test-template-hash",
+            label_selector=f"{SANDBOX_NAME_HASH_LABEL}=test-hash",
         )
 
     def test_snapshots_list_no_pod_name(self):
@@ -637,13 +636,13 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.assertEqual(result.error_code, ERROR_CODE)
         self.assertIn("Pod name not found", result.error_reason)
 
-    def test_snapshots_list_no_template_hash(self):
-        """Test list snapshots fails when template reference hash is missing."""
-        self.engine.get_sandbox_template_ref_hash_func.return_value = None
+    def test_snapshots_list_no_sandbox_name_hash(self):
+        """Test list snapshots fails when sandbox name hash is missing."""
+        self.engine.get_sandbox_name_hash_func.return_value = None
         result = self.engine.list()
         self.assertFalse(result.success)
         self.assertEqual(result.error_code, ERROR_CODE)
-        self.assertIn("Template reference hash not found", result.error_reason)
+        self.assertIn("Sandbox name hash not found", result.error_reason)
 
     def test_snapshots_list_api_exception(self):
         self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.side_effect = ApiException(
@@ -1157,6 +1156,30 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             "status": {"podIPs": ["10.0.0.1"]}
         }
         self.assertFalse(self.sandbox.is_suspended())
+
+    def test_get_sandbox_name_hash_success(self):
+        """Test get_sandbox_name_hash reads from status.selector and caches it."""
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {"selector": f"{SANDBOX_NAME_HASH_LABEL}=test-hash-value"}
+        }
+        
+        # First call should fetch from K8s
+        res1 = self.sandbox.get_sandbox_name_hash()
+        self.assertEqual(res1, "test-hash-value")
+        self.mock_k8s_helper.get_sandbox.assert_called_once_with("test-id", "test-ns")
+        
+        # Second call should use cache
+        self.mock_k8s_helper.get_sandbox.reset_mock()
+        res2 = self.sandbox.get_sandbox_name_hash()
+        self.assertEqual(res2, "test-hash-value")
+        self.mock_k8s_helper.get_sandbox.assert_not_called()
+
+    def test_get_sandbox_name_hash_not_found(self):
+        """Test get_sandbox_name_hash returns None when not found."""
+        self.mock_k8s_helper.get_sandbox.return_value = {}
+        
+        res = self.sandbox.get_sandbox_name_hash()
+        self.assertIsNone(res)
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -15,7 +15,6 @@
 import atexit
 import logging
 import requests
-from kubernetes.client import ApiException
 from .trace_manager import create_tracer_manager, trace_span, trace
 from .commands.command_executor import CommandExecutor
 from .files.filesystem import Filesystem

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -15,6 +15,7 @@
 import atexit
 import logging
 import requests
+from kubernetes.client import ApiException
 from .trace_manager import create_tracer_manager, trace_span, trace
 from .commands.command_executor import CommandExecutor
 from .files.filesystem import Filesystem
@@ -26,7 +27,7 @@ from .models import (
 )
 from .k8s_helper import K8sHelper
 from .connector import SandboxConnector
-from .constants import POD_NAME_ANNOTATION
+from .constants import POD_NAME_ANNOTATION, SANDBOX_TEMPLATE_REF_HASH_LABEL
 
 class Sandbox:
     """
@@ -93,6 +94,15 @@ class Sandbox:
         pod_name = annotations.get(POD_NAME_ANNOTATION)
         self._pod_name = pod_name if pod_name is not None else self.sandbox_id
         return self._pod_name
+
+    def get_sandbox_template_ref_hash(self) -> str | None:
+        """Fetches the Sandbox object from Kubernetes and retrieves its template ref hash."""
+        sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
+        spec = sandbox_object.get('spec') or {}
+        pod_template = spec.get('podTemplate') or {}
+        pt_metadata = pod_template.get('metadata') or {}
+        pt_labels = pt_metadata.get('labels') or {}
+        return pt_labels.get(SANDBOX_TEMPLATE_REF_HASH_LABEL)
 
     def get_pod_ip(self) -> str | None:
         """Fetches the first pod IP from the Sandbox status.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -26,7 +26,7 @@ from .models import (
 )
 from .k8s_helper import K8sHelper
 from .connector import SandboxConnector
-from .constants import POD_NAME_ANNOTATION, SANDBOX_TEMPLATE_REF_HASH_LABEL
+from .constants import POD_NAME_ANNOTATION, SANDBOX_NAME_HASH_LABEL
 
 class Sandbox:
     """
@@ -81,6 +81,7 @@ class Sandbox:
         # Internal state tracking
         self._is_closed = False
         self._pod_name = None
+        self._sandbox_name_hash = None
         
     def get_pod_name(self) -> str:
         """Fetches the Sandbox object from Kubernetes and retrieves its current pod name."""
@@ -94,14 +95,25 @@ class Sandbox:
         self._pod_name = pod_name if pod_name is not None else self.sandbox_id
         return self._pod_name
 
-    def get_sandbox_template_ref_hash(self) -> str | None:
-        """Fetches the Sandbox object from Kubernetes and retrieves its template ref hash."""
+
+    def get_sandbox_name_hash(self) -> str | None:
+        """Fetches the Sandbox object from Kubernetes and retrieves its name hash from selector.
+        Caches the result to avoid repeated API calls.
+        """
+        # Return cached value if available
+        if self._sandbox_name_hash is not None:
+            return self._sandbox_name_hash
+
         sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
-        spec = sandbox_object.get('spec') or {}
-        pod_template = spec.get('podTemplate') or {}
-        pt_metadata = pod_template.get('metadata') or {}
-        pt_labels = pt_metadata.get('labels') or {}
-        return pt_labels.get(SANDBOX_TEMPLATE_REF_HASH_LABEL)
+        status = sandbox_object.get('status') or {}
+        selector = status.get('selector') or ""
+        if "=" in selector:
+            key, value = selector.split("=")
+            if key == SANDBOX_NAME_HASH_LABEL:
+                self._sandbox_name_hash = value
+                return value
+                
+        return None
 
     def get_pod_ip(self) -> str | None:
         """Fetches the first pod IP from the Sandbox status.

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -56,7 +56,7 @@ def test_snapshot_response(snapshot_response: SnapshotResponse, snapshot_name: s
 def wait_for_snapshot_ready(sandbox, snapshot_uid: str, max_retries: int = 30, sleep_time: int = 2) -> bool:
     """Helper to poll until a specific snapshot UID is reported as ready."""
     for _ in range(max_retries):
-        check_list = sandbox.snapshots.list()
+        check_list = sandbox.snapshots.list(filter_by={"grouping_labels": {"tenant-id": "test-tenant", "user-id": "test-user"}})
         if check_list.success and any(s.snapshot_uid == snapshot_uid for s in check_list.snapshots):
             print(f"Snapshot '{snapshot_uid}' is ready.")
             return True
@@ -132,7 +132,7 @@ def test_list_and_delete(sandbox, first_snapshot_uid: str, second_snapshot_uid: 
     """Tests listing all snapshots and verifying snapshot deletion."""
     print("\n======= Testing List and Delete =======")
     print(f"\nListing all snapshots for sandbox '{sandbox.sandbox_id}'...")
-    list_result = sandbox.snapshots.list()
+    list_result = sandbox.snapshots.list(filter_by={"grouping_labels": {"tenant-id": "test-tenant", "user-id": "test-user"}})
     assert list_result.success, list_result.error_reason
 
     for snap in list_result.snapshots:

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -96,10 +96,6 @@ def test_manual_snapshots(client, sandbox, template_name: str, namespace: str) -
     print(
         f"\nChecking if sandbox was restored from latest snapshot '{second_snapshot_uid}'..."
     )
-    restored_sandbox = client.create_sandbox(template_name, namespace=namespace)
-    restore_result = restored_sandbox.is_restored_from_snapshot(second_snapshot_uid)
-    assert restore_result.success, restore_result.error_reason
-    print("Pod was restored from the most recent snapshot.")
 
     return first_snapshot_uid, second_snapshot_uid
 


### PR DESCRIPTION
This PR updates the Agent Sandbox Python SDK to support the stable` v1` version of the GKE PodSnapshot API.
Also updated the `'list` method of the snapshots to support the updated crd of the Podsnapshot Custom Resource. 
The method now checks the `sandboxNameHash` label of the podsnapshot resource. 

**Note:** It is expected that the label `agents.x-k8s.io/sandbox-name-hash` is added a grouping label in the podsnapshot policy. 

#### Release Note
Podsnapshot API version is upgraded from `v1alpha1` to `v1`. With the upgrade, it is expected that the label `agents.x-k8s.io/sandbox-name-hash` is added a grouping label in the podsnapshot policy. And restoring a sandbox by creation of a new claim based on the template of the previous snapshot is not supported anymore. 
Suspend, resume and restoration of a sandbox from its own snapshots are only supported currently.


#### Integration Test:
```
$ python3 test_podsnapshot_extension.py --template-name python-counter-template --namespace sandbox-test 
--- Starting Sandbox Client Test (Namespace: sandbox-test, Port: 8888) ---

***** Phase 1: Starting Counter *****

======= Testing Pod Snapshot Extension =======
2026-05-01 21:57:00,208 - INFO - Creating SandboxClaim 'sandbox-claim-9aca5464' in namespace 'sandbox-test' using template 'python-counter-template'...
2026-05-01 21:57:00,267 - INFO - Resolving sandbox name from claim 'sandbox-claim-9aca5464'...
2026-05-01 21:57:00,351 - INFO - Resolved sandbox name 'sandbox-claim-9aca5464' from claim status
2026-05-01 21:57:00,352 - INFO - Watching for Sandbox sandbox-claim-9aca5464 to become ready...
2026-05-01 21:57:01,482 - INFO - Sandbox sandbox-claim-9aca5464 is ready.
Creating first manual pod snapshot 'test-snapshot-10' after 10 seconds...
2026-05-01 21:57:11,670 - INFO - Waiting for snapshot manual trigger 'test-snapshot-10-20260501-215711-04d45ad5' to be processed...
2026-05-01 21:57:14,386 - INFO - Snapshot manual trigger 'test-snapshot-10-20260501-215711-04d45ad5' processed successfully. Created Snapshot UID: d36d1363-a7c4-4559-8e35-b5478e60aef1
Trigger Name: test-snapshot-10-20260501-215711-04d45ad5
First snapshot UID: d36d1363-a7c4-4559-8e35-b5478e60aef1

Creating second manual pod snapshot 'test-snapshot-20' after 10 seconds...
2026-05-01 21:57:24,521 - INFO - Waiting for snapshot manual trigger 'test-snapshot-20-20260501-215724-acb32681' to be processed...
2026-05-01 21:57:27,231 - INFO - Snapshot manual trigger 'test-snapshot-20-20260501-215724-acb32681' processed successfully. Created Snapshot UID: 6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657
Trigger Name: test-snapshot-20-20260501-215724-acb32681
Recent snapshot UID: 6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657
Waiting for second snapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657' to become ready...
2026-05-01 21:57:27,367 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=1f100339,tenant-id=test-tenant,user-id=test-user
2026-05-01 21:57:27,425 - INFO - Found 2 snapshots.
Snapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657' is ready.

Checking if sandbox was restored from latest snapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657'...

======= Testing Suspend and Resume =======

Suspending sandbox 'sandbox-claim-9aca5464'...
2026-05-01 21:57:27,534 - INFO - Waiting for snapshot manual trigger 'suspend-sandbox-claim-9aca5464-20260501-215727-33eeb61f' to be processed...
2026-05-01 21:57:31,428 - INFO - Snapshot manual trigger 'suspend-sandbox-claim-9aca5464-20260501-215727-33eeb61f' processed successfully. Created Snapshot UID: 090f17b8-e5a3-46c3-ab35-2d074b658938
2026-05-01 21:57:31,702 - INFO - Sandbox 'sandbox-claim-9aca5464' suspended (scaled down to 0 replicas).
2026-05-01 21:57:31,703 - INFO - Waiting up to 180s for pod 'sandbox-claim-9aca5464' (UID: b77526eb-850b-486f-b507-4f1b96987d4c) to terminate...
2026-05-01 21:57:33,806 - INFO - Sandbox 'sandbox-claim-9aca5464' pod successfully terminated.
Sandbox suspended. Snapshot UID: 090f17b8-e5a3-46c3-ab35-2d074b658938
Waiting for suspend snapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' to become ready...
2026-05-01 21:57:33,854 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=1f100339,tenant-id=test-tenant,user-id=test-user
2026-05-01 21:57:33,907 - INFO - Found 3 snapshots.
Snapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' is ready.

Resuming sandbox 'sandbox-claim-9aca5464'...
2026-05-01 21:57:33,958 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=1f100339
2026-05-01 21:57:34,011 - INFO - Found 3 snapshots.
2026-05-01 21:57:34,071 - INFO - Sandbox 'sandbox-claim-9aca5464' resumed (scaled up to 1 replica).
2026-05-01 21:57:34,071 - INFO - Waiting up to 180s for pod to become ready...
2026-05-01 21:57:36,230 - INFO - Sandbox 'sandbox-claim-9aca5464' successfully restored from snapshot '090f17b8-e5a3-46c3-ab35-2d074b658938'.
Sandbox resumed. Restored from Snapshot UID: 090f17b8-e5a3-46c3-ab35-2d074b658938

======= Testing List and Delete =======

Listing all snapshots for sandbox 'sandbox-claim-9aca5464'...
2026-05-01 21:57:46,279 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=1f100339,tenant-id=test-tenant,user-id=test-user
2026-05-01 21:57:46,336 - INFO - Found 3 snapshots.
Snapshot UID: 090f17b8-e5a3-46c3-ab35-2d074b658938, Source Pod: sandbox-claim-9aca5464, Creation Time: 2026-05-01T21:57:27Z
Snapshot UID: 6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657, Source Pod: sandbox-claim-9aca5464, Creation Time: 2026-05-01T21:57:24Z
Snapshot UID: d36d1363-a7c4-4559-8e35-b5478e60aef1, Source Pod: sandbox-claim-9aca5464, Creation Time: 2026-05-01T21:57:11Z

Deleting snapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' of the sandbox 'sandbox-claim-9aca5464'...
2026-05-01 21:57:46,336 - INFO - Deleting PodSnapshot '090f17b8-e5a3-46c3-ab35-2d074b658938'...
2026-05-01 21:57:46,399 - INFO - PodSnapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' deletion requested. Waiting for confirmation...
2026-05-01 21:57:46,447 - INFO - Waiting for PodSnapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' to be deleted...
2026-05-01 21:57:47,067 - INFO - PodSnapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' confirmed deleted.
2026-05-01 21:57:47,067 - INFO - Snapshot deletion process completed. Deleted 1 snapshots.
Snapshot '090f17b8-e5a3-46c3-ab35-2d074b658938' deleted successfully.

Deleting all snapshots for sandbox 'sandbox-claim-9aca5464'...
2026-05-01 21:57:47,068 - INFO - Deleting every snapshot for this pod...
2026-05-01 21:57:47,068 - INFO - Deleting ALL snapshots for this pod.
2026-05-01 21:57:47,068 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=1f100339
2026-05-01 21:57:47,202 - INFO - Found 2 snapshots.
2026-05-01 21:57:47,202 - INFO - Deleting PodSnapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657'...
2026-05-01 21:57:47,266 - INFO - PodSnapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657' deletion requested. Waiting for confirmation...
2026-05-01 21:57:47,317 - INFO - Waiting for PodSnapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657' to be deleted...
2026-05-01 21:57:47,887 - INFO - PodSnapshot '6bcf2a2d-dfbf-4dcc-9c6d-d116dad62657' confirmed deleted.
2026-05-01 21:57:47,887 - INFO - Deleting PodSnapshot 'd36d1363-a7c4-4559-8e35-b5478e60aef1'...
2026-05-01 21:57:48,062 - INFO - PodSnapshot 'd36d1363-a7c4-4559-8e35-b5478e60aef1' deletion requested. Waiting for confirmation...
2026-05-01 21:57:48,112 - INFO - Waiting for PodSnapshot 'd36d1363-a7c4-4559-8e35-b5478e60aef1' to be deleted...
2026-05-01 21:57:48,668 - INFO - PodSnapshot 'd36d1363-a7c4-4559-8e35-b5478e60aef1' confirmed deleted.
2026-05-01 21:57:48,669 - INFO - Snapshot deletion process completed. Deleted 2 snapshots.
Snapshots deleted successfully.
--- Pod Snapshot Test Passed! ---
Cleaning up all sandboxes...
2026-05-01 21:57:48,812 - INFO - Deleted PodSnapshotManualTrigger 'test-snapshot-10-20260501-215711-04d45ad5'
2026-05-01 21:57:48,876 - INFO - Deleted PodSnapshotManualTrigger 'test-snapshot-20-20260501-215724-acb32681'
2026-05-01 21:57:48,938 - INFO - Deleted PodSnapshotManualTrigger 'suspend-sandbox-claim-9aca5464-20260501-215727-33eeb61f'
2026-05-01 21:57:48,939 - INFO - Connection to sandbox claim 'sandbox-claim-9aca5464' has been closed.
2026-05-01 21:57:49,001 - INFO - Terminated SandboxClaim: sandbox-claim-9aca5464

--- Sandbox Client Test Finished ---
```
