### PR TITLE
Store assigned Sandbox name in annotations instead of labels to bypass length constraints

### DIFF
--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -26,8 +26,8 @@ const (
 	// ClaimExpiredReason is the reason used in conditions/events when a claim expires.
 	ClaimExpiredReason = "ClaimExpired"
 
-	// AssignedSandboxNameLabel is the label key applied to the claim to identify the adopted Sandbox name.
-	AssignedSandboxNameLabel = "agents.x-k8s.io/sandbox-name"
+	// AssignedSandboxNameAnnotation is the annotation key applied to the claim to identify the adopted Sandbox Name.
+	AssignedSandboxNameAnnotation = "agents.x-k8s.io/sandbox-name"
 )
 
 // WarmPoolPolicy describes the policy for using warm pools.

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -26,6 +26,10 @@ const (
 	// ClaimExpiredReason is the reason used in conditions/events when a claim expires.
 	ClaimExpiredReason = "ClaimExpired"
 
+	// DeprecatedAssignedSandboxNameLabel is the legacy label key applied to the claim to identify the adopted Sandbox name.
+	// Deprecated: Use AssignedSandboxNameAnnotation instead.
+	DeprecatedAssignedSandboxNameLabel = "agents.x-k8s.io/sandbox-name"
+
 	// AssignedSandboxNameAnnotation is the annotation key applied to the claim to identify the adopted Sandbox Name.
 	AssignedSandboxNameAnnotation = "agents.x-k8s.io/sandbox-name"
 )

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1105,6 +1105,17 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	return sandbox, nil
 }
 
+// migrateLegacyAssignedSandboxLabel migrates legacy assigned Sandbox name from label to annotation.
+func (r *SandboxClaimReconciler) migrateLegacyAssignedSandboxLabel(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sbName string) error {
+	patch := client.MergeFrom(claim.DeepCopy())
+	if claim.Annotations == nil {
+		claim.Annotations = make(map[string]string)
+	}
+	claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sbName
+	delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+	return r.Patch(ctx, claim, patch)
+}
+
 func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, _ *extensionsv1beta1.SandboxTemplate) (*v1beta1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	logger.V(1).Info("Executing getOrCreateSandbox", "claim", claim.Name)
@@ -1115,13 +1126,15 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		sandbox := &v1beta1.Sandbox{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
-				logger.Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
+				logger.V(4).Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
 				return sandbox, nil
 			}
 		} else if !k8errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get sandbox %q from status: %w", statusName, err)
 		}
-	} // Check if a previously adopted sandbox is recorded in claim annotations or legacy labels
+	}
+
+	// Check if a previously adopted sandbox is recorded in claim annotations or legacy labels
 	var sbName string
 	var fromLabel bool
 	if claim.Annotations != nil {
@@ -1133,26 +1146,19 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			fromLabel = true
 		}
 	}
