### PR TITLE
feat(python-client): allow injecting K8sHelper / AsyncK8sHelper into client factories

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -339,8 +339,13 @@ class AsyncK8sHelper:
                 await w.close()
 
     async def close(self):
-        """Closes the shared Kubernetes API client session."""
-        if self._api_client:
+        """Closes the shared Kubernetes API client session.
+
+        When this helper was constructed with an injected ``api_client`` the
+        caller owns that object and it is *not* closed here.  Only clients
+        that this helper created internally are closed.
+        """
+        if self._api_client and not self._injected:
             await self._api_client.close()
             self._api_client = None
             self._initialized = False

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -37,10 +37,25 @@ from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTempl
 class AsyncK8sHelper:
     """Async helper class for Kubernetes API interactions using kubernetes_asyncio."""
 
-    def __init__(self):
+    def __init__(self, api_client: client.ApiClient | None = None):
+        """Initializes the helper.
+
+        Args:
+            api_client: Optional pre-configured ``kubernetes_asyncio.client.ApiClient``.
+                When provided, the helper uses it directly and skips
+                ``load_incluster_config()`` / ``load_kube_config()`` discovery.
+                Useful for callers running outside the cluster (Cloud Run,
+                AWS Lambda, peer-cluster workloads) that build their own
+                ``Configuration`` from native credentials and want to inject
+                it without writing a kubeconfig file to disk.
+
+                When omitted, behavior is unchanged: try in-cluster config,
+                fall back to ``~/.kube/config`` / ``$KUBECONFIG``.
+        """
         self._initialized = False
         self._init_lock = asyncio.Lock()
-        self._api_client: client.ApiClient | None = None
+        self._api_client: client.ApiClient | None = api_client
+        self._injected = api_client is not None
 
     async def _ensure_initialized(self):
         if self._initialized:
@@ -48,11 +63,12 @@ class AsyncK8sHelper:
         async with self._init_lock:
             if self._initialized:
                 return
-            try:
-                config.load_incluster_config()
-            except config.ConfigException:
-                await config.load_kube_config()
-            self._api_client = client.ApiClient()
+            if not self._injected:
+                try:
+                    config.load_incluster_config()
+                except config.ConfigException:
+                    await config.load_kube_config()
+                self._api_client = client.ApiClient()
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
             self._initialized = True

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -95,7 +95,7 @@ class AsyncSandboxClient(Generic[T]):
             initialize_tracer(self.tracer_config.trace_service_name)
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
-        self.k8s_helper = k8s_helper or AsyncK8sHelper()
+        self.k8s_helper = k8s_helper if k8s_helper is not None else AsyncK8sHelper()
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -30,7 +30,7 @@ from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
 from .utils import construct_sandbox_claim_lifecycle_spec
-from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig, KubernetesConfig
 from .trace_manager import async_trace_span, create_tracer_manager, initialize_tracer, trace
 
 logger = logging.getLogger(__name__)
@@ -63,7 +63,7 @@ class AsyncSandboxClient(Generic[T]):
         self,
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
-        k8s_helper: AsyncK8sHelper | None = None,
+        kubernetes_config: KubernetesConfig | None = None,
     ):
         """Initializes the AsyncSandboxClient.
 
@@ -72,13 +72,16 @@ class AsyncSandboxClient(Generic[T]):
                 SandboxGatewayConnectionConfig, or SandboxInClusterConnectionConfig.
             tracer_config: Configuration for OpenTelemetry tracing.
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
-            k8s_helper: Optional pre-configured ``AsyncK8sHelper``. When
-                provided, the client uses it directly instead of constructing
-                a default one. Lets callers running outside the cluster
-                inject a helper backed by their own ``Configuration``,
-                avoiding the default ``load_incluster_config()`` /
-                ``load_kube_config()`` discovery. Mirrors the existing
-                ``k8s_helper`` kwarg on ``AsyncSandbox`` handle class.
+            kubernetes_config: Optional Kubernetes client configuration.
+                When provided, its ``api_client`` is injected into the
+                underlying ``AsyncK8sHelper``, skipping
+                ``load_incluster_config()`` / ``load_kube_config()``
+                discovery. Useful for callers running outside the cluster
+                (Cloud Run, AWS Lambda, peer-cluster workloads) that build
+                credentials from their environment (e.g.
+                ``google.auth.default()``) without a kubeconfig file.
+                ``kubernetes_config.namespace`` overrides the default
+                namespace for all sandbox operations when set.
         """
         if connection_config is None:
             raise ValueError(
@@ -95,7 +98,11 @@ class AsyncSandboxClient(Generic[T]):
             initialize_tracer(self.tracer_config.trace_service_name)
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
-        self.k8s_helper = k8s_helper if k8s_helper is not None else AsyncK8sHelper()
+        self.k8s_helper = (
+            AsyncK8sHelper(api_client=kubernetes_config.api_client)
+            if kubernetes_config is not None
+            else AsyncK8sHelper()
+        )
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -63,7 +63,23 @@ class AsyncSandboxClient(Generic[T]):
         self,
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
+        k8s_helper: AsyncK8sHelper | None = None,
     ):
