### PR TITLE
Fix log package shadowing in controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ ai-label.log
 ai-review
 ai-review.log
 hermes-sandbox-knowledge.md
+
+# Local IDE, editor, and AI tool folders
+.idea
+.ship
+.claude

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -41,11 +41,11 @@ const (
 	SandboxPodNameAnnotation = "agents.x-k8s.io/pod-name"
 	// SandboxTemplateRefAnnotation is the annotation used to track the sandbox template ref.
 	SandboxTemplateRefAnnotation = "agents.x-k8s.io/sandbox-template-ref"
-	// SandboxLaunchTypeLabel is the label used to track whether the Sandbox was cold-created or warm-adopted.
+	// SandboxLaunchTypeLabel is the label used to track whether the Sandbox was cold-created or originated from a warm pool.
 	SandboxLaunchTypeLabel = "agents.x-k8s.io/launch-type"
 	// SandboxLaunchTypeCold indicates the Sandbox was cold-created.
 	SandboxLaunchTypeCold = "cold"
-	// SandboxLaunchTypeWarm indicates the Sandbox was warm-adopted from a SandboxWarmPool.
+	// SandboxLaunchTypeWarm indicates the Sandbox was pre-provisioned by or adopted from a SandboxWarmPool.
 	SandboxLaunchTypeWarm = "warm"
 	// SandboxPodTemplateHashLabel is the label used to track the pod template hash.
 	SandboxPodTemplateHashLabel = "agents.x-k8s.io/sandbox-pod-template-hash"

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -37,10 +37,16 @@ const (
 	// SandboxReasonPodFailed indicates the backing Pod completed unsuccessfully.
 	SandboxReasonPodFailed = "PodFailed"
 
-	// SandboxPodNameAnnotation is the annotation used to track the pod name adopted from a warm pool.
+	// SandboxPodNameAnnotation is the annotation used to track the pod name bound to a Sandbox.
 	SandboxPodNameAnnotation = "agents.x-k8s.io/pod-name"
 	// SandboxTemplateRefAnnotation is the annotation used to track the sandbox template ref.
 	SandboxTemplateRefAnnotation = "agents.x-k8s.io/sandbox-template-ref"
+	// SandboxLaunchTypeLabel is the label used to track whether the Sandbox was cold-created or warm-adopted.
+	SandboxLaunchTypeLabel = "agents.x-k8s.io/launch-type"
+	// SandboxLaunchTypeCold indicates the Sandbox was cold-created.
+	SandboxLaunchTypeCold = "cold"
+	// SandboxLaunchTypeWarm indicates the Sandbox was warm-adopted from a SandboxWarmPool.
+	SandboxLaunchTypeWarm = "warm"
 	// SandboxPodTemplateHashLabel is the label used to track the pod template hash.
 	SandboxPodTemplateHashLabel = "agents.x-k8s.io/sandbox-pod-template-hash"
 	// SandboxPropagatedLabelsAnnotation is the annotation used to track the labels explicitly propagated from sandbox spec to pod.

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -146,12 +146,12 @@ type SandboxReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	sandbox := &sandboxv1alpha1.Sandbox{}
 	if err := r.Get(ctx, req.NamespacedName, sandbox); err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.Info("sandbox resource not found. Ignoring since object must be deleted")
+			logger.Info("sandbox resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -167,7 +167,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// If the sandbox is being deleted, do nothing
 	if !sandbox.DeletionTimestamp.IsZero() {
-		log.Info("Sandbox is being deleted")
+		logger.Info("Sandbox is being deleted")
 		return ctrl.Result{}, nil
 	}
 
@@ -204,7 +204,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 		}
 
-		log.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
+		logger.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
 		sandboxDeleted, err = r.handleSandboxExpiry(ctx, sandbox)
 	} else {
 		err = r.reconcileChildResources(ctx, sandbox)
@@ -380,14 +380,14 @@ func podIPsFromStatus(podIPs []corev1.PodIP) []string {
 }
 
 func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1alpha1.SandboxStatus, sandbox *sandboxv1alpha1.Sandbox) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	if reflect.DeepEqual(oldStatus, &sandbox.Status) {
 		return nil
 	}
 
 	if err := r.Status().Update(ctx, sandbox); err != nil {
-		log.Error(err, "Failed to update sandbox status")
+		logger.Error(err, "Failed to update sandbox status")
 		return err
 	}
 
@@ -409,18 +409,17 @@ func NameHash(objectName string) string {
 }
 
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Service, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	desired := sandbox.Spec.Service
-
 	service := &corev1.Service{}
 	if err := r.Get(ctx, types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, service); err != nil {
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to get Service")
+			logger.Error(err, "Failed to get Service")
 			return nil, fmt.Errorf("service get failed: %w", err)
 		}
 		// Service does not exist, and desired is true — create service
 		if desired != nil && *desired {
-			log.Info("Creating a new Headless Service", "Service.Namespace", sandbox.Namespace, "Service.Name", sandbox.Name)
+			logger.Info("Creating a new Headless Service", "Service.Namespace", sandbox.Namespace, "Service.Name", sandbox.Name)
 			service = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandbox.Name,
@@ -438,12 +437,12 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			}
 			service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 			if err := ctrl.SetControllerReference(sandbox, service, r.Scheme); err != nil {
-				log.Error(err, "Failed to set controller reference")
+				logger.Error(err, "Failed to set controller reference")
 				return nil, fmt.Errorf("SetControllerReference for Service failed: %w", err)
 			}
 			err := r.Create(ctx, service, client.FieldOwner(sandboxControllerFieldOwner))
 			if err != nil {
-				log.Error(err, "Failed to create", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
+				logger.Error(err, "Failed to create", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
 				return nil, err
 			}
 			r.setServiceStatus(sandbox, service)
@@ -455,14 +454,14 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 	}
 
 	// Service exists
-	log.Info("Found Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
+	logger.Info("Found Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
 
 	ownership, controllerRef := checkOwnership(service, sandbox)
 
 	if desired != nil && !*desired {
 		// desired is false — delete owned service
 		if ownership == resourceOwnedBySandbox {
-			log.Info("Deleting owned service because service is disabled",
+			logger.Info("Deleting owned service because service is disabled",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 			if err := r.Delete(ctx, service); err != nil && !k8serrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to delete service: %w", err)
@@ -475,7 +474,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 	// desired == nil or true
 	switch ownership {
 	case resourceOwnedByOther:
-		log.Info("Refusing to use service: service is owned by a different controller",
+		logger.Info("Refusing to use service: service is owned by a different controller",
 			"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 			"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 		return nil, fmt.Errorf("service %q is owned by %s/%s (UID: %s), not by sandbox %q",
@@ -489,14 +488,14 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		}
 		// desired is true + unowned service — adopt
 		if service.Spec.ClusterIP != corev1.ClusterIPNone && service.Spec.ClusterIP != "" {
-			log.Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
+			logger.Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 				"Service.ClusterIP", service.Spec.ClusterIP)
 			return nil, fmt.Errorf("cannot adopt service %q: ClusterIP is %q (expected %q, field is immutable)",
 				service.Name, service.Spec.ClusterIP, corev1.ClusterIPNone)
 		}
 
-		log.Info("Adopting unowned service", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
+		logger.Info("Adopting unowned service", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 
 		if service.Labels == nil {
 			service.Labels = make(map[string]string)
@@ -533,7 +532,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		}
 
 		if needsUpdate {
-			log.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
+			logger.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
 			if err := r.Patch(ctx, service, patch); err != nil {
 				return nil, fmt.Errorf("failed to patch owned service: %w", err)
 			}
@@ -549,13 +548,13 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; !exists {
 		return nil
 	}
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	patch := client.MergeFrom(sandbox.DeepCopy())
 	delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
 	if err := r.Patch(ctx, sandbox, patch); err != nil {
 		return fmt.Errorf("failed to clear pod name annotation: %w", err)
 	}
-	log.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
+	logger.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
 	return nil
 }
 
@@ -572,7 +571,7 @@ func (r *SandboxReconciler) clearServiceStatus(sandbox *sandboxv1alpha1.Sandbox)
 }
 
 func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Pod, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
 	ctx, end := r.Tracer.StartSpan(ctx, nil, "reconcilePod", nil)
@@ -589,29 +588,29 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		LabelSelector: labelSelector,
 		Namespace:     sandbox.Namespace,
 	}); err != nil {
-		log.Error(err, "Failed to list pods")
+		logger.Error(err, "Failed to list pods")
 	}
 
 	if len(podList.Items) > 1 {
-		log.Info("Multiple pods found for sandbox, this should not happen", "Sandbox", sandbox.Name, "PodCount", len(podList.Items))
+		logger.Info("Multiple pods found for sandbox, this should not happen", "Sandbox", sandbox.Name, "PodCount", len(podList.Items))
 	}
 
 	// Determine the pod name to look up
 	podName := resolvePodName(sandbox)
 	_, podNameAnnotationExists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]
 	if podName != sandbox.Name {
-		log.Info("Using tracked pod name from sandbox annotation", "podName", podName)
+		logger.Info("Using tracked pod name from sandbox annotation", "podName", podName)
 	}
 
 	pod := &corev1.Pod{}
 	err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: sandbox.Namespace}, pod)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to get Pod")
+			logger.Error(err, "Failed to get Pod")
 			return nil, fmt.Errorf("pod get failed: %w", err)
 		}
 		if podNameAnnotationExists {
-			log.Info("Pod referenced by annotation not found, clearing annotation to recover state", "podName", podName)
+			logger.Info("Pod referenced by annotation not found, clearing annotation to recover state", "podName", podName)
 			if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
 				return nil, err
 			}
@@ -625,18 +624,18 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			switch ownership {
 			case resourceOwnedBySandbox:
 				if pod.DeletionTimestamp.IsZero() {
-					log.Info("Deleting Pod because .Spec.Replicas is 0", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+					logger.Info("Deleting Pod because .Spec.Replicas is 0", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 					if err := r.Delete(ctx, pod); err != nil {
 						return nil, fmt.Errorf("failed to delete pod: %w", err)
 					}
 				} else {
-					log.Info("Pod is already being deleted", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+					logger.Info("Pod is already being deleted", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 				}
 			case resourceUnowned:
-				log.Info("Refusing to delete pod: pod has no controllerRef pointing to this sandbox",
+				logger.Info("Refusing to delete pod: pod has no controllerRef pointing to this sandbox",
 					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
 			case resourceOwnedByOther:
-				log.Info("Refusing to delete pod: pod is owned by a different controller",
+				logger.Info("Refusing to delete pod: pod is owned by a different controller",
 					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 			}
@@ -661,7 +660,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		}
 
 		if annotatedPodName != "" {
-			log.Info("Skipping pod name annotation update because sandbox already tracks a different pod", "trackedPodName", annotatedPodName, "podName", podName)
+			logger.Info("Skipping pod name annotation update because sandbox already tracks a different pod", "trackedPodName", annotatedPodName, "podName", podName)
 			return nil
 		}
 
@@ -678,7 +677,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 
 	reconcileExistingPod := func(pod *corev1.Pod) (*corev1.Pod, error) {
-		log.Info("Found Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		logger.Info("Found Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 
 		if r.Tracer.IsRecording(ctx) {
 			r.Tracer.AddEvent(ctx, "ExistingPodStatusObserved", map[string]string{
@@ -690,7 +689,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		ownership, controllerRef := checkOwnership(pod, sandbox)
 		switch ownership {
 		case resourceOwnedByOther:
-			log.Info("Refusing to adopt pod: pod is owned by a different controller",
+			logger.Info("Refusing to adopt pod: pod is owned by a different controller",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 
@@ -732,7 +731,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 
 	// Create new Pod
-	log.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
+	logger.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
 	labels := map[string]string{
 		sandboxLabel: nameHash,
 	}
@@ -788,7 +787,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 	if err := r.Create(ctx, pod, client.FieldOwner(sandboxControllerFieldOwner)); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			log.Info("Pod already exists, fetching existing pod",
+			logger.Info("Pod already exists, fetching existing pod",
 				"Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 			existingPod := &corev1.Pod{}
 			if getErr := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, existingPod); getErr != nil {
@@ -796,7 +795,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			}
 			return reconcileExistingPod(existingPod)
 		}
-		log.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		logger.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 		return nil, err
 	}
 
@@ -894,7 +893,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 }
 
 func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
 	ctx, end := r.Tracer.StartSpan(ctx, nil, "reconcilePVCs", nil)
@@ -908,14 +907,14 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 			ownership, controllerRef := checkOwnership(pvc, sandbox)
 			switch ownership {
 			case resourceOwnedByOther:
-				log.Info("Refusing to use PVC: PVC is owned by a different controller",
+				logger.Info("Refusing to use PVC: PVC is owned by a different controller",
 					"PVC.Name", pvcName, "Sandbox.Name", sandbox.Name,
 					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 				return fmt.Errorf("PVC %q is owned by %s/%s (UID: %s), not by sandbox %q",
 					pvcName, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
 
 			case resourceUnowned:
-				log.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
+				logger.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
 				if err := ctrl.SetControllerReference(sandbox, pvc, r.Scheme); err != nil {
 					return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 				}
@@ -930,7 +929,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 		}
 
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to get PVC")
+			logger.Error(err, "Failed to get PVC")
 			return fmt.Errorf("PVC Get Failed: %w", err)
 		}
 
@@ -940,7 +939,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 		}
 		pvcLabels[sandboxLabel] = nameHash
 
-		log.Info("Creating a new PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
+		logger.Info("Creating a new PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
 		pvc = &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pvcName,
@@ -954,7 +953,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 			return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 		}
 		if err := r.Create(ctx, pvc, client.FieldOwner(sandboxControllerFieldOwner)); err != nil {
-			log.Error(err, "Failed to create PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
+			logger.Error(err, "Failed to create PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
 			return err
 		}
 	}
@@ -963,7 +962,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 
 // handles sandbox expiry by deleting child resources and the sandbox itself if needed.
 func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) (bool, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	var allErrors error
 
 	// Delete pod only if owned by this sandbox
@@ -981,10 +980,10 @@ func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sa
 				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete pod: %w", err))
 			}
 		case resourceUnowned:
-			log.Info("Skipping pod deletion during expiry: pod has no controllerRef pointing to this sandbox",
+			logger.Info("Skipping pod deletion during expiry: pod has no controllerRef pointing to this sandbox",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
 		case resourceOwnedByOther:
-			log.Info("Skipping pod deletion during expiry: pod is owned by a different controller",
+			logger.Info("Skipping pod deletion during expiry: pod is owned by a different controller",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 		}
@@ -1004,10 +1003,10 @@ func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sa
 				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete service: %w", err))
 			}
 		case resourceUnowned:
-			log.Info("Skipping service deletion during expiry: service has no controllerRef pointing to this sandbox",
+			logger.Info("Skipping service deletion during expiry: service has no controllerRef pointing to this sandbox",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 		case resourceOwnedByOther:
-			log.Info("Skipping service deletion during expiry: service is owned by a different controller",
+			logger.Info("Skipping service deletion during expiry: service is owned by a different controller",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 		}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1074,6 +1074,13 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
+				launchType := v1alpha1.SandboxLaunchTypeCold
+				if claim.Labels[extensionsv1alpha1.AssignedSandboxNameLabel] == statusName || statusName != claim.Name {
+					launchType = v1alpha1.SandboxLaunchTypeWarm
+				}
+				if err := r.ensureSandboxLaunchTypeLabel(ctx, sandbox, launchType); err != nil {
+					return nil, fmt.Errorf("failed to ensure launch type label on sandbox %q: %w", sandbox.Name, err)
+				}
 				return sandbox, nil
 			}
 		} else if !k8errors.IsNotFound(err) {
@@ -1089,6 +1096,9 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
 				if metav1.IsControlledBy(sandbox, claim) {
 					logger.Info("Found existing adopted sandbox from labels", "sandbox", sbName, "claim", claim.Name)
+					if err := r.ensureSandboxLaunchTypeLabel(ctx, sandbox, v1alpha1.SandboxLaunchTypeWarm); err != nil {
+						return nil, fmt.Errorf("failed to ensure launch type label on sandbox %q: %w", sandbox.Name, err)
+					}
 					return sandbox, nil
 				}
 
@@ -1145,6 +1155,9 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			logger.Error(err, "Sandbox controller mismatch")
 			return nil, err
 		}
+		if err := r.ensureSandboxLaunchTypeLabel(ctx, sandbox, v1alpha1.SandboxLaunchTypeCold); err != nil {
+			return nil, fmt.Errorf("failed to ensure launch type label on sandbox %q: %w", sandbox.Name, err)
+		}
 		return sandbox, nil
 	}
 
@@ -1173,6 +1186,19 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 
 	// No warm pool sandbox available; caller decides whether to create
 	return nil, nil
+}
+
+func (r *SandboxClaimReconciler) ensureSandboxLaunchTypeLabel(ctx context.Context, sandbox *v1alpha1.Sandbox, launchType string) error {
+	if sandbox.Labels != nil && sandbox.Labels[v1alpha1.SandboxLaunchTypeLabel] == launchType {
+		return nil
+	}
+
+	patch := client.MergeFrom(sandbox.DeepCopy())
+	if sandbox.Labels == nil {
+		sandbox.Labels = make(map[string]string)
+	}
+	sandbox.Labels[v1alpha1.SandboxLaunchTypeLabel] = launchType
+	return r.Patch(ctx, sandbox, patch)
 }
 
 func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensionsv1alpha1.SandboxClaim) (*extensionsv1alpha1.SandboxTemplate, error) {

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -724,6 +724,10 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	delete(adopted.Labels, warmPoolSandboxLabel)
 	delete(adopted.Labels, sandboxTemplateRefHash)
 	delete(adopted.Labels, v1alpha1.SandboxPodTemplateHashLabel)
+	if adopted.Labels == nil {
+		adopted.Labels = make(map[string]string)
+	}
+	adopted.Labels[v1alpha1.SandboxLaunchTypeLabel] = v1alpha1.SandboxLaunchTypeWarm
 
 	// Transfer ownership from SandboxWarmPool to SandboxClaim
 	adopted.OwnerReferences = nil
@@ -953,6 +957,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	// (KEP-0174 only propagates to pod template labels; platform's informer reads
 	// Sandbox.metadata.labels).
 	sandbox.Labels = ensureClaimIdentityLabels(sandbox.Labels, claim)
+	sandbox.Labels[v1alpha1.SandboxLaunchTypeLabel] = v1alpha1.SandboxLaunchTypeCold
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(sandbox.Spec.PodTemplate.ObjectMeta.Labels, claim)
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = sandboxcontrollers.NameHash(template.Name)
 
@@ -1327,7 +1332,7 @@ func getLaunchType(sandbox *v1alpha1.Sandbox) string {
 	if sandbox == nil {
 		return asmetrics.LaunchTypeUnknown
 	}
-	if sandbox.Annotations[v1alpha1.SandboxPodNameAnnotation] != "" {
+	if sandbox.Labels[v1alpha1.SandboxLaunchTypeLabel] == v1alpha1.SandboxLaunchTypeWarm {
 		return asmetrics.LaunchTypeWarm
 	}
 	return asmetrics.LaunchTypeCold

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1568,8 +1568,9 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				Namespace:         "default",
 				CreationTimestamp: creationTime,
 				Labels: map[string]string{
-					warmPoolSandboxLabel:   poolNameHash,
-					sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+					warmPoolSandboxLabel:                   poolNameHash,
+					sandboxTemplateRefHash:                 sandboxcontrollers.NameHash("test-template"),
+					sandboxv1alpha1.SandboxLaunchTypeLabel: sandboxv1alpha1.SandboxLaunchTypeWarm,
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{
@@ -1868,6 +1869,9 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				if _, exists := adoptedSandbox.Labels[sandboxTemplateRefHash]; exists {
 					t.Errorf("expected template ref label to be removed from adopted sandbox")
 				}
+				if val := adoptedSandbox.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel]; val != sandboxv1alpha1.SandboxLaunchTypeWarm {
+					t.Errorf("expected adopted sandbox to have launch type label %q, got %q; labels=%v", sandboxv1alpha1.SandboxLaunchTypeWarm, val, adoptedSandbox.Labels)
+				}
 
 				// 2. Verify SandboxID label was added to pod template
 				expectedUID := string(types.UID("claim-uid"))
@@ -1898,6 +1902,9 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				err = fakeClient.Get(ctx, req.NamespacedName, &sandbox)
 				if err != nil {
 					t.Fatalf("expected sandbox to be created but got error: %v", err)
+				}
+				if val := sandbox.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel]; val != sandboxv1alpha1.SandboxLaunchTypeCold {
+					t.Errorf("expected new sandbox to have launch type label %q, got %q; labels=%v", sandboxv1alpha1.SandboxLaunchTypeCold, val, sandbox.Labels)
 				}
 			}
 		})
@@ -2323,6 +2330,55 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 			t.Errorf("expected metric count 1, got %v", val)
 		}
 	})
+}
+
+func TestGetLaunchType(t *testing.T) {
+	testCases := []struct {
+		name    string
+		sandbox *sandboxv1alpha1.Sandbox
+		want    string
+	}{
+		{
+			name: "nil sandbox is unknown",
+			want: asmetrics.LaunchTypeUnknown,
+		},
+		{
+			name: "warm launch label is warm",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						sandboxv1alpha1.SandboxLaunchTypeLabel: sandboxv1alpha1.SandboxLaunchTypeWarm,
+					},
+				},
+			},
+			want: asmetrics.LaunchTypeWarm,
+		},
+		{
+			name: "cold launch label with pod name annotation remains cold",
+			sandbox: &sandboxv1alpha1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						sandboxv1alpha1.SandboxLaunchTypeLabel: sandboxv1alpha1.SandboxLaunchTypeCold,
+					},
+					Annotations: map[string]string{
+						sandboxv1alpha1.SandboxPodNameAnnotation: "sandbox-cold",
+					},
+				},
+			},
+			want: asmetrics.LaunchTypeCold,
+		},
+		{
+			name:    "missing launch label defaults cold",
+			sandbox: &sandboxv1alpha1.Sandbox{},
+			want:    asmetrics.LaunchTypeCold,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, getLaunchType(tc.sandbox))
+		})
+	}
 }
 
 func newScheme(t *testing.T) *runtime.Scheme {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2061,6 +2061,14 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 	if _, ok := extra.Labels[warmPoolSandboxLabel]; !ok {
 		t.Error("pool sandbox should still have warm pool label (should not have been adopted)")
 	}
+
+	var updatedAdopted sandboxv1alpha1.Sandbox
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: "adopted-sb", Namespace: "default"}, &updatedAdopted); err != nil {
+		t.Fatalf("failed to get adopted sandbox: %v", err)
+	}
+	if val := updatedAdopted.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel]; val != sandboxv1alpha1.SandboxLaunchTypeWarm {
+		t.Errorf("expected previously adopted sandbox to have launch type label %q, got %q; labels=%v", sandboxv1alpha1.SandboxLaunchTypeWarm, val, updatedAdopted.Labels)
+	}
 }
 
 func TestRecordCreationLatencyMetric(t *testing.T) {
@@ -3487,6 +3495,13 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	}
 	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
 		t.Errorf("expected claim status to be updated with 'adopted-sb' on 2nd pass, got %q", updatedClaim.Status.SandboxStatus.Name)
+	}
+
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "adopted-sb", Namespace: "default"}, &adopted); err != nil {
+		t.Fatalf("failed to get adopted sandbox: %v", err)
+	}
+	if val := adopted.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel]; val != sandboxv1alpha1.SandboxLaunchTypeWarm {
+		t.Errorf("expected assigned adopted sandbox to have launch type label %q, got %q; labels=%v", sandboxv1alpha1.SandboxLaunchTypeWarm, val, adopted.Labels)
 	}
 
 	// Verify that the extra warm sandbox was STILL NOT adopted (it should still have its warm pool labels)

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -217,7 +217,19 @@ func (r *SandboxWarmPoolReconciler) adoptSandbox(ctx context.Context, warmPool *
 	if err := controllerutil.SetControllerReference(warmPool, sb, r.Scheme); err != nil {
 		return err
 	}
+	setWarmLaunchTypeLabelIfNeeded(sb)
 	return r.Update(ctx, sb)
+}
+
+func setWarmLaunchTypeLabelIfNeeded(sb *sandboxv1alpha1.Sandbox) bool {
+	if sb.Labels == nil {
+		sb.Labels = make(map[string]string)
+	}
+	if sb.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel] == sandboxv1alpha1.SandboxLaunchTypeWarm {
+		return false
+	}
+	sb.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel] = sandboxv1alpha1.SandboxLaunchTypeWarm
+	return true
 }
 
 // filterActiveSandboxes filters the list of sandboxes, deleting stale ones and adopting orphans.
