### PR TITLE
Preserve sandbox selector label when replicas is 0

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
@@ -70,13 +70,15 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
 
 ### Test Phases:
 
-1.  **Phase 1: Starting Counter Sandbox & Snapshotting**:
-    *   Starts a sandbox with a counter application.
-    *   Takes a snapshot (`test-snapshot-10`) after ~10 seconds.
-    *   Takes a snapshot (`test-snapshot-20`) after ~20 seconds.
-2.  **Phase 2: Restoring from Recent Snapshot**:
-    *   Restores a sandbox from the second snapshot.
-    *   Verifies that the sandbox has been restored from the recent snapshot. 
+1.  **Phase 1: Starting Counter Sandbox, Suspend, Resume & Snapshot Deletion**:
+    - Starts a sandbox with a counter application.
+    - Takes two manual snapshots (`test-snapshot-10` and `test-snapshot-20`).
+    - Suspends and resumes the active sandbox.
+    - Verifies lists of all snapshots, deletes a specific snapshot by UID, and cleans up the rest.
+2.  **Phase 2: Testing Suspend/Resume on a New Sandbox Instance**:
+    - Launches a new sandbox instance and suspends it to take a state snapshot.
+    - Resumes the new sandbox instance, which restores from the sandbox's snapshot.
+    - Cleans up the snapshot from the system.
 
 ### Prerequisites
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -162,7 +162,6 @@ class SandboxWithSnapshotSupport(Sandbox):
             )
 
         # Ensure the sandbox name hash is fetched and cached before we scale down to 0 replicas.
-        # If it failed during client init (transient error), retry fetching now while sandbox is still active.
         try:
             sandbox_name_hash = self.get_sandbox_name_hash()
             if not sandbox_name_hash:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -161,6 +161,21 @@ class SandboxWithSnapshotSupport(Sandbox):
                 error_code=SUCCESS_CODE
             )
 
