### PR TITLE
Improve system label validation and name hashing robustness

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -16,9 +16,10 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"maps"
 	"reflect"
 	"slices"
@@ -444,17 +445,23 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	return nil
 }
 
-// GetNumericHash generates a raw FNV-1a hash value.
-func GetNumericHash(input string) uint32 {
-	h := fnv.New32a()
-	h.Write([]byte(input))
-	return h.Sum32()
+func isSystemLabel(key string) bool {
+	return key == sandboxLabel || key == sandboxv1alpha1.SandboxPodTemplateHashLabel
 }
 
-// NameHash generates an FNV-1a hash from a string and returns
-// it as a fixed-length hexadecimal string.
+func isSystemAnnotation(key string) bool {
+	return key == sandboxv1alpha1.SandboxPodNameAnnotation ||
+		key == sandboxv1alpha1.SandboxTemplateRefAnnotation ||
+		key == sandboxv1alpha1.SandboxPropagatedLabelsAnnotation ||
+		key == sandboxv1alpha1.SandboxPropagatedAnnotationsAnnotation ||
+		key == "opentelemetry.io/trace-context"
+}
+
+// NameHash generates a SHA-256 hash from a string and returns
+// it as a 32-character hexadecimal string using memory-efficient slice encoding.
 func NameHash(objectName string) string {
-	return fmt.Sprintf("%08x", GetNumericHash(objectName))
+	hash := sha256.Sum256([]byte(objectName))
+	return hex.EncodeToString(hash[:16])
 }
 
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Service, error) {
@@ -784,18 +791,24 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 
 	// Create new Pod
 	logger.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
-	podLabels := map[string]string{
-		sandboxLabel: nameHash,
-	}
+	podLabels := make(map[string]string)
 
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		if isSystemLabel(k) {
+			continue
+		}
 		podLabels[k] = v
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
+	podLabels[sandboxLabel] = nameHash
+
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+		if isSystemAnnotation(k) {
+			continue
+		}
 		annotations[k] = v
 		managedAnnotationKeys = append(managedAnnotationKeys, k)
 	}
@@ -877,6 +890,9 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		if isSystemLabel(k) {
+			continue
+		}
 		if pod.Labels[k] != v {
 			pod.Labels[k] = v
 			updated = true
@@ -888,7 +904,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 	if propagatedLabelsStr != "" {
 		propagatedLabels := strings.SplitSeq(propagatedLabelsStr, ",")
 		for k := range propagatedLabels {
-			if k == "" {
+			if k == "" || isSystemLabel(k) {
 				continue
 			}
 			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Labels[k]; !ok {
@@ -904,6 +920,9 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 			pod.Annotations = make(map[string]string)
 		}
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+			if isSystemAnnotation(k) {
+				continue
+			}
 			if pod.Annotations[k] != v {
 				pod.Annotations[k] = v
 				updated = true
@@ -916,7 +935,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 	if propagatedAnnotationsStr != "" {
 		propagatedAnnotations := strings.SplitSeq(propagatedAnnotationsStr, ",")
 		for k := range propagatedAnnotations {
-			if k == "" {
+			if k == "" || isSystemAnnotation(k) {
 				continue
 			}
 			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[k]; !ok {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"reflect"
 	"slices"
@@ -52,7 +53,7 @@ const (
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
 
-	// Allowed tracking labels under system prefix
+	// Allowed tracking labels under system prefix.
 	warmPoolSandboxLabel        = "agents.x-k8s.io/warm-pool-sandbox"
 	sandboxTemplateRefHashLabel = "agents.x-k8s.io/sandbox-template-ref-hash"
 )
@@ -472,6 +473,15 @@ func isSystemAnnotation(key string) bool {
 func NameHash(objectName string) string {
 	hash := sha256.Sum256([]byte(objectName))
 	return hex.EncodeToString(hash[:16])
+}
+
+// FNVNameHash generates an FNV-1a hash from a string and returns
+// it as an 8-character hexadecimal string.
+func FNVNameHash(objectName string) string {
+	h := fnv.New32a()
+	h.Write([]byte(objectName))
+	hashValue := h.Sum32()
+	return fmt.Sprintf("%08x", hashValue)
 }
 
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Service, error) {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -567,6 +567,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 
 		logger.Info("Adopting unowned service", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 
+		patch := client.MergeFrom(service.DeepCopy())
 		if service.Labels == nil {
 			service.Labels = make(map[string]string)
 		}
@@ -578,8 +579,8 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		if err := ctrl.SetControllerReference(sandbox, service, r.Scheme); err != nil {
 			return nil, fmt.Errorf("SetControllerReference for Service failed: %w", err)
 		}
-		if err := r.Update(ctx, service); err != nil {
-			return nil, fmt.Errorf("failed to update service with owner reference: %w", err)
+		if err := r.Patch(ctx, service, patch); err != nil {
+			return nil, fmt.Errorf("failed to patch service with owner reference and selector: %w", err)
 		}
 
 	case resourceOwnedBySandbox:

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -451,13 +451,6 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 }
 
 func isSystemLabel(key string) bool {
-	// We explicitly allow-list the warm pool and template tracking labels
-	if key == sandboxv1beta1.SandboxPodTemplateHashLabel ||
-		key == warmPoolSandboxLabel ||
-		key == sandboxTemplateRefHashLabel {
-		return false
-	}
-
 	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
 		strings.HasPrefix(key, "extensions.agents.x-k8s.io/")
 }
@@ -815,7 +808,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
-			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k)
 			continue
 		}
 		podLabels[k] = v
@@ -823,11 +816,22 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 	podLabels[sandboxLabel] = nameHash
 
+	// Explicitly copy trusted warm pool tracking labels from Sandbox CR if present
+	if v, ok := sandbox.Labels[warmPoolSandboxLabel]; ok {
+		podLabels[warmPoolSandboxLabel] = v
+	}
+	if v, ok := sandbox.Labels[sandboxTemplateRefHashLabel]; ok {
+		podLabels[sandboxTemplateRefHashLabel] = v
+	}
+	if v, ok := sandbox.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel]; ok {
+		podLabels[sandboxv1beta1.SandboxPodTemplateHashLabel] = v
+	}
+
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 		if isSystemAnnotation(k) {
-			logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+			logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k)
 			continue
 		}
 		annotations[k] = v
@@ -925,7 +929,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
-			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k)
 			continue
 		}
 		if pod.Labels[k] != v {
@@ -933,6 +937,26 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 			updated = true
 		}
 		managedLabelKeys = append(managedLabelKeys, k)
+	}
+
+	// Explicitly copy trusted warm pool tracking labels from Sandbox CR if present
+	if v, ok := sandbox.Labels[warmPoolSandboxLabel]; ok {
+		if pod.Labels[warmPoolSandboxLabel] != v {
+			pod.Labels[warmPoolSandboxLabel] = v
+			updated = true
+		}
+	}
+	if v, ok := sandbox.Labels[sandboxTemplateRefHashLabel]; ok {
+		if pod.Labels[sandboxTemplateRefHashLabel] != v {
+			pod.Labels[sandboxTemplateRefHashLabel] = v
+			updated = true
+		}
+	}
+	if v, ok := sandbox.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel]; ok {
+		if pod.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel] != v {
+			pod.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel] = v
+			updated = true
+		}
 	}
 	// Handle deletion of labels
 	propagatedLabelsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedLabelsAnnotation]
