### PR TITLE
Fix: SandboxTemplate controller unauthorized NetworkPolicy modification

### DIFF
--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -79,14 +79,20 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// 3. Handle "Unmanaged" Opt-Out
 	if management == extensionsv1beta1.NetworkPolicyManagementUnmanaged {
-		existingNP := &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: npName, Namespace: npNamespace},
-		}
-		if err := r.Delete(ctx, existingNP); err != nil && !k8errors.IsNotFound(err) {
-			logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
-			return ctrl.Result{}, err
-		} else if err == nil {
+		existingNP := &networkingv1.NetworkPolicy{}
+		err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
+		if err == nil {
+			if !metav1.IsControlledBy(existingNP, template) {
+				logger.Info("Skipping deletion of NetworkPolicy not owned by template", "name", npName)
+				return ctrl.Result{}, nil
+			}
+			if err := r.Delete(ctx, existingNP); err != nil {
+				logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
+				return ctrl.Result{}, err
+			}
 			logger.Info("Deleted unmanaged NetworkPolicy", "name", existingNP.Name)
+		} else if !k8errors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy: %w", err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -116,6 +122,9 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
 
 	if err == nil {
+		if !metav1.IsControlledBy(existingNP, template) {
+			return ctrl.Result{}, fmt.Errorf("refusing to update NetworkPolicy %q as it is not controlled by SandboxTemplate %q", npName, template.Name)
+		}
 		// Policy exists: Semantic DeepEqual check for drift
 		if equality.Semantic.DeepEqual(existingNP.Spec, desiredSpec) {
 			return ctrl.Result{}, nil // Perfect match, O(1) efficiency.

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -47,7 +47,7 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	}
 
 	templateWithNP := &extensionsv1beta1.SandboxTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom", Namespace: "default", UID: "template-custom-uid"},
 		Spec: extensionsv1beta1.SandboxTemplateSpec{
 			NetworkPolicy: &extensionsv1beta1.NetworkPolicySpec{
 				Ingress: []networkingv1.NetworkPolicyIngressRule{
@@ -69,7 +69,7 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	}
 
 	templateOptOut := &extensionsv1beta1.SandboxTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout", Namespace: "default", UID: "template-optout-uid"},
 		Spec: extensionsv1beta1.SandboxTemplateSpec{
 			NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementUnmanaged,
 			NetworkPolicy: &extensionsv1beta1.NetworkPolicySpec{
@@ -79,16 +79,42 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	}
 
 	existingNPToDelete := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout-network-policy", Namespace: "default"},
-		Spec:       networkingv1.NetworkPolicySpec{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-template-optout-network-policy",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+					Kind:       "SandboxTemplate",
+					Name:       templateOptOut.Name,
+					UID:        templateOptOut.UID,
+					Controller: new(bool),
+				},
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{},
 	}
+	*existingNPToDelete.OwnerReferences[0].Controller = true
 
 	outdatedNPToUpdate := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom-network-policy", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-template-custom-network-policy",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+					Kind:       "SandboxTemplate",
+					Name:       templateWithNP.Name,
+					UID:        templateWithNP.UID,
+					Controller: new(bool),
+				},
+			},
+		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"old-label": "outdated"}}, // Will be overwritten
 		},
 	}
+	*outdatedNPToUpdate.OwnerReferences[0].Controller = true
 
 	testCases := []struct {
 		name                  string
@@ -198,4 +224,105 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
+	scheme := newScheme(t)
+
+	t.Run("Does not delete unowned NetworkPolicy when Unmanaged", func(t *testing.T) {
+		template := &extensionsv1beta1.SandboxTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "victim", Namespace: "default"},
+			Spec: extensionsv1beta1.SandboxTemplateSpec{
+				NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementUnmanaged,
+			},
+		}
+
+		// This NetworkPolicy is NOT owned by the template
+		unownedNP := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "victim-network-policy",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"keep": "me"}},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, unownedNP).Build()
+		reconciler := &SandboxTemplateReconciler{
+			Client:   client,
+			Scheme:   scheme,
+			Recorder: events.NewFakeRecorder(10),
+			Tracer:   asmetrics.NewNoOp(),
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "victim", Namespace: "default"},
+		}
+
+		_, err := reconciler.Reconcile(context.Background(), req)
+		if err != nil {
+			t.Fatalf("reconcile: (%v)", err)
+		}
+
+		// Check if unownedNP still exists
+		var np networkingv1.NetworkPolicy
+		err = client.Get(context.Background(), types.NamespacedName{Name: "victim-network-policy", Namespace: "default"}, &np)
+		if err != nil {
+			if k8errors.IsNotFound(err) {
+				t.Errorf("VULNERABILITY: Unowned NetworkPolicy was deleted!")
+			} else {
+				t.Fatalf("failed to get network policy: %v", err)
+			}
+		}
+	})
+
+	t.Run("Does not update unowned NetworkPolicy", func(t *testing.T) {
+		template := &extensionsv1beta1.SandboxTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "victim", Namespace: "default"},
+			Spec: extensionsv1beta1.SandboxTemplateSpec{
+				NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementManaged,
+			},
+		}
+
+		// This NetworkPolicy is NOT owned by the template
+		unownedNP := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "victim-network-policy",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"keep": "me"}},
+			},
+		}
+
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, unownedNP).Build()
+		reconciler := &SandboxTemplateReconciler{
+			Client:   client,
+			Scheme:   scheme,
+			Recorder: events.NewFakeRecorder(10),
+			Tracer:   asmetrics.NewNoOp(),
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "victim", Namespace: "default"},
+		}
+
+		_, err := reconciler.Reconcile(context.Background(), req)
+		// We expect an error here once fixed, but currently it might succeed and overwrite
+		if err != nil {
+			t.Logf("Reconcile returned error (expected after fix): %v", err)
+		}
+
+		// Check if unownedNP was updated
+		var np networkingv1.NetworkPolicy
+		err = client.Get(context.Background(), types.NamespacedName{Name: "victim-network-policy", Namespace: "default"}, &np)
+		if err != nil {
+			t.Fatalf("failed to get network policy: %v", err)
+		}
+
+		if _, ok := np.Spec.PodSelector.MatchLabels["keep"]; !ok {
+			t.Errorf("VULNERABILITY: Unowned NetworkPolicy was updated/overwritten!")
+		}
+	})
 }


### PR DESCRIPTION
The SandboxTemplate controller was deleting or updating NetworkPolicy resources based on name alone, without verifying ownership. This allowed an attacker with SandboxTemplate RBAC to bypass authorization and arbitrarily delete or overwrite any NetworkPolicy in the namespace whose name ends with '-network-policy'.

This change adds an ownership check using `metav1.IsControlledBy` before performing any delete or update operations on existing NetworkPolicy resources.

Fixes cluster-10963

Generated by **Overseer** (powered by the gemini-3-flash-preview model)