### PR TITLE
Fix Sandbox router can be abused as an unauthenticated internal proxy

### DIFF
--- a/clients/python/agentic-sandbox-client/gateway-kind/run-test-kind.sh
+++ b/clients/python/agentic-sandbox-client/gateway-kind/run-test-kind.sh
@@ -53,6 +53,7 @@ kubectl apply -f python-sandbox-template.yaml
 cd ../sandbox-router
 echo "Applying CRD for router template"
 sed -i "s|\${ROUTER_IMAGE}|${SANDBOX_ROUTER_IMG}|g" sandbox_router.yaml
+sed -i 's|value: "false"|value: "true"|g' sandbox_router.yaml
 kubectl apply -f sandbox_router.yaml
 kubectl rollout status deployment/sandbox-router-deployment --timeout=60s
 

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -14,6 +14,8 @@
 
 
 import os
+import re
+import secrets
 
 import httpx
 from fastapi import FastAPI, Request, HTTPException
@@ -58,17 +60,40 @@ def _get_cluster_domain() -> str:
 
 
 cluster_domain = _get_cluster_domain()
+
+DNS_LABEL_REGEX = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
+
+
+def _is_valid_dns_label(label: str) -> bool:
+    if not label or len(label) > 63:
+        return False
+    return bool(DNS_LABEL_REGEX.match(label))
+
+
+def _env_var_is_truthy(name: str) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
 proxy_timeout = _get_proxy_timeout()
 client = httpx.AsyncClient(timeout=proxy_timeout)
 
 ROUTER_AUTH_TOKEN = os.environ.get("ROUTER_AUTH_TOKEN")
+ALLOW_UNAUTHENTICATED_ROUTER = _env_var_is_truthy("ALLOW_UNAUTHENTICATED_ROUTER")
 
 print(f"Sandbox router configured with proxy timeout: {proxy_timeout}s")
 print(f"Sandbox router configured with cluster_domain: {cluster_domain}")
 if ROUTER_AUTH_TOKEN:
     print("Authentication enabled: requests must include valid Bearer token.")
+elif ALLOW_UNAUTHENTICATED_ROUTER:
+    print("WARNING: Running in UNAUTHENTICATED mode because "
+          "ALLOW_UNAUTHENTICATED_ROUTER is enabled. Anyone can use this proxy!")
 else:
-    print("WARNING: Running in UNAUTHENTICATED mode. Anyone can use this proxy!")
+    raise RuntimeError(
+        "ROUTER_AUTH_TOKEN must be set to start the sandbox router securely. "
+        "If you intentionally need unauthenticated mode for local development or testing, "
+        "set ALLOW_UNAUTHENTICATED_ROUTER=true explicitly."
+    )
 
 
 @app.get("/healthz")
@@ -86,10 +111,18 @@ async def proxy_request(request: Request, full_path: str):
     # Check authentication if enabled
     if ROUTER_AUTH_TOKEN:
         auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            raise HTTPException(status_code=401, detail="Missing or invalid Authorization header.")
-        token = auth_header.split(" ")[1]
-        if token != ROUTER_AUTH_TOKEN:
+        if not auth_header:
+            raise HTTPException(
+                status_code=401,
+                detail="Missing or invalid Authorization header.",
+            )
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            raise HTTPException(
+                status_code=401,
+                detail="Missing or invalid Authorization header.",
+            )
+        if not secrets.compare_digest(parts[1], ROUTER_AUTH_TOKEN):
             raise HTTPException(status_code=401, detail="Invalid token.")
 
     sandbox_id = request.headers.get("X-Sandbox-ID")
@@ -98,14 +131,14 @@ async def proxy_request(request: Request, full_path: str):
             status_code=400, detail="X-Sandbox-ID header is required.")
 
     # Sanitize sandbox_id to prevent DNS injection and directory traversal style attacks
-    if not sandbox_id.replace("-", "").isalnum():
+    if not _is_valid_dns_label(sandbox_id):
         raise HTTPException(status_code=400, detail="Invalid sandbox ID format.")
 
     # Dynamic discovery via headers
     namespace = request.headers.get("X-Sandbox-Namespace", DEFAULT_NAMESPACE)
     
     # Sanitize namespace to prevent DNS injection
