### PR TITLE
Fix Python Gateway client trusts Gateway status addresses without validation

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -298,30 +298,14 @@ class AsyncK8sHelper:
         except client.ApiException as e:
             logger.error(f"Error listing sandbox claims in namespace {namespace}: {e}")
             raise
+
     def _is_valid_ip(self, s: str) -> bool:
-        import ipaddress
-        try:
-            ipaddress.ip_address(s)
-            return True
-        except ValueError:
-            return False
+        from .utils import is_valid_ip
+        return is_valid_ip(s)
 
     def _is_valid_gateway_hostname(self, s: str) -> bool:
-        if not s or len(s) > 253:
-            return False
-        for i, c in enumerate(s):
-            if 'a' <= c <= 'z' or 'A' <= c <= 'Z' or '0' <= c <= '9':
-                continue
-            elif c == '-':
-                if i == 0 or s[i-1] == '.':
-                    return False
-            elif c == '.':
-                if i == 0 or s[i-1] == '.' or s[i-1] == '-':
-                    return False
-            else:
-                return False
-        last = s[-1]
-        return last != '-' and last != '.'
+        from .utils import is_valid_gateway_hostname
+        return is_valid_gateway_hostname(s)
 
     async def wait_for_gateway_ip(self, gateway_name: str, namespace: str, timeout: int) -> str:
         """Waits for the Gateway to be assigned an external IP."""
@@ -350,20 +334,28 @@ class AsyncK8sHelper:
                         gateway_object = event["object"]
                         status = gateway_object.get("status") or {}
                         addresses = status.get("addresses", [])
-                        if addresses:
-                            ip_address = addresses[0].get("value")
-                            if ip_address:
-                                # Validate the address to prevent SSRF via a compromised Gateway resource.
-                                if any(c in ip_address for c in "/?#@"):
-                                    logger.warning(f"Gateway address rejected by validation (contains special chars): {ip_address}")
-                                    continue
+                        for address in addresses:
+                            ip_address = address.get("value")
+                            if not ip_address:
+                                continue
+                            
+                            # Validate the address to prevent SSRF via a compromised Gateway resource.
+                            if any(c in ip_address for c in "/?#@"):
+                                logger.warning(
+                                    "Gateway address rejected by validation (contains special chars): %r",
+                                    ip_address,
+                                )
+                                continue
+                            
+                            if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
+                                logger.warning(
+                                    "Gateway address rejected by validation: %r",
+                                    ip_address,
+                                )
+                                continue
                                 
-                                if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
-                                    logger.warning(f"Gateway address rejected by validation: {ip_address}")
-                                    continue
-                                    
-                                logger.info(f"Gateway ready. IP: {ip_address}")
-                                return ip_address
+                            logger.info(f"Gateway ready. IP: {ip_address}")
+                            return ip_address
             finally:
                 await w.close()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -335,7 +335,7 @@ class AsyncK8sHelper:
                             
                             if not is_valid_ip(ip_address) and not is_valid_gateway_hostname(ip_address):
                                 logger.warning(
-                                    "Gateway address rejected by validation: %r",
+                                    "Gateway address rejected because %r is neither a valid IP address nor a valid gateway hostname.",
                                     ip_address,
                                 )
                                 continue

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -32,7 +32,7 @@ from .constants import (
     SANDBOX_PLURAL_NAME,
 )
 from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
-from .utils import select_pod_ip
+from .utils import select_pod_ip, is_valid_ip, is_valid_gateway_hostname
 
 
 class AsyncK8sHelper:
@@ -299,14 +299,6 @@ class AsyncK8sHelper:
             logger.error(f"Error listing sandbox claims in namespace {namespace}: {e}")
             raise
 
-    def _is_valid_ip(self, s: str) -> bool:
-        from .utils import is_valid_ip
-        return is_valid_ip(s)
-
-    def _is_valid_gateway_hostname(self, s: str) -> bool:
-        from .utils import is_valid_gateway_hostname
-        return is_valid_gateway_hostname(s)
-
     async def wait_for_gateway_ip(self, gateway_name: str, namespace: str, timeout: int) -> str:
         """Waits for the Gateway to be assigned an external IP."""
         await self._ensure_initialized()
