### PR TITLE
Adds `cleanup=True` support to `AsyncSandboxClient`

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -20,6 +20,7 @@ Requires the ``async`` optional dependencies::
 """
 
 import asyncio
+import atexit
 import logging
 import re
 import time
@@ -51,10 +52,13 @@ class AsyncSandboxClient(Generic[T]):
     ``connection_config`` is required — the async client does not support
     ``SandboxLocalTunnelConnectionConfig``.
 
-    Unlike the sync ``SandboxClient``, there is no ``atexit`` fallback because
-    async cleanup cannot run in an atexit handler. Use the ``async with``
-    context manager or explicitly call ``await client.delete_all()`` followed
-    by ``await client.close()`` to avoid orphaned claims.
+    Pass ``cleanup=True`` to register an atexit hook that deletes all tracked
+    sandboxes on program termination::
+
+        client = AsyncSandboxClient(connection_config=config, cleanup=True)
+
+    Alternatively, use the ``async with`` context manager or explicitly call
+    ``await client.delete_all()`` followed by ``await client.close()``.
     """
 
     sandbox_class: type[T] = AsyncSandbox  # type: ignore
@@ -63,7 +67,21 @@ class AsyncSandboxClient(Generic[T]):
         self,
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
+        cleanup: bool = False,
     ):
+        """
+        Args:
+            connection_config: Configuration for connecting to the sandboxes.
+                Required — the async client does not support
+                ``SandboxLocalTunnelConnectionConfig``.
+            tracer_config: Configuration for OpenTelemetry tracing.
+                Defaults to an empty SandboxTracerConfig (tracing disabled).
+            cleanup: If True, registers an atexit hook to automatically delete
+                all tracked sandboxes when the program terminates. The hook
+                runs ``asyncio.run(self.delete_all())`` after the main event
+                loop has exited, creating a short-lived loop for cleanup.
+                Defaults to False.
+        """
         if connection_config is None:
             raise ValueError(
                 "connection_config is required for AsyncSandboxClient. "
@@ -83,6 +101,11 @@ class AsyncSandboxClient(Generic[T]):
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()
+
+        # asyncio.run() creates a fresh event loop, safe to call from atexit
+        # after the main loop has already exited.
+        if cleanup:
+            atexit.register(lambda: asyncio.run(self.delete_all()))
 
     async def __aenter__(self) -> "AsyncSandboxClient[T]":
         return self

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -202,6 +202,20 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             AsyncSandboxClient(connection_config=None)
         self.assertIn("connection_config is required", str(ctx.exception))
 
+    def test_cleanup_true_registers_atexit(self):
+        """cleanup=True should register an atexit handler that calls delete_all."""
+        with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:
+            AsyncSandboxClient(connection_config=self.config, cleanup=True)
+            mock_atexit.register.assert_called_once()
+            registered_fn = mock_atexit.register.call_args[0][0]
+            self.assertTrue(callable(registered_fn))
+
+    def test_cleanup_false_does_not_register_atexit(self):
+        """cleanup=False (default) should not register any atexit handler."""
+        with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:
+            AsyncSandboxClient(connection_config=self.config, cleanup=False)
+            mock_atexit.register.assert_not_called()
+
     async def test_validate_labels_rejects_invalid_value(self):
         with self.assertRaises(ValueError):
             await self.client.create_sandbox("t", labels={"agent": "invalid value!"})


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->