### PR TITLE
add an AKS example using kata container and sandbox warm pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ hermes-sandbox-knowledge.md
 .idea
 .ship
 .claude
+.vscode

--- a/extensions/examples/kata-aks/README.md
+++ b/extensions/examples/kata-aks/README.md
@@ -42,7 +42,7 @@ with `I am bob's agent`, the routing is broken.
 | File | Purpose |
 | --- | --- |
 | [`agent/`](agent/) | Source for the owner-aware FastAPI agent: `agent.py`, `Dockerfile`, `requirements.txt`. Build it into your ACR (Step 2). |
-| [`sandboxtemplate.yaml`](sandboxtemplate.yaml) | Admin-owned blueprint: agent container + AKS Pod Sandboxing runtime + Foundry Secret references + per-template NetworkPolicy. |
+| [`sandboxtemplate.yaml`](sandboxtemplate.yaml) | Admin-owned blueprint: agent container + AKS Pod Sandboxing runtime + OpenAI-compatible endpoint Secret references + per-template NetworkPolicy. |
 | [`sandboxwarmpool.yaml`](sandboxwarmpool.yaml) | Pre-warms N Kata agent pods so claim adoption is fast. |
 | [`sandboxclaim.yaml`](sandboxclaim.yaml) | User-facing claim that adopts one agent sandbox from the pool. |
 | [`router.yaml`](router.yaml) | The sandbox-router `Deployment`, a `ClusterIP` Service for in-cluster callers, and a `LoadBalancer` Service for the public Azure LB IP. |
@@ -145,14 +145,21 @@ on `sandbox-agent-demo` across all the YAML files in this directory
 
 ## Step 1 — Create the model endpoint Secret
 
-The agent reads three values from a `Secret` named
+**What you need:** an **OpenAI-compatible v1 REST endpoint** for chat
+completions — i.e. something that accepts `POST /chat/completions`
+against the OpenAI Python client. Any provider that speaks that API
+will work without code changes: Microsoft Foundry, Azure OpenAI,
+OpenAI directly, Together, Anyscale, a self-hosted vLLM, etc. Pick
+one, grab its base URL, API key, and model (or deployment) name.
+
+The agent reads those three values from a `Secret` named
 `azure-foundry` in the same namespace as the template:
 
