### PR TITLE
feat(controllers): add structured Kubernetes Events to SandboxReconciler

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -241,6 +241,7 @@ func main() {
 		Scheme:        mgr.GetScheme(),
 		Tracer:        instrumenter,
 		ClusterDomain: clusterDomain,
+		Recorder:      mgr.GetEventRecorder("sandbox-controller"),
 	}).SetupWithManager(mgr, sandboxConcurrentWorkers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")
 		os.Exit(1)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -124,6 +125,7 @@ type SandboxReconciler struct {
 	Scheme        *runtime.Scheme
 	Tracer        asmetrics.Instrumenter
 	ClusterDomain string
+	Recorder      events.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
@@ -132,7 +134,8 @@ type SandboxReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -187,6 +190,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	oldStatus := sandbox.Status.DeepCopy()
 	var err error
 	sandboxDeleted := false
+	ranCleanup := false
 	result := ctrl.Result{}
 
 	expired, _ := checkSandboxExpiry(sandbox, time.Now())
@@ -201,6 +205,9 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		logger.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
 		sandboxDeleted, err = r.handleSandboxExpiry(ctx, sandbox)
+		// ranCleanup is true when cleanup succeeded and the sandbox was not self-deleted.
+		ranCleanup = !sandboxDeleted && err == nil
+
 	} else {
 		err = r.reconcileChildResources(ctx, sandbox)
 		expiredAfterReconcile, requeueAfter := checkSandboxExpiry(sandbox, time.Now())
@@ -211,11 +218,34 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	// Detect Ready transition before the status update persists the new conditions.
+	readyTransitioned := false
+	if err == nil && r.Recorder != nil {
+		oldReady := meta.FindStatusCondition(oldStatus.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+		newReady := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+		readyTransitioned = newReady != nil && newReady.Status == metav1.ConditionTrue &&
+			(oldReady == nil || oldReady.Status != metav1.ConditionTrue)
+	}
+
+	// Suppress ranCleanup if the status did not actually change — this means
+	// cleanup already ran on a prior reconcile and the event was already emitted.
+	if ranCleanup && reflect.DeepEqual(oldStatus, &sandbox.Status) {
+		ranCleanup = false
+	}
+
 	if !sandboxDeleted {
 		// Update status
 		if statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
 			// Surface update error
 			err = errors.Join(err, statusUpdateErr)
+		} else if r.Recorder != nil {
+			// Emit lifecycle events only after the status update has been persisted.
+			if readyTransitioned {
+				r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, "SandboxReady", "Ready", "Sandbox is ready")
+			}
+			if ranCleanup {
+				r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, "SandboxExpired", "Expiry", "Sandbox has expired and child resources have been cleaned up")
+			}
 		}
 	}
 	// return errors seen
@@ -857,7 +887,17 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return reconcileExistingPod(existingPod)
 		}
 		logger.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		if r.Recorder != nil {
+			r.Recorder.Eventf(sandbox, nil, corev1.EventTypeWarning, "SandboxPodFailed", "PodCreation", "Failed to create pod %q: %v", pod.Name, err)
+		}
 		return nil, err
+	}
+
+	// Emit the SandboxPodCreated event immediately after successful pod creation,
+	// before any subsequent metadata updates, so the event is recorded even if
+	// annotation or tracing operations temporarily fail.
+	if r.Recorder != nil {
+		r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, "SandboxPodCreated", "PodCreation", "Created pod %q", pod.Name)
 	}
 
 	if err := ensurePodNameAnnotation(pod.Name); err != nil {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,6 +48,17 @@ func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
 		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
 		WithRuntimeObjects(initialObjs...).
 		Build()
+}
+
+type failOnPodCreateClient struct {
+	client.WithWatch
+}
+
+func (c *failOnPodCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*corev1.Pod); ok {
+		return k8serrors.NewInternalError(errors.New("simulated pod creation failure"))
+	}
+	return c.WithWatch.Create(ctx, obj, opts...)
 }
 
 const sandboxUID = types.UID("test-sandbox-uid")
