### PR TITLE
Security fix: Secure Adoption of Unowned Pods and PVCs

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -660,6 +661,37 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 				pod.Name, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
 
 		case resourceUnowned:
+			// Validate provenance and spec before adopting an unowned pod.
+			hasProvenance := pod.Labels != nil && pod.Labels[sandboxLabel] == nameHash
+
+			expectedSpec := sandbox.Spec.PodTemplate.Spec.DeepCopy()
+			var pvcVolumes []corev1.Volume
+			for _, pvcTemplate := range sandbox.Spec.VolumeClaimTemplates {
+				pvcName := pvcTemplate.Name + "-" + sandbox.Name
+				pvcVolumes = append(pvcVolumes, corev1.Volume{
+					Name: pvcTemplate.Name,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				})
+			}
+			expectedSpec.Volumes = MergeVolumeClaimVolumes(expectedSpec.Volumes, pvcVolumes)
+
+			if !hasProvenance || !equality.Semantic.DeepEqual(&pod.Spec, expectedSpec) {
+				log.Info("Refusing to adopt pod: pod lacks provenance or fails spec validation",
+					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
+					"hasProvenance", hasProvenance)
+
+				if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
+					return nil, err
+				}
+
+				return nil, fmt.Errorf("cannot adopt unowned pod %q: lacks provenance or fails spec validation", pod.Name)
+			}
+
+			log.Info("Adopting unowned pod with valid provenance and spec", "Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
 			if err := ctrl.SetControllerReference(sandbox, pod, r.Scheme); err != nil {
 				return nil, fmt.Errorf("SetControllerReference for Pod failed: %w", err)
 			}
@@ -668,7 +700,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			// No additional action needed — label applied below.
 		}
 
-		updated := r.updatePodMetadata(pod, sandbox, nameHash)
+		updated := r.updatePodMetadata(pod, sandbox, nameHash) || ownership == resourceUnowned
 		if updated {
 			if err := r.Update(ctx, pod); err != nil {
 				return nil, fmt.Errorf("failed to update pod: %w", err)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -905,7 +905,15 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 					pvcName, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
 
 			case resourceUnowned:
-				log.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
+				hasProvenance := pvc.Labels != nil && pvc.Labels[sandboxLabel] == nameHash
+				if !hasProvenance || !equality.Semantic.DeepEqual(&pvc.Spec, &pvcTemplate.Spec) {
+					log.Info("Refusing to adopt PVC: PVC lacks provenance or fails spec validation",
+						"PVC.Name", pvcName, "Sandbox.Name", sandbox.Name,
+						"hasProvenance", hasProvenance)
+					return fmt.Errorf("cannot adopt unowned PVC %q: lacks provenance or fails spec validation", pvcName)
+				}
+
+				log.Info("Adopting unowned PVC with valid provenance and spec", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
 				if err := ctrl.SetControllerReference(sandbox, pvc, r.Scheme); err != nil {
 					return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 				}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -975,11 +975,14 @@ func TestReconcilePod(t *testing.T) {
 						Name:            sandboxName,
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "foo",
+								Name: "test-container",
 							},
 						},
 					},
@@ -1005,7 +1008,7 @@ func TestReconcilePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "foo",
+							Name: "test-container",
 						},
 					},
 				},
@@ -1083,7 +1086,7 @@ func TestReconcilePod(t *testing.T) {
 			wantPod: nil,
 		},
 		{
-			name: "adopts existing pod via annotation - pod gets label and owner reference",
+			name: "refuses to adopt existing unowned pod without provenance or matching spec",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1095,6 +1098,52 @@ func TestReconcilePod(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name: "existing-container",
+							},
+						},
+					},
+				},
+			},
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "adopted-pod-name",
+					},
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: new(int32(1)),
+					PodTemplate: sandboxv1alpha1.PodTemplate{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "test-container",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPod:   nil,
+			expectErr: true,
+		},
+		{
+			name: "adopts existing unowned pod with valid provenance and matching spec",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "adopted-pod-name",
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
 							},
 						},
 					},
@@ -1135,7 +1184,7 @@ func TestReconcilePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: "existing-container",
+							Name: "test-container",
 						},
 					},
 				},

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2198,13 +2198,35 @@ func TestReconcilePVCs(t *testing.T) {
 			errContains: "is owned by",
 		},
 		{
-			name: "adopts unowned PVC",
+			name: "refuses to adopt existing unowned PVC without provenance or matching spec",
 			initialObjs: []runtime.Object{
 				&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      pvcName,
 						Namespace: sandboxNs,
-						// No owner references.
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "adopts existing unowned PVC with valid provenance and matching spec",
+			initialObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvcName,
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							sandboxLabel: NameHash(sandboxName),
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR addresses two security vulnerabilities in the Sandbox controller related to the insecure adoption of unowned resources (Finding 3: Sandbox controller adopts pre-existing unowned pods without provenance or spec validation and Finding 4: Sandbox controller adopts existing PVCs without provenance or spec checks).

**Key changes for Finding 3 (Secure Pod Adoption):**
*   **Provenance Validation**: The controller now verifies that an existing unowned pod carries the expected `agents.x-k8s.io/sandbox-name-hash` label before attempting adoption.
*   **Spec Integrity Check**: Added a semantic deep equality check to ensure the existing pod's specification (container images, commands, and volumes) matches the Sandbox template.
*   **Hijack Prevention**: If validation fails, the controller refuses adoption and clears the `SandboxPodNameAnnotation` to prevent further reconciliation loops on an invalid resource.
*   **Regression Testing**: Added unit tests to `controllers/sandbox_controller_test.go` to verify that pods without provenance or matching specs are rejected.

**Key changes for Finding 4 (Secure PVC Adoption):**
*   **Mandatory Provenance**: The controller now checks for the correct `sandboxLabel` on existing PVCs to ensure they were intended for the specific Sandbox instance.
*   **Parameter Validation**: Implemented strict validation to assert that an existing PVC's size, storage class, and access modes align perfectly with the user-defined template before attaching it.
*   **Validation Tests**: Expanded the test suite to include scenarios where unowned PVCs with mismatched specs are correctly identified and rejected.

#### Release Notes
```
SECURITY: Fixed a vulnerability where the Sandbox controller could adopt pre-seeded malicious pods by adding mandatory provenance and specification validation during reconciliation.
SECURITY: Enhanced PVC adoption security by requiring existing unowned volumes to match the template specification and carry valid provenance labels.
```