@@ -266,6 +278,14 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 					log.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
 					allErrors = errors.Join(allErrors, err)
 				}
+				continue
+			}
+		}
+
+		if isControlledByPool && setWarmLaunchTypeLabelIfNeeded(&sb) {
+			if err := r.Update(ctx, &sb); err != nil {
+				log.Error(err, "Failed to update sandbox launch type label", "sandbox", sb.Name)
+				allErrors = errors.Join(allErrors, err)
 				continue
 			}
 		}

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -316,6 +316,7 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	sandboxLabels := map[string]string{
 		warmPoolSandboxLabel:                        poolNameHash,
 		sandboxTemplateRefHash:                      sandboxcontrollers.NameHash(warmPool.Spec.TemplateRef.Name),
+		sandboxv1alpha1.SandboxLaunchTypeLabel:      sandboxv1alpha1.SandboxLaunchTypeWarm,
 		sandboxv1alpha1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
 	}
 

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -61,22 +61,22 @@ type SandboxWarmPoolReconciler struct {
 
 // Reconcile implements the reconciliation loop for SandboxWarmPool.
 func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Fetch the SandboxWarmPool instance
 	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
 	if err := r.Get(ctx, req.NamespacedName, warmPool); err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.Info("SandboxWarmPool resource not found. Ignoring since object must be deleted")
+			logger.Info("SandboxWarmPool resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
-		log.Error(err, "Failed to get SandboxWarmPool")
+		logger.Error(err, "Failed to get SandboxWarmPool")
 		return ctrl.Result{}, err
 	}
 
 	// Handle deletion
 	if !warmPool.DeletionTimestamp.IsZero() {
-		log.Info("SandboxWarmPool is being deleted")
+		logger.Info("SandboxWarmPool is being deleted")
 		return ctrl.Result{}, nil
 	}
 
@@ -90,7 +90,7 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Update status if it has changed
 	if err := r.updateStatus(ctx, oldStatus, warmPool); err != nil {
-		log.Error(err, "Failed to update SandboxWarmPool status")
+		logger.Error(err, "Failed to update SandboxWarmPool status")
 		return ctrl.Result{}, err
 	}
 
@@ -99,7 +99,7 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // reconcilePool ensures the correct number of pre-allocated sandboxes exist in the pool.
 func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Compute hash of the warm pool name for the pool label
 	poolNameHash := sandboxcontrollers.NameHash(warmPool.Name)
@@ -114,7 +114,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		LabelSelector: labelSelector,
 		Namespace:     warmPool.Namespace,
 	}); err != nil {
-		log.Error(err, "Failed to list sandboxes")
+		logger.Error(err, "Failed to list sandboxes")
 		return err
 	}
 