-		}
-	}
 
 	if sbName != "" {
 		logger.V(1).Info("Checking assigned sandbox name", "sandboxName", sbName, "fromLabel", fromLabel, "claim", claim.Name)
 		sandbox := &v1beta1.Sandbox{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
-				logger.Info("Found existing adopted sandbox", "sandbox", sbName, "claim", claim.Name)
+				logger.V(4).Info("Found existing adopted sandbox", "sandbox", sbName, "claim", claim.Name)
 				if fromLabel {
-					patch := client.MergeFrom(claim.DeepCopy())
-					if claim.Annotations == nil {
-						claim.Annotations = make(map[string]string)
-					}
-					claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sbName
-					delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
-					if err := r.Patch(ctx, claim, patch); err != nil {
+					if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
 						logger.Error(err, "Failed to migrate legacy sandbox label to annotation (non-fatal)", "claim", claim.Name)
+					} else {
+						logger.Info("Successfully migrated legacy sandbox label to annotation", "claim", claim.Name)
 					}
-					logger.Info("Successfully migrated legacy sandbox label to annotation", "claim", claim.Name)
 				}
 				return sandbox, nil
 			}
@@ -1161,31 +1167,39 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
 				// Still in warm pool. Try to complete adoption!
 				logger.Info("Sandbox found in claim metadata still in warm pool, trying to complete adoption", "sandbox", sbName, "claim", claim.Name)
-				if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
-					if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
-						logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
+				if err := verifySandboxCandidate(sandbox, claim); err != nil {
+					logger.Info("Sandbox recorded in claim metadata cannot be adopted, removing stale reference", "sandboxName", sbName, "fromLabel", fromLabel, "claim", claim.Name, "reason", err.Error())
+					patch := client.MergeFrom(claim.DeepCopy())
+					if fromLabel {
+						delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
 					} else {
-						return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
+						delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+					}
+					if err := r.Patch(ctx, claim, patch); err != nil {
+						return nil, fmt.Errorf("failed to remove invalid sandbox reference: %w", err)
 					}
 				} else {
-					if fromLabel {
-						patch := client.MergeFrom(claim.DeepCopy())
-						if claim.Annotations == nil {
-							claim.Annotations = make(map[string]string)
+					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
+						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
+							logger.V(4).Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
+						} else {
+							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
 						}
-						claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sbName
-						delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
-						if err := r.Patch(ctx, claim, patch); err != nil {
-							logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+					} else {
+						if fromLabel {
+							if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
+								logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+							} else {
+								logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+							}
 						}
-						logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+						// If succeeded, return error to retry so next reconcile sees it controlled by us!
+						logger.Info("Triggered adoption completion for sandbox, retry", "sandbox", sbName, "claim", claim.Name)
+						return nil, fmt.Errorf("triggered adoption completion for sandbox %s, retry", sbName)
 					}
-					// If succeeded, return error to retry so next reconcile sees it controlled by us!
-					logger.Info("Triggered adoption completion for sandbox, retry", "sandbox", sbName, "claim", claim.Name)
-					return nil, fmt.Errorf("triggered adoption completion for sandbox %s, retry", sbName)
 				}
 			}
