### PR TITLE
test: catch memory leaks and reduce per-scrape allocations

### DIFF
--- a/clients/go/sandbox/client_test.go
+++ b/clients/go/sandbox/client_test.go
@@ -82,6 +82,25 @@ func TestClient_Registry(t *testing.T) {
 	if active[0].ClaimName != "test-claim" {
 		t.Errorf("expected test-claim, got %s", active[0].ClaimName)
 	}
+
+	// Inactive sandboxes (baseURL=="") are pruned from the registry.
+	inactive := &Sandbox{log: logr.Discard()}
+	inactive.connector = &connector{} // baseURL="" -> IsReady() = false
+	key = Key{Namespace: "default", ClaimName: "inactive-claim"}
+	c.mu.Lock()
+	c.registry[key] = inactive
+	c.mu.Unlock()
+
+	got := c.ListActiveSandboxes()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 active after adding inactive, got %d", len(got))
+	}
+	c.mu.Lock()
+	_, stillPresent := c.registry[key]
+	c.mu.Unlock()
+	if stillPresent {
+		t.Error("inactive sandbox should have been pruned from registry")
+	}
 }
 
 func TestClient_DeleteAll(t *testing.T) {
@@ -193,6 +212,46 @@ func TestClient_GetSandbox_ReturnsCached(t *testing.T) {
 	}
 	if got != sb {
 		t.Error("expected cached handle to be returned")
+	}
+}
+
+func TestClient_DeleteSandbox_Tracked(t *testing.T) {
+	c, extensionsCS := newTestClient(t)
+
+	extensionsCS.PrependReactor("delete", "sandboxclaims", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+
+	sb := &Sandbox{
+		k8s:  c.k8s,
+		log:  logr.Discard(),
+		opts: c.opts,
+		connector: &connector{
+			strategy:   &DirectStrategy{URL: "http://fake"},
+			httpClient: &http.Client{},
+		},
+		inflightOps:  &sync.WaitGroup{},
+		lifecycleSem: make(chan struct{}, 1),
+	}
+	sb.mu.Lock()
+	sb.claimName = "tracked-claim"
+	sb.sandboxName = "sb-tracked"
+	sb.mu.Unlock()
+
+	key := Key{Namespace: "default", ClaimName: "tracked-claim"}
+	c.mu.Lock()
+	c.registry[key] = sb
+	c.mu.Unlock()
+
+	if err := c.DeleteSandbox(context.Background(), "tracked-claim", "default"); err != nil {
+		t.Fatalf("DeleteSandbox for tracked sandbox: %v", err)
+	}
+
+	c.mu.Lock()
+	remaining := len(c.registry)
+	c.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("expected empty registry after DeleteSandbox of tracked sandbox, got %d", remaining)
 	}
 }
 

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -525,6 +525,15 @@ func TestRetry_AllExhausted(t *testing.T) {
 	if !strings.Contains(errStr, "502") {
 		t.Errorf("expected error to mention status 502, got: %v", err)
 	}
+	if !errors.Is(err, ErrRetriesExhausted) {
+		t.Errorf("expected ErrRetriesExhausted in error chain, got: %v", err)
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Errorf("expected HTTPError in error chain, got: %v", err)
+	} else if httpErr.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected status 502 in HTTPError, got %d", httpErr.StatusCode)
+	}
 }
 
 func TestRetry_AllRetryableStatusCodes(t *testing.T) {
@@ -673,6 +682,48 @@ func TestRetry_NonSeekableBody(t *testing.T) {
 	}
 	if got := attempts.Load(); got != 1 {
 		t.Errorf("expected 1 attempt with non-seekable body, got %d", got)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed *int32
+}
+
+func (t *trackingReadCloser) Close() error {
+	atomic.AddInt32(t.closed, 1)
+	return nil
+}
+
+func TestSendRequest_ClosesBodyOnRetryableError(t *testing.T) {
+	c := newReadyTestSandbox("http://example.com")
+	var closed int32
+	c.connector.httpClient.Transport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Body:       &trackingReadCloser{Reader: strings.NewReader("error"), closed: &closed},
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	resp, err := c.connector.SendRequest(context.Background(), http.MethodGet, "exists/x", nil, "", 1)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Without closing retry bodies, HTTP connections leak and cannot be reused.
+	if atomic.LoadInt32(&closed) == 0 {
+		t.Fatal("expected response body to be closed")
 	}
 }
 
@@ -1386,6 +1437,46 @@ func TestWithMaxAttempts_InvalidUsesDefault(t *testing.T) {
 				t.Errorf("WithMaxAttempts(%d) should use default (%d attempts), got %d", n, maxAttempts, got)
 			}
 		})
