### PR TITLE
PSS SDK: Enable restoration from dedicated snapshot

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -27,6 +27,7 @@ SANDBOX_PLURAL_NAME = "sandboxes"
 
 POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
 PODSNAPSHOT_POD_NAME_ANNOTATION = "podsnapshot.gke.io/origin-pod"
+PODSNAPSHOT_NAME_ANNOTATION = "podsnapshot.gke.io/ps-name"
 SANDBOX_NAME_HASH_LABEL = "agents.x-k8s.io/sandbox-name-hash"
 
 PODSNAPSHOT_API_GROUP = "podsnapshot.gke.io"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/exceptions.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/exceptions.py
@@ -27,6 +27,10 @@ class SandboxNotFoundError(SandboxError):
     """Raised when the sandbox or sandbox claim cannot be found or was deleted."""
 
 
+class SnapshotNotFoundError(SandboxError):
+    """Raised when the requested snapshot does not exist."""
+
+
 class SandboxTemplateNotFoundError(SandboxError):
     """Raised when the requested sandbox template does not exist."""
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md
@@ -64,7 +64,19 @@ try:
     print("Resuming sandbox...")
     resume_response = sandbox.resume()
     if resume_response.success:
-        print(f"Sandbox resumed! Restored from snapshot: {resume_response.restored_from_snapshot}")
+        print(f"Sandbox resumed! Restored from snapshot: {resume_response.snapshot_uid}")
+
+    # Suspend the sandbox before performing a dedicated restore
+    print("Suspending sandbox...")
+    suspend_response = sandbox.suspend(snapshot_before_suspend=False)
+    if suspend_response.success:
+        print("Sandbox suspended successfully.")
+
+    # Restore the sandbox to a specific previous snapshot
+    print("Restoring sandbox to a specific snapshot...")
+    restore_response = sandbox.restore(snapshot_uid=response.snapshot_uid)
+    if restore_response.success:
+        print(f"Sandbox restored! Restored from snapshot: {restore_response.snapshot_uid}")
 finally:
     sandbox.terminate()
 ```
@@ -130,8 +142,9 @@ This file, located in the parent directory (`clients/python/agentic-sandbox-clie
           groupRetentionPolicy:
             maxSnapshotCountPerGroup: 3
     ```
+4.  **Sandbox Template**: A `SandboxTemplate` (e.g., `python-counter-template`) referencing a template with runtime gVisor, appropriate KSA and label that matches that selector label in `PodSnapshotPolicy` must be available in the cluster.
 
-5.  **Sandbox WarmPool**: A `SandboxWarmPool` (e.g., `python-counter-pool`) referencing a template with runtime gVisor, appropriate KSA and label that matches that selector label in `PodSnapshotPolicy` must be available in the cluster.
+5.  **Sandbox WarmPool**: A `SandboxWarmPool` (e.g., `python-counter-pool`) with appropriate replica count that references the `SandboxTemplate` must be available in the cluster.
 
 ### Running Tests:
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -14,19 +14,27 @@
 
 import logging
 from kubernetes.client import ApiException
+from k8s_agent_sandbox.exceptions import SnapshotNotFoundError
 from .snapshot_engine import SnapshotEngine, SnapshotResponse
 from k8s_agent_sandbox.sandbox import Sandbox
-from k8s_agent_sandbox.constants import SANDBOX_API_GROUP, SANDBOX_API_VERSION, SANDBOX_PLURAL_NAME
+from k8s_agent_sandbox.constants import (
+    SANDBOX_API_GROUP,
+    SANDBOX_API_VERSION,
+    SANDBOX_PLURAL_NAME,
+    PODSNAPSHOT_NAME_ANNOTATION,
+)
 from .utils import (
     check_pod_restored_from_snapshot,
     RestoreCheckResult,
     wait_for_pod_termination,
     wait_for_pod_ready,
+    wait_for_sandbox_propagation,
 )
 from pydantic import BaseModel
 
 SUCCESS_CODE = 0
 ERROR_CODE = 1
+INTERNAL_ERROR_CODE = 2
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +50,14 @@ class SuspendResponse(BaseModel):
 
 class ResumeResponse(BaseModel):
     """Result of a resume operation."""
+    success: bool
+    restored_from_snapshot: bool | None = None
+    snapshot_uid: str | None = None
+    error_reason: str = ""
+    error_code: int = 0
+
+class RestorationResponse(BaseModel):
+    """Result of a restore operation."""
     success: bool
     restored_from_snapshot: bool | None = None
     snapshot_uid: str | None = None
@@ -231,6 +247,65 @@ class SandboxWithSnapshotSupport(Sandbox):
             error_code=ERROR_CODE
         )
 
+    def _restore_internal(self, target_snapshot_uid: str | None, wait_timeout: int) -> RestorationResponse:
+        """Internal restore logic shared by resume() and restore()."""
+        # Clear cached pod name and connection before resuming to ensure we pick up the new pod
+        self.connector.close()
+        self._pod_name = None
+
+        try:
+            self._set_operating_mode(OPERATING_MODE_RUNNING)
+            logger.info(f"Sandbox '{self.sandbox_id}' pod created successfully (operatingMode set to {OPERATING_MODE_RUNNING}).")
+        except Exception as e:
+            logger.error(f"Failed to create a new pod for Sandbox '{self.sandbox_id}': {e}")
+            return RestorationResponse(
+                success=False,
+                restored_from_snapshot=False,
+                snapshot_uid=None,
+                error_reason=f"Failed to patch operatingMode: {e}",
+                error_code=ERROR_CODE
+            )
+
+        if wait_for_pod_ready(self.k8s_helper, self.namespace, self.get_pod_name, wait_timeout):
+            if not target_snapshot_uid:
+                logger.info(f"No previous snapshots found for Sandbox '{self.sandbox_id}'. Skipping restore verification.")
+                return RestorationResponse(
+                    success=True,
+                    restored_from_snapshot=False,
+                    snapshot_uid=None,
+                    error_reason="",
+                    error_code=SUCCESS_CODE
+                )
+
+            restore_check = self._is_restored_from_snapshot(target_snapshot_uid)
+            if restore_check.success:
+                logger.info(f"Sandbox '{self.sandbox_id}' successfully restored from snapshot '{target_snapshot_uid}'.")
+                return RestorationResponse(
+                    success=True,
+                    restored_from_snapshot=True,
+                    snapshot_uid=target_snapshot_uid,
+                    error_reason="",
+                    error_code=SUCCESS_CODE
+                )
+            else:
+                logger.error(f"Sandbox '{self.sandbox_id}' was not restored from snapshot '{target_snapshot_uid}': {restore_check.error_reason}")
+                return RestorationResponse(
+                    success=False,
+                    restored_from_snapshot=False,
+                    snapshot_uid=target_snapshot_uid,
+                    error_reason=f"Pod ready but not restored from snapshot: {restore_check.error_reason}",
+                    error_code=ERROR_CODE
+                )
+        
+        logger.warning(f"Timed out waiting for Sandbox '{self.sandbox_id}' pod to become ready.")
+        return RestorationResponse(
+            success=False,
+            restored_from_snapshot=False,
+            snapshot_uid=target_snapshot_uid,
+            error_reason="Timed out waiting for pod to become ready.",
+            error_code=ERROR_CODE
+        )
+
     def resume(self, wait_timeout: int = 180) -> ResumeResponse:
         """
         Resumes the sandbox from the latest available snapshot.
@@ -266,57 +341,109 @@ class SandboxWithSnapshotSupport(Sandbox):
             )
 
         try:
-            self._set_operating_mode(OPERATING_MODE_RUNNING)
-            logger.info(f"Sandbox '{self.sandbox_id}' resumed (operatingMode set to {OPERATING_MODE_RUNNING}).")
+            body = {
+                "spec": {
+                    "additionalPodMetadata": {
+                        "annotations": {
+                            PODSNAPSHOT_NAME_ANNOTATION: None
+                        }
+                    }
+                }
+            }
+            self.k8s_helper.patch_sandbox_claim(self.claim_name, self.namespace, body)
         except Exception as e:
-            logger.error(f"Failed to resume Sandbox '{self.sandbox_id}': {e}")
+            logger.error(f"Failed to clean up restore annotation before resuming: {e}")
             return ResumeResponse(
                 success=False,
                 restored_from_snapshot=False,
                 snapshot_uid=None,
-                error_reason=f"Failed to patch operatingMode: {e}",
-                error_code=ERROR_CODE
+                error_reason=f"Failed to clean up restore annotation before resuming: {e}",
+                error_code=ERROR_CODE,
             )
 
-        if wait_for_pod_ready(self.k8s_helper, self.namespace, self.get_pod_name, wait_timeout):
-            if not latest_snapshot_uid:
-                logger.info(f"No previous snapshots found for Sandbox '{self.sandbox_id}'. Skipping restore verification.")
-                return ResumeResponse(
-                    success=True,
-                    restored_from_snapshot=False,
-                    snapshot_uid=None,
-                    error_reason="",
-                    error_code=SUCCESS_CODE
-                )
+        if not wait_for_sandbox_propagation(self.k8s_helper, self.namespace, self.sandbox_id, None):
+            logger.error("Timed out waiting for restore annotation cleanup to propagate to Sandbox spec.")
+            return ResumeResponse(
+                success=False,
+                restored_from_snapshot=False,
+                snapshot_uid=None,
+                error_reason="Internal Error: Timed out waiting for restore annotation cleanup.",
+                error_code=INTERNAL_ERROR_CODE,
+            )
 
-            restore_check = self._is_restored_from_snapshot(latest_snapshot_uid)
-            if restore_check.success:
-                logger.info(f"Sandbox '{self.sandbox_id}' successfully restored from snapshot '{latest_snapshot_uid}'.")
-                return ResumeResponse(
-                    success=True,
-                    restored_from_snapshot=True,
-                    snapshot_uid=latest_snapshot_uid,
-                    error_reason="",
-                    error_code=SUCCESS_CODE
-                )
-            else:
-                logger.error(f"Sandbox '{self.sandbox_id}' was not restored from snapshot '{latest_snapshot_uid}': {restore_check.error_reason}")
-                return ResumeResponse(
+        res = self._restore_internal(latest_snapshot_uid, wait_timeout)
+        return ResumeResponse(
+            success=res.success,
+            restored_from_snapshot=res.restored_from_snapshot,
+            snapshot_uid=res.snapshot_uid,
+            error_reason=res.error_reason,
+            error_code=res.error_code,
+        )
+
+    def _verify_snapshot_exists(self, snapshot_uid: str) -> None:
+        """Verifies that a snapshot exists for this sandbox."""
+        list_result = self.snapshots.list()
+        if not list_result.success:
+            raise RuntimeError(f"Failed to list snapshots: {list_result.error_reason}")
+        if not any(snap.snapshot_uid == snapshot_uid for snap in list_result.snapshots):
+            raise SnapshotNotFoundError(f"Snapshot '{snapshot_uid}' does not exist for this sandbox.")
+
+    def restore(self, snapshot_uid: str, sandbox_ready_timeout: int = 180) -> RestorationResponse:
+        """Restores this sandbox from a specific snapshot."""
+        try:
+            self._verify_snapshot_exists(snapshot_uid)
+
+            if not self.is_suspended():
+                return RestorationResponse(
                     success=False,
                     restored_from_snapshot=False,
-                    snapshot_uid=latest_snapshot_uid,
-                    error_reason=f"Pod ready but not restored from snapshot: {restore_check.error_reason}",
+                    snapshot_uid=snapshot_uid,
+                    error_reason="Sandbox is currently running and cannot be restored.",
                     error_code=ERROR_CODE
                 )
-        
-        logger.warning(f"Timed out waiting for Sandbox '{self.sandbox_id}' pod to become ready.")
-        return ResumeResponse(
-            success=False,
-            restored_from_snapshot=False,
-            snapshot_uid=latest_snapshot_uid,
-            error_reason="Timed out waiting for pod to become ready.",
-            error_code=ERROR_CODE
-        )
+
+            body = {
+                "spec": {
+                    "additionalPodMetadata": {
+                        "annotations": {
+                            PODSNAPSHOT_NAME_ANNOTATION: snapshot_uid
+                        }
+                    }
+                }
+            }
+            self.k8s_helper.patch_sandbox_claim(self.claim_name, self.namespace, body)
+
+            if not wait_for_sandbox_propagation(self.k8s_helper, self.namespace, self.sandbox_id, snapshot_uid):
+                logger.error(f"Timed out waiting for snapshot UID to propagate to Sandbox spec.")
+                return RestorationResponse(
+                    success=False,
+                    restored_from_snapshot=False,
+                    snapshot_uid=snapshot_uid,
+                    error_reason="Internal Error: Timed out waiting for sandbox restoration.",
+                    error_code=INTERNAL_ERROR_CODE
+                )
+
+            logger.info(f"Restoring sandbox '{self.sandbox_id}' from snapshot '{snapshot_uid}'.")
+            return self._restore_internal(snapshot_uid, sandbox_ready_timeout)
+
+        except SnapshotNotFoundError as e:
+            logger.warning(f"Failed to restore Sandbox '{self.sandbox_id}': {e}")
+            return RestorationResponse(
+                success=False,
+                restored_from_snapshot=False,
+                snapshot_uid=snapshot_uid,
+                error_reason=str(e),
+                error_code=ERROR_CODE
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error during restore for Sandbox '{self.sandbox_id}': {e}")
+            return RestorationResponse(
+                success=False,
+                restored_from_snapshot=False,
+                snapshot_uid=snapshot_uid,
+                error_reason=f"Unexpected error: {e}",
+                error_code=ERROR_CODE
+            )
     
     def terminate(self):
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -1458,6 +1458,20 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.assertEqual(result.error_code, INTERNAL_ERROR_CODE)
         self.assertIn("Internal Error: Timed out waiting for sandbox restoration", result.error_reason)
 
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_restore_patch_exception(self, mock_is_suspended):
+        """Test restore returns failure when patch_sandbox_claim raises an exception."""
+        self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": [{"metadata": {"name": "snap-uid-123"}, "status": {"conditions": [{"type": "Ready", "status": "True"}]}}]
+        }
+        self.mock_k8s_helper.patch_sandbox_claim.side_effect = Exception("Patch failed")
+
+        result = self.sandbox.restore(snapshot_uid="snap-uid-123")
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, ERROR_CODE)
+        self.assertIn("Unexpected error: Patch failed", result.error_reason)
+
     @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_sandbox_propagation', return_value=True)
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
     @patch.object(SandboxWithSnapshotSupport, '_restore_internal')

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -22,9 +22,11 @@ from k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support im
     SandboxWithSnapshotSupport,
     SUCCESS_CODE,
     ERROR_CODE,
+    INTERNAL_ERROR_CODE,
     SuspendResponse,
-    ResumeResponse,
+    RestorationResponse,
 )
+from k8s_agent_sandbox.exceptions import SnapshotNotFoundError
 from k8s_agent_sandbox.constants import (
     SANDBOX_NAME_HASH_LABEL,
     PODSNAPSHOT_POD_NAME_ANNOTATION,
@@ -36,6 +38,7 @@ from k8s_agent_sandbox.constants import (
     SANDBOX_API_GROUP,
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
+    PODSNAPSHOT_NAME_ANNOTATION,
 )
 from k8s_agent_sandbox.gke_extensions.snapshots.snapshot_engine import (
     ListSnapshotResult,
@@ -1376,6 +1379,162 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         
         res = self.sandbox.get_sandbox_name_hash()
         self.assertIsNone(res)
+
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_restore_fails_when_running(self, mock_is_suspended):
+        self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {
+                        "name": "snap-uid-123",
+                        "uid": "uid-123",
+                        "creationTimestamp": "2023-01-01T00:00:00Z",
+                    },
+                    "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+                }
+            ]
+        }
+
+        result = self.sandbox.restore(snapshot_uid="snap-uid-123")
+
+        self.assertFalse(result.success)
+        self.assertIn("Sandbox is currently running and cannot be restored.", result.error_reason)
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_sandbox_propagation', return_value=True)
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    @patch.object(SandboxWithSnapshotSupport, '_restore_internal')
+    def test_restore_success_suspended(self, mock_restore_internal, mock_is_suspended, mock_propagate):
+        self.sandbox.connector.close = MagicMock()
+
+        mock_restore_internal.return_value = RestorationResponse(
+            success=True,
+            restored_from_snapshot=True,
+            snapshot_uid="snap-uid-123",
+            error_reason="",
+            error_code=0
+        )
+        self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {
+                        "name": "snap-uid-123",
+                        "uid": "uid-123",
+                        "creationTimestamp": "2023-01-01T00:00:00Z",
+                    },
+                    "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+                }
+            ]
+        }
+
+        result = self.sandbox.restore(snapshot_uid="snap-uid-123")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.snapshot_uid, "snap-uid-123")
+        self.mock_k8s_helper.patch_sandbox_claim.assert_called_once_with(
+            "test-claim", "test-ns",
+            {
+                "spec": {
+                    "additionalPodMetadata": {
+                        "annotations": {
+                            PODSNAPSHOT_NAME_ANNOTATION: "snap-uid-123"
+                        }
+                    }
+                }
+            }
+        )
+        mock_restore_internal.assert_called_once_with("snap-uid-123", 180)
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_sandbox_propagation', return_value=False)
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_restore_propagation_timeout(self, mock_is_suspended, mock_propagate):
+        """Test restore returns failure when propagation times out."""
+        self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": [{"metadata": {"name": "snap-uid-123"}, "status": {"conditions": [{"type": "Ready", "status": "True"}]}}]
+        }
+
+        result = self.sandbox.restore(snapshot_uid="snap-uid-123")
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, INTERNAL_ERROR_CODE)
+        self.assertIn("Internal Error: Timed out waiting for sandbox restoration", result.error_reason)
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_sandbox_propagation', return_value=True)
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    @patch.object(SandboxWithSnapshotSupport, '_restore_internal')
+    def test_resume_success_with_propagation(self, mock_restore_internal, mock_is_suspended, mock_propagate):
+        """Test resume successfully patches SandboxClaim and waits for propagation."""
+        self.sandbox.connector.close = MagicMock()
+        mock_restore_internal.return_value = RestorationResponse(
+            success=True,
+            restored_from_snapshot=True,
+            snapshot_uid="snap-uid-123",
+            error_reason="",
+            error_code=0
+        )
+        with patch.object(self.sandbox, '_get_latest_snapshot_uid', return_value='snap-uid-123'):
+            result = self.sandbox.resume()
+
+            self.assertTrue(result.success)
+            self.mock_k8s_helper.patch_sandbox_claim.assert_called_once_with(
+                "test-claim", "test-ns",
+                {
+                    "spec": {
+                        "additionalPodMetadata": {
+                            "annotations": {
+                                PODSNAPSHOT_NAME_ANNOTATION: None
+                            }
+                        }
+                    }
+                }
+            )
+            mock_propagate.assert_called_once_with(self.mock_k8s_helper, "test-ns", "test-id", None)
+            mock_restore_internal.assert_called_once_with("snap-uid-123", 180)
+
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_resume_patch_exception(self, mock_is_suspended):
+        """Test resume returns failure when patch_sandbox_claim raises an exception."""
+        self.mock_k8s_helper.patch_sandbox_claim.side_effect = Exception("Patch failed")
+        with patch.object(self.sandbox, '_get_latest_snapshot_uid', return_value='snap-uid-123'):
+            result = self.sandbox.resume()
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.error_code, ERROR_CODE)
+            self.assertIn("Failed to clean up restore annotation before resuming: Patch failed", result.error_reason)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_not_called()
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_sandbox_propagation', return_value=False)
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_resume_propagation_timeout(self, mock_is_suspended, mock_propagate):
+        """Test resume returns failure when propagation times out."""
+        with patch.object(self.sandbox, '_get_latest_snapshot_uid', return_value='snap-uid-123'):
+            result = self.sandbox.resume()
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.error_code, INTERNAL_ERROR_CODE)
+            self.assertIn("Internal Error: Timed out waiting for restore annotation cleanup", result.error_reason)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_not_called()
+
+    def test_restore_fails_when_snapshot_does_not_exist(self):
+        """Test restore returns failure cleanly when snapshot does not exist."""
+        self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": []
+        }
+
+        result = self.sandbox.restore(snapshot_uid="non-existent-snap")
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error_code, ERROR_CODE)
+        self.assertIn("Snapshot 'non-existent-snap' does not exist for this sandbox.", result.error_reason)
+        self.mock_k8s_helper.patch_sandbox_claim.assert_not_called()
+
+    def test_verify_snapshot_exists_raises_exception(self):
+        """Test _verify_snapshot_exists raises SnapshotNotFoundError when snapshot does not exist."""
+        self.mock_k8s_helper.custom_objects_api.list_namespaced_custom_object.return_value = {
+            "items": []
+        }
+        with self.assertRaises(SnapshotNotFoundError) as context:
+            self.sandbox._verify_snapshot_exists("non-existent-snap")
+        self.assertIn("Snapshot 'non-existent-snap' does not exist for this sandbox.", str(context.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/utils.py
@@ -24,6 +24,7 @@ from k8s_agent_sandbox.constants import (
     PODSNAPSHOT_API_VERSION,
     PODSNAPSHOT_PLURAL,
     PODSNAPSHOTMANUALTRIGGER_PLURAL,
+    PODSNAPSHOT_NAME_ANNOTATION,
 )
 
 logger = logging.getLogger(__name__)
@@ -320,6 +321,37 @@ def wait_for_pod_ready(
         time.sleep(2)
     return False
 
+
+def wait_for_sandbox_propagation(
+    k8s_helper,
+    namespace: str,
+    sandbox_id: str,
+    snapshot_uid: str,
+    timeout: int = 30,
+) -> bool:
+    """Waits for the snapshot UID to propagate from SandboxClaim to Sandbox spec."""
+    import logging
+    logger = logging.getLogger(__name__)
+    import time
+    
+    logger.info(f"Waiting up to {timeout}s for snapshot UID '{snapshot_uid}' to propagate to Sandbox '{sandbox_id}'...")
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            sandbox_obj = k8s_helper.get_sandbox(sandbox_id, namespace)
+            if sandbox_obj:
+                spec = sandbox_obj.get("spec", {}) or {}
+                pod_template = spec.get("podTemplate", {}) or {}
+                metadata = pod_template.get("metadata", {}) or {}
+                annotations = metadata.get("annotations", {}) or {}
+                
+                if annotations.get(PODSNAPSHOT_NAME_ANNOTATION) == snapshot_uid:
+                    logger.info("Snapshot UID propagated successfully.")
+                    return True
+        except Exception as e:
+            logger.error(f"Error checking sandbox propagation: {e}")
+        time.sleep(2)
+    return False
 
 def normalize_datetime(v):
     """Normalizes a datetime object or ISO string to a timezone-aware UTC datetime."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -201,6 +201,17 @@ class K8sHelper:
                 return None
             raise
 
+    def patch_sandbox_claim(self, name: str, namespace: str, body: dict):
+        """Patches a SandboxClaim custom resource."""
+        return self.custom_objects_api.patch_namespaced_custom_object(
+            group=CLAIM_API_GROUP,
+            version=CLAIM_API_VERSION,
+            namespace=namespace,
+            plural=CLAIM_PLURAL_NAME,
+            name=name,
+            body=body
+        )
+
     def get_sandbox_claim(self, name: str, namespace: str):
         """Gets a SandboxClaim custom resource (or ``None`` if it doesn't exist)."""
         try:

--- a/clients/python/agentic-sandbox-client/python-counter-pool.yaml
+++ b/clients/python/agentic-sandbox-client/python-counter-pool.yaml
@@ -1,0 +1,10 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: python-counter-pool
+  namespace: sandbox-test
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    # This name must exactly match the 'metadata.name' of your SandboxTemplate.
+    name: python-counter-template

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -274,7 +274,7 @@ def test_suspend_resume_restore_cycle(sandbox) -> tuple[str, str]:
     assert res_suspend1.success, res_suspend1.error_reason
     snap_a_uid = res_suspend1.snapshot_response.snapshot_uid
     print(f"1st Suspend snapshot: {snap_a_uid}")
-    wait_for_snapshot_ready(sandbox, snap_a_uid)
+    assert wait_for_snapshot_ready(sandbox, snap_a_uid), f"Snapshot '{snap_a_uid}' did not become ready in time."
     
     print("Resuming sandbox (1st time)...")
     res_resume = sandbox.resume()
@@ -287,7 +287,7 @@ def test_suspend_resume_restore_cycle(sandbox) -> tuple[str, str]:
     assert res_suspend2.success, res_suspend2.error_reason
     snap_b_uid = res_suspend2.snapshot_response.snapshot_uid
     print(f"2nd Suspend snapshot: {snap_b_uid}")
-    wait_for_snapshot_ready(sandbox, snap_b_uid)
+    assert wait_for_snapshot_ready(sandbox, snap_b_uid), f"Snapshot '{snap_b_uid}' did not become ready in time."
     
     print(f"Restoring sandbox back to 1st snapshot '{snap_a_uid}'...")
     res_restore = sandbox.restore(snapshot_uid=snap_a_uid)
@@ -300,7 +300,7 @@ def test_suspend_resume_restore_cycle(sandbox) -> tuple[str, str]:
     assert res_suspend3.success, res_suspend3.error_reason
     snap_c_uid = res_suspend3.snapshot_response.snapshot_uid
     print(f"3rd Suspend snapshot: {snap_c_uid}")
-    wait_for_snapshot_ready(sandbox, snap_c_uid)
+    assert wait_for_snapshot_ready(sandbox, snap_c_uid), f"Snapshot '{snap_c_uid}' did not become ready in time."
     
     print("Resuming sandbox (after restoration)...")
     res_resume2 = sandbox.resume()

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -235,6 +235,82 @@ def test_list_and_delete(sandbox, first_snapshot_uid: str, second_snapshot_uid: 
     print(f"Remaining snapshots deleted successfully: {delete_result.deleted_snapshots}")
 
 
+def test_restore_from_snapshot(sandbox, snapshot_uid: str):
+    """Tests restoring a sandbox from a previous snapshot."""
+    print("\n======= Testing Restore from Previous Snapshot =======")
+    
+    print(f"\nSuspending sandbox '{sandbox.sandbox_id}' before dedicated restore...")
+    suspend_result = sandbox.suspend(snapshot_before_suspend=False)
+    assert suspend_result.success, f"Suspend failed before restore: {suspend_result.error_reason}"
+    assert sandbox.is_suspended(), "Sandbox should be suspended."
+
+    print(f"\nRestoring sandbox '{sandbox.sandbox_id}' from snapshot '{snapshot_uid}'...")
+    restore_result = sandbox.restore(snapshot_uid=snapshot_uid)
+    
+    assert restore_result.success, f"Restore failed: {restore_result.error_reason}"
+    assert restore_result.restored_from_snapshot, "Sandbox should have been restored from snapshot."
+    assert restore_result.snapshot_uid == snapshot_uid, f"Expected restored snapshot UID '{snapshot_uid}', but got '{restore_result.snapshot_uid}'"
+    
+    print(f"Sandbox successfully restored from Snapshot UID: {restore_result.snapshot_uid}")
+
+
+def test_restore_fails_on_running_sandbox(sandbox, snapshot_uid: str):
+    """Tests that restore fails gracefully on a running sandbox."""
+    print("\n======= Testing Restore Fails on a Running Sandbox =======")
+    assert not sandbox.is_suspended(), "Sandbox should be running."
+    
+    result = sandbox.restore(snapshot_uid=snapshot_uid)
+    assert not result.success, "Expected restore to fail on a running sandbox."
+    assert "Sandbox is currently running and cannot be restored." in result.error_reason, f"Unexpected error message: {result.error_reason}"
+    print("Restore on a running sandbox failed gracefully as expected.")
+
+
+def test_suspend_resume_restore_cycle(sandbox) -> tuple[str, str]:
+    """Tests a full suspend, resume, suspend, and restore cycle."""
+    print("\n======= Testing Suspend-Resume-Suspend-Restore-Suspend-Resume Cycle =======")
+    
+    print("Suspending sandbox (1st time)...")
+    res_suspend1 = sandbox.suspend(snapshot_before_suspend=True)
+    assert res_suspend1.success, res_suspend1.error_reason
+    snap_a_uid = res_suspend1.snapshot_response.snapshot_uid
+    print(f"1st Suspend snapshot: {snap_a_uid}")
+    wait_for_snapshot_ready(sandbox, snap_a_uid)
+    
+    print("Resuming sandbox (1st time)...")
+    res_resume = sandbox.resume()
+    assert res_resume.success, res_resume.error_reason
+    assert res_resume.restored_from_snapshot
+    assert res_resume.snapshot_uid == snap_a_uid
+    
+    print("Suspending sandbox (2nd time)...")
+    res_suspend2 = sandbox.suspend(snapshot_before_suspend=True)
+    assert res_suspend2.success, res_suspend2.error_reason
+    snap_b_uid = res_suspend2.snapshot_response.snapshot_uid
+    print(f"2nd Suspend snapshot: {snap_b_uid}")
+    wait_for_snapshot_ready(sandbox, snap_b_uid)
+    
+    print(f"Restoring sandbox back to 1st snapshot '{snap_a_uid}'...")
+    res_restore = sandbox.restore(snapshot_uid=snap_a_uid)
+    assert res_restore.success, res_restore.error_reason
+    assert res_restore.restored_from_snapshot
+    assert res_restore.snapshot_uid == snap_a_uid
+    
+    print("Suspending sandbox (3rd time, after restoration)...")
+    res_suspend3 = sandbox.suspend(snapshot_before_suspend=True)
+    assert res_suspend3.success, res_suspend3.error_reason
+    snap_c_uid = res_suspend3.snapshot_response.snapshot_uid
+    print(f"3rd Suspend snapshot: {snap_c_uid}")
+    wait_for_snapshot_ready(sandbox, snap_c_uid)
+    
+    print("Resuming sandbox (after restoration)...")
+    res_resume2 = sandbox.resume()
+    assert res_resume2.success, res_resume2.error_reason
+    assert res_resume2.restored_from_snapshot
+    assert res_resume2.snapshot_uid == snap_c_uid
+
+    print("Suspend-Resume-Suspend-Restore cycle (with subsequent suspend-resume) completed successfully.")
+    return snap_a_uid, snap_b_uid
+
 def main(
     warmpool_name: str,
     api_url: str | None,
@@ -282,9 +358,19 @@ def main(
         
         time.sleep(WAIT_TIME_SECONDS)
         
+        test_restore_from_snapshot(sandbox, first_snapshot_uid)
+
+        test_restore_fails_on_running_sandbox(sandbox, first_snapshot_uid)
+        
         test_list_and_delete(
             sandbox, first_snapshot_uid, second_snapshot_uid, suspend_third_snapshot_uid
         )
+        
+        test_suspend_resume_restore_cycle(sandbox)
+        
+        print("\nCleaning up remaining snapshots from extra tests...")
+        delete_result = sandbox.snapshots.delete_all(delete_by="all")
+        assert delete_result.success, delete_result.error_reason
 
         # Create a fresh sandbox to test suspend-resume flow on a brand new instance
         print("\n***** Phase 2: Testing Suspend/Resume on a new Sandbox *****")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR introduces the ability to restore a sandbox (suspended) to a specific previous state using a dedicated snapshot UID.


Key additions include:
- `restore()` method: Added to `SandboxWithSnapshotSupport` to allow manual restoration from any valid snapshot UID.
- Shared Restoration Logic: Refactored `resume()` and `restore()` to use a common `_restore_internal()` helper for consistency.
- Propagation Check: Implemented `wait_for_sandbox_propagation()` to verify that the snapshot UID annotation successfully propagates from the `SandboxClaim` to the `Sandbox` specification.
- K8s Helpers: Added `patch_sandbox_claim` to `k8s_helper.py `for managing claim-level metadata.

 
#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->


#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```
Added a restore() method to the Python client's snapshot extension, enabling restoration of sandboxes from a specific snapshot UID.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added snapshot restore capability to return sandboxes to specific snapshot UIDs with validation and clear success/failure reporting.
  * New error type for missing snapshots to surface when a requested snapshot does not exist.

* **Documentation**
  * Expanded usage examples showing suspend → resume → suspend → restore cycles and explicit restore-by-UID workflows and prerequisites.

* **Tests**
  * Added unit and integration tests covering restore/resume flows, propagation timeouts, patch failures, and missing-snapshot errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->