### PR TITLE
Check Orphaned Sandbox Stale Check

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -446,9 +446,17 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 		return true
 	}
 
-	// If hashes match, it's fresh.
-	if sandboxHash != "" && sandboxHash == currentPodTemplateHash {
-		return false
+	// Check if the sandbox is unowned (orphaned).
+	controllerRef := metav1.GetControllerOf(sandbox)
+	isOrphan := controllerRef == nil
+
+	// If the sandbox is controlled by the warm pool, we can safely use the hash shortcut.
+	// Unowned sandboxes must bypass the hash shortcut to prevent label spoofing attacks.
+	if !isOrphan {
+		// If hashes match, it's fresh.
+		if sandboxHash != "" && sandboxHash == currentPodTemplateHash {
+			return false
+		}
 	}
 
 	// If currentPodTemplateHash is empty, it means we failed to compute it.
@@ -460,7 +468,8 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	}
 
 	// Check if we've already evaluated this specific old version.
-	if sandboxHash != "" {
+	// Unowned sandboxes must bypass the cache to ensure full semantic comparison.
+	if !isOrphan && sandboxHash != "" {
 		if isStale, found := vettedHashes[sandboxHash]; found {
 			return isStale
 		}
@@ -471,8 +480,9 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	// used during creation to avoid false positives from controller-injected fields.
 	isStale := !r.comparePodSpecs(template, &sandbox.Spec.PodTemplate.Spec)
 
-	// Save the result for the next sandbox with this same hash.
-	if sandboxHash != "" {
+	// Save the result for the next sandbox with this same hash,
+	// but only for pool-controlled sandboxes where the hash is trustworthy.
+	if !isOrphan && sandboxHash != "" {
 		vettedHashes[sandboxHash] = isStale
 	}
 

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -449,14 +449,14 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	// Check if the sandbox is unowned (orphaned).
 	controllerRef := metav1.GetControllerOf(sandbox)
 	isOrphan := controllerRef == nil
+	if isOrphan {
+		// Always perform full semantic comparison for orphans.
+		return !r.comparePodSpecs(template, &sandbox.Spec.PodTemplate.Spec)
+	}
 
-	// If the sandbox is controlled by the warm pool, we can safely use the hash shortcut.
-	// Unowned sandboxes must bypass the hash shortcut to prevent label spoofing attacks.
-	if !isOrphan {
-		// If hashes match, it's fresh.
-		if sandboxHash != "" && sandboxHash == currentPodTemplateHash {
-			return false
-		}
+	// If hashes match, it's fresh.
+	if sandboxHash != "" && sandboxHash == currentPodTemplateHash {
+		return false
 	}
 
 	// If currentPodTemplateHash is empty, it means we failed to compute it.
@@ -468,8 +468,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	}
 
 	// Check if we've already evaluated this specific old version.
-	// Unowned sandboxes must bypass the cache to ensure full semantic comparison.
-	if !isOrphan && sandboxHash != "" {
+	if sandboxHash != "" {
 		if isStale, found := vettedHashes[sandboxHash]; found {
 			return isStale
 		}
@@ -480,9 +479,8 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	// used during creation to avoid false positives from controller-injected fields.
 	isStale := !r.comparePodSpecs(template, &sandbox.Spec.PodTemplate.Spec)
 
-	// Save the result for the next sandbox with this same hash,
-	// but only for pool-controlled sandboxes where the hash is trustworthy.
-	if !isOrphan && sandboxHash != "" {
+	// Save the result for the next sandbox with this same hash.
+	if sandboxHash != "" {
 		vettedHashes[sandboxHash] = isStale
 	}
 

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -53,6 +53,7 @@ func createPoolSandbox(poolName, namespace, poolNameHash string, template *exten
 	if template != nil {
 		templateRefHash = sandboxcontrollers.NameHash(template.Name)
 		podSpec = *template.Spec.PodTemplate.Spec.DeepCopy()
+		ApplySandboxSecureDefaults(template, &podSpec)
 		// If template has a version label, we could use it as part of the hash placeholder
 		if v, ok := template.Spec.PodTemplate.ObjectMeta.Labels["version"]; ok {
 			podTemplateHash = "pod-hash-" + v
@@ -1263,4 +1264,81 @@ func TestReconcilePool_TemplateUpdate_DNSPolicy(t *testing.T) {
 	for _, sb := range sandboxes.Items {
 		require.Equal(t, corev1.DNSClusterFirst, sb.Spec.PodTemplate.Spec.DNSPolicy, "Sandbox should have updated DNSPolicy")
 	}
+}
+
+func TestIsSandboxStale_OrphanedSandboxVetting(t *testing.T) {
+	poolName := "test-pool"
+	poolNamespace := "default"
+	templateName := "test-template"
+	ctx := context.Background()
+	scheme := newTestScheme()
+
+	template := &extensionsv1alpha1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      templateName,
+			Namespace: poolNamespace,
+		},
+		Spec: extensionsv1alpha1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "genuine-image"},
+					},
+				},
+			},
+		},
+	}
+
+	currentPodTemplateHash, err := computePodTemplateHash(template)
+	require.NoError(t, err)
+	templateRefHash := SandboxTemplateRefHash(template.Name)
+
+	r := &SandboxWarmPoolReconciler{Scheme: scheme}
+	vettedHashes := make(map[string]bool)
+
+	// Case 1: Orphaned sandbox with matching hash label but modified PodSpec (Spoofed).
+	// Should be detected as stale because unowned sandboxes must undergo full vetting.
+	spoofedSpec := template.Spec.PodTemplate.Spec.DeepCopy()
+	spoofedSpec.Containers[0].Image = "malicious-image"
+
+	spoofedOrphan := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "spoofed-orphan",
+			Namespace: poolNamespace,
+			Labels: map[string]string{
+				sandboxv1alpha1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
+				sandboxTemplateRefHash:                      templateRefHash,
+				warmPoolSandboxLabel:                        sandboxcontrollers.NameHash(poolName),
+			},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{Spec: *spoofedSpec},
+		},
+	}
+
+	isStaleSpoofed := r.isSandboxStale(ctx, spoofedOrphan, template, currentPodTemplateHash, vettedHashes)
+	require.True(t, isStaleSpoofed, "Orphaned sandbox with spoofed hash but modified PodSpec should be stale")
+
+	// Case 2: Orphaned sandbox with matching hash label and genuine/fully vetted PodSpec.
+	// Should be evaluated as fresh (not stale) after passing full semantic comparison.
+	genuineSpec := template.Spec.PodTemplate.Spec.DeepCopy()
+	ApplySandboxSecureDefaults(template, genuineSpec)
+
+	genuineOrphan := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "genuine-orphan",
+			Namespace: poolNamespace,
+			Labels: map[string]string{
+				sandboxv1alpha1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
+				sandboxTemplateRefHash:                      templateRefHash,
+				warmPoolSandboxLabel:                        sandboxcontrollers.NameHash(poolName),
+			},
+		},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{Spec: *genuineSpec},
+		},
+	}
+
+	isStaleGenuine := r.isSandboxStale(ctx, genuineOrphan, template, currentPodTemplateHash, vettedHashes)
+	require.False(t, isStaleGenuine, "Orphaned sandbox with genuine fully vetted PodSpec should be fresh")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR refactors `isSandboxStale` in the SandboxWarmPool controller.

**Changes**:
- Modified `isSandboxStale` in `extensions/controllers/sandboxwarmpool_controller.go` to identify if a Sandbox is unowned (orphaned).
- Unowned sandboxes now bypass the hash-matching "shortcut" and the `vettedHashes` cache 
- Forced a full semantic deep equality check using `comparePodSpecs` for all unowned Sandboxes to ensure their `PodSpec` truly matches the template before they are considered fresh.
- Added comprehensive unit tests in `extensions/controllers/sandboxwarmpool_controller_test.go` to verify that spoofed orphaned sandboxes are correctly identified as stale.
#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes(internal link) - [b/511322745](https://buganizer.corp.google.com/issues/511322745)[b/511322745](https://buganizer.corp.google.com/issues/511322745)
#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->