### PR TITLE
chore(helm): add podAnnotations and podLabels values to controller chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -97,3 +97,5 @@ The following table lists the configurable parameters and their defaults.
 | `nodeSelector` | Node selector for the controller pod | `{}` |
 | `tolerations` | Tolerations for the controller pod | `[]` |
 | `affinity` | Affinity rules for the controller pod | `{}` |
+| `podAnnotations` | Annotations added to the controller pod template (e.g. service-mesh sidecar toggles, Prometheus scrape autodiscovery) | `{}` |
+| `podLabels` | Extra labels added to the controller pod template alongside the chart's selector labels (selector labels take precedence on conflict) | `{}` |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -14,6 +14,13 @@ spec:
     metadata:
       labels:
         {{- include "agent-sandbox.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: agent-sandbox-controller
       containers:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -12,11 +12,9 @@ spec:
       {{- include "agent-sandbox.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- $selectorLabels := include "agent-sandbox.selectorLabels" . | fromYaml }}
       labels:
-        {{- include "agent-sandbox.selectorLabels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml (merge (dict) $selectorLabels .Values.podLabels) | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,6 +10,22 @@ image:
 
 replicaCount: 1
 
+# podAnnotations are added to the controller pod template.
+# Useful for service-mesh sidecar injection toggles, Prometheus scrape
+# autodiscovery (e.g. Datadog `ad.datadoghq.com/...`), or any platform-
+# specific pod-level annotation.
+podAnnotations: {}
+  # ad.datadoghq.com/agent-sandbox-controller.check_names: '["openmetrics"]'
+  # ad.datadoghq.com/agent-sandbox-controller.init_configs: '[{}]'
+  # ad.datadoghq.com/agent-sandbox-controller.instances: |
+  #   [{"openmetrics_endpoint": "http://%%host%%:8080/metrics", "namespace": "agent_sandbox", "metrics": [".*"]}]
+
+# podLabels are added to the controller pod template, in addition to
+# the chart's selector labels. Useful for cost-allocation labels,
+# network policy selectors, or pod-level metadata.
+podLabels: {}
+  # team: platform
+
 controller:
   ##### Unset flags are omitted
   # clusterDomain: "cluster.local"


### PR DESCRIPTION
## What

Adds `podAnnotations` and `podLabels` values to the controller pod template, both defaulting to `{}`.

```yaml
# helm/values.yaml
podAnnotations: {}
podLabels: {}
```

```yaml
# helm/templates/deployment.yaml
template:
  metadata:
    labels:
      {{- include "agent-sandbox.selectorLabels" . | nindent 8 }}
      {{- with .Values.podLabels }}
      {{- toYaml . | nindent 8 }}
      {{- end }}
    {{- with .Values.podAnnotations }}
    annotations:
      {{- toYaml . | nindent 8 }}
    {{- end }}
```

## Why

Downstream operators frequently need pod-level annotations and labels for things like:

- Prometheus scrape autodiscovery (Datadog `ad.datadoghq.com/...`, Prometheus Operator `prometheus.io/scrape`)
- Service mesh sidecar injection control (Istio, Linkerd)
- Cost allocation labels
- Network policy selectors

Today the chart has no way to set these without forking the rendered manifest, which causes drift on every upstream version bump. The pattern matches what's already done for `nodeSelector`, `affinity`, `tolerations`, and `resources` in this same template, and what's standard across most community Helm charts (Datadog, Prometheus, cert-manager, ingress-nginx, etc.).

## Test plan

- [x] `helm template ./helm --set image.tag=v0.1.1`: rendered Deployment has no `annotations:` block and only the default selector labels — no behavior change for existing users
- [x] `helm template ./helm --set image.tag=v0.1.1 --set podAnnotations.foo=bar --set podLabels.team=platform`: rendered Deployment has `annotations: { foo: bar }` and `team: platform` alongside selector labels under `spec.template.metadata`

## Motivation

Several downstream consumers — including NVIDIA's internal Astra platform — currently fork the manifest to add Datadog OpenMetrics scrape annotations so the controller's `agent_sandbox_claim_creation_total` counter can be reported on. With this change, those operators can set the value cleanly via Helm values and stay on a clean upstream chart.