### PR TITLE
ci: declare contents: read on check-api-docs and check

### DIFF
--- a/.github/workflows/check-api-docs.yml
+++ b/.github/workflows/check-api-docs.yml
@@ -9,6 +9,9 @@ on:
       - 'config.yaml'
       - '.github/workflows/check-api-docs.yml'
 
+permissions:
+  contents: read
+
 jobs:
   check-api-docs:
     name: Verify Generated API Docs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   toc-update:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Adds an explicit `permissions: contents: read` block to the two CI workflows that hadn't declared their token scope. Both only run local make/script commands to verify generated docs and KEP table-of-contents.

YAML validated locally.