### PR TITLE
Default SDK-created sandboxes to 12h TTL

### DIFF
--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -131,6 +131,7 @@ func (h *K8sHelper) createClaim(ctx context.Context, namespace, templateName str
 			"opentelemetry.io/trace-context": traceCtx,
 		}
 	}
+	shutdownTime := metav1.NewTime(time.Now().Add(defaultShutdownAfter))
 
 	claim := &extv1beta1.SandboxClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -141,6 +142,10 @@ func (h *K8sHelper) createClaim(ctx context.Context, namespace, templateName str
 		Spec: extv1beta1.SandboxClaimSpec{
 			TemplateRef: extv1beta1.SandboxTemplateRef{
 				Name: templateName,
+			},
+			Lifecycle: &extv1beta1.Lifecycle{
+				ShutdownTime:   &shutdownTime,
+				ShutdownPolicy: extv1beta1.ShutdownPolicyDelete,
 			},
 		},
 	}

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -36,6 +36,7 @@ const (
 	defaultCleanupTimeout          = 30 * time.Second
 	defaultRequestTimeout          = 180 * time.Second
 	defaultPerAttemptTimeout       = 60 * time.Second
+	defaultShutdownAfter           = 12 * time.Hour
 	defaultMaxDownloadSize         = 256 << 20 // 256 MB
 	defaultMaxUploadSize           = 256 << 20 // 256 MB
 )

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -1350,6 +1350,7 @@ func TestOpen_CreateClaimSendsCorrectTemplate(t *testing.T) {
 	c, agentsCS, extensionsCS := newTestSandbox(opts)
 
 	var capturedTemplate string
+	var capturedLifecycle *extv1beta1.Lifecycle
 	fakeWatcher := watch.NewFake()
 
 	extensionsCS.PrependReactor("create", "sandboxclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
@@ -1360,6 +1361,7 @@ func TestOpen_CreateClaimSendsCorrectTemplate(t *testing.T) {
 				claim.Name = claim.GenerateName + "test12345"
 			}
 			capturedTemplate = claim.Spec.TemplateRef.Name
+			capturedLifecycle = claim.Spec.Lifecycle
 			go fakeWatcher.Add(readySandbox(claim.Name))
 		}
 		return false, nil, nil
@@ -1367,13 +1369,30 @@ func TestOpen_CreateClaimSendsCorrectTemplate(t *testing.T) {
 
 	agentsCS.PrependWatchReactor("sandboxes", ktesting.DefaultWatchReactor(fakeWatcher, nil))
 
+	before := time.Now()
 	if err := c.Open(context.Background()); err != nil {
 		t.Fatalf("Open() error: %v", err)
 	}
+	after := time.Now()
 	defer c.Close(context.Background())
 
 	if capturedTemplate != opts.TemplateName {
 		t.Errorf("expected template name %q, got %q", opts.TemplateName, capturedTemplate)
+	}
+	if capturedLifecycle == nil {
+		t.Fatal("expected default lifecycle on created SandboxClaim")
+	}
+	if capturedLifecycle.ShutdownPolicy != extv1beta1.ShutdownPolicyDelete {
+		t.Errorf("expected shutdown policy Delete, got %q", capturedLifecycle.ShutdownPolicy)
+	}
+	if capturedLifecycle.ShutdownTime == nil {
+		t.Fatal("expected shutdown time")
+	}
+	if capturedLifecycle.ShutdownTime.Time.Before(before.Add(defaultShutdownAfter)) {
+		t.Errorf("shutdown time %s is before expected lower bound", capturedLifecycle.ShutdownTime.Time)
+	}
+	if capturedLifecycle.ShutdownTime.Time.After(after.Add(defaultShutdownAfter + time.Second)) {
+		t.Errorf("shutdown time %s is after expected upper bound", capturedLifecycle.ShutdownTime.Time)
 	}
 }
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -122,7 +122,8 @@ class AsyncSandboxClient(Generic[T]):
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
             labels: Optional Kubernetes labels to attach to the claim.
             warmpool: Optional warm pool policy for sandbox adoption (e.g. "default", "none", or custom).
-            shutdown_after_seconds: Optional TTL in seconds. When set, the
+            shutdown_after_seconds: Optional TTL in seconds. Defaults to 12 hours.
+                When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
                 of ``"Delete"``, so the controller auto-deletes the claim on
@@ -140,7 +141,7 @@ class AsyncSandboxClient(Generic[T]):
         if labels:
             self._validate_labels(labels)
 
-        lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
+        lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds)
 
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -28,6 +28,7 @@ SANDBOX_PLURAL_NAME = "sandboxes"
 POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
 PODSNAPSHOT_POD_NAME_ANNOTATION = "podsnapshot.gke.io/origin-pod"
 SANDBOX_NAME_HASH_LABEL = "agents.x-k8s.io/sandbox-name-hash"
