### PR TITLE
docs: update NetworkPolicy documentation

### DIFF
--- a/examples/policy/network-policy-management/README.md
+++ b/examples/policy/network-policy-management/README.md
@@ -161,6 +161,74 @@ spec:
 - Retaining Internet Access: We copy the public internet egress rules from the secure defaults to ensure the agent can still make external API calls while blocking lateral movement across the internal cluster network.
 
 
+**Example 3: GCP Workload Identity & Google Cloud Services (Vertex AI, GCS, etc.)**
+
+If your AI sandboxes interact with Google Cloud APIs (e.g., Vertex AI model generation or reading/writing data to Google Cloud Storage buckets), you must configure your network policy to support **Workload Identity** and prevent latency hangs.
+
+There are two critical gotchas to be aware of when using Google Cloud APIs inside a sandboxed environment:
+1. **Workload Identity (169.254.169.254)**: Google Cloud SDKs authenticate by querying the GCP Metadata Server at `169.254.169.254`. This link-local address is blocked by default under the Secure-by-Default posture, so you must explicitly permit it.
+2. **IPv6 / DNS**: Modern runtimes (such as Node.js clients using `fetch` or Python SDKs using libraries like `urllib3`, `requests`, or `aiohttp`) may attempt to reach Google API domains (like `aiplatform.googleapis.com` or `storage.googleapis.com`) over both IPv4 and IPv6. Because standard Kubernetes network policies are default-deny, if you omit the IPv6 egress block (`::/0`), the CNI may silently drop the outbound IPv6 packets. This can cause the application to hang for up to ~2 minutes before falling back to IPv4, depending on the runtime and network stack.
+
+To support Google Cloud APIs natively without experiencing these latency hangs or resolution failures, you must:
+1. Explicitly allow **both** IPv4 and IPv6 egress to the internet.
+2. Add a separate, narrow egress rule allowing traffic only to the GCP Metadata Server (`169.254.169.254/32` on TCP port 80) rather than leaving the entire `169.254.0.0/16` link-local range exposed.
+3. Configure custom DNS resolvers (like public Google/Cloudflare DNS) directly in the sandbox `podTemplate`. Since defining a custom `networkPolicy` disables the automatic "Secure-by-Default" DNS override, and since RFC1918 private subnets are blocked by the custom egress rules, the sandbox would be unable to reach internal cluster DNS (CoreDNS), causing DNS lookups for external domains to fail.
+
+```yaml
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: gcp-agent-template
+spec:
+  networkPolicyManagement: Managed
+  networkPolicy:
+    ingress:
+      # Re-allow the standard Sandbox Router
+      - from:
+        - podSelector:
+            matchLabels:
+              app: sandbox-router
+    egress:
+      # 1. Allow outbound IPv4 to the public internet (excluding private subnets and link-local)
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+
+      # 2. Allow outbound IPv6
+      - to:
+        - ipBlock:
+            cidr: "::/0"
+            except:
+              - "fc00::/7"
+
+      # 3. Allow narrow egress to the GCP Metadata Server for Workload Identity
+      - to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        ports:
+          - protocol: TCP
+            port: 80
+
+  podTemplate:
+    spec:
+      # Custom networkPolicies disable the automatic "Secure-by-Default" DNS override.
+      # Since private subnets are blocked above, we must configure external public resolvers
+      # here so that the sandbox can resolve public Google API domains.
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+          - 8.8.8.8
+          - 1.1.1.1
+      # ... rest of the pod template spec (containers, volumes, etc.)
+```
+
+
+
 ## Troubleshooting
 
 **How can I confirm which network policy is actively applied to a Sandbox?**


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds Example 3: GCP Workload Identity & Google Cloud Services (Vertex AI, GCS, etc.) to the network-policy-management documentation.

When using custom egress network policies on GKE clusters with dual-stack enabled, two major gotchas can arise that break Google Cloud SDKs or cause them to experience 2-minute delays:

1. Workload Identity Egress Block: The GCP Metadata Server (`169.254.169.254`) is blocked by the default egress block list. Custom network policies must explicitly omit it from the excluded subnets to enable token exchange.
2. IPv6 Timeout: Runtimes such as Node.js or Python HTTP clients concurrently attempt to resolve Google API subdomains via both IPv4 and IPv6. Because standard Kubernetes network policies operate on a default-deny posture, omitting the IPv6 egress catch-all (`::/0`) causes outbound IPv6 SYN packets to be dropped. This forces the application to wait for the full 127-second TCP SYN retransmission timeout before falling back to IPv4.

This addition provides a robust, dual-stack template example showing how to safely authorize both IPv4 and IPv6 external egress while preserving strict namespace and internal network boundaries.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
No issue, just an improvement to the doc

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->