### PR TITLE
Fix command injection in Docker build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY internal/ ./internal/
 
 # Build the binary with optimizations
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
-    -ldflags="-s -w -X sigs.k8s.io/agent-sandbox/internal/version.gitVersion=${GIT_VERSION} -X sigs.k8s.io/agent-sandbox/internal/version.gitSHA=${GIT_SHA} -X sigs.k8s.io/agent-sandbox/internal/version.buildDate=${BUILD_DATE}" \
+    -ldflags="-s -w -X sigs.k8s.io/agent-sandbox/internal/version.gitVersion='${GIT_VERSION}' -X sigs.k8s.io/agent-sandbox/internal/version.gitSHA='${GIT_SHA}' -X sigs.k8s.io/agent-sandbox/internal/version.buildDate='${BUILD_DATE}'" \
     -o /agent-sandbox-controller ./cmd/agent-sandbox-controller
 
 

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -23,8 +23,9 @@ from shared import utils
 def _get_version_build_args():
     """Returns build args for version info injection into Go binaries."""
     import datetime
-    git_version = utils.git_describe()
-    git_sha = utils.git_sha()
+    import shlex
+    git_version = shlex.quote(utils.git_describe())
+    git_sha = shlex.quote(utils.git_sha())
     build_date = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     return [
         f"--build-arg=GIT_VERSION={git_version}",


### PR DESCRIPTION
This PR fixes a command injection vulnerability where unsanitized git tags could be executed as part of a RUN command in the Dockerfile.

We now use `shlex.quote` in the python build script and added single quotes around the variables in the Dockerfile `ldflags`.

Fixes cluster-10029

Generated by Overseer (powered by the gemini-3-flash-preview model).