### PR TITLE
[RFC] Add agent_sandbox_claims metric to track claim states

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -237,6 +237,7 @@ func main() {
 
 	if extensions {
 		warmSandboxQueue := queue.NewSimpleSandboxQueue()
+		asmetrics.RegisterSandboxClaimCollector(mgr.GetClient(), mgr.GetLogger().WithName("sandboxclaim-collector"))
 		if err = (&extensionscontrollers.SandboxClaimReconciler{
 			Client:           mgr.GetClient(),
 			Scheme:           mgr.GetScheme(),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -108,6 +108,19 @@ var (
 		nil,
 	)
 
+	// AgentSandboxClaimsDesc describes the agent_sandbox_claims metric point-in-time counts.
+	// Labels:
+	// - namespace: the namespace of the claim
+	// - ready_status: "true" | "false"
+	// - reason: condition reason (e.g., "ClaimExpired", "SandboxMissing")
+	// - sandbox_template: sandboxTemplateRef.
+	AgentSandboxClaimsDesc = prometheus.NewDesc(
+		"agent_sandbox_claims",
+		"Monitor the point-in-time number of sandbox claims in the cluster.",
+		[]string{"namespace", "ready_status", "reason", "sandbox_template"},
+		nil,
+	)
+
 	buildVersionInfo = version.Get()
 
 	// BuildInfo exposes agent-sandbox-controller build metadata as a constant gauge.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -111,13 +111,13 @@ var (
 	// AgentSandboxClaimsDesc describes the agent_sandbox_claims metric point-in-time counts.
 	// Labels:
 	// - namespace: the namespace of the claim
-	// - ready_status: "true" | "false"
+	// - ready_condition: "true" | "false"
 	// - reason: condition reason (e.g., "ClaimExpired", "SandboxMissing")
 	// - sandbox_template: sandboxTemplateRef.
 	AgentSandboxClaimsDesc = prometheus.NewDesc(
 		"agent_sandbox_claims",
 		"Monitor the point-in-time number of sandbox claims in the cluster.",
-		[]string{"namespace", "ready_status", "reason", "sandbox_template"},
+		[]string{"namespace", "ready_condition", "reason", "sandbox_template"},
 		nil,
 	)
 

--- a/internal/metrics/sandboxclaim_collector.go
+++ b/internal/metrics/sandboxclaim_collector.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// AgentSandboxClaimsMetricKey is used to aggregate counts for identical SandboxClaims metric label combinations.
+type AgentSandboxClaimsMetricKey struct {
+	Namespace   string
+	ReadyStatus string
+	Reason      string
+	Template    string
+}
+
+// NewAgentSandboxClaimsConstMetric creates a new Prometheus ConstMetric for the agent_sandbox_claims gauge.
+func NewAgentSandboxClaimsConstMetric(count int, key AgentSandboxClaimsMetricKey) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		AgentSandboxClaimsDesc,
+		prometheus.GaugeValue,
+		float64(count),
+		key.Namespace,
+		key.ReadyStatus,
+		key.Reason,
+		key.Template,
+	)
+}
+
+// RegisterSandboxClaimCollector registers the custom Prometheus collector for sandbox claim counts.
+func RegisterSandboxClaimCollector(c client.Client, logger logr.Logger) {
+	collector := NewSandboxClaimCollector(c, logger)
+	if err := metrics.Registry.Register(collector); err != nil {
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			logger.Error(err, "Failed to register SandboxClaimCollector")
+		} else {
+			logger.Info("SandboxClaimCollector already registered, ignoring")
+		}
+	}
+}
+
+// SandboxClaimCollector is a custom Prometheus collector that dynamically fetches sandbox claim counts.
+type SandboxClaimCollector struct {
+	client                 client.Client
+	logger                 logr.Logger
+	agentSandboxClaimsDesc *prometheus.Desc
+}
+
+// NewSandboxClaimCollector initializes a SandboxClaimCollector.
+func NewSandboxClaimCollector(c client.Client, logger logr.Logger) *SandboxClaimCollector {
+	return &SandboxClaimCollector{
+		client:                 c,
+		logger:                 logger,
+		agentSandboxClaimsDesc: AgentSandboxClaimsDesc,
+	}
+}
+
+// Describe sends the metric descriptor to the channel.
+func (c *SandboxClaimCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.agentSandboxClaimsDesc
+}
+
+// Collect fetches sandbox claims, calculates labels, and sends metrics to the channel.
+func (c *SandboxClaimCollector) Collect(ch chan<- prometheus.Metric) {
+	var claimList extensionsv1alpha1.SandboxClaimList
+	ctx, cancel := context.WithTimeout(context.Background(), metricsCollectTimeout)
+	defer cancel()
+
+	if err := c.client.List(ctx, &claimList); err != nil {
+		c.logger.Error(err, "Failed to list sandbox claims for metrics collection")
+		return
+	}
+
+	counts := make(map[AgentSandboxClaimsMetricKey]int)
+	for _, claim := range claimList.Items {
+		readyStatusStr := "false"
+		reasonStr := "Unknown"
+
+		readyCond := meta.FindStatusCondition(claim.Status.Conditions, string(sandboxv1alpha1.SandboxConditionReady))
+		if readyCond != nil {
+			if readyCond.Status == metav1.ConditionTrue {
+				readyStatusStr = "true"
+			}
+			reasonStr = readyCond.Reason
+		}
+
+		templateStr := claim.Spec.TemplateRef.Name
+
+		key := AgentSandboxClaimsMetricKey{
+			Namespace:   claim.Namespace,
+			ReadyStatus: readyStatusStr,
+			Reason:      reasonStr,
+			Template:    templateStr,
+		}
+		counts[key]++
+	}
+
+	for key, count := range counts {
+		ch <- NewAgentSandboxClaimsConstMetric(count, key)
+	}
+}

--- a/internal/metrics/sandboxclaim_collector.go
+++ b/internal/metrics/sandboxclaim_collector.go
@@ -29,10 +29,10 @@ import (
 
 // AgentSandboxClaimsMetricKey is used to aggregate counts for identical SandboxClaims metric label combinations.
 type AgentSandboxClaimsMetricKey struct {
-	Namespace   string
-	ReadyStatus string
-	Reason      string
-	Template    string
+	Namespace      string
+	ReadyCondition string
+	Reason         string
+	Template       string
 }
 
 // NewAgentSandboxClaimsConstMetric creates a new Prometheus ConstMetric for the agent_sandbox_claims gauge.
@@ -42,7 +42,7 @@ func NewAgentSandboxClaimsConstMetric(count int, key AgentSandboxClaimsMetricKey
 		prometheus.GaugeValue,
 		float64(count),
 		key.Namespace,
-		key.ReadyStatus,
+		key.ReadyCondition,
 		key.Reason,
 		key.Template,
 	)
@@ -87,6 +87,9 @@ func (c *SandboxClaimCollector) Collect(ch chan<- prometheus.Metric) {
 	ctx, cancel := context.WithTimeout(context.Background(), metricsCollectTimeout)
 	defer cancel()
 
+	// TODO(chw120): The current O(N) List call during metrics collection poses a scalability concern.
+	// In large clusters, frequent scrapes could lead to high CPU usage or OOM.
+	// This should be replaced with a more efficient implementation.
 	if err := c.client.List(ctx, &claimList); err != nil {
 		c.logger.Error(err, "Failed to list sandbox claims for metrics collection")
 		return
@@ -94,24 +97,27 @@ func (c *SandboxClaimCollector) Collect(ch chan<- prometheus.Metric) {
 
 	counts := make(map[AgentSandboxClaimsMetricKey]int)
 	for _, claim := range claimList.Items {
-		readyStatusStr := "false"
+		readyConditionStr := "false"
 		reasonStr := "Unknown"
 
 		readyCond := meta.FindStatusCondition(claim.Status.Conditions, string(sandboxv1alpha1.SandboxConditionReady))
 		if readyCond != nil {
 			if readyCond.Status == metav1.ConditionTrue {
-				readyStatusStr = "true"
+				readyConditionStr = "true"
 			}
 			reasonStr = readyCond.Reason
 		}
 
 		templateStr := claim.Spec.TemplateRef.Name
+		if templateStr == "" {
+			templateStr = "unknown"
+		}
 
 		key := AgentSandboxClaimsMetricKey{
-			Namespace:   claim.Namespace,
-			ReadyStatus: readyStatusStr,
-			Reason:      reasonStr,
-			Template:    templateStr,
+			Namespace:      claim.Namespace,
+			ReadyCondition: readyConditionStr,
+			Reason:         reasonStr,
+			Template:       templateStr,
 		}
 		counts[key]++
 	}

--- a/internal/metrics/sandboxclaim_collector_test.go
+++ b/internal/metrics/sandboxclaim_collector_test.go
@@ -1,0 +1,264 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+)
+
+func newFakeClientWithClaims(objects ...runtime.Object) *fake.ClientBuilder {
+	scheme := runtime.NewScheme()
+	_ = sandboxv1alpha1.AddToScheme(scheme)
+	_ = extensionsv1alpha1.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...)
+}
+
+func TestSandboxClaimCollector(t *testing.T) {
+	testCases := []struct {
+		name           string
+		claims         []runtime.Object
+		expectedCount  int
+		expectedLabels map[string]int
+	}{
+		{
+			name: "single ready claim",
+			claims: []runtime.Object{
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-1",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "my-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+								Reason: "SandboxReady",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"namespace:default ready_status:true reason:SandboxReady sandbox_template:my-template": 1,
+			},
+		},
+		{
+			name: "pending claim missing sandbox",
+			claims: []runtime.Object{
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-pending",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "my-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionFalse,
+								Reason: "SandboxMissing",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"namespace:default ready_status:false reason:SandboxMissing sandbox_template:my-template": 1,
+			},
+		},
+		{
+			name: "failed claim template not found",
+			claims: []runtime.Object{
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-failed",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "missing-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionFalse,
+								Reason: "TemplateNotFound",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"namespace:default ready_status:false reason:TemplateNotFound sandbox_template:missing-template": 1,
+			},
+		},
+		{
+			name: "expired claim",
+			claims: []runtime.Object{
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-expired",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "my-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionFalse,
+								Reason: "ClaimExpired",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"namespace:default ready_status:false reason:ClaimExpired sandbox_template:my-template": 1,
+			},
+		},
+		{
+			name: "mixed claims",
+			claims: []runtime.Object{
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-1",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "my-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+								Reason: "SandboxReady",
+							},
+						},
+					},
+				},
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-2",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "my-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+								Reason: "SandboxReady",
+							},
+						},
+					},
+				},
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-3",
+						Namespace: "test-ns",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "other-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1alpha1.SandboxConditionReady),
+								Status: metav1.ConditionFalse,
+								Reason: "SandboxMissing",
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 2, // 2 series: (default, true, SandboxReady, my-template) and (test-ns, false, SandboxMissing, other-template)
+			expectedLabels: map[string]int{
+				"namespace:default ready_status:true reason:SandboxReady sandbox_template:my-template": 2,
+				"namespace:test-ns ready_status:false reason:SandboxMissing sandbox_template:other-template": 1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := newFakeClientWithClaims(tc.claims...).Build()
+			collector := NewSandboxClaimCollector(fakeClient, logr.Discard())
+			registry := prometheus.NewRegistry()
+			registry.MustRegister(collector)
+			count, err := testutil.GatherAndCount(registry, "agent_sandbox_claims")
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCount, count)
+			metrics, err := registry.Gather()
+			require.NoError(t, err)
+			actualLabels := make(map[string]int)
+			for _, mf := range metrics {
+				if mf.GetName() == "agent_sandbox_claims" {
+					for _, m := range mf.GetMetric() {
+						labelStr := ""
+						for _, l := range m.GetLabel() {
+							labelStr += l.GetName() + ":" + l.GetValue() + " "
+						}
+						// Trim trailing space
+						if len(labelStr) > 0 {
+							labelStr = labelStr[:len(labelStr)-1]
+						}
+						actualLabels[labelStr] = int(m.GetGauge().GetValue())
+					}
+				}
+			}
+			require.Equal(t, tc.expectedLabels, actualLabels)
+		})
+	}
+}

