### PR TITLE
[RFC] Add claimed label to agent_sandboxes metric

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -101,7 +101,7 @@ var (
 	// - expired: "true" | "false"
 	// - launch_type: "warm" | "cold"
 	// - sandbox_template: sandboxTemplateRef.
-	// - owned_by: "SandboxClaim" | "Warmpool" | "None"
+	// - owned_by: "SandboxClaim" | "Warmpool" | "None".
 	AgentSandboxesDesc = prometheus.NewDesc(
 		"agent_sandboxes",
 		"Monitor the point-in-time number of sandboxes in the cluster.",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -104,7 +104,7 @@ var (
 	AgentSandboxesDesc = prometheus.NewDesc(
 		"agent_sandboxes",
 		"Monitor the point-in-time number of sandboxes in the cluster.",
-		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template"},
+		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template", "claimed"},
 		nil,
 	)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -101,10 +101,11 @@ var (
 	// - expired: "true" | "false"
 	// - launch_type: "warm" | "cold"
 	// - sandbox_template: sandboxTemplateRef.
+	// - owned_by: "SandboxClaim" | "Warmpool" | "None"
 	AgentSandboxesDesc = prometheus.NewDesc(
 		"agent_sandboxes",
 		"Monitor the point-in-time number of sandboxes in the cluster.",
-		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template", "claimed"},
+		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template", "owned_by"},
 		nil,
 	)
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -101,7 +101,7 @@ var (
 	// - expired: "true" | "false"
 	// - launch_type: "warm" | "cold"
 	// - sandbox_template: sandboxTemplateRef.
-	// - owned_by: "SandboxClaim" | "Warmpool" | "None".
+	// - owned_by: "SandboxClaim" | "SandboxWarmPool" | "None".
 	AgentSandboxesDesc = prometheus.NewDesc(
 		"agent_sandboxes",
 		"Monitor the point-in-time number of sandboxes in the cluster.",

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -39,7 +39,7 @@ type AgentSandboxesMetricKey struct {
 	Expired        string
 	LaunchType     string
 	Template       string
-	Claimed        string
+	OwnedBy        string
 }
 
 // NewAgentSandboxesConstMetric creates a new Prometheus ConstMetric for the agent_sandboxes gauge.
@@ -53,7 +53,7 @@ func NewAgentSandboxesConstMetric(count int, key AgentSandboxesMetricKey) promet
 		key.Expired,
 		key.LaunchType,
 		key.Template,
-		key.Claimed,
+		key.OwnedBy,
 	)
 }
 
@@ -135,9 +135,13 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			sandboxTemplateStr = template
 		}
 
-		claimedStr := "false"
-		if controllerRef := metav1.GetControllerOf(&sandbox); controllerRef != nil && controllerRef.Kind == "SandboxClaim" {
-			claimedStr = "true"
+		ownedByStr := "None"
+		if controllerRef := metav1.GetControllerOf(&sandbox); controllerRef != nil {
+			if controllerRef.Kind == "SandboxClaim" {
+				ownedByStr = "SandboxClaim"
+			} else if controllerRef.Kind == "SandboxWarmPool" {
+				ownedByStr = "Warmpool"
+			}
 		}
 
 		key := AgentSandboxesMetricKey{
@@ -146,7 +150,7 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			Expired:        expiredStr,
 			LaunchType:     launchTypeStr,
 			Template:       sandboxTemplateStr,
-			Claimed:        claimedStr,
+			OwnedBy:        ownedByStr,
 		}
 		counts[key]++
 	}

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -137,9 +137,9 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 
 		ownedByStr := "None"
 		if controllerRef := metav1.GetControllerOf(&sandbox); controllerRef != nil {
-			if controllerRef.Kind == "SandboxClaim" {
+			if controllerRef.Kind == "SandboxClaim" && controllerRef.APIVersion == "extensions.agents.x-k8s.io/v1alpha1" {
 				ownedByStr = "SandboxClaim"
-			} else if controllerRef.Kind == "SandboxWarmPool" {
+			} else if controllerRef.Kind == "SandboxWarmPool" && controllerRef.APIVersion == "extensions.agents.x-k8s.io/v1alpha1" {
 				ownedByStr = "Warmpool"
 			}
 		}

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -39,6 +39,7 @@ type AgentSandboxesMetricKey struct {
 	Expired        string
 	LaunchType     string
 	Template       string
+	Claimed        string
 }
 
 // NewAgentSandboxesConstMetric creates a new Prometheus ConstMetric for the agent_sandboxes gauge.
@@ -52,6 +53,7 @@ func NewAgentSandboxesConstMetric(count int, key AgentSandboxesMetricKey) promet
 		key.Expired,
 		key.LaunchType,
 		key.Template,
+		key.Claimed,
 	)
 }
 
@@ -133,12 +135,18 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			sandboxTemplateStr = template
 		}
 
+		claimedStr := "false"
+		if controllerRef := metav1.GetControllerOf(&sandbox); controllerRef != nil && controllerRef.Kind == "SandboxClaim" {
+			claimedStr = "true"
+		}
+
 		key := AgentSandboxesMetricKey{
 			Namespace:      sandbox.Namespace,
 			ReadyCondition: readyConditionStr,
 			Expired:        expiredStr,
 			LaunchType:     launchTypeStr,
 			Template:       sandboxTemplateStr,
+			Claimed:        claimedStr,
 		}
 		counts[key]++
 	}

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -135,12 +136,16 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			sandboxTemplateStr = template
 		}
 