+	}
+}
+
+func TestCancelOnClose_InvokesCancel(t *testing.T) {
+	cancelled := false
+	rc := &cancelOnClose{
+		ReadCloser: io.NopCloser(strings.NewReader("body")),
+		cancel:     func() { cancelled = true },
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	if !cancelled {
+		t.Error("cancelOnClose.Close() did not invoke cancel; request-context goroutines will not be released")
+	}
+}
+
+func TestRetry_LargeBodyOnRetryable(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write(make([]byte, maxDrainBytes*3)) // well over the 4 KB drain cap
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]bool{"exists": true})
+	}))
+	defer server.Close()
+
+	c := newReadyTestSandbox(server.URL)
+	exists, err := c.Exists(context.Background(), "test.txt")
+	if err != nil {
+		t.Fatalf("Exists() should succeed after retry past large error body: %v", err)
+	}
+	if !exists {
+		t.Error("expected exists=true after retry")
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("expected 2 attempts, got %d", got)
 	}
 }
 

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -330,6 +330,15 @@ func TestOpen_TimeoutWhenNotReady(t *testing.T) {
 	if !errors.Is(err, ErrTimeout) {
 		t.Errorf("expected ErrTimeout, got: %v", err)
 	}
+
+	c.mu.Lock()
+	span := c.lifecycleSpan
+	lifecycleCtx := c.lifecycleCtx
+	c.mu.Unlock()
+	// Without clearing lifecycle state on failure, spans leak across sessions.
+	if span != nil || lifecycleCtx != nil {
+		t.Error("expected lifecycle span/context to be cleared after timeout")
+	}
 }
 
 func TestClose_DeletesClaim(t *testing.T) {
@@ -2074,6 +2083,20 @@ func TestHTTPError_CanBeExtracted(t *testing.T) {
 	if httpErr.Operation != "read" {
 		t.Errorf("expected Operation=read, got %s", httpErr.Operation)
 	}
+
+	// Error() truncates bodies longer than 256 chars.
+	longE := &HTTPError{StatusCode: 500, Body: strings.Repeat("x", 300), Operation: "op"}
+	msg := longE.Error()
+	if !strings.Contains(msg, "... [truncated]") {
+		t.Error("expected truncation marker for body > 256 chars")
+	}
+	if strings.Contains(msg, strings.Repeat("x", 257)) {
+		t.Error("body was not truncated to 256 chars")
+	}
+	shortE := &HTTPError{StatusCode: 404, Body: "short", Operation: "op"}
+	if strings.Contains(shortE.Error(), "truncated") {
+		t.Error("short body should not be marked as truncated")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -2582,6 +2605,13 @@ func TestClose_DeleteFailure_ClearsIdentityButKeepsClaim(t *testing.T) {
 	if c.PodName() != "" {
 		t.Error("expected PodName to be cleared after failed Close")
 	}
+	// Span must be nil regardless of delete error. an unended span leaks tracer resources.
+	c.mu.Lock()
+	span := c.lifecycleSpan
+	c.mu.Unlock()
+	if span != nil {
+		t.Error("lifecycleSpan must be nil after Close() even when claim deletion fails; span leak")
+	}
 	if err := c.Open(context.Background()); !errors.Is(err, ErrOrphanedClaim) {
 		t.Fatalf("expected ErrOrphanedClaim after failed Close, got: %v", err)
 	}
@@ -2863,6 +2893,78 @@ func TestDisconnect_Timeout(t *testing.T) {
 
 	// Release the sem for cleanup.
 	<-c.lifecycleSem
+}
+
+func TestDeleteClaim_EmptyName(t *testing.T) {
+	extensionsCS := fakeextensions.NewSimpleClientset() //nolint:staticcheck
+	deleteCalled := false
+	extensionsCS.PrependReactor("delete", "sandboxclaims", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		deleteCalled = true
+		return true, nil, nil
+	})
+	h := &K8sHelper{
+		ExtensionsClient: extensionsCS.ExtensionsV1alpha1(),
+		Log:              logr.Discard(),
+	}
+	if err := h.deleteClaim(context.Background(), "", "default"); err != nil {
+		t.Fatalf("deleteClaim(\"\") should return nil, got: %v", err)
+	}
+	if deleteCalled {
+		t.Error("deleteClaim(\"\") should not call the k8s API")
+	}
+}
+
+func TestTrackOp_WhenDraining(t *testing.T) {
+	opts := defaultTestOpts()
+	c, _, _ := newTestSandbox(opts)
+
+	c.mu.Lock()
+	c.draining = true
+	c.mu.Unlock()
+
+	done := c.trackOp()
+	done() // must not panic; no Done() on a WaitGroup that had no Add
+
+	// Verify WaitGroup was not incremented by confirming Wait returns immediately.
+	c.mu.Lock()
+	wg := c.inflightOps
+	c.draining = false
+	c.mu.Unlock()
+
+	waitDone := make(chan struct{})
+	go func() { wg.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("WaitGroup was incremented by trackOp when draining=true")
+	}
+}
+
+// TestOpen_FailureClearsLifecycleSpan verifies that a failed Open ends and
+// clears the lifecycle span.
+func TestOpen_FailureClearsLifecycleSpan(t *testing.T) {
+	opts := defaultTestOpts()
+	c, _, extensionsCS := newTestSandbox(opts)
+	extensionsCS.PrependReactor("create", "sandboxclaims", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("injected failure")
+	})
+
+	if err := c.Open(context.Background()); err == nil {
+		c.Close(context.Background())
+		t.Fatal("expected Open() to fail")
+	}
+
+	c.mu.Lock()
+	span := c.lifecycleSpan
+	ctx := c.lifecycleCtx
+	c.mu.Unlock()
+
+	if span != nil {
+		t.Error("lifecycleSpan must be nil after failed Open(); unended span leaks tracer resources")
+	}
+	if ctx != nil {
+		t.Error("lifecycleCtx must be nil after failed Open(); context leak")
+	}
 }
 
 func TestDisconnect_DoubleDisconnect(t *testing.T) {

--- a/clients/go/sandbox/testmain_test.go
+++ b/clients/go/sandbox/testmain_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/clients/go/sandbox/tracing_test.go
+++ b/clients/go/sandbox/tracing_test.go
@@ -429,6 +429,13 @@ func TestTracingErrorRecording(t *testing.T) {
 	t.Error("run span not found")
 }
 
+func TestTraceContextJSON_NoActiveSpan(t *testing.T) {
+	// Background context carries no span; carrier will be empty -> return "".
+	if got := traceContextJSON(context.Background()); got != "" {
+		t.Errorf("expected empty string for context without an active span, got %q", got)
+	}
+}
+
 // --- helpers ---
 
 func spanNames(spans tracetest.SpanStubs) []string {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2462,3 +2462,81 @@ func TestMergeVolumeClaimVolumes(t *testing.T) {
 		require.NotNil(t, result[0].EmptyDir)
 	})
 }
+
+// TestSandboxReconcile_ConditionsDoNotAccumulate verifies that reconciling a
+// ready sandbox many times does not grow the conditions slice. A bug
+// that appends instead of upserts the Ready condition will cause unbounded
+// status growth.
+func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
+	sbName := "no-grow-sandbox"
+	sbNs := "default"
+	nameHash := NameHash(sbName)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sbName, Namespace: sbNs,
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To[int32](1),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sbName, Namespace: sbNs,
+			Labels:          map[string]string{sandboxLabel: nameHash},
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sbName)},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "img"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			PodIPs: []corev1.PodIP{{IP: "10.0.0.1"}},
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: sbName, Namespace: sbNs,
+			Labels:          map[string]string{sandboxLabel: nameHash},
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sbName)},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Selector:  map[string]string{sandboxLabel: nameHash},
+		},
+	}
+
+	fc := newFakeClient(sandbox, pod, svc)
+	r := &SandboxReconciler{
+		Client: fc,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sbName, Namespace: sbNs}}
+
+	const iters = 20
+	for i := range iters {
+		_, err := r.Reconcile(ctx, req)
+		require.NoError(t, err, "reconcile iteration %d", i)
+	}
+
+	var got sandboxv1alpha1.Sandbox
+	require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: sbName, Namespace: sbNs}, &got))
+	require.Len(t, got.Status.Conditions, 1,
+		"conditions slice must not grow across %d reconcile iterations — controller must upsert not append", iters)
+}