-			logger.Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
+			logger.V(4).Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
 		} else if k8errors.IsNotFound(err) {
 			logger.Info("Sandbox recorded in claim metadata not found, removing stale reference", "sandboxName", sbName, "claim", claim.Name)
 			patch := client.MergeFrom(claim.DeepCopy())
@@ -1219,7 +1233,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	}
 
 	if sandbox != nil {
-		logger.Info("sandbox already exists, skipping update", "name", sandbox.Name)
+		logger.V(4).Info("sandbox already exists, skipping update", "name", sandbox.Name)
 		if !metav1.IsControlledBy(sandbox, claim) {
 			err := fmt.Errorf("sandbox %q is not controlled by claim %q. Please use a different claim name or delete the sandbox manually", sandbox.Name, claim.Name)
 			logger.Error(err, "Sandbox controller mismatch")
@@ -1238,7 +1252,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	}
 
 	if policy == extensionsv1beta1.WarmPoolPolicyNone {
-		logger.Info("Skipping warm pool adoption based on warmpool policy", "claim", claim.Name, "warmpool", policy)
+		logger.V(4).Info("Skipping warm pool adoption based on warmpool policy", "claim", claim.Name, "warmpool", policy)
 		return nil, nil
 	}
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -671,10 +671,10 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			logger.Info("Attempting sandbox adoption", "sandbox candidate", adopted.Name, "warm pool", poolName, "claim", claim.Name)
 
 			// Update claim to record adoption (optimistic lock)
-			if claim.Labels == nil {
-				claim.Labels = make(map[string]string)
+			if claim.Annotations == nil {
+				claim.Annotations = make(map[string]string)
 			}
-			claim.Labels[extensionsv1beta1.AssignedSandboxNameLabel] = adopted.Name
+			claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = adopted.Name
 			if err := r.Update(ctx, claim); err != nil {
 				r.WarmSandboxQueue.Add(templateHash, adoptedKey)
 				if k8errors.IsConflict(err) {
@@ -1123,56 +1123,54 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		}
 	}
 
-	// Check if a previously adopted sandbox is recorded in claim labels
-	sbName := ""
-	if claim.Labels != nil {
-		sbName = claim.Labels[extensionsv1beta1.AssignedSandboxNameLabel]
-	}
-	if sbName != "" {
-		logger.V(1).Info("Checking labels for sandbox name", "label", sbName, "claim", claim.Name)
-		sandbox := &v1beta1.Sandbox{}
-		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
-			if metav1.IsControlledBy(sandbox, claim) {
-				logger.Info("Found existing adopted sandbox from labels", "sandbox", sbName, "claim", claim.Name)
-				return sandbox, nil
-			}
+	// Check if a previously adopted sandbox is recorded in claim annotations
+	if claim.Annotations != nil {
+		if sbName := claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]; sbName != "" {
+			logger.V(1).Info("Checking annotations for sandbox name", "annotation", sbName, "claim", claim.Name)
+			sandbox := &v1beta1.Sandbox{}
+			if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
+				if metav1.IsControlledBy(sandbox, claim) {
+					logger.Info("Found existing adopted sandbox from annotations", "sandbox", sandbox.Name, "claim", claim.Name)
+					return sandbox, nil
+				}
 
-			controllerRef := metav1.GetControllerOf(sandbox)
-			if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
-				// Still in warm pool. Try to complete adoption!
-				logger.Info("Sandbox found by label still in warm pool, checking if it matches template", "sandbox", sbName, "claim", claim.Name)
+				controllerRef := metav1.GetControllerOf(sandbox)
+				if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
+					// Still in warm pool. Try to complete adoption!
+					logger.Info("Sandbox found by annotation still in warm pool, trying to complete adoption", "sandbox", sandbox.Name, "claim", claim.Name)
 
-				if err := verifySandboxCandidate(sandbox, claim); err != nil {
-					logger.Info("Sandbox recorded in label cannot be adopted, removing stale label", "sandbox", sbName, "claim", claim.Name, "reason", err.Error())
-					patch := client.MergeFrom(claim.DeepCopy())
-					delete(claim.Labels, extensionsv1beta1.AssignedSandboxNameLabel)
-					if err := r.Patch(ctx, claim, patch); err != nil {
-						return nil, fmt.Errorf("failed to remove invalid sandbox label: %w", err)
-					}
-				} else {
-					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
-						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
-							logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
-						} else {
-							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
+					if err := verifySandboxCandidate(sandbox, claim); err != nil {
+						logger.Info("Sandbox recorded in annotation cannot be adopted, removing stale annotation", "sandbox", sbName, "claim", claim.Name, "reason", err.Error())
+						patch := client.MergeFrom(claim.DeepCopy())
+						delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+						if err := r.Patch(ctx, claim, patch); err != nil {
+							return nil, fmt.Errorf("failed to remove invalid sandbox annotation: %w", err)
 						}
 					} else {
-						// If succeeded, return error to retry so next reconcile sees it controlled by us!
-						return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sbName)
+						if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
+							if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
+								logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sandbox.Name, "claim", claim.Name)
+							} else {
+								return nil, fmt.Errorf("failed to complete adoption of %q: %w", sandbox.Name, err)
+							}
+						} else {
+							// If succeeded, return error to retry so next reconcile sees it controlled by us!
+							return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sandbox.Name)
+						}
 					}
+				} else {
+					logger.Info("Sandbox recorded in annotation belongs to another claim, falling through", "sandbox", sandbox.Name, "claim", claim.Name)
 				}
+			} else if k8errors.IsNotFound(err) {
+				logger.Info("Sandbox recorded in annotation not found, removing stale annotation", "sandboxName", sbName, "claim", claim.Name)
+				patch := client.MergeFrom(claim.DeepCopy())
+				delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+				if err := r.Patch(ctx, claim, patch); err != nil {
+					return nil, fmt.Errorf("failed to remove stale sandbox annotation: %w", err)
+				}
+			} else {
+				return nil, fmt.Errorf("failed to get sandbox %q for annotation lookup: %w", sbName, err)
 			}