-    if not namespace.replace("-", "").isalnum():
+    if not _is_valid_dns_label(namespace):
         raise HTTPException(status_code=400, detail="Invalid namespace format.")
 
     try:
@@ -128,8 +161,11 @@ async def proxy_request(request: Request, full_path: str):
     print(f"Proxying request for sandbox '{sandbox_id}' to URL: {target_url}")
 
     try:
-        headers = {key: value for (
-            key, value) in request.headers.items() if key.lower() != 'host'}
+        headers = {
+            key: value
+            for (key, value) in request.headers.items()
+            if key.lower() not in {"host", "authorization"}
+        }
 
         req = client.build_request(
             method=request.method,
@@ -149,7 +185,9 @@ async def proxy_request(request: Request, full_path: str):
         print(
             f"ERROR: Connection to sandbox at {target_url} failed. Error: {e}")
         raise HTTPException(
-            status_code=502, detail=f"Could not connect to the backend sandbox: {sandbox_id}")
+            status_code=502,
+            detail=f"Could not connect to the backend sandbox: {sandbox_id}",
+        )
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         raise HTTPException(

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -16,6 +16,7 @@
 import os
 import re
 import secrets
+import ipaddress
 
 import httpx
 from fastapi import FastAPI, Request, HTTPException
@@ -25,6 +26,9 @@ from fastapi.responses import StreamingResponse
 app = FastAPI()
 
 # Configuration
+MIN_TCP_PORT = 1
+MAX_TCP_PORT = 65535
+
 DEFAULT_SANDBOX_PORT = 8888
 DEFAULT_NAMESPACE = "default"
 DEFAULT_PROXY_TIMEOUT = 180.0
@@ -78,7 +82,7 @@ def _env_var_is_truthy(name: str) -> bool:
 proxy_timeout = _get_proxy_timeout()
 client = httpx.AsyncClient(timeout=proxy_timeout)
 
-ROUTER_AUTH_TOKEN = os.environ.get("ROUTER_AUTH_TOKEN")
+ROUTER_AUTH_TOKEN = os.environ.get("ROUTER_AUTH_TOKEN", "").strip() or None
 ALLOW_UNAUTHENTICATED_ROUTER = _env_var_is_truthy("ALLOW_UNAUTHENTICATED_ROUTER")
 
 print(f"Sandbox router configured with proxy timeout: {proxy_timeout}s")
@@ -143,13 +147,21 @@ async def proxy_request(request: Request, full_path: str):
 
     try:
         port = int(request.headers.get("X-Sandbox-Port", DEFAULT_SANDBOX_PORT))
+        if not (MIN_TCP_PORT <= port <= MAX_TCP_PORT):
+            raise ValueError()
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid port format.")
 
     # Dynamic routing: route by Pod IP if provided by client, otherwise fallback to DNS name
     pod_ip = request.headers.get("X-Sandbox-Pod-IP")
     if pod_ip:
-        target_host = pod_ip
+        try:
+            ip = ipaddress.ip_address(pod_ip)
+            if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+                raise HTTPException(status_code=400, detail="Invalid target IP address.")
+            target_host = str(ip)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid target IP address format.")
     else:
         # Construct the K8s internal DNS name
         target_host = f"{sandbox_id}.{namespace}.svc.{cluster_domain}"
@@ -176,10 +188,17 @@ async def proxy_request(request: Request, full_path: str):
 
         resp = await client.send(req, stream=True)
 
+        async def stream_generator():
+            try:
+                async for chunk in resp.aiter_bytes():
+                    yield chunk
+            finally:
+                await resp.aclose()
+
         return StreamingResponse(
-            content=resp.aiter_bytes(),
+            content=stream_generator(),
             status_code=resp.status_code,
-            headers=resp.headers
+            headers=dict(resp.headers)
         )
     except httpx.ConnectError as e:
         print(

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -61,8 +61,14 @@ cluster_domain = _get_cluster_domain()
 proxy_timeout = _get_proxy_timeout()
 client = httpx.AsyncClient(timeout=proxy_timeout)
 
+ROUTER_AUTH_TOKEN = os.environ.get("ROUTER_AUTH_TOKEN")
+
 print(f"Sandbox router configured with proxy timeout: {proxy_timeout}s")
 print(f"Sandbox router configured with cluster_domain: {cluster_domain}")
+if ROUTER_AUTH_TOKEN:
+    print("Authentication enabled: requests must include valid Bearer token.")
+else:
+    print("WARNING: Running in UNAUTHENTICATED mode. Anyone can use this proxy!")
 
 
 @app.get("/healthz")
@@ -77,10 +83,23 @@ async def proxy_request(request: Request, full_path: str):
     Receives all incoming requests, determines the target sandbox from headers,
     and asynchronously proxies the request to it.
     """
+    # Check authentication if enabled
+    if ROUTER_AUTH_TOKEN:
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="Missing or invalid Authorization header.")
+        token = auth_header.split(" ")[1]
+        if token != ROUTER_AUTH_TOKEN:
+            raise HTTPException(status_code=401, detail="Invalid token.")
+
     sandbox_id = request.headers.get("X-Sandbox-ID")
     if not sandbox_id:
         raise HTTPException(
             status_code=400, detail="X-Sandbox-ID header is required.")
+
+    # Sanitize sandbox_id to prevent DNS injection and directory traversal style attacks
+    if not sandbox_id.replace("-", "").isalnum():
+        raise HTTPException(status_code=400, detail="Invalid sandbox ID format.")
 
     # Dynamic discovery via headers
     namespace = request.headers.get("X-Sandbox-Namespace", DEFAULT_NAMESPACE)

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
@@ -43,6 +43,11 @@ spec:
         env:
         - name: PROXY_TIMEOUT_SECONDS
           value: "180"
+        # - name: ROUTER_AUTH_TOKEN
+        #   valueFrom:
+        #     secretKeyRef:
+        #       name: sandbox-router-auth
+        #       key: auth-token
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
@@ -43,6 +43,8 @@ spec:
         env:
         - name: PROXY_TIMEOUT_SECONDS
           value: "180"
+        - name: ALLOW_UNAUTHENTICATED_ROUTER
+          value: "true"
         # - name: ROUTER_AUTH_TOKEN
         #   valueFrom:
         #     secretKeyRef:

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
@@ -44,7 +44,7 @@ spec:
         - name: PROXY_TIMEOUT_SECONDS
           value: "180"
         - name: ALLOW_UNAUTHENTICATED_ROUTER
-          value: "true"
+          value: "false"
         # - name: ROUTER_AUTH_TOKEN
         #   valueFrom:
         #     secretKeyRef:

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -63,6 +63,16 @@ class TestProxyRequestValidation:
         assert resp.status_code == 400
         assert "Invalid port format." == resp.json()["detail"]
 
+    def test_invalid_sandbox_id_format(self, client):
+        resp = client.post(
+            "/execute",
+            headers={
+                "X-Sandbox-ID": "bad.sandbox.id",
+            },
+        )
+        assert resp.status_code == 400
+        assert "Invalid sandbox ID format." == resp.json()["detail"]
+
     def test_valid_namespace_with_hyphens(self, client):
         """Namespaces like 'my-ns' should pass validation and result in a connection attempt."""
         with patch.object(
@@ -112,6 +122,75 @@ class TestClusterDomain:
             importlib.reload(sandbox_router)
             assert sandbox_router.cluster_domain == "my.custom.domain"
 
+
+class TestAuthentication:
+    def test_auth_disabled_by_default(self, client):
+        # When ROUTER_AUTH_TOKEN is not set, requests should proceed (and fail with 502 because target is unreachable)
+        with patch.object(
+            sandbox_router.client,
+            "send",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("stop here")
+        ):
+            resp = client.post(
+                "/execute",
+                headers={"X-Sandbox-ID": "my-sandbox"},
+            )
+        assert resp.status_code == 502
+
+    def test_auth_enabled_valid_token(self):
+        with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
+            importlib.reload(sandbox_router)
+            from fastapi.testclient import TestClient
+            client = TestClient(sandbox_router.app)
+            
+            with patch.object(
+                sandbox_router.client,
+                "send",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("stop here")
+            ):
+                resp = client.post(
+                    "/execute",
+                    headers={
+                        "X-Sandbox-ID": "my-sandbox",
+                        "Authorization": "Bearer secret-token",
+                    },
+                )
+            assert resp.status_code == 502
+        
+        importlib.reload(sandbox_router)
+
+    def test_auth_enabled_missing_token(self):
+        with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
+            importlib.reload(sandbox_router)
+            from fastapi.testclient import TestClient
+            client = TestClient(sandbox_router.app)
+            
+            resp = client.post(
+                "/execute",
+                headers={"X-Sandbox-ID": "my-sandbox"},
+            )
+            assert resp.status_code == 401
+            assert "Missing or invalid Authorization header." == resp.json()["detail"]
+            
+        importlib.reload(sandbox_router)
+
+    def test_auth_enabled_invalid_token(self):
+        with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
+            importlib.reload(sandbox_router)
+            from fastapi.testclient import TestClient
+            client = TestClient(sandbox_router.app)
+            
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "Authorization": "Bearer wrong-token",
+                },
+            )
+            assert resp.status_code == 401
+            assert "Invalid token." == resp.json()["detail"]
         importlib.reload(sandbox_router)
 
 

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -20,6 +20,7 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+os.environ["ALLOW_UNAUTHENTICATED_ROUTER"] = "true"
 import sandbox_router
 
 
@@ -124,19 +125,32 @@ class TestClusterDomain:
 
 
 class TestAuthentication:
-    def test_auth_disabled_by_default(self, client):
-        # When ROUTER_AUTH_TOKEN is not set, requests should proceed (and fail with 502 because target is unreachable)
-        with patch.object(
-            sandbox_router.client,
-            "send",
-            new_callable=AsyncMock,
-            side_effect=httpx.ConnectError("stop here")
-        ):
-            resp = client.post(
-                "/execute",
-                headers={"X-Sandbox-ID": "my-sandbox"},
-            )
-        assert resp.status_code == 502
+    def test_auth_required_by_default_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(RuntimeError, match="ROUTER_AUTH_TOKEN must be set"):
+                importlib.reload(sandbox_router)
+
+        importlib.reload(sandbox_router)
+
+    def test_auth_disabled_by_default(self):
+        with patch.dict(os.environ, {"ALLOW_UNAUTHENTICATED_ROUTER": "true"}, clear=True):
+            importlib.reload(sandbox_router)
+            from fastapi.testclient import TestClient
+            client = TestClient(sandbox_router.app)
+
+            with patch.object(
+                sandbox_router.client,
+                "send",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("stop here")
+            ):
+                resp = client.post(
+                    "/execute",
+                    headers={"X-Sandbox-ID": "my-sandbox"},
+                )
+            assert resp.status_code == 502
+
+        importlib.reload(sandbox_router)
 
     def test_auth_enabled_valid_token(self):
         with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
@@ -208,7 +222,7 @@ class TestProxyTimeout:
         importlib.reload(sandbox_router)
 
     def test_default_when_env_var_unset(self):
-        with patch.dict(os.environ, {}, clear=True):
+        with patch.dict(os.environ, {"ALLOW_UNAUTHENTICATED_ROUTER": "true"}, clear=True):
             importlib.reload(sandbox_router)
             assert sandbox_router.proxy_timeout == 180.0
 
@@ -318,6 +332,24 @@ class TestProxyRouting:
             forwarded_host = captured_request.get("headers", {}).get("host", "")
             assert "evil.example.com" not in forwarded_host
 
+    def test_authorization_header_not_forwarded(self, client):
+        """The 'authorization' header should not be forwarded to the sandbox."""
+        captured_request = {}
+
+        async def capture_send(req, **kwargs):
+            captured_request["headers"] = dict(req.headers)
+            raise httpx.ConnectError("stop here")
+
+        with patch.object(sandbox_router.client, "send", side_effect=capture_send):
+            client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "Authorization": "Bearer secret-token",
+                },
+            )
+            assert "authorization" not in captured_request.get("headers", {})
+
     def test_query_parameters_forwarded(self, client):
         """Query parameters should be preserved in the proxied request."""
         captured_request = {}
@@ -334,9 +366,8 @@ class TestProxyRouting:
             assert captured_request.get("params", {}).get("cmd") == "ls"
             assert captured_request.get("params", {}).get("arg") == "-la"
 
-    @pytest.mark.asyncio
     @patch.object(httpx.AsyncClient, "send", new_callable=AsyncMock)
-    async def test_request_body_streamed(self, mock_send, client):
+    def test_request_body_streamed(self, mock_send, client):
         """Verify that the request body is passed as a stream to httpx."""
         mock_resp = AsyncMock(spec=httpx.Response)
         mock_resp.status_code = 200

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -29,6 +29,18 @@ def client():
     return TestClient(sandbox_router.app)
 
 
+@pytest.fixture(autouse=True)
+def reload_router():
+    # Save the original environment before the test
+    orig_env = dict(os.environ)
+    yield
+    # Restore original environment variables
+    os.environ.clear()
+    os.environ.update(orig_env)
+    # Reload the module under the original environment to restore clean baseline
+    importlib.reload(sandbox_router)
+
+
 class TestHealthCheck:
     def test_returns_ok(self, client):
         resp = client.get("/healthz")
@@ -64,6 +76,18 @@ class TestProxyRequestValidation:
         assert resp.status_code == 400
         assert "Invalid port format." == resp.json()["detail"]
 
+    def test_invalid_port_bounds(self, client):
+        for bad_port in ["0", "65536", "-80", "100000"]:
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Port": bad_port,
+                },
+            )
+            assert resp.status_code == 400
+            assert "Invalid port format." == resp.json()["detail"]
+
     def test_invalid_sandbox_id_format(self, client):
         resp = client.post(
             "/execute",
@@ -73,6 +97,59 @@ class TestProxyRequestValidation:
         )
         assert resp.status_code == 400
         assert "Invalid sandbox ID format." == resp.json()["detail"]
+
+    def test_invalid_pod_ip_address_verification(self, client):
+        # Invalid IP format
+        for bad_ip in ["not-an-ip", "999.999.999.999", "10.20.30"]:
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Pod-IP": bad_ip,
+                },
+            )
+            assert resp.status_code == 400
+            assert "Invalid target IP address format." == resp.json()["detail"]
+
+        # Loopback, link-local, multicast, unspecified IPs
+        forbidden_ips = [
+            "127.0.0.1",
+            "::1",
+            "169.254.169.254",
+            "fe80::1",
+            "224.0.0.1",
+            "ff02::1",
+            "0.0.0.0",
+            "::",
+        ]
+        for ip in forbidden_ips:
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Pod-IP": ip,
+                },
+            )
+            assert resp.status_code == 400
+            assert "Invalid target IP address." == resp.json()["detail"]
+
+    def test_valid_pod_ip_address_routing(self, client):
+        with patch.object(
+            sandbox_router.client,
+            "send",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("expected"),
+        ) as mock_send:
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Pod-IP": "192.168.1.50",
+                },
+            )
+            # Expect 502 because IP validation passes and request goes to fake backend
+            assert resp.status_code == 502
+            assert "Could not connect to the backend sandbox" in resp.json()["detail"]
 
     def test_valid_namespace_with_hyphens(self, client):
         """Namespaces like 'my-ns' should pass validation and result in a connection attempt."""
@@ -130,8 +207,6 @@ class TestAuthentication:
             with pytest.raises(RuntimeError, match="ROUTER_AUTH_TOKEN must be set"):
                 importlib.reload(sandbox_router)
 
-        importlib.reload(sandbox_router)
-
     def test_auth_disabled_by_default(self):
         with patch.dict(os.environ, {"ALLOW_UNAUTHENTICATED_ROUTER": "true"}, clear=True):
             importlib.reload(sandbox_router)
@@ -149,8 +224,6 @@ class TestAuthentication:
                     headers={"X-Sandbox-ID": "my-sandbox"},
                 )
             assert resp.status_code == 502
-
-        importlib.reload(sandbox_router)
 
     def test_auth_enabled_valid_token(self):
         with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
@@ -172,8 +245,6 @@ class TestAuthentication:
                     },
                 )
             assert resp.status_code == 502
-        
-        importlib.reload(sandbox_router)
 
     def test_auth_enabled_missing_token(self):
         with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
@@ -187,8 +258,6 @@ class TestAuthentication:
             )
             assert resp.status_code == 401
             assert "Missing or invalid Authorization header." == resp.json()["detail"]
-            
-        importlib.reload(sandbox_router)
 
     def test_auth_enabled_invalid_token(self):
         with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "secret-token"}):
@@ -205,7 +274,31 @@ class TestAuthentication:
             )
             assert resp.status_code == 401
             assert "Invalid token." == resp.json()["detail"]
-        importlib.reload(sandbox_router)
+
+    def test_auth_enabled_whitespace_trimming(self):
+        with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "  secret-token\n "}):
+            importlib.reload(sandbox_router)
+            from fastapi.testclient import TestClient
+            client = TestClient(sandbox_router.app)
+            
+            with patch.object(
+                sandbox_router.client,
+                "send",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("stop here")
+            ):
+                resp = client.post(
+                    "/execute",
+                    headers={
+                        "X-Sandbox-ID": "my-sandbox",
+                        "Authorization": "Bearer secret-token",
+                    },
+                )
+            assert resp.status_code == 502
+
+        with patch.dict(os.environ, {"ROUTER_AUTH_TOKEN": "   "}, clear=True):
+            with pytest.raises(RuntimeError, match="ROUTER_AUTH_TOKEN must be set"):
+                importlib.reload(sandbox_router)
 
 
 class TestProxyTimeout:
@@ -219,14 +312,10 @@ class TestProxyTimeout:
             assert sandbox_router.client.timeout.connect == 600.0
             assert sandbox_router.client.timeout.read == 600.0
 
-        importlib.reload(sandbox_router)
-
     def test_default_when_env_var_unset(self):
         with patch.dict(os.environ, {"ALLOW_UNAUTHENTICATED_ROUTER": "true"}, clear=True):
             importlib.reload(sandbox_router)
             assert sandbox_router.proxy_timeout == 180.0
-
-        importlib.reload(sandbox_router)
 
 
 class TestProxyRouting:

--- a/test/e2e/clients/python/test_e2e_python_sdk.py
+++ b/test/e2e/clients/python/test_e2e_python_sdk.py
@@ -68,6 +68,8 @@ def deploy_router(tc, temp_namespace):
 
     with open(ROUTER_YAML_PATH, "r") as f:
         manifest = f.read().replace("${ROUTER_IMAGE}", router_image)
+        # Enable unauthenticated mode for local E2E test execution
+        manifest = manifest.replace('value: "false"', 'value: "true"')
 
     print(f"Applying router manifest to namespace: {temp_namespace}")
     tc.apply_manifest_text(manifest, namespace=temp_namespace)


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR addresses a high-risk security vulnerability (Finding 1) where the sandbox-router could be manipulated into acting as an unauthenticated internal proxy. 

**Key changes included**:

- **Input Validation**: Enforces strict character validation on the sandbox_id to allow only alphanumeric characters and hyphens, matching Kubernetes DNS subdomain conventions.
- **Optional Authentication**: Introduces support for a ROUTER_AUTH_TOKEN environment variable. When set, the router requires a valid Bearer token in the Authorization header.
- **Deployment Configuration**: Adds commented-out environment variable templates in sandbox_router.yaml for easier authentication setup.
- **Tests**: Adds unit tests covering invalid sandbox_id formats and various authentication scenarios (missing token, invalid token, and disabled mode).

#### Release Note
```
SECURITY: Fixed a vulnerability in the sandbox router that allowed unauthenticated proxying to arbitrary internal cluster endpoints. This fix introduces strict validation for sandbox IDs and an optional Bearer token authentication layer.
```