-| Key | Example (Azure OpenAI) | Example (OpenAI) |
-| --- | --- | --- |
-| `OPENAI_BASE_URL` | `https://<resource>.openai.azure.com/openai/v1/` | `https://api.openai.com/v1` |
-| `OPENAI_API_KEY` | Azure OpenAI key | OpenAI API key |
-| `LLM_MODEL` | `gpt-4o` (deployment name) | `gpt-4o` (model name) |
+| Key | Description | Example (Microsoft Foundry / Azure OpenAI) | Example (OpenAI) |
+| --- | --- | --- | --- |
+| `OPENAI_BASE_URL` | OpenAI-compatible v1 base URL | `https://<resource>.openai.azure.com/openai/v1/` | `https://api.openai.com/v1` |
+| `OPENAI_API_KEY` | API key for that endpoint | Azure OpenAI key | OpenAI API key |
+| `LLM_MODEL` | Model (or deployment) name to call | `gpt-4o` (deployment name) | `gpt-4o` (model name) |
 
 ```bash
 kubectl create secret generic azure-foundry \
@@ -165,16 +172,17 @@ kubectl create secret generic azure-foundry \
 The Secret name (`azure-foundry`) and the three keys above are what
 [`sandboxtemplate.yaml`](sandboxtemplate.yaml) references via
 `secretKeyRef`, and [`agent/agent.py`](agent/agent.py) reads them
-out of the environment under those exact names. If you rename any
-of them, update both files to match.
+out of the environment under those exact names. The Secret name is
+historical — feel free to rename it to something provider-neutral if
+you prefer, but update both files to match.
 
 ### Switching providers
 
-The agent uses the upstream `openai` Python client — anything that speaks
-the OpenAI v1 `/chat/completions` API (Azure OpenAI, OpenAI directly,
-Together, Anyscale, self-hosted vLLM, …) will work without any code change.
-Just point the Secret's `OPENAI_BASE_URL` and `OPENAI_API_KEY` at the
-provider you want and put their model name in `LLM_MODEL`.
+Because the agent only assumes the OpenAI v1 `/chat/completions`
+shape, swapping providers is a Secret-only change: point
+`OPENAI_BASE_URL` and `OPENAI_API_KEY` at the new endpoint and put
+the right model identifier in `LLM_MODEL`. No image rebuild, no code
+edits.
 
 ## Step 2 — Build the agent image into your ACR
 

--- a/extensions/examples/kata-aks/README.md
+++ b/extensions/examples/kata-aks/README.md
@@ -1,0 +1,577 @@
+# Kata-Isolated Per-Owner Agent Warm Pool on AKS
+
+This example shows how to combine the `agent-sandbox` extension CRDs with
+the **AKS Pod Sandboxing** feature (Kata Containers on Microsoft Hyper-V)
+to run a fleet of owner-aware AI agents on Azure Kubernetes Service.
+Every user gets their own agent process inside its own lightweight VM,
+and all users share a single public IP fronted by a header-routed proxy
+so a request tagged for Alice always lands on Alice's pod.
+
+The agent itself is a small FastAPI shim over an OpenAI-compatible
+chat endpoint (Microsoft Foundry, Azure OpenAI, vanilla OpenAI, …).
+It reads the caller's identity from the `X-Owner` HTTP header, bakes
+it into the system prompt, and tells the model to begin every reply
+with `I am <owner>'s agent.` That gives you a **falsifiable,
+end-to-end proof of routing**: if Alice ever sees a reply that begins
+with `I am bob's agent`, the routing is broken.
+
+## What you get
+
+- A `SandboxTemplate` that pins
+  `runtimeClassName: kata-vm-isolation` (the AKS Pod Sandboxing
+  RuntimeClass) so every pod produced from it is scheduled onto a Kata
+  micro-VM, plus a node selector and toleration that pin the pods to
+  the Kata-capable node pool, plus a `NetworkPolicy` that allows only
+  the router pods to reach the agent port.
+- A `SandboxWarmPool` that pre-creates a handful of Kata sandboxes so
+  claims do not pay the Kata cold-start cost.
+- A `SandboxClaim` that a regular user submits to grab one agent
+  sandbox out of the pool.
+- A `sandbox-router` Deployment + two Services (ClusterIP for
+  in-cluster, LoadBalancer for the public Azure LB IP) that proxies
+  user requests to the correct per-user pod based on HTTP headers.
+- A runnable Go program (`client/`) that uses the Go SDK to
+  provision a sandbox per owner (one-shot or long-lived), chats with
+  it through the public IP, and asserts the reply names the right
+  owner.
+- An agent that keeps an in-process per-owner chat history, so a
+  `-reuse`d sandbox supports real multi-turn conversations.
+
+## Files in this directory
+
+| File | Purpose |
+| --- | --- |
+| [`agent/`](agent/) | Source for the owner-aware FastAPI agent: `agent.py`, `Dockerfile`, `requirements.txt`. Build it into your ACR (Step 2). |
+| [`sandboxtemplate.yaml`](sandboxtemplate.yaml) | Admin-owned blueprint: agent container + AKS Pod Sandboxing runtime + Foundry Secret references + per-template NetworkPolicy. |
+| [`sandboxwarmpool.yaml`](sandboxwarmpool.yaml) | Pre-warms N Kata agent pods so claim adoption is fast. |
+| [`sandboxclaim.yaml`](sandboxclaim.yaml) | User-facing claim that adopts one agent sandbox from the pool. |
+| [`router.yaml`](router.yaml) | The sandbox-router `Deployment`, a `ClusterIP` Service for in-cluster callers, and a `LoadBalancer` Service for the public Azure LB IP. |
+| [`client/main.go`](client/main.go) | Runnable Go program that uses the agent-sandbox Go SDK to provision an agent sandbox (one-shot or `-reuse`d) and chat with it through the public IP. |
+
+## Prerequisites
+
+All commands below assume you have the Azure CLI (`az`) and `kubectl`
+available locally, and that `az login` has selected the subscription
+you want to deploy into.
+
+1. **An AKS cluster with the `agent-sandbox` controller plus its
+   extensions installed.** Follow the install instructions in the
+   project root README of this repository. You need the `Sandbox` core
+   CRD and the `SandboxTemplate` / `SandboxWarmPool` / `SandboxClaim`
+   extension CRDs.
+
+2. **A Kata-capable AKS node pool with the `kata-vm-isolation`
+   RuntimeClass registered.** AKS exposes Kata Containers through the
+   "Pod Sandboxing" feature, which requires Azure Linux nodes and a
+   Gen2 VM SKU that supports nested virtualisation (D-series v3/v4/v5,
+   etc.). The RuntimeClass name is `kata-vm-isolation` on the rollouts
+   that this example targets (newer Microsoft documentation sometimes
+   calls it `kata-mshv-vm-isolation` — same feature, different label;
+   the template, selectors and taints are all wired to
+   `kata-vm-isolation`). Create the pool with
+   `--workload-runtime KataMshvVmIsolation` — the RuntimeClass is
+   registered automatically when at least one such node joins the
+   cluster:
+
+   ```bash
+   # One-time per cluster: register the preview feature (if not already).
+   az feature register --namespace Microsoft.ContainerService --name KataVMIsolationPreview
+   az provider register --namespace Microsoft.ContainerService
+
+   # Add a Kata-capable node pool (Azure Linux + Gen2 D-series). AKS
+   # will label the nodes `kubernetes.azure.com/kata-vm-isolation=true`
+   # and taint them `kata=enabled:NoSchedule` so general workloads do
+   # not land on the pool by accident.
+   az aks nodepool add \
+     --resource-group <rg> \
+     --cluster-name <aks-cluster> \
+     --name sandboxagent \
+     --os-sku AzureLinux \
+     --workload-runtime KataMshvVmIsolation \
+     --node-vm-size Standard_D4s_v3 \
+     --node-count 2
+
+   # Verify:
+   kubectl get runtimeclass kata-vm-isolation
+   kubectl get nodes -L kubernetes.azure.com/kata-vm-isolation -L agentpool
+   ```
+
+   [`sandboxtemplate.yaml`](sandboxtemplate.yaml) already pins
+   scheduling to nodes labelled
+   `kubernetes.azure.com/kata-vm-isolation: "true"` and adds a matching
+   toleration for the `kata=enabled:NoSchedule` taint that AKS applies
+   to those nodes.
+
+3. **A NetworkPolicy-aware CNI on the cluster.** AKS supports policy
+   enforcement via Azure Network Policy Manager, Calico, or Cilium
+   (Azure CNI Powered by Cilium). Pick one at cluster create time —
+   e.g. `--network-plugin azure --network-policy cilium` for Azure CNI
+   Powered by Cilium. Clusters without a policy engine will silently
+   ignore the `NetworkPolicy` this example renders and your isolation
+   guarantees will be weaker than what this document claims.
+
+4. **An Azure Container Registry attached to the cluster.** Used to
+   build and host the agent image in Step 2. AKS attaches an ACR with:
+
+   ```bash
+   az aks update --resource-group <rg> --name <aks-cluster> --attach-acr <your-acr>
+   ```
+
+5. **Access to a Microsoft Foundry / Azure OpenAI deployment exposing
+   the OpenAI-compatible `/openai/v1/` endpoint.** You will need the
+   base URL, an API key, and a model deployment name. Any other
+   OpenAI-compatible endpoint works too — see "Switching providers"
+   near the bottom.
+
+6. **Go 1.22+** on your workstation if you want to run the SDK demo
+   in Step 6.
+
+## Step 0 — Create the demo namespace
+
+Everything in this example — the `Secret`, `SandboxTemplate`,
+`SandboxWarmPool`, `SandboxClaim`, router `Deployment` and Services —
+lives in a dedicated namespace so you can tear the whole demo down
+with one `kubectl delete namespace`. Every YAML file in this directory
+pins `metadata.namespace: sandbox-agent-demo`, and every `kubectl`
+command in the steps below passes `-n sandbox-agent-demo` explicitly so
+nothing accidentally lands in `default`.
+
+```bash
+kubectl create namespace sandbox-agent-demo
+```
+
+If you would rather use a different namespace, do a find-and-replace
+on `sandbox-agent-demo` across all the YAML files in this directory
+(and in [`client/main.go`](client/main.go)) before you start.
+
+## Step 1 — Create the Foundry Secret
+
+The agent reads three values from a `Secret` named
+`azure-foundry` in the same namespace as the template:
+
+| Key | Where it comes from |
+| --- | --- |
+| `AZURE_FOUNDRY_BASE_URL` | Your Foundry / Azure OpenAI resource's v1 endpoint, e.g. `https://<resource>.openai.azure.com/openai/v1/`. |
+| `AZURE_FOUNDRY_API_KEY` | KEY 1 or KEY 2 from the same resource's "Keys and Endpoint" view. |
+| `AZURE_FOUNDRY_MODEL` | The model deployment name (e.g. `gpt-4o`, `gpt-5.4-mini`). |
+
+```bash
+kubectl create secret generic azure-foundry \
+  -n sandbox-agent-demo \
+  --from-literal=AZURE_FOUNDRY_BASE_URL="https://<resource>.openai.azure.com/openai/v1/" \
+  --from-literal=AZURE_FOUNDRY_API_KEY="<your-azure-foundry-key>" \
+  --from-literal=AZURE_FOUNDRY_MODEL="gpt-4o"
+```
+
+The Secret name (`azure-foundry`) is what
+[`sandboxtemplate.yaml`](sandboxtemplate.yaml) references via
+`secretKeyRef`. If you rename the Secret, update the template too.
+
+### Switching providers
+
+The agent uses the upstream `openai` Python client pointed at
+`AZURE_FOUNDRY_BASE_URL` — anything that speaks the OpenAI v1
+`/chat/completions` shape (OpenAI directly, Together, Anyscale,
+self-hosted vLLM, …) will work without any code change. Just point the
+Secret's `AZURE_FOUNDRY_BASE_URL` and `AZURE_FOUNDRY_API_KEY` at the
+provider you want and put their model name in `AZURE_FOUNDRY_MODEL`.
+
+## Step 2 — Build the agent image into your ACR
+
+[`agent/`](agent/) contains the full source: `agent.py` (FastAPI +
+the OpenAI client + per-owner chat history), a `Dockerfile`, and
+`requirements.txt`. Build it into your ACR with `az acr build` — no
+local Docker needed:
+
+```bash
+ACR_NAME=<your-acr-name>          # the short name, not the full login server
+export AGENT_IMAGE="$ACR_NAME.azurecr.io/kata-owner-agent:v1"
+
+az acr build \
+  --registry "$ACR_NAME" \
+  --image kata-owner-agent:v1 \
+  --file agent/Dockerfile \
+  agent/
+```
+
+`$AGENT_IMAGE` is what [`sandboxtemplate.yaml`](sandboxtemplate.yaml)
+substitutes via `envsubst` in the next step.
+
+## Step 3 — Apply the template and warm pool (admin)
+
+These two objects are typically managed by a cluster admin or platform
+team and are reused across many users:
+
+```bash
+envsubst < sandboxtemplate.yaml | kubectl apply -f -
+kubectl apply -f sandboxwarmpool.yaml
+```
+
+Watch the pool fill with pre-warmed Kata sandboxes:
+
+```bash
+kubectl get sandboxwarmpool kata-aks-warmpool -n sandbox-agent-demo -w
+kubectl get sandboxes -n sandbox-agent-demo
+kubectl get pods -n sandbox-agent-demo -o wide   # RUNTIME_CLASS column should show kata-vm-isolation
+```
+
+Confirm the NetworkPolicy was rendered for the template:
+
+```bash
+kubectl get networkpolicy -n sandbox-agent-demo
+```
+
+## Step 4 — Claim a sandbox (user)
+
+A normal user (or the Go SDK on their behalf, see Step 6) creates a
+`SandboxClaim`:
+
+```bash
+kubectl apply -f sandboxclaim.yaml
+kubectl get sandboxclaim my-aks-agent -n sandbox-agent-demo -o yaml
+```
+
+The controller adopts one of the pre-warmed Kata pods into the claim
+and writes the adopted sandbox name into `status.sandbox.name`. The
+`SandboxWarmPool` then provisions a replacement to keep the pool at
+its target size.
+
+> **`kubectl port-forward` will not work for Kata pods.** kubelet
+> implements port-forward by entering the *host* network namespace and
+> dialing `127.0.0.1:<port>`, but the agent listener lives inside the
+> Kata guest VM, not on the host. The connection is refused. Reach
+> the agent through the in-cluster router (Step 5) or `kubectl exec`
+> into the pod and curl `127.0.0.1:8080` from there.
+
+## Step 5 — Stand up the sandbox-router
+
+The router is a small reverse proxy. It takes incoming HTTP requests
+carrying three headers — `X-Sandbox-ID`, `X-Sandbox-Namespace`,
+`X-Sandbox-Port` — and forwards each request to the matching per-user
+pod via the headless Service that `sandboxtemplate.yaml` instructs the
+controller to create (`service: true`). It also forwards every other
+header through untouched, which is how `X-Owner` reaches the agent.
+
+The router is the **only** ingress source allowed by the template's
+NetworkPolicy, so all sandbox-bound traffic must flow through it.
+
+### Pick a router image
+
+The router is a **separate component** from the agent you built in
+Step 2. The agent is the per-user FastAPI pod that talks to Foundry;
+the router is a small reverse proxy that sits in front of every agent
+pod and forwards requests based on the `X-Sandbox-*` headers. Its
+source lives in the main `agent-sandbox` repo (not in this directory),
+and the project publishes it as a public SIG staging image so you do
+not need to build it yourself:
+
+```text
+us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router:latest-main
+```
+
+This is a public Google Artifact Registry image — AKS can pull it
+directly without any registry attach, credentials, or workload-identity
+plumbing. For a pinned deployment, replace `latest-main` with the
+project release tag you are using.
+
+```bash
+export ROUTER_IMAGE="us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router:latest-main"
+```
+
+### Deploy the router
+
+[`router.yaml`](router.yaml) declares two Services pointed at the same
+router pods — a `ClusterIP` (`sandbox-router-svc`) for in-cluster
+callers and the NetworkPolicy, plus a `LoadBalancer`
+(`sandbox-router-public`) that AKS fronts with an Azure Standard Load
+Balancer public IP.
+
+Substitute the image and apply (`envsubst` ships in the
+`gettext-base` package on most distros):
+
+```bash
+envsubst < router.yaml | kubectl apply -f -
+
+kubectl rollout status deployment/sandbox-router-deployment -n sandbox-agent-demo
+kubectl get pods -n sandbox-agent-demo -l app=sandbox-router
+```
+
+Wait for AKS to allocate the public IP (usually under a minute):
+
+```bash
+kubectl get svc sandbox-router-public -n sandbox-agent-demo -w
+# When EXTERNAL-IP shows a real address, grab it:
+export ROUTER_BASE_URL="http://$(kubectl get svc sandbox-router-public \
+  -n sandbox-agent-demo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+echo "$ROUTER_BASE_URL"
+```
+
+That URL is the single public entrypoint for every user's sandbox.
+
+### Smoke-test from your laptop
+
+Pick any pod from the warm pool and send a chat request to it,
+identifying yourself with `X-Owner`:
+
+```bash
+SANDBOX=$(kubectl get sandbox -n sandbox-agent-demo \
+  -l agents.x-k8s.io/warm-pool-sandbox \
+  -o jsonpath='{.items[0].metadata.name}')
+
+curl -s "$ROUTER_BASE_URL/chat" \
+  -H 'Content-Type: application/json' \
+  -H "X-Sandbox-ID: $SANDBOX" \
+  -H 'X-Sandbox-Namespace: sandbox-agent-demo' \
+  -H 'X-Sandbox-Port: 8080' \
+  -H 'X-Owner: alice' \
+  -d '{"prompt":"In one sentence, introduce yourself."}'
+```
+
+You should see something like:
+
+```json
+{"owner":"alice","reply":"I am alice's agent. I'm alice's personal AI assistant in a private sandbox.","history_turns":1}
+```
+
+Repeat with `-H 'X-Owner: bob'` and a different pod name — the reply
+will begin with `I am bob's agent.` That `I am <owner>'s agent.`
+prefix is the routing proof: it can only show the right name if the
+agent really did receive the `X-Owner` header from the router, which
+means the request really did land on the per-user pod you addressed.
+
+## Step 6 — Chat with the agent via the Go SDK
+
+For real workloads each user (or each agent process) should manage
+their own `SandboxClaim` via the Go SDK rather than hand-applying
+YAML. [`client/main.go`](client/main.go) is a tiny CLI that does
+exactly that. It supports two modes:
+
+- **One-shot** (default): create a fresh claim, send one prompt, tear
+  the claim down on exit.
+- **`-reuse`**: keep the same claim across invocations so each call
+  lands on the same Kata pod — which is what unlocks multi-turn
+  conversations, since the agent keeps per-owner history in process
+  memory.
+
+### Add the dependency (only if you're copying the client into your own project)
+
+From the directory containing your `go.mod`:
+
+```bash
+go get sigs.k8s.io/agent-sandbox/clients/go/sandbox
+```
+
+The in-repo `client/` already has this wired up, so for this demo you
+can just `go run ./client` from this directory.
+
+### Point the client at the router
+
+```bash
+export ROUTER_BASE_URL="http://$(kubectl get svc sandbox-router-public \
+  -n sandbox-agent-demo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+echo "$ROUTER_BASE_URL"
+```
+
+### One-shot: claim, chat, tear down
+
+```bash
+go run ./client -name alice -msg "In one sentence, introduce yourself."
+```
+
+What happens end-to-end:
+
+1. The SDK creates a `SandboxClaim`. The `kata-aks-warmpool` adopts a
+   pre-warmed Kata pod into it, so the claim becomes Ready in a
+   couple of seconds.
+2. The client POSTs `/chat` to `$ROUTER_BASE_URL` with `X-Sandbox-ID`
+   set to the adopted sandbox name and `X-Owner: alice`.
+3. The router forwards to
+   `<sandbox-name>.<namespace>.svc.cluster.local:8080`, preserving
+   `X-Owner`. The agent reads it, asks the model to introduce itself
+   as alice's agent, and returns the reply.
+4. The client asserts the reply contains `i am alice's agent` (case
+   insensitive) and fails loudly otherwise.
+5. On exit the SDK deletes the claim, which cascades to the
+   `Sandbox`, Pod, and headless Service. The warm pool immediately
+   reconciles back to its target replica count.
+
+Run it again with a different owner to see the routing proof:
+
+```bash
+go run ./client -name bob -msg "In one sentence, introduce yourself."
+```
+
+Bob's reply must begin with `I am bob's agent.` — if it ever names
+the wrong owner, routing is broken.
+
+### Multi-turn: `-reuse` to keep the same Kata pod across calls
+
+```bash
+go run ./client -reuse -name ryan -msg "my favorite color is teal. remember that."
+go run ./client -reuse -name ryan -msg "what is my favorite color?"
+go run ./client -reuse -name ryan -msg "summarize what we have discussed so far."
+```
+
+The first `-reuse` call creates a claim and caches the claim name at
+`/tmp/kata-aks-client-<name>.claim`. Subsequent `-reuse` calls with
+the same `-name` look up that cache, call `GetSandbox`, and re-bind
+to the same pod. The agent prepends prior turns to each prompt, so
+the model actually remembers what you told it. The log line includes
+`turn=N` so you can see history accumulating.
+
+Clear the conversation without destroying the sandbox:
+
+```bash
+go run ./client -reuse -name ryan -reset
+```
+
+Destroy the sandbox when you're done:
+
+```bash
+go run ./client -reuse -name ryan -delete
+```
+
+> **Caveats on multi-turn memory.** History lives in process memory
+> in the agent pod. Restarting the pod (or the warm pool replacing
+> it) wipes the history. The pod is shared by anyone with the same
+> `X-Owner` value addressing the same Kata pod, so don't rely on
+> `X-Owner` as a security boundary — the boundary is the Kata
+> sandbox itself, plus the per-template NetworkPolicy.
+
+### What about more than one user?
+
+The same CLI scales to N users — just run it from N shells (or N
+goroutines in your own program), one per owner. Each `-name` gets
+its own claim, its own Kata pod, and (with `-reuse`) its own cached
+history. There is nothing two-user-specific in the design; the
+smoke-test commands above just happen to use two names.
+
+## NetworkPolicy: how the lockdown works
+
+[`sandboxtemplate.yaml`](sandboxtemplate.yaml) declares a
+`networkPolicy` block, so the agent-sandbox controller renders a
+single shared `NetworkPolicy` that applies to every sandbox produced
+from `kata-aks-template`. The intent: **only the sandbox-router
+pods may reach an agent pod; nothing else can.**
+
+The relevant fragment:
+
+```yaml
+networkPolicyManagement: Managed
+networkPolicy:
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: sandbox-router    # the proxy fleet that fronts every sandbox
+      ports:
+      - protocol: TCP
+        port: 8080                 # the agent port
+  egress:
+    - ports:                       # DNS so the agent can resolve the model endpoint
+      - protocol: UDP
+        port: 53
+      - protocol: TCP
+        port: 53
+    - ports:                       # HTTPS to the model endpoint
+      - protocol: TCP
+        port: 443
+```
+
+What this guarantees, given a NetworkPolicy-aware CNI:
+
+- **No sandbox-to-sandbox traffic.** Alice's pod cannot connect to
+  Bob's pod even though they share a namespace and a warm pool — the
+  only allowed ingress source is `app=sandbox-router`.
+- **No direct ingress from the LoadBalancer.** The LB Service targets
+  the router pods, not the agent pods. Every external request enters
+  via the router.
+- **No egress to the Kubernetes API server, cloud metadata, or other
+  in-cluster services.** The agent can only reach DNS and HTTPS
+  endpoints, which is enough to call the model provider and nothing
+  else.
+
+Notes if you need to adjust the policy:
+
+- If your sandbox-router pods run in a different namespace, add a
+  `namespaceSelector` alongside the `podSelector` in the `from` block
+  — pod-label matching alone is not cross-namespace.
+- If sidecars (Istio, OTEL collector, etc.) inject into the sandbox
+  pods, add their ports to the `ingress` rule or those sidecars will
+  fail their health checks. The controller deliberately enforces
+  default-deny ingress.
+- For Cilium / other CNIs that own their own policy story, set
+  `networkPolicyManagement: Unmanaged` in the template and let the
+  CNI manage isolation. The controller will then skip creating any
+  `NetworkPolicy` for this template.
+
+After editing the template, re-apply it:
+
+```bash
+envsubst < sandboxtemplate.yaml | kubectl apply -f -
+kubectl get networkpolicy -n sandbox-agent-demo   # confirm a policy for the template exists
+```
+
+## Cleanup
+
+Deleting the namespace removes every object created by this example
+in one shot, including the public LB IP:
+
+```bash
+kubectl delete namespace sandbox-agent-demo
+```
+
+If you used `-reuse` with the Go client, also remove the local
+claim-name cache so a future run on a fresh namespace doesn't try to
+adopt a dead claim:
+
+```bash
+rm -f /tmp/kata-aks-client-*.claim
+```
+
+If you would rather tear things down piecemeal:
+
+```bash
+kubectl delete -f sandboxclaim.yaml
+kubectl delete -f sandboxwarmpool.yaml
+envsubst < sandboxtemplate.yaml | kubectl delete -f -
+envsubst < router.yaml | kubectl delete -f -
+kubectl delete secret azure-foundry -n sandbox-agent-demo
+rm -f /tmp/kata-aks-client-*.claim
+```
+
+If you no longer need the Kata-capable node pool, also remove it from
+AKS:
+
+```bash
+az aks nodepool delete \
+  --resource-group <rg> \
+  --cluster-name <aks-cluster> \
+  --name sandboxagent
+```
+
+## Notes on AKS Pod Sandboxing
+
+- **Resource requests are not optional.** A Kata pod is a real
+  micro-VM, and the kubelet sizes the guest VM from the sum of
+  container requests/limits. The template sets explicit `cpu` and
+  `memory` requests/limits to avoid guest OOM kills. Tune them for
+  the model traffic you expect.
+- **Cold start is slower than runc.** Booting a Kata micro-VM and
+  pulling the image takes noticeably longer than a runc pod — which
+  is exactly why the `SandboxWarmPool` matters here. For bursty
+  workloads, drive `replicas` from an HPA on the
+  `agent_sandbox_claim_creation_total` metric (the project's
+  `examples/hpa-swp-scaling/` directory shows the wiring).
+- **VM SKU matters.** AKS Pod Sandboxing requires Gen2 VMs with
+  nested virtualisation. D-series v3/v4/v5 work; B-series burstable
+  SKUs and most ARM SKUs do not. If pods stay `Pending` with a
+  Kata-related scheduling error, the node pool SKU is almost always
+  the cause.
+- **Azure Linux only.** The `kata-vm-isolation` RuntimeClass is only
+  registered on Azure Linux node pools. Ubuntu pools cannot host
+  Kata sandboxes on AKS today.
+- **Image pulling.** AKS Pod Sandboxing pulls images on the host (not
+  inside the guest), so the standard ACR→AKS attach via
+  `az aks update --attach-acr` is sufficient — no `imagePullSecrets`
+  needed for either the agent image or the router image.

--- a/extensions/examples/kata-aks/README.md
+++ b/extensions/examples/kata-aks/README.md
@@ -117,11 +117,10 @@ you want to deploy into.
    az aks update --resource-group <rg> --name <aks-cluster> --attach-acr <your-acr>
    ```
 