-
-			logger.Info("Sandbox recorded in label belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
-		} else if k8errors.IsNotFound(err) {
-			logger.Info("Sandbox recorded in label not found, removing stale label", "sandbox", sbName, "claim", claim.Name)
-			patch := client.MergeFrom(claim.DeepCopy())
-			delete(claim.Labels, extensionsv1beta1.AssignedSandboxNameLabel)
-			if err := r.Patch(ctx, claim, patch); err != nil {
-				return nil, fmt.Errorf("failed to remove stale sandbox label: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("failed to get sandbox %q from labels: %w", sbName, err)
 		}
 	}
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1141,7 +1141,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		sandbox := &v1beta1.Sandbox{}
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
-				logger.Info("Found existing adopted sandbox", "sandbox", sandbox.Name, "fromLabel", fromLabel, "claim", claim.Name)
+				logger.Info("Found existing adopted sandbox", "sandbox", sbName, "claim", claim.Name)
 				if fromLabel {
 					patch := client.MergeFrom(claim.DeepCopy())
 					if claim.Annotations == nil {
@@ -1161,12 +1161,12 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			controllerRef := metav1.GetControllerOf(sandbox)
 			if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
 				// Still in warm pool. Try to complete adoption!
-				logger.Info("Sandbox found in claim metadata still in warm pool, trying to complete adoption", "sandbox", sandbox.Name, "fromLabel", fromLabel, "claim", claim.Name)
+				logger.Info("Sandbox found in claim metadata still in warm pool, trying to complete adoption", "sandbox", sbName, "claim", claim.Name)
 				if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
 					if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
-						logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sandbox.Name, "claim", claim.Name)
+						logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
 					} else {
-						return nil, fmt.Errorf("failed to complete adoption of %q: %w", sandbox.Name, err)
+						return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
 					}
 				} else {
 					if fromLabel {
@@ -1181,12 +1181,12 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 						}
 					}
 					// If succeeded, return error to retry so next reconcile sees it controlled by us!
-					return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sandbox.Name)
+					return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sbName)
 				}
 			}
-			logger.Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sandbox.Name, "claim", claim.Name)
+			logger.Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
 		} else if k8errors.IsNotFound(err) {
-			logger.Info("Sandbox recorded in claim metadata not found, removing stale reference", "sandboxName", sbName, "from claim metadata", claim.Name)
+			logger.Info("Sandbox recorded in claim metadata not found, removing stale reference", "sandboxName", sbName, "claim", claim.Name)
 			patch := client.MergeFrom(claim.DeepCopy())
 			if fromLabel {
 				delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1121,7 +1121,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		} else if !k8errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get sandbox %q from status: %w", statusName, err)
 		}
-	}	// Check if a previously adopted sandbox is recorded in claim annotations or legacy labels
+	} // Check if a previously adopted sandbox is recorded in claim annotations or legacy labels
 	var sbName string
 	var fromLabel bool
 	if claim.Annotations != nil {
@@ -1151,9 +1151,8 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 					delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
 					if err := r.Patch(ctx, claim, patch); err != nil {
 						logger.Error(err, "Failed to migrate legacy sandbox label to annotation (non-fatal)", "claim", claim.Name)
-					} else {
-						logger.Info("Successfully migrated legacy sandbox label to annotation", "claim", claim.Name)
 					}
+					logger.Info("Successfully migrated legacy sandbox label to annotation", "claim", claim.Name)
 				}
 				return sandbox, nil
 			}
@@ -1179,9 +1178,11 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 						if err := r.Patch(ctx, claim, patch); err != nil {
 							logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 						}
+						logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 					}
 					// If succeeded, return error to retry so next reconcile sees it controlled by us!
-					return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sbName)
+					logger.Info("Triggered adoption completion for sandbox, retry", "sandbox", sbName, "claim", claim.Name)
+					return nil, fmt.Errorf("triggered adoption completion for sandbox %s, retry", sbName)
 				}
 			}
 			logger.Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
@@ -1196,6 +1197,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			if err := r.Patch(ctx, claim, patch); err != nil {
 				return nil, fmt.Errorf("failed to remove stale sandbox reference from claim metadata: %w", err)
 			}
+			logger.Info("Successfully removed stale sandbox reference from claim metadata", "sandbox", sbName, "claim", claim.Name)
 		} else {
 			return nil, fmt.Errorf("failed to get sandbox %q for sandbox name lookup: %w", sbName, err)
 		}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1121,56 +1121,83 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		} else if !k8errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get sandbox %q from status: %w", statusName, err)
 		}
