### PR TITLE
feat: add CLUSTER_DOMAIN environment variable to the agent sandbox ro…

### DIFF
--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -26,6 +26,7 @@ app = FastAPI()
 DEFAULT_SANDBOX_PORT = 8888
 DEFAULT_NAMESPACE = "default"
 DEFAULT_PROXY_TIMEOUT = 180.0
+DEFAULT_CLUSTER_DOMAIN = "cluster.local"
 
 
 def _get_proxy_timeout() -> float:
@@ -45,10 +46,23 @@ def _get_proxy_timeout() -> float:
     return value
 
 
+def _get_cluster_domain() -> str:
+    cluster_domain = os.environ.get("CLUSTER_DOMAIN")
+    if cluster_domain is None:
+        return DEFAULT_CLUSTER_DOMAIN
+    if cluster_domain == "":
+        print("WARNING: CLUSTER_DOMAIN must not be an empty string, "
+              f"falling back to {DEFAULT_CLUSTER_DOMAIN}")
+        return DEFAULT_CLUSTER_DOMAIN
+    return cluster_domain
+
+
+cluster_domain = _get_cluster_domain()
 proxy_timeout = _get_proxy_timeout()
 client = httpx.AsyncClient(timeout=proxy_timeout)
 
 print(f"Sandbox router configured with proxy timeout: {proxy_timeout}s")
+print(f"Sandbox router configured with cluster_domain: {cluster_domain}")
 
 
 @app.get("/healthz")
@@ -85,7 +99,8 @@ async def proxy_request(request: Request, full_path: str):
     if pod_ip:
         target_host = pod_ip
     else:
-        target_host = f"{sandbox_id}.{namespace}.svc.cluster.local"
+        # Construct the K8s internal DNS name
+        target_host = f"{sandbox_id}.{namespace}.svc.{cluster_domain}"
 
     target_url = str(
         request.url.replace(scheme="http", hostname=target_host, port=port)

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -83,6 +83,38 @@ class TestProxyRequestValidation:
         assert "Could not connect to the backend sandbox" in resp.json()["detail"]
 
 
+class TestClusterDomain:
+    def test_default_cluster_domain(self):
+        assert sandbox_router.DEFAULT_CLUSTER_DOMAIN == "cluster.local"
+
+    def test_default_when_env_var_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "CLUSTER_DOMAIN"}
+        with patch.dict(os.environ, env, clear=True):
+            assert sandbox_router._get_cluster_domain() == "cluster.local"
+
+    def test_env_var_overrides_cluster_domain(self):
+        with patch.dict(os.environ, {"CLUSTER_DOMAIN": "my.custom.domain"}):
+            assert sandbox_router._get_cluster_domain() == "my.custom.domain"
+
+    def test_empty_env_var_falls_back_to_default(self, capsys):
+        with patch.dict(os.environ, {"CLUSTER_DOMAIN": ""}):
+            result = sandbox_router._get_cluster_domain()
+        assert result == "cluster.local"
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "CLUSTER_DOMAIN" in captured.out
+
+    def test_module_level_cluster_domain_default(self):
+        assert sandbox_router.cluster_domain == "cluster.local"
+
+    def test_env_var_sets_module_level_cluster_domain(self):
+        with patch.dict(os.environ, {"CLUSTER_DOMAIN": "my.custom.domain"}):
+            importlib.reload(sandbox_router)
+            assert sandbox_router.cluster_domain == "my.custom.domain"
+
+        importlib.reload(sandbox_router)
+
+
 class TestProxyTimeout:
     def test_default_timeout(self):
         assert sandbox_router.DEFAULT_PROXY_TIMEOUT == 180.0
@@ -166,6 +198,27 @@ class TestProxyRouting:
                 request_obj.url
             )
 
+    def test_target_url_uses_custom_cluster_domain(self, client):
+        """Module-level cluster_domain should be used when constructing the target URL."""
+        with patch.object(sandbox_router, "cluster_domain", "custom.domain"):
+            with patch.object(
+                sandbox_router.client,
+                "send",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("expected"),
+            ) as mock_send:
+                client.post(
+                    "/some/path",
+                    headers={
+                        "X-Sandbox-ID": "test-box",
+                        "X-Sandbox-Namespace": "prod",
+                        "X-Sandbox-Port": "9999",
+                    },
+                )
+                request_obj = mock_send.call_args[0][0]
+                assert "test-box.prod.svc.custom.domain:9999/some/path" in str(
+                    request_obj.url
+                )
 
     def test_original_host_header_not_forwarded(self, client):
         """The original 'host' header should not be forwarded to the sandbox."""


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
These changes add an optional CLUSTER_DOMAIN environment variable to the sandbox router app. Some Kubernetes clusters have custom cluster domains that differ from the default `cluster.local`. The sandbox router won't work in these clusters becasue can't correctly build the `target_url` it needs to route requests to sandboxes. These changes allow a user to set the `CLUSTER_DOMAIN` environment variable and for the sandbox router to able to correctly proxy requests in clusters when this domain is not `cluster.local`

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->