### PR TITLE
controllers: clear stale status.selector when sandbox has no pod

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -242,6 +242,7 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 	if pod == nil {
 		sandbox.Status.Replicas = 0
+		sandbox.Status.LabelSelector = ""
 		sandbox.Status.PodIPs = nil
 	} else {
 		sandbox.Status.Replicas = 1

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -288,6 +288,7 @@ func TestReconcile(t *testing.T) {
 		name                 string
 		initialObjs          []runtime.Object
 		sandboxSpec          sandboxv1beta1.SandboxSpec
+		initialStatus        sandboxv1beta1.SandboxStatus
 		sandboxAnnotations   map[string]string
 		reconcileCount       int
 		deletionTimestamp    *metav1.Time
@@ -343,6 +344,36 @@ func TestReconcile(t *testing.T) {
 								Name: "test-container",
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "clears stale selector when no pod exists",
+			sandboxSpec: sandboxv1beta1.SandboxSpec{
+				Replicas: new(int32),
+			},
+			initialStatus: sandboxv1beta1.SandboxStatus{
+				Replicas:      1,
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				PodIPs:        []string{"10.0.0.1"},
+			},
+			wantStatus: sandboxv1beta1.SandboxStatus{
+				Replicas: 0,
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonSuspendedPodTerminated,
+						Message:            "Pod has been terminated. Sandbox is not operational.",
+					},
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionReady),
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonSuspended,
+						Message:            "Sandbox is suspended",
 					},
 				},
 			},
@@ -955,6 +986,7 @@ func TestReconcile(t *testing.T) {
 				sb.Finalizers = []string{"test-finalizer"}
 			}
 			sb.Spec = tc.sandboxSpec
+			sb.Status = tc.initialStatus
 			if tc.sandboxAnnotations != nil {
 				sb.Annotations = tc.sandboxAnnotations
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:
Clears `Sandbox.status.selector` when a Sandbox has no backing pod.

Today, when `reconcilePod()` returns `nil`, the controller clears `status.replicas` and `status.podIPs` but leaves `status.selector` unchanged. This can expose stale selector state through the scale subresource after a Sandbox is scaled to zero. This PR clears `status.selector` in the no-pod path and adds a regression test covering the stale status case.

#### Which issue(s) this PR is related to:
Fixes #837