+	}	// Check if a previously adopted sandbox is recorded in claim annotations or legacy labels
+	var sbName string
+	var fromLabel bool
+	if claim.Annotations != nil {
+		sbName = claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]
+	}
+	if sbName == "" && claim.Labels != nil {
+		sbName = claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel]
+		if sbName != "" {
+			fromLabel = true
+		}
+	}
+		}
 	}
 
-	// Check if a previously adopted sandbox is recorded in claim annotations
-	if claim.Annotations != nil {
-		if sbName := claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]; sbName != "" {
-			logger.V(1).Info("Checking annotations for sandbox name", "annotation", sbName, "claim", claim.Name)
-			sandbox := &v1beta1.Sandbox{}
-			if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
-				if metav1.IsControlledBy(sandbox, claim) {
-					logger.Info("Found existing adopted sandbox from annotations", "sandbox", sandbox.Name, "claim", claim.Name)
-					return sandbox, nil
-				}
-
-				controllerRef := metav1.GetControllerOf(sandbox)
-				if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
-					// Still in warm pool. Try to complete adoption!
-					logger.Info("Sandbox found by annotation still in warm pool, trying to complete adoption", "sandbox", sandbox.Name, "claim", claim.Name)
-
-					if err := verifySandboxCandidate(sandbox, claim); err != nil {
-						logger.Info("Sandbox recorded in annotation cannot be adopted, removing stale annotation", "sandbox", sbName, "claim", claim.Name, "reason", err.Error())
-						patch := client.MergeFrom(claim.DeepCopy())
-						delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
-						if err := r.Patch(ctx, claim, patch); err != nil {
-							return nil, fmt.Errorf("failed to remove invalid sandbox annotation: %w", err)
-						}
+	if sbName != "" {
+		logger.V(1).Info("Checking assigned sandbox name", "sandboxName", sbName, "fromLabel", fromLabel, "claim", claim.Name)
+		sandbox := &v1beta1.Sandbox{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
+			if metav1.IsControlledBy(sandbox, claim) {
+				logger.Info("Found existing adopted sandbox", "sandbox", sandbox.Name, "fromLabel", fromLabel, "claim", claim.Name)
+				if fromLabel {
+					patch := client.MergeFrom(claim.DeepCopy())
+					if claim.Annotations == nil {
+						claim.Annotations = make(map[string]string)
+					}
+					claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sbName
+					delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+					if err := r.Patch(ctx, claim, patch); err != nil {
+						logger.Error(err, "Failed to migrate legacy sandbox label to annotation (non-fatal)", "claim", claim.Name)
 					} else {
-						if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
-							if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
-								logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sandbox.Name, "claim", claim.Name)
-							} else {
-								return nil, fmt.Errorf("failed to complete adoption of %q: %w", sandbox.Name, err)
-							}
-						} else {
-							// If succeeded, return error to retry so next reconcile sees it controlled by us!
-							return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sandbox.Name)
-						}
+						logger.Info("Successfully migrated legacy sandbox label to annotation", "claim", claim.Name)
+					}
+				}
+				return sandbox, nil
+			}
+
+			controllerRef := metav1.GetControllerOf(sandbox)
+			if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
+				// Still in warm pool. Try to complete adoption!
+				logger.Info("Sandbox found in claim metadata still in warm pool, trying to complete adoption", "sandbox", sandbox.Name, "fromLabel", fromLabel, "claim", claim.Name)
+				if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
+					if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
+						logger.Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sandbox.Name, "claim", claim.Name)
+					} else {
+						return nil, fmt.Errorf("failed to complete adoption of %q: %w", sandbox.Name, err)
 					}
 				} else {
-					logger.Info("Sandbox recorded in annotation belongs to another claim, falling through", "sandbox", sandbox.Name, "claim", claim.Name)
+					if fromLabel {
+						patch := client.MergeFrom(claim.DeepCopy())
+						if claim.Annotations == nil {
+							claim.Annotations = make(map[string]string)
+						}
+						claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sbName
+						delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+						if err := r.Patch(ctx, claim, patch); err != nil {
+							logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+						}
+					}
+					// If succeeded, return error to retry so next reconcile sees it controlled by us!
+					return nil, fmt.Errorf("triggered adoption completion for %q: retrying", sandbox.Name)
 				}