-5. **Access to a Microsoft Foundry / Azure OpenAI deployment exposing
-   the OpenAI-compatible `/openai/v1/` endpoint.** You will need the
-   base URL, an API key, and a model deployment name. Any other
-   OpenAI-compatible endpoint works too — see "Switching providers"
-   near the bottom.
+5. **An OpenAI-compatible REST endpoint** (e.g., Azure OpenAI,
+   Microsoft Foundry, OpenAI directly, or a self-hosted service like
+   vLLM). You will need the base URL, an API key, and a model name.
+   See "Switching providers" below for details.
 
 6. **Go 1.22+** on your workstation if you want to run the SDK demo
    in Step 6.
@@ -144,37 +143,38 @@ If you would rather use a different namespace, do a find-and-replace
 on `sandbox-agent-demo` across all the YAML files in this directory
 (and in [`client/main.go`](client/main.go)) before you start.
 
-## Step 1 — Create the Foundry Secret
+## Step 1 — Create the model endpoint Secret
 
 The agent reads three values from a `Secret` named
 `azure-foundry` in the same namespace as the template:
 
-| Key | Where it comes from |
-| --- | --- |
-| `AZURE_FOUNDRY_BASE_URL` | Your Foundry / Azure OpenAI resource's v1 endpoint, e.g. `https://<resource>.openai.azure.com/openai/v1/`. |
-| `AZURE_FOUNDRY_API_KEY` | KEY 1 or KEY 2 from the same resource's "Keys and Endpoint" view. |
-| `AZURE_FOUNDRY_MODEL` | The model deployment name (e.g. `gpt-4o`, `gpt-5.4-mini`). |
+| Key | Example (Azure OpenAI) | Example (OpenAI) |
+| --- | --- | --- |
+| `OPENAI_BASE_URL` | `https://<resource>.openai.azure.com/openai/v1/` | `https://api.openai.com/v1` |
+| `OPENAI_API_KEY` | Azure OpenAI key | OpenAI API key |
+| `LLM_MODEL` | `gpt-4o` (deployment name) | `gpt-4o` (model name) |
 
 ```bash
 kubectl create secret generic azure-foundry \
   -n sandbox-agent-demo \
-  --from-literal=AZURE_FOUNDRY_BASE_URL="https://<resource>.openai.azure.com/openai/v1/" \
-  --from-literal=AZURE_FOUNDRY_API_KEY="<your-azure-foundry-key>" \
-  --from-literal=AZURE_FOUNDRY_MODEL="gpt-4o"
+  --from-literal=OPENAI_BASE_URL="https://<your-endpoint>/v1/" \
+  --from-literal=OPENAI_API_KEY="<your-api-key>" \
+  --from-literal=LLM_MODEL="<model-name>"
 ```
 
