### PR TITLE
fix(controllers): block IPv6 link-local traffic in default NetworkPolicy

### DIFF
--- a/examples/policy/network-policy-management/README.md
+++ b/examples/policy/network-policy-management/README.md
@@ -61,6 +61,8 @@ This is designed for running untrusted code safely:
 
   - Internal IPv6 Unique Local Addresses (`fc00::/7`).
 
+  - IPv6 Link-Local (`fe80::/10`).
+
   - Internal Cluster DNS (CoreDNS).
 
 
@@ -152,6 +154,7 @@ spec:
             cidr: "::/0"
             except:
               - "fc00::/7"
+              - "fe80::/10"
 ```
 
 - Total Override: Because the Secure Defaults are replaced, we must manually re-add the rule allowing ingress from the `sandbox-router` if we still want that functionality.  

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -202,7 +202,8 @@ func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPoli
 						IPBlock: &networkingv1.IPBlock{
 							CIDR: "::/0", // IPv6 Catch-all
 							Except: []string{
-								"fc00::/7", // Block IPv6 Unique Local Addresses (Internal)
+								"fc00::/7",  // Block IPv6 Unique Local Addresses (Internal)
+								"fe80::/10", // Block IPv6 Link-Local
 							},
 						},
 					},

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -109,8 +110,22 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 				if len(np.Spec.Ingress) != 1 || np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app"] != "sandbox-router" {
 					t.Errorf("Expected Default Ingress rule to target sandbox-router")
 				}
-				if len(np.Spec.Egress) != 1 || np.Spec.Egress[0].To[0].IPBlock.CIDR != "0.0.0.0/0" {
+				if len(np.Spec.Egress) != 1 {
+					t.Fatalf("Expected 1 Default Egress rule, got %d", len(np.Spec.Egress))
+				}
+				if len(np.Spec.Egress[0].To) != 2 {
+					t.Fatalf("Expected 2 Egress peers (IPv4 and IPv6), got %d", len(np.Spec.Egress[0].To))
+				}
+				if np.Spec.Egress[0].To[0].IPBlock == nil || np.Spec.Egress[0].To[0].IPBlock.CIDR != "0.0.0.0/0" {
 					t.Fatalf("Expected Default Egress IPBlock 0.0.0.0/0")
+				}
+				ipv6Peer := np.Spec.Egress[0].To[1]
+				if ipv6Peer.IPBlock == nil || ipv6Peer.IPBlock.CIDR != "::/0" {
+					t.Fatalf("Expected Default Egress IPv6 IPBlock ::/0")
+				}
+				hasIPv6LinkLocalExcept := slices.Contains(ipv6Peer.IPBlock.Except, "fe80::/10")
+				if !hasIPv6LinkLocalExcept {
+					t.Errorf("Expected IPv6 Egress Except list to contain fe80::/10, got %v", ipv6Peer.IPBlock.Except)
 				}
 				expectedLabelKey := "agents.x-k8s.io/sandbox-template-ref-hash"
 				if _, ok := np.Spec.PodSelector.MatchLabels[expectedLabelKey]; !ok {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR addresses a security vulnerability (Finding 08) where the default `NetworkPolicy` for sandboxes blocked IPv4 link-local traffic but inadvertently allowed IPv6 link-local egress (`fe80::/10`). 

**Changes included:**
*   Modified `sandboxtemplate_controller.go` to add `fe80::/10` to the `Except` block of the default IPv6 egress policy.
*   Updated `examples/policy/network-policy-management/README.md` documentation to reflect the inclusion of the IPv6 link-local block.

#### Release Note
```release-note
SECURITY: Updated the default sandbox NetworkPolicy to block egress to IPv6 link-local addresses (fe80::/10). This prevents untrusted code from accessing local services and cloud metadata endpoints over IPv6.
```