### PR TITLE
Fix: Pin kubernetes_asyncio to <34.0.0 to resolve unit test import error

### DIFF
--- a/clients/python/agentic-sandbox-client/pyproject.toml
+++ b/clients/python/agentic-sandbox-client/pyproject.toml
@@ -48,14 +48,14 @@ root = "../../.."
 [project.optional-dependencies]
 async = [
     "httpx",
-    "kubernetes_asyncio<35.0.0",
+    "kubernetes_asyncio<34.0.0",
 ]
 test = [
     "pytest",
     "pytest-xdist",
     "pytest-asyncio",
     "httpx",
-    "kubernetes_asyncio<35.0.0",
+    "kubernetes_asyncio<34.0.0",
 ]
 tracing = [
     "opentelemetry-api~=1.39.0",

--- a/clients/python/agentic-sandbox-client/pyproject.toml
+++ b/clients/python/agentic-sandbox-client/pyproject.toml
@@ -48,14 +48,14 @@ root = "../../.."
 [project.optional-dependencies]
 async = [
     "httpx",
-    "kubernetes_asyncio",
+    "kubernetes_asyncio<35.0.0",
 ]
 test = [
     "pytest",
     "pytest-xdist",
     "pytest-asyncio",
     "httpx",
-    "kubernetes_asyncio",
+    "kubernetes_asyncio<35.0.0",
 ]
 tracing = [
     "opentelemetry-api~=1.39.0",

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import subprocess
 import sys
 
@@ -67,6 +68,12 @@ def run_python_tests(repo_root):
         venv_pip = os.path.join(venv_dir, "bin", "pip")
 
         print(f"\n=== Setting up Python venv for {suite['name']} tests ===")
+        if os.path.isdir(venv_dir):
+            # Safely verify the directory is indeed a virtual environment before removing
+            if os.path.exists(os.path.join(venv_dir, "pyvenv.cfg")):
+                shutil.rmtree(venv_dir)
+            else:
+                print(f"WARNING: Directory {venv_dir} exists but does not appear to be a venv (missing pyvenv.cfg). Skipping clean.")
         subprocess.check_call([sys.executable, "-m", "venv", venv_dir])
 
         env = os.environ.copy()


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates `clients/python/agentic-sandbox-client/pyproject.toml` to pin the `kubernetes_asyncio` dependency to `<34.0.0` in the `async` and `test` optional dependencies. This resolves an `ImportError` where `Any` cannot be imported from `kubernetes_asyncio.config`, which is currently causing the `presubmit-agent-sandbox-unit-test` job to fail.

#### Which issue(s) this PR is related to:
Fixes #840