-			} else if k8errors.IsNotFound(err) {
-				logger.Info("Sandbox recorded in annotation not found, removing stale annotation", "sandboxName", sbName, "claim", claim.Name)
-				patch := client.MergeFrom(claim.DeepCopy())
-				delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
-				if err := r.Patch(ctx, claim, patch); err != nil {
-					return nil, fmt.Errorf("failed to remove stale sandbox annotation: %w", err)
-				}
-			} else {
-				return nil, fmt.Errorf("failed to get sandbox %q for annotation lookup: %w", sbName, err)
 			}
+			logger.Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sandbox.Name, "claim", claim.Name)
+		} else if k8errors.IsNotFound(err) {
+			logger.Info("Sandbox recorded in claim metadata not found, removing stale reference", "sandboxName", sbName, "from claim metadata", claim.Name)
+			patch := client.MergeFrom(claim.DeepCopy())
+			if fromLabel {
+				delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+			} else {
+				delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+			}
+			if err := r.Patch(ctx, claim, patch); err != nil {
+				return nil, fmt.Errorf("failed to remove stale sandbox reference from claim metadata: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("failed to get sandbox %q for sandbox name lookup: %w", sbName, err)
 		}
 	}
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3431,7 +3431,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			Name:      "test-claim",
 			Namespace: "default",
 			UID:       "claim-uid-123",
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				"agents.x-k8s.io/sandbox-name": "adopted-sb",
 			},
 		},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3831,3 +3831,94 @@ func TestMapTemplateToClaims(t *testing.T) {
 		}
 	}
 }
+
+func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
+	scheme := newScheme(t)
+
+	claim := &extensionsv1alpha1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim-legacy",
+			Namespace: "default",
+			UID:       "claim-uid-legacy",
+			Labels: map[string]string{
+				extensionsv1alpha1.DeprecatedAssignedSandboxNameLabel: "adopted-sb-legacy",
+			},
+		},
+		Spec: extensionsv1alpha1.SandboxClaimSpec{
+			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+		},
+	}
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	adoptedSandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adopted-sb-legacy",
+			Namespace: "default",
+			UID:       "adopted-sb-legacy-uid",
+			Labels: map[string]string{
+				extensionsv1alpha1.SandboxIDLabel: "claim-uid-legacy",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+				Kind:       "SandboxClaim",
+				Name:       "test-claim-legacy",
+				UID:        "claim-uid-legacy",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				ObjectMeta: sandboxv1alpha1.PodMetadata{
+					Labels: map[string]string{
+						extensionsv1alpha1.SandboxIDLabel: "claim-uid-legacy",
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, claim, adoptedSandbox).
+		WithStatusSubresource(claim).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim-legacy", Namespace: "default"}}
+
+	// Run reconcile
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected reconcile to succeed, but got error: %v", err)
+	}
+
+	// Verify that the claim was migrated: DeprecatedAssignedSandboxNameLabel removed, AssignedSandboxNameAnnotation added
+	updatedClaim := &extensionsv1alpha1.SandboxClaim{}
+	if err := fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim); err != nil {
+		t.Fatalf("failed to get claim: %v", err)
+	}
+
+	if _, ok := updatedClaim.Labels[extensionsv1alpha1.DeprecatedAssignedSandboxNameLabel]; ok {
+		t.Error("expected legacy label to be removed after migration")
+	}
+	if updatedClaim.Annotations[extensionsv1alpha1.AssignedSandboxNameAnnotation] != "adopted-sb-legacy" {
+		t.Errorf("expected annotation to be set to 'adopted-sb-legacy', got %q", updatedClaim.Annotations[extensionsv1alpha1.AssignedSandboxNameAnnotation])
+	}
+}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3421,7 +3421,7 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 }
 
 // TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag verifies that during informer cache lag,
-// the assigned sandbox label on the claim is used to identify the previously adopted Sandbox,
+// the assigned sandbox annotation on the claim is used to identify the previously adopted Sandbox,
 // preventing duplicate adoptions from the warm pool.
 func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	scheme := newScheme(t)