--- a/internal/metrics/sandboxclaim_collector_test.go
+++ b/internal/metrics/sandboxclaim_collector_test.go
@@ -225,7 +225,7 @@ func TestSandboxClaimCollector(t *testing.T) {
 			},
 			expectedCount: 2, // 2 series: (default, true, SandboxReady, my-template) and (test-ns, false, SandboxMissing, other-template)
 			expectedLabels: map[string]int{
-				"namespace:default ready_status:true reason:SandboxReady sandbox_template:my-template": 2,
+				"namespace:default ready_status:true reason:SandboxReady sandbox_template:my-template":       2,
 				"namespace:test-ns ready_status:false reason:SandboxMissing sandbox_template:other-template": 1,
 			},
 		},

--- a/internal/metrics/sandboxclaim_collector_test.go
+++ b/internal/metrics/sandboxclaim_collector_test.go
@@ -69,7 +69,7 @@ func TestSandboxClaimCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"namespace:default ready_status:true reason:SandboxReady sandbox_template:my-template": 1,
+				"namespace:default ready_condition:true reason:SandboxReady sandbox_template:my-template": 1,
 			},
 		},
 		{
@@ -98,7 +98,7 @@ func TestSandboxClaimCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"namespace:default ready_status:false reason:SandboxMissing sandbox_template:my-template": 1,
+				"namespace:default ready_condition:false reason:SandboxMissing sandbox_template:my-template": 1,
 			},
 		},
 		{
@@ -127,7 +127,7 @@ func TestSandboxClaimCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"namespace:default ready_status:false reason:TemplateNotFound sandbox_template:missing-template": 1,
+				"namespace:default ready_condition:false reason:TemplateNotFound sandbox_template:missing-template": 1,
 			},
 		},
 		{
@@ -156,7 +156,30 @@ func TestSandboxClaimCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"namespace:default ready_status:false reason:ClaimExpired sandbox_template:my-template": 1,
+				"namespace:default ready_condition:false reason:ClaimExpired sandbox_template:my-template": 1,
+			},
+		},
+		{
+			name: "claim without conditions",
+			claims: []runtime.Object{
+				&extensionsv1alpha1.SandboxClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "claim-no-cond",
+						Namespace: "default",
+					},
+					Spec: extensionsv1alpha1.SandboxClaimSpec{
+						TemplateRef: extensionsv1alpha1.SandboxTemplateRef{
+							Name: "my-template",
+						},
+					},
+					Status: extensionsv1alpha1.SandboxClaimStatus{
+						Conditions: nil,
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"namespace:default ready_condition:false reason:Unknown sandbox_template:my-template": 1,
 			},
 		},
 		{
@@ -225,8 +248,8 @@ func TestSandboxClaimCollector(t *testing.T) {
 			},
 			expectedCount: 2, // 2 series: (default, true, SandboxReady, my-template) and (test-ns, false, SandboxMissing, other-template)
 			expectedLabels: map[string]int{
-				"namespace:default ready_status:true reason:SandboxReady sandbox_template:my-template":       2,
-				"namespace:test-ns ready_status:false reason:SandboxMissing sandbox_template:other-template": 1,
+				"namespace:default ready_condition:true reason:SandboxReady sandbox_template:my-template":       2,
+				"namespace:test-ns ready_condition:false reason:SandboxMissing sandbox_template:other-template": 1,
 			},
 		},
 	}