-The Secret name (`azure-foundry`) is what
+The Secret name (`azure-foundry`) and the three keys above are what
 [`sandboxtemplate.yaml`](sandboxtemplate.yaml) references via
-`secretKeyRef`. If you rename the Secret, update the template too.
+`secretKeyRef`, and [`agent/agent.py`](agent/agent.py) reads them
+out of the environment under those exact names. If you rename any
+of them, update both files to match.
 
 ### Switching providers
 
-The agent uses the upstream `openai` Python client pointed at
-`AZURE_FOUNDRY_BASE_URL` — anything that speaks the OpenAI v1
-`/chat/completions` shape (OpenAI directly, Together, Anyscale,
-self-hosted vLLM, …) will work without any code change. Just point the
-Secret's `AZURE_FOUNDRY_BASE_URL` and `AZURE_FOUNDRY_API_KEY` at the
-provider you want and put their model name in `AZURE_FOUNDRY_MODEL`.
+The agent uses the upstream `openai` Python client — anything that speaks
+the OpenAI v1 `/chat/completions` API (Azure OpenAI, OpenAI directly,
+Together, Anyscale, self-hosted vLLM, …) will work without any code change.
+Just point the Secret's `OPENAI_BASE_URL` and `OPENAI_API_KEY` at the
+provider you want and put their model name in `LLM_MODEL`.
 
 ## Step 2 — Build the agent image into your ACR
 
@@ -285,6 +285,19 @@ router pods — a `ClusterIP` (`sandbox-router-svc`) for in-cluster
 callers and the NetworkPolicy, plus a `LoadBalancer`
 (`sandbox-router-public`) that AKS fronts with an Azure Standard Load
 Balancer public IP.
+
+> ⚠️ **Demo-only authentication.** [`router.yaml`](router.yaml) sets
+> `ALLOW_UNAUTHENTICATED_ROUTER=true` so the public LoadBalancer
+> accepts every request unconditionally. **This is fine for a throwaway
+> demo cluster you are about to delete; it is not fine for anything
+> else** — anyone who finds the public IP can use the router as an open
+> proxy into your sandbox pods. For a real deployment, mint a token,
+> store it in a Secret, plumb it in as `ROUTER_AUTH_TOKEN`, and have
+> callers send `Authorization: Bearer <token>`. The shape to copy lives
+> at [`clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml`](../../../clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml).
+> Note that the Go SDK used in Step 6 does not yet plumb `Authorization`
+> headers, so swapping to token auth requires either an SDK change or
+> bypassing the SDK for the HTTP layer.
 
 Substitute the image and apply (`envsubst` ships in the
 `gettext-base` package on most distros):