+		apiVersion := extensionsv1alpha1.GroupVersion.String()
 		ownedByStr := "None"
 		if controllerRef := metav1.GetControllerOf(&sandbox); controllerRef != nil {
-			if controllerRef.Kind == "SandboxClaim" && controllerRef.APIVersion == "extensions.agents.x-k8s.io/v1alpha1" {
-				ownedByStr = "SandboxClaim"
-			} else if controllerRef.Kind == "SandboxWarmPool" && controllerRef.APIVersion == "extensions.agents.x-k8s.io/v1alpha1" {
-				ownedByStr = "Warmpool"
+			if controllerRef.APIVersion == apiVersion {
+				switch controllerRef.Kind {
+				case "SandboxClaim":
+					ownedByStr = "SandboxClaim"
+				case "SandboxWarmPool":
+					ownedByStr = "SandboxWarmPool"
+				}
 			}
 		}
 

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -62,7 +62,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown": 1,
+				"claimed:false expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -80,7 +80,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown": 1,
+				"claimed:false expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -150,9 +150,41 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 3, // We expect 3 distinct metric series for the 4 sandboxes
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown":     1,
-				"expired:true launch_type:warm namespace:test-ns ready_condition:false sandbox_template:my-template": 1,
-				"expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown":    2,
+				"claimed:false expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown":     1,
+				"claimed:false expired:true launch_type:warm namespace:test-ns ready_condition:false sandbox_template:my-template": 1,
+				"claimed:false expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown":    2,
+			},
+		},
+		{
+			name: "claimed sandbox",
+			sandboxes: []runtime.Object{
+				&sandboxv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-claimed",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "agents.x-k8s.io/v1alpha1",
+								Kind:       "SandboxClaim",
+								Name:       "my-claim",
+								UID:        "1234",
+								Controller: new(true),
+							},
+						},
+					},
+					Status: sandboxv1alpha1.SandboxStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"claimed:true expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 	}

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
-	"k8s.io/utils/ptr"
 )
 
 func newFakeClient(objects ...runtime.Object) *fake.ClientBuilder {
@@ -37,6 +36,7 @@ func newFakeClient(objects ...runtime.Object) *fake.ClientBuilder {
 }
 
 func TestSandboxCollector(t *testing.T) {
+	trueVal := true
 	testCases := []struct {
 		name           string
 		sandboxes      []runtime.Object
@@ -169,7 +169,7 @@ func TestSandboxCollector(t *testing.T) {
 								Kind:       "SandboxClaim",
 								Name:       "my-claim",
 								UID:        "1234",
-								Controller: ptr.To(true),
+								Controller: &trueVal,
 							},
 						},
 					},
@@ -201,7 +201,7 @@ func TestSandboxCollector(t *testing.T) {
 								Kind:       "SandboxWarmPool",
 								Name:       "my-warmpool",
 								UID:        "5678",
-								Controller: ptr.To(true),
+								Controller: &trueVal,
 							},
 						},
 					},

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	"k8s.io/utils/ptr"
 )
 
 func newFakeClient(objects ...runtime.Object) *fake.ClientBuilder {
@@ -164,11 +165,11 @@ func TestSandboxCollector(t *testing.T) {
 						Namespace: "default",
 						OwnerReferences: []metav1.OwnerReference{
 							{
-								APIVersion: "agents.x-k8s.io/v1alpha1",
+								APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
 								Kind:       "SandboxClaim",
 								Name:       "my-claim",
 								UID:        "1234",
-								Controller: new(true),
+								Controller: ptr.To(true),
 							},
 						},
 					},
@@ -200,7 +201,7 @@ func TestSandboxCollector(t *testing.T) {
 								Kind:       "SandboxWarmPool",
 								Name:       "my-warmpool",
 								UID:        "5678",
-								Controller: new(true),
+								Controller: ptr.To(true),
 							},
 						},
 					},

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -62,7 +62,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"claimed:false expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown": 1,
+				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -80,7 +80,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"claimed:false expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown": 1,
+				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -150,9 +150,9 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 3, // We expect 3 distinct metric series for the 4 sandboxes
 			expectedLabels: map[string]int{
-				"claimed:false expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown":     1,
-				"claimed:false expired:true launch_type:warm namespace:test-ns ready_condition:false sandbox_template:my-template": 1,
-				"claimed:false expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown":    2,
+				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown":     1,
+				"expired:true launch_type:warm namespace:test-ns owned_by:None ready_condition:false sandbox_template:my-template": 1,
+				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown":    2,
 			},
 		},
 		{
@@ -184,7 +184,39 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"claimed:true expired:false launch_type:cold namespace:default ready_condition:true sandbox_template:unknown": 1,
+				"expired:false launch_type:cold namespace:default owned_by:SandboxClaim ready_condition:true sandbox_template:unknown": 1,
+			},
+		},
+		{
+			name: "warmpool sandbox",
+			sandboxes: []runtime.Object{
+				&sandboxv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-warmpool",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+								Kind:       "SandboxWarmPool",
+								Name:       "my-warmpool",
+								UID:        "5678",
+								Controller: new(true),
+							},
+						},
+					},
+					Status: sandboxv1alpha1.SandboxStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"expired:false launch_type:cold namespace:default owned_by:Warmpool ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 	}

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -217,7 +217,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:Warmpool ready_condition:true sandbox_template:unknown": 1,
+				"expired:false launch_type:cold namespace:default owned_by:SandboxWarmPool ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 	}