+        # Ensure the sandbox name hash is fetched and cached before we scale down to 0 replicas.
+        # If it failed during client init (transient error), retry fetching now while sandbox is still active.
+        try:
+            sandbox_name_hash = self.get_sandbox_name_hash()
+            if not sandbox_name_hash:
+                raise ValueError(f"Sandbox name hash resolved to empty or None: {sandbox_name_hash}")
+        except Exception as e:
+            logger.error(f"Cannot suspend Sandbox: failed to retrieve required name hash label: {e}")
+            return SuspendResponse(
+                success=False,
+                snapshot_response=None,
+                error_reason=f"Failed to resolve sandbox name hash: {e}",
+                error_code=ERROR_CODE
+            )
+
         snapshot_response = None
         if snapshot_before_suspend and self.snapshots:
             # Generate a unique trigger name for this suspend action

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -56,6 +56,9 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         mock_ctm.return_value = (None, None)
 
         self.mock_k8s_helper = MagicMock()
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {"selector": f"{SANDBOX_NAME_HASH_LABEL}=test-hash"}
+        }
 
         # Create SandboxWithSnapshotSupport
         self.sandbox = SandboxWithSnapshotSupport(
@@ -1142,6 +1145,18 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             self.assertFalse(result.success)
             self.assertIn("Timed out", result.error_reason)
 
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_missing_name_hash(self, mock_is_suspended):
+        """Test suspend fails gracefully when sandbox name hash is missing/not found."""
+        self.sandbox._sandbox_name_hash = None
+        self.mock_k8s_helper.get_sandbox.return_value = {} # No selector info in status
+        
+        result = self.sandbox.suspend(snapshot_before_suspend=False)
+        
+        self.assertFalse(result.success)
+        self.assertIn("Failed to resolve sandbox name hash", result.error_reason)
+        self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_not_called()
+
 
     def test_is_suspended_true(self):
         self.mock_k8s_helper.custom_objects_api.get_namespaced_custom_object.return_value = {
@@ -1159,6 +1174,10 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
 
     def test_get_sandbox_name_hash_success(self):
         """Test get_sandbox_name_hash reads from status.selector and caches it."""
+        # Reset mock from calls made during eager fetch in Sandbox __init__
+        self.mock_k8s_helper.get_sandbox.reset_mock()
+        self.sandbox._sandbox_name_hash = None
+        
         self.mock_k8s_helper.get_sandbox.return_value = {
             "status": {"selector": f"{SANDBOX_NAME_HASH_LABEL}=test-hash-value"}
         }
@@ -1176,6 +1195,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
 
     def test_get_sandbox_name_hash_not_found(self):
         """Test get_sandbox_name_hash returns None when not found."""
+        self.sandbox._sandbox_name_hash = None
         self.mock_k8s_helper.get_sandbox.return_value = {}
         
         res = self.sandbox.get_sandbox_name_hash()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -83,12 +83,6 @@ class Sandbox:
         self._pod_name = None
         self._sandbox_name_hash = None
         
-        # Cache the sandbox name hash while sandbox is running/active
-        try:
-            self.get_sandbox_name_hash()
-        except Exception as e:
-            logging.warning(f"Could not fetch sandbox name hash during initialization: {e}")
-        
     def get_pod_name(self) -> str:
         """Fetches the Sandbox object from Kubernetes and retrieves its current pod name."""
         if self._pod_name is not None:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -83,6 +83,12 @@ class Sandbox:
         self._pod_name = None
         self._sandbox_name_hash = None
         
+        # Cache the sandbox name hash while sandbox is running/active
+        try:
+            self.get_sandbox_name_hash()
+        except Exception as e:
+            logging.warning(f"Could not fetch sandbox name hash during initialization: {e}")
+        
     def get_pod_name(self) -> str:
         """Fetches the Sandbox object from Kubernetes and retrieves its current pod name."""
         if self._pod_name is not None:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import unittest
+
 from unittest.mock import MagicMock, patch
+
 
 from k8s_agent_sandbox.sandbox import Sandbox
 from k8s_agent_sandbox.models import SandboxLocalTunnelConnectionConfig, SandboxTracerConfig
@@ -214,6 +216,42 @@ class TestSandbox(unittest.TestCase):
             mock_close.assert_called_once()
 
         self.mock_k8s_helper.delete_sandbox_claim.assert_called_once_with(self.claim_name, self.namespace)
+
+    def test_get_sandbox_name_hash_from_k8s(self):
+        """Tests retrieving sandbox name hash from status.selector when it is present."""
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {
+                "selector": "agents.x-k8s.io/sandbox-name-hash=abc12345"
+            }
+        }
+        # Verify it returns correct parsed hash
+        self.assertEqual(self.sandbox.get_sandbox_name_hash(), "abc12345")
+        self.mock_k8s_helper.get_sandbox.assert_called_once_with(self.sandbox_id, self.namespace)
+
+    def test_get_sandbox_name_hash_returns_none_when_selector_missing(self):
+        """Tests that get_sandbox_name_hash returns None when status.selector is missing."""
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {}
+        }
+        self.assertIsNone(self.sandbox.get_sandbox_name_hash())
+        self.mock_k8s_helper.get_sandbox.assert_called_once_with(self.sandbox_id, self.namespace)
+
+
+    def test_get_sandbox_name_hash_caching(self):
+        """Tests that sandbox name hash is cached and does not query Kubernetes repeatedly."""
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {
+                "selector": "agents.x-k8s.io/sandbox-name-hash=mycachedhash"
+            }
+        }
+        # Call it once to populate cache
+        self.assertEqual(self.sandbox.get_sandbox_name_hash(), "mycachedhash")
+        
+        # Reset mock and call again - it should return cached value without querying K8s helper again
+        self.mock_k8s_helper.get_sandbox.reset_mock()
+        self.assertEqual(self.sandbox.get_sandbox_name_hash(), "mycachedhash")
+        self.mock_k8s_helper.get_sandbox.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -124,6 +124,40 @@ def test_suspend_resume(sandbox) -> str:
     return suspend_third_snapshot_uid
 
 