@@ -3432,7 +3432,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			Namespace: "default",
 			UID:       "claim-uid-123",
 			Annotations: map[string]string{
-				"agents.x-k8s.io/sandbox-name": "adopted-sb",
+				extensionsv1alpha1.AssignedSandboxNameAnnotation: "adopted-sb",
 			},
 		},
 		Spec: extensionsv1beta1.SandboxClaimSpec{

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2041,6 +2041,15 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					}
 				}
 
+				// 5. Verify the claim records the assigned sandbox annotation
+				var updatedClaim extensionsv1alpha1.SandboxClaim
+				if err := fakeClient.Get(ctx, req.NamespacedName, &updatedClaim); err != nil {
+					t.Fatalf("failed to get updated claim: %v", err)
+				}
+				if val := updatedClaim.Annotations[extensionsv1alpha1.AssignedSandboxNameAnnotation]; val != tc.expectedAdoptedSandbox {
+					t.Errorf("expected claim to have assigned sandbox annotation %q, got %q", tc.expectedAdoptedSandbox, val)
+				}
+
 			} else if tc.expectNewSandboxCreated {
 				// Verify a new sandbox was created with the claim's name
 				var sandbox sandboxv1beta1.Sandbox

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2031,24 +2031,18 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				}
 
 				// 4. Verify the adopted sandbox records the adopted pod name
-				if val := adoptedSandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation]; val != adoptedSandbox.Name {
-					t.Errorf("expected adopted sandbox to have %q annotation %q, got %q; annotations=%v", sandboxv1beta1.SandboxPodNameAnnotation, adoptedSandbox.Name, val, adoptedSandbox.Annotations)
-				}
+				require.Equal(t, adoptedSandbox.Name, adoptedSandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation])
 
 				for key, expected := range tc.expectedAnnotations {
-					if val := adoptedSandbox.Annotations[key]; val != expected {
-						t.Errorf("expected adopted sandbox to preserve annotation %q=%q, got %q; annotations=%v", key, expected, val, adoptedSandbox.Annotations)
-					}
+					require.Equal(t, expected, adoptedSandbox.Annotations[key])
 				}
 
 				// 5. Verify the claim records the assigned sandbox annotation
-				var updatedClaim extensionsv1alpha1.SandboxClaim
+				var updatedClaim extensionsv1beta1.SandboxClaim
 				if err := fakeClient.Get(ctx, req.NamespacedName, &updatedClaim); err != nil {
 					t.Fatalf("failed to get updated claim: %v", err)
 				}
