### PR TITLE
Fix(client): Disable automatic HTTP redirects in SandboxConnector to prevent SSRF

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -152,7 +152,7 @@ class AsyncSandboxConnector:
         for attempt in range(MAX_RETRIES + 1):
             try:
                 response = await self.client.request(
-                    method, url, headers=headers, **kwargs
+                    method, url, headers=headers, follow_redirects=False, **kwargs
                 )
                 if response.status_code in RETRYABLE_STATUS_CODES and attempt < MAX_RETRIES:
                     delay = BACKOFF_FACTOR * (2 ** attempt)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -127,6 +127,9 @@ class AsyncSandboxConnector:
         url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
         headers = kwargs.pop("headers", {}).copy()
+        # Ensure follow_redirects is not passed in kwargs to prevent duplicate parameter TypeError
+        kwargs.pop("follow_redirects", None)
+
         if self._inject_router_headers:
             headers["X-Sandbox-ID"] = self.id
             headers["X-Sandbox-Namespace"] = self.namespace
@@ -163,6 +166,12 @@ class AsyncSandboxConnector:
                     last_response = response
                     await asyncio.sleep(delay)
                     continue
+                if response.is_redirect:
+                    raise httpx.HTTPStatusError(
+                        f"Redirection is not allowed (status code {response.status_code}).",
+                        request=response.request,
+                        response=response,
+                    )
                 response.raise_for_status()
                 return response
             except httpx.HTTPStatusError as e:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -123,11 +123,44 @@ class AsyncSandboxConnector:
         return self._base_url
 
     async def send_request(self, method: str, endpoint: str, **kwargs) -> httpx.Response:
+        """Sends an HTTP request asynchronously to the sandbox with standard parameters.
+
+        This method automatically resolves the gateway connection, appends the router/sandbox
+        identity headers, overrides redirect options to disable client-side automatic
+        redirection (for security/SSRF mitigation), and raises appropriate exceptions on errors.
+
+        Args:
+            method: The HTTP method (e.g., "GET", "POST").
+            endpoint: The API endpoint path.
+            **kwargs: Extra keyword arguments passed directly to the underlying
+                `httpx.AsyncClient.request` invocation. Note that 'follow_redirects'
+                is explicitly popped and overridden.
+
+        Returns:
+            The `httpx.Response` object representing the response from the sandbox.
+
+        Raises:
+            SandboxRequestError: If a connection/HTTP status error occurs, or if a redirect is
+                returned (status codes 301, 302, 303, 307, 308).
+
+        Note on Redirect Handling:
+            Automatic redirection (SSRF risk mitigation) is explicitly disabled in the
+            HTTP client. If a redirect status code recognized by httpx (301, 302,
+            303, 307, 308) is returned, a SandboxRequestError wrapping HTTPStatusError is
+            raised. Non-redirect 3xx status codes, such as 300 (Multiple Choices), 304
+            (Not Modified), 305 (Use Proxy), and 306 (Switch Proxy), do not trigger
+            automatic client redirection or raise redirect errors; they are returned
+            directly to the caller because httpx does not consider them redirects
+            and raise_for_status only raises for status codes 400 and above.
+        """
         base_url = await self._resolve_base_url()
         url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
         headers = kwargs.pop("headers", {}).copy()
-        # Ensure follow_redirects is not passed in kwargs to prevent duplicate parameter TypeError
+        # For security and SSRF mitigation, the SDK explicitly mandates blocking all HTTP redirects
+        # to the internal sandbox endpoints. Any user-provided redirect settings are overridden and
+        # ignored. We pop 'follow_redirects' here to prevent a TypeError due to duplicate keyword
+        # arguments when calling httpx.AsyncClient.request.
         kwargs.pop("follow_redirects", None)
 
         if self._inject_router_headers:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -350,8 +350,16 @@ class SandboxConnector:
                         headers["X-Sandbox-Pod-IP"] = self._pod_ip
             kwargs["headers"] = headers
 
+            # Ensure allow_redirects is not passed in kwargs to prevent duplicate parameter TypeError
+            kwargs.pop("allow_redirects", None)
+
             # Send the request
             response = self.session.request(method, url, allow_redirects=False, **kwargs)
+            if response.is_redirect:
+                raise requests.exceptions.HTTPError(
+                    f"Redirection is not allowed (status code {response.status_code}).",
+                    response=response,
+                )
             response.raise_for_status()
             return response
         except SandboxPortForwardError:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -351,7 +351,7 @@ class SandboxConnector:
             kwargs["headers"] = headers
 
             # Send the request
-            response = self.session.request(method, url, **kwargs)
+            response = self.session.request(method, url, allow_redirects=False, **kwargs)
             response.raise_for_status()
             return response
         except SandboxPortForwardError:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -317,6 +317,38 @@ class SandboxConnector:
             self.session.close()
 
     def send_request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
+        """Sends an HTTP request to the sandbox with standard parameters.
+
+        This method automatically resolves the gateway or tunnel connection,
+        appends the router/sandbox identity headers, overrides redirect options to
+        disable client-side automatic redirection (for security/SSRF mitigation),
+        and raises appropriate exceptions on errors.
+
+        Args:
+            method: The HTTP method (e.g., "GET", "POST").
+            endpoint: The API endpoint path.
+            **kwargs: Extra keyword arguments passed directly to the underlying
+                `requests.Session.request` invocation. Note that 'allow_redirects'
+                is explicitly popped and overridden.
+
+        Returns:
+            The `requests.Response` object representing the response from the sandbox.
+
+        Raises:
+            SandboxRequestError: If a connection error occurs, or if a redirect is
+                returned (status codes 301, 302, 303, 307, 308).
+            SandboxPortForwardError: If the local port-forward tunnel crashes.
+
+        Note on Redirect Handling:
+            Automatic redirection (SSRF risk mitigation) is explicitly disabled in the
+            HTTP client. If a redirect status code recognized by requests (301, 302,
+            303, 307, 308) is returned, a SandboxRequestError wrapping HTTPError is
+            raised. Non-redirect 3xx status codes, such as 300 (Multiple Choices), 304
+            (Not Modified), 305 (Use Proxy), and 306 (Switch Proxy), do not trigger
+            automatic client redirection or raise redirect errors; they are returned
+            directly to the caller because requests does not consider them redirects
+            and raise_for_status only raises for status codes 400 and above.
+        """
         try:
             # Establish connection (re-establishes if closed/dead)
             base_url = self.connect()
@@ -350,10 +382,13 @@ class SandboxConnector:
                         headers["X-Sandbox-Pod-IP"] = self._pod_ip
             kwargs["headers"] = headers
 
-            # Ensure allow_redirects is not passed in kwargs to prevent duplicate parameter TypeError
+            # For security and SSRF mitigation, the SDK explicitly mandates blocking all HTTP redirects
+            # to the internal sandbox endpoints. Any user-provided redirect settings are overridden and
+            # ignored. We pop 'allow_redirects' here to prevent a TypeError due to duplicate keyword
+            # arguments when calling requests.Session.request.
             kwargs.pop("allow_redirects", None)
 
-            # Send the request
+            # Send the request with redirections blocked
             response = self.session.request(method, url, allow_redirects=False, **kwargs)
             if response.is_redirect:
                 raise requests.exceptions.HTTPError(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -425,6 +425,21 @@ class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
         finally:
             await connector.close()
 
+    async def test_follow_redirects_is_false(self):
+        connector = self._make_connector()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            await connector.send_request("GET", "health")
+            
+            call_args, call_kwargs = connector.client.request.call_args
+            self.assertFalse(call_kwargs.get("follow_redirects", True))
+        finally:
+            await connector.close()
+
     async def test_post_execute(self):
         connector = self._make_connector()
         try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -429,14 +429,58 @@ class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
         connector = self._make_connector()
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.raise_for_status = MagicMock()
         connector.client.request = AsyncMock(return_value=mock_response)
 
         try:
             await connector.send_request("GET", "health")
-            
+
             call_args, call_kwargs = connector.client.request.call_args
             self.assertFalse(call_kwargs.get("follow_redirects", True))
+        finally:
+            await connector.close()
+
+    async def test_follow_redirects_in_kwargs_popped(self):
+        connector = self._make_connector()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.is_redirect = False
+        mock_response.raise_for_status = MagicMock()
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            await connector.send_request("GET", "health", follow_redirects=True)
+
+            call_args, call_kwargs = connector.client.request.call_args
+            self.assertFalse(call_kwargs.get("follow_redirects", True))
+        finally:
+            await connector.close()
+
+    async def test_redirect_raises_error(self):
+        connector = self._make_connector()
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.is_redirect = True
+        mock_response.raise_for_status = MagicMock()
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            with self.assertRaises(SandboxRequestError):
+                await connector.send_request("GET", "health")
+        finally:
+            await connector.close()
+
+    async def test_304_does_not_raise_redirect_error(self):
+        connector = self._make_connector()
+        mock_response = MagicMock()
+        mock_response.status_code = 304
+        mock_response.is_redirect = False
+        mock_response.raise_for_status = MagicMock()
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            await connector.send_request("GET", "health")
         finally:
             await connector.close()
 
@@ -587,6 +631,7 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
         # Mock httpx client to return 404 on first request
         mock_response = MagicMock()
         mock_response.status_code = 404
+        mock_response.is_redirect = False
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "404 Not Found",
             request=MagicMock(),
@@ -673,6 +718,7 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
         # First request to establish base_url
         mock_response_ok = MagicMock()
         mock_response_ok.status_code = 200
+        mock_response_ok.is_redirect = False
         mock_response_ok.raise_for_status = MagicMock()
         connector.client.request = AsyncMock(return_value=mock_response_ok)
 
@@ -682,6 +728,7 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
         # Now return 503 error
         mock_response_error = MagicMock()
         mock_response_error.status_code = 503
+        mock_response_error.is_redirect = False
         mock_response_error.raise_for_status.side_effect = httpx.HTTPStatusError(
             "503 Service Unavailable",
             request=MagicMock(),

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -484,6 +484,19 @@ class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
         finally:
             await connector.close()
 
+    async def test_300_does_not_raise_redirect_error(self):
+        connector = self._make_connector()
+        mock_response = MagicMock()
+        mock_response.status_code = 300
+        mock_response.is_redirect = False
+        mock_response.raise_for_status = MagicMock()
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            await connector.send_request("GET", "health")
+        finally:
+            await connector.close()
+
     async def test_post_execute(self):
         connector = self._make_connector()
         try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -256,5 +256,18 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
 
         connector.send_request("GET", "/execute")
 
+    def test_300_does_not_raise_redirect_error(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+
+        mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.status_code = 300
+        mock_resp.is_redirect = False
+        mock_resp.raise_for_status.return_value = None
+        mock_session.request.return_value = mock_resp
+
+        connector.send_request("GET", "/execute")
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -161,6 +161,8 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
 
     def _mock_ok_response(self):
         mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.status_code = 200
+        mock_resp.is_redirect = False
         mock_resp.raise_for_status.return_value = None
         return mock_resp
 
@@ -215,6 +217,44 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
         call_args, call_kwargs = mock_session.request.call_args
         self.assertFalse(call_kwargs.get("allow_redirects", True))
 
+    def test_allow_redirects_in_kwargs_popped(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute", allow_redirects=True)
+
+        call_args, call_kwargs = mock_session.request.call_args
+        self.assertFalse(call_kwargs.get("allow_redirects", True))
+
+    def test_redirect_raises_error(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+
+        mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.status_code = 302
+        mock_resp.is_redirect = True
+        mock_resp.raise_for_status.return_value = None
+        mock_session.request.return_value = mock_resp
+
+        from k8s_agent_sandbox.connector import SandboxRequestError
+        with self.assertRaises(SandboxRequestError):
+            connector.send_request("GET", "/execute")
+
+    def test_304_does_not_raise_redirect_error(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+
+        mock_resp = MagicMock(spec=requests.Response)
+        mock_resp.status_code = 304
+        mock_resp.is_redirect = False
+        mock_resp.raise_for_status.return_value = None
+        mock_session.request.return_value = mock_resp
+
+        connector.send_request("GET", "/execute")
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -204,6 +204,17 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
         url = call_args[1]
         self.assertEqual(url, "http://my-sb.my-ns.svc.cluster.local:8888/execute")
 
+    def test_allow_redirects_is_false(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute")
+
+        call_args, call_kwargs = mock_session.request.call_args
+        self.assertFalse(call_kwargs.get("allow_redirects", True))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR disables automatic HTTP redirects in the `agentic-sandbox-client` Python SDK to prevent a **High-severity Server-Side Request Forgery (SSRF)** vulnerability. 

Currently, the SDK's `SandboxConnector` and `AsyncSandboxConnector` use default HTTP client settings that automatically follow 3xx redirects. Since the sandbox environment is inherently untrusted, an attacker with execution capabilities can force the orchestrator to perform unauthorized `GET` requests against internal infrastructure—such as cloud IMDS metadata (e.g., `169.254.169.254`) or private internal APIs—by issuing a malicious redirect. 

This fix explicitly sets `allow_redirects=False` (for `requests`) and `follow_redirects=False` (for `httpx`) to ensure the security boundary between the untrusted sandbox and the orchestrator's network is strictly enforced.

#### Release Note
```release-note
SECURITY: Disables automatic HTTP redirects in the Python SDK's SandboxConnector to mitigate potential Server-Side Request Forgery (SSRF) attacks from compromised sandboxes.
