### PR TITLE
Fix package shadowing in controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ ai-label.log
 ai-review
 ai-review.log
 hermes-sandbox-knowledge.md
+
+# Local IDE, editor, and AI tool folders
+.idea
+.ship
+.claude

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -146,12 +146,12 @@ type SandboxReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	sandbox := &sandboxv1alpha1.Sandbox{}
 	if err := r.Get(ctx, req.NamespacedName, sandbox); err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.Info("sandbox resource not found. Ignoring since object must be deleted")
+			logger.Info("sandbox resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -167,7 +167,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// If the sandbox is being deleted, do nothing
 	if !sandbox.DeletionTimestamp.IsZero() {
-		log.Info("Sandbox is being deleted")
+		logger.Info("Sandbox is being deleted")
 		return ctrl.Result{}, nil
 	}
 
@@ -204,7 +204,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 		}
 
-		log.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
+		logger.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
 		sandboxDeleted, err = r.handleSandboxExpiry(ctx, sandbox)
 	} else {
 		err = r.reconcileChildResources(ctx, sandbox)
@@ -380,14 +380,14 @@ func podIPsFromStatus(podIPs []corev1.PodIP) []string {
 }
 
 func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1alpha1.SandboxStatus, sandbox *sandboxv1alpha1.Sandbox) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	if reflect.DeepEqual(oldStatus, &sandbox.Status) {
 		return nil
 	}
 
 	if err := r.Status().Update(ctx, sandbox); err != nil {
-		log.Error(err, "Failed to update sandbox status")
+		logger.Error(err, "Failed to update sandbox status")
 		return err
 	}
 