+def test_suspend_resume_new_sandbox(client, template_name: str, namespace: str) -> None:
+    """Tests creating a sandbox, suspending it (generating a snapshot), terminating it, provisioning a brand new sandbox, and resuming/restoring it from that snapshot."""
+    print("\n======= Testing Suspend and Resume in a NEW Sandbox =======")
+
+    # Create the initial sandbox to take the snapshot from
+    print(f"Creating initial sandbox from template '{template_name}'...")
+    sandbox = client.create_sandbox(template_name, namespace=namespace)
+    print(f"Initial sandbox '{sandbox.sandbox_id}' ready.")
+
+    print(f"\nSuspending current sandbox '{sandbox.sandbox_id}'...")
+    suspend_result = sandbox.suspend(snapshot_before_suspend=True)
+    assert suspend_result.success, f"Suspend failed: {suspend_result.error_reason}"
+    assert sandbox.is_suspended(), "Sandbox should be suspended."
+    suspend_snapshot_uid = suspend_result.snapshot_response.snapshot_uid if suspend_result.snapshot_response else 'None'
+    print(f"Sandbox suspended. Snapshot UID: {suspend_snapshot_uid}")   
+
+    print(f"\nResuming sandbox '{sandbox.sandbox_id}'...")
+    resume_result = sandbox.resume()
+    assert resume_result.success, f"Resume failed: {resume_result.error_reason}"
+    assert resume_result.restored_from_snapshot, "Sandbox should have been restored from snapshot."
+    assert not sandbox.is_suspended(), "Sandbox should not be suspended after resume."
+    print(f"Sandbox successfully resumed and restored from Snapshot UID: {resume_result.snapshot_uid}")
+
+    # Cleanup snapshots
+    print(f"\nRunning cleanup of remaining snapshots on the restored sandbox '{sandbox.sandbox_id}'...")
+    list_result = sandbox.snapshots.list()
+    assert list_result.success, list_result.error_reason
+    print(f"Found {len(list_result.snapshots)} snapshots remaining for the sandbox.")
+    
+    delete_result = sandbox.snapshots.delete_all(delete_by="all")
+    assert delete_result.success, delete_result.error_reason
+    print("Cleaned up remaining snapshots.")
+
+
 def test_list_and_delete(sandbox, first_snapshot_uid: str, second_snapshot_uid: str, suspend_third_snapshot_uid: str):
     """Tests listing all snapshots and verifying snapshot deletion."""
     print("\n======= Testing List and Delete =======")