@@ -972,7 +996,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		}
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 			if isSystemAnnotation(k) {
-				logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+				logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k)
 				continue
 			}
 			if pod.Annotations[k] != v {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -450,10 +450,10 @@ func isSystemLabel(key string) bool {
 }
 
 func isSystemAnnotation(key string) bool {
-	return key == sandboxv1alpha1.SandboxPodNameAnnotation ||
-		key == sandboxv1alpha1.SandboxTemplateRefAnnotation ||
-		key == sandboxv1alpha1.SandboxPropagatedLabelsAnnotation ||
-		key == sandboxv1alpha1.SandboxPropagatedAnnotationsAnnotation ||
+	return key == sandboxv1beta1.SandboxPodNameAnnotation ||
+		key == sandboxv1beta1.SandboxTemplateRefAnnotation ||
+		key == sandboxv1beta1.SandboxPropagatedLabelsAnnotation ||
+		key == sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation ||
 		key == asmetrics.TraceContextAnnotation
 }
 

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -922,14 +922,14 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 			}
 			delete(pod.Labels, k)
 			updated = true
-			logger.Info("Removed unauthorized system label from Pod", "key", k)
+			logger.Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
 		}
 	}
 	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
-			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k)
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "pod", pod.Name, "key", k)
 			continue
 		}
 		if pod.Labels[k] != v {
@@ -985,7 +985,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 			}
 			delete(pod.Annotations, k)
 			updated = true
-			logger.Info("Removed unauthorized system annotation from Pod", "key", k)
+			logger.Info("Removed unauthorized system annotation from Pod", "pod", pod.Name, "key", k)
 		}
 	}
 	// Propagate pod template annotations to the existing pod
@@ -996,7 +996,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		}
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 			if isSystemAnnotation(k) {
-				logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k)
+				logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "pod", pod.Name, "key", k)
 				continue
 			}
 			if pod.Annotations[k] != v {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -913,13 +913,23 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		pod.Labels[sandboxLabel] = nameHash
 		updated = true
 	}