@@ -409,18 +409,18 @@ func NameHash(objectName string) string {
 }
 
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Service, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	desired := sandbox.Spec.Service
 
 	service := &corev1.Service{}
 	if err := r.Get(ctx, types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, service); err != nil {
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to get Service")
+			logger.Error(err, "Failed to get Service")
 			return nil, fmt.Errorf("service get failed: %w", err)
 		}
 		// Service does not exist, and desired is true — create service
 		if desired != nil && *desired {
-			log.Info("Creating a new Headless Service", "Service.Namespace", sandbox.Namespace, "Service.Name", sandbox.Name)
+			logger.Info("Creating a new Headless Service", "Service.Namespace", sandbox.Namespace, "Service.Name", sandbox.Name)
 			service = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandbox.Name,
@@ -438,12 +438,12 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			}
 			service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
 			if err := ctrl.SetControllerReference(sandbox, service, r.Scheme); err != nil {
-				log.Error(err, "Failed to set controller reference")
+				logger.Error(err, "Failed to set controller reference")
 				return nil, fmt.Errorf("SetControllerReference for Service failed: %w", err)
 			}
 			err := r.Create(ctx, service, client.FieldOwner(sandboxControllerFieldOwner))
 			if err != nil {
-				log.Error(err, "Failed to create", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
+				logger.Error(err, "Failed to create", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
 				return nil, err
 			}
 			r.setServiceStatus(sandbox, service)
@@ -455,14 +455,14 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 	}
 
 	// Service exists
-	log.Info("Found Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
+	logger.Info("Found Service", "Service.Namespace", service.Namespace, "Service.Name", service.Name)
 
 	ownership, controllerRef := checkOwnership(service, sandbox)
 
 	if desired != nil && !*desired {
 		// desired is false — delete owned service
 		if ownership == resourceOwnedBySandbox {
-			log.Info("Deleting owned service because service is disabled",
+			logger.Info("Deleting owned service because service is disabled",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 			if err := r.Delete(ctx, service); err != nil && !k8serrors.IsNotFound(err) {
 				return nil, fmt.Errorf("failed to delete service: %w", err)
@@ -475,7 +475,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 	// desired == nil or true
 	switch ownership {
 	case resourceOwnedByOther:
-		log.Info("Refusing to use service: service is owned by a different controller",
+		logger.Info("Refusing to use service: service is owned by a different controller",
 			"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 			"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 		return nil, fmt.Errorf("service %q is owned by %s/%s (UID: %s), not by sandbox %q",
@@ -489,14 +489,14 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		}
 		// desired is true + unowned service — adopt
 		if service.Spec.ClusterIP != corev1.ClusterIPNone && service.Spec.ClusterIP != "" {
-			log.Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
+			logger.Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 				"Service.ClusterIP", service.Spec.ClusterIP)
 			return nil, fmt.Errorf("cannot adopt service %q: ClusterIP is %q (expected %q, field is immutable)",
 				service.Name, service.Spec.ClusterIP, corev1.ClusterIPNone)
 		}
 
-		log.Info("Adopting unowned service", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
+		logger.Info("Adopting unowned service", "Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 
 		if service.Labels == nil {
 			service.Labels = make(map[string]string)
@@ -533,7 +533,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		}
 
 		if needsUpdate {
-			log.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
+			logger.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
 			if err := r.Patch(ctx, service, patch); err != nil {
 				return nil, fmt.Errorf("failed to patch owned service: %w", err)
 			}
@@ -549,13 +549,13 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	if _, exists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]; !exists {
 		return nil
 	}
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	patch := client.MergeFrom(sandbox.DeepCopy())
 	delete(sandbox.Annotations, sandboxv1alpha1.SandboxPodNameAnnotation)
 	if err := r.Patch(ctx, sandbox, patch); err != nil {
 		return fmt.Errorf("failed to clear pod name annotation: %w", err)
 	}
-	log.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
+	logger.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
 	return nil
 }
 
@@ -572,7 +572,7 @@ func (r *SandboxReconciler) clearServiceStatus(sandbox *sandboxv1alpha1.Sandbox)
 }
 
 func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) (*corev1.Pod, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
 	ctx, end := r.Tracer.StartSpan(ctx, nil, "reconcilePod", nil)
@@ -589,29 +589,29 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		LabelSelector: labelSelector,
 		Namespace:     sandbox.Namespace,
 	}); err != nil {
-		log.Error(err, "Failed to list pods")
+		logger.Error(err, "Failed to list pods")
 	}
 
 	if len(podList.Items) > 1 {
-		log.Info("Multiple pods found for sandbox, this should not happen", "Sandbox", sandbox.Name, "PodCount", len(podList.Items))
+		logger.Info("Multiple pods found for sandbox, this should not happen", "Sandbox", sandbox.Name, "PodCount", len(podList.Items))
 	}
 
 	// Determine the pod name to look up
 	podName := resolvePodName(sandbox)
 	_, podNameAnnotationExists := sandbox.Annotations[sandboxv1alpha1.SandboxPodNameAnnotation]
 	if podName != sandbox.Name {
-		log.Info("Using tracked pod name from sandbox annotation", "podName", podName)
+		logger.Info("Using tracked pod name from sandbox annotation", "podName", podName)
 	}
 
 	pod := &corev1.Pod{}
 	err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: sandbox.Namespace}, pod)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to get Pod")
+			logger.Error(err, "Failed to get Pod")
 			return nil, fmt.Errorf("pod get failed: %w", err)
 		}
 		if podNameAnnotationExists {
-			log.Info("Pod referenced by annotation not found, clearing annotation to recover state", "podName", podName)
+			logger.Info("Pod referenced by annotation not found, clearing annotation to recover state", "podName", podName)
 			if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
 				return nil, err
 			}
@@ -625,18 +625,18 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			switch ownership {
 			case resourceOwnedBySandbox:
 				if pod.DeletionTimestamp.IsZero() {
-					log.Info("Deleting Pod because .Spec.Replicas is 0", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+					logger.Info("Deleting Pod because .Spec.Replicas is 0", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 					if err := r.Delete(ctx, pod); err != nil {
 						return nil, fmt.Errorf("failed to delete pod: %w", err)
 					}
 				} else {
-					log.Info("Pod is already being deleted", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+					logger.Info("Pod is already being deleted", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 				}
 			case resourceUnowned:
-				log.Info("Refusing to delete pod: pod has no controllerRef pointing to this sandbox",
+				logger.Info("Refusing to delete pod: pod has no controllerRef pointing to this sandbox",
 					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
 			case resourceOwnedByOther:
-				log.Info("Refusing to delete pod: pod is owned by a different controller",
+				logger.Info("Refusing to delete pod: pod is owned by a different controller",
 					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 			}
@@ -661,7 +661,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		}
 
 		if annotatedPodName != "" {
-			log.Info("Skipping pod name annotation update because sandbox already tracks a different pod", "trackedPodName", annotatedPodName, "podName", podName)
+			logger.Info("Skipping pod name annotation update because sandbox already tracks a different pod", "trackedPodName", annotatedPodName, "podName", podName)
 			return nil
 		}
 
@@ -678,7 +678,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 
 	reconcileExistingPod := func(pod *corev1.Pod) (*corev1.Pod, error) {
-		log.Info("Found Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		logger.Info("Found Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 
 		if r.Tracer.IsRecording(ctx) {
 			r.Tracer.AddEvent(ctx, "ExistingPodStatusObserved", map[string]string{
@@ -690,7 +690,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		ownership, controllerRef := checkOwnership(pod, sandbox)
 		switch ownership {
 		case resourceOwnedByOther:
-			log.Info("Refusing to adopt pod: pod is owned by a different controller",
+			logger.Info("Refusing to adopt pod: pod is owned by a different controller",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 
@@ -732,7 +732,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 
 	// Create new Pod
-	log.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
+	logger.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
 	labels := map[string]string{
 		sandboxLabel: nameHash,
 	}
@@ -788,7 +788,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 	if err := r.Create(ctx, pod, client.FieldOwner(sandboxControllerFieldOwner)); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			log.Info("Pod already exists, fetching existing pod",
+			logger.Info("Pod already exists, fetching existing pod",
 				"Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 			existingPod := &corev1.Pod{}
 			if getErr := r.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, existingPod); getErr != nil {
@@ -796,7 +796,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			}
 			return reconcileExistingPod(existingPod)
 		}
-		log.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		logger.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 		return nil, err
 	}
 
@@ -894,7 +894,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 }
 
 func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox, nameHash string) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
 	ctx, end := r.Tracer.StartSpan(ctx, nil, "reconcilePVCs", nil)
@@ -908,14 +908,14 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 			ownership, controllerRef := checkOwnership(pvc, sandbox)
 			switch ownership {
 			case resourceOwnedByOther:
-				log.Info("Refusing to use PVC: PVC is owned by a different controller",
+				logger.Info("Refusing to use PVC: PVC is owned by a different controller",
 					"PVC.Name", pvcName, "Sandbox.Name", sandbox.Name,
 					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 				return fmt.Errorf("PVC %q is owned by %s/%s (UID: %s), not by sandbox %q",
 					pvcName, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
 
 			case resourceUnowned:
-				log.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
+				logger.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)
 				if err := ctrl.SetControllerReference(sandbox, pvc, r.Scheme); err != nil {
 					return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 				}
@@ -930,7 +930,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 		}
 
 		if !k8serrors.IsNotFound(err) {
-			log.Error(err, "Failed to get PVC")
+			logger.Error(err, "Failed to get PVC")
 			return fmt.Errorf("PVC Get Failed: %w", err)
 		}
 
@@ -940,7 +940,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 		}
 		pvcLabels[sandboxLabel] = nameHash
 
-		log.Info("Creating a new PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
+		logger.Info("Creating a new PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
 		pvc = &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        pvcName,
@@ -954,7 +954,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 			return fmt.Errorf("SetControllerReference for PVC failed: %w", err)
 		}
 		if err := r.Create(ctx, pvc, client.FieldOwner(sandboxControllerFieldOwner)); err != nil {
-			log.Error(err, "Failed to create PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
+			logger.Error(err, "Failed to create PVC", "PVC.Namespace", sandbox.Namespace, "PVC.Name", pvcName)
 			return err
 		}
 	}
@@ -963,7 +963,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 
 // handles sandbox expiry by deleting child resources and the sandbox itself if needed.
 func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sandboxv1alpha1.Sandbox) (bool, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	var allErrors error
 
 	// Delete pod only if owned by this sandbox
@@ -981,10 +981,10 @@ func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sa
 				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete pod: %w", err))
 			}
 		case resourceUnowned:
-			log.Info("Skipping pod deletion during expiry: pod has no controllerRef pointing to this sandbox",
+			logger.Info("Skipping pod deletion during expiry: pod has no controllerRef pointing to this sandbox",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
 		case resourceOwnedByOther:
-			log.Info("Skipping pod deletion during expiry: pod is owned by a different controller",
+			logger.Info("Skipping pod deletion during expiry: pod is owned by a different controller",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 		}
@@ -1004,10 +1004,10 @@ func (r *SandboxReconciler) handleSandboxExpiry(ctx context.Context, sandbox *sa
 				allErrors = errors.Join(allErrors, fmt.Errorf("failed to delete service: %w", err))
 			}
 		case resourceUnowned:
-			log.Info("Skipping service deletion during expiry: service has no controllerRef pointing to this sandbox",
+			logger.Info("Skipping service deletion during expiry: service has no controllerRef pointing to this sandbox",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name)
 		case resourceOwnedByOther:
-			log.Info("Skipping service deletion during expiry: service is owned by a different controller",
+			logger.Info("Skipping service deletion during expiry: service is owned by a different controller",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 		}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -733,13 +733,13 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 
 	// Create new Pod
 	logger.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
-	labels := map[string]string{
+	podLabels := map[string]string{
 		sandboxLabel: nameHash,
 	}
 
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
-		labels[k] = v
+		podLabels[k] = v
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
 	annotations := map[string]string{}
@@ -777,7 +777,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        sandbox.Name,
 			Namespace:   sandbox.Namespace,
-			Labels:      labels,
+			Labels:      podLabels,
 			Annotations: annotations,
 		},
 		Spec: *mutatedSpec,

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -61,22 +61,22 @@ type SandboxWarmPoolReconciler struct {
 
 // Reconcile implements the reconciliation loop for SandboxWarmPool.
 func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Fetch the SandboxWarmPool instance
 	warmPool := &extensionsv1alpha1.SandboxWarmPool{}
 	if err := r.Get(ctx, req.NamespacedName, warmPool); err != nil {
 		if k8serrors.IsNotFound(err) {
-			log.Info("SandboxWarmPool resource not found. Ignoring since object must be deleted")
+			logger.Info("SandboxWarmPool resource not found. Ignoring since object must be deleted")
 			return ctrl.Result{}, nil
 		}
-		log.Error(err, "Failed to get SandboxWarmPool")
+		logger.Error(err, "Failed to get SandboxWarmPool")
 		return ctrl.Result{}, err
 	}
 
 	// Handle deletion
 	if !warmPool.DeletionTimestamp.IsZero() {
-		log.Info("SandboxWarmPool is being deleted")
+		logger.Info("SandboxWarmPool is being deleted")
 		return ctrl.Result{}, nil
 	}
 
@@ -90,7 +90,7 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Update status if it has changed
 	if err := r.updateStatus(ctx, oldStatus, warmPool); err != nil {
-		log.Error(err, "Failed to update SandboxWarmPool status")
+		logger.Error(err, "Failed to update SandboxWarmPool status")
 		return ctrl.Result{}, err
 	}
 
@@ -99,7 +99,7 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // reconcilePool ensures the correct number of pre-allocated sandboxes exist in the pool.
 func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Compute hash of the warm pool name for the pool label
 	poolNameHash := sandboxcontrollers.NameHash(warmPool.Name)
@@ -114,7 +114,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		LabelSelector: labelSelector,
 		Namespace:     warmPool.Namespace,
 	}); err != nil {
-		log.Error(err, "Failed to list sandboxes")
+		logger.Error(err, "Failed to list sandboxes")
 		return err
 	}
 
@@ -130,11 +130,11 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	var healthySandboxes []sandboxv1alpha1.Sandbox
 	for _, sb := range activeSandboxes {
 		if !isSandboxReady(&sb) && !sb.CreationTimestamp.IsZero() && now.Sub(sb.CreationTimestamp.Time) > warmPoolReadinessGracePeriod {
-			log.Info("Deleting stuck warm pool sandbox",
+			logger.Info("Deleting stuck warm pool sandbox",
 				"sandbox", sb.Name,
 				"age", now.Sub(sb.CreationTimestamp.Time).Round(time.Second))
 			if err := r.Delete(ctx, &sb); err != nil {
-				log.Error(err, "Failed to delete stuck sandbox", "sandbox", sb.Name)
+				logger.Error(err, "Failed to delete stuck sandbox", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 			}
 			continue
@@ -146,7 +146,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	desiredReplicas := warmPool.Spec.Replicas
 	currentReplicas := int32(len(activeSandboxes))
 
-	log.Info("Pool status",
+	logger.Info("Pool status",
 		"desired", desiredReplicas,
 		"current", currentReplicas,
 		"poolName", warmPool.Name,
@@ -167,11 +167,11 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	// Create new sandboxes if we need more
 	if currentReplicas < desiredReplicas && tmplErr == nil {
 		sandboxesToCreate := desiredReplicas - currentReplicas
-		log.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
+		logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
 
 		for range sandboxesToCreate {
 			if err := r.createPoolSandbox(ctx, warmPool, poolNameHash, template, currentPodTemplateHash); err != nil {
-				log.Error(err, "Failed to create pool sandbox")
+				logger.Error(err, "Failed to create pool sandbox")
 				allErrors = errors.Join(allErrors, err)
 			}
 		}
@@ -180,7 +180,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	// Delete excess sandboxes if we have too many
 	if currentReplicas > desiredReplicas {
 		sandboxesToDelete := currentReplicas - desiredReplicas
-		log.Info("Deleting excess sandboxes", "count", sandboxesToDelete)
+		logger.Info("Deleting excess sandboxes", "count", sandboxesToDelete)
 
 		// Prioritize deleting unready sandboxes before ready ones,
 		// then newest first within each group.
@@ -199,7 +199,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		for i := int32(0); i < sandboxesToDelete && i < int32(len(activeSandboxes)); i++ {
 			sb := &activeSandboxes[i]
 			if err := r.Delete(ctx, sb); err != nil {
-				log.Error(err, "Failed to delete sandbox", "sandbox", sb.Name)
+				logger.Error(err, "Failed to delete sandbox", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 			}
 		}
@@ -222,7 +222,7 @@ func (r *SandboxWarmPoolReconciler) adoptSandbox(ctx context.Context, warmPool *
 
 // filterActiveSandboxes filters the list of sandboxes, deleting stale ones and adopting orphans.
 func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool, sandboxes []sandboxv1alpha1.Sandbox, template *extensionsv1alpha1.SandboxTemplate, currentPodTemplateHash string, tmplErr error) ([]sandboxv1alpha1.Sandbox, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	var activeSandboxes []sandboxv1alpha1.Sandbox
 	var allErrors error
 
@@ -241,7 +241,7 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 	case extensionsv1alpha1.OnReplenishSandboxWarmPoolUpdateStrategyType, "":
 		updateStrategy = extensionsv1alpha1.OnReplenishSandboxWarmPoolUpdateStrategyType
 	default:
-		log.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", updateStrategyType)
+		logger.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", updateStrategyType)
 		updateStrategy = extensionsv1alpha1.OnReplenishSandboxWarmPoolUpdateStrategyType
 	}
 
@@ -255,15 +255,15 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 		isControlledByPool := controllerRef != nil && controllerRef.UID == warmPool.UID
 
 		if !isOrphan && !isControlledByPool {
-			log.Info("Ignoring sandbox with different controller", "sandbox", sb.Name, "controller", controllerRef.Name)
+			logger.Info("Ignoring sandbox with different controller", "sandbox", sb.Name, "controller", controllerRef.Name)
 			continue
 		}
 
 		if tmplErr == nil && (updateStrategy == extensionsv1alpha1.RecreateSandboxWarmPoolUpdateStrategyType || isOrphan) {
 			if r.isSandboxStale(ctx, &sb, template, currentPodTemplateHash, vettedHashes) {
-				log.Info("Deleting stale sandbox", "sandbox", sb.Name, "isOrphan", isOrphan)
+				logger.Info("Deleting stale sandbox", "sandbox", sb.Name, "isOrphan", isOrphan)
 				if err := r.Delete(ctx, &sb); err != nil {
-					log.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
+					logger.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
 					allErrors = errors.Join(allErrors, err)
 				}
 				continue
@@ -271,9 +271,9 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 		}
 
 		if isOrphan {
-			log.Info("Adopting orphaned sandbox", "sandbox", sb.Name)
+			logger.Info("Adopting orphaned sandbox", "sandbox", sb.Name)
 			if err := r.adoptSandbox(ctx, warmPool, &sb); err != nil {
-				log.Error(err, "Failed to adopt sandbox", "sandbox", sb.Name)
+				logger.Error(err, "Failed to adopt sandbox", "sandbox", sb.Name)
 				allErrors = errors.Join(allErrors, err)
 				continue
 			}
@@ -295,7 +295,7 @@ func computePodTemplateHash(template *extensionsv1alpha1.SandboxTemplate) (strin
 
 // fetchTemplateAndHash fetches the sandbox template and computes its hash.
 func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool) (*extensionsv1alpha1.SandboxTemplate, string, error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	template, tmplErr := r.getTemplate(ctx, warmPool)
 	var currentPodTemplateHash string
 	if tmplErr == nil {
@@ -303,14 +303,14 @@ func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, wa
 	}
 
 	if tmplErr != nil {
-		log.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
+		logger.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
 	}
 	return template, currentPodTemplateHash, tmplErr
 }
 
 // createPoolSandbox creates a full Sandbox CR (with pod template, service, etc.) for the warm pool.
 func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmPool *extensionsv1alpha1.SandboxWarmPool, poolNameHash string, template *extensionsv1alpha1.SandboxTemplate, currentPodTemplateHash string) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Build labels for the Sandbox CR
 	sandboxLabels := map[string]string{
@@ -374,17 +374,17 @@ func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmP
 	}
 
 	if err := r.Create(ctx, sandbox); err != nil {
-		log.Error(err, "Failed to create pool sandbox")
+		logger.Error(err, "Failed to create pool sandbox")
 		return err
 	}
 
-	log.Info("Created new pool sandbox", "sandbox", sandbox.Name, "poolName", warmPool.Name)
+	logger.Info("Created new pool sandbox", "sandbox", sandbox.Name, "poolName", warmPool.Name)
 	return nil
 }
 
 // updateStatus updates the status of the SandboxWarmPool if it has changed.
 func (r *SandboxWarmPoolReconciler) updateStatus(ctx context.Context, oldStatus *extensionsv1alpha1.SandboxWarmPoolStatus, warmPool *extensionsv1alpha1.SandboxWarmPool) error {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Check if status has changed
 	if equality.Semantic.DeepEqual(oldStatus, &warmPool.Status) {
@@ -404,11 +404,11 @@ func (r *SandboxWarmPoolReconciler) updateStatus(ctx context.Context, oldStatus 
 	}
 
 	if err := r.Status().Patch(ctx, patch, client.Apply, client.FieldOwner("warmpool-controller"), client.ForceOwnership); err != nil { //nolint:staticcheck // SA1019: client.Apply requires generated apply configurations
-		log.Error(err, "Failed to apply SandboxWarmPool status via SSA")
+		logger.Error(err, "Failed to apply SandboxWarmPool status via SSA")
 		return err
 	}
 
-	log.Info("Updated SandboxWarmPool status", "replicas", warmPool.Status.Replicas)
+	logger.Info("Updated SandboxWarmPool status", "replicas", warmPool.Status.Replicas)
 	return nil
 }
 
@@ -517,7 +517,7 @@ func (r *SandboxWarmPoolReconciler) SetupWithManager(mgr ctrl.Manager, concurren
 
 // findWarmPoolsForTemplate returns a list of reconcile.Requests for all SandboxWarmPools that reference the template.
 func (r *SandboxWarmPoolReconciler) findWarmPoolsForTemplate(ctx context.Context, obj client.Object) []reconcile.Request {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	template, ok := obj.(*extensionsv1alpha1.SandboxTemplate)
 	if !ok {
 		return nil
@@ -525,7 +525,7 @@ func (r *SandboxWarmPoolReconciler) findWarmPoolsForTemplate(ctx context.Context
 
 	warmPools := &extensionsv1alpha1.SandboxWarmPoolList{}
 	if err := r.List(ctx, warmPools, client.InNamespace(template.Namespace), client.MatchingFields{extensionsv1alpha1.TemplateRefField: template.Name}); err != nil {
-		log.Error(err, "Failed to list warm pools for template", "template", template.Name)
+		logger.Error(err, "Failed to list warm pools for template", "template", template.Name)
 		return nil
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
  This PR cleans up local development and controller code readability issues.

  It adds common local IDE/editor and AI tool directories to `.gitignore` so contributor-only files are not accidentally staged.

  It also renames local logger variables from `log` to `logger` in the Sandbox and SandboxWarmPool controllers. The previous name shadowed the imported controller-runtime
  `log` package, which made the code harder to read and could trigger static analysis warnings. A local pod label map in the Sandbox controller is also renamed from
  `labels` to `podLabels` to avoid shadowing the Kubernetes `labels` package.

  These changes are intentionally behavior-preserving.

  Tested:
  `go test ./controllers ./extensions/controllers`

#### Which issue(s) this PR is related to:
  None

 #### Release Note
```release-note
  NONE
```