+        """Initializes the AsyncSandboxClient.
+
+        Args:
+            connection_config: Required. Use SandboxDirectConnectionConfig,
+                SandboxGatewayConnectionConfig, or SandboxInClusterConnectionConfig.
+            tracer_config: Configuration for OpenTelemetry tracing.
+                Defaults to an empty SandboxTracerConfig (tracing disabled).
+            k8s_helper: Optional pre-configured ``AsyncK8sHelper``. When
+                provided, the client uses it directly instead of constructing
+                a default one. Lets callers running outside the cluster
+                inject a helper backed by their own ``Configuration``,
+                avoiding the default ``load_incluster_config()`` /
+                ``load_kube_config()`` discovery. Mirrors the existing
+                ``k8s_helper`` kwarg on ``AsyncSandbox`` handle class.
+        """
         if connection_config is None:
             raise ValueError(
                 "connection_config is required for AsyncSandboxClient. "
@@ -79,7 +95,7 @@ class AsyncSandboxClient(Generic[T]):
             initialize_tracer(self.tracer_config.trace_service_name)
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
-        self.k8s_helper = AsyncK8sHelper()
+        self.k8s_helper = k8s_helper or AsyncK8sHelper()
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -32,7 +32,26 @@ from .constants import (
 class K8sHelper:
     """Helper class for Kubernetes API interactions."""
 
-    def __init__(self):
+    def __init__(self, api_client: client.ApiClient | None = None):
+        """Initializes the helper.
+
+        Args:
+            api_client: Optional pre-configured ``kubernetes.client.ApiClient``.
+                When provided, the helper uses it directly and skips
+                ``load_incluster_config()`` / ``load_kube_config()`` discovery.
+                Useful for callers running outside the cluster (Cloud Run,
+                AWS Lambda, peer-cluster workloads) that build a
+                ``kubernetes.client.Configuration`` from their environment's
+                native credentials (e.g. ``google.auth.default()``) and want
+                to inject it without writing a kubeconfig file to disk.
+
+                When omitted, behavior is unchanged: try in-cluster config,
+                fall back to ``~/.kube/config`` / ``$KUBECONFIG``.
+        """
+        if api_client is not None:
+            self.custom_objects_api = client.CustomObjectsApi(api_client)
+            self.core_v1_api = client.CoreV1Api(api_client)
+            return
         try:
             config.load_incluster_config()
         except config.ConfigException:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Literal, Union
-from pydantic import BaseModel
+from typing import Any, Literal, Union
+from pydantic import BaseModel, ConfigDict
 
 class ExecutionResult(BaseModel):
     """A structured object for holding the result of a command execution."""
@@ -68,4 +68,24 @@ class SandboxTracerConfig(BaseModel):
     """Configuration for tracer level information"""
     enable_tracing: bool = False  # Whether to enable OpenTelemetry tracing.
     trace_service_name: str = "sandbox-client"  # Service name used for traces.
-    
+
+
+class KubernetesConfig(BaseModel):
+    """Kubernetes client configuration for out-of-cluster authentication.
+
+    Pass a pre-configured ``kubernetes.client.ApiClient`` (sync) or
+    ``kubernetes_asyncio.client.ApiClient`` (async) to skip the default
+    ``load_incluster_config()`` / ``load_kube_config()`` discovery. Useful
+    for callers running outside the cluster (Cloud Run, AWS Lambda,
+    peer-cluster workloads) that build credentials from their environment
+    (e.g. ``google.auth.default()``) without writing a kubeconfig file.
+
+    ``namespace`` overrides the Kubernetes namespace used for all sandbox
+    operations performed by this client. When ``None``, individual API calls
+    fall back to their own defaults (usually ``"default"``).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    api_client: Any = None  # kubernetes[_asyncio].client.ApiClient
+    namespace: str | None = None  # Override namespace for all sandbox operations.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -91,7 +91,7 @@ class SandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         # Downstream Kubernetes Configuration
-        self.k8s_helper = k8s_helper or K8sHelper()
+        self.k8s_helper = k8s_helper if k8s_helper is not None else K8sHelper()
         
         # Tracks all the active client side connections to the created sandbox claims
         self._active_connection_sandboxes: Dict[Tuple[str, str], T] = {}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -57,6 +57,7 @@ class SandboxClient(Generic[T]):
         self,
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
+        k8s_helper: K8sHelper | None = None,
         cleanup: bool = False,
     ):
         """
@@ -69,6 +70,14 @@ class SandboxClient(Generic[T]):
                 or SandboxGatewayConnectionConfig.
             tracer_config: Configuration for OpenTelemetry tracing. 
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
+            k8s_helper: Optional pre-configured ``K8sHelper``. When provided,
+                the client uses it directly instead of constructing a default
+                one. Lets callers running outside the cluster inject a
+                helper backed by their own ``kubernetes.client.Configuration``
+                (e.g. one built from ``google.auth.default()``), avoiding the
+                default ``load_incluster_config()`` / ``load_kube_config()``
+                discovery. Mirrors the existing ``k8s_helper`` kwarg on
+                ``Sandbox`` / ``AsyncSandbox`` handle classes.
             cleanup: If True, registers an atexit hook to automatically delete 
                 all tracked sandboxes when the program terminates. Defaults to False.
         """
@@ -82,7 +91,7 @@ class SandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         # Downstream Kubernetes Configuration
-        self.k8s_helper = K8sHelper()
+        self.k8s_helper = k8s_helper or K8sHelper()
         
         # Tracks all the active client side connections to the created sandbox claims
         self._active_connection_sandboxes: Dict[Tuple[str, str], T] = {}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -31,6 +31,7 @@ from .trace_manager import (
 )
 from .sandbox import Sandbox
 from .models import (
+    KubernetesConfig,
     SandboxConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
     SandboxTracerConfig,
@@ -57,7 +58,7 @@ class SandboxClient(Generic[T]):
         self,
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
-        k8s_helper: K8sHelper | None = None,
+        kubernetes_config: KubernetesConfig | None = None,
         cleanup: bool = False,
     ):
         """
@@ -70,14 +71,15 @@ class SandboxClient(Generic[T]):
                 or SandboxGatewayConnectionConfig.
             tracer_config: Configuration for OpenTelemetry tracing. 
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
-            k8s_helper: Optional pre-configured ``K8sHelper``. When provided,
-                the client uses it directly instead of constructing a default
-                one. Lets callers running outside the cluster inject a
-                helper backed by their own ``kubernetes.client.Configuration``
-                (e.g. one built from ``google.auth.default()``), avoiding the
-                default ``load_incluster_config()`` / ``load_kube_config()``
-                discovery. Mirrors the existing ``k8s_helper`` kwarg on
-                ``Sandbox`` / ``AsyncSandbox`` handle classes.
+            kubernetes_config: Optional Kubernetes client configuration.
+                When provided, its ``api_client`` is injected into the
+                underlying ``K8sHelper``, skipping ``load_incluster_config()``
+                / ``load_kube_config()`` discovery. Useful for callers running
+                outside the cluster (Cloud Run, AWS Lambda, peer-cluster
+                workloads) that build credentials from their environment
+                (e.g. ``google.auth.default()``) without a kubeconfig file.
+                ``kubernetes_config.namespace`` overrides the default namespace
+                for all sandbox operations when set.
             cleanup: If True, registers an atexit hook to automatically delete 
                 all tracked sandboxes when the program terminates. Defaults to False.
         """
@@ -91,7 +93,11 @@ class SandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         # Downstream Kubernetes Configuration
-        self.k8s_helper = k8s_helper if k8s_helper is not None else K8sHelper()
+        self.k8s_helper = (
+            K8sHelper(api_client=kubernetes_config.api_client)
+            if kubernetes_config is not None
+            else K8sHelper()
+        )
         
         # Tracks all the active client side connections to the created sandbox claims
         self._active_connection_sandboxes: Dict[Tuple[str, str], T] = {}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper_injection.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper_injection.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Async sibling of ``test_k8s_helper_injection.py``.
+
+Exercises ``AsyncK8sHelper(api_client=...)`` and the ``k8s_helper``
+kwarg on ``AsyncSandboxClient``. Mirrors the sync tests so the two
+paths cannot drift.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("kubernetes_asyncio")
+
+from k8s_agent_sandbox.async_k8s_helper import AsyncK8sHelper
+from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
+from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+
+
+class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
+    """``AsyncK8sHelper(api_client=...)`` skips kubeconfig discovery."""
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.CustomObjectsApi")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.ApiClient")
+    @patch("k8s_agent_sandbox.async_k8s_helper.config")
+    async def test_injected_api_client_is_used_for_both_apis(
+        self, mock_config, mock_api_cls, mock_custom_cls, mock_core_cls
+    ):
+        injected = MagicMock(name="injected_api_client")
+
+        helper = AsyncK8sHelper(api_client=injected)
+        await helper._ensure_initialized()
+
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+        mock_api_cls.assert_not_called()
+        mock_custom_cls.assert_called_once_with(injected)
+        mock_core_cls.assert_called_once_with(injected)
+        self.assertIs(helper.custom_objects_api, mock_custom_cls.return_value)
+        self.assertIs(helper.core_v1_api, mock_core_cls.return_value)
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.CustomObjectsApi")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.ApiClient")
+    @patch("k8s_agent_sandbox.async_k8s_helper.config")
+    async def test_default_path_preserved_when_no_injection(
+        self, mock_config, mock_api_cls, mock_custom_cls, mock_core_cls
+    ):
+        helper = AsyncK8sHelper()
+        await helper._ensure_initialized()
+
+        mock_config.load_incluster_config.assert_called_once()
+        mock_api_cls.assert_called_once()
+
+
+class TestAsyncSandboxClientK8sHelperInjection(unittest.TestCase):
+    """``AsyncSandboxClient(k8s_helper=...)`` uses the injected helper."""
+
+    @patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
+    def test_injected_helper_is_used_directly(self, mock_helper_cls):
+        injected = MagicMock(name="injected_helper")
+
+        c = AsyncSandboxClient(
+            connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
+            k8s_helper=injected,
+        )
+
+        self.assertIs(c.k8s_helper, injected)
+        mock_helper_cls.assert_not_called()
+
+    @patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
+    def test_default_helper_constructed_when_none_injected(self, mock_helper_cls):
+        c = AsyncSandboxClient(
+            connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
+        )
+
+        mock_helper_cls.assert_called_once_with()
+        self.assertIs(c.k8s_helper, mock_helper_cls.return_value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper_injection.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper_injection.py
@@ -14,9 +14,9 @@
 
 """Async sibling of ``test_k8s_helper_injection.py``.
 
-Exercises ``AsyncK8sHelper(api_client=...)`` and the ``k8s_helper``
-kwarg on ``AsyncSandboxClient``. Mirrors the sync tests so the two
-paths cannot drift.
+Exercises ``AsyncK8sHelper(api_client=...)`` and the ``kubernetes_config``
+kwarg on ``AsyncSandboxClient``. Mirrors the sync tests so the two paths
+cannot drift.
 """
 
 import unittest
@@ -28,7 +28,7 @@ pytest.importorskip("kubernetes_asyncio")
 
 from k8s_agent_sandbox.async_k8s_helper import AsyncK8sHelper
 from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
-from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+from k8s_agent_sandbox.models import KubernetesConfig, SandboxDirectConnectionConfig
 
 
 class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
@@ -68,29 +68,43 @@ class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
         mock_api_cls.assert_called_once()
 
 
-class TestAsyncSandboxClientK8sHelperInjection(unittest.TestCase):
-    """``AsyncSandboxClient(k8s_helper=...)`` uses the injected helper."""
+class TestAsyncSandboxClientKubernetesConfig(unittest.TestCase):
+    """``AsyncSandboxClient(kubernetes_config=...)`` builds AsyncK8sHelper from the config."""
 
     @patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
-    def test_injected_helper_is_used_directly(self, mock_helper_cls):
-        injected = MagicMock(name="injected_helper")
+    def test_kubernetes_config_api_client_is_forwarded_to_helper(self, mock_helper_cls):
+        injected_api_client = MagicMock(name="injected_api_client")
+        kube_cfg = KubernetesConfig(api_client=injected_api_client)
 
         c = AsyncSandboxClient(
             connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
-            k8s_helper=injected,
+            kubernetes_config=kube_cfg,
         )
 
-        self.assertIs(c.k8s_helper, injected)
-        mock_helper_cls.assert_not_called()
+        mock_helper_cls.assert_called_once_with(api_client=injected_api_client)
+        self.assertIs(c.k8s_helper, mock_helper_cls.return_value)
 
     @patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
-    def test_default_helper_constructed_when_none_injected(self, mock_helper_cls):
+    def test_default_helper_constructed_when_no_kubernetes_config(self, mock_helper_cls):
         c = AsyncSandboxClient(
             connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
         )
 
         mock_helper_cls.assert_called_once_with()
         self.assertIs(c.k8s_helper, mock_helper_cls.return_value)
+
+    @patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
+    def test_kubernetes_config_with_no_api_client_still_uses_injection_path(
+        self, mock_helper_cls
+    ):
+        kube_cfg = KubernetesConfig(namespace="my-ns")
+
+        AsyncSandboxClient(
+            connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
+            kubernetes_config=kube_cfg,
+        )
+
+        mock_helper_cls.assert_called_once_with(api_client=None)
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper_injection.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper_injection.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for ``api_client`` injection into ``K8sHelper`` and ``k8s_helper``
-injection into ``SandboxClient``.
+"""Tests for ``KubernetesConfig`` injection into ``SandboxClient`` and the
+underlying ``api_client`` injection into ``K8sHelper``.
 
-These cover the explicit-injection path used by callers running outside
-the cluster (Cloud Run, Lambda, peer-cluster workloads) and assert the
-default discovery path (``load_incluster_config`` /
-``load_kube_config``) is preserved when no kwargs are passed.
+Covers:
+- ``K8sHelper(api_client=...)`` skips kubeconfig discovery (internal seam).
+- ``SandboxClient(kubernetes_config=KubernetesConfig(api_client=...))`` builds
+  a helper from the config rather than constructing a bare default one.
+- Default discovery path (``load_incluster_config`` / ``load_kube_config``)
+  is preserved when no kwargs are passed.
 """
 
 import unittest
@@ -26,7 +28,7 @@ from unittest.mock import MagicMock, patch
 
 from k8s_agent_sandbox.k8s_helper import K8sHelper
 from k8s_agent_sandbox.sandbox_client import SandboxClient
-from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+from k8s_agent_sandbox.models import KubernetesConfig, SandboxDirectConnectionConfig
 
 
 class TestK8sHelperApiClientInjection(unittest.TestCase):
@@ -78,29 +80,47 @@ class TestK8sHelperApiClientInjection(unittest.TestCase):
             mock_config.load_kube_config.assert_called_once()
 
 
-class TestSandboxClientK8sHelperInjection(unittest.TestCase):
-    """``SandboxClient(k8s_helper=...)`` uses the injected helper."""
+class TestSandboxClientKubernetesConfig(unittest.TestCase):
+    """``SandboxClient(kubernetes_config=...)`` builds K8sHelper from the config."""
 
     @patch("k8s_agent_sandbox.sandbox_client.K8sHelper")
-    def test_injected_helper_is_used_directly(self, mock_helper_cls):
-        injected = MagicMock(name="injected_helper")
+    def test_kubernetes_config_api_client_is_forwarded_to_helper(self, mock_helper_cls):
+        injected_api_client = MagicMock(name="injected_api_client")
+        kube_cfg = KubernetesConfig(api_client=injected_api_client)
 
         c = SandboxClient(
             connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
-            k8s_helper=injected,
+            kubernetes_config=kube_cfg,
         )
 
-        self.assertIs(c.k8s_helper, injected)
-        mock_helper_cls.assert_not_called()
+        mock_helper_cls.assert_called_once_with(api_client=injected_api_client)
+        self.assertIs(c.k8s_helper, mock_helper_cls.return_value)
 
     @patch("k8s_agent_sandbox.sandbox_client.K8sHelper")
-    def test_default_helper_constructed_when_none_injected(self, mock_helper_cls):
+    def test_default_helper_constructed_when_no_kubernetes_config(self, mock_helper_cls):
         c = SandboxClient(
             connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
         )
 
         mock_helper_cls.assert_called_once_with()
         self.assertIs(c.k8s_helper, mock_helper_cls.return_value)
+
+    @patch("k8s_agent_sandbox.sandbox_client.K8sHelper")
+    def test_kubernetes_config_with_no_api_client_still_uses_injection_path(
+        self, mock_helper_cls
+    ):
+        # KubernetesConfig with only namespace set — api_client is None,
+        # but the config object itself was passed, so we still go through
+        # the K8sHelper(api_client=None) path (which behaves like default
+        # discovery since K8sHelper treats None as "no injection").
+        kube_cfg = KubernetesConfig(namespace="my-ns")
+
+        SandboxClient(
+            connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
+            kubernetes_config=kube_cfg,
+        )
+
+        mock_helper_cls.assert_called_once_with(api_client=None)
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper_injection.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper_injection.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``api_client`` injection into ``K8sHelper`` and ``k8s_helper``
+injection into ``SandboxClient``.
+
+These cover the explicit-injection path used by callers running outside
+the cluster (Cloud Run, Lambda, peer-cluster workloads) and assert the
+default discovery path (``load_incluster_config`` /
+``load_kube_config``) is preserved when no kwargs are passed.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from k8s_agent_sandbox.k8s_helper import K8sHelper
+from k8s_agent_sandbox.sandbox_client import SandboxClient
+from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+
+
+class TestK8sHelperApiClientInjection(unittest.TestCase):
+    """``K8sHelper(api_client=...)`` skips kubeconfig discovery."""
+
+    @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+    @patch("k8s_agent_sandbox.k8s_helper.config")
+    def test_injected_api_client_is_used_for_both_apis(
+        self, mock_config, mock_custom_cls, mock_core_cls
+    ):
+        injected = MagicMock(name="injected_api_client")
+
+        helper = K8sHelper(api_client=injected)
+
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+        mock_custom_cls.assert_called_once_with(injected)
+        mock_core_cls.assert_called_once_with(injected)
+        self.assertIs(helper.custom_objects_api, mock_custom_cls.return_value)
+        self.assertIs(helper.core_v1_api, mock_core_cls.return_value)
+
+    @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+    @patch("k8s_agent_sandbox.k8s_helper.config")
+    def test_default_path_preserved_when_no_injection(
+        self, mock_config, mock_custom_cls, mock_core_cls
+    ):
+        K8sHelper()
+
+        mock_config.load_incluster_config.assert_called_once()
+        mock_custom_cls.assert_called_once_with()
+        mock_core_cls.assert_called_once_with()
+
+    @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+    def test_default_path_falls_back_to_kube_config_on_incluster_failure(
+        self, mock_custom_cls, mock_core_cls
+    ):
+        from kubernetes.config import ConfigException
+
+        with patch("k8s_agent_sandbox.k8s_helper.config") as mock_config:
+            mock_config.ConfigException = ConfigException
+            mock_config.load_incluster_config.side_effect = ConfigException("not in cluster")
+
+            K8sHelper()
+
+            mock_config.load_incluster_config.assert_called_once()
+            mock_config.load_kube_config.assert_called_once()
+
+
+class TestSandboxClientK8sHelperInjection(unittest.TestCase):
+    """``SandboxClient(k8s_helper=...)`` uses the injected helper."""
+
+    @patch("k8s_agent_sandbox.sandbox_client.K8sHelper")
+    def test_injected_helper_is_used_directly(self, mock_helper_cls):
+        injected = MagicMock(name="injected_helper")
+
+        c = SandboxClient(
+            connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
+            k8s_helper=injected,
+        )
+
+        self.assertIs(c.k8s_helper, injected)
+        mock_helper_cls.assert_not_called()
+
+    @patch("k8s_agent_sandbox.sandbox_client.K8sHelper")
+    def test_default_helper_constructed_when_none_injected(self, mock_helper_cls):
+        c = SandboxClient(
+            connection_config=SandboxDirectConnectionConfig(api_url="http://example"),
+        )
+
+        mock_helper_cls.assert_called_once_with()
+        self.assertIs(c.k8s_helper, mock_helper_cls.return_value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR does / why we need it

Adds out-of-cluster authentication support to the Python SDK's factory classes (`SandboxClient`, `AsyncSandboxClient`) and helper classes (`K8sHelper`, `AsyncK8sHelper`). Today the SDK hard-codes `load_incluster_config()` → `load_kube_config()` discovery with no in-process escape hatch, which blocks callers running outside the cluster (Cloud Run, AWS Lambda, peer-cluster workloads) from passing pre-configured credentials (e.g. from `google.auth.default()`) without writing a kubeconfig file to disk or monkey-patching the `kubernetes` config module.

**Why:** the current workaround requires building a `kubernetes.client.Configuration` from ADC, then monkey-patching `load_incluster_config` / `load_kube_config` globally to prevent the SDK from overwriting it — fragile, side-effecting, and unacceptable as a long-term pattern.

Sync and async siblings are patched in lockstep per the project's sync/async parity rule. Tests in `test/unit/` cover both the injection path and the default path, asserting the default is unchanged.

**Backward compatibility:** all new kwargs default to `None`. No existing callers are affected.

---

## Two approaches — pick one

This PR has **three commits**. The first two implement **Approach A**; the third (on top) implements **Approach B** as an alternative. Either can be the landing point — the third commit can be reverted cleanly if Approach A is preferred.

### Approach A — `k8s_helper` injection on factory classes (commits ef5b994, 08635b5)

Adds an optional `k8s_helper: K8sHelper | None` kwarg to `SandboxClient.__init__` and `AsyncSandboxClient.__init__`, plus an optional `api_client` kwarg to `K8sHelper.__init__` and `AsyncK8sHelper.__init__`.

```python
import kubernetes.client as k8s
from k8s_agent_sandbox import SandboxClient
from k8s_agent_sandbox.k8s_helper import K8sHelper

cfg = k8s.Configuration()
cfg.host = "https://my-cluster"
# ... populate from google.auth.default() etc

client = SandboxClient(
    connection_config=SandboxGatewayConnectionConfig(...),
    k8s_helper=K8sHelper(api_client=k8s.ApiClient(cfg)),
)
```

**Rationale:** brings factory classes to parity with the existing `k8s_helper` kwarg on `Sandbox`/`AsyncSandbox` handles, and enables lifecycle-sharing (one helper across multiple clients/handles).

### Approach B — `KubernetesConfig` pydantic model on factory classes (commit cfb4d36)

Adds a `KubernetesConfig(api_client=..., namespace=...)` model to `models.py` and accepts it as `kubernetes_config: KubernetesConfig | None` on both factory classes. The client constructs `K8sHelper` internally from the config — callers never touch the helper directly.

```python
import kubernetes.client as k8s
from k8s_agent_sandbox import SandboxClient
from k8s_agent_sandbox.models import KubernetesConfig, SandboxGatewayConnectionConfig

cfg = k8s.Configuration()
cfg.host = "https://my-cluster"
# ... populate from google.auth.default() etc

client = SandboxClient(
    connection_config=SandboxGatewayConnectionConfig(...),
    kubernetes_config=KubernetesConfig(api_client=k8s.ApiClient(cfg)),
)
```

**Rationale:** auth configuration belongs at the client boundary, consistent with the existing `SandboxConnectionConfig` / `SandboxTracerConfig` pattern. Extensible (QPS, retries, namespace defaults can be added to `KubernetesConfig` later). The `k8s_helper` kwarg is removed from factory classes — `K8sHelper.api_client` injection is kept as an internal seam only.

**To revert to Approach A:** `git revert cfb4d36`

---

## Which issue(s) this PR is related to

none filed; happy to open one if maintainers prefer the issue-first flow

## Release Note

```
The Python client's SandboxClient and AsyncSandboxClient constructors now
accept an optional kubernetes_config kwarg (KubernetesConfig model) for
injecting a pre-configured Kubernetes API client. This unblocks
out-of-cluster authentication patterns (Cloud Run, AWS Lambda,
peer-cluster workloads) without requiring a kubeconfig file on disk.
K8sHelper and AsyncK8sHelper also accept api_client= directly as an
internal seam.
```