@@ -130,11 +130,11 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	var healthySandboxes []sandboxv1alpha1.Sandbox
 	for _, sb := range activeSandboxes {
 		if !isSandboxReady(&sb) && !sb.CreationTimestamp.IsZero() && now.Sub(sb.CreationTimestamp.Time) > warmPoolReadinessGracePeriod {
-			log.Info("Deleting stuck warm pool sandbox",
+			logger.Info("Deleting stuck warm pool sandbox",
 				"sandbox", sb.Name,
 				"age", now.Sub(sb.CreationTimestamp.Time).Round(time.Second))
 			if err := r.Delete(ctx, &sb); err != nil {
-				log.Error(err, "Failed to delete stuck sandbox", "sandbox", sb.Name)
+				logger.Error(err, "Failed to delete stuck sandbox", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 			}
 			continue
@@ -146,7 +146,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	desiredReplicas := warmPool.Spec.Replicas
 	currentReplicas := int32(len(activeSandboxes))
 
-	log.Info("Pool status",
+	logger.Info("Pool status",
 		"desired", desiredReplicas,
 		"current", currentReplicas,
 		"poolName", warmPool.Name,
@@ -167,11 +167,11 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	// Create new sandboxes if we need more
 	if currentReplicas < desiredReplicas && tmplErr == nil {
 		sandboxesToCreate := desiredReplicas - currentReplicas
-		log.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
+		logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
 
 		for range sandboxesToCreate {
 			if err := r.createPoolSandbox(ctx, warmPool, poolNameHash, template, currentPodTemplateHash); err != nil {
-				log.Error(err, "Failed to create pool sandbox")
+				logger.Error(err, "Failed to create pool sandbox")
 				allErrors = errors.Join(allErrors, err)
 			}
 		}
@@ -180,7 +180,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	// Delete excess sandboxes if we have too many
 	if currentReplicas > desiredReplicas {
 		sandboxesToDelete := currentReplicas - desiredReplicas
-		log.Info("Deleting excess sandboxes", "count", sandboxesToDelete)
+		logger.Info("Deleting excess sandboxes", "count", sandboxesToDelete)
 
 		// Prioritize deleting unready sandboxes before ready ones,
 		// then newest first within each group.
@@ -199,7 +199,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		for i := int32(0); i < sandboxesToDelete && i < int32(len(activeSandboxes)); i++ {
 			sb := &activeSandboxes[i]
 			if err := r.Delete(ctx, sb); err != nil {
-				log.Error(err, "Failed to delete sandbox", "sandbox", sb.Name)
+				logger.Error(err, "Failed to delete sandbox", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 			}
 		}
@@ -234,7 +234,7 @@ func setWarmLaunchTypeLabelIfNeeded(sb *sandboxv1alpha1.Sandbox) bool {
 
 // filterActiveSandboxes filters the list of sandboxes, deleting stale ones and adopting orphans.
 func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool, sandboxes []sandboxv1alpha1.Sandbox, template *extensionsv1alpha1.SandboxTemplate, currentPodTemplateHash string, tmplErr error) ([]sandboxv1alpha1.Sandbox, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	var activeSandboxes []sandboxv1alpha1.Sandbox
 	var allErrors error
 
@@ -253,7 +253,7 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 	case extensionsv1alpha1.OnReplenishSandboxWarmPoolUpdateStrategyType, "":
 		updateStrategy = extensionsv1alpha1.OnReplenishSandboxWarmPoolUpdateStrategyType
 	default:
-		log.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", updateStrategyType)
+		logger.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", updateStrategyType)
 		updateStrategy = extensionsv1alpha1.OnReplenishSandboxWarmPoolUpdateStrategyType
 	}
 
@@ -267,15 +267,15 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 		isControlledByPool := controllerRef != nil && controllerRef.UID == warmPool.UID
 
 		if !isOrphan && !isControlledByPool {
-			log.Info("Ignoring sandbox with different controller", "sandbox", sb.Name, "controller", controllerRef.Name)
+			logger.Info("Ignoring sandbox with different controller", "sandbox", sb.Name, "controller", controllerRef.Name)
 			continue
 		}
 
 		if tmplErr == nil && (updateStrategy == extensionsv1alpha1.RecreateSandboxWarmPoolUpdateStrategyType || isOrphan) {
 			if r.isSandboxStale(ctx, &sb, template, currentPodTemplateHash, vettedHashes) {
-				log.Info("Deleting stale sandbox", "sandbox", sb.Name, "isOrphan", isOrphan)
+				logger.Info("Deleting stale sandbox", "sandbox", sb.Name, "isOrphan", isOrphan)
 				if err := r.Delete(ctx, &sb); err != nil {
-					log.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
+					logger.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
 					allErrors = errors.Join(allErrors, err)
 				}
 				continue
@@ -284,16 +284,16 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 
 		if isControlledByPool && setWarmLaunchTypeLabelIfNeeded(&sb) {
 			if err := r.Update(ctx, &sb); err != nil {
-				log.Error(err, "Failed to update sandbox launch type label", "sandbox", sb.Name)
+				logger.Error(err, "Failed to update sandbox launch type label", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 				continue
 			}
 		}
 
 		if isOrphan {
-			log.Info("Adopting orphaned sandbox", "sandbox", sb.Name)
+			logger.Info("Adopting orphaned sandbox", "sandbox", sb.Name)
 			if err := r.adoptSandbox(ctx, warmPool, &sb); err != nil {
-				log.Error(err, "Failed to adopt sandbox", "sandbox", sb.Name)
+				logger.Error(err, "Failed to adopt sandbox", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 				continue
 			}
@@ -315,7 +315,7 @@ func computePodTemplateHash(template *extensionsv1alpha1.SandboxTemplate) (strin
 
 // fetchTemplateAndHash fetches the sandbox template and computes its hash.
 func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool) (*extensionsv1alpha1.SandboxTemplate, string, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	template, tmplErr := r.getTemplate(ctx, warmPool)
 	var currentPodTemplateHash string
 	if tmplErr == nil {
@@ -323,14 +323,14 @@ func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, wa
 	}
 
 	if tmplErr != nil {
-		log.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
+		logger.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
 	}
 	return template, currentPodTemplateHash, tmplErr
 }
 
 // createPoolSandbox creates a full Sandbox CR (with pod template, service, etc.) for the warm pool.
 func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool, poolNameHash string, template *extensionsv1alpha1.SandboxTemplate, currentPodTemplateHash string) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Build labels for the Sandbox CR
 	sandboxLabels := map[string]string{
@@ -395,17 +395,17 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	}
 
 	if err := r.Create(ctx, sandbox); err != nil {
-		log.Error(err, "Failed to create pool sandbox")
+		logger.Error(err, "Failed to create pool sandbox")
 		return err
 	}
 
-	log.Info("Created new pool sandbox", "sandbox", sandbox.Name, "poolName", warmPool.Name)
+	logger.Info("Created new pool sandbox", "sandbox", sandbox.Name, "poolName", warmPool.Name)
 	return nil
 }
 
 // updateStatus updates the status of the SandboxWarmPool if it has changed.
 func (r *SandboxWarmPoolReconciler) updateStatus(ctx context.Context, oldStatus *extensionsv1alpha1.SandboxWarmPoolStatus, warmPool *extensionsv1alpha1.SandboxWarmPool) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Check if status has changed
 	if equality.Semantic.DeepEqual(oldStatus, &warmPool.Status) {
@@ -425,11 +425,11 @@ func (r *SandboxWarmPoolReconciler) updateStatus(ctx context.Context, oldStatus 
 	}
 
 	if err := r.Status().Patch(ctx, patch, client.Apply, client.FieldOwner("warmpool-controller"), client.ForceOwnership); err != nil { //nolint:staticcheck // SA1019: client.Apply requires generated apply configurations
-		log.Error(err, "Failed to apply SandboxWarmPool status via SSA")
+		logger.Error(err, "Failed to apply SandboxWarmPool status via SSA")
 		return err
 	}
 
-	log.Info("Updated SandboxWarmPool status", "replicas", warmPool.Status.Replicas)
+	logger.Info("Updated SandboxWarmPool status", "replicas", warmPool.Status.Replicas)
 	return nil
 }
 
@@ -538,7 +538,7 @@ func (r *SandboxWarmPoolReconciler) SetupWithManager(mgr ctrl.Manager, concurren
 
 // findWarmPoolsForTemplate returns a list of reconcile.Requests for all SandboxWarmPools that reference the template.
 func (r *SandboxWarmPoolReconciler) findWarmPoolsForTemplate(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	template, ok := obj.(*extensionsv1alpha1.SandboxTemplate)
 	if !ok {
 		return nil
@@ -546,7 +546,7 @@ func (r *SandboxWarmPoolReconciler) findWarmPoolsForTemplate(ctx context.Context
 
 	warmPools := &extensionsv1alpha1.SandboxWarmPoolList{}
 	if err := r.List(ctx, warmPools, client.InNamespace(template.Namespace), client.MatchingFields{extensionsv1alpha1.TemplateRefField: template.Name}); err != nil {
-		log.Error(err, "Failed to list warm pools for template", "template", template.Name)
+		logger.Error(err, "Failed to list warm pools for template", "template", template.Name)
 		return nil
 	}
 

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -439,6 +439,8 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 				"sandbox %s should have correct warm pool label", sb.Name)
 			require.Equal(t, sandboxcontrollers.NameHash(templateName), sb.Labels[sandboxTemplateRefHash],
 				"sandbox %s should have correct template ref label", sb.Name)
+			require.Equal(t, sandboxv1alpha1.SandboxLaunchTypeWarm, sb.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel],
+				"sandbox %s should have warm launch type label", sb.Name)
 
 			// Verify pod template labels are propagated into the sandbox's pod template
 			require.Equal(t, "2.0", sb.Spec.PodTemplate.ObjectMeta.Labels["version"])

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -354,6 +354,8 @@ func TestReconcilePoolControllerRef(t *testing.T) {
 					controllerRef := metav1.GetControllerOf(&sb)
 					if controllerRef != nil && controllerRef.UID == warmPool.UID {
 						ownedCount++
+						require.Equal(t, sandboxv1alpha1.SandboxLaunchTypeWarm, sb.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel],
+							"sandbox %s should have warm launch type label", sb.Name)
 					}
 				}
 			}

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -122,7 +122,7 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		launchTypeStr := LaunchTypeCold
-		if _, ok := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; ok && sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation] != "" {
+		if sandbox.Labels[sandboxv1alpha1.SandboxLaunchTypeLabel] == sandboxv1alpha1.SandboxLaunchTypeWarm {
 			launchTypeStr = LaunchTypeWarm
 		}
 

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -84,6 +84,45 @@ func TestSandboxCollector(t *testing.T) {
 			},
 		},
 		{
+			name: "cold launch label with pod name annotation remains cold",
+			sandboxes: []runtime.Object{
+				&sandboxv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-cold",
+						Namespace: "default",
+						Labels: map[string]string{
+							sandboxv1alpha1.SandboxLaunchTypeLabel: sandboxv1alpha1.SandboxLaunchTypeCold,
+						},
+						Annotations: map[string]string{
+							sandboxv1alpha1.SandboxPodNameAnnotation: "sandbox-cold",
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"expired:false launch_type:cold namespace:default ready_condition:false sandbox_template:unknown": 1,
+			},
+		},
+		{
+			name: "warm launch label reports warm",
+			sandboxes: []runtime.Object{
+				&sandboxv1alpha1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-warm",
+						Namespace: "default",
+						Labels: map[string]string{
+							sandboxv1alpha1.SandboxLaunchTypeLabel: sandboxv1alpha1.SandboxLaunchTypeWarm,
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"expired:false launch_type:warm namespace:default ready_condition:false sandbox_template:unknown": 1,
+			},
+		},
+		{
 			name: "mixed sandboxes",
 			sandboxes: []runtime.Object{
 				&sandboxv1alpha1.Sandbox{
@@ -104,6 +143,9 @@ func TestSandboxCollector(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sandbox-2",
 						Namespace: "test-ns",
+						Labels: map[string]string{
+							sandboxv1alpha1.SandboxLaunchTypeLabel: sandboxv1alpha1.SandboxLaunchTypeWarm,
+						},
 						Annotations: map[string]string{
 							sandboxv1alpha1.SandboxPodNameAnnotation:     "adopted-pod",
 							sandboxv1alpha1.SandboxTemplateRefAnnotation: "my-template",


### PR DESCRIPTION
#### What this PR does / why we need it:
  This PR renames local logger variables from `log` to `logger` in the Sandbox and SandboxWarmPool controllers.

  The previous `log := log.FromContext(ctx)` pattern shadows the imported `controller-runtime/pkg/log` package name, which makes the code less clear and can trigger
  shadowing checks. Using `logger` keeps the package import and local logger variable distinct without changing behavior.

  #### Which issue(s) this PR is related to:
  NONE

  #### Release Note
  ```release-note
  NONE