--- a/extensions/examples/kata-aks/agent/Dockerfile
+++ b/extensions/examples/kata-aks/agent/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+RUN groupadd --gid 1000 appuser \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /usr/sbin/nologin appuser \
+    && chown appuser:appuser /app
+
+COPY --chown=1000:1000 requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY --chown=1000:1000 agent.py .
+
+EXPOSE 8080
+
+USER appuser
+
+CMD ["uvicorn", "agent:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/extensions/examples/kata-aks/agent/agent.py
+++ b/extensions/examples/kata-aks/agent/agent.py
@@ -1,0 +1,101 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Per-owner agent backed by Azure Foundry's OpenAI-compatible v1 endpoint.
+
+Each pod is identical; the per-user identity comes from the X-Owner header
+on the incoming request, so a single warm-pool of pods can serve every
+user without any per-pod customization.
+"""
+
+import os
+from collections import defaultdict, deque
+from threading import Lock
+
+from fastapi import FastAPI, Header
+from openai import OpenAI
+from pydantic import BaseModel
+
+# AZURE_FOUNDRY_BASE_URL must point at the OpenAI-compatible v1 endpoint,
+# e.g. https://<resource>.openai.azure.com/openai/v1/ .
+_base_url = os.getenv("AZURE_FOUNDRY_BASE_URL")
+_api_key = os.getenv("AZURE_FOUNDRY_API_KEY")
+_model = os.getenv("AZURE_FOUNDRY_MODEL")
+
+_missing_settings = [
+    name
+    for name, value in (
+        ("AZURE_FOUNDRY_BASE_URL", _base_url),
+        ("AZURE_FOUNDRY_API_KEY", _api_key),
+        ("AZURE_FOUNDRY_MODEL", _model),
+    )
+    if not value
+]
+if _missing_settings:
+    raise RuntimeError(
+        "Missing required environment setting(s): "
+        + ", ".join(_missing_settings)
+    )
+
+_client = OpenAI(
+    base_url=_base_url,
+    api_key=_api_key,
+)
+
+# In-process per-owner chat history. A bounded deque keeps the prompt
+# size predictable on long conversations; bump _HISTORY_TURNS if you
+# need more context. History lives in memory only — restarting the pod
+# wipes it, which is fine for a demo sandbox.
+_HISTORY_TURNS = 20  # user+assistant message pairs per owner
+_history: dict[str, deque] = defaultdict(lambda: deque(maxlen=_HISTORY_TURNS * 2))
+_history_lock = Lock()
+
+app = FastAPI()
+
+
+class ChatRequest(BaseModel):
+    prompt: str
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"ok": True}
+
+
+@app.post("/reset")
+def reset(x_owner: str = Header(default="anonymous")) -> dict:
+    """Drop the conversation history for this owner."""
+    with _history_lock:
+        _history.pop(x_owner, None)
+    return {"owner": x_owner, "reset": True}
+
+
+@app.post("/chat")
+def chat(body: ChatRequest, x_owner: str = Header(default="anonymous")) -> dict:
+    system = (
+        f"You are {x_owner}'s personal AI agent running in a private sandbox. "
+        f"Always begin your reply with 'I am {x_owner}'s agent.' "
+        f"Never claim to belong to anyone else. Keep replies under three sentences."
+    )
+
+    with _history_lock:
+        prior = list(_history[x_owner])
+
+    messages = [{"role": "system", "content": system}]
+    messages.extend(prior)
+    messages.append({"role": "user", "content": body.prompt})
+
+    resp = _client.chat.completions.create(model=_model, messages=messages)
+    reply = resp.choices[0].message.content
+
+    with _history_lock:
+        h = _history[x_owner]
+        h.append({"role": "user", "content": body.prompt})
+        h.append({"role": "assistant", "content": reply})
+
+    return {"owner": x_owner, "reply": reply, "history_turns": len(prior) // 2 + 1}

--- a/extensions/examples/kata-aks/agent/agent.py
+++ b/extensions/examples/kata-aks/agent/agent.py
@@ -6,7 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 
-"""Per-owner agent backed by Azure Foundry's OpenAI-compatible v1 endpoint.
+"""Per-owner agent backed by OpenAI-compatible endpoint.
 
 Each pod is identical; the per-user identity comes from the X-Owner header
 on the incoming request, so a single warm-pool of pods can serve every
@@ -21,18 +21,18 @@ from fastapi import FastAPI, Header
 from openai import OpenAI
 from pydantic import BaseModel
 
-# AZURE_FOUNDRY_BASE_URL must point at the OpenAI-compatible v1 endpoint,
+# OPENAI_BASE_URL must point at the OpenAI-compatible v1 endpoint,
 # e.g. https://<resource>.openai.azure.com/openai/v1/ .
-_base_url = os.getenv("AZURE_FOUNDRY_BASE_URL")
-_api_key = os.getenv("AZURE_FOUNDRY_API_KEY")
-_model = os.getenv("AZURE_FOUNDRY_MODEL")
+_base_url = os.getenv("OPENAI_BASE_URL")
+_api_key = os.getenv("OPENAI_API_KEY")
+_model = os.getenv("LLM_MODEL")
 
 _missing_settings = [
     name
     for name, value in (
-        ("AZURE_FOUNDRY_BASE_URL", _base_url),
-        ("AZURE_FOUNDRY_API_KEY", _api_key),
-        ("AZURE_FOUNDRY_MODEL", _model),
+        ("OPENAI_BASE_URL", _base_url),
+        ("OPENAI_API_KEY", _api_key),
+        ("LLM_MODEL", _model),
     )
     if not value
 ]

--- a/extensions/examples/kata-aks/agent/requirements.txt
+++ b/extensions/examples/kata-aks/agent/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.4
+uvicorn==0.32.0
+openai==1.59.2
+httpx==0.27.2

--- a/extensions/examples/kata-aks/client/main.go
+++ b/extensions/examples/kata-aks/client/main.go
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Two-user example for the kata-aks SandboxTemplate.
+// Single-user CLI for the kata-aks SandboxTemplate.
 //
-// Provisions one Kata-isolated agent sandbox per user in parallel via
-// the Go SDK, then sends each user's prompt to their own sandbox through
-// the shared sandbox-router. Each user lands on a separate Kata VM; the
-// per-template NetworkPolicy (where the CNI enforces it) keeps the two
-// pods from talking to each other.
+// One invocation provisions (or adopts) exactly one Kata-isolated agent
+// sandbox keyed by `-name`, sends one prompt to that sandbox through
+// the shared sandbox-router, and (in one-shot mode) tears it down on
+// exit. To exercise the "multiple users in parallel" story, run the
+// CLI concurrently in separate shells with different `-name` values —
+// each invocation lands on its own Kata VM, and the per-template
+// NetworkPolicy (where the CNI enforces it) keeps the pods isolated
+// from each other.
 //
 // The agent image baked into the template is owner-agnostic. Identity
 // comes from the `X-Owner` header on the incoming request, which is
@@ -70,6 +73,15 @@ const (
 	agentPort    = "8080" // FastAPI agent in sandboxtemplate.yaml
 )
 
+// httpClient is a dedicated client with an explicit Timeout, shared by
+// /chat and /reset. http.DefaultClient is shared process-wide and has
+// no Timeout, so a stalled DNS or TCP handshake can hang the CLI
+// indefinitely even when the request context has a deadline. The
+// 5-minute ceiling is generous enough to cover slow model responses
+// (the router itself uses PROXY_TIMEOUT_SECONDS=180 server-side) and
+// well under the main 10-minute context budget in main().
+var httpClient = &http.Client{Timeout: 5 * time.Minute}
+
 type chatResponse struct {
 	Owner        string `json:"owner"`
 	Reply        string `json:"reply"`
@@ -95,7 +107,7 @@ func chat(ctx context.Context, routerBaseURL, sandboxName, ns, owner, prompt str
 	req.Header.Set("X-Sandbox-Port", agentPort)
 	req.Header.Set("X-Owner", owner)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +174,7 @@ func resetHistory(ctx context.Context, routerBaseURL string, sb *sandbox.Sandbox
 	req.Header.Set("X-Sandbox-Namespace", namespace)
 	req.Header.Set("X-Sandbox-Port", agentPort)
 	req.Header.Set("X-Owner", owner)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/extensions/examples/kata-aks/client/main.go
+++ b/extensions/examples/kata-aks/client/main.go
@@ -1,0 +1,315 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Two-user example for the kata-aks SandboxTemplate.
+//
+// Provisions one Kata-isolated agent sandbox per user in parallel via
+// the Go SDK, then sends each user's prompt to their own sandbox through
+// the shared sandbox-router. Each user lands on a separate Kata VM; the
+// per-template NetworkPolicy (where the CNI enforces it) keeps the two
+// pods from talking to each other.
+//
+// The agent image baked into the template is owner-agnostic. Identity
+// comes from the `X-Owner` header on the incoming request, which is
+// folded into the system prompt so the model is told who its user is
+// and instructed to start every reply with "I am <owner>'s agent.".
+// That gives us a falsifiable end-to-end proof of routing: if Alice ever
+// sees a reply that begins with "I am bob's agent", routing is broken.
+//
+// Usage:
+//
+//	export ROUTER_BASE_URL=http://<sandbox-router-public-IP>
+//
+//	# one-shot: claim a fresh sandbox, chat, tear it down
+//	go run ./client -name alice -msg "In one sentence, introduce yourself."
+//
+//	# reuse the same sandbox across runs (claim survives until you delete it):
+//	go run ./client -reuse -name ryan -msg "what day is today"
+//	go run ./client -reuse -name ryan -msg "and tomorrow?"
+//
+//	# tear down a reused sandbox:
+//	go run ./client -reuse -name ryan -delete
+//
+// In -reuse mode the claim name is cached at
+// /tmp/kata-aks-client-<name>.claim so subsequent invocations adopt
+// the same SandboxClaim (and therefore the same Kata pod).
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+const (
+	templateName = "kata-aks-template"
+	namespace    = "sandbox-agent-demo"
+	agentPort    = "8080" // FastAPI agent in sandboxtemplate.yaml
+)
+
+type chatResponse struct {
+	Owner        string `json:"owner"`
+	Reply        string `json:"reply"`
+	HistoryTurns int    `json:"history_turns"`
+}
+
+// chat sends one prompt to a specific sandbox through the router and
+// returns the agent's response. The router fans out using the X-Sandbox-*
+// headers; the agent persona comes from X-Owner, which the router
+// forwards untouched.
+func chat(ctx context.Context, routerBaseURL, sandboxName, ns, owner, prompt string) (*chatResponse, error) {
+	payload, err := json.Marshal(map[string]string{"prompt": prompt})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, routerBaseURL+"/chat", bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Sandbox-ID", sandboxName)
+	req.Header.Set("X-Sandbox-Namespace", ns)
+	req.Header.Set("X-Sandbox-Port", agentPort)
+	req.Header.Set("X-Owner", owner)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("router returned %d: %s", resp.StatusCode, body)
+	}
+	var out chatResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode reply: %w (body=%s)", err, body)
+	}
+	return &out, nil
+}
+
+// runForUser provisions one sandbox, sends one prompt, asserts the reply
+// names the right owner, and tears the sandbox down on exit. The Client's
+// DeleteAll is the safety net if this best-effort cleanup is skipped
+// (e.g. panic).
+func runForUser(ctx context.Context, client *sandbox.Client, routerBaseURL, owner, prompt string) {
+	sb, err := client.CreateSandbox(ctx, templateName, namespace)
+	if err != nil {
+		log.Printf("[%s] create failed: %v", owner, err)
+		return
+	}
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = client.DeleteSandbox(cleanupCtx, sb.ClaimName(), namespace)
+	}()
+
+	log.Printf("[%s] sandbox ready: claim=%s sandbox=%s pod=%s",
+		owner, sb.ClaimName(), sb.SandboxName(), sb.PodName())
+
+	chatAndAssert(ctx, routerBaseURL, sb, owner, prompt)
+}
+
+// chatAndAssert sends one prompt and verifies the owner-naming guarantee.
+func chatAndAssert(ctx context.Context, routerBaseURL string, sb *sandbox.Sandbox, owner, prompt string) {
+	resp, err := chat(ctx, routerBaseURL, sb.SandboxName(), namespace, owner, prompt)
+	if err != nil {
+		log.Printf("[%s] chat failed: %v", owner, err)
+		return
+	}
+	want := strings.ToLower(fmt.Sprintf("i am %s's agent", owner))
+	if !strings.Contains(strings.ToLower(resp.Reply), want) {
+		log.Printf("[%s] FAIL: reply does not name owner. owner-in-resp=%q reply=%q",
+			owner, resp.Owner, resp.Reply)
+		return
+	}
+	log.Printf("[%s] OK pod=%s turn=%d reply=%q", owner, sb.PodName(), resp.HistoryTurns, resp.Reply)
+}
+
+// resetHistory POSTs /reset to wipe the per-owner conversation history on the agent pod.
+func resetHistory(ctx context.Context, routerBaseURL string, sb *sandbox.Sandbox, owner string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, routerBaseURL+"/reset", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Sandbox-ID", sb.SandboxName())
+	req.Header.Set("X-Sandbox-Namespace", namespace)
+	req.Header.Set("X-Sandbox-Port", agentPort)
+	req.Header.Set("X-Owner", owner)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("router returned %d: %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+// claimCachePath returns the local file used to remember the claim name
+// for a given owner across -reuse invocations. /tmp is fine for a demo
+// client; production callers should track the claim name themselves.
+func claimCachePath(owner string) string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("kata-aks-client-%s.claim", owner))
+}
+
+func readCachedClaim(owner string) string {
+	b, err := os.ReadFile(claimCachePath(owner))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func writeCachedClaim(owner, claimName string) error {
+	return os.WriteFile(claimCachePath(owner), []byte(claimName+"\n"), 0o600)
+}
+
+func clearCachedClaim(owner string) {
+	_ = os.Remove(claimCachePath(owner))
+}
+
+// runReuse adopts (or creates) a long-lived sandbox keyed by owner name,
+// chats with it, and intentionally does NOT delete it on exit.
+func runReuse(ctx context.Context, client *sandbox.Client, routerBaseURL, owner, prompt string, deleteOnly, resetOnly bool) {
+	cached := readCachedClaim(owner)
+
+	if deleteOnly {
+		if cached == "" {
+			log.Printf("[%s] no cached claim to delete", owner)
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := client.DeleteSandbox(cleanupCtx, cached, namespace); err != nil {
+			log.Printf("[%s] delete claim=%s failed: %v", owner, cached, err)
+		}
+		clearCachedClaim(owner)
+		log.Printf("[%s] deleted claim=%s", owner, cached)
+		return
+	}
+
+	var sb *sandbox.Sandbox
+	if cached != "" {
+		var err error
+		sb, err = client.GetSandbox(ctx, cached, namespace)
+		if err != nil {
+			if errors.Is(err, sandbox.ErrSandboxDeleted) || strings.Contains(err.Error(), "not found") {
+				log.Printf("[%s] cached claim=%s is gone, provisioning a new one", owner, cached)
+				clearCachedClaim(owner)
+				sb = nil
+			} else {
+				log.Printf("[%s] get cached claim=%s failed: %v", owner, cached, err)
+				return
+			}
+		} else {
+			log.Printf("[%s] reusing claim=%s sandbox=%s pod=%s",
+				owner, sb.ClaimName(), sb.SandboxName(), sb.PodName())
+		}
+	}
+	if sb == nil {
+		var err error
+		sb, err = client.CreateSandbox(ctx, templateName, namespace)
+		if err != nil {
+			log.Printf("[%s] create failed: %v", owner, err)
+			return
+		}
+		if err := writeCachedClaim(owner, sb.ClaimName()); err != nil {
+			log.Printf("[%s] warning: could not cache claim name: %v", owner, err)
+		}
+		log.Printf("[%s] created and cached claim=%s sandbox=%s pod=%s",
+			owner, sb.ClaimName(), sb.SandboxName(), sb.PodName())
+	}
+
+	if resetOnly {
+		if err := resetHistory(ctx, routerBaseURL, sb, owner); err != nil {
+			log.Printf("[%s] reset failed: %v", owner, err)
+			return
+		}
+		log.Printf("[%s] history reset on pod=%s", owner, sb.PodName())
+		return
+	}
+
+	chatAndAssert(ctx, routerBaseURL, sb, owner, prompt)
+}
+
+func main() {
+	var (
+		name    = flag.String("name", "", "owner name (sent as X-Owner; also keys the -reuse cache)")
+		msg     = flag.String("msg", "In one sentence, introduce yourself.", "prompt to send")
+		reuse   = flag.Bool("reuse", false, "reuse the previously-created sandbox for -name (do not delete on exit)")
+		delOnly = flag.Bool("delete", false, "with -reuse: delete the cached sandbox for -name and exit")
+		reset   = flag.Bool("reset", false, "with -reuse: wipe the agent's per-owner chat history and exit")
+	)
+	flag.Parse()
+
+	routerBaseURL := os.Getenv("ROUTER_BASE_URL")
+	if routerBaseURL == "" {
+		log.Fatal("ROUTER_BASE_URL must be set to the sandbox-router's external URL " +
+			"(e.g. http://<sandbox-router-public-IP>)")
+	}
+	if *name == "" {
+		log.Fatal("-name is required")
+	}
+	if *delOnly && !*reuse {
+		log.Fatal("-delete requires -reuse")
+	}
+	if *reset && !*reuse {
+		log.Fatal("-reset requires -reuse")
+	}
+	if *reset && *delOnly {
+		log.Fatal("-reset and -delete are mutually exclusive")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	client, err := sandbox.NewClient(ctx, sandbox.Options{
+		TemplateName: templateName,
+		Namespace:    namespace,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *reuse {
+		// Reuse path: do NOT register a signal-cleanup handler or call
+		// DeleteAll on exit — the whole point is for the claim to survive.
+		runReuse(ctx, client, routerBaseURL, *name, *msg, *delOnly, *reset)
+		return
+	}
+
+	// One-shot path: create on the fly, tear down on exit.
+	stop := client.EnableAutoCleanup()
+	defer client.DeleteAll(ctx)
+	defer stop()
+	runForUser(ctx, client, routerBaseURL, *name, *msg)
+}

--- a/extensions/examples/kata-aks/client/main.go
+++ b/extensions/examples/kata-aks/client/main.go
@@ -65,7 +65,7 @@ import (
 )
 
 const (
-	templateName = "kata-aks-template"
+	warmPoolName = "kata-aks-warmpool"
 	namespace    = "sandbox-agent-demo"
 	agentPort    = "8080" // FastAPI agent in sandboxtemplate.yaml
 )
@@ -119,7 +119,7 @@ func chat(ctx context.Context, routerBaseURL, sandboxName, ns, owner, prompt str
 // DeleteAll is the safety net if this best-effort cleanup is skipped
 // (e.g. panic).
 func runForUser(ctx context.Context, client *sandbox.Client, routerBaseURL, owner, prompt string) {
-	sb, err := client.CreateSandbox(ctx, templateName, namespace)
+	sb, err := client.CreateSandbox(ctx, warmPoolName, namespace)
 	if err != nil {
 		log.Printf("[%s] create failed: %v", owner, err)
 		return
@@ -237,7 +237,7 @@ func runReuse(ctx context.Context, client *sandbox.Client, routerBaseURL, owner,
 	}
 	if sb == nil {
 		var err error
-		sb, err = client.CreateSandbox(ctx, templateName, namespace)
+		sb, err = client.CreateSandbox(ctx, warmPoolName, namespace)
 		if err != nil {
 			log.Printf("[%s] create failed: %v", owner, err)
 			return
@@ -293,7 +293,7 @@ func main() {
 	defer cancel()
 
 	client, err := sandbox.NewClient(ctx, sandbox.Options{
-		TemplateName: templateName,
+		WarmPoolName: warmPoolName,
 		Namespace:    namespace,
 	})
 	if err != nil {

--- a/extensions/examples/kata-aks/router.yaml
+++ b/extensions/examples/kata-aks/router.yaml
@@ -1,0 +1,103 @@
+# Sandbox-router: a small reverse proxy that fans out incoming requests to the
+# correct per-user Sandbox pod based on three HTTP headers set by the caller
+# (or by the Go/Python SDK on their behalf):
+#
+#   X-Sandbox-ID         — the Sandbox object name (== pod name)
+#   X-Sandbox-Namespace  — the namespace the Sandbox lives in
+#   X-Sandbox-Port       — the container port on that pod to forward to (8080
+#                          for the FastAPI owner-agent in sandboxtemplate.yaml)
+#
+# Two Services point at the same router pods:
+#   * sandbox-router-svc       (ClusterIP)    — in-cluster callers; also what
+#                                              the per-Sandbox NetworkPolicy
+#                                              in sandboxtemplate.yaml allows
+#                                              ingress from.
+#   * sandbox-router-public    (LoadBalancer) — public Azure Load Balancer IP
+#                                              for the SDK / curl from outside
+#                                              the cluster.
+#
+# Build the router image yourself (see the README) and replace ${ROUTER_IMAGE}
+# below before applying.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-router-svc
+  namespace: sandbox-agent-demo
+spec:
+  type: ClusterIP
+  selector:
+    app: sandbox-router
+  ports:
+  - name: http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-router-public
+  namespace: sandbox-agent-demo
+spec:
+  type: LoadBalancer
+  selector:
+    app: sandbox-router
+  ports:
+  - name: http
+    protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-router-deployment
+  namespace: sandbox-agent-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sandbox-router
+  template:
+    metadata:
+      labels:
+        app: sandbox-router
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: sandbox-router
+      containers:
+      - name: router
+        image: ${ROUTER_IMAGE}
+        # imagePullPolicy: Never  # Uncomment when loading a local image into kind/minikube.
+        env:
+        - name: PROXY_TIMEOUT_SECONDS
+          value: "180"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/extensions/examples/kata-aks/router.yaml
+++ b/extensions/examples/kata-aks/router.yaml
@@ -77,6 +77,13 @@ spec:
         env:
         - name: PROXY_TIMEOUT_SECONDS
           value: "180"
+        # DEMO ONLY. The router fronts a public LoadBalancer below; in any
+        # real deployment, replace this with ROUTER_AUTH_TOKEN sourced from
+        # a Secret and have callers send `Authorization: Bearer <token>`.
+        # See clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
+        # for the production-shaped manifest.
+        - name: ALLOW_UNAUTHENTICATED_ROUTER
+          value: "true"
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/extensions/examples/kata-aks/sandboxclaim.yaml
+++ b/extensions/examples/kata-aks/sandboxclaim.yaml
@@ -2,20 +2,18 @@
 # warm pool defined in sandboxwarmpool.yaml. The claim is the only object a
 # regular (non-admin) user is expected to create — they do not need access
 # to the SandboxTemplate or SandboxWarmPool.
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
   name: my-aks-agent
-  # Must be the same namespace as the SandboxTemplate.
+  # Must be the same namespace as the SandboxWarmPool.
   namespace: sandbox-agent-demo
 spec:
-  sandboxTemplateRef:
-    name: kata-aks-template
-
-  # Prefer adopting from the named warm pool. Set to "none" to always
-  # provision a fresh sandbox (incurs Kata VM cold-start), or "default" to
-  # let the controller pick any matching pool.
-  warmpool: kata-aks-warmpool
+  # Adopt a pre-warmed sandbox from the named warm pool. The pool's
+  # sandboxTemplateRef determines the pod blueprint; the claim itself
+  # no longer references the SandboxTemplate directly in v1beta1.
+  warmPoolRef:
+    name: kata-aks-warmpool
 
   # Example lifecycle: auto-shut down 1h after the claim is created and
   # delete the claim (and its underlying Sandbox/Pod/PVC) on expiry.

--- a/extensions/examples/kata-aks/sandboxclaim.yaml
+++ b/extensions/examples/kata-aks/sandboxclaim.yaml
@@ -1,0 +1,25 @@
+# A user-facing claim that adopts one Kata-isolated Hermes sandbox from the
+# warm pool defined in sandboxwarmpool.yaml. The claim is the only object a
+# regular (non-admin) user is expected to create — they do not need access
+# to the SandboxTemplate or SandboxWarmPool.
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: my-aks-agent
+  # Must be the same namespace as the SandboxTemplate.
+  namespace: sandbox-agent-demo
+spec:
+  sandboxTemplateRef:
+    name: kata-aks-template
+
+  # Prefer adopting from the named warm pool. Set to "none" to always
+  # provision a fresh sandbox (incurs Kata VM cold-start), or "default" to
+  # let the controller pick any matching pool.
+  warmpool: kata-aks-warmpool
+
+  # Example lifecycle: auto-shut down 1h after the claim is created and
+  # delete the claim (and its underlying Sandbox/Pod/PVC) on expiry.
+  # Uncomment and adjust the absolute timestamp as needed.
+  # lifecycle:
+  #   shutdownTime: "2026-12-31T23:59:59Z"
+  #   shutdownPolicy: Delete

--- a/extensions/examples/kata-aks/sandboxtemplate.yaml
+++ b/extensions/examples/kata-aks/sandboxtemplate.yaml
@@ -1,0 +1,146 @@
+# SandboxTemplate that runs a small, owner-aware FastAPI agent inside an
+# AKS Pod Sandboxing (Kata Containers on Microsoft Hyper-V) micro-VM for
+# strong, hypervisor-level isolation. This template is the pod blueprint
+# used by both the warm pool (pre-creating pods) and any SandboxClaim that
+# adopts from it.
+#
+# The agent itself is owner-agnostic — each request carries an `X-Owner`
+# header (forwarded by the sandbox-router) that is baked into the system
+# prompt. That is what lets a single warm pool of identical pods serve
+# many users without per-pod customization.
+#
+# The single distinguishing line from a regular Sandbox is
+# `runtimeClassName: kata-vm-isolation`. AKS registers this RuntimeClass
+# automatically on Pod Sandboxing–enabled node pools (older clusters use
+# the same name; newer documentation sometimes calls it
+# `kata-mshv-vm-isolation`, but it is the same feature — use whichever
+# RuntimeClass actually exists on the cluster).
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: kata-aks-template
+  namespace: sandbox-agent-demo
+spec:
+  # Allow the SandboxClaim to inject extra env vars (e.g. per-user model
+  # overrides) without letting it overwrite the Azure Foundry env vars
+  # defined below. Set to Disallowed if claims should not touch env at all.
+  envVarsInjectionPolicy: Allowed
+
+  # Have the controller create the per-Sandbox headless Service so the
+  # sandbox-router (or any in-cluster client) can reach the agent via
+  # <sandbox-name>.<namespace>.svc.cluster.local.
+  service: true
+
+  podTemplate:
+    spec:
+      # Run the pod inside the AKS Pod Sandboxing runtime (Kata Containers
+      # on Hyper-V). AKS registers this RuntimeClass on Kata-enabled node
+      # pools. The handler can be either `kata` or `kata-mshv` depending on
+      # the AKS release — the RuntimeClass name is what we pin here.
+      runtimeClassName: kata-vm-isolation
+
+      # Pin scheduling to the Kata-capable node pool. AKS labels every node
+      # in such a pool with `kubernetes.azure.com/kata-vm-isolation: "true"`
+      # and taints them with `kata=enabled:NoSchedule` so general workloads
+      # cannot land on the pool by accident. The toleration below opts this
+      # template into that pool.
+      nodeSelector:
+        kubernetes.azure.com/kata-vm-isolation: "true"
+      tolerations:
+      - key: kata
+        operator: Equal
+        value: enabled
+        effect: NoSchedule
+
+      # Kata pods are full micro-VMs, so the kubelet sizes guest memory from
+      # the sum of container requests/limits. Always set explicit requests
+      # and limits — leaving them unset is a common cause of OOM kills under
+      # Kata.
+      containers:
+      - name: agent
+        # Built from ./agent/ in this directory and pushed to an ACR you
+        # own. The README's Step 1 walks through `az acr build`.
+        # ${AGENT_IMAGE} is substituted by envsubst before kubectl apply.
+        image: ${AGENT_IMAGE}
+        # Mutable tags like :v1 cache aggressively on Kata nodes; force a
+        # pull so a rebuilt-and-repushed image is actually picked up.
+        imagePullPolicy: Always
+        # Per-request identity comes from the X-Owner header forwarded by
+        # the router; the pod itself is owner-agnostic, which is what lets
+        # a single warm pool serve every user.
+        env:
+        - name: AZURE_FOUNDRY_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: azure-foundry
+              key: AZURE_FOUNDRY_BASE_URL
+        - name: AZURE_FOUNDRY_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: azure-foundry
+              key: AZURE_FOUNDRY_API_KEY
+        - name: AZURE_FOUNDRY_MODEL
+          valueFrom:
+            secretKeyRef:
+              name: azure-foundry
+              key: AZURE_FOUNDRY_MODEL
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+
+  # NetworkPolicy enforced uniformly across every sandbox produced from this
+  # template (the controller renders a single shared NetworkPolicy per
+  # template — see SandboxTemplateSpec.NetworkPolicyManagement).
+  #
+  # Posture:
+  #   * Ingress: only the sandbox-router proxy pods (app=sandbox-router) may
+  #     reach the agent port. Sandbox-to-sandbox traffic is therefore denied
+  #     by default, which matters when many tenants share the same warm pool.
+  #   * Egress: DNS (UDP/TCP 53) is allowed so the agent can resolve
+  #     endpoints, and TCP/443 is allowed to any destination. Because the
+  #     HTTPS rule is not constrained with a `to` selector or `ipBlock`,
+  #     this policy does not by itself block in-cluster or other endpoints
+  #     that listen on 443.
+  #
+  # NOTE: enforcement requires a NetworkPolicy-aware CNI (Azure NPM, Calico,
+  # or Cilium). AKS clusters created with `--network-policy none` will
+  # accept this resource but silently ignore it.
+  networkPolicyManagement: Managed
+  networkPolicy:
+    ingress:
+      - from:
+        - podSelector:
+            matchLabels:
+              app: sandbox-router
+        ports:
+        - protocol: TCP
+          port: 8080
+    egress:
+      - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+      - ports:
+        - protocol: TCP
+          port: 443

--- a/extensions/examples/kata-aks/sandboxtemplate.yaml
+++ b/extensions/examples/kata-aks/sandboxtemplate.yaml
@@ -65,6 +65,22 @@ spec:
         # Mutable tags like :v1 cache aggressively on Kata nodes; force a
         # pull so a rebuilt-and-repushed image is actually picked up.
         imagePullPolicy: Always
+        # The agent Dockerfile already creates a non-root user (uid/gid
+        # 1000) and runs uvicorn as it; the securityContext below
+        # enforces that posture at the pod-spec level so the example
+        # stays compliant even if someone later edits the Dockerfile,
+        # and so it satisfies common admission policies (PSA
+        # `restricted`, OPA/Kyverno baselines, etc.) out of the box.
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
         # Per-request identity comes from the X-Owner header forwarded by
         # the router; the pod itself is owner-agnostic, which is what lets
         # a single warm pool serve every user.

--- a/extensions/examples/kata-aks/sandboxtemplate.yaml
+++ b/extensions/examples/kata-aks/sandboxtemplate.yaml
@@ -15,7 +15,7 @@
 # the same name; newer documentation sometimes calls it
 # `kata-mshv-vm-isolation`, but it is the same feature — use whichever
 # RuntimeClass actually exists on the cluster).
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
   name: kata-aks-template
@@ -69,21 +69,21 @@ spec:
         # the router; the pod itself is owner-agnostic, which is what lets
         # a single warm pool serve every user.
         env:
-        - name: AZURE_FOUNDRY_BASE_URL
+        - name: OPENAI_BASE_URL
           valueFrom:
             secretKeyRef:
               name: azure-foundry
-              key: AZURE_FOUNDRY_BASE_URL
-        - name: AZURE_FOUNDRY_API_KEY
+              key: OPENAI_BASE_URL
+        - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:
               name: azure-foundry
-              key: AZURE_FOUNDRY_API_KEY
-        - name: AZURE_FOUNDRY_MODEL
+              key: OPENAI_API_KEY
+        - name: LLM_MODEL
           valueFrom:
             secretKeyRef:
               name: azure-foundry
-              key: AZURE_FOUNDRY_MODEL
+              key: LLM_MODEL
         ports:
         - containerPort: 8080
           name: http

--- a/extensions/examples/kata-aks/sandboxwarmpool.yaml
+++ b/extensions/examples/kata-aks/sandboxwarmpool.yaml
@@ -1,0 +1,26 @@
+# Pre-warms a pool of Kata-isolated Hermes sandboxes so that SandboxClaims
+# get adopted (and become Ready) without paying the cold-start cost of
+# scheduling a new Kata VM, pulling the image, and binding a PVC.
+#
+# The pool is sized for a small demo. For production use, drive `replicas`
+# from an HPA on the claim-creation-rate custom metric — see
+# examples/hpa-swp-scaling/ for a working setup.
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: kata-aks-warmpool
+  namespace: sandbox-agent-demo
+spec:
+  # Number of pre-warmed Hermes sandboxes to keep ready for adoption.
+  replicas: 3
+
+  # Must match the SandboxTemplate referenced by this warm pool.
+  sandboxTemplateRef:
+    name: kata-aks-template
+
+  updateStrategy:
+    # OnReplenish: stale pods are replaced only when they are adopted by a
+    # claim or manually deleted. This avoids killing healthy Kata VMs every
+    # time the template changes — flip to Recreate if you want immediate
+    # rollout of template updates.
+    type: OnReplenish

--- a/extensions/examples/kata-aks/sandboxwarmpool.yaml
+++ b/extensions/examples/kata-aks/sandboxwarmpool.yaml
@@ -5,7 +5,7 @@
 # The pool is sized for a small demo. For production use, drive `replicas`
 # from an HPA on the claim-creation-rate custom metric — see
 # examples/hpa-swp-scaling/ for a working setup.
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxWarmPool
 metadata:
   name: kata-aks-warmpool


### PR DESCRIPTION
#### What this PR does / why we need it:
This pull request introduces a complete example for running owner-aware AI agents inside AKS Pod Sandboxing (Kata Containers) micro-VMs, including all necessary Kubernetes manifests, a FastAPI-based agent, and a Go client for end-to-end testing. The design demonstrates strong per-user isolation, dynamic per-owner identity via HTTP headers, and secure network policies. The most significant changes are grouped below.

#### Which issue(s) this PR is related to:
Just add an example

#### Release Note

**Kubernetes Manifests for AKS Pod Sandboxing:**

- Added a `SandboxTemplate` manifest for running the agent inside a Kata Containers (Hyper-V) micro-VM, with strict resource requests/limits, environment variable injection from secrets, and a managed `NetworkPolicy` that only allows ingress from the router and egress to DNS/HTTPS. (`sandboxtemplate.yaml`, [extensions/examples/kata-aks/sandboxtemplate.yamlR1-R145](diffhunk://#diff-36a3a22f62bd438325aae6ba3753deed675ef70f6b451e31a99dfc6f451520d7R1-R145))
- Provided a `SandboxClaim` manifest for users to claim isolated sandboxes from a warm pool, with optional lifecycle management. (`sandboxclaim.yaml`, [extensions/examples/kata-aks/sandboxclaim.yamlR1-R25](diffhunk://#diff-8eff44360e7b9dfff47dcfea1b5edc759717b85930d80faa59c8f759fceb7d20R1-R25))

**Sandbox Router and Networking:**

- Added a manifest for the `sandbox-router`, a reverse proxy that routes requests to the correct per-user sandbox pod based on HTTP headers. Includes both an internal ClusterIP and an external LoadBalancer service, as well as deployment and resource settings. (`router.yaml`, [extensions/examples/kata-aks/router.yamlR1-R103](diffhunk://#diff-0eda71dd0822770e71c80693061230d6f3b5c7b1e5ced4b81148f76e81ea26dfR1-R103))

**Agent Implementation and Packaging:**

- Added a new FastAPI-based agent (`agent.py`) that serves as a per-owner AI assistant, using Azure Foundry's OpenAI-compatible endpoint. The agent maintains in-memory, per-user chat history, enforces owner identity in responses, and exposes `/chat`, `/reset`, and `/healthz` endpoints. (`agent/agent.py`, [extensions/examples/kata-aks/agent/agent.pyR1-R83](diffhunk://#diff-905b21b428cdfe4ce6152e3ada9bbcb06ee7c8779e1c3291437bbbba6df0e63fR1-R83))
- Introduced a corresponding `Dockerfile` and `requirements.txt` for packaging and deploying the agent in a minimal Python container. (`agent/Dockerfile`, [[1]](diffhunk://#diff-dc95ea18e5bab7fa8738b97e00ca1712115551ab886393bb3bee341df0c2d320R1-R14); `agent/requirements.txt`, [[2]](diffhunk://#diff-88cbb16f2268b7cc50ddef744f82a83bf077e6296e533a1786edd74bb0ed6f98R1-R4)

**End-to-End Client Example:**

- Introduced a Go client (`client/main.go`) that provisions sandboxes, sends prompts to the agent via the router, verifies correct per-owner routing in responses, and supports claim reuse, chat history reset, and cleanup. (`client/main.go`, [extensions/examples/kata-aks/client/main.goR1-R315](diffhunk://#diff-c8c2b4eb71ba304902e316339f9421a8813b8b42d164c238bd4f89976ed710acR1-R315))
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->