+DEFAULT_SHUTDOWN_AFTER_SECONDS = 12 * 60 * 60
 
 PODSNAPSHOT_API_GROUP = "podsnapshot.gke.io"
 PODSNAPSHOT_API_VERSION = "v1"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -101,7 +101,8 @@ class SandboxClient(Generic[T]):
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
             labels: Optional Kubernetes labels to attach to the claim.
             warmpool: Optional warm pool policy for sandbox adoption (e.g. "default", "none", or custom).
-            shutdown_after_seconds: Optional TTL in seconds. When set, the
+            shutdown_after_seconds: Optional TTL in seconds. Defaults to 12 hours.
+                When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
                 of ``"Delete"``, so the controller auto-deletes the claim on
@@ -119,7 +120,7 @@ class SandboxClient(Generic[T]):
         if labels:
             self._validate_labels(labels)
 
-        lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
+        lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds)
 
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
         

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import unittest
+from datetime import datetime, timezone
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
@@ -65,7 +66,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             sandbox = await self.client.create_sandbox("test-template", "test-namespace")
 
             mock_create.assert_called_once_with(
-                ANY, "test-template", "test-namespace", labels=None, lifecycle=None, warmpool=None
+                ANY, "test-template", "test-namespace", labels=None, lifecycle=ANY, warmpool=None
             )
             self.assertEqual(sandbox, mock_sandbox_instance)
 
@@ -230,20 +231,24 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(lifecycle["shutdownPolicy"], "Delete")
             self.assertIn("shutdownTime", lifecycle)
 
-    async def test_create_sandbox_without_shutdown_after_seconds(self):
+    async def test_create_sandbox_uses_default_shutdown_after_seconds(self):
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
         with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+             patch("k8s_agent_sandbox.utils.datetime") as mock_datetime, \
              patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+            mock_datetime.now.return_value = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+            mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
 
             await self.client.create_sandbox("test-template", "test-namespace")
 
             call_kwargs = mock_create.call_args
             lifecycle = call_kwargs[1].get("lifecycle")
-            self.assertIsNone(lifecycle)
+            self.assertEqual(lifecycle["shutdownPolicy"], "Delete")
+            self.assertEqual(lifecycle["shutdownTime"], "2026-06-16T00:00:00Z")
 
     async def test_shutdown_after_seconds_validation_zero(self):
         with self.assertRaises(ValueError):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle.py
@@ -16,6 +16,7 @@ import unittest
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+from k8s_agent_sandbox.constants import DEFAULT_SHUTDOWN_AFTER_SECONDS
 from k8s_agent_sandbox.utils import construct_sandbox_claim_lifecycle_spec
 
 
@@ -29,6 +30,17 @@ class TestConstructSandboxClaimLifecycleSpec(unittest.TestCase):
         result = construct_sandbox_claim_lifecycle_spec(300)
 
         self.assertEqual(result["shutdownTime"], "2026-06-15T12:05:00Z")