-	// Explicitly remove any unauthorized system-reserved labels from pod metadata
-	for k := range pod.Labels {
-		if isSystemLabel(k) {
-			// Do not delete the ones we intentionally set!
-			if k == sandboxLabel || k == sandboxv1beta1.SandboxPodTemplateHashLabel || k == warmPoolSandboxLabel || k == sandboxTemplateRefHashLabel {
-				continue
+	// Only remove reserved labels that were attempted via the Sandbox PodTemplate.
+	// This prevents PodTemplate-based hijacking without deleting unrelated system
+	// labels that may be legitimately managed by other internal components.
+	reservedTemplateLabelKeys := make(map[string]struct{})
+	if sandbox.Spec.PodTemplate.ObjectMeta.Labels != nil {
+		for k := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+			if isSystemLabel(k) &&
+				k != sandboxLabel &&
+				k != sandboxv1beta1.SandboxPodTemplateHashLabel &&
+				k != warmPoolSandboxLabel &&
+				k != sandboxTemplateRefHashLabel {
+				reservedTemplateLabelKeys[k] = struct{}{}
 			}
+		}
+	}
+	for k := range reservedTemplateLabelKeys {
+		if _, exists := pod.Labels[k]; exists {
 			delete(pod.Labels, k)
 			updated = true
 			logger.Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
@@ -972,17 +982,22 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 			}
 		}
 	}
-	// Explicitly remove any unauthorized system-reserved annotations from pod metadata
-	for k := range pod.Annotations {
-		if isSystemAnnotation(k) {
-			// Do not delete the ones we intentionally set!
-			if k == sandboxv1beta1.SandboxPodNameAnnotation ||
-				k == sandboxv1beta1.SandboxTemplateRefAnnotation ||
-				k == sandboxv1beta1.SandboxPropagatedLabelsAnnotation ||
-				k == sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation ||
-				k == asmetrics.TraceContextAnnotation {
-				continue
+	// Only remove reserved annotations that were attempted via the Sandbox PodTemplate.
+	reservedTemplateAnnotationKeys := make(map[string]struct{})
+	if sandbox.Spec.PodTemplate.ObjectMeta.Annotations != nil {
+		for k := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+			if isSystemAnnotation(k) &&
+				k != sandboxv1beta1.SandboxPodNameAnnotation &&
+				k != sandboxv1beta1.SandboxTemplateRefAnnotation &&
+				k != sandboxv1beta1.SandboxPropagatedLabelsAnnotation &&
+				k != sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation &&
+				k != asmetrics.TraceContextAnnotation {
+				reservedTemplateAnnotationKeys[k] = struct{}{}
 			}
+		}
+	}
+	for k := range reservedTemplateAnnotationKeys {
+		if _, exists := pod.Annotations[k]; exists {
 			delete(pod.Annotations, k)
 			updated = true
 			logger.Info("Removed unauthorized system annotation from Pod", "pod", pod.Name, "key", k)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -446,14 +446,13 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 }
 
 func isSystemLabel(key string) bool {
-	return key == sandboxLabel
+	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
+		strings.HasPrefix(key, "extensions.agents.x-k8s.io/")
 }
 
 func isSystemAnnotation(key string) bool {
-	return key == sandboxv1beta1.SandboxPodNameAnnotation ||
-		key == sandboxv1beta1.SandboxTemplateRefAnnotation ||
-		key == sandboxv1beta1.SandboxPropagatedLabelsAnnotation ||
-		key == sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation ||
+	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
+		strings.HasPrefix(key, "extensions.agents.x-k8s.io/") ||
 		key == asmetrics.TraceContextAnnotation
 }
 
@@ -767,9 +766,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		case resourceOwnedBySandbox:
 			// No additional action needed — label applied below.
 		}
-
-		metadataUpdated := r.updatePodMetadata(pod, sandbox, nameHash)
-		if metadataUpdated || needsUpdate {
+		updated := r.updatePodMetadata(ctx, pod, sandbox, nameHash)
+		if updated || needsUpdate {
 			if err := r.Update(ctx, pod); err != nil {
 				return nil, fmt.Errorf("failed to update pod: %w", err)
 			}
@@ -796,6 +794,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
+			logger.Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 			continue
 		}
 		podLabels[k] = v
@@ -807,6 +806,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 		if isSystemAnnotation(k) {
+			logger.Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 			continue
 		}
 		annotations[k] = v
@@ -878,7 +878,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	return pod, nil
 }
 
-func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv1beta1.Sandbox, nameHash string) bool {
+func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.Pod, sandbox *sandboxv1beta1.Sandbox, nameHash string) bool {
+	logger := log.FromContext(ctx)
 	updated := false
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
@@ -891,6 +892,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
+			logger.Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 			continue
 		}
 		if pod.Labels[k] != v {
@@ -921,6 +923,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 		}
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 			if isSystemAnnotation(k) {
+				logger.Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 				continue
 			}
 			if pod.Annotations[k] != v {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -446,7 +446,7 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 }
 
 func isSystemLabel(key string) bool {
-	return key == sandboxLabel || key == sandboxv1alpha1.SandboxPodTemplateHashLabel
+	return key == sandboxLabel
 }
 
 func isSystemAnnotation(key string) bool {
@@ -986,15 +986,28 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 
 			case resourceUnowned:
 				logger.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
+				if pvc.Labels == nil {
+					pvc.Labels = make(map[string]string)
+				}
+				pvc.Labels[sandboxLabel] = nameHash
 				if err := ctrl.SetControllerReference(sandbox, pvc, r.Scheme); err != nil {
 					return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 				}
 				if err := r.Update(ctx, pvc); err != nil {
-					return fmt.Errorf("failed to update PVC with owner reference: %w", err)
+					return fmt.Errorf("failed to update PVC with owner reference and labels: %w", err)
 				}
 
 			case resourceOwnedBySandbox:
-				// Already owned by this sandbox — no action needed.
+				if pvc.Labels == nil {
+					pvc.Labels = make(map[string]string)
+				}
+				if pvc.Labels[sandboxLabel] != nameHash {
+					pvc.Labels[sandboxLabel] = nameHash
+					if err := r.Update(ctx, pvc); err != nil {
+						return fmt.Errorf("failed to update PVC labels: %w", err)
+					}
+					logger.Info("Updated owned PVC labels", "PVC.Name", pvcName)
+				}
 			}
 			continue
 		}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -51,6 +51,10 @@ const (
 	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
+
+	// Allowed tracking labels under system prefix
+	warmPoolSandboxLabel        = "agents.x-k8s.io/warm-pool-sandbox"
+	sandboxTemplateRefHashLabel = "agents.x-k8s.io/sandbox-template-ref-hash"
 )
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
@@ -446,6 +450,13 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 }
 
 func isSystemLabel(key string) bool {
+	// We explicitly allow-list the warm pool and template tracking labels
+	if key == sandboxv1beta1.SandboxPodTemplateHashLabel ||
+		key == warmPoolSandboxLabel ||
+		key == sandboxTemplateRefHashLabel {
+		return false
+	}
+
 	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
 		strings.HasPrefix(key, "extensions.agents.x-k8s.io/")
 }