--- a/controllers/testmain_test.go
+++ b/controllers/testmain_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -16,11 +16,17 @@
 package metrics
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"sigs.k8s.io/agent-sandbox/internal/version"
 )
 
@@ -102,4 +108,25 @@ func TestBuildInfo(t *testing.T) {
 	if err := testutil.CollectAndCompare(BuildInfo, strings.NewReader(expected)); err != nil {
 		t.Errorf("BuildInfo metric mismatch: %v", err)
 	}
+}
+
+func TestStartSpanEndFuncEndsSpan(t *testing.T) {
+	// StartSpan returns an end func; if the caller never invokes it, span.End is never called and
+	// the span is never exported, a span resource leak. This mini test just proves the func closes the span.
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	inst := &otelInstrumenter{
+		tracer:     tp.Tracer("test"),
+		propagator: propagation.TraceContext{},
+		logger:     logr.Discard(),
+	}
+
+	_, end := inst.StartSpan(context.Background(), nil, "op", nil)
+	end()
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	require.False(t, spans[0].EndTime.IsZero(), "end func must call span.End")
 }

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -89,20 +89,16 @@ func (c *SandboxCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 // Collect fetches sandboxes, calculates labels, and sends metrics to the channel.
-// Note: Using client.List to fetch all sandboxes in the cluster on every metrics scrape
-// introduces O(N) memory allocation and CPU overhead due to deep-copying thousands of objects.
-// While updating a GaugeVec in the Reconcile loop might be slightly harder to manage,
-// it operates in O(1) memory during scrapes and is generally more performant.
-// This is a known performance trade-off to keep the Reconcile loop simpler.
+// UnsafeDisableDeepCopy avoids O(N) deep-copy overhead on every scrape; safe here because
+// Collect only reads fields for label aggregation and never mutates or retains the objects.
+// A GaugeVec updated in the Reconcile loop would be more performant (O(1) per scrape),
+// but this is a known trade-off to keep the Reconcile loop simpler.
 func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 	var sandboxList sandboxv1alpha1.SandboxList
 	ctx, cancel := context.WithTimeout(context.Background(), metricsCollectTimeout)
 	defer cancel()
 
-	// TODO(chw120): The current O(N) List call during metrics collection poses a scalability concern.
-	// In large clusters, frequent scrapes could lead to high CPU usage or OOM.
-	// This should be replaced with a more efficient implementation.
-	if err := c.client.List(ctx, &sandboxList); err != nil {
+	if err := c.client.List(ctx, &sandboxList, client.UnsafeDisableDeepCopy); err != nil {
 		c.logger.Error(err, "Failed to list sandboxes for metrics collection")
 		return
 	}

--- a/internal/metrics/testmain_test.go
+++ b/internal/metrics/testmain_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
follow up: #692 
fixes: #636 

## New Tests
- Add goleak TestMain across controllers, clients/go/sandbox and internal/metrics
- Add targeted tests for span, connection, context, and conditions-accumulation leaks

## Metrics

This also ships `UnsafeDisableDeepCopy` in `SandboxCollector.Collect`, which could live
in its own PR but is a minimal one-liner and fits here since it directly reduces the
per-scrape memory overhead (similar to memory leaks). Collect only reads sandbox
fields to build label counts and never mutates them, so skipping the per-object
deep-copy is safe. benchmarked by spinning up a real controller-runtime cache with `10000` sandboxes and running `c.List` under both modes:
```go
  BenchmarkSandboxCollect/WithDeepCopy       319 ops    17960811 ns/op   29080501 B/op   92547 allocs/op
  BenchmarkSandboxCollect/WithoutDeepCopy   1567 ops     3667834 ns/op   10331436 B/op      10 allocs/op
```

Benchmarking happens through simple test using `testEnv`

```go
	c, err := cache.New(cfg, cache.Options{Scheme: scheme})
         ...
	// WithDeepCopy
	b.Run("WithDeepCopy", func(b *testing.B) {
		b.ReportAllocs()
		for b.Loop() {
			var list sandboxv1alpha1.SandboxList
			if err := c.List(ctx, &list); err != nil {
				b.Fatal(err)
			}
		}
	})

	// WithoutDeepCopy
	b.Run("WithoutDeepCopy", func(b *testing.B) {
		b.ReportAllocs()
		for b.Loop() {
			var list sandboxv1alpha1.SandboxList
			if err := c.List(ctx, &list, client.UnsafeDisableDeepCopy); err != nil {
				b.Fatal(err)
			}
		}
	})
}

```
