### PR TITLE
Update apiVersion to v1beta2 for kueue-agent-sandbox

### DIFF
--- a/examples/kueue-agent-sandbox/README.md
+++ b/examples/kueue-agent-sandbox/README.md
@@ -15,13 +15,13 @@ Kueue is designed for batch workloads that run to completion, while Agent Sandbo
 ## Step 1: Create Kueue Queues
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
@@ -37,7 +37,7 @@ spec:
       - name: memory
         nominalQuota: 1Gi
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: user-queue
@@ -66,7 +66,7 @@ spec:
   podTemplate:
     metadata:
       labels:
-        kueue.x-k8s.io/queue-name: sandbox-local-queue
+        kueue.x-k8s.io/queue-name: user-queue
     spec:
       restartPolicy: Never
       containers:
@@ -93,7 +93,7 @@ kubectl apply -f sandbox-kueue.yaml
 Kueue uses this label to associate sandbox pods with a queue for admission control:
 
 ```
-kueue.x-k8s.io/queue-name: sandbox-local-queue
+kueue.x-k8s.io/queue-name: user-queue
 ```
 
 ## How it works


### PR DESCRIPTION
## Fixes #662

## Title 
Update apiVersion for Kueue integration example for Agent Sandbox

## Description

This PR updates the apiVersion of the Kueue integration example for Agent Sandbox to v1beta2

## Changes
- Updated the apiVersion to kueue.x-k8s.io/v1beta2 from v1beta1
- Updated the queue-name: user-queue from sandbox-local-queue