@@ -2749,4 +2762,233 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 	require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: sbName, Namespace: sbNs}, &got))
 	require.Len(t, got.Status.Conditions, 1,
 		"conditions slice must not grow across %d reconcile iterations — controller must upsert not append", iters)
+}
+
+func TestReconcileEvents(t *testing.T) {
+	sandboxName := "sandbox-events"
+	sandboxNs := "default"
+
+	newSandbox := func(spec sandboxv1beta1.SandboxSpec) *sandboxv1beta1.Sandbox {
+		sb := &sandboxv1beta1.Sandbox{}
+		sb.Name = sandboxName
+		sb.Namespace = sandboxNs
+		sb.UID = sandboxUID
+		sb.Generation = 1
+		sb.Spec = spec
+		return sb
+	}
+
+	minimalSpec := sandboxv1beta1.SandboxSpec{
+		PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c"}},
+			},
+		},
+	}
+
+	drainEvents := func(ch chan string) []string {
+		var got []string
+		for {
+			select {
+			case e := <-ch:
+				got = append(got, e)
+			default:
+				return got
+			}
+		}
+	}
+
+	t.Run("SandboxPodCreated emitted on new pod creation", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		sb := newSandbox(minimalSpec)
+		r := SandboxReconciler{
+			Client:        newFakeClient(sb),
+			Scheme:        Scheme,
+			Tracer:        asmetrics.NewNoOp(),
+			ClusterDomain: "cluster.local",
+			Recorder:      recorder,
+		}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.NoError(t, err)
+		got := drainEvents(recorder.Events)
+		require.Contains(t, got, `Normal SandboxPodCreated Created pod "sandbox-events"`)
+	})
+
+	t.Run("SandboxPodFailed emitted on pod creation failure", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		sb := newSandbox(minimalSpec)
+		r := SandboxReconciler{
+			Client:        &failOnPodCreateClient{WithWatch: newFakeClient(sb)},
+			Scheme:        Scheme,
+			Tracer:        asmetrics.NewNoOp(),
+			ClusterDomain: "cluster.local",
+			Recorder:      recorder,
+		}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.Error(t, err)
+		got := drainEvents(recorder.Events)
+		require.NotEmpty(t, got, "expected at least one event")
+		found := false
+		for _, e := range got {
+			if strings.Contains(e, "SandboxPodFailed") {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected SandboxPodFailed event, got: %v", got)
+	})
+
+	t.Run("SandboxReady emitted on first False to True Ready transition", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		// Seed a running, ready pod so the Ready condition becomes True.
+		existingPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            sandboxName,
+				Namespace:       sandboxNs,
+				Labels:          map[string]string{"agents.x-k8s.io/sandbox-name-hash": NameHash(sandboxName)},
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIPs: []corev1.PodIP{{IP: "10.0.0.1"}},
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		sb := newSandbox(minimalSpec)
+		r := SandboxReconciler{
+			Client:        newFakeClient(sb, existingPod),
+			Scheme:        Scheme,
+			Tracer:        asmetrics.NewNoOp(),
+			ClusterDomain: "cluster.local",
+			Recorder:      recorder,
+		}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.NoError(t, err)
+		got := drainEvents(recorder.Events)
+		require.Contains(t, got, "Normal SandboxReady Sandbox is ready")
+	})
+
+	t.Run("SandboxReady not re-emitted when already ready", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		existingPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            sandboxName,
+				Namespace:       sandboxNs,
+				Labels:          map[string]string{"agents.x-k8s.io/sandbox-name-hash": NameHash(sandboxName)},
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+			Status: corev1.PodStatus{
+				Phase:  corev1.PodRunning,
+				PodIPs: []corev1.PodIP{{IP: "10.0.0.1"}},
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				},
+			},
+		}
+		// Pre-set the sandbox Ready condition to True so it's already in that state.
+		sb := newSandbox(minimalSpec)
+		sb.Status.Conditions = []metav1.Condition{
+			{
+				Type:               string(sandboxv1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				Reason:             "DependenciesReady",
+				ObservedGeneration: 1,
+			},
+		}
+		r := SandboxReconciler{
+			Client:        newFakeClient(sb, existingPod),
+			Scheme:        Scheme,
+			Tracer:        asmetrics.NewNoOp(),
+			ClusterDomain: "cluster.local",
+			Recorder:      recorder,
+		}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.NoError(t, err)
+		got := drainEvents(recorder.Events)
+		for _, e := range got {
+			require.NotContains(t, e, "SandboxReady", "SandboxReady must not re-emit when already ready")
+		}
+	})
+
+	t.Run("SandboxExpired emitted after cleanup with Retain policy", func(t *testing.T) {
+		recorder := events.NewFakeRecorder(10)
+		existingPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            sandboxName,
+				Namespace:       sandboxNs,
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+		}
+		existingSvc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            sandboxName,
+				Namespace:       sandboxNs,
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+		}
+		expiredSpec := sandboxv1beta1.SandboxSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+			},
+			Lifecycle: sandboxv1beta1.Lifecycle{
+				ShutdownTime:   new(metav1.NewTime(time.Now().Add(-1 * time.Hour))),
+				ShutdownPolicy: ptr.To(sandboxv1beta1.ShutdownPolicyRetain),
+			},
+		}
+		sb := newSandbox(expiredSpec)
+		// Pre-populate live-resource status to simulate a sandbox that was running
+		// before it expired. handleSandboxExpiry clears these fields, so the
+		// status diff will detect the change and emit SandboxExpired.
+		sb.Status = sandboxv1beta1.SandboxStatus{
+			Service:       sandboxName,
+			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=test",
+		}
+		r := SandboxReconciler{
+			Client:        newFakeClient(sb, existingPod, existingSvc),
+			Scheme:        Scheme,
+			Tracer:        asmetrics.NewNoOp(),
+			ClusterDomain: "cluster.local",
+			Recorder:      recorder,
+		}
+		// First reconcile marks sandbox as expired.
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.NoError(t, err)
+		// Second reconcile performs cleanup and emits SandboxExpired.
+		_, err = r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.NoError(t, err)
+		got := drainEvents(recorder.Events)
+		require.Contains(t, got, "Normal SandboxExpired Sandbox has expired and child resources have been cleaned up")
+	})
+
+	t.Run("no events emitted when Recorder is nil", func(t *testing.T) {
+		// Sanity check: ensure nil Recorder doesn't panic.
+		sb := newSandbox(minimalSpec)
+		r := SandboxReconciler{
+			Client:        newFakeClient(sb),
+			Scheme:        Scheme,
+			Tracer:        asmetrics.NewNoOp(),
+			ClusterDomain: "cluster.local",
+			Recorder:      nil,
+		}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+		})
+		require.NoError(t, err)
+	})
 }

--- a/helm/templates/rbac.generated.yaml
+++ b/helm/templates/rbac.generated.yaml
@@ -19,6 +19,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -50,10 +59,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -19,6 +19,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -50,10 +59,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Currently, `SandboxReconciler` emits no Kubernetes Events, making `kubectl describe sandbox` silent on lifecycle transitions. This PR wires in `events.EventRecorder` to emit structured events at key lifecycle points.

So the changes are:
- Adds the `events.EventRecorder` field to `SandboxReconciler` and injects it via `mgr.GetEventRecorder` in `main.go`.
- Emits a `SandboxPodCreated` (Normal) event upon successful pod creation.
- Emits a `SandboxPodFailed` (Warning) event if pod creation fails.
- Emits a `SandboxReady` (Normal) event on the first `False` → `True` transition of the `Ready` condition.
- Emits a `SandboxExpired` (Normal) event after successful cleanup of child resources on expiry (for the `Retain` shutdown policy path).
- Updates RBAC markers to include `core` `events` and adds the `update` verb to the `events.k8s.io` marker.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #759

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->