-				if val := updatedClaim.Annotations[extensionsv1alpha1.AssignedSandboxNameAnnotation]; val != tc.expectedAdoptedSandbox {
-					t.Errorf("expected claim to have assigned sandbox annotation %q, got %q", tc.expectedAdoptedSandbox, val)
-				}
+				require.Equal(t, tc.expectedAdoptedSandbox, updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
 
 			} else if tc.expectNewSandboxCreated {
 				// Verify a new sandbox was created with the claim's name
@@ -3441,7 +3435,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 			Namespace: "default",
 			UID:       "claim-uid-123",
 			Annotations: map[string]string{
-				extensionsv1alpha1.AssignedSandboxNameAnnotation: "adopted-sb",
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "adopted-sb",
 			},
 		},
 		Spec: extensionsv1beta1.SandboxClaimSpec{
@@ -3535,7 +3529,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 
 	// Run reconcile
 	_, err := reconciler.Reconcile(context.Background(), req)
-	expectedErr := "triggered adoption completion for \"adopted-sb\": retrying"
+	expectedErr := "triggered adoption completion for sandbox adopted-sb, retry"
 	if err == nil {
 		t.Fatal("Expected reconcile to fail with cache lag error, but it succeeded")
 	} else if err.Error() != expectedErr {
@@ -3844,24 +3838,24 @@ func TestMapTemplateToClaims(t *testing.T) {
 func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
 	scheme := newScheme(t)
 
-	claim := &extensionsv1alpha1.SandboxClaim{
+	claim := &extensionsv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-claim-legacy",
 			Namespace: "default",
 			UID:       "claim-uid-legacy",
 			Labels: map[string]string{
-				extensionsv1alpha1.DeprecatedAssignedSandboxNameLabel: "adopted-sb-legacy",
+				extensionsv1beta1.DeprecatedAssignedSandboxNameLabel: "adopted-sb-legacy",
 			},
 		},
-		Spec: extensionsv1alpha1.SandboxClaimSpec{
-			TemplateRef: extensionsv1alpha1.SandboxTemplateRef{Name: "test-template"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"},
 		},
 	}
 
-	template := &extensionsv1alpha1.SandboxTemplate{
+	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
-		Spec: extensionsv1alpha1.SandboxTemplateSpec{
-			PodTemplate: sandboxv1alpha1.PodTemplate{
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "c", Image: "img"}},
 				},
@@ -3869,27 +3863,27 @@ func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
 		},
 	}
 
-	adoptedSandbox := &sandboxv1alpha1.Sandbox{
+	adoptedSandbox := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "adopted-sb-legacy",
 			Namespace: "default",
 			UID:       "adopted-sb-legacy-uid",
 			Labels: map[string]string{
-				extensionsv1alpha1.SandboxIDLabel: "claim-uid-legacy",
+				extensionsv1beta1.SandboxIDLabel: "claim-uid-legacy",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
 				Kind:       "SandboxClaim",
 				Name:       "test-claim-legacy",
 				UID:        "claim-uid-legacy",
 				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
-		Spec: sandboxv1alpha1.SandboxSpec{
-			PodTemplate: sandboxv1alpha1.PodTemplate{
-				ObjectMeta: sandboxv1alpha1.PodMetadata{
+		Spec: sandboxv1beta1.SandboxSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				ObjectMeta: sandboxv1beta1.PodMetadata{
 					Labels: map[string]string{
-						extensionsv1alpha1.SandboxIDLabel: "claim-uid-legacy",
+						extensionsv1beta1.SandboxIDLabel: "claim-uid-legacy",
 					},
 				},
 			},
@@ -3919,15 +3913,11 @@ func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
 	}
 
 	// Verify that the claim was migrated: DeprecatedAssignedSandboxNameLabel removed, AssignedSandboxNameAnnotation added
-	updatedClaim := &extensionsv1alpha1.SandboxClaim{}
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
 	if err := fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim); err != nil {
 		t.Fatalf("failed to get claim: %v", err)
 	}
 
-	if _, ok := updatedClaim.Labels[extensionsv1alpha1.DeprecatedAssignedSandboxNameLabel]; ok {
-		t.Error("expected legacy label to be removed after migration")
-	}
-	if updatedClaim.Annotations[extensionsv1alpha1.AssignedSandboxNameAnnotation] != "adopted-sb-legacy" {
-		t.Errorf("expected annotation to be set to 'adopted-sb-legacy', got %q", updatedClaim.Annotations[extensionsv1alpha1.AssignedSandboxNameAnnotation])
-	}
+	require.NotContains(t, updatedClaim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+	require.Equal(t, "adopted-sb-legacy", updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR modifies the `SandboxClaim` logic to store the name of an adopted Sandbox in the claim's annotations rather than its labels. 

The primary motivation for this change is to bypass the 63-character length constraint imposed on Kubernetes label values. Sandbox names can potentially exceed this limit, leading to errors when attempting to record the assignment. Annotations provide a more flexible storage location for this metadata as they allow for much larger values.

**Changes included:**
*   **API Update**: Defined `AssignedSandboxNameAnnotation` in `extensions/api/v1alpha1/sandboxclaim_types.go`.
*   **Controller Update**: Updated `SandboxClaimReconciler` in `extensions/controllers/sandboxclaim_controller.go` to set the annotation during adoption and read from it when checking for existing assignments.
*   **Test Update**: Adjusted `extensions/controllers/sandboxclaim_controller_test.go` to verify that the controller correctly handles the assigned name when stored in annotations.

#### Which issue(s) this PR is related to:
Fixes #770

#### Release Note
```release-note
The assigned Sandbox name on a SandboxClaim is now stored in an annotation (agents.x-k8s.io/sandbox-name) instead of a label to support names longer than 63 characters.
```