### PR TITLE
controllers: prevent sandbox-name-hash label override

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -788,6 +788,9 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		if k == sandboxLabel {
+			continue // Do not allow users to override the routing hash
+		}
 		podLabels[k] = v
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
@@ -875,6 +878,9 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		if k == sandboxLabel {
+			continue // Do not allow users to override the routing hash
+		}
 		if pod.Labels[k] != v {
 			pod.Labels[k] = v
 			updated = true

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -941,6 +941,58 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "prevent sandbox label override on Pod",
+			sandboxSpec: sandboxv1beta1.SandboxSpec{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					ObjectMeta: sandboxv1beta1.PodMetadata{
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "attacker-hash",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+					},
+				},
+			},
+			wantStatus: sandboxv1beta1.SandboxStatus{
+				Replicas:      1,
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonDependenciesNotReady,
+						Message:            "Pod exists with phase: ",
+					},
+				},
+			},
+			wantObjs: []client.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "test-container",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This change ensures that user-provided labels in the Sandbox spec cannot override the critical controller-managed 'agents.x-k8s.io/sandbox-name-hash' label on the Pod. This prevents attackers from hijacking traffic meant for other sandboxes by spoofing the routing label.

Fixes #511321750

This PR was generated by Overseer (powered by the gemini-3-flash-preview model).