### PR TITLE
Enable parallel sandbox creation/deletion in Sandbox WarmPool controller

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -65,6 +65,7 @@ func main() {
 	var sandboxClaimConcurrentWorkers int
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
+	var sandboxWarmPoolMaxBatchSize int
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
@@ -93,6 +94,7 @@ func main() {
 	flag.IntVar(&sandboxClaimConcurrentWorkers, "sandbox-claim-concurrent-workers", 1, "Max concurrent reconciles for the SandboxClaim controller")
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
+	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -111,11 +113,17 @@ func main() {
 		"sandboxClaim", sandboxClaimConcurrentWorkers,
 		"sandboxWarmPool", sandboxWarmPoolConcurrentWorkers,
 		"sandboxTemplate", sandboxTemplateConcurrentWorkers,
+		"sandboxWarmPoolMaxBatchSize", sandboxWarmPoolMaxBatchSize,
 	)
 
 	// Validation checks for concurrency flags
 	if sandboxConcurrentWorkers <= 0 || sandboxClaimConcurrentWorkers <= 0 || sandboxWarmPoolConcurrentWorkers <= 0 {
 		setupLog.Error(nil, "concurrent workers must be greater than 0")
+		os.Exit(1)
+	}
+	// Validation checks for sandboxWarmPoolMaxBatchSize (maximum batch size for sandbox creation and deletion in SandboxWarmPool controller)
+	if sandboxWarmPoolMaxBatchSize <= 0 {
+		setupLog.Error(nil, "sandbox-warm-pool-max-batch-size must be greater than 0")
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -259,8 +267,9 @@ func main() {
 		}
 
 		if err = (&extensionscontrollers.SandboxWarmPoolReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
+			Client:       mgr.GetClient(),
+			Scheme:       mgr.GetScheme(),
+			MaxBatchSize: sandboxWarmPoolMaxBatchSize,
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")
 			os.Exit(1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 * `--sandbox-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the Sandbox controller.
 * `--sandbox-claim-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxClaim controller.
 * `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller.
+* `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch.
 * `--kube-api-qps` (default: -1 ; no rate limiting): The maximum Queries Per Second (QPS) sent to the Kubernetes API server from the controller.
 * `--kube-api-burst` (default: 10): The maximum burst for throttle requests to the Kubernetes API server.
 
@@ -45,6 +46,7 @@ If you are deploying the extensions controller (which includes the core controll
         - --sandbox-concurrent-workers=10
         - --sandbox-claim-concurrent-workers=10
         - --sandbox-warm-pool-concurrent-workers=10
+        - --sandbox-warm-pool-max-batch-size=500
         - --kube-api-qps=50
         - --kube-api-burst=100
 ```
@@ -59,6 +61,7 @@ kubectl patch deployment agent-sandbox-controller \
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-concurrent-workers=10"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-claim-concurrent-workers=10"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-concurrent-workers=10"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-max-batch-size=500"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=50"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}
   ]'
@@ -84,6 +87,7 @@ spec:
         - --sandbox-concurrent-workers=10
         - --sandbox-claim-concurrent-workers=10
         - --sandbox-warm-pool-concurrent-workers=10
+        - --sandbox-warm-pool-max-batch-size=500
         - --kube-api-qps=50
         - --kube-api-burst=100
 ```

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -175,13 +175,19 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		sandboxesToCreate := min(desiredReplicas-currentReplicas, maxBatchSize)
 		logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
 
-		// Parallel sandbox creation with adaptive slow-start batching (starts with 1 and doubles on success)
-		_, createErr := slowStartBatch(ctx, int(sandboxesToCreate), 1, func(_ int) error {
-			return r.createPoolSandbox(ctx, warmPool, poolNameHash, template, currentPodTemplateHash)
-		})
-		if createErr != nil {
-			logger.Error(createErr, "Failed to create pool sandboxes")
-			allErrors = errors.Join(allErrors, createErr)
+		sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash)
+		if err != nil {
+			logger.Error(err, "Failed to build sandbox CR blueprint")
+			allErrors = errors.Join(allErrors, err)
+		} else {
+			// Parallel sandbox creation with adaptive slow-start batching (starts with 1 and doubles on success)
+			_, createErr := slowStartBatch(ctx, int(sandboxesToCreate), 1, func(_ int) error {
+				return r.createPoolSandbox(ctx, warmPool, sandboxCR)
+			})
+			if createErr != nil {
+				logger.Error(createErr, "Failed to create pool sandboxes")
+				allErrors = errors.Join(allErrors, createErr)
+			}
 		}
 	}
 
@@ -318,11 +324,8 @@ func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, wa
 	return template, currentPodTemplateHash, tmplErr
 }
 
-// createPoolSandbox creates a full Sandbox CR (with pod template and volume claim templates) for the warm pool.
-func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, poolNameHash string, template *extensionsv1beta1.SandboxTemplate, currentPodTemplateHash string) error {
-	logger := log.FromContext(ctx)
-
-	// Build labels for the Sandbox CR
+// buildSandboxCR constructs the base Sandbox CR (with pod template and volume claim templates) for the warm pool.
+func (r *SandboxWarmPoolReconciler) buildSandboxCR(warmPool *extensionsv1beta1.SandboxWarmPool, poolNameHash string, template *extensionsv1beta1.SandboxTemplate, currentPodTemplateHash string) (*sandboxv1beta1.Sandbox, error) {
 	sandboxLabels := map[string]string{
 		warmPoolSandboxLabel:                       poolNameHash,
 		sandboxTemplateRefHash:                     SandboxTemplateRefHash(warmPool.Spec.TemplateRef.Name),
@@ -380,9 +383,16 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 
 	// Set controller reference so the Sandbox is owned by the SandboxWarmPool
 	if err := ctrl.SetControllerReference(warmPool, sandbox, r.Scheme); err != nil {
-		return fmt.Errorf("SetControllerReference for Sandbox failed: %w", err)
+		return nil, fmt.Errorf("SetControllerReference for Sandbox failed: %w", err)
 	}
 
+	return sandbox, nil
+}
+
+// createPoolSandbox creates a full Sandbox CR for the warm pool using a pre-built sandboxCR.
+func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, sandboxCR *sandboxv1beta1.Sandbox) error {
+	logger := log.FromContext(ctx)
+	sandbox := sandboxCR.DeepCopy()
 	if err := r.Create(ctx, sandbox); err != nil {
 		logger.Error(err, "Failed to create pool sandbox")
 		return err

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,14 +46,16 @@ import (
 )
 
 const (
-	sandboxTemplateRefHash = "agents.x-k8s.io/sandbox-template-ref-hash"
-	warmPoolSandboxLabel   = "agents.x-k8s.io/warm-pool-sandbox"
+	sandboxTemplateRefHash          = "agents.x-k8s.io/sandbox-template-ref-hash"
+	warmPoolSandboxLabel            = "agents.x-k8s.io/warm-pool-sandbox"
+	sandboxCreateDeleteMaxBatchSize = 300
 )
 
 // SandboxWarmPoolReconciler reconciles a SandboxWarmPool object.
 type SandboxWarmPoolReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme       *runtime.Scheme
+	MaxBatchSize int
 }
 
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools,verbs=get;list;watch;create;update;patch;delete
@@ -164,22 +168,26 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	}
 	warmPool.Status.ReadyReplicas = readyReplicas
 
+	maxBatchSize := int32(r.MaxBatchSize)
+
 	// Create new sandboxes if we need more
 	if currentReplicas < desiredReplicas && tmplErr == nil {
-		sandboxesToCreate := desiredReplicas - currentReplicas
+		sandboxesToCreate := min(desiredReplicas-currentReplicas, maxBatchSize)
 		logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
 
-		for range sandboxesToCreate {
-			if err := r.createPoolSandbox(ctx, warmPool, poolNameHash, template, currentPodTemplateHash); err != nil {
-				logger.Error(err, "Failed to create pool sandbox")
-				allErrors = errors.Join(allErrors, err)
-			}
+		// Parallel sandbox creation with adaptive slow-start batching (starts with 1 and doubles on success)
+		_, createErr := slowStartBatch(ctx, int(sandboxesToCreate), 1, func(_ int) error {
+			return r.createPoolSandbox(ctx, warmPool, poolNameHash, template, currentPodTemplateHash)
+		})
+		if createErr != nil {
+			logger.Error(createErr, "Failed to create pool sandboxes")
+			allErrors = errors.Join(allErrors, createErr)
 		}
 	}
 
 	// Delete excess sandboxes if we have too many
 	if currentReplicas > desiredReplicas {
-		sandboxesToDelete := currentReplicas - desiredReplicas
+		sandboxesToDelete := min(currentReplicas-desiredReplicas, maxBatchSize)
 		logger.Info("Deleting excess sandboxes", "count", sandboxesToDelete)
 
 		// Prioritize deleting unready sandboxes before ready ones,
@@ -196,12 +204,14 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 			return b.CreationTimestamp.Compare(a.CreationTimestamp.Time) // newest first
 		})
 
-		for i := int32(0); i < sandboxesToDelete && i < int32(len(activeSandboxes)); i++ {
-			sb := &activeSandboxes[i]
-			if err := r.Delete(ctx, sb); err != nil {
-				logger.Error(err, "Failed to delete sandbox", "sandbox", sb.Name)
-				allErrors = errors.Join(allErrors, err)
-			}
+		toDeleteCount := min(sandboxesToDelete, int32(len(activeSandboxes)))
+		// Parallel sandbox deletion with adaptive slow-start batching (starts with 1 and doubles on success)
+		_, deleteErr := slowStartBatch(ctx, int(toDeleteCount), 1, func(idx int) error {
+			return r.deletePoolSandbox(ctx, &activeSandboxes[idx])
+		})
+		if deleteErr != nil {
+			logger.Error(deleteErr, "Failed to delete pool sandboxes")
+			allErrors = errors.Join(allErrors, deleteErr)
 		}
 	}
 
@@ -308,7 +318,7 @@ func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, wa
 	return template, currentPodTemplateHash, tmplErr
 }
 
-// createPoolSandbox creates a full Sandbox CR (with pod template, service, etc.) for the warm pool.
+// createPoolSandbox creates a full Sandbox CR (with pod template and volume claim templates) for the warm pool.
 func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, poolNameHash string, template *extensionsv1beta1.SandboxTemplate, currentPodTemplateHash string) error {
 	logger := log.FromContext(ctx)
 
@@ -379,6 +389,16 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	}
 
 	logger.Info("Created new pool sandbox", "sandbox", sandbox.Name, "poolName", warmPool.Name)
+	return nil
+}
+
+// deletePoolSandbox deletes a Sandbox CR from the warm pool. Ignores not found errors to not abort the batch deletion if some sandboxes are already deleted.
+func (r *SandboxWarmPoolReconciler) deletePoolSandbox(ctx context.Context, sb *sandboxv1beta1.Sandbox) error {
+	logger := log.FromContext(ctx)
+	if err := r.Delete(ctx, sb); err != nil && client.IgnoreNotFound(err) != nil {
+		logger.Error(err, "Failed to delete sandbox", "sandbox", sb.Name, "namespace", sb.Namespace)
+		return err
+	}
 	return nil
 }
 
@@ -502,6 +522,9 @@ func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxWarmPoolReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
+	if r.MaxBatchSize <= 0 {
+		r.MaxBatchSize = sandboxCreateDeleteMaxBatchSize
+	}
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &extensionsv1beta1.SandboxWarmPool{}, extensionsv1beta1.TemplateRefField, func(rawObj client.Object) []string {
 		wp := rawObj.(*extensionsv1beta1.SandboxWarmPool)
 		if wp.Spec.TemplateRef.Name == "" {
@@ -547,4 +570,42 @@ func (r *SandboxWarmPoolReconciler) findWarmPoolsForTemplate(ctx context.Context
 		})
 	}
 	return requests
+}
+
+// slowStartBatch is a helper that runs a given function fn multiple times in parallel batches.
+// It starts with initialBatchSize, and doubles the batch size for each successful batch.
+// If any execution of fn returns an error, it stops and returns the first encountered error.
+func slowStartBatch(ctx context.Context, count int, initialBatchSize int, fn func(int) error) (int, error) {
+	remaining := count
+	successes := 0
+
+	for batchSize := min(remaining, initialBatchSize); batchSize > 0; batchSize = min(2*batchSize, remaining) {
+		if ctx.Err() != nil {
+			return successes, ctx.Err()
+		}
+
+		eg, _ := errgroup.WithContext(ctx)
+		var batchSuccesses atomic.Int64
+
+		for i := 0; i < batchSize; i++ {
+			index := successes + i
+			eg.Go(func() error {
+				if err := fn(index); err != nil {
+					return err
+				}
+				batchSuccesses.Add(1)
+				return nil
+			})
+		}
+
+		if err := eg.Wait(); err != nil {
+			successes += int(batchSuccesses.Load())
+			return successes, err
+		}
+
+		successes += int(batchSuccesses.Load())
+		remaining -= batchSize
+	}
+
+	return successes, nil
 }

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -17,6 +17,8 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -196,7 +198,8 @@ func TestReconcilePool(t *testing.T) {
 					WithScheme(scheme).
 					WithRuntimeObjects(tc.initialObjs...).
 					Build(),
-				Scheme: scheme,
+				Scheme:       scheme,
+				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
 
 			ctx := context.Background()
@@ -334,7 +337,8 @@ func TestReconcilePoolControllerRef(t *testing.T) {
 					WithScheme(scheme).
 					WithRuntimeObjects(tc.initialObjs...).
 					Build(),
-				Scheme: scheme,
+				Scheme:       scheme,
+				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
 
 			ctx := context.Background()
@@ -422,7 +426,8 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 				WithScheme(scheme).
 				WithRuntimeObjects(template).
 				Build(),
-			Scheme: scheme,
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 		}
 
 		expectedPoolNameHash := sandboxcontrollers.NameHash(poolName)
@@ -518,7 +523,8 @@ func TestCreatePoolSandboxPropagatesVolumeClaimTemplates(t *testing.T) {
 			WithScheme(scheme).
 			WithRuntimeObjects(template).
 			Build(),
-		Scheme: scheme,
+		Scheme:       scheme,
+		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 	}
 
 	err := r.reconcilePool(ctx, warmPool)
@@ -616,7 +622,8 @@ func TestCreatePoolSandboxAppliesSecureDefaults(t *testing.T) {
 					WithScheme(scheme).
 					WithRuntimeObjects(template).
 					Build(),
-				Scheme: scheme,
+				Scheme:       scheme,
+				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
 
 			err := r.reconcilePool(ctx, warmPool)
@@ -791,7 +798,8 @@ func TestReconcilePoolGCStuckSandboxes(t *testing.T) {
 					createSandboxWithAge("-healthy", metav1.ConditionTrue, 10*time.Minute),
 				).
 				Build(),
-			Scheme: scheme,
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 		}
 
 		ctx := context.Background()
@@ -823,7 +831,8 @@ func TestReconcilePoolGCStuckSandboxes(t *testing.T) {
 					createSandboxWithAge("-healthy", metav1.ConditionTrue, 10*time.Minute),
 				).
 				Build(),
-			Scheme: scheme,
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 		}
 
 		ctx := context.Background()