+        self.assertEqual(result["shutdownPolicy"], "Delete")
+
+    @patch("k8s_agent_sandbox.utils.datetime")
+    def test_uses_default_twelve_hour_ttl(self, mock_datetime):
+        frozen_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = frozen_now
+
+        result = construct_sandbox_claim_lifecycle_spec()
+
+        self.assertEqual(DEFAULT_SHUTDOWN_AFTER_SECONDS, 43200)
+        self.assertEqual(result["shutdownTime"], "2026-06-16T00:00:00Z")
         self.assertEqual(result["shutdownPolicy"], "Delete")
 
     @patch("k8s_agent_sandbox.utils.datetime")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py
@@ -87,11 +87,11 @@ class TestLifecycleIntegration(unittest.TestCase):
         self.assertEqual(body["kind"], "SandboxClaim")
         self.assertEqual(body["spec"]["sandboxTemplateRef"]["name"], "my-template")
 
-    def test_create_sandbox_without_shutdown_omits_lifecycle_in_manifest(
+    def test_create_sandbox_without_shutdown_uses_default_lifecycle_in_manifest(
         self, MockClientK8sHelper, mock_config, mock_api_cls, mock_core_cls
     ):
         """Full path: create_sandbox() without shutdown_after_seconds
-        produces no spec.lifecycle."""
+        embeds the default lifecycle in the manifest."""
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -112,10 +112,17 @@ class TestLifecycleIntegration(unittest.TestCase):
         real_helper.resolve_sandbox_name = MagicMock(return_value="sandbox-abc")
         real_helper.wait_for_sandbox_ready = MagicMock()
 
+        before = datetime.now(timezone.utc)
         sandbox_client.create_sandbox("my-template", "default")
+        after = datetime.now(timezone.utc)
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
-        self.assertNotIn("lifecycle", body["spec"])
+        lifecycle = body["spec"]["lifecycle"]
+        self.assertEqual(lifecycle["shutdownPolicy"], "Delete")
+        shutdown_time = datetime.strptime(lifecycle["shutdownTime"], "%Y-%m-%dT%H:%M:%SZ")
+        shutdown_time = shutdown_time.replace(tzinfo=timezone.utc)
+        self.assertGreaterEqual(shutdown_time, before.replace(microsecond=0) + timedelta(hours=12))
+        self.assertLessEqual(shutdown_time, after.replace(microsecond=0) + timedelta(hours=12, seconds=1))
         self.assertEqual(body["spec"]["sandboxTemplateRef"]["name"], "my-template")
 
     def test_invalid_shutdown_never_reaches_k8s_api(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -65,7 +65,7 @@ class TestSandboxClient(unittest.TestCase):
             
             sandbox = self.client.create_sandbox("test-template", "test-namespace")
             
-            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace", labels=None, lifecycle=None, warmpool=None)
+            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-template", "test-namespace", labels=None, lifecycle=ANY, warmpool=None)
             self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
             mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
             self.assertEqual(sandbox, mock_sandbox_instance)
@@ -206,7 +206,7 @@ class TestSandboxClient(unittest.TestCase):
             mock_create_claim.assert_called_once_with(
                 "sandbox-claim-1234abcd", "test-template", "test-namespace",
                 labels={"agent": "code-agent", "team": "platform"},
-                lifecycle=None,
+                lifecycle=ANY,
                 warmpool=None,
             )
 
@@ -310,21 +310,26 @@ class TestSandboxClient(unittest.TestCase):
             self.assertIn("shutdownTime", lifecycle)
 
     @patch('uuid.uuid4')
-    def test_create_sandbox_without_shutdown_after_seconds(self, mock_uuid):
+    def test_create_sandbox_uses_default_shutdown_after_seconds(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
 
         mock_sandbox_instance = MagicMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
+        frozen_now = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
         with patch.object(self.client, '_create_claim') as mock_create_claim, \
+             patch("k8s_agent_sandbox.utils.datetime") as mock_datetime, \
              patch.object(self.client, '_wait_for_sandbox_ready'):
+            mock_datetime.now.return_value = frozen_now
+            mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
 
             self.client.create_sandbox("test-template", "test-namespace")
 
             call_kwargs = mock_create_claim.call_args
             lifecycle = call_kwargs[1].get("lifecycle")
-            self.assertIsNone(lifecycle)
+            self.assertEqual(lifecycle["shutdownPolicy"], "Delete")
+            self.assertEqual(lifecycle["shutdownTime"], "2026-06-16T00:00:00Z")
 
     @patch("k8s_agent_sandbox.utils.datetime")
     def test_create_claim_with_lifecycle(self, mock_datetime):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -14,17 +14,23 @@
 
 from datetime import datetime, timedelta, timezone
 
+from .constants import DEFAULT_SHUTDOWN_AFTER_SECONDS
 
-def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
+
+def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int | None = None) -> dict[str, str]:
     """Construct a SandboxClaim lifecycle spec dict from a TTL in seconds.
 
     Returns a dict suitable for inclusion as ``spec.lifecycle`` in a
     SandboxClaim manifest, with ``shutdownTime`` set to *now + TTL* (UTC)
     and ``shutdownPolicy`` set to ``"Delete"``.
 
+    If no TTL is provided, a default 12 hour TTL is used.
+
     Raises ``ValueError`` if the input is not a positive integer or is
     too large for datetime arithmetic.
     """
+    if shutdown_after_seconds is None:
+        shutdown_after_seconds = DEFAULT_SHUTDOWN_AFTER_SECONDS
     if type(shutdown_after_seconds) is not int:
         raise ValueError(
             f"shutdown_after_seconds must be an integer, got {type(shutdown_after_seconds).__name__}"

--- a/site/content/docs/getting_started/sdk_reference/_index.md
+++ b/site/content/docs/getting_started/sdk_reference/_index.md
@@ -75,7 +75,8 @@ the underlying infrastructure.
 - `namespace` - Kubernetes namespace for the claim.
 - `sandbox_ready_timeout` - Seconds to wait for the sandbox to be ready.
 - `labels` - Optional Kubernetes labels to attach to the claim.
-- `shutdown_after_seconds` - Optional TTL in seconds. When set, the
+- `shutdown_after_seconds` - Optional TTL in seconds. Defaults to 12 hours.
+  When set, the
   claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
   of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
   of ``"Delete"``, so the controller auto-deletes the claim on

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -69,7 +69,7 @@ kubectl get sandbox dynamic-ephemeral-sandbox
 When creating a new sandbox via the `k8s_agent_sandbox` SDK, you can customize its readiness checks and lifecycle behavior using optional parameters:
 
 * **`sandbox_ready_timeout`**: The maximum time (in seconds) the client will wait for the sandbox environment to become ready before timing out.
-* **`shutdown_after_seconds`**: A Time-To-Live (TTL) integer in seconds. Setting this parameter tells the SDK to automatically populate the underlying Kubernetes claim's `spec.lifecycle` with a `shutdownPolicy` of `"Delete"` and schedule the deletion for *now + shutdown_after_seconds* (UTC). 
+* **`shutdown_after_seconds`**: A Time-To-Live (TTL) integer in seconds. The SDK defaults new sandbox claims to 12 hours. Setting this parameter overrides the default and tells the SDK to automatically populate the underlying Kubernetes claim's `spec.lifecycle` with a `shutdownPolicy` of `"Delete"` and schedule the deletion for *now + shutdown_after_seconds* (UTC).
 
 The following example demonstrates how to pass these parameters. Notice how the SDK handles the cluster cleanup policy for you:
 


### PR DESCRIPTION
## Summary
- default Python SDK-created SandboxClaims to a 12 hour lifecycle TTL
- default Go SDK-created SandboxClaims to a 12 hour lifecycle TTL
- update lifecycle docs and tests for the default TTL

## Testing
- `/tmp/agent-sandbox-venv/bin/pytest clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle.py clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py`
- `python3 -m py_compile clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py`

Not run locally: Go tests/gofmt because this container does not have `go` installed.