@@ -456,7 +467,7 @@ func isSystemAnnotation(key string) bool {
 		key == asmetrics.TraceContextAnnotation
 }
 
-// NameHash generates a SHA-256 hash from a string and returns
+// NameHash generates a truncated SHA-256 hash (first 16 bytes) from a string and returns
 // it as a 32-character hexadecimal string using memory-efficient slice encoding.
 func NameHash(objectName string) string {
 	hash := sha256.Sum256([]byte(objectName))
@@ -794,7 +805,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
-			logger.Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 			continue
 		}
 		podLabels[k] = v
@@ -806,7 +817,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 		if isSystemAnnotation(k) {
-			logger.Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+			logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 			continue
 		}
 		annotations[k] = v
@@ -888,11 +899,23 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		pod.Labels[sandboxLabel] = nameHash
 		updated = true
 	}
+	// Explicitly remove any unauthorized system-reserved labels from pod metadata
+	for k := range pod.Labels {
+		if isSystemLabel(k) {
+			// Do not delete the ones we intentionally set!
+			if k == sandboxLabel || k == sandboxv1beta1.SandboxPodTemplateHashLabel || k == warmPoolSandboxLabel || k == sandboxTemplateRefHashLabel {
+				continue
+			}
+			delete(pod.Labels, k)
+			updated = true
+			logger.Info("Removed unauthorized system label from Pod", "key", k)
+		}
+	}
 	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
-			logger.Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 			continue
 		}
 		if pod.Labels[k] != v {
@@ -915,6 +938,22 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 			}
 		}
 	}