@@ -335,19 +327,13 @@ class AsyncK8sHelper:
                         status = gateway_object.get("status") or {}
                         addresses = status.get("addresses", [])
                         for address in addresses:
+                            if not isinstance(address, dict):
+                                continue
                             ip_address = address.get("value")
                             if not ip_address:
                                 continue
                             
-                            # Validate the address to prevent SSRF via a compromised Gateway resource.
-                            if any(c in ip_address for c in "/?#@"):
-                                logger.warning(
-                                    "Gateway address rejected by validation (contains special chars): %r",
-                                    ip_address,
-                                )
-                                continue
-                            
-                            if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
+                            if not is_valid_ip(ip_address) and not is_valid_gateway_hostname(ip_address):
                                 logger.warning(
                                     "Gateway address rejected by validation: %r",
                                     ip_address,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -298,6 +298,30 @@ class AsyncK8sHelper:
         except client.ApiException as e:
             logger.error(f"Error listing sandbox claims in namespace {namespace}: {e}")
             raise
+    def _is_valid_ip(self, s: str) -> bool:
+        import ipaddress
+        try:
+            ipaddress.ip_address(s)
+            return True
+        except ValueError:
+            return False
+
+    def _is_valid_gateway_hostname(self, s: str) -> bool:
+        if not s or len(s) > 253:
+            return False
+        for i, c in enumerate(s):
+            if 'a' <= c <= 'z' or 'A' <= c <= 'Z' or '0' <= c <= '9':
+                continue
+            elif c == '-':
+                if i == 0 or s[i-1] == '.':
+                    return False
+            elif c == '.':
+                if i == 0 or s[i-1] == '.' or s[i-1] == '-':
+                    return False
+            else:
+                return False
+        last = s[-1]
+        return last != '-' and last != '.'
 
     async def wait_for_gateway_ip(self, gateway_name: str, namespace: str, timeout: int) -> str:
         """Waits for the Gateway to be assigned an external IP."""
@@ -329,6 +353,15 @@ class AsyncK8sHelper:
                         if addresses:
                             ip_address = addresses[0].get("value")
                             if ip_address:
+                                # Validate the address to prevent SSRF via a compromised Gateway resource.
+                                if any(c in ip_address for c in "/?#@"):
+                                    logger.warning(f"Gateway address rejected by validation (contains special chars): {ip_address}")
+                                    continue
+                                
+                                if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
+                                    logger.warning(f"Gateway address rejected by validation: {ip_address}")
+                                    continue
+                                    
                                 logger.info(f"Gateway ready. IP: {ip_address}")
                                 return ip_address
             finally:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -299,7 +299,7 @@ class K8sHelper:
                         
                         if not is_valid_ip(ip_address) and not is_valid_gateway_hostname(ip_address):
                             logging.warning(
-                                "Gateway address rejected by validation: %r",
+                                "Gateway address rejected because %r is neither a valid IP address nor a valid gateway hostname.",
                                 ip_address,
                             )
                             continue

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -266,29 +266,12 @@ class K8sHelper:
             raise
 
     def _is_valid_ip(self, s: str) -> bool:
-        import ipaddress
-        try:
-            ipaddress.ip_address(s)
-            return True
-        except ValueError:
-            return False
+        from .utils import is_valid_ip
+        return is_valid_ip(s)
 
     def _is_valid_gateway_hostname(self, s: str) -> bool:
-        if not s or len(s) > 253:
-            return False
-        for i, c in enumerate(s):
-            if 'a' <= c <= 'z' or 'A' <= c <= 'Z' or '0' <= c <= '9':
-                continue
-            elif c == '-':
-                if i == 0 or s[i-1] == '.':
-                    return False
-            elif c == '.':
-                if i == 0 or s[i-1] == '.' or s[i-1] == '-':
-                    return False
-            else:
-                return False
-        last = s[-1]
-        return last != '-' and last != '.'
+        from .utils import is_valid_gateway_hostname
+        return is_valid_gateway_hostname(s)
 
     def wait_for_gateway_ip(self, gateway_name: str, namespace: str, timeout: int) -> str:
         """Waits for the Gateway to be assigned an external IP."""
@@ -314,18 +297,26 @@ class K8sHelper:
                     gateway_object = event['object']
                     status = gateway_object.get('status') or {}
                     addresses = status.get('addresses', [])
-                    if addresses:
-                        ip_address = addresses[0].get('value')
-                        if ip_address:
-                            # Validate the address to prevent SSRF via a compromised Gateway resource.
-                            if any(c in ip_address for c in "/?#@"):
-                                logging.warning(f"Gateway address rejected by validation (contains special chars): {ip_address}")
-                                continue
-                            
-                            if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
-                                logging.warning(f"Gateway address rejected by validation: {ip_address}")
-                                continue
-                                
-                            logging.info(f"Gateway ready. IP: {ip_address}")
-                            w.stop()
-                            return ip_address
+                    for address in addresses:
+                        ip_address = address.get('value')
+                        if not ip_address:
+                            continue
+                        
+                        # Validate the address to prevent SSRF via a compromised Gateway resource.
+                        if any(c in ip_address for c in "/?#@"):
+                            logging.warning(
+                                "Gateway address rejected by validation (contains special chars): %r",
+                                ip_address,
+                            )
+                            continue
+                        
+                        if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
+                            logging.warning(
+                                "Gateway address rejected by validation: %r",
+                                ip_address,
+                            )
+                            continue
+                        
+                        logging.info(f"Gateway ready. IP: {ip_address}")
+                        w.stop()
+                        return ip_address

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -265,6 +265,31 @@ class K8sHelper:
             logging.error(f"Error listing sandbox claims in namespace {namespace}: {e}")
             raise
 
+    def _is_valid_ip(self, s: str) -> bool:
+        import ipaddress
+        try:
+            ipaddress.ip_address(s)
+            return True
+        except ValueError:
+            return False
+
+    def _is_valid_gateway_hostname(self, s: str) -> bool:
+        if not s or len(s) > 253:
+            return False
+        for i, c in enumerate(s):
+            if 'a' <= c <= 'z' or 'A' <= c <= 'Z' or '0' <= c <= '9':
+                continue
+            elif c == '-':
+                if i == 0 or s[i-1] == '.':
+                    return False
+            elif c == '.':
+                if i == 0 or s[i-1] == '.' or s[i-1] == '-':
+                    return False
+            else:
+                return False
+        last = s[-1]
+        return last != '-' and last != '.'
+
     def wait_for_gateway_ip(self, gateway_name: str, namespace: str, timeout: int) -> str:
         """Waits for the Gateway to be assigned an external IP."""
         deadline = time.monotonic() + timeout
@@ -292,6 +317,15 @@ class K8sHelper:
                     if addresses:
                         ip_address = addresses[0].get('value')
                         if ip_address:
+                            # Validate the address to prevent SSRF via a compromised Gateway resource.
+                            if any(c in ip_address for c in "/?#@"):
+                                logging.warning(f"Gateway address rejected by validation (contains special chars): {ip_address}")
+                                continue
+                            
+                            if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
+                                logging.warning(f"Gateway address rejected by validation: {ip_address}")
+                                continue
+                                
                             logging.info(f"Gateway ready. IP: {ip_address}")
                             w.stop()
                             return ip_address

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -17,6 +17,7 @@ import time
 from typing import List
 from kubernetes import client, config, watch
 from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
+from .utils import is_valid_ip, is_valid_gateway_hostname
 from .constants import (
     CLAIM_API_GROUP,
     CLAIM_API_VERSION,
@@ -265,14 +266,6 @@ class K8sHelper:
             logging.error(f"Error listing sandbox claims in namespace {namespace}: {e}")
             raise
 
-    def _is_valid_ip(self, s: str) -> bool:
-        from .utils import is_valid_ip
-        return is_valid_ip(s)
-
-    def _is_valid_gateway_hostname(self, s: str) -> bool:
-        from .utils import is_valid_gateway_hostname
-        return is_valid_gateway_hostname(s)
-
     def wait_for_gateway_ip(self, gateway_name: str, namespace: str, timeout: int) -> str:
         """Waits for the Gateway to be assigned an external IP."""
         deadline = time.monotonic() + timeout
@@ -298,19 +291,13 @@ class K8sHelper:
                     status = gateway_object.get('status') or {}
                     addresses = status.get('addresses', [])
                     for address in addresses:
+                        if not isinstance(address, dict):
+                            continue
                         ip_address = address.get('value')
                         if not ip_address:
                             continue
                         
-                        # Validate the address to prevent SSRF via a compromised Gateway resource.
-                        if any(c in ip_address for c in "/?#@"):
-                            logging.warning(
-                                "Gateway address rejected by validation (contains special chars): %r",
-                                ip_address,
-                            )
-                            continue
-                        
-                        if not self._is_valid_ip(ip_address) and not self._is_valid_gateway_hostname(ip_address):
+                        if not is_valid_ip(ip_address) and not is_valid_gateway_hostname(ip_address):
                             logging.warning(
                                 "Gateway address rejected by validation: %r",
                                 ip_address,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -366,7 +366,7 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
             self.assertEqual(ip, "192.168.1.2")
 
-    async def test_wait_for_gateway_ip_rejects_ipv6(self):
+    async def test_wait_for_gateway_ip_accepts_ipv6(self):
         async def _async_gen(*args, **kwargs):
             yield {
                 "type": "MODIFIED",
@@ -374,15 +374,6 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
                     "metadata": {"name": "test-gateway"},
                     "status": {
                         "addresses": [{"value": "2001:db8::1"}]
-                    }
-                }
-            }
-            yield {
-                "type": "MODIFIED",
-                "object": {
-                    "metadata": {"name": "test-gateway"},
-                    "status": {
-                        "addresses": [{"value": "192.168.1.1"}]
                     }
                 }
             }
@@ -394,7 +385,7 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             MockWatch.return_value = mock_watch
 
             ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
-            self.assertEqual(ip, "192.168.1.1")
+            self.assertEqual(ip, "2001:db8::1")
 
     async def test_wait_for_gateway_ip_disguised_ip_decimal(self):
         async def _async_gen(*args, **kwargs):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -396,6 +396,157 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
             self.assertEqual(ip, "192.168.1.1")
 
+    async def test_wait_for_gateway_ip_disguised_ip_decimal(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "2130706433"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_disguised_ip_hex(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "0x7f000001"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_disguised_ip_dotted_hex(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "0x7f.0x0.0x0.0x1"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_invalid_label_length(self):
+        long_label = "a" * 64
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": f"{long_label}.example.com"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "gateway.example.com"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "gateway.example.com")
+
+    async def test_wait_for_gateway_ip_non_dict_address(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": ["not-a-dict"]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -486,6 +486,66 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
             self.assertEqual(ip, "192.168.1.1")
 
+    async def test_wait_for_gateway_ip_bare_hex_prefix_ip(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "0x.1"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_bare_hex_prefix_ip_dotted(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "00.0x.0x.1"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
     async def test_wait_for_gateway_ip_invalid_label_length(self):
         long_label = "a" * 64
         async def _async_gen(*args, **kwargs):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -547,6 +547,36 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
             self.assertEqual(ip, "192.168.1.1")
 
+    async def test_wait_for_gateway_ip_integer_value(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": 2130706433}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -233,5 +233,169 @@ class TestAsyncK8sHelperDeleteSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ctx.exception.status, 403)
 
 
+class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.helper = AsyncK8sHelper()
+        self.helper._initialized = True
+        self.helper.custom_objects_api = MagicMock()
+
+    async def test_wait_for_gateway_ip_valid_ip(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_valid_hostname(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "gateway.example.com"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "gateway.example.com")
+
+    async def test_wait_for_gateway_ip_invalid_address_special_chars(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1/path"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_invalid_hostname(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "bad_hostname"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+    async def test_wait_for_gateway_ip_multiple_addresses_in_event(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [
+                            {"value": "bad_hostname"},
+                            {"value": "192.168.1.2"},
+                        ]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.2")
+
+    async def test_wait_for_gateway_ip_rejects_ipv6(self):
+        async def _async_gen(*args, **kwargs):
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "2001:db8::1"}]
+                    }
+                }
+            }
+            yield {
+                "type": "MODIFIED",
+                "object": {
+                    "metadata": {"name": "test-gateway"},
+                    "status": {
+                        "addresses": [{"value": "192.168.1.1"}]
+                    }
+                }
+            }
+
+        with patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch") as MockWatch:
+            mock_watch = MagicMock()
+            mock_watch.stream = _async_gen
+            mock_watch.close = AsyncMock()
+            MockWatch.return_value = mock_watch
+
+            ip = await self.helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+            self.assertEqual(ip, "192.168.1.1")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -349,6 +349,147 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
         self.assertEqual(ip, "192.168.1.1")
 
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_disguised_ip_decimal(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "2130706433"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_disguised_ip_hex(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "0x7f000001"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_disguised_ip_dotted_hex(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "0x7f.0x0.0x0.0x1"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_invalid_label_length(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        long_label = "a" * 64
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": f"{long_label}.example.com"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "gateway.example.com"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "gateway.example.com")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_non_dict_address(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": ["not-a-dict"]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -434,6 +434,62 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         self.assertEqual(ip, "192.168.1.1")
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_bare_hex_prefix_ip(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "0x.1"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_bare_hex_prefix_ip_dotted(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "00.0x.0x.1"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
     def test_wait_for_gateway_ip_invalid_label_length(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
         mock_watch = MagicMock()
         long_label = "a" * 64

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -490,6 +490,34 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
         self.assertEqual(ip, "192.168.1.1")
 
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_integer_value(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": 2130706433}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -299,6 +299,56 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
         self.assertEqual(ip, "192.168.1.1")
 
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_multiple_addresses_in_event(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [
+                        {"value": "bad_hostname"},
+                        {"value": "192.168.1.2"},
+                    ]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.2")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_rejects_ipv6(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_ipv6 = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "2001:db8::1"}]
+                }
+            }
+        }
+        mock_event_ipv4 = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_ipv6, mock_event_ipv4]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -322,7 +322,7 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         self.assertEqual(ip, "192.168.1.2")
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
-    def test_wait_for_gateway_ip_rejects_ipv6(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+    def test_wait_for_gateway_ip_accepts_ipv6(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
         mock_watch = MagicMock()
         mock_event_ipv6 = {
             "type": "MODIFIED",
@@ -333,21 +333,12 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
                 }
             }
         }
-        mock_event_ipv4 = {
-            "type": "MODIFIED",
-            "object": {
-                "metadata": {"name": "test-gateway"},
-                "status": {
-                    "addresses": [{"value": "192.168.1.1"}]
-                }
-            }
-        }
-        mock_watch.stream.return_value = [mock_event_ipv6, mock_event_ipv4]
+        mock_watch.stream.return_value = [mock_event_ipv6]
         mock_watch_class.return_value = mock_watch
 
         helper = K8sHelper()
         ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
-        self.assertEqual(ip, "192.168.1.1")
+        self.assertEqual(ip, "2001:db8::1")
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
     def test_wait_for_gateway_ip_disguised_ip_decimal(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -200,5 +200,105 @@ class TestK8sHelperDeleteSandboxClaim(unittest.TestCase):
         self.assertEqual(ctx.exception.status, 403)
 
 
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_valid_ip(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_valid_hostname(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "gateway.example.com"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "gateway.example.com")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_invalid_address_special_chars(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1/path"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_gateway_ip_invalid_hostname(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event_invalid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "bad_hostname"}]
+                }
+            }
+        }
+        mock_event_valid = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-gateway"},
+                "status": {
+                    "addresses": [{"value": "192.168.1.1"}]
+                }
+            }
+        }
+        mock_watch.stream.return_value = [mock_event_invalid, mock_event_valid]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
+        self.assertEqual(ip, "192.168.1.1")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -110,8 +110,27 @@ def is_valid_ip(s: str) -> bool:
         return False
 
 
+def _is_integer_label(label: str) -> bool:
+    if not label:
+        return False
+    if label.isdigit():
+        return True
+    if label.lower().startswith("0x"):
+        val = label[2:]
+        return len(val) > 0 and all(c in "0123456789abcdef" for c in val.lower())
+    return False
+
+
 def is_valid_gateway_hostname(s: str) -> bool:
     if not s or len(s) > 253:
+        return False
+    labels = s.split('.')
+    # Reject hostnames that consist entirely of integer labels (decimal or hex)
+    # as they can resolve to loopback or other IP addresses via libc resolvers.
+    if all(_is_integer_label(label) for label in labels):
+        return False
+    # Enforce DNS label length limit of 63 characters (RFC 1123 / RFC 1035)
+    if any(len(label) > 63 for label in labels):
         return False
     for i, c in enumerate(s):
         if 'a' <= c <= 'z' or 'A' <= c <= 'Z' or '0' <= c <= '9':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -103,11 +103,8 @@ def is_valid_ip(s: str) -> bool:
         return False
     import ipaddress
     try:
-        # Downstream callers construct URLs with `http://{ip_address}`,
-        # which only works for IPv4 literals without additional
-        # normalization. Reject IPv6 here to keep the returned value
-        # compatible with existing URL construction.
-        return isinstance(ipaddress.ip_address(s), ipaddress.IPv4Address)
+        ipaddress.ip_address(s)
+        return True
     except ValueError:
         return False
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -96,3 +96,33 @@ def select_pod_ip(ips: Sequence[object] | None) -> str | None:
             continue
 
     return first_valid
+
+
+def is_valid_ip(s: str) -> bool:
+    import ipaddress
+    try:
+        # Downstream callers construct URLs with `http://{ip_address}`,
+        # which only works for IPv4 literals without additional
+        # normalization. Reject IPv6 here to keep the returned value
+        # compatible with existing URL construction.
+        return isinstance(ipaddress.ip_address(s), ipaddress.IPv4Address)
+    except ValueError:
+        return False
+
+
+def is_valid_gateway_hostname(s: str) -> bool:
+    if not s or len(s) > 253:
+        return False
+    for i, c in enumerate(s):
+        if 'a' <= c <= 'z' or 'A' <= c <= 'Z' or '0' <= c <= '9':
+            continue
+        elif c == '-':
+            if i == 0 or s[i-1] == '.':
+                return False
+        elif c == '.':
+            if i == 0 or s[i-1] == '.' or s[i-1] == '-':
+                return False
+        else:
+            return False
+    last = s[-1]
+    return last != '-' and last != '.'

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -99,6 +99,8 @@ def select_pod_ip(ips: Sequence[object] | None) -> str | None:
 
 
 def is_valid_ip(s: str) -> bool:
+    if not isinstance(s, str):
+        return False
     import ipaddress
     try:
         # Downstream callers construct URLs with `http://{ip_address}`,
@@ -122,6 +124,8 @@ def _is_integer_label(label: str) -> bool:
 
 
 def is_valid_gateway_hostname(s: str) -> bool:
+    if not isinstance(s, str):
+        return False
     if not s or len(s) > 253:
         return False
     labels = s.split('.')

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -119,7 +119,7 @@ def _is_integer_label(label: str) -> bool:
         return True
     if label.lower().startswith("0x"):
         val = label[2:]
-        return len(val) > 0 and all(c in "0123456789abcdef" for c in val.lower())
+        return len(val) == 0 or all(c in "0123456789abcdef" for c in val.lower())
     return False
 
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR addresses a medium-risk security vulnerability (Finding 9) where the Python client for the agentic sandbox would directly accept and use addresses from a Gateway resource's status block without validation.

**Key changes included:**

- **Address Validation Helper**: Added _is_valid_ip (using the ipaddress module) and _is_valid_gateway_hostname to ensure that the retrieved address conforms to expected formats.
- **Special Character Filtering**: Implemented a check to reject any address containing special characters like /, ?, #, or @, which are commonly used in SSRF payloads to manipulate URL parsing.
- **Secure Gateway Resolution**: Updated the wait_for_gateway_ip method in both synchronous and asynchronous helpers to apply these validation checks before returning the address to the caller.
- **Unit Tests**: Added comprehensive tests in test_k8s_helper.py to verify that valid IPs and hostnames are accepted while malformed addresses (e.g., those with special characters or invalid formats) are correctly rejected.

#### Release Note
```
SECURITY: Fixed a vulnerability where the Python SDK blindly trusted addresses from Gateway resource statuses. This fix introduces strict validation for IP addresses and hostnames to prevent SSRF.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved gateway external-address selection by validating candidates before returning them, ignoring malformed/non-address entries, and choosing the first verified IPv4 or compliant hostname.
  * Added stricter hostname validation (label length/format) and improved handling of valid IPv6 addresses.
  * Kept support for “disguised” IPv4 inputs (decimal/hex and related variants) to resolve correctly.

* **Tests**
  * Expanded unit coverage for mixed watch events, multi-address lists, invalid encodings, hostname edge cases, and type-robustness (including IPv6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->