### PR TITLE
docs: fix e2e benchmark test command

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ make test-e2e
 ## Running only e2e benchmarks
 To run only e2e benchmarks:
 ```shell
-make test-e2e --suite=benchmarks
+make test-e2e-benchmarks
 ```
 ## Running Tests with Race Detector
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Updates the testing docs to use the existing `make test-e2e-benchmarks` target instead of passing `--suite=benchmarks` directly to `make`, which is not valid make syntax.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Verified with `make -n test-e2e-benchmarks`.