+	// Explicitly remove any unauthorized system-reserved annotations from pod metadata
+	for k := range pod.Annotations {
+		if isSystemAnnotation(k) {
+			// Do not delete the ones we intentionally set!
+			if k == sandboxv1beta1.SandboxPodNameAnnotation ||
+				k == sandboxv1beta1.SandboxTemplateRefAnnotation ||
+				k == sandboxv1beta1.SandboxPropagatedLabelsAnnotation ||
+				k == sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation ||
+				k == asmetrics.TraceContextAnnotation {
+				continue
+			}
+			delete(pod.Annotations, k)
+			updated = true
+			logger.Info("Removed unauthorized system annotation from Pod", "key", k)
+		}
+	}
 	// Propagate pod template annotations to the existing pod
 	var managedAnnotationKeys []string
 	if sandbox.Spec.PodTemplate.ObjectMeta.Annotations != nil {
@@ -923,7 +962,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		}
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
 			if isSystemAnnotation(k) {
-				logger.Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
+				logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate to prevent hijacking", "key", k, "value", v)
 				continue
 			}
 			if pod.Annotations[k] != v {
@@ -989,6 +1028,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 
 			case resourceUnowned:
 				logger.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
+				patch := client.MergeFrom(pvc.DeepCopy())
 				if pvc.Labels == nil {
 					pvc.Labels = make(map[string]string)
 				}
@@ -996,8 +1036,8 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 				if err := ctrl.SetControllerReference(sandbox, pvc, r.Scheme); err != nil {
 					return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 				}
-				if err := r.Update(ctx, pvc); err != nil {
-					return fmt.Errorf("failed to update PVC with owner reference and labels: %w", err)
+				if err := r.Patch(ctx, pvc, patch); err != nil {
+					return fmt.Errorf("failed to patch PVC with owner reference and labels: %w", err)
 				}
 
 			case resourceOwnedBySandbox:
@@ -1005,9 +1045,10 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 					pvc.Labels = make(map[string]string)
 				}
 				if pvc.Labels[sandboxLabel] != nameHash {
+					patch := client.MergeFrom(pvc.DeepCopy())
 					pvc.Labels[sandboxLabel] = nameHash
-					if err := r.Update(ctx, pvc); err != nil {
-						return fmt.Errorf("failed to update PVC labels: %w", err)
+					if err := r.Patch(ctx, pvc, patch); err != nil {
+						return fmt.Errorf("failed to patch PVC labels: %w", err)
 					}
 					logger.Info("Updated owned PVC labels", "PVC.Name", pvcName)
 				}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -462,7 +462,7 @@ func isSystemAnnotation(key string) bool {
 }
 
 // NameHash generates a truncated SHA-256 hash (first 16 bytes) from a string and returns
-// it as a 32-character hexadecimal string using memory-efficient slice encoding.
+// it as a 32-character hexadecimal string.
 func NameHash(objectName string) string {
 	hash := sha256.Sum256([]byte(objectName))
 	return hex.EncodeToString(hash[:16])

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -454,7 +454,7 @@ func isSystemAnnotation(key string) bool {
 		key == sandboxv1alpha1.SandboxTemplateRefAnnotation ||
 		key == sandboxv1alpha1.SandboxPropagatedLabelsAnnotation ||
 		key == sandboxv1alpha1.SandboxPropagatedAnnotationsAnnotation ||
-		key == "opentelemetry.io/trace-context"
+		key == asmetrics.TraceContextAnnotation
 }
 
 // NameHash generates a SHA-256 hash from a string and returns

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -284,6 +284,7 @@ func TestResolvePodName(t *testing.T) {
 func TestReconcile(t *testing.T) {
 	sandboxName := "sandbox-name"
 	sandboxNs := "sandbox-ns"
+	nameHash := NameHash(sandboxName)
 	testCases := []struct {
 		name                 string
 		initialObjs          []runtime.Object
@@ -367,7 +368,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a", // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash, // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -386,7 +387,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -405,13 +406,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						ClusterIP: "None",
 					},
@@ -463,7 +464,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a", // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash, // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -482,7 +483,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 							"custom-label":                      "label-val",
 						},
 						Annotations: map[string]string{
@@ -518,13 +519,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						ClusterIP: "None",
 					},
@@ -533,9 +534,9 @@ func TestReconcile(t *testing.T) {
 				&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-pvc-sandbox-name",
-						Namespace: sandboxNs,
+						Namespace:       sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 							"custom-label":                      "label-val",
 						},
 						Annotations:     map[string]string{"custom-annotation": "anno-val"},
@@ -561,7 +562,7 @@ func TestReconcile(t *testing.T) {
 						Name:      sandboxName,
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -588,7 +589,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				PodIPs:        []string{"10.244.0.5", "fd00::5"},
 				Conditions: []metav1.Condition{
 					{
@@ -608,13 +609,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						ClusterIP: "None",
 					},
@@ -1155,6 +1156,58 @@ func TestReconcilePod(t *testing.T) {
 		{
 			name:    "reconcilePod creates a new Pod",
 			sandbox: sandboxObj,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ignores user-supplied system-reserved labels and annotations to prevent hijacking",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+				},
+				Spec: sandboxv1alpha1.SandboxSpec{
+					Replicas: new(int32(1)),
+					PodTemplate: sandboxv1alpha1.PodTemplate{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test-container"}},
+						},
+						ObjectMeta: sandboxv1alpha1.PodMetadata{
+							Labels: map[string]string{
+								"agents.x-k8s.io/sandbox-name-hash": "malicious-hijacked-hash",
+								"custom-label":                      "label-val",
+							},
+							Annotations: map[string]string{
+								"agents.x-k8s.io/pod-name": "malicious-pod-name",
+								"custom-annotation":        "anno-val",
+							},
+						},
+					},
+				},
+			},
 			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            sandboxName,

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1604,8 +1604,9 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						sandboxLabel: nameHash,
-						"keep-label": "value",
+						sandboxLabel:                   nameHash,
+						"keep-label":                   "value",
+						"agents.x-k8s.io/system-label": "value",
 					},
 					Annotations: map[string]string{
 						"keep-annotation":                        "value",

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -315,7 +315,7 @@ func TestReconcile(t *testing.T) {
 			// Verify Sandbox status
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a",
 				Conditions: []metav1.Condition{
 					{
 						Type:               "Ready",
@@ -334,7 +334,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -630,7 +630,7 @@ func TestReconcile(t *testing.T) {
 						Name:      sandboxName,
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -654,7 +654,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a",
 				PodIPs:        []string{"10.244.0.5"},
 				Conditions: []metav1.Condition{
 					{
@@ -1183,19 +1183,19 @@ func TestReconcilePod(t *testing.T) {
 		},
 		{
 			name: "ignores user-supplied system-reserved labels and annotations to prevent hijacking",
-			sandbox: &sandboxv1alpha1.Sandbox{
+			sandbox: &sandboxv1beta1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandboxName,
 					Namespace: sandboxNs,
 					UID:       sandboxUID,
 				},
-				Spec: sandboxv1alpha1.SandboxSpec{
+				Spec: sandboxv1beta1.SandboxSpec{
 					Replicas: new(int32(1)),
-					PodTemplate: sandboxv1alpha1.PodTemplate{
+					PodTemplate: sandboxv1beta1.PodTemplate{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{{Name: "test-container"}},
 						},
-						ObjectMeta: sandboxv1alpha1.PodMetadata{
+						ObjectMeta: sandboxv1beta1.PodMetadata{
 							Labels: map[string]string{
 								"agents.x-k8s.io/sandbox-name-hash": "malicious-hijacked-hash",
 								"custom-label":                      "label-val",

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -315,7 +315,7 @@ func TestReconcile(t *testing.T) {
 			// Verify Sandbox status
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				Conditions: []metav1.Condition{
 					{
 						Type:               "Ready",
@@ -334,7 +334,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -368,7 +368,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash, // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -464,7 +464,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash, // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -630,7 +630,7 @@ func TestReconcile(t *testing.T) {
 						Name:      sandboxName,
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -654,7 +654,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				PodIPs:        []string{"10.244.0.5"},
 				Conditions: []metav1.Condition{
 					{

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -534,7 +534,7 @@ func TestReconcile(t *testing.T) {
 				&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "my-pvc-sandbox-name",
-						Namespace:       sandboxNs,
+						Namespace: sandboxNs,
 						Labels: map[string]string{
 							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 							"custom-label":                      "label-val",

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1027,7 +1027,7 @@ func TestReconcilePod(t *testing.T) {
 			UID:       sandboxUID,
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
-			Replicas: new(int32(1)),
+			Replicas: ptr.To[int32](1),
 			PodTemplate: sandboxv1beta1.PodTemplate{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -1190,7 +1190,7 @@ func TestReconcilePod(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 					PodTemplate: sandboxv1beta1.PodTemplate{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{{Name: "test-container"}},
@@ -1301,7 +1301,7 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 					PodTemplate: sandboxv1beta1.PodTemplate{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
@@ -1506,7 +1506,7 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 					PodTemplate: sandboxv1beta1.PodTemplate{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{{Name: "test-container"}},
@@ -1582,7 +1582,7 @@ func TestReconcilePod(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 					PodTemplate: sandboxv1beta1.PodTemplate{
 						ObjectMeta: sandboxv1beta1.PodMetadata{
 							Labels: map[string]string{
@@ -1604,9 +1604,8 @@ func TestReconcilePod(t *testing.T) {
 					Namespace:       sandboxNs,
 					ResourceVersion: "2",
 					Labels: map[string]string{
-						sandboxLabel:                   nameHash,
-						"keep-label":                   "value",
-						"agents.x-k8s.io/system-label": "value",
+						sandboxLabel: nameHash,
+						"keep-label": "value",
 					},
 					Annotations: map[string]string{
 						"keep-annotation":                        "value",
@@ -1694,7 +1693,7 @@ func TestReconcileService(t *testing.T) {
 			UID:       sandboxUID,
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
-			Replicas: new(int32(1)),
+			Replicas: ptr.To[int32](1),
 			Service:  new(true),
 		},
 	}
@@ -1915,7 +1914,7 @@ func TestReconcileService(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 				},
 			},
 			wantNilService:        true,
@@ -1944,7 +1943,7 @@ func TestReconcileService(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 				},
 			},
 			wantService: &corev1.Service{
@@ -1988,7 +1987,7 @@ func TestReconcileService(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 				},
 			},
 			wantNilService:        true,
@@ -2014,7 +2013,7 @@ func TestReconcileService(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 					Service:  new(false),
 				},
 			},
@@ -2041,7 +2040,7 @@ func TestReconcileService(t *testing.T) {
 					UID:       sandboxUID,
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
-					Replicas: new(int32(1)),
+					Replicas: ptr.To[int32](1),
 					Service:  new(false),
 				},
 			},

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -367,7 +367,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a", // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -386,7 +386,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -405,13 +405,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						ClusterIP: "None",
 					},
@@ -463,7 +463,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a", // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -482,7 +482,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 							"custom-label":                      "label-val",
 						},
 						Annotations: map[string]string{
@@ -518,13 +518,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						ClusterIP: "None",
 					},
@@ -535,7 +535,7 @@ func TestReconcile(t *testing.T) {
 						Name:      "my-pvc-sandbox-name",
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 							"custom-label":                      "label-val",
 						},
 						Annotations:     map[string]string{"custom-annotation": "anno-val"},
@@ -561,7 +561,7 @@ func TestReconcile(t *testing.T) {
 						Name:      sandboxName,
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -588,7 +588,7 @@ func TestReconcile(t *testing.T) {
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				Replicas:      1,
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=48ef8902639c4db8ff663259d106869a",
 				PodIPs:        []string{"10.244.0.5", "fd00::5"},
 				Conditions: []metav1.Condition{
 					{
@@ -608,13 +608,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": "48ef8902639c4db8ff663259d106869a",
 						},
 						ClusterIP: "None",
 					},

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -1,0 +1,73 @@
+# Security Threat Model
+
+This document outlines the security threat model for `agent-sandbox`. It defines the trust boundaries, identifies key threat scenarios, and documents the mitigations designed to ensure strong tenant isolation when executing unpredictable or untrusted AI-generated workloads.
+
+---
+
+## 1. Trust Boundaries
+
+In an `agent-sandbox` deployment, resources are divided across three distinct trust levels:
+
+```mermaid
+graph TD
+    subgraph Cluster Control Plane (Highly Trusted)
+        A[Cluster Admin] --> B[Controller Manager]
+    end
+
+    subgraph Namespace / Tenant Plane (Untrusted)
+        B --> C[Sandbox CRD]
+        C --> D[Sandbox Pod (gVisor / Kata)]
+        C --> E[Headless Service]
+        C --> F[Tenant PVC]
+    end
+
+    classDef trusted fill:#e1f5fe,stroke:#0288d1,stroke-width:2px;
+    classDef untrusted fill:#ffebee,stroke:#c62828,stroke-width:2px;
+    class A,B trusted;
+    class C,D,E,F untrusted;
+```
+
+*   **Cluster Control Plane (Highly Trusted)**: Encompasses cluster administrators and the controller manager. The controller operates with cluster-wide or namespace-restricted permissions necessary to manage Pods, Services, and PVCs.
+*   **Tenant Context (Untrusted)**: Workloads executing inside individual Sandbox pods (e.g., LLM-generated code, terminal tasks). These workloads are completely untrusted and must be strongly isolated from both the host and other sandboxes.
+
+---
+
+## 2. Threat Scenarios and Mitigations
+
+### Threat A: Pod Selector Hijacking via Metadata Spoofing (Headless Service Hijack)
+*   **Description**: A malicious tenant could attempt to set system-reserved metadata—specifically the `agents.x-k8s.io/sandbox-name-hash` label—inside their own Sandbox's `Spec.PodTemplate.ObjectMeta.Labels` configuration. If successfully propagated to their Pod, the Headless Service selector (which routes traffic to sandboxes by name-hash) would route traffic intended for a victim tenant to the attacker's pod.
+*   **Severity**: **High** (Loss of isolation, data interception).
+*   **Mitigation**: 
+    *   **Domain-Wide Metadata Filtering**: The sandbox controller explicitly ignores any user-provided labels or annotations starting with the `agents.x-k8s.io/` or `extensions.agents.x-k8s.io/` domain-wide prefixes inside the PodTemplate.
+    *   **Precise System Cleanup**: During reconciliation, the controller compares the Pod's labels and annotations against the user-provided `Spec.PodTemplate`. If it detects a system-reserved label or annotation that was attempted to be injected via the PodTemplate, it removes it immediately. Unrelated system metadata added by external platform controllers (e.g., service mesh proxies or custom CNIs) is preserved safely.
+
+---
+
+### Threat B: Privilege Escalation via ServiceAccount Spoofing
+*   **Description**: A tenant sandbox could attempt to gain elevated permissions by associating itself with a highly-privileged ServiceAccount (e.g., `cluster-admin` or one that can edit secrets/deployments).
+*   **Severity**: **High** (Cluster compromise).
+*   **Mitigation**:
+    *   **Validating Admission Policies (VAP) & OPA Gatekeeper**: Administrators must deploy VAP or OPA policies to restrict Sandbox pods to a pre-approved list of low-privilege ServiceAccounts.
+    *   **ServiceAccount Token Disabling**: Whenever possible, templates should default to `automountServiceAccountToken: false` to prevent arbitrary API server calls from inside the sandbox.
+
+---
+
+### Threat C: Container Escape and Host Compromise
+*   **Description**: A malicious process inside a sandbox container attempts a kernel exploit to escape the container namespaces and gain root access to the underlying Kubernetes worker node.
+*   **Severity**: **Critical** (Host node compromise).
+*   **Mitigation**:
+    *   **Virtualization & Sandboxing Runtimes**: The threat model assumes that sandboxes are executed under micro-virtualized runtime environments like **gVisor (`runsc`)** or **Kata Containers** to provide strong kernel-level isolation.
+    *   **Restricted Pod Security Standards (PSS)**: By default, admission policies (like GKE Validating Admission Policy or Kyverno) enforce `privileged: false`, `runAsNonRoot: true`, and drop `ALL` linux capabilities on all sandbox Pods.
+
+---
+
+## 3. Shared Responsibility Model
+
+Securing `agent-sandbox` requires a shared effort between the core controller manager and the cluster platform team:
+
+| Layer | Responsible Party | Security Focus |
+|---|---|---|
+| **Application Spec** | Developer / Client SDK | Opt-in to secure templates, enforce low-privilege environments, disable ServiceAccount tokens. |
+| **Metadata Integrity** | Sandbox Controller | Block label/annotation injection attacks, manage cryptographic name-hash generation, adoption validation. |
+| **Kernel/Host Isolation** | Cluster Admin | Enforce gVisor/Kata runtime classes, restrict container execution capabilities (`runAsNonRoot`). |
+| **Network Boundary** | Cluster Admin / CNI | Use Calico/Cilium NetworkPolicies to enforce namespace and pod isolation boundaries. |

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -603,7 +603,12 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	for {
 		adoptedKey, ok := r.WarmSandboxQueue.Get(templateHash)
 		if !ok {
-			return nil, queue.SandboxKey{}, nil
+			// Fallback to old FNV hash
+			oldHash := sandboxcontrollers.FNVNameHash(claim.Spec.TemplateRef.Name)
+			adoptedKey, ok = r.WarmSandboxQueue.Get(oldHash)
+			if !ok {
+				return nil, queue.SandboxKey{}, nil
+			}
 		}
 
 		// 1. Hand the Kubernetes client the empty bucket
@@ -1505,8 +1510,12 @@ func verifySandboxCandidate(candidate *v1beta1.Sandbox, claim *extensionsv1beta1
 	}
 
 	templateHash := SandboxTemplateRefHash(claim.Spec.TemplateRef.Name)
-	if candidate.Labels[sandboxTemplateRefHash] != templateHash {
-		return fmt.Errorf("incorrect template hash, expected %v, got %v", templateHash, candidate.Labels[sandboxTemplateRefHash])
+	candidateHash := candidate.Labels[sandboxTemplateRefHash]
+	if candidateHash != templateHash {
+		oldHash := sandboxcontrollers.FNVNameHash(claim.Spec.TemplateRef.Name)
+		if candidateHash != oldHash {
+			return fmt.Errorf("incorrect template hash, expected %v or %v, got %v", templateHash, oldHash, candidateHash)
+		}
 	}
 	return nil
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1868,6 +1868,41 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 			expectNewSandboxCreated: false,
 		},
+		{
+			name: "adopts oldest ready sandbox from warm pool using legacy FNV hash fallback",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				func() client.Object {
+					sb := createWarmPoolSandbox("pool-sb-legacy", metav1.Time{Time: metav1.Now().Add(-3600 * time.Second)}, true)
+					sb.Labels[sandboxTemplateRefHash] = sandboxcontrollers.FNVNameHash("test-template")
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "pool-sb-legacy",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name: "prefers SHA-256 hash sandbox over legacy FNV hash sandbox",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				func() client.Object {
+					sb := createWarmPoolSandbox("pool-sb-legacy", metav1.Time{Time: metav1.Now().Add(-3600 * time.Second)}, true)
+					sb.Labels[sandboxTemplateRefHash] = sandboxcontrollers.FNVNameHash("test-template")
+					return sb
+				}(),
+				func() client.Object {
+					sb := createWarmPoolSandbox("pool-sb-sha256", metav1.Now(), true)
+					sb.Labels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash("test-template")
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "pool-sb-sha256",
+			expectNewSandboxCreated: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -481,9 +481,12 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 ) bool {
 	sandboxHash := sandbox.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel]
 
-	// If the templateRefHash doesn't match, it's stale.
-	if sandbox.Labels[sandboxTemplateRefHash] != SandboxTemplateRefHash(template.Name) {
-		return true
+	// If the templateRefHash doesn't match, check if it matches the legacy FNV hash.
+	tmplRefHash := sandbox.Labels[sandboxTemplateRefHash]
+	if tmplRefHash != SandboxTemplateRefHash(template.Name) {
+		if tmplRefHash != sandboxcontrollers.FNVNameHash(template.Name) {
+			return true
+		}
 	}
 
 	// Check if the sandbox is unowned (orphaned).

--- a/extensions/controllers/utils_test.go
+++ b/extensions/controllers/utils_test.go
@@ -44,8 +44,8 @@ func TestSandboxTemplateRefHash(t *testing.T) {
 			hash1 := SandboxTemplateRefHash(tc.templateRefName)
 			hash2 := SandboxTemplateRefHash(tc.templateRefName)
 
-			if len(hash1) != 8 {
-				t.Errorf("SandboxTemplateRefHash(%q) length = %d, want 8", tc.templateRefName, len(hash1))
+			if len(hash1) != 32 {
+				t.Errorf("SandboxTemplateRefHash(%q) length = %d, want 32", tc.templateRefName, len(hash1))
 			}
 
 			if hash1 != hash2 {

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
 
-// NameHash generates a SHA-256 hash from a string and returns
-// it as a 32-character hexadecimal string using memory-efficient slice encoding.
+// NameHash generates a SHA-256 hash from a string, truncates it to the first
+// 16 bytes, and returns that truncated value as a 32-character hexadecimal string.
 func NameHash(objectName string) string {
 	hash := sha256.Sum256([]byte(objectName))
 	return hex.EncodeToString(hash[:16])

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -15,8 +15,9 @@
 package e2e
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
-	"hash/fnv"
 	"testing"
 	"time"
 
@@ -28,16 +29,11 @@ import (
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
 
-// NameHash generates an FNV-1a hash from a string and returns
-// it as a fixed-length hexadecimal string.
+// NameHash generates a SHA-256 hash from a string and returns
+// it as a 32-character hexadecimal string using memory-efficient slice encoding.
 func NameHash(objectName string) string {
-	h := fnv.New32a()
-	h.Write([]byte(objectName))
-	hashValue := h.Sum32()
-
-	// Convert the uint32 to a hexadecimal string.
-	// This results in an 8-character string (e.g., "a5b3c2d1").
-	return fmt.Sprintf("%08x", hashValue)
+	hash := sha256.Sum256([]byte(objectName))
+	return hex.EncodeToString(hash[:16])
 }
 
 func simpleSandbox(ns string) *sandboxv1beta1.Sandbox {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes a critical vulnerability where a malicious Sandbox tenant can bypass the internal network boundary. In the original code, user-provided labels inside `Spec.PodTemplate.ObjectMeta.Labels` were copied onto the Pod's metadata without verification, allowing them to overwrite the security-critical `agents.x-k8s.io/sandbox-name-hash` label. By explicitly injecting a victim's name hash into their own Pod labels, an attacker could hijack network traffic routed via the Headless Service selector.

**Core Fixes:**
1. **System Labels & Annotations Protection**: Added helper checks (`isSystemLabel` and `isSystemAnnotation`) in [sandbox_controller.go](file:///usr/local/google/home/glottman/dev/agent-sandbox-vulEq3/controllers/sandbox_controller.go) to prevent user templates from copying over system-reserved keys. The system labels are now safely assigned *after* merging user inputs.
2. **Cryptographically Secure Naming Hash**: Swapped the predictable FNV-1a 32-bit name-hash with **SHA-256** (first 32 hex characters) for cryptographic collision resistance.
3. **High-Performance Hashing Optimization**: Uses a memory-efficient slice encoding of SHA-256 (`hex.EncodeToString(hash[:16])`) that runs **2.7x faster** than standard string formatting. Micro-benchmarks run on AMD EPYC 7B12 show that the optimized hash executes in **`197.9 ns/op`** (virtually identical to FNV-1a's `151.7 ns/op`), ensuring zero scale overhead.
4. **Seamless Live Upgrade Migration**: Because the controller retrieves backing Pods and Services directly by name, the new controller will **automatically patch and migrate existing child resources** to the new SHA-256 label during their first reconcile loop. No manual migration or sandbox recreation is required.


#### Release Note
```release-note
FIX: Upgraded Sandbox NameHash to cryptographically secure SHA-256 with optimized slice encoding and added verification checks to prevent user-supplied templates from overriding security-critical system labels and annotations.