@@ -923,7 +932,8 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 					WithScheme(scheme).
 					WithRuntimeObjects(template, warmPool).
 					Build(),
-				Scheme: scheme,
+				Scheme:       scheme,
+				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
 
 			ctx := context.Background()
@@ -1068,7 +1078,8 @@ func TestReconcilePool_TemplateRefUpdate_SameSpec(t *testing.T) {
 			WithScheme(scheme).
 			WithRuntimeObjects(template1, warmPool).
 			Build(),
-		Scheme: scheme,
+		Scheme:       scheme,
+		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 	}
 
 	ctx := context.Background()
@@ -1334,7 +1345,8 @@ func TestReconcilePool_TemplateUpdate_DNSPolicy(t *testing.T) {
 			WithScheme(scheme).
 			WithRuntimeObjects(template, warmPool).
 			Build(),
-		Scheme: scheme,
+		Scheme:       scheme,
+		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 	}
 
 	// Initial reconcile to create sandboxes
@@ -1444,4 +1456,82 @@ func TestIsSandboxStale_OrphanedSandboxVetting(t *testing.T) {
 
 	isStaleGenuine := r.isSandboxStale(ctx, genuineOrphan, template, currentPodTemplateHash, vettedHashes)
 	require.False(t, isStaleGenuine, "Orphaned sandbox with genuine fully vetted PodSpec should be fresh")
+}
+
+func TestSlowStartBatch(t *testing.T) {
+	tests := []struct {
+		name               string
+		count              int
+		initialBatchSize   int
+		failAtIndices      *int
+		cancelContextAtIdx *int
+		expectedSuccess    int
+		expectError        bool
+		expectedCallCount  int
+		expectedErrMsgs    []string
+	}{
+		{
+			name:              "all succeed with batch trimming (count=14)",
+			count:             14,
+			initialBatchSize:  1,
+			expectedSuccess:   14,
+			expectedCallCount: 14,
+		},
+		{
+			name:              "zero count",
+			count:             0,
+			initialBatchSize:  1,
+			expectedSuccess:   0,
+			expectedCallCount: 0,
+		},
+		{
+			name:              "early exit on failure",
+			count:             14,
+			initialBatchSize:  1,
+			failAtIndices:     new(5),
+			expectedSuccess:   6, // index 0, 1, 2, 3, 4, and 6 succeeds, 5 fails - 6 successful calls
+			expectError:       true,
+			expectedCallCount: 7, // 1 + 2 + 4 = 7 calls in total.
+			expectedErrMsgs:   []string{"injected error at idx 5"},
+		},
+		{
+			name:               "context canceled in middle of batch",
+			count:              14,
+			initialBatchSize:   1,
+			cancelContextAtIdx: new(2), // cancels during batch 2 (indices 1, 2)
+			expectedSuccess:    3,      // indices 0, 1, 2 complete successfully before cancellation aborts batch 3
+			expectError:        true,
+			expectedCallCount:  3,
+			expectedErrMsgs:    []string{"context canceled"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var callCount atomic.Int32
+			ctx, cancel := context.WithCancel(context.Background())
+			successes, err := slowStartBatch(ctx, tt.count, tt.initialBatchSize, func(idx int) error {
+				callCount.Add(1)
+				if tt.cancelContextAtIdx != nil && *tt.cancelContextAtIdx == idx {
+					cancel()
+				}
+				if tt.failAtIndices != nil && *tt.failAtIndices == idx {
+					return fmt.Errorf("injected error at idx %d", idx)
+				}
+				return nil
+			})
+
+			if tt.expectError {
+				require.Error(t, err)
+				for _, expectedErrMsg := range tt.expectedErrMsgs {
+					require.Contains(t, err.Error(), expectedErrMsg)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expectedSuccess, successes)
+			require.Equal(t, int32(tt.expectedCallCount), callCount.Load())
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/goleak v1.3.0
+	golang.org/x/sync v0.20.0
 	k8s.io/api v0.35.4
 	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
@@ -77,7 +78,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Enable the parallel creation and deletion of sandboxes during Sandbox WarmPool reconcile loop. 

Before this PR: 
- For both creations/deletion we have a simple for loop and we do all operations sequentially.

After this PR:
- We are able to do the creations and deletions of sandboxes in the warmpool in parallel.
- In order to not spam the kube api server we must have a limit of sandboxes per batch. Added `sandbox-warm-pool-max-batch-size` flag to make the batch size configurable, if not provided the default we will be 300. (tested also 500, but got a lot of "Too Many Request" errors).
- To be on the safe side both creations and deletions do the slow start with 1 and then double each time until we reach `maxBatchSize` or have an error. This was somewhat inspired by https://github.com/kubernetes/kubernetes/blob/56c6f6bf877e1adb0af2056a86a131c5c0704772/pkg/controller/replicaset/replica_set.go#L649 

Testing:

Measured the time it takes to create 3300 sandboxes for the warm pool with the image generated from the head without and with my changes and got the following results: 

|      | Start | Finish | Duration | 
| -------- | ------- | ------- | ------- |
| W/o parallelization  | 2026-05-13 06:33:31.633    | 2026-05-13 06:34:27.827 | 56.2 sec |
| With parallelization | 2026-05-13 09:54:09.411     | 2026-05-13 09:54:22.633 | 13.2 sec  |
| Difference    |     |  | 4.26 times faster |


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
Added new flag "sandbox-warm-pool-max-batch-size" which sets the maximum number of sandboxes that we create/delete during one reconcile loop of Sandbox Warmpool controller. The default is 300.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->