### PR DESCRIPTION
### Problem Statement

In a previous RFC ([#711](https://github.com/kubernetes-sigs/agent-sandbox/pull/711)), we discussed improving observability for sandbox utilization by adding a `claimed` label to the `agent_sandboxes` metric. While tracking claimed sandboxes helps, it does not provide visibility into the state of `SandboxClaims` themselves. Specifically, we cannot currently see how many claims are pending (waiting for a sandbox), failed, or expired and retained without looking at individual resource statuses.

### Proposed Solution

As a follow-up to that discussion and to address the need for better claim-level observability, this PR proposes a new Gauge metric `agent_sandbox_claims` to track the point-in-time number of sandbox claims in the cluster.

To avoid creating artificial states that might diverge from controller logic, this implementation exposes labels that directly reflect the underlying `Ready` condition of the claim:
- `ready_status`: `"true"` | `"false"`
- `reason`: The condition reason (e.g., `SandboxMissing`, `TemplateNotFound`, `ClaimExpired`).

This provides high-fidelity visibility into why claims are not ready, enabling better monitoring of pending queues and provisioning failures.

### Intention

Similar to PR #771, this PR is submitted as an **RFC (Request for Comments)**. While the implementation is functional and includes unit tests, it is **not intended to be merged as is**. The primary goal is to inspire discussion on the best way to achieve these observability goals and to determine if this metric provides the expected operational value.

We are seeking feedback on:
- Whether exposing `ready_status` and `reason` as labels is the right abstraction.
- If this metric provides the expected operational value for tracking user experience and system health.
- If there is a better way to achieve these goals (e.g., using different metric types, different labels, or relying more on tracing).

### Changes Included
- `internal/metrics/metrics.go`: Defined `AgentSandboxClaimsDesc`.
- `internal/metrics/sandboxclaim_collector.go`: Implemented `SandboxClaimCollector` to fetch and aggregate counts.
- `cmd/agent-sandbox-controller/main.go`: Registered the new collector when extensions are enabled.
- `internal/metrics/sandboxclaim_collector_test.go`: Added unit tests to verify the collector logic.

### Verification Results
- Unit tests passed: `go test ./internal/metrics/...`
