### PR TITLE
Add Hermes Agent Sandbox example with persistence and custom skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ ai-label
 ai-label.log
 ai-review
 ai-review.log
+hermes-sandbox-knowledge.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
 - [**hello-world-sandbox**](./hello-world-sandbox): A simple "Hello World" sandbox example.
+- [**hermes-agent**](./hermes-agent): An example of running Hermes Agent with persistence and custom skills.
 - [**hpa-swp-scaling**](./hpa-swp-scaling): An example of scaling a SandboxWarmPool using Kubernetes Horizontal Pod Autoscaler (HPA).
 - [**jupyterlab**](./jupyterlab): An example of running JupyterLab on Agent-Sandbox.
 - [**langchain**](./langchain): An example of a coding agent using Agent-Sandbox and LangGraph.

--- a/examples/hermes-agent/README.md
+++ b/examples/hermes-agent/README.md
@@ -1,0 +1,104 @@
+# Hermes Agent in Kubernetes Sandbox Example
+
+This project provides a complete, informational example of how to run [Hermes Agent](https://hermes-agent.nousresearch.com/) inside a Kubernetes cluster using the `Sandbox` CRD from [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox).
+
+## Prerequisites
+
+1.  A Kubernetes cluster (e.g., GKE, Minikube).
+2.  `agent-sandbox` installed in the cluster.
+3.  `kubectl` configured to access your cluster.
+4.  Python 3 (for running tests and chat scripts).
+
+## Files
+
+-   `sandbox.yaml`: The Kubernetes manifest for the `Sandbox` resource (core infrastructure).
+-   `k8s-developer.md`: The source file for the custom "Kubernetes Developer" skill.
+-   `test_hermes.py`: Automated Python script to verify the agent is running.
+-   `chat_hermes.py`: Interactive Python script to chat with the agent via CLI.
+
+## How to Use
+
+### 1. Deploy the Sandbox
+
+#### (Optional) Add Custom Skills
+
+If you want to load the custom "Kubernetes Developer" skill, create a ConfigMap from the file **before** deploying the sandbox:
+
+```bash
+kubectl create configmap hermes-skills --from-file=k8s-developer.md
+```
+
+Apply the core manifest to your cluster:
+
+```bash
+kubectl apply -f sandbox.yaml
+```
+
+### 2. Verify the Deployment
+
+#### Automated Verification
+
+Run the provided test script. It will automatically find the pod, set up port-forwarding, and query the API:
+
+```bash
+python3 test_hermes.py
+```
+
+#### Manual Verification
+
+Check if the Sandbox resource and Pod are created:
+
+```bash
+kubectl get sandboxes
+kubectl get pods
+```
+
+You should see a pod named `hermes-agent` (matching the Sandbox `metadata.name`).
+
+### 3. Interact with the Agent
+
+#### Option A: Interactive CLI Chat
+
+Use the provided chat script to talk to the agent.
+
+1.  First, find your pod name and start port-forwarding in a separate terminal:
+    ```bash
+    kubectl get pods
+    kubectl port-forward pod/<your-pod-name> 8642:8642
+    ```
+2.  Then run the chat script:
+    ```bash
+    python3 chat_hermes.py
+    ```
+
+#### Option B: Access the Dashboard
+
+The dashboard runs on port `9119`.
+
+1.  Start port-forwarding:
+    ```bash
+    kubectl port-forward pod/<your-pod-name> 9119:9119
+    ```
+2.  Open `http://localhost:9119` in your browser.
+
+## Configuration
+
+To configure API keys or other environment variables, modify the `sandbox.yaml` file to include them in the `env` section or use a Kubernetes Secret.
+
+Example using a Secret:
+
+1. Create a secret with your API keys:
+    ```bash
+    kubectl create secret generic hermes-agent-api-keys \
+      --from-literal=GEMINI_API_KEY="your_gemini_key" \
+      --from-literal=OPENAI_API_KEY="your_openai_key"
+    ```
+2. The `sandbox.yaml` is already configured to use this secret:
+    ```yaml
+    env:
+    - name: GEMINI_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: hermes-agent-api-keys
+          key: GEMINI_API_KEY
+    ```

--- a/examples/hermes-agent/chat_hermes.py
+++ b/examples/hermes-agent/chat_hermes.py
@@ -1,0 +1,48 @@
+import urllib.request
+import json
+
+def chat_with_hermes(prompt):
+    url = "http://localhost:8642/v1/chat/completions"
+    headers = {"Content-Type": "application/json"}
+    data = {
+        "model": "hermes-2-pro-mistral-7b",
+        "messages": [{"role": "user", "content": prompt}]
+    }
+    
+    try:
+        req = urllib.request.Request(url, data=json.dumps(data).encode(), headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as response:
+            if response.status == 200:
+                res_data = json.loads(response.read().decode())
+                return res_data['choices'][0]['message']['content']
+            else:
+                return f"Error: Received status code {response.status}"
+    except Exception as e:
+        return f"Connection failed: {e}. Is port-forwarding running?"
+
+def main():
+    print("====================================================")
+    print("Hermes Agent Chat")
+    print("Make sure to run: kubectl port-forward pod/<pod-name> 8642:8642")
+    print("Type 'exit' or 'quit' to stop.")
+    print("====================================================")
+    
+    while True:
+        try:
+            user_input = input("\nYou: ")
+            if user_input.lower() in ['exit', 'quit']:
+                print("Goodbye!")
+                break
+            if not user_input.strip():
+                continue
+                
+            response = chat_with_hermes(user_input)
+            print(f"\nHermes: {response}")
+        except KeyboardInterrupt:
+            print("\nGoodbye!")
+            break
+        except Exception as e:
+            print(f"\nAn error occurred: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/examples/hermes-agent/chat_hermes.py
+++ b/examples/hermes-agent/chat_hermes.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import urllib.request
 import json
 

--- a/examples/hermes-agent/k8s-developer.md
+++ b/examples/hermes-agent/k8s-developer.md
@@ -1,0 +1,21 @@
+---
+title: "Kubernetes Developer Persona"
+sidebar_label: "K8s Developer"
+description: "Persona for Kubernetes development and debugging"
+---
+
+# Kubernetes Developer Persona
+
+Use this skill when the user wants help with Kubernetes development, debugging, or manifest creation.
+
+## Core behavior
+- You are an expert Kubernetes developer.
+- You follow best practices for K8s manifests (labels, resource limits, security context).
+- You can help debug cluster issues using `kubectl`.
+- You understand core K8s resources like Pods, Deployments, StatefulSets, PVCs, Services, and Ingress.
+- You can explain complex K8s concepts simply.
+
+## Interaction style
+- Be precise and technical when needed.
+- Provide actionable commands and manifest snippets.
+- Explain the rationale behind design choices.

--- a/examples/hermes-agent/sandbox.yaml
+++ b/examples/hermes-agent/sandbox.yaml
@@ -1,0 +1,48 @@
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: hermes-agent
+spec:
+  podTemplate:
+    spec:
+      containers:
+      - name: hermes
+        image: nousresearch/hermes-agent:latest
+        args: ["gateway"]
+        env:
+        - name: HERMES_DASHBOARD
+          value: "1"
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: hermes-agent-api-keys
+              key: GEMINI_API_KEY
+        - name: OPENAI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: hermes-agent-api-keys
+              key: OPENAI_API_KEY
+        ports:
+        - containerPort: 8642
+          name: api
+        - containerPort: 9119
+          name: dashboard
+        volumeMounts:
+        - name: data
+          mountPath: /opt/data
+        - name: skill-k8s-dev
+          mountPath: /opt/data/skills/custom/k8s-developer.md
+          subPath: k8s-developer.md
+      volumes:
+      - name: skill-k8s-dev
+        configMap:
+          name: hermes-skills
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+

--- a/examples/hermes-agent/test_hermes.py
+++ b/examples/hermes-agent/test_hermes.py
@@ -1,0 +1,71 @@
+import subprocess
+import time
+import urllib.request
+import json
+import sys
+import os
+
+def get_pod_name():
+    try:
+        # Use local kubeconfig file if present
+        cmd = ["kubectl"]
+        if os.path.exists("kubeconfig"):
+            cmd.append("--kubeconfig=kubeconfig")
+        cmd.extend(["get", "pods", "-o", "name"])
+        
+        output = subprocess.check_output(cmd, text=True)
+        for line in output.strip().split('\n'):
+            if "hermes-agent" in line:
+                return line.strip().replace("pod/", "")
+    except Exception as e:
+        print(f"Error getting pod name: {e}")
+        return None
+    return None
+
+def test_hermes():
+    pod_name = get_pod_name()
+    if not pod_name:
+        print("Failed to find hermes-agent pod.")
+        sys.exit(1)
+    
+    print(f"Found pod: {pod_name}")
+    
+    # Start port forwarding using local kubeconfig if present
+    cmd = ["kubectl"]
+    if os.path.exists("kubeconfig"):
+        cmd.append("--kubeconfig=kubeconfig")
+    cmd.extend(["port-forward", f"pod/{pod_name}", "8642:8642"])
+    
+    pf_process = subprocess.Popen(cmd)
+    
+    success = False
+    try:
+        print("Waiting for port-forwarding to be ready...")
+        time.sleep(5) # Give it some time to establish
+        
+        url = "http://localhost:8642/v1/models"
+        print(f"Querying {url}...")
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=5) as response:
+            if response.status == 200:
+                data = json.loads(response.read().decode())
+                print(f"Success! Response: {data}")
+                success = True
+            else:
+                print(f"Failed with status code: {response.status}")
+    except Exception as e:
+        print(f"Connection failed: {e}")
+    finally:
+        print("Cleaning up port-forwarding...")
+        pf_process.terminate()
+        pf_process.wait()
+        
+    if success:
+        print("Test Passed!")
+        sys.exit(0)
+    else:
+        print("Test Failed!")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    test_hermes()

--- a/examples/hermes-agent/test_hermes.py
+++ b/examples/hermes-agent/test_hermes.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import subprocess
 import time
 import urllib.request


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds a new example demonstrating how to run the [Hermes Agent](https://hermes-agent.nousresearch.com/) inside the Kubernetes Agent Sandbox.

The example showcases:
*   **Core Infrastructure**: A `Sandbox` manifest configured with persistent storage via `volumeClaimTemplates` to ensure the agent's state, memories, and configuration survive restarts.
*   **Custom Skill Injection**: An example of how to inject custom personas or skills into the agent using a Kubernetes `ConfigMap` without needing to build a new container image.
*   **Example Persona**: A sample "Kubernetes Developer" skill file.
*   **Client Scripts**: Scripts for automated verification (`test_hermes.py`) and interactive chat (`chat_hermes.py`) via the agent's API.

This contribution provides a complete, practical example for users wanting to deploy stateful AI agents with custom capabilities on Kubernetes.

#### Which issue(s) this PR is related to:
Fixes #765

#### Release Note
```release-note
Added a new example demonstrating how to run the Hermes Agent in the Sandbox with persistence and custom skills.