@@ -220,6 +254,10 @@ def main(
         test_list_and_delete(
             sandbox, first_snapshot_uid, second_snapshot_uid, suspend_third_snapshot_uid
         )
+
+        # Create a fresh sandbox to test suspend-resume flow on a brand new instance
+        print("\n***** Phase 2: Testing Suspend/Resume on a NEW Sandbox client *****")
+        test_suspend_resume_new_sandbox(client, template_name, namespace)
 
         print("--- Pod Snapshot Test Passed! ---")
 

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -269,7 +269,7 @@ def main(
         )
 
         # Create a fresh sandbox to test suspend-resume flow on a brand new instance
-        print("\n***** Phase 2: Testing Suspend/Resume on a NEW Sandbox client *****")
+        print("\n***** Phase 2: Testing Suspend/Resume on a new Sandbox *****")
         test_suspend_resume_new_sandbox(client, template_name, namespace)
 
         print("--- Pod Snapshot Test Passed! ---")

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -125,7 +125,10 @@ def test_suspend_resume(sandbox) -> str:
 
 
 def test_suspend_resume_new_sandbox(client, template_name: str, namespace: str) -> None:
-    """Tests creating a sandbox, suspending it (generating a snapshot), terminating it, provisioning a brand new sandbox, and resuming/restoring it from that snapshot."""
+    """
+    Tests creating a sandbox, suspending it (generating a snapshot), terminating it, 
+    provisioning a sandbox handle for the same sandbox, and resuming the sandbox from that snapshot.
+    """
     print("\n======= Testing Suspend and Resume in a NEW Sandbox =======")
 
     # Create the initial sandbox to take the snapshot from
@@ -140,20 +143,30 @@ def test_suspend_resume_new_sandbox(client, template_name: str, namespace: str) 
     suspend_snapshot_uid = suspend_result.snapshot_response.snapshot_uid if suspend_result.snapshot_response else 'None'
     print(f"Sandbox suspended. Snapshot UID: {suspend_snapshot_uid}")   
 
-    print(f"\nResuming sandbox '{sandbox.sandbox_id}'...")
-    resume_result = sandbox.resume()
+    print(f"Waiting for suspend snapshot '{suspend_snapshot_uid}' to become ready...")
+    wait_for_snapshot_ready(sandbox, suspend_snapshot_uid)
+
+    claim_name = sandbox.claim_name
+    print("Closing connection for the old sandbox handle...")
+    sandbox.close_connection()
+
+    print(f"\nRe-attaching to sandbox claim '{claim_name}' to get a fresh handle...")
+    new_sandbox_handle = client.get_sandbox(claim_name, namespace=namespace)
+
+    print(f"\nResuming sandbox '{new_sandbox_handle.sandbox_id}'...")
+    resume_result = new_sandbox_handle.resume()
     assert resume_result.success, f"Resume failed: {resume_result.error_reason}"
     assert resume_result.restored_from_snapshot, "Sandbox should have been restored from snapshot."
-    assert not sandbox.is_suspended(), "Sandbox should not be suspended after resume."
+    assert not new_sandbox_handle.is_suspended(), "Sandbox should not be suspended after resume."
     print(f"Sandbox successfully resumed and restored from Snapshot UID: {resume_result.snapshot_uid}")
 
     # Cleanup snapshots
-    print(f"\nRunning cleanup of remaining snapshots on the restored sandbox '{sandbox.sandbox_id}'...")
-    list_result = sandbox.snapshots.list()
+    print(f"\nRunning cleanup of remaining snapshots on the restored sandbox '{new_sandbox_handle.sandbox_id}'...")
+    list_result = new_sandbox_handle.snapshots.list()
     assert list_result.success, list_result.error_reason
     print(f"Found {len(list_result.snapshots)} snapshots remaining for the sandbox.")
     
-    delete_result = sandbox.snapshots.delete_all(delete_by="all")
+    delete_result = new_sandbox_handle.snapshots.delete_all(delete_by="all")
     assert delete_result.success, delete_result.error_reason
     print("Cleaned up remaining snapshots.")
 

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -242,7 +242,6 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 	if pod == nil {
 		sandbox.Status.Replicas = 0
-		sandbox.Status.LabelSelector = ""
 		sandbox.Status.PodIPs = nil
 	} else {
 		sandbox.Status.Replicas = 1

--- a/test/e2e/replicas_test.go
+++ b/test/e2e/replicas_test.go
@@ -79,7 +79,7 @@ func TestSandboxReplicas(t *testing.T) {
 			Service:       "my-sandbox",
 			ServiceFQDN:   "my-sandbox.my-sandbox-ns.svc.cluster.local",
 			Replicas:      0,
-			LabelSelector: "",
+			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
 					Message:            "Pod does not exist, replicas is 0; Service Exists",


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This change addresses an issue where the sandbox name hash (selector label) is not be available when a sandbox is scaled down to zero replicas during suspension. 
Updated `sandbox_controller` to not unset the value of `status.labelselector` when the replicas is 0. 
If the hash cannot be resolved, the suspension fails gracefully with a clear error reason 

Additionally, this PR:
- Adds unit tests to verify graceful failure when the sandbox name hash is missing.
- Introduces an integration test phase for testing suspend and resume on a new sandbox client instance.
- Updates the documentation to reflect the expanded testing phases.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #749 

Integration Test: `test_podsnapshot_extension.py`

```
....
....
***** Phase 2: Testing Suspend/Resume on a NEW Sandbox client *****

======= Testing Suspend and Resume in a new Sandbox =======
Creating initial sandbox from template 'python-counter-template'...
2026-05-11 17:46:58,250 - INFO - Creating SandboxClaim 'sandbox-claim-052be361' in namespace 'sandbox-test' using template 'python-counter-template'...
2026-05-11 17:46:58,384 - INFO - Resolving sandbox name from claim 'sandbox-claim-052be361'...
2026-05-11 17:46:58,463 - INFO - Resolved sandbox name 'sandbox-claim-052be361' from claim status
2026-05-11 17:46:58,463 - INFO - Watching for Sandbox sandbox-claim-052be361 to become ready...
2026-05-11 17:46:59,439 - INFO - Sandbox sandbox-claim-052be361 is ready.
Initial sandbox 'sandbox-claim-052be361' ready.

Suspending current sandbox 'sandbox-claim-052be361'...
2026-05-11 17:46:59,734 - INFO - Waiting for snapshot manual trigger 'suspend-sandbox-claim-052be361-20260511-174659-9f789fde' to be processed...
2026-05-11 17:47:02,429 - INFO - Snapshot manual trigger 'suspend-sandbox-claim-052be361-20260511-174659-9f789fde' processed successfully. Created Snapshot UID: a3d3ddf1-655e-4098-b337-8273dbb42eed
2026-05-11 17:47:02,621 - INFO - Sandbox 'sandbox-claim-052be361' suspended (scaled down to 0 replicas).
2026-05-11 17:47:02,621 - INFO - Waiting up to 180s for pod 'sandbox-claim-052be361' (UID: 4c73f31d-2341-4de7-b01b-a21fde15ddc1) to terminate...
2026-05-11 17:47:04,716 - INFO - Sandbox 'sandbox-claim-052be361' pod successfully terminated.
Sandbox suspended. Snapshot UID: a3d3ddf1-655e-4098-b337-8273dbb42eed
Waiting for suspend snapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed' to become ready...
2026-05-11 17:47:04,766 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=aea8e3fe,tenant-id=test-tenant,user-id=test-user
2026-05-11 17:47:04,821 - INFO - Found 1 snapshots.
Snapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed' is ready.
Closing connection for the old sandbox handle...
2026-05-11 17:47:04,822 - INFO - Connection to sandbox claim 'sandbox-claim-052be361' has been closed.

Re-attaching to sandbox claim 'sandbox-claim-052be361' to get a fresh handle...
2026-05-11 17:47:04,822 - INFO - Resolving sandbox name from claim 'sandbox-claim-052be361'...
2026-05-11 17:47:04,874 - INFO - Resolved sandbox name 'sandbox-claim-052be361' from claim status

Resuming sandbox 'sandbox-claim-052be361'...
2026-05-11 17:47:05,160 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=aea8e3fe
2026-05-11 17:47:05,215 - INFO - Found 1 snapshots.
2026-05-11 17:47:05,286 - INFO - Sandbox 'sandbox-claim-052be361' resumed (scaled up to 1 replica).
2026-05-11 17:47:05,286 - INFO - Waiting up to 180s for pod to become ready...
2026-05-11 17:47:09,486 - INFO - Sandbox 'sandbox-claim-052be361' successfully restored from snapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed'.
Sandbox successfully resumed and restored from Snapshot UID: a3d3ddf1-655e-4098-b337-8273dbb42eed

Running cleanup of remaining snapshots on the restored sandbox 'sandbox-claim-052be361'...
2026-05-11 17:47:09,536 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=aea8e3fe
2026-05-11 17:47:09,590 - INFO - Found 1 snapshots.
Found 1 snapshots remaining for the sandbox.
2026-05-11 17:47:09,590 - INFO - Deleting every snapshot for this pod...
2026-05-11 17:47:09,590 - INFO - Deleting ALL snapshots for this pod.
2026-05-11 17:47:09,590 - INFO - Listing snapshots with label selector: agents.x-k8s.io/sandbox-name-hash=aea8e3fe
2026-05-11 17:47:09,690 - INFO - Found 1 snapshots.
2026-05-11 17:47:09,690 - INFO - Deleting PodSnapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed'...
2026-05-11 17:47:09,759 - INFO - PodSnapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed' deletion requested. Waiting for confirmation...
2026-05-11 17:47:09,809 - INFO - Waiting for PodSnapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed' to be deleted...
2026-05-11 17:47:10,537 - INFO - PodSnapshot 'a3d3ddf1-655e-4098-b337-8273dbb42eed' confirmed deleted.
2026-05-11 17:47:10,537 - INFO - Snapshot deletion process completed. Deleted 1 snapshots.
Cleaned up remaining snapshots.
--- Pod Snapshot Test Passed! ---
....
....
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->