### PR TITLE
fix typo in recently added get_sandbox_claim_template_name method name

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -364,7 +364,7 @@ class SandboxClient(Generic[T]):
         except Exception as e:
             logging.error(f"Failed to cleanup SandboxClaim '{claim_name}': {e}")
 
-    def get_sandbox_claim_temlpate_name(self, claim_name: str, namespace: str) -> str:
+    def get_sandbox_claim_template_name(self, claim_name: str, namespace: str) -> str:
         """Get template name of a sandbox claim."""
         claim_object = self.k8s_helper.get_sandbox_claim(claim_name, namespace)
         if not claim_object:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -394,13 +394,13 @@ class TestSandboxClient(unittest.TestCase):
         self.mock_k8s_helper.get_sandbox_claim.return_value = {
             "spec": {"sandboxTemplateRef": {"name": "my-template"}},
         }
-        template_name = self.client.get_sandbox_claim_temlpate_name("my-claim", "my-namespace")
+        template_name = self.client.get_sandbox_claim_template_name("my-claim", "my-namespace")
         self.assertEqual(template_name, "my-template")
 
     def test_get_sandbox_claim_template_name_claim_not_found(self):
         self.mock_k8s_helper.get_sandbox_claim.return_value = None
         with self.assertRaises(SandboxNotFoundError):
-            self.client.get_sandbox_claim_temlpate_name("my-claim", "my-namespace")
+            self.client.get_sandbox_claim_template_name("my-claim", "my-namespace")
 
 
 class SandboxHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
Fixes the typo in the method `get_sandbox_claim_template_name` that was added in the PR https://github.com/kubernetes-sigs/agent-sandbox/pull/695