### PR DESCRIPTION
### Problem Statement

Currently, the `agent_sandboxes` metric does not distinguish between sandboxes that are actively claimed by a user/agent and those that are sitting idle in the warm pool. This makes it difficult to track actual utilization of the sandbox pool from metrics alone.

### Proposed Solution (RFC)

To provide a more reliable and explicit way to track this state, this PR proposes adding a `claimed="true|false"` label to the `agent_sandboxes` metric.

Instead of relying on annotations, this implementation checks the `OwnerReferences` of the `Sandbox` resource. If the `Sandbox` is controlled by a `SandboxClaim`, it is marked as `claimed="true"`. Otherwise, it defaults to `"false"`.

This approach keeps the metric cardinality low (only two values for `claimed`) while providing high-value visibility into the actual utilization of the sandbox pool.

### Intention

This PR is submitted as an **RFC (Request for Comments)**. While the code is functional and includes unit tests, the primary goal is to start a discussion on the best way to model this state in our metrics and to seek general advice on **actionable metrics** for the Sandbox system.

Specifically, we are interested in metrics that can help answer operational questions such as:
- **Is the warm pool healthy?** (e.g., detecting unusable or stuck sandboxes in the warm pool).
- **Do we need to upsize the sandbox serving cluster?** (e.g., tracking current utilization relative to max nodes limit).
- **Corroborating upstream systems**: Providing numbers on concurrent sandboxes actively being used (claimed) to compare with upstream expectations.

We are also looking for feedback on:
- Whether a boolean `claimed` label is the right abstraction for this specific metric.
- What other metrics would be valuable to make the system more observable and operable (e.g., warm pool depletion rate, detailed breakdown of startup latency stages).
- If this aligns with the project's long-term observability goals.

We hope this sparks some inspiration and discussion!

### Changes Included
- `internal/metrics/metrics.go`: Added `"claimed"` to `AgentSandboxesDesc` labels.
- `internal/metrics/sandbox_collector.go`: Updated `Collect` method to check `OwnerReferences` and set the `claimed` label.
- `internal/metrics/sandbox_collector_test.go`: Added test cases to verify the new label behavior.

### Verification Results
- Unit tests passed: `go test -v ./internal/metrics/...`
- Linter passed with 0 issues.
