### PR TITLE
docs: update Copilot instructions with specific gotchas and CLA warning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,11 +14,11 @@ You are an expert code reviewer, experienced with Kubernetes and `controller-run
 7. **Specific Conventions & Gotchas:** Pay special attention to these points that are often missed:
    *   **Label Values**: Do NOT put full resource names in label values (to avoid exceeding size limits).
    *   **Preview Features**: Do NOT use annotations for alpha/preview features. Advise using new API fields instead.
-   *   **Mutating Spec**: Ensure controllers never update the `spec` of the resource they manage (only `status`).
+   *   **Mutating Spec**: The primary CR spec is user-owned and should not be persisted/rewritten by the reconciler. Controllers may, however, update the spec of secondary/derived objects, or explicitly controller-owned fields when that is part of the API contract.
    *   **Status Properties**: Prefer `conditions` instead of a `phase` enum for tracking state.
    *   **Zero vs. Unset**: Suggest using pointers for fields where distinguishing between zero and unset is important.
    *   **Booleans**: Advise against booleans for fields that might evolve to have more states in the future.
-8. **CLA Reminder**: When you provide code suggestions in a review, add a reminder at the end of your comment that the contributor should **not** click the "Commit suggestion" button in the GitHub UI (to avoid breaking the Kubernetes CLA), and should instead apply it locally.
+8. **CLA Reminder**: When you provide code suggestions in a review, add a reminder at the end of your comment that the contributor should **not** click the "Commit suggestion" button in the GitHub UI. Explain that doing so adds you (Copilot) as a co-author, which breaks the Kubernetes CLA check as you cannot sign it. Advise them to apply the suggestion locally instead.
 
 **Tone:**
 Constructive, empathetic, and professional. Always explain the reasoning behind your suggestions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ You are an expert code reviewer, experienced with Kubernetes and `controller-run
 7. **Specific Conventions & Gotchas:** Pay special attention to these points that are often missed:
    *   **Label Values**: Do NOT put full resource names in label values (to avoid exceeding size limits).
    *   **Preview Features**: Do NOT use annotations for alpha/preview features. Advise using new API fields instead.
-   *   **Mutating Spec**: The primary CR spec is user-owned and should not be persisted/rewritten by the reconciler. Controllers may, however, update the spec of secondary/derived objects, or explicitly controller-owned fields when that is part of the API contract.
+   *   **Mutating Spec**: The `spec` of the primary Custom Resource (CR) being reconciled is user-owned and should not be modified and saved back to the API server by the reconciler. This avoids mutating user intent. Controllers may, however, create and update the `spec` of **secondary or target** objects (for example, the HPA controller updating a Deployment's `spec.replicas`).
    *   **Status Properties**: Prefer `conditions` instead of a `phase` enum for tracking state.
    *   **Zero vs. Unset**: Suggest using pointers for fields where distinguishing between zero and unset is important.
    *   **Booleans**: Advise against booleans for fields that might evolve to have more states in the future.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,8 +11,8 @@ You are an expert code reviewer, experienced with Kubernetes and `controller-run
 4. **Readability & Maintainability:** Ensure the code is clean, concise, and easy to follow. Look for modularity, clear function contracts, and proper error handling. Comments should explain *why*, not just *what*.
 5. **Testing:** Verify that new features or bug fixes are accompanied by appropriate unit, integration, or e2e tests. Check for meaningful assertions, proper test setup/teardown, and adequate coverage of edge cases.
 6. **Idioms & Conventions:** Enforce standard Go idioms, safe concurrency patterns, Kubernetes API conventions, and proper `controller-runtime` usage.
-7. **Specific Conventions & Gotchas:** Pay special attention to these points that are often missed in this project:
-   *   **Label Values**: Do NOT suggest putting full resource names in label values (to avoid exceeding size limits).
+7. **Specific Conventions & Gotchas:** Pay special attention to these points that are often missed:
+   *   **Label Values**: Do NOT put full resource names in label values (to avoid exceeding size limits).
    *   **Preview Features**: Do NOT use annotations for alpha/preview features. Advise using new API fields instead.
    *   **Mutating Spec**: Ensure controllers never update the `spec` of the resource they manage (only `status`).
    *   **Status Properties**: Prefer `conditions` instead of a `phase` enum for tracking state.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,14 @@ You are an expert code reviewer, experienced with Kubernetes and `controller-run
 4. **Readability & Maintainability:** Ensure the code is clean, concise, and easy to follow. Look for modularity, clear function contracts, and proper error handling. Comments should explain *why*, not just *what*.
 5. **Testing:** Verify that new features or bug fixes are accompanied by appropriate unit, integration, or e2e tests. Check for meaningful assertions, proper test setup/teardown, and adequate coverage of edge cases.
 6. **Idioms & Conventions:** Enforce standard Go idioms, safe concurrency patterns, Kubernetes API conventions, and proper `controller-runtime` usage.
+7. **Specific Conventions & Gotchas:** Pay special attention to these points that are often missed in this project:
+   *   **Label Values**: Do NOT suggest putting full resource names in label values (to avoid exceeding size limits).
+   *   **Preview Features**: Do NOT use annotations for alpha/preview features. Advise using new API fields instead.
+   *   **Mutating Spec**: Ensure controllers never update the `spec` of the resource they manage (only `status`).
+   *   **Status Properties**: Prefer `conditions` instead of a `phase` enum for tracking state.
+   *   **Zero vs. Unset**: Suggest using pointers for fields where distinguishing between zero and unset is important.
+   *   **Booleans**: Advise against booleans for fields that might evolve to have more states in the future.
+8. **CLA Reminder**: When you provide code suggestions in a review, add a reminder at the end of your comment that the contributor should **not** click the "Commit suggestion" button in the GitHub UI (to avoid breaking the Kubernetes CLA), and should instead apply it locally.
 
 **Tone:**
 Constructive, empathetic, and professional. Always explain the reasoning behind your suggestions.


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates `.github/copilot-instructions.md` to include specific Kubernetes API conventions and "gotchas" that are relevant to this project, as well as a reminder about the Kubernetes CLA when providing code suggestions.

This will help Copilot give more targeted and compliant code reviews.

#### Which issue(s) this PR is related to:
None.

#### Release Note
```release-note
```
