### PR TITLE
[WIP]export sandbox label constant and reuse across controllers

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -47,6 +47,9 @@ const (
 	SandboxPropagatedLabelsAnnotation = "agents.x-k8s.io/propagated-labels"
 	// SandboxPropagatedAnnotationsAnnotation is the annotation used to track the annotations explicitly propagated from sandbox spec to pod.
 	SandboxPropagatedAnnotationsAnnotation = "agents.x-k8s.io/propagated-annotations"
+	// SandboxNameHashLabel is a shared label used by controllers and extensions
+	// to associate resources with a Sandbox.
+	SandboxNameHashLabel = sandboxv1alpha1.SandboxNameHashLabel
 )
 
 type PodMetadata struct {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
+	sandboxLabel                = sandboxv1alpha1.SandboxNameHashLabel
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
 )

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -992,7 +992,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 						"custom-label":                      "label-val",
 					},
 					Annotations: map[string]string{
@@ -1023,7 +1023,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "1",
 					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 						"custom-label":                      "label-val",
 					},
 					Annotations: map[string]string{
@@ -1128,7 +1128,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
@@ -1257,7 +1257,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "1",
 					Labels: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					Annotations: map[string]string{
 						"agents.x-k8s.io/template":               "default",
@@ -1321,7 +1321,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "1",
 					Labels: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					Annotations: map[string]string{
 						"agents.x-k8s.io/template":               "default",
@@ -1555,7 +1555,7 @@ func TestReconcilePod(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							sandboxLabel:                   nameHash,
+							sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 							"remove-label":                 "value",
 							"keep-label":                   "value",
 							"agents.x-k8s.io/system-label": "value",
@@ -1603,7 +1603,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						sandboxLabel:                   nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 						"keep-label":                   "value",
 						"agents.x-k8s.io/system-label": "value",
 					},
@@ -1721,14 +1721,14 @@ func TestReconcileService(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "1",
 					Labels: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.ServiceSpec{
 					ClusterIP: "None",
 					Selector: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 				},
 			},
@@ -1780,13 +1780,13 @@ func TestReconcileService(t *testing.T) {
 					ResourceVersion: "2",
 					Labels: map[string]string{
 						"keep":       "me",
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
-						sandboxLabel: nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 				},
 			},
@@ -1838,13 +1838,13 @@ func TestReconcileService(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 				},
 			},
@@ -1894,14 +1894,14 @@ func TestReconcileService(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.ServiceSpec{
 					ClusterIP: "None",
 					Selector: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1alpha1.SandboxNameHashLabel: nameHash,
 					},
 				},
 			},

--- a/dev/load-test/test-recipes/warmpool-burst-test.yaml
+++ b/dev/load-test/test-recipes/warmpool-burst-test.yaml
@@ -121,7 +121,7 @@ steps:
       objectTemplatePath: templates/cluster-loader-sandbox-claim.yaml
     waits:
     - type: Deleted
-      labelSelector: "agents.x-k8s.io/sandbox-name-hash"
+      labelSelector: sandboxv1alpha1.SandboxNameHashLabel
 
 - name: Delete Warmpools and Templates
   phases:

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -79,7 +79,7 @@ func TestSimpleSandbox(t *testing.T) {
 			Service:       "my-sandbox",
 			ServiceFQDN:   fmt.Sprintf("my-sandbox.%s.svc.cluster.local", ns.Name),
 			Replicas:      1,
-			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+			LabelSelector: "sandboxv1alpha1.SandboxNameHashLabel" + "=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
 					Message:            "Pod is Ready; Service Exists",

--- a/test/e2e/extensions/warmpool_sandbox_watcher_test.go
+++ b/test/e2e/extensions/warmpool_sandbox_watcher_test.go
@@ -220,7 +220,7 @@ func TestWarmPoolSandboxWatcher(t *testing.T) {
 			return false
 		}
 
-		_, hasSandboxLabel := adoptedPod.Labels["agents.x-k8s.io/sandbox-name-hash"]
+		_, hasSandboxLabel := adoptedPod.Labels[sandboxv1alpha1.SandboxNameHashLabel]
 		return hasSandboxLabel
 	}, 30*time.Second, 500*time.Millisecond, "sandbox controller should adopt the pod before deletion")
 


### PR DESCRIPTION
## Fixes #216 

## Title 
Export sandbox label constant and reuse across controllers(#216)

## Description
This PR centralizes the agents.x-k8s.io/sandbox-name-hash label definition by moving it to the API package and exporting it as: SandboxNameHashLabel

## Changes
- Move the sandbox name hash label to the API package as SandboxNameHashLabel to avoid duplication and ensure consistency across controllers and extensions.
- Update controller and e2e tests to use the shared constant instead of hardcoding the label value.
- Added exported constant in API: api/v1alpha1/sandbox_types.go
- Updated controller to reuse the shared constant
- Updated e2e test to use the shared constant instead of hardcoded string
- Removed duplicate string usage

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->