### PR TITLE
Create a shared utility for generating hash of a sandbox's TemplateRef name

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -357,7 +357,7 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 				mergedMeta.Labels = make(map[string]string)
 			}
 			mergedMeta.Labels[extensionsv1alpha1.SandboxIDLabel] = string(claim.UID)
-			mergedMeta.Labels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(template.Name)
+			mergedMeta.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
 
 			if err := mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
 				return nil, err
@@ -638,7 +638,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 
 func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*v1alpha1.Sandbox, error) {
 	logger := log.FromContext(ctx)
-	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+	templateHash := SandboxTemplateRefHash(claim.Spec.TemplateRef.Name)
 
 	// Keep trying until we successfully adopt a sandbox, or run out of candidates
 	for range 3 {
@@ -750,7 +750,7 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	adopted.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(adopted.Spec.PodTemplate.ObjectMeta.Labels, claim)
 
 	// Fetch the template to construct the mergedMeta that reconcileActive will build.
-	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+	templateHash := SandboxTemplateRefHash(claim.Spec.TemplateRef.Name)
 	template, templateErr := r.getTemplate(ctx, claim)
 	if templateErr == nil && template != nil {
 		var mergedMeta v1alpha1.PodMetadata
@@ -953,7 +953,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	// Sandbox.metadata.labels).
 	sandbox.Labels = ensureClaimIdentityLabels(sandbox.Labels, claim)
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(sandbox.Spec.PodTemplate.ObjectMeta.Labels, claim)
-	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(template.Name)
+	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
 
 	if err := mergePodMetadata(&sandbox.Spec.PodTemplate.ObjectMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
 		return nil, err
@@ -1483,7 +1483,7 @@ func verifySandboxCandidate(candidate *v1alpha1.Sandbox, claim *extensionsv1alph
 		return err
 	}
 
-	templateHash := sandboxcontrollers.NameHash(claim.Spec.TemplateRef.Name)
+	templateHash := SandboxTemplateRefHash(claim.Spec.TemplateRef.Name)
 	if candidate.Labels[sandboxTemplateRefHash] != templateHash {
 		return fmt.Errorf("incorrect template hash, expected %v, got %v", templateHash, candidate.Labels[sandboxTemplateRefHash])
 	}
@@ -1547,7 +1547,7 @@ func (h *templateEventHandler) Delete(ctx context.Context, e event.DeleteEvent, 
 		return
 	}
 
-	templateHash := sandboxcontrollers.NameHash(template.Name)
+	templateHash := SandboxTemplateRefHash(template.Name)
 	logger := log.FromContext(ctx)
 	logger.Info("SandboxTemplate deleted, cleaning up memory queue", "template", template.Name, "hash", templateHash)
 

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
+
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
@@ -101,7 +101,7 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		desiredSpec = networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					sandboxTemplateRefHash: sandboxcontrollers.NameHash(template.Name),
+					sandboxTemplateRefHash: SandboxTemplateRefHash(template.Name),
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{
@@ -160,7 +160,7 @@ func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPoli
 	return networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				sandboxTemplateRefHash: sandboxcontrollers.NameHash(templateName),
+				sandboxTemplateRefHash: SandboxTemplateRefHash(templateName),
 			},
 		},
 		PolicyTypes: []networkingv1.PolicyType{

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -315,7 +315,7 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	// Build labels for the Sandbox CR
 	sandboxLabels := map[string]string{
 		warmPoolSandboxLabel:                        poolNameHash,
-		sandboxTemplateRefHash:                      sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name),
+		sandboxTemplateRefHash:                      SandboxTemplateRefHash(warmPool.Spec.TemplateRef.Name),
 		sandboxv1alpha1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
 	}
 
@@ -329,7 +329,7 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	maps.Copy(podLabels, template.Spec.PodTemplate.ObjectMeta.Labels)
 	// Propagate pool and template labels to pod template for consistency and targeting
 	podLabels[warmPoolSandboxLabel] = poolNameHash
-	podLabels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name)
+	podLabels[sandboxTemplateRefHash] = SandboxTemplateRefHash(warmPool.Spec.TemplateRef.Name)
 	podLabels[sandboxv1alpha1.SandboxPodTemplateHashLabel] = currentPodTemplateHash
 
 	podAnnotations := make(map[string]string)
@@ -441,7 +441,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	sandboxHash := sandbox.Labels[sandboxv1alpha1.SandboxPodTemplateHashLabel]
 
 	// If the templateRefHash doesn't match, it's stale.
-	if sandbox.Labels[sandboxTemplateRefHash] != sandboxcontrollers.NameHash(template.Name) {
+	if sandbox.Labels[sandboxTemplateRefHash] != SandboxTemplateRefHash(template.Name) {
 		return true
 	}
 

--- a/extensions/controllers/utils.go
+++ b/extensions/controllers/utils.go
@@ -16,8 +16,8 @@ package controllers
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
+	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 )
 
 // ApplySandboxSecureDefaults applies the controller's "Secure by Default" logic to a PodSpec.
@@ -49,11 +49,11 @@ func ApplySandboxSecureDefaults(template *extensionsv1alpha1.SandboxTemplate, sp
 
 // SandboxTemplateRefHash encapsulates the generation of the hash for a sandbox template ref.
 func SandboxTemplateRefHash(templateRefName string) string {
-	return hashSandboxTemplateRefName(templateRefName)
+	return HashUsingSandboxTemplateRefName(templateRefName)
 }
 
-// HashUsingSandboxTemplateRefName generates the hash of a sandbox template ref, using only its name
-// TODO: once https://github.com/kubernetes-sigs/agent-sandbox/issues/703 is fixed, deprecate this
+// HashUsingSandboxTemplateRefName generates the hash of a sandbox template ref, using only its name.
+// TODO: once https://github.com/kubernetes-sigs/agent-sandbox/issues/703 is fixed, deprecate this.
 func HashUsingSandboxTemplateRefName(templateRefName string) string {
 	return sandboxcontrollers.NameHash(templateRefName)
 }

--- a/extensions/controllers/utils.go
+++ b/extensions/controllers/utils.go
@@ -49,5 +49,11 @@ func ApplySandboxSecureDefaults(template *extensionsv1alpha1.SandboxTemplate, sp
 
 // SandboxTemplateRefHash encapsulates the generation of the hash for a sandbox template ref.
 func SandboxTemplateRefHash(templateRefName string) string {
+	return hashSandboxTemplateRefName(templateRefName)
+}
+
+// HashUsingSandboxTemplateRefName generates the hash of a sandbox template ref, using only its name
+// TODO: once https://github.com/kubernetes-sigs/agent-sandbox/issues/703 is fixed, deprecate this
+func HashUsingSandboxTemplateRefName(templateRefName string) string {
 	return sandboxcontrollers.NameHash(templateRefName)
 }

--- a/extensions/controllers/utils.go
+++ b/extensions/controllers/utils.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
+	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 )
 
 // ApplySandboxSecureDefaults applies the controller's "Secure by Default" logic to a PodSpec.
@@ -44,4 +45,9 @@ func ApplySandboxSecureDefaults(template *extensionsv1alpha1.SandboxTemplate, sp
 			Nameservers: []string{"8.8.8.8", "1.1.1.1"}, // Google & Cloudflare public DNS
 		}
 	}
+}
+
+// SandboxTemplateRefHash encapsulates the generation of the hash for a sandbox template ref.
+func SandboxTemplateRefHash(templateRefName string) string {
+	return sandboxcontrollers.NameHash(templateRefName)
 }

--- a/extensions/controllers/utils_test.go
+++ b/extensions/controllers/utils_test.go
@@ -57,7 +57,15 @@ func TestSandboxTemplateRefHash(t *testing.T) {
 	}
 
 	// Check that different inputs produce different hashes
-	if results["simple template ref name"] == results["a different template ref name"] {
-		t.Errorf("SandboxTemplateRefHash produced same hash for different inputs: %q", results["simple template ref name"])
+	for descA, resultA := range results {
+		for descB, resultB := range results {
+			if descA == descB {
+				continue
+			}
+
+			if resultA == resultB {
+				t.Errorf("SandboxTemplateRefHash produced same hash for different inputs: case '%q' and case '%q'", descA, descB)
+			}
+		}
 	}
 }

--- a/extensions/controllers/utils_test.go
+++ b/extensions/controllers/utils_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+)
+
+func TestSandboxTemplateRefHash(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		templateRefName string
+	}{
+		{
+			desc:            "simple template ref name",
+			templateRefName: "sandbox-name",
+		},
+		{
+			desc:            "a different template ref name",
+			templateRefName: "other-template",
+		},
+		{
+			desc:            "empty template ref name",
+			templateRefName: "",
+		},
+	}
+
+	results := make(map[string]string)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			hash1 := SandboxTemplateRefHash(tc.templateRefName)
+			hash2 := SandboxTemplateRefHash(tc.templateRefName)
+
+			if len(hash1) != 8 {
+				t.Errorf("SandboxTemplateRefHash(%q) length = %d, want 8", tc.templateRefName, len(hash1))
+			}
+
+			if hash1 != hash2 {
+				t.Errorf("SandboxTemplateRefHash(%q) is not deterministic: %q != %q", tc.templateRefName, hash1, hash2)
+			}
+
+			results[tc.desc] = hash1
+		})
+	}
+
+	// Check that different inputs produce different hashes
+	if results["simple template ref name"] == results["a different template ref name"] {
+		t.Errorf("SandboxTemplateRefHash produced same hash for different inputs: %q", results["simple template ref name"])
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Create a shared utility for generating hash of a sandbox's TemplateRef name

The code was modified with the help of https://antigravity.google/.

The next step will be creating a new utility which uses the namespace in addition to name

#### Which issue(s) this PR is related to:

This is part of the fix for issue #703.

#### Release Note

NONE