### PR TITLE
[Draft/RFC] Envoy + ext_proc alternative for KEP-NNNN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,15 @@ LD_FLAGS := -s -w -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
 	-X $(VERSION_PKG).buildDate=$(BUILD_DATE)
 
 .PHONY: build
-build:
+build: build-controller build-sandbox-router-ext-proc
+
+.PHONY: build-controller
+build-controller:
 	go build -ldflags "$(LD_FLAGS)" -o bin/manager ./cmd/agent-sandbox-controller
+
+.PHONY: build-sandbox-router-ext-proc
+build-sandbox-router-ext-proc:
+	go build -ldflags "$(LD_FLAGS)" -o bin/ext-proc ./sandbox-router/cmd/ext-proc
 
 KIND_CLUSTER=agent-sandbox
 

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -72,9 +72,14 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
     for tag in args.extra_image_tags:  # additional image tags
         extra_tag = utils.get_full_image_name(args, service_name, tag=tag)
         build_cmd.extend(["-t", extra_tag])
+    # Use the Dockerfile path relative to the build context so overrides
+    # like context_dir="." with a Dockerfile under a subdirectory (e.g.
+    # sandbox-router/Dockerfile) resolve correctly. os.path.basename
+    # alone collapses to "Dockerfile" and accidentally picks up the
+    # repo-root Dockerfile when cwd=".".
     build_cmd.extend([
         "-f",
-        os.path.basename(dockerfile_path),
+        os.path.relpath(dockerfile_path, srcdir),
         ".",
     ])
     # Inject version info into Go binaries
@@ -126,6 +131,14 @@ def main(args):
 
             if service_name == ".":
                 service_name = "agent-sandbox-controller"
+
+            # The sandbox-router/Dockerfile needs the repo root as the
+            # build context because it imports the shared Go module.
+            # Image is named sandbox-router-ext-proc to avoid colliding
+            # with the Python router's "sandbox-router" image.
+            if root == os.path.join(".", "sandbox-router"):
+                context_dir = "."
+                service_name = "sandbox-router-ext-proc"
 
             if args.images and service_name not in args.images:
                 continue

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 toolchain go1.26.4
 
 require (
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
@@ -16,6 +17,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/sync v0.20.0
+	google.golang.org/grpc v1.80.0
 	k8s.io/api v0.36.0
 	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.0
@@ -30,8 +32,10 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
@@ -62,6 +66,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
@@ -85,7 +90,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,12 +14,18 @@ github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moA
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
+github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
+github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
+github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
+github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
@@ -121,6 +127,8 @@ github.com/onsi/gomega v1.39.0/go.mod h1:ZCU1pkQcXDO5Sl9/VVEGlDyp+zm0m1cmeG5TOzL
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
+github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/sandbox-router/Dockerfile
+++ b/sandbox-router/Dockerfile
@@ -1,0 +1,28 @@
+# Build the ext-proc binary as a static distroless image. Build context
+# MUST be the repo root because the binary depends on the shared Go
+# module (internal/, api/, etc. via transitive imports).
+# dev/tools/push-images is patched to use the repo root as build context
+# for this Dockerfile; see the patch in dev/tools/push-images.
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+
+ARG TARGETARCH
+ARG GIT_VERSION=unknown
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Only the modules this binary actually imports.
+COPY sandbox-router/ ./sandbox-router/
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+    -ldflags="-s -w" \
+    -o /ext-proc ./sandbox-router/cmd/ext-proc
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /ext-proc /ext-proc
+EXPOSE 50051
+ENTRYPOINT ["/ext-proc"]

--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -38,10 +38,12 @@ Envoy expects these headers from the client (preserved from the Python router fo
 
 | Header | Required? | Default | Notes |
 |---|---|---|---|
-| `X-Sandbox-ID` | yes | — | Sandbox name. Used for DNS-form fallback when UID is missing or uncached. |
+| `X-Sandbox-ID` | yes | — | Sandbox name. Used for DNS-form fallback when UID is missing or uncached. Must be a valid DNS-1123 label (`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, max 63 chars). |
 | `X-Sandbox-UID` | recommended | — | Sandbox CR UID. Primary key for cache lookup; non-guessable. |
-| `X-Sandbox-Namespace` | no | `default` | ASCII letters/digits/hyphens, ≥1 alphanumeric. |
-| `X-Sandbox-Port` | no | `8888` | Numeric. |
+| `X-Sandbox-Namespace` | no | `default` | Same DNS-1123 label check as ID. |
+| `X-Sandbox-Port` | no | `8888` | Integer in `[1, 65535]`. |
+
+DNS-label validation on both ID and namespace prevents DNS injection (e.g. `foo.evil.com` interpolating extra components into the upstream FQDN) and traversal-style inputs (e.g. `foo/bar`). Matches the Python router's `_is_valid_dns_label` check.
 
 Routing precedence:
 
@@ -50,6 +52,14 @@ Routing precedence:
 3. If `X-Sandbox-ID` is missing → 400 `{"detail":"X-Sandbox-ID header is required."}`.
 
 The ext_proc handler returns Python-router-compatible JSON error bodies (`{"detail":"..."}`) for validation failures so existing clients keep working.
+
+### Headers stripped before forwarding
+
+The `HeaderMutation` returned to Envoy always removes:
+
+- **`Authorization`** — identity-checking authorizers in front of ext_proc (TokenReview, JWT, etc.) consume the bearer credential. Forwarding it to the sandbox would let the sandbox impersonate the caller against the K8s API or any other Bearer-protected service. Matches the Python router, which strips `Authorization` right next to `Host`.
+- **`x-envoy-original-dst-host`** on the listener (defense in depth) — an `envoy.filters.http.header_mutation` filter runs *before* ext_proc and removes any client-supplied value, so ext_proc is provably the only writer of that header. Without this, a future route that disables ext_proc and uses the ORIGINAL_DST cluster would dispatch to whatever the client asked for.
+- **`Origin` on upgrade requests** — see the WebSockets section below.
 
 ### WebSockets and X-Forwarded-* headers
 

--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -1,12 +1,12 @@
 # sandbox-router
 
-A top-level component implementing [KEP-NNNN](../docs/keps/NNNN-sandbox-router/) (Go-Based Sandbox Router with Pod IP Mapping) using **Envoy + ext_proc** rather than a from-scratch Go reverse proxy.
+A top-level component implementing [KEP-NNNN](https://github.com/kubernetes-sigs/agent-sandbox/pull/758) (Go-Based Sandbox Router with Pod IP Mapping) using **Envoy + ext_proc** rather than a from-scratch Go reverse proxy.
 
 The KEP's three core mechanisms — informer-backed UID→PodIP map, direct Pod IP dispatch, drift-handling — are still implemented in Go. Everything else (TLS termination, mTLS, rate limiting, circuit breaker, access logs, tracing, retries) is delegated to Envoy.
 
 ## Architecture
 
-```
+```text
 client ──► Envoy listener (:8080)
             │
             ├── HTTP filter: ext_proc

--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -1,0 +1,175 @@
+# sandbox-router
+
+A top-level component implementing [KEP-NNNN](../docs/keps/NNNN-sandbox-router/) (Go-Based Sandbox Router with Pod IP Mapping) using **Envoy + ext_proc** rather than a from-scratch Go reverse proxy.
+
+The KEP's three core mechanisms — informer-backed UID→PodIP map, direct Pod IP dispatch, drift-handling — are still implemented in Go. Everything else (TLS termination, mTLS, rate limiting, circuit breaker, access logs, tracing, retries) is delegated to Envoy.
+
+## Architecture
+
+```
+client ──► Envoy listener (:8080)
+            │
+            ├── HTTP filter: ext_proc
+            │     │
+            │     │  gRPC ProcessingRequest (RequestHeaders)
+            │     ▼
+            │   ext-proc-sandbox-router service
+            │     │  - K8s Pod informer (labeled sandbox-name-hash)
+            │     │  - In-memory UID → PodIP map
+            │     │  - Reads X-Sandbox-UID + X-Sandbox-ID etc.
+            │     │  - Returns header mutation:
+            │     │    x-envoy-original-dst-host = <PodIP>:<port>
+            │     │    (or DNS form on cache miss)
+            │     ▼
+            │   gRPC ProcessingResponse (HeaderMutation + ClearRouteCache)
+            │
+            └── HTTP filter: router → ORIGINAL_DST cluster
+                                       (reads x-envoy-original-dst-host)
+                ─────► sandbox Pod
+```
+
+**What Envoy owns:** TLS termination, mTLS, rate limiting (Envoy's `local_ratelimit` filter), circuit breaker / outlier detection on per-Pod-IP endpoints, access logs (Envoy access log), distributed tracing (OTel native), retries, hedged retries, JWT auth, WAF — everything Envoy is good at, available without further code.
+
+**What the Go ext-proc service owns:** the single piece of K8s-aware state. ~300 lines of Go.
+
+## Request contract
+
+Envoy expects these headers from the client (preserved from the Python router for compatibility):
+
+| Header | Required? | Default | Notes |
+|---|---|---|---|
+| `X-Sandbox-ID` | yes | — | Sandbox name. Used for DNS-form fallback when UID is missing or uncached. |
+| `X-Sandbox-UID` | recommended | — | Sandbox CR UID. Primary key for cache lookup; non-guessable. |
+| `X-Sandbox-Namespace` | no | `default` | ASCII letters/digits/hyphens, ≥1 alphanumeric. |
+| `X-Sandbox-Port` | no | `8888` | Numeric. |
+
+Routing precedence:
+
+1. If `X-Sandbox-UID` is set and the cache has an entry → upstream is `<PodIP>:<port>` (fast path).
+2. Otherwise → upstream is `<X-Sandbox-ID>.<namespace>.svc.<cluster-domain>:<port>` (DNS fallback; works without UID, slower).
+3. If `X-Sandbox-ID` is missing → 400 `{"detail":"X-Sandbox-ID header is required."}`.
+
+The ext_proc handler returns Python-router-compatible JSON error bodies (`{"detail":"..."}`) for validation failures so existing clients keep working.
+
+## Components
+
+| Path | Purpose |
+|---|---|
+| `cmd/ext-proc/main.go` | Binary entrypoint. Wires K8s client + cache + ext_proc server + gRPC health. |
+| `internal/cache/` | `SharedInformer` on Pods filtered by `agents.x-k8s.io/sandbox-name-hash`; thread-safe `UID → Entry` map; `Get()` returns `(Entry, bool)`. |
+| `internal/extproc/` | Envoy ext_proc v3 `ExternalProcessor` server. Reads request headers, looks up via cache, sets `x-envoy-original-dst-host`. |
+| `deploy/envoy/` | ConfigMap with the Envoy config, Deployment, Service named `sandbox-router-svc`. |
+| `deploy/ext-proc/` | Deployment (3 replicas), headless Service, ServiceAccount, ClusterRole (`get`/`list`/`watch` on Pods), PDB. |
+| `Dockerfile` | Multi-stage distroless static. |
+
+## Flags
+
+`./bin/ext-proc --help` lists the full set. Highlights:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--listen-address` | `:50051` | gRPC bind address for ext_proc. |
+| `--namespace` | `""` (cluster-wide) | Restrict informer to a single namespace. |
+| `--cluster-domain` | `cluster.local` | Suffix for the DNS-form fallback. |
+| `--informer-sync-timeout` | `2m` | Max wait for initial Pod list before /readyz stays failing. |
+| `--shutdown-timeout` | `30s` | Drain budget for in-flight ext_proc streams on SIGTERM. |
+| `--kubeconfig` | unset | Out-of-cluster path; honors `KUBECONFIG`. In-cluster otherwise. |
+
+## Build
+
+```sh
+make build-sandbox-router-ext-proc       # writes bin/ext-proc
+go test ./sandbox-router/...             # unit tests
+```
+
+## Load testing
+
+A standalone harness at [`cmd/load-test`](cmd/load-test/) runs the real `Server` + real `Cache` (backed by a fake K8s client) in-process and drives concurrent gRPC clients against it. Useful for characterizing the per-replica ceiling without a kind cluster.
+
+```sh
+go run ./sandbox-router/cmd/load-test \
+    --sandboxes=5000 --churn-rate=100 \
+    --clients=64 --duration=30s --cache-hit-pct=80
+```
+
+Reference numbers on a single development machine (Linux x86_64, Go 1.26, TCP loopback) — these are **upper bounds per replica**; real deployments add Envoy + network overhead:
+
+| Pool size | Clients | Churn ops/s | Throughput | p50 | p99 | Errors |
+|---:|---:|---:|---:|---:|---:|---:|
+| 5,000 | 64 | 0 | 38,700 req/s | 1.4 ms | 6.0 ms | 0 |
+| 5,000 | 64 | 100 | 35,000 req/s | 1.5 ms | 7.3 ms | 0 |
+| 10,000 | 200 | 500 | 37,200 req/s | 4.2 ms | 21.1 ms | 0 |
+| 5,000 | 64 | 1,000 | 30,300 req/s | 1.6 ms | 7.1 ms | 0 |
+| 1,000 | 256 | 0 | 45,800 req/s | 4.6 ms | 21.1 ms | 0 |
+
+The bottleneck at these numbers is the gRPC machinery itself (TCP loopback + protobuf encode/decode), not the cache lookup — even at 1,000 churn ops/s (≈ 40 % of the pool replaced per minute) throughput only drops ~20 % and there are no errors. Cache size accurately tracks the target throughout.
+
+## Deploy
+
+```sh
+kubectl apply -f sandbox-router/deploy/ext-proc/
+kubectl apply -f sandbox-router/deploy/envoy/
+
+# Wait for both Deployments to be ready
+kubectl rollout status deploy/ext-proc-sandbox-router
+kubectl rollout status deploy/sandbox-router-envoy
+
+# Verify Envoy /healthz (bypasses ext_proc)
+kubectl run -it --rm curl --image=curlimages/curl --restart=Never -- \
+    curl -sS http://sandbox-router-svc.default.svc.cluster.local:8080/healthz
+# expected: {"status":"ok"}
+```
+
+## How requests flow (end-to-end)
+
+1. Client sends `GET / HTTP/1.1\r\nX-Sandbox-ID: abc\r\nX-Sandbox-UID: <uuid>\r\n…` to `sandbox-router-svc:8080`.
+2. Envoy's HCM ext_proc filter sends a `ProcessingRequest{RequestHeaders}` gRPC message to the ext_proc service.
+3. ext_proc service reads the headers, looks up the UID in its in-memory cache, and replies with a `HeadersResponse{HeaderMutation}` setting `x-envoy-original-dst-host: 10.0.4.42:8888` and `ClearRouteCache: true`.
+4. Envoy re-runs route matching with the mutated header; the `sandbox_upstream` ORIGINAL_DST cluster reads `x-envoy-original-dst-host` and dispatches the request directly to `10.0.4.42:8888`.
+5. Sandbox Pod processes the request; response streams back through Envoy to the client.
+
+Total per-request overhead: one gRPC round-trip to the ext_proc service (~sub-ms in-cluster) plus one TCP connection to the Pod IP (or a reused one from Envoy's pool).
+
+## Drift handling
+
+Three mechanisms compose to keep stale entries from causing user-visible errors:
+
+| Drift case | Mitigation |
+|---|---|
+| Sandbox Pod deleted but ext_proc cache lags | Envoy ORIGINAL_DST outlier detection ejects the dead IP after 3 consecutive 5xx; next dispatch falls through to a fresh resolve. |
+| Sandbox Pod NotReady mid-request | ext_proc cache removes the entry on the NotReady UPDATE event; subsequent requests fall back to DNS or get 502. |
+| ext_proc replica with stale cache (just started, informer not synced) | gRPC health check stays NOT_SERVING until `informer.HasSynced()`; Envoy routes around. |
+| Sandbox UID never seen by cache (informer missed event) | DNS form fallback (`<sandbox-id>.<namespace>.svc.<cluster-domain>`) routes through standard K8s networking. |
+| ext_proc service entirely down | Envoy filter has `failure_mode_allow: false`; client gets 503 immediately rather than mis-routing. |
+
+## Comparison with the from-scratch Go router
+
+| Concern | From-scratch Go router | Envoy + ext_proc (this) |
+|---|---|---|
+| TLS / mTLS | Custom implementation (~400 LOC + hot reload) | Envoy native |
+| Rate limit | Would need to add | Envoy `local_ratelimit` filter |
+| Circuit breaker | Would need to add | Envoy outlier detection (built in) |
+| Access logs | Custom middleware (~150 LOC) | Envoy access log (config-only) |
+| Tracing | Custom OTel middleware (~100 LOC) | Envoy OTel native |
+| Retries | Custom retry transport (~150 LOC + tests) | Envoy retry policy + hedged retries |
+| Custom Go LOC | ~5,000 | ~300 |
+| K8s API surface | Optional informer | Required informer (same code) |
+| Operational footprint | One Go binary | Envoy + Go service (two Deployments) |
+
+## Not in this prototype
+
+These were intentionally deferred to keep the prototype small. None blocks the core routing path:
+
+- **TokenReview auth.** The KEP's middleware example. Drops in as an `ext_authz` filter pointing at an authz extension of this service (or a sibling).
+- **TLS on the ext_proc gRPC channel.** Envoy↔ext_proc is currently plaintext-on-cluster. Add `transport_socket: tls` for production.
+- **Prometheus metrics on the ext_proc service.** Envoy's own stats cover most of it; the Go service can expose its own `/metrics` later for cache size / sync state.
+- **Hardening of the example manifests.** No NetworkPolicy, no HPA, replica counts are minimum. See the `deploy/` files for what to tighten.
+- **Load test capture.** Should add once the prototype is running against kind.
+
+## Why the Sandbox UID isn't a Pod label
+
+The KEP says "Sandbox CRD UID (read from Pod labels)" but in practice the controller does NOT stamp the UID on the Pod as a label today. The only labels on a sandbox Pod are `agents.x-k8s.io/sandbox-name-hash` and any propagated user labels from `PodTemplate.Labels`.
+
+The Sandbox UID IS available on `Pod.metadata.ownerReferences[0].UID` (set by `ctrl.SetControllerReference()` in `controllers/sandbox_controller.go`). We extract it from there, filtering on `Kind=Sandbox` and `APIGroup=agents.x-k8s.io`. No second informer needed.
+
+If we want to allow direct label-based lookup (which would let other controllers query "what's the UID of sandbox X" without walking ownerReferences), that's a follow-up — small controller change to add an `agents.x-k8s.io/sandbox-uid` label on the Pod.

--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -51,6 +51,13 @@ Routing precedence:
 
 The ext_proc handler returns Python-router-compatible JSON error bodies (`{"detail":"..."}`) for validation failures so existing clients keep working.
 
+### WebSockets and X-Forwarded-* headers
+
+Two small carve-outs make browser-facing backends (vscode-server, Jupyter, anything that holds an Origin/Host CSRF check) work without changes:
+
+- **`Origin` is stripped on upgrade requests.** When the inbound request carries `Connection: Upgrade` + a non-empty `Upgrade:` header, the ext_proc handler returns a `HeaderMutation` with `RemoveHeaders: ["origin"]` alongside the dst-host set. The reason: vscode-server and similar backends reject the WebSocket upgrade with a `1006` close when the client-supplied `Origin` doesn't match the backend's own `Host`. Normal HTTP traffic preserves `Origin` so CORS preflights stay intact.
+- **`X-Forwarded-Host` is set in the Envoy config** via `request_headers_to_add` (the value is `%REQ(:AUTHORITY)%`). `X-Forwarded-For` and `X-Forwarded-Proto` come for free from `use_remote_address: true`. Browser-facing backends use these to construct correct self-links and redirects.
+
 ## Components
 
 | Path | Purpose |

--- a/sandbox-router/cmd/ext-proc/main.go
+++ b/sandbox-router/cmd/ext-proc/main.go
@@ -140,11 +140,7 @@ func run(log logr.Logger, cfg runConfig) error {
 	grpcSrv := grpc.NewServer()
 	extprocv3.RegisterExternalProcessorServer(grpcSrv, srv)
 
-	// Health server — NOT_SERVING until informer.HasSynced(); Envoy's
-	// gRPC health check sees this and routes around us until ready.
-	healthSrv := health.NewServer()
-	healthSrv.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
-	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+	healthSrv := newHealthServer()
 	healthpb.RegisterHealthServer(grpcSrv, healthSrv)
 
 	go func() {
@@ -153,7 +149,6 @@ func run(log logr.Logger, cfg runConfig) error {
 		if cch.WaitForSync(syncCtx) {
 			log.Info("informer synced; advertising READY")
 			healthSrv.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_SERVING)
-			healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 		} else {
 			log.Error(nil, "informer failed to sync within timeout; staying NOT_SERVING")
 		}
@@ -181,10 +176,12 @@ func run(log logr.Logger, cfg runConfig) error {
 		return fmt.Errorf("grpc serve: %w", err)
 	}
 
-	// Flip health to NOT_SERVING immediately so Envoy stops routing new
-	// streams here while the existing ones drain.
+	// Flip the named (readiness-gating) service to NOT_SERVING so Envoy
+	// and the kubelet readinessProbe stop routing new streams while
+	// in-flight ones drain. Leave the default service ("") SERVING —
+	// flipping it would make the kubelet livenessProbe fail mid-drain
+	// and SIGKILL us before GracefulStop finishes.
 	healthSrv.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
-	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
 
 	// Graceful shutdown: drain in-flight streams, then close listeners.
 	// Bounded by shutdownGrace; if drain stalls, fall back to a hard stop.
@@ -201,4 +198,29 @@ func run(log logr.Logger, cfg runConfig) error {
 		<-drained
 	}
 	return nil
+}
+
+// newHealthServer returns a grpc/health.Server with two services
+// reported separately, by design:
+//
+//   - The NAMED service (envoy.service.ext_proc.v3.ExternalProcessor)
+//     gates readiness: NOT_SERVING until the informer cache has synced.
+//     Envoy's gRPC health check and the kubelet readinessProbe both
+//     target this service, so neither sends real traffic until we can
+//     resolve UIDs.
+//
+//   - The DEFAULT service ("") gates liveness only: SERVING from the
+//     moment the gRPC server is up, period. The kubelet livenessProbe
+//     targets the empty service name. Coupling it to informer sync
+//     would mean a slow initial LIST (large cluster, throttled
+//     apiserver) blows past the liveness window and the kubelet
+//     restart-loops the pod forever, never letting sync complete.
+//
+// Exported as a helper so the test in main_test.go can pin this split
+// without spinning up the full process.
+func newHealthServer() *health.Server {
+	h := health.NewServer()
+	h.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	h.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+	return h
 }

--- a/sandbox-router/cmd/ext-proc/main.go
+++ b/sandbox-router/cmd/ext-proc/main.go
@@ -1,0 +1,204 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary ext-proc is the sandbox-router's ext_proc service. It runs a K8s
+// informer over sandbox Pods, maintains a UID→PodIP cache, and serves
+// Envoy's ext_proc v3 gRPC protocol. Envoy uses our header mutation to
+// drive ORIGINAL_DST dispatch to the right sandbox Pod.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"sigs.k8s.io/agent-sandbox/sandbox-router/internal/cache"
+	"sigs.k8s.io/agent-sandbox/sandbox-router/internal/extproc"
+)
+
+// healthServiceName is the gRPC health-check service name Envoy uses to
+// probe whether this replica is ready to serve. We keep it NOT_SERVING
+// until the informer cache has synced, so Envoy's gRPC health check
+// routes around freshly-started replicas that would otherwise miss cache
+// lookups.
+const healthServiceName = "envoy.service.ext_proc.v3.ExternalProcessor"
+
+func main() {
+	var (
+		listenAddr    string
+		namespace     string
+		clusterDomain string
+		syncTimeout   time.Duration
+		shutdownGrace time.Duration
+	)
+	flag.StringVar(&listenAddr, "listen-address", ":50051",
+		"Address for the ext_proc gRPC server.")
+	flag.StringVar(&namespace, "namespace", "",
+		"K8s namespace to watch for sandbox Pods. Empty means cluster-wide (the usual setting).")
+	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local",
+		"K8s cluster DNS suffix used for the DNS-form fallback when a UID is not cached.")
+	flag.DurationVar(&syncTimeout, "informer-sync-timeout", 2*time.Minute,
+		"Max time to wait for the initial Pod informer sync before failing readiness.")
+	flag.DurationVar(&shutdownGrace, "shutdown-timeout", 30*time.Second,
+		"Time budget for draining in-flight ext_proc streams on SIGTERM.")
+	// Note: --kubeconfig is registered by controller-runtime's
+	// client-go auth plugin import; ctrl.GetConfig() honors it
+	// alongside KUBECONFIG and in-cluster config.
+
+	zapOpts := zap.Options{Development: false}
+	zapOpts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
+	log := ctrl.Log.WithName("ext-proc")
+
+	if err := run(log, runConfig{
+		listenAddr:    listenAddr,
+		namespace:     namespace,
+		clusterDomain: clusterDomain,
+		syncTimeout:   syncTimeout,
+		shutdownGrace: shutdownGrace,
+	}); err != nil {
+		log.Error(err, "exited with error")
+		os.Exit(1)
+	}
+}
+
+type runConfig struct {
+	listenAddr    string
+	namespace     string
+	clusterDomain string
+	syncTimeout   time.Duration
+	shutdownGrace time.Duration
+}
+
+func run(log logr.Logger, cfg runConfig) error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// --- K8s client -----------------------------------------------------
+	// ctrl.GetConfig handles --kubeconfig flag, KUBECONFIG env, in-cluster
+	// config, and ~/.kube/config in that order.
+	restCfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("build kube REST config: %w", err)
+	}
+	client, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("kube client: %w", err)
+	}
+
+	// --- Cache ----------------------------------------------------------
+	cacheLog := log.WithName("cache")
+	cch, err := cache.New(cache.Options{
+		Client:    client,
+		Log:       cacheLog,
+		Namespace: cfg.namespace,
+	})
+	if err != nil {
+		return fmt.Errorf("cache: %w", err)
+	}
+	cch.Start(ctx)
+
+	// --- gRPC server ----------------------------------------------------
+	srv, err := extproc.NewServer(extproc.Options{
+		Cache:         cch,
+		ClusterDomain: cfg.clusterDomain,
+		Log:           log.WithName("handler"),
+	})
+	if err != nil {
+		return fmt.Errorf("extproc server: %w", err)
+	}
+
+	grpcSrv := grpc.NewServer()
+	extprocv3.RegisterExternalProcessorServer(grpcSrv, srv)
+
+	// Health server — NOT_SERVING until informer.HasSynced(); Envoy's
+	// gRPC health check sees this and routes around us until ready.
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+	healthpb.RegisterHealthServer(grpcSrv, healthSrv)
+
+	go func() {
+		syncCtx, cancel := context.WithTimeout(ctx, cfg.syncTimeout)
+		defer cancel()
+		if cch.WaitForSync(syncCtx) {
+			log.Info("informer synced; advertising READY")
+			healthSrv.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_SERVING)
+			healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+		} else {
+			log.Error(nil, "informer failed to sync within timeout; staying NOT_SERVING")
+		}
+	}()
+
+	// --- Listen ---------------------------------------------------------
+	lis, err := net.Listen("tcp", cfg.listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", cfg.listenAddr, err)
+	}
+	log.Info("starting ext-proc",
+		"address", lis.Addr().String(),
+		"namespace", cfg.namespace,
+		"clusterDomain", cfg.clusterDomain,
+	)
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- grpcSrv.Serve(lis) }()
+
+	// --- Wait for signal or serve error --------------------------------
+	select {
+	case <-ctx.Done():
+		log.Info("shutdown initiated")
+	case err := <-serveErr:
+		return fmt.Errorf("grpc serve: %w", err)
+	}
+
+	// Flip health to NOT_SERVING immediately so Envoy stops routing new
+	// streams here while the existing ones drain.
+	healthSrv.SetServingStatus(healthServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+
+	// Graceful shutdown: drain in-flight streams, then close listeners.
+	// Bounded by shutdownGrace; if drain stalls, fall back to a hard stop.
+	drained := make(chan struct{})
+	go func() {
+		grpcSrv.GracefulStop()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(cfg.shutdownGrace):
+		log.Info("graceful shutdown timed out; forcing stop", "timeout", cfg.shutdownGrace)
+		grpcSrv.Stop()
+		<-drained
+	}
+	return nil
+}

--- a/sandbox-router/cmd/ext-proc/main_test.go
+++ b/sandbox-router/cmd/ext-proc/main_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// TestHealthServerSplitsLivenessAndReadiness pins the contract that
+// the default ("") service is SERVING from boot (so the kubelet
+// livenessProbe — which targets the empty service name — never
+// fails-and-restart-loops while the informer is still syncing on
+// large clusters) while the named ext_proc service stays NOT_SERVING
+// until WaitForSync completes (so neither Envoy nor the kubelet
+// readinessProbe sends real traffic prematurely).
+func TestHealthServerSplitsLivenessAndReadiness(t *testing.T) {
+	h := newHealthServer()
+	ctx := context.Background()
+
+	def, err := h.Check(ctx, &healthpb.HealthCheckRequest{Service: ""})
+	if err != nil {
+		t.Fatalf("default service Check: %v", err)
+	}
+	if def.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("default service: got %s, want SERVING (liveness must succeed at boot)", def.Status)
+	}
+
+	named, err := h.Check(ctx, &healthpb.HealthCheckRequest{Service: healthServiceName})
+	if err != nil {
+		t.Fatalf("named service Check: %v", err)
+	}
+	if named.Status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("named service: got %s, want NOT_SERVING at boot (gated on informer sync)", named.Status)
+	}
+}

--- a/sandbox-router/cmd/load-test/main.go
+++ b/sandbox-router/cmd/load-test/main.go
@@ -1,0 +1,565 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary load-test is a standalone harness that measures the ext-proc
+// service under realistic-ish load: a sandbox pool of configurable size,
+// continuous churn driven through the fake K8s informer path, and
+// concurrent gRPC clients sending ProcessingRequest messages against the
+// real Server. It reports throughput, latency percentiles, cache hit
+// ratio, and memory usage.
+//
+// Everything runs in-process. There is no real Kubernetes cluster and no
+// Envoy — the goal is to characterize the SERVER's capacity, not the
+// cluster end-to-end. For end-to-end testing, run this binary against a
+// kind cluster with --listen-address instead of in-process.
+//
+// Usage:
+//
+//	go run ./sandbox-router/cmd/load-test \
+//	    --sandboxes=5000 --churn-rate=100 \
+//	    --clients=64 --duration=30s --cache-hit-pct=80
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	mathrand "math/rand/v2"
+	"net"
+	"os"
+	"runtime"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	routercache "sigs.k8s.io/agent-sandbox/sandbox-router/internal/cache"
+	"sigs.k8s.io/agent-sandbox/sandbox-router/internal/extproc"
+)
+
+func main() {
+	var (
+		sandboxes     int
+		churnRate     int
+		clients       int
+		duration      time.Duration
+		warmup        time.Duration
+		cacheHitPct   int
+		clusterDomain string
+		listenAddr    string
+	)
+	flag.IntVar(&sandboxes, "sandboxes", 1000,
+		"Target sandbox pool size (cache entries maintained throughout the run).")
+	flag.IntVar(&churnRate, "churn-rate", 0,
+		"Add+remove operations per second on the informer. 0 = static pool.")
+	flag.IntVar(&clients, "clients", 32,
+		"Number of concurrent gRPC clients. Each runs a tight Send/Recv loop on its own stream.")
+	flag.DurationVar(&duration, "duration", 15*time.Second,
+		"How long to drive load before stopping.")
+	flag.DurationVar(&warmup, "warmup", 2*time.Second,
+		"Warmup window during which samples are NOT recorded; lets the JIT, cache, and informer settle.")
+	flag.IntVar(&cacheHitPct, "cache-hit-pct", 80,
+		"Percentage of requests that should target a known UID. The rest use random UIDs (cache miss → DNS fallback).")
+	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local",
+		"Cluster domain passed to the extproc server (only affects the DNS-form fallback target).")
+	flag.StringVar(&listenAddr, "listen-address", "127.0.0.1:0",
+		"TCP address for the in-process gRPC server. 127.0.0.1:0 picks a free port.")
+	flag.Parse()
+
+	if cacheHitPct < 0 || cacheHitPct > 100 {
+		fmt.Fprintln(os.Stderr, "--cache-hit-pct must be in [0,100]")
+		os.Exit(2)
+	}
+
+	if err := run(runConfig{
+		sandboxes:     sandboxes,
+		churnRate:     churnRate,
+		clients:       clients,
+		duration:      duration,
+		warmup:        warmup,
+		cacheHitPct:   cacheHitPct,
+		clusterDomain: clusterDomain,
+		listenAddr:    listenAddr,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "load-test failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type runConfig struct {
+	sandboxes     int
+	churnRate     int
+	clients       int
+	duration      time.Duration
+	warmup        time.Duration
+	cacheHitPct   int
+	clusterDomain string
+	listenAddr    string
+}
+
+func run(cfg runConfig) error {
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.duration+cfg.warmup+10*time.Second)
+	defer cancel()
+
+	// ---- pre-populate sandboxes ----
+	initial := make([]*corev1.Pod, 0, cfg.sandboxes)
+	for i := range cfg.sandboxes {
+		initial = append(initial, makePod(i))
+	}
+	objs := make([]kruntime.Object, len(initial))
+	for i, p := range initial {
+		objs[i] = p
+	}
+	client := fake.NewSimpleClientset(objs...)
+
+	// ---- start cache + server ----
+	cch, err := routercache.New(routercache.Options{Client: client, Log: logr.Discard()})
+	if err != nil {
+		return fmt.Errorf("cache: %w", err)
+	}
+	cch.Start(ctx)
+	if !cch.WaitForSync(ctx) {
+		return fmt.Errorf("informer sync timed out")
+	}
+
+	srv, err := extproc.NewServer(extproc.Options{
+		Cache:         cch,
+		ClusterDomain: cfg.clusterDomain,
+		Log:           logr.Discard(),
+	})
+	if err != nil {
+		return fmt.Errorf("server: %w", err)
+	}
+
+	lis, err := net.Listen("tcp", cfg.listenAddr)
+	if err != nil {
+		return fmt.Errorf("listen: %w", err)
+	}
+	defer lis.Close()
+	gsrv := grpc.NewServer()
+	extprocv3.RegisterExternalProcessorServer(gsrv, srv)
+	go func() { _ = gsrv.Serve(lis) }()
+	defer gsrv.Stop()
+
+	// ---- pool of "known" UIDs the clients will hit ----
+	pool := newUIDPool(initial)
+
+	// ---- churn ----
+	churnDone := make(chan struct{})
+	if cfg.churnRate > 0 {
+		go runChurn(ctx, client, pool, cfg.churnRate, churnDone)
+	} else {
+		close(churnDone)
+	}
+
+	// ---- start clients ----
+	addr := lis.Addr().String()
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close()
+
+	stats := &statsCollector{}
+	startTime := time.Now()
+	recordingStart := startTime.Add(cfg.warmup)
+	stopAt := startTime.Add(cfg.warmup + cfg.duration)
+
+	wg := sync.WaitGroup{}
+	wg.Add(cfg.clients)
+	for range cfg.clients {
+		go func() {
+			defer wg.Done()
+			driveClient(ctx, conn, pool, cfg.cacheHitPct, recordingStart, stopAt, stats)
+		}()
+	}
+
+	// Wait either for stopAt + a small grace, or for ctx cancel.
+	deadline := time.NewTimer(time.Until(stopAt) + 200*time.Millisecond)
+	defer deadline.Stop()
+	select {
+	case <-deadline.C:
+	case <-ctx.Done():
+	}
+	cancel() // signal churn + clients to stop
+	wg.Wait()
+	<-churnDone
+
+	// ---- final memory snapshot ----
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	stats.report(cfg, cch.Len(), mem)
+	return nil
+}
+
+// ---- fake objects + pool --------------------------------------------------
+
+// makePod constructs a synthetic sandbox Pod with a unique UID, name, and
+// IP. Looks indistinguishable to the cache from a real controller-created
+// Pod. Index i is encoded into the IP for debuggability.
+func makePod(i int) *corev1.Pod {
+	tru := true
+	name := fmt.Sprintf("sb-%06d", i)
+	uid := randomUID()
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "tenants",
+			Labels:    map[string]string{routercache.PodSandboxNameHashLabel: "loadtest"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: routercache.SandboxAPIGroup + "/v1beta1",
+				Kind:       routercache.SandboxKind,
+				Name:       name,
+				UID:        uid,
+				Controller: &tru,
+			}},
+		},
+		Status: corev1.PodStatus{
+			PodIP: fmt.Sprintf("10.%d.%d.%d", (i>>16)&0xff, (i>>8)&0xff, i&0xff),
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+func randomUID() types.UID {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return types.UID(hex.EncodeToString(b))
+}
+
+// uidPool is the set of currently-known (cached) sandboxes. Clients pick
+// random members of this pool when they want to generate cache-hit
+// traffic. Churn mutates it.
+type uidPool struct {
+	mu  sync.RWMutex
+	ids []poolEntry
+}
+
+type poolEntry struct {
+	name      string
+	namespace string
+	uid       types.UID
+}
+
+func newUIDPool(pods []*corev1.Pod) *uidPool {
+	p := &uidPool{ids: make([]poolEntry, 0, len(pods))}
+	for _, pod := range pods {
+		if len(pod.OwnerReferences) == 0 {
+			continue
+		}
+		p.ids = append(p.ids, poolEntry{
+			name:      pod.Name,
+			namespace: pod.Namespace,
+			uid:       pod.OwnerReferences[0].UID,
+		})
+	}
+	return p
+}
+
+func (p *uidPool) pickHit() (poolEntry, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if len(p.ids) == 0 {
+		return poolEntry{}, false
+	}
+	return p.ids[mathrand.IntN(len(p.ids))], true
+}
+
+func (p *uidPool) replace(remove, add poolEntry) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.ids) == 0 {
+		return
+	}
+	// Find remove (O(N); pool size is bounded by sandbox count, fine).
+	idx := slices.IndexFunc(p.ids, func(e poolEntry) bool { return e.uid == remove.uid })
+	if idx >= 0 {
+		p.ids[idx] = add
+	}
+}
+
+// ---- churn ---------------------------------------------------------------
+
+// runChurn drives add+remove operations at rate ops/sec, keeping the
+// sandbox pool size constant. Each "op" is one remove + one add (a
+// replacement), so churn-rate=100 = 100 replacements/s = ~200 informer
+// events/s.
+func runChurn(ctx context.Context, client *fake.Clientset, pool *uidPool, ratePerSec int, done chan<- struct{}) {
+	defer close(done)
+	if ratePerSec <= 0 {
+		return
+	}
+	interval := time.Second / time.Duration(ratePerSec)
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	next := mathrand.Uint64() // for fresh sandbox indices
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			// Pick a victim to remove.
+			pool.mu.Lock()
+			if len(pool.ids) == 0 {
+				pool.mu.Unlock()
+				continue
+			}
+			victimIdx := mathrand.IntN(len(pool.ids))
+			victim := pool.ids[victimIdx]
+			pool.mu.Unlock()
+
+			// Spawn a new sandbox to replace it. Different name and UID so
+			// the informer sees both a Delete (or Update if reused) and an
+			// Add — exercising both event paths.
+			next++
+			newPod := makePod(int(next))
+			newEntry := poolEntry{
+				name:      newPod.Name,
+				namespace: newPod.Namespace,
+				uid:       newPod.OwnerReferences[0].UID,
+			}
+
+			_ = client.CoreV1().Pods(victim.namespace).Delete(ctx, victim.name, metav1.DeleteOptions{})
+			_, _ = client.CoreV1().Pods(newPod.Namespace).Create(ctx, newPod, metav1.CreateOptions{})
+			pool.replace(victim, newEntry)
+		}
+	}
+}
+
+// ---- clients -------------------------------------------------------------
+
+// driveClient opens a single ext_proc stream and pumps requests through
+// it in a tight loop. Latency is recorded only for samples taken inside
+// the recording window (after warmup, before stop).
+func driveClient(ctx context.Context, conn *grpc.ClientConn, pool *uidPool, hitPct int,
+	recordStart, stopAt time.Time, stats *statsCollector,
+) {
+	cli := extprocv3.NewExternalProcessorClient(conn)
+	stream, err := cli.Process(ctx)
+	if err != nil {
+		stats.errors.Add(1)
+		return
+	}
+	defer func() { _ = stream.CloseSend() }()
+
+	for {
+		now := time.Now()
+		if !now.Before(stopAt) || ctx.Err() != nil {
+			return
+		}
+		req := buildRequest(pool, hitPct)
+
+		t0 := time.Now()
+		if err := stream.Send(req); err != nil {
+			stats.errors.Add(1)
+			return
+		}
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			stats.errors.Add(1)
+			return
+		}
+		latency := time.Since(t0)
+
+		hit := isCacheHit(resp)
+		if now.After(recordStart) {
+			stats.record(latency, hit)
+		}
+	}
+}
+
+func buildRequest(pool *uidPool, hitPct int) *extprocv3.ProcessingRequest {
+	var (
+		id        string
+		uid       string
+		namespace string
+	)
+	if mathrand.IntN(100) < hitPct {
+		if e, ok := pool.pickHit(); ok {
+			id = e.name
+			uid = string(e.uid)
+			namespace = e.namespace
+		}
+	}
+	if id == "" {
+		// Cache-miss path: random sandbox id, random UID; expected to hit
+		// DNS fallback in the server.
+		id = "miss-" + hex.EncodeToString(randomBytes(4))
+		uid = string(randomUID())
+		namespace = "tenants"
+	}
+	return &extprocv3.ProcessingRequest{
+		Request: &extprocv3.ProcessingRequest_RequestHeaders{
+			RequestHeaders: &extprocv3.HttpHeaders{
+				Headers: &corev3.HeaderMap{
+					Headers: []*corev3.HeaderValue{
+						{Key: extproc.HeaderSandboxID, RawValue: []byte(id)},
+						{Key: extproc.HeaderSandboxUID, RawValue: []byte(uid)},
+						{Key: extproc.HeaderSandboxNamespace, RawValue: []byte(namespace)},
+						{Key: extproc.HeaderSandboxPort, RawValue: []byte("8888")},
+					},
+				},
+			},
+		},
+	}
+}
+
+// isCacheHit inspects the server's HeaderMutation. We tagged cache vs
+// DNS by inspecting whether the target ends with the cluster suffix —
+// the server emits IP:port for cache hits and "<id>.<ns>.svc.cluster.local:port"
+// for DNS fallback.
+func isCacheHit(resp *extprocv3.ProcessingResponse) bool {
+	hr := resp.GetRequestHeaders()
+	if hr == nil || hr.Response == nil || hr.Response.HeaderMutation == nil {
+		return false
+	}
+	for _, h := range hr.Response.HeaderMutation.SetHeaders {
+		if h.Header.Key != extproc.HeaderOriginalDstHost {
+			continue
+		}
+		v := string(h.Header.RawValue)
+		// DNS form contains ".svc."; cache hits are bare IP:port.
+		for i := 0; i+5 <= len(v); i++ {
+			if v[i:i+5] == ".svc." {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func randomBytes(n int) []byte {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return b
+}
+
+// ---- stats ---------------------------------------------------------------
+
+type statsCollector struct {
+	mu        sync.Mutex
+	latencies []time.Duration
+	hits      atomic.Int64
+	misses    atomic.Int64
+	errors    atomic.Int64
+}
+
+func (s *statsCollector) record(latency time.Duration, hit bool) {
+	s.mu.Lock()
+	s.latencies = append(s.latencies, latency)
+	s.mu.Unlock()
+	if hit {
+		s.hits.Add(1)
+	} else {
+		s.misses.Add(1)
+	}
+}
+
+func (s *statsCollector) report(cfg runConfig, finalCacheSize int, mem runtime.MemStats) {
+	s.mu.Lock()
+	lats := slices.Clone(s.latencies)
+	s.mu.Unlock()
+	slices.Sort(lats)
+
+	total := int64(len(lats))
+	hits := s.hits.Load()
+	misses := s.misses.Load()
+	errs := s.errors.Load()
+
+	fmt.Println()
+	fmt.Println("=== ext-proc load test ===")
+	fmt.Printf("  sandboxes (target):  %d\n", cfg.sandboxes)
+	fmt.Printf("  cache size (final):  %d\n", finalCacheSize)
+	fmt.Printf("  churn rate:          %d ops/s\n", cfg.churnRate)
+	fmt.Printf("  clients:             %d\n", cfg.clients)
+	fmt.Printf("  duration (recorded): %s  (+ warmup %s)\n", cfg.duration, cfg.warmup)
+	fmt.Printf("  cache-hit target:    %d%%\n", cfg.cacheHitPct)
+	fmt.Println()
+	fmt.Println("  --- throughput ---")
+	if cfg.duration > 0 {
+		fmt.Printf("    requests recorded: %d\n", total)
+		fmt.Printf("    throughput:        %.0f req/s\n", float64(total)/cfg.duration.Seconds())
+	}
+	fmt.Println("  --- outcomes ---")
+	if hits+misses > 0 {
+		fmt.Printf("    cache hits:        %d (%.1f%%)\n", hits, 100*float64(hits)/float64(hits+misses))
+		fmt.Printf("    cache misses:      %d (%.1f%%)\n", misses, 100*float64(misses)/float64(hits+misses))
+	}
+	fmt.Printf("    errors:            %d\n", errs)
+	fmt.Println("  --- latency (request → response on the gRPC stream) ---")
+	if len(lats) == 0 {
+		fmt.Println("    (no samples recorded)")
+	} else {
+		fmt.Printf("    p50:   %s\n", pct(lats, 50))
+		fmt.Printf("    p90:   %s\n", pct(lats, 90))
+		fmt.Printf("    p95:   %s\n", pct(lats, 95))
+		fmt.Printf("    p99:   %s\n", pct(lats, 99))
+		fmt.Printf("    p999:  %s\n", pct(lats, 99.9))
+		fmt.Printf("    max:   %s\n", lats[len(lats)-1].Round(time.Microsecond))
+	}
+	fmt.Println("  --- memory (final) ---")
+	fmt.Printf("    heap in-use:       %s\n", humanBytes(mem.HeapInuse))
+	fmt.Printf("    heap allocated:    %s\n", humanBytes(mem.HeapAlloc))
+	fmt.Printf("    GC cycles:         %d\n", mem.NumGC)
+	fmt.Println()
+}
+
+func pct(s []time.Duration, p float64) time.Duration {
+	if len(s) == 0 {
+		return 0
+	}
+	idx := int(float64(len(s)) * p / 100)
+	if idx >= len(s) {
+		idx = len(s) - 1
+	}
+	return s[idx].Round(time.Microsecond)
+}
+
+func humanBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := uint64(unit), 0
+	for n/div >= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/sandbox-router/deploy/envoy/configmap.yaml
+++ b/sandbox-router/deploy/envoy/configmap.yaml
@@ -93,6 +93,22 @@ data:
                       timeout: 180s
 
               http_filters:
+              # Strip any inbound x-envoy-original-dst-host BEFORE
+              # ext_proc runs. ext_proc always sets this header via
+              # HeaderMutation, so after this filter chain the value
+              # in the header is provably the one ext_proc wrote (or
+              # absent if ext_proc was bypassed for the route, in
+              # which case the ORIGINAL_DST cluster won't find a
+              # target and returns 503 — fail-closed). Defense-in-
+              # depth: keeps the security of the data path from
+              # resting on "ext_proc is enabled on every route".
+              - name: envoy.filters.http.header_mutation
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+                  mutations:
+                    request_mutations:
+                    - remove: x-envoy-original-dst-host
+
               # ext_proc must run before the router filter so we get the
               # header mutation applied + route cache cleared before the
               # routing decision is made.

--- a/sandbox-router/deploy/envoy/configmap.yaml
+++ b/sandbox-router/deploy/envoy/configmap.yaml
@@ -37,6 +37,11 @@ data:
               # Forward x-request-id, generate one if missing — useful when
               # paired with ext_proc to trace a request end-to-end.
               generate_request_id: true
+              # use_remote_address gives us X-Forwarded-For (client IP) and
+              # X-Forwarded-Proto (http/https from the listener) for free
+              # on every upstream request. X-Forwarded-Host is set
+              # separately in request_headers_to_add below — Envoy doesn't
+              # populate it as part of use_remote_address.
               use_remote_address: true
 
               access_log:
@@ -49,6 +54,18 @@ data:
                 virtual_hosts:
                 - name: any
                   domains: ["*"]
+                  # X-Forwarded-Host: copy the inbound :authority (the
+                  # client-visible Host) into a header the upstream can
+                  # read. Browser-facing backends like vscode-server and
+                  # Jupyter need this to construct correct self-links
+                  # and redirects when sitting behind a proxy that
+                  # dispatches by IP. Overwrite rather than append so a
+                  # well-formed single value reaches the backend.
+                  request_headers_to_add:
+                  - header:
+                      key: X-Forwarded-Host
+                      value: "%REQ(:AUTHORITY)%"
+                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
                   routes:
                   # Cheap liveness — bypasses ext_proc so a broken
                   # ext-proc service doesn't take Envoy down with it.

--- a/sandbox-router/deploy/envoy/configmap.yaml
+++ b/sandbox-router/deploy/envoy/configmap.yaml
@@ -1,0 +1,173 @@
+# Envoy configuration for the sandbox-router.
+#
+# Pattern: every request flows through an ext_proc filter that asks the
+# sandbox-router ext_proc service "where should this go?". The handler
+# returns a header mutation setting `x-envoy-original-dst-host` to the
+# resolved upstream (Pod IP or DNS form). The single ORIGINAL_DST cluster
+# then dispatches the request to whatever that header says.
+#
+# No xDS, no per-sandbox cluster configuration. New sandboxes are routable
+# as soon as the ext_proc service's informer sees them as Ready.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sandbox-router-envoy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: sandbox-router-envoy
+    app.kubernetes.io/component: sandbox-router
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+    static_resources:
+      listeners:
+      - name: proxy
+        address:
+          socket_address: { address: 0.0.0.0, port_value: 8080 }
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: sandbox_router
+              codec_type: AUTO
+              # Forward x-request-id, generate one if missing — useful when
+              # paired with ext_proc to trace a request end-to-end.
+              generate_request_id: true
+              use_remote_address: true
+
+              access_log:
+              - name: envoy.access_loggers.stdout
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+
+              route_config:
+                name: sandbox
+                virtual_hosts:
+                - name: any
+                  domains: ["*"]
+                  routes:
+                  # Cheap liveness — bypasses ext_proc so a broken
+                  # ext-proc service doesn't take Envoy down with it.
+                  # ext_proc would otherwise reject this with 400 (no
+                  # X-Sandbox-ID header) before the route matches, so we
+                  # explicitly disable ext_proc on this route.
+                  - match: { path: "/healthz" }
+                    direct_response:
+                      status: 200
+                      body: { inline_string: '{"status":"ok"}' }
+                    typed_per_filter_config:
+                      envoy.filters.http.ext_proc:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute
+                        disabled: true
+                  # Everything else: the ext_proc filter has already set
+                  # x-envoy-original-dst-host (or rejected with 4xx).
+                  # ORIGINAL_DST cluster reads that header.
+                  - match: { prefix: "/" }
+                    route:
+                      cluster: sandbox_upstream
+                      # Be generous on per-route timeout; long-lived sandbox
+                      # operations (file uploads, code execution) need
+                      # minutes, not seconds. Tune via your own config if
+                      # you need stricter SLOs.
+                      timeout: 180s
+
+              http_filters:
+              # ext_proc must run before the router filter so we get the
+              # header mutation applied + route cache cleared before the
+              # routing decision is made.
+              - name: envoy.filters.http.ext_proc
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                  grpc_service:
+                    envoy_grpc:
+                      cluster_name: ext_proc_sandbox_router
+                    # Per-stream timeout — gives the ext_proc handler
+                    # plenty of slack while still failing fast on stalls.
+                    timeout: 1s
+                  # Without this, an unreachable / slow ext_proc service
+                  # would silently let requests through with no routing
+                  # target, which would 503 anyway. Fail fast and surface
+                  # the problem.
+                  failure_mode_allow: false
+                  message_timeout: 0.2s
+                  # By default ext_proc cannot mutate x-envoy-* headers (a
+                  # security default to stop external processors spoofing
+                  # internal Envoy state). We rely on x-envoy-original-dst-host
+                  # for the routing decision, so we have to opt back in.
+                  # disallow_is_error stays default (false) so any future
+                  # blocked mutation fails silently rather than 500'ing.
+                  mutation_rules:
+                    allow_envoy: true
+                  processing_mode:
+                    request_header_mode: SEND
+                    response_header_mode: SKIP
+                    request_body_mode: NONE
+                    response_body_mode: NONE
+                    request_trailer_mode: SKIP
+                    response_trailer_mode: SKIP
+                  # ext_proc must not be allowed to override the mode at
+                  # runtime — keeps the contract simple.
+                  allow_mode_override: false
+
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+      clusters:
+      # Cluster for the ext_proc gRPC service. Headless K8s Service +
+      # STRICT_DNS gives us per-pod LB; gRPC streams are multiplexed.
+      - name: ext_proc_sandbox_router
+        type: STRICT_DNS
+        lb_policy: ROUND_ROBIN
+        connect_timeout: 1s
+        # gRPC requires HTTP/2.
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
+        load_assignment:
+          cluster_name: ext_proc_sandbox_router
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: ext-proc-sandbox-router.default.svc.cluster.local
+                    port_value: 50051
+        health_checks:
+        - timeout: 1s
+          interval: 5s
+          unhealthy_threshold: 2
+          healthy_threshold: 1
+          grpc_health_check:
+            service_name: envoy.service.ext_proc.v3.ExternalProcessor
+        # Eject replicas that consistently fail so new streams don't pile
+        # up on a half-broken instance.
+        outlier_detection:
+          consecutive_5xx: 3
+          base_ejection_time: 10s
+          max_ejection_percent: 50
+
+      # The actual sandbox traffic cluster. ORIGINAL_DST reads the
+      # upstream address from the x-envoy-original-dst-host header (set
+      # by our ext_proc filter). No static endpoints — every dispatch is
+      # per-request.
+      - name: sandbox_upstream
+        type: ORIGINAL_DST
+        lb_policy: CLUSTER_PROVIDED
+        connect_timeout: 5s
+        original_dst_lb_config:
+          use_http_header: true
+        # Outlier detection on the synthetic per-IP endpoints — flaps a
+        # dead Pod IP out for a short cooldown after consecutive failures.
+        outlier_detection:
+          consecutive_5xx: 3
+          base_ejection_time: 30s
+          max_ejection_percent: 100
+        # No active health checking — Pod IPs come and go too quickly for
+        # it to be useful; we rely on the cache + outlier detection.

--- a/sandbox-router/deploy/envoy/deployment.yaml
+++ b/sandbox-router/deploy/envoy/deployment.yaml
@@ -1,0 +1,89 @@
+# Envoy frontend for the sandbox-router. Mounts the ConfigMap as
+# /etc/envoy/envoy.yaml and runs Envoy as a non-root user.
+#
+# Tune replicaCount + resources for your traffic — Envoy handles thousands
+# of req/s per replica on modest CPU. Two replicas is the HA minimum.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-router-envoy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: sandbox-router-envoy
+    app.kubernetes.io/component: sandbox-router
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sandbox-router-envoy
+      app.kubernetes.io/component: sandbox-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sandbox-router-envoy
+        app.kubernetes.io/component: sandbox-router
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: sandbox-router-envoy
+      containers:
+      - name: envoy
+        # Distroless Envoy image; pin to a release rather than -latest in
+        # production. See https://github.com/envoyproxy/envoy/releases
+        image: envoyproxy/envoy:distroless-v1.32-latest
+        args:
+        - --config-path
+        - /etc/envoy/envoy.yaml
+        - --log-level
+        - info
+        ports:
+        - name: proxy
+          containerPort: 8080
+          protocol: TCP
+        - name: admin
+          containerPort: 9901
+          protocol: TCP
+        # /healthz bypasses ext_proc (defined in the route table) so
+        # Envoy is alive iff its own listener is up. /ready could be
+        # added later as a deeper probe (e.g. through ext_proc).
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: proxy
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: proxy
+          initialDelaySeconds: 1
+          periodSeconds: 5
+        volumeMounts:
+        - name: config
+          mountPath: /etc/envoy
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 2
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 101 # envoy user in the distroless image
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: sandbox-router-envoy
+      terminationGracePeriodSeconds: 30

--- a/sandbox-router/deploy/envoy/service.yaml
+++ b/sandbox-router/deploy/envoy/service.yaml
@@ -1,0 +1,22 @@
+# Service name `sandbox-router-svc` preserves the Python router's name so
+# existing Gateway / HTTPRoute manifests pointing at it keep working.
+# Callers see the same DNS name + port; the implementation behind it has
+# moved to Envoy + ext_proc.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-router-svc
+  namespace: default
+  labels:
+    app.kubernetes.io/name: sandbox-router-envoy
+    app.kubernetes.io/component: sandbox-router
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sandbox-router-envoy
+    app.kubernetes.io/component: sandbox-router
+  ports:
+  - name: proxy
+    port: 8080
+    targetPort: proxy
+    protocol: TCP

--- a/sandbox-router/deploy/ext-proc/deployment.yaml
+++ b/sandbox-router/deploy/ext-proc/deployment.yaml
@@ -1,0 +1,86 @@
+# ext-proc-sandbox-router runs the K8s informer + UID→PodIP cache +
+# Envoy ext_proc gRPC handler. Stateless; 3 replicas is a reasonable HA
+# floor. Each replica maintains its own informer cache.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ext-proc-sandbox-router
+  namespace: default
+  labels:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ext-proc-sandbox-router
+      app.kubernetes.io/component: sandbox-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ext-proc-sandbox-router
+        app.kubernetes.io/component: sandbox-router
+    spec:
+      serviceAccountName: ext-proc-sandbox-router
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: ext-proc-sandbox-router
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: ext-proc-sandbox-router
+      containers:
+      - name: ext-proc
+        # Replace with the published image tag.
+        image: registry.k8s.io/agent-sandbox/sandbox-router-ext-proc:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --listen-address=:50051
+        - --cluster-domain=cluster.local
+        # --namespace="" (cluster-wide watch) is the default; uncomment
+        # to scope this replica to a single tenant namespace.
+        # - --namespace=my-tenant
+        ports:
+        - name: grpc
+          containerPort: 50051
+          protocol: TCP
+        # K8s native gRPC probes (1.24+). The health server starts as
+        # NOT_SERVING and flips to SERVING only after the informer cache
+        # has synced, so /readyz waits out the informer cold-start.
+        readinessProbe:
+          grpc:
+            port: 50051
+            service: envoy.service.ext_proc.v3.ExternalProcessor
+          initialDelaySeconds: 1
+          periodSeconds: 3
+          failureThreshold: 2
+        livenessProbe:
+          grpc:
+            port: 50051
+          # No service: probes the empty default service name. Tracks
+          # process-aliveness rather than informer-readiness.
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 1
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+      terminationGracePeriodSeconds: 45

--- a/sandbox-router/deploy/ext-proc/pdb.yaml
+++ b/sandbox-router/deploy/ext-proc/pdb.yaml
@@ -1,0 +1,17 @@
+# Keep at least one ext_proc replica available during voluntary
+# disruptions; otherwise Envoy's failure_mode_allow=false would 503 all
+# proxy traffic while the fleet is draining.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ext-proc-sandbox-router
+  namespace: default
+  labels:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ext-proc-sandbox-router
+      app.kubernetes.io/component: sandbox-router

--- a/sandbox-router/deploy/ext-proc/rbac.yaml
+++ b/sandbox-router/deploy/ext-proc/rbac.yaml
@@ -1,0 +1,29 @@
+# Minimal RBAC for the ext_proc service. Only needs to read Pods labeled
+# as sandboxes — no writes, no other resources.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ext-proc-sandbox-router
+  labels:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ext-proc-sandbox-router
+  labels:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ext-proc-sandbox-router
+subjects:
+- kind: ServiceAccount
+  name: ext-proc-sandbox-router
+  namespace: default

--- a/sandbox-router/deploy/ext-proc/service.yaml
+++ b/sandbox-router/deploy/ext-proc/service.yaml
@@ -1,0 +1,22 @@
+# Headless Service: Envoy's STRICT_DNS cluster resolves the A records and
+# load-balances per-replica directly, which is the right shape for gRPC
+# streams. The Envoy ConfigMap targets this exact Service DNS name.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-proc-sandbox-router
+  namespace: default
+  labels:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  type: ClusterIP
+  clusterIP: None # headless
+  selector:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router
+  ports:
+  - name: grpc
+    port: 50051
+    targetPort: grpc
+    protocol: TCP

--- a/sandbox-router/deploy/ext-proc/serviceaccount.yaml
+++ b/sandbox-router/deploy/ext-proc/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ext-proc-sandbox-router
+  namespace: default
+  labels:
+    app.kubernetes.io/name: ext-proc-sandbox-router
+    app.kubernetes.io/component: sandbox-router

--- a/sandbox-router/internal/cache/cache.go
+++ b/sandbox-router/internal/cache/cache.go
@@ -1,0 +1,315 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache maintains an in-memory map from Sandbox UID to Pod IP,
+// populated by a Kubernetes Pod informer. It is the single piece of
+// K8s-aware state in the sandbox-router; the ext_proc handler reads from
+// it on every request to drive Envoy's ORIGINAL_DST cluster.
+//
+// The Sandbox UID is taken from the Pod's controller OwnerReference,
+// not from a Pod label (the controller does not stamp the Sandbox UID as
+// a label today; see sandbox-router/README.md "Why OwnerReferences" for
+// the rationale).
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// SandboxAPIGroup is the API group of the Sandbox CR. We match on this
+	// + Kind="Sandbox" when inspecting Pod OwnerReferences to identify
+	// sandbox-owned Pods regardless of which CRD version created them.
+	SandboxAPIGroup = "agents.x-k8s.io"
+
+	// SandboxKind is the kind of the controlling resource for sandbox Pods.
+	SandboxKind = "Sandbox"
+
+	// PodSandboxNameHashLabel is the label every sandbox-owned Pod carries
+	// (its value is hash(sandbox.Name)). We use it as a label-selector
+	// filter on the Pod informer so we only get events for sandbox Pods.
+	//
+	// The constant is duplicated here because the controller defines it as
+	// a package-private string (controllers.sandboxLabel). Future work:
+	// promote it to api/v1beta1 so we can import it directly.
+	PodSandboxNameHashLabel = "agents.x-k8s.io/sandbox-name-hash"
+
+	// defaultResync is the informer relist period. Short enough to catch
+	// missed events; long enough to not hammer the API server. Matches
+	// typical controller-runtime defaults.
+	defaultResync = 10 * time.Minute
+)
+
+// Entry is a single cached mapping. Returned by Get so future fields
+// (e.g. ready timestamp, ownership labels for authz) can be added without
+// breaking call sites.
+type Entry struct {
+	// PodIP is the IPv4/IPv6 address of the sandbox Pod. The ext_proc
+	// handler combines this with the inbound X-Sandbox-Port to build the
+	// upstream target.
+	PodIP string
+
+	// SandboxName is the human-readable Sandbox CR name (== Pod.Name). Used
+	// for logging and to construct DNS-form upstream targets on cache miss.
+	SandboxName string
+
+	// Namespace is the K8s namespace of the Sandbox / Pod.
+	Namespace string
+}
+
+// Cache is a thread-safe Sandbox-UID → Entry map kept up to date by a
+// background Pod informer. Lookups are O(1) and lock-free for the common
+// path (RLock + map read).
+type Cache struct {
+	log      logr.Logger
+	informer cache.SharedIndexInformer
+	factory  informers.SharedInformerFactory
+	stopOnce sync.Once
+	stopCh   chan struct{}
+
+	mu      sync.RWMutex
+	entries map[types.UID]Entry
+}
+
+// Options configure the cache. Namespace is empty for cluster-wide
+// (recommended for the router; sandbox Pods can live in many namespaces).
+type Options struct {
+	Client    kubernetes.Interface
+	Log       logr.Logger
+	Namespace string
+	Resync    time.Duration
+}
+
+// New constructs a Cache backed by a filtered Pod SharedInformer. The
+// informer is NOT started; call Start to launch it and WaitForSync to
+// gate readiness.
+func New(o Options) (*Cache, error) {
+	if o.Client == nil {
+		return nil, errors.New("cache: Client is required")
+	}
+	if o.Resync == 0 {
+		o.Resync = defaultResync
+	}
+	// Server-side filter: only Pods carrying the sandbox-name-hash label.
+	// Reduces informer memory and API traffic substantially in mixed
+	// clusters where most Pods are NOT sandboxes.
+	hashSel, err := labels.NewRequirement(PodSandboxNameHashLabel, selection.Exists, nil)
+	if err != nil {
+		return nil, err
+	}
+	tweak := func(opts *metav1.ListOptions) {
+		opts.LabelSelector = labels.NewSelector().Add(*hashSel).String()
+		// Skip Pods that have been scheduled but have no IP yet — they
+		// can't be a useful routing target. Apiserver-side filter.
+		opts.FieldSelector = fields.OneTermNotEqualSelector("status.podIP", "").String()
+	}
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		o.Client, o.Resync,
+		informers.WithNamespace(o.Namespace),
+		informers.WithTweakListOptions(tweak),
+	)
+	podInformer := factory.Core().V1().Pods().Informer()
+
+	c := &Cache{
+		log:      o.Log,
+		informer: podInformer,
+		factory:  factory,
+		stopCh:   make(chan struct{}),
+		entries:  make(map[types.UID]Entry),
+	}
+
+	if _, err := podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.onAddOrUpdate,
+		UpdateFunc: func(_, newObj any) { c.onAddOrUpdate(newObj) },
+		DeleteFunc: c.onDelete,
+	}); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Start launches the informer goroutines. Safe to call once; subsequent
+// calls are no-ops.
+func (c *Cache) Start(ctx context.Context) {
+	go func() {
+		<-ctx.Done()
+		c.stop()
+	}()
+	c.factory.Start(c.stopCh)
+}
+
+// WaitForSync blocks until the informer's initial LIST has been
+// processed, or ctx is canceled. Returns true on successful sync.
+// The gRPC health check should gate SERVING on this.
+func (c *Cache) WaitForSync(ctx context.Context) bool {
+	return cache.WaitForCacheSync(ctx.Done(), c.informer.HasSynced)
+}
+
+// HasSynced reports whether the informer has completed its initial LIST.
+func (c *Cache) HasSynced() bool {
+	return c.informer.HasSynced()
+}
+
+// Get looks up the cached entry for the given Sandbox UID. Returns
+// (Entry, true) when known, (Entry{}, false) on cache miss. Lock-free in
+// the common case via sync.RWMutex.
+func (c *Cache) Get(uid types.UID) (Entry, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[uid]
+	c.mu.RUnlock()
+	return e, ok
+}
+
+// Len returns the current number of cached entries. Primarily for tests
+// and metrics; not on the request hot path.
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	n := len(c.entries)
+	c.mu.RUnlock()
+	return n
+}
+
+func (c *Cache) stop() {
+	c.stopOnce.Do(func() { close(c.stopCh) })
+}
+
+// onAddOrUpdate is invoked by the informer for every Add and Update
+// event. We extract the controlling Sandbox UID from OwnerReferences and
+// store (or refresh) the entry only when the Pod is Ready and has an IP.
+//
+// A Pod that flips from Ready to NotReady is removed from the cache so
+// requests don't get routed to a Pod that isn't accepting traffic.
+func (c *Cache) onAddOrUpdate(obj any) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	uid, ok := sandboxUIDOf(pod)
+	if !ok {
+		return
+	}
+	if !podReady(pod) || pod.Status.PodIP == "" {
+		c.remove(uid)
+		return
+	}
+	c.upsert(uid, Entry{
+		PodIP:       pod.Status.PodIP,
+		SandboxName: pod.Name,
+		Namespace:   pod.Namespace,
+	})
+}
+
+func (c *Cache) onDelete(obj any) {
+	// DeletedFinalStateUnknown wraps the last-known state when the
+	// informer missed the delete event. Unwrap it.
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if uid, ok := sandboxUIDOf(pod); ok {
+		c.remove(uid)
+	}
+}
+
+func (c *Cache) upsert(uid types.UID, e Entry) {
+	c.mu.Lock()
+	prev, existed := c.entries[uid]
+	c.entries[uid] = e
+	c.mu.Unlock()
+	if !existed {
+		c.log.V(1).Info("cache add", "uid", uid, "pod", e.SandboxName, "ip", e.PodIP, "ns", e.Namespace)
+	} else if prev.PodIP != e.PodIP {
+		c.log.V(1).Info("cache update", "uid", uid, "pod", e.SandboxName, "ip", e.PodIP, "ns", e.Namespace, "prev_ip", prev.PodIP)
+	}
+}
+
+func (c *Cache) remove(uid types.UID) {
+	c.mu.Lock()
+	_, existed := c.entries[uid]
+	delete(c.entries, uid)
+	c.mu.Unlock()
+	if existed {
+		c.log.V(1).Info("cache remove", "uid", uid)
+	}
+}
+
+// sandboxUIDOf extracts the Sandbox CR UID from a Pod's controller
+// OwnerReference. Returns ("", false) for Pods not owned by a Sandbox
+// (which shouldn't reach us thanks to the label filter, but the check is
+// cheap insurance against stray events).
+func sandboxUIDOf(pod *corev1.Pod) (types.UID, bool) {
+	for i := range pod.OwnerReferences {
+		ref := &pod.OwnerReferences[i]
+		if ref.Controller == nil || !*ref.Controller {
+			continue
+		}
+		if ref.Kind != SandboxKind {
+			continue
+		}
+		// OwnerReference.APIVersion looks like "agents.x-k8s.io/v1beta1";
+		// match the group prefix so we don't break across API versions.
+		if !apiVersionInGroup(ref.APIVersion, SandboxAPIGroup) {
+			continue
+		}
+		return ref.UID, true
+	}
+	return "", false
+}
+
+// apiVersionInGroup reports whether apiVersion ("group/version") is in
+// the given group. Handles versionless input gracefully.
+func apiVersionInGroup(apiVersion, group string) bool {
+	if apiVersion == group {
+		return true
+	}
+	for i := 0; i < len(apiVersion); i++ {
+		if apiVersion[i] == '/' {
+			return apiVersion[:i] == group
+		}
+	}
+	return false
+}
+
+// podReady reports whether the Pod's status carries a PodReady=True
+// condition. We require Ready (not just Running) because containers may
+// still be initializing or failing probes; routing to such a Pod produces
+// noisy 502s for the caller.
+func podReady(pod *corev1.Pod) bool {
+	for i := range pod.Status.Conditions {
+		c := &pod.Status.Conditions[i]
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/sandbox-router/internal/cache/cache_test.go
+++ b/sandbox-router/internal/cache/cache_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testUID     = types.UID("e2e6c7b8-2222-4444-8888-aaaaaaaaaaaa")
+	testUID2    = types.UID("11111111-2222-4444-8888-bbbbbbbbbbbb")
+	testPodName = "sandbox-1"
+	testPodNS   = "tenants"
+	testPodIP   = "10.0.4.42"
+	testPodIP2  = "10.0.4.99"
+)
+
+// makePod builds a sandbox Pod with the conventional label, an
+// OwnerReference to a Sandbox CR with the given UID, a PodIP, and the
+// Ready condition status (when ready is true).
+func makePod(name, ns string, sandboxUID types.UID, ip string, ready bool) *corev1.Pod {
+	tru := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{PodSandboxNameHashLabel: "abc123"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: SandboxAPIGroup + "/v1beta1",
+				Kind:       SandboxKind,
+				Name:       name,
+				UID:        sandboxUID,
+				Controller: &tru,
+			}},
+		},
+		Status: corev1.PodStatus{
+			PodIP: ip,
+		},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}}
+	} else {
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionFalse,
+		}}
+	}
+	return pod
+}
+
+// waitFor polls until cond returns true or 1s elapses; helper for
+// informer-driven async expectations. Tests have not needed a custom
+// timeout yet — keep this caller-simple.
+func waitFor(t *testing.T, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+func newCache(t *testing.T, objs ...runtime.Object) (*Cache, *fake.Clientset, context.CancelFunc) {
+	t.Helper()
+	client := fake.NewSimpleClientset(objs...)
+	c, err := New(Options{
+		Client:    client,
+		Log:       logr.Discard(),
+		Namespace: "", // cluster-wide
+		Resync:    time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	c.Start(ctx)
+	if ok := c.WaitForSync(ctx); !ok {
+		cancel()
+		t.Fatalf("WaitForSync failed")
+	}
+	return c, client, cancel
+}
+
+func TestSandboxUIDOf(t *testing.T) {
+	cases := []struct {
+		name string
+		pod  *corev1.Pod
+		want types.UID
+		ok   bool
+	}{
+		{
+			name: "owner is sandbox v1beta1 → uid extracted",
+			pod:  makePod("p", "n", testUID, "1.1.1.1", true),
+			want: testUID,
+			ok:   true,
+		},
+		{
+			name: "owner is sandbox v1alpha1 → also extracted",
+			pod: func() *corev1.Pod {
+				p := makePod("p", "n", testUID, "1.1.1.1", true)
+				p.OwnerReferences[0].APIVersion = SandboxAPIGroup + "/v1alpha1"
+				return p
+			}(),
+			want: testUID,
+			ok:   true,
+		},
+		{
+			name: "owner is Deployment → ignored",
+			pod: func() *corev1.Pod {
+				p := makePod("p", "n", testUID, "1.1.1.1", true)
+				p.OwnerReferences[0].Kind = "Deployment"
+				p.OwnerReferences[0].APIVersion = "apps/v1"
+				return p
+			}(),
+			ok: false,
+		},
+		{
+			name: "owner from different group → ignored",
+			pod: func() *corev1.Pod {
+				p := makePod("p", "n", testUID, "1.1.1.1", true)
+				p.OwnerReferences[0].APIVersion = "other.example.com/v1"
+				return p
+			}(),
+			ok: false,
+		},
+		{
+			name: "non-controller owner ref → ignored",
+			pod: func() *corev1.Pod {
+				p := makePod("p", "n", testUID, "1.1.1.1", true)
+				f := false
+				p.OwnerReferences[0].Controller = &f
+				return p
+			}(),
+			ok: false,
+		},
+		{
+			name: "no owner refs at all → not found",
+			pod: func() *corev1.Pod {
+				p := makePod("p", "n", testUID, "1.1.1.1", true)
+				p.OwnerReferences = nil
+				return p
+			}(),
+			ok: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := sandboxUIDOf(tc.pod)
+			if ok != tc.ok {
+				t.Fatalf("ok: got %v want %v", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("uid: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodReady(t *testing.T) {
+	if podReady(&corev1.Pod{}) {
+		t.Error("empty pod must not be ready")
+	}
+	p := makePod("p", "n", testUID, "1.1.1.1", true)
+	if !podReady(p) {
+		t.Error("ready pod must return true")
+	}
+	p = makePod("p", "n", testUID, "1.1.1.1", false)
+	if podReady(p) {
+		t.Error("not-ready pod must return false")
+	}
+}
+
+func TestCache_PreseededPodCachedOnSync(t *testing.T) {
+	pod := makePod(testPodName, testPodNS, testUID, testPodIP, true)
+	c, _, cancel := newCache(t, pod)
+	defer cancel()
+
+	if !waitFor(t, func() bool { return c.Len() == 1 }) {
+		t.Fatalf("expected 1 entry, got %d", c.Len())
+	}
+	e, ok := c.Get(testUID)
+	if !ok {
+		t.Fatalf("Get(%q): not found", testUID)
+	}
+	if e.PodIP != testPodIP || e.SandboxName != testPodName || e.Namespace != testPodNS {
+		t.Fatalf("entry mismatch: %+v", e)
+	}
+}
+
+func TestCache_AddEventCaches(t *testing.T) {
+	c, client, cancel := newCache(t)
+	defer cancel()
+
+	pod := makePod(testPodName, testPodNS, testUID, testPodIP, true)
+	if _, err := client.CoreV1().Pods(testPodNS).Create(t.Context(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !waitFor(t, func() bool { _, ok := c.Get(testUID); return ok }) {
+		t.Fatalf("Add event was not reflected in cache")
+	}
+}
+
+func TestCache_NotReadyPodNotCached(t *testing.T) {
+	pod := makePod(testPodName, testPodNS, testUID, testPodIP, false)
+	c, _, cancel := newCache(t, pod)
+	defer cancel()
+
+	// Give the informer a beat to process the initial list.
+	time.Sleep(100 * time.Millisecond)
+	if _, ok := c.Get(testUID); ok {
+		t.Fatalf("not-ready pod must not be cached")
+	}
+}
+
+func TestCache_FlipsOutWhenPodGoesNotReady(t *testing.T) {
+	pod := makePod(testPodName, testPodNS, testUID, testPodIP, true)
+	c, client, cancel := newCache(t, pod)
+	defer cancel()
+
+	if !waitFor(t, func() bool { _, ok := c.Get(testUID); return ok }) {
+		t.Fatalf("initial cache add failed")
+	}
+
+	// Update the pod to NotReady.
+	pod = pod.DeepCopy()
+	pod.Status.Conditions[0].Status = corev1.ConditionFalse
+	if _, err := client.CoreV1().Pods(testPodNS).UpdateStatus(t.Context(), pod, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	if !waitFor(t, func() bool { _, ok := c.Get(testUID); return !ok }) {
+		t.Fatalf("cache entry must be removed when pod flips to NotReady")
+	}
+}
+
+func TestCache_DeleteRemoves(t *testing.T) {
+	pod := makePod(testPodName, testPodNS, testUID, testPodIP, true)
+	c, client, cancel := newCache(t, pod)
+	defer cancel()
+
+	if !waitFor(t, func() bool { _, ok := c.Get(testUID); return ok }) {
+		t.Fatalf("initial cache add failed")
+	}
+	if err := client.CoreV1().Pods(testPodNS).Delete(t.Context(), testPodName, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !waitFor(t, func() bool { _, ok := c.Get(testUID); return !ok }) {
+		t.Fatalf("delete event was not reflected in cache")
+	}
+}
+
+func TestCache_PodIPUpdateRefreshesEntry(t *testing.T) {
+	pod := makePod(testPodName, testPodNS, testUID, testPodIP, true)
+	c, client, cancel := newCache(t, pod)
+	defer cancel()
+
+	if !waitFor(t, func() bool { _, ok := c.Get(testUID); return ok }) {
+		t.Fatalf("initial cache add failed")
+	}
+	pod = pod.DeepCopy()
+	pod.Status.PodIP = testPodIP2
+	if _, err := client.CoreV1().Pods(testPodNS).UpdateStatus(t.Context(), pod, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	if !waitFor(t, func() bool {
+		e, ok := c.Get(testUID)
+		return ok && e.PodIP == testPodIP2
+	}) {
+		t.Fatalf("PodIP update was not reflected in cache; current entry: %+v", func() Entry {
+			e, _ := c.Get(testUID)
+			return e
+		}())
+	}
+}
+
+func TestCache_HandlesMultipleSandboxesIndependently(t *testing.T) {
+	a := makePod("a", "ns-a", testUID, "10.0.0.1", true)
+	b := makePod("b", "ns-b", testUID2, "10.0.0.2", true)
+	c, _, cancel := newCache(t, a, b)
+	defer cancel()
+
+	if !waitFor(t, func() bool { return c.Len() == 2 }) {
+		t.Fatalf("expected 2 entries, got %d", c.Len())
+	}
+	if ea, ok := c.Get(testUID); !ok || ea.PodIP != "10.0.0.1" {
+		t.Errorf("entry A wrong: %+v ok=%v", ea, ok)
+	}
+	if eb, ok := c.Get(testUID2); !ok || eb.PodIP != "10.0.0.2" {
+		t.Errorf("entry B wrong: %+v ok=%v", eb, ok)
+	}
+}
+
+func TestApiVersionInGroup(t *testing.T) {
+	cases := map[string]bool{
+		"agents.x-k8s.io/v1beta1":  true,
+		"agents.x-k8s.io/v1alpha1": true,
+		"agents.x-k8s.io":          true,
+		"apps/v1":                  false,
+		"other.example.com/v1":     false,
+		"":                         false,
+	}
+	for in, want := range cases {
+		if got := apiVersionInGroup(in, SandboxAPIGroup); got != want {
+			t.Errorf("apiVersionInGroup(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/sandbox-router/internal/extproc/server.go
+++ b/sandbox-router/internal/extproc/server.go
@@ -1,0 +1,322 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package extproc implements the Envoy ext_proc v3 ExternalProcessor
+// service for the sandbox-router. The handler is intentionally narrow: it
+// only observes request headers, and its only side effect is setting the
+// `x-envoy-original-dst-host` header so Envoy's ORIGINAL_DST cluster
+// dispatches the request to the right sandbox Pod.
+package extproc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/agent-sandbox/sandbox-router/internal/cache"
+)
+
+// Header names the handler consumes. Envoy normalizes to lowercase per
+// HTTP/2 spec, so we match lowercase exactly.
+const (
+	HeaderSandboxID        = "x-sandbox-id"
+	HeaderSandboxUID       = "x-sandbox-uid"
+	HeaderSandboxNamespace = "x-sandbox-namespace"
+	HeaderSandboxPort      = "x-sandbox-port"
+
+	// HeaderOriginalDstHost is the header Envoy's ORIGINAL_DST cluster
+	// reads to select the upstream when `use_http_header: true`. We set
+	// it to "<ip-or-host>:<port>" on every accepted request.
+	HeaderOriginalDstHost = "x-envoy-original-dst-host"
+)
+
+const (
+	defaultSandboxPort      = 8888
+	defaultSandboxNamespace = "default"
+)
+
+// Lookup is the slice of the cache the handler depends on. Defined as an
+// interface so tests can inject a stub without spinning a real informer.
+type Lookup interface {
+	Get(uid types.UID) (cache.Entry, bool)
+}
+
+// Server implements envoy.service.ext_proc.v3.ExternalProcessorServer.
+type Server struct {
+	extprocv3.UnimplementedExternalProcessorServer
+
+	cache         Lookup
+	clusterDomain string
+	log           logr.Logger
+}
+
+// Options configure a new Server. ClusterDomain is the K8s cluster DNS
+// suffix used for the DNS-form fallback (defaults to "cluster.local").
+type Options struct {
+	Cache         Lookup
+	ClusterDomain string
+	Log           logr.Logger
+}
+
+// NewServer constructs a Server. Cache is required; ClusterDomain
+// defaults if empty.
+func NewServer(o Options) (*Server, error) {
+	if o.Cache == nil {
+		return nil, errors.New("extproc: Cache is required")
+	}
+	if o.ClusterDomain == "" {
+		o.ClusterDomain = "cluster.local"
+	}
+	return &Server{
+		cache:         o.Cache,
+		clusterDomain: o.ClusterDomain,
+		log:           o.Log,
+	}, nil
+}
+
+// Process is the bidirectional stream Envoy opens per request. We only
+// inspect REQUEST_HEADERS; other phases come back as immediate
+// CONTINUE responses so Envoy can move on without further callbacks.
+// The Envoy ProcessingMode config should be set to skip the other phases
+// so we don't waste round-trips, but defending here keeps the server
+// correct under misconfiguration.
+func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error {
+	for {
+		req, err := stream.Recv()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		resp := s.handle(stream.Context(), req)
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
+}
+
+// handle is the side-effect-free part of Process. Returns the response to
+// send back to Envoy. Header decisions never need to abort the stream —
+// validation failures come back as ImmediateResponse, not stream errors.
+func (s *Server) handle(ctx context.Context, req *extprocv3.ProcessingRequest) *extprocv3.ProcessingResponse {
+	switch r := req.Request.(type) {
+	case *extprocv3.ProcessingRequest_RequestHeaders:
+		return s.onRequestHeaders(ctx, r.RequestHeaders)
+	default:
+		// Any other phase (request body / response headers / etc.) — just
+		// continue. Envoy's processing_mode config should have prevented
+		// these from being sent at all.
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_RequestHeaders{
+				RequestHeaders: &extprocv3.HeadersResponse{
+					Response: &extprocv3.CommonResponse{Status: extprocv3.CommonResponse_CONTINUE},
+				},
+			},
+		}
+	}
+}
+
+// onRequestHeaders parses the routing headers, looks up the target, and
+// returns either a HeadersResponse mutating x-envoy-original-dst-host or
+// an ImmediateResponse on validation failure.
+func (s *Server) onRequestHeaders(_ context.Context, hdrs *extprocv3.HttpHeaders) *extprocv3.ProcessingResponse {
+	r := readHeaders(hdrs.Headers)
+
+	if r.id == "" {
+		return immediate(400, `{"detail":"X-Sandbox-ID header is required."}`)
+	}
+	if !validNamespace(r.namespace) {
+		return immediate(400, `{"detail":"Invalid namespace format."}`)
+	}
+	if r.port == 0 {
+		return immediate(400, `{"detail":"Invalid port format."}`)
+	}
+
+	target, source := s.resolve(r)
+	if target == "" {
+		// Shouldn't happen — resolve only returns "" when both cache miss
+		// AND we can't construct a DNS form, which requires no id (already
+		// rejected above). Defensive.
+		return immediate(500, `{"detail":"unable to resolve sandbox target"}`)
+	}
+
+	s.log.V(2).Info("routing",
+		"sandbox_id", r.id,
+		"sandbox_uid", r.uid,
+		"namespace", r.namespace,
+		"port", r.port,
+		"target", target,
+		"source", source,
+	)
+
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_RequestHeaders{
+			RequestHeaders: &extprocv3.HeadersResponse{
+				Response: &extprocv3.CommonResponse{
+					Status: extprocv3.CommonResponse_CONTINUE,
+					HeaderMutation: &extprocv3.HeaderMutation{
+						SetHeaders: []*corev3.HeaderValueOption{{
+							Header: &corev3.HeaderValue{
+								Key:      HeaderOriginalDstHost,
+								RawValue: []byte(target),
+							},
+							AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+						}},
+					},
+					// Route is recomputed after our mutation so Envoy picks
+					// the ORIGINAL_DST cluster with the new dst host.
+					ClearRouteCache: true,
+				},
+			},
+		},
+	}
+}
+
+// resolve picks the upstream host:port for the request. Returns the
+// target and a tag describing how it was resolved (for logs/metrics).
+//
+// Order: cache hit by UID wins (fast + secure); DNS form is the fallback
+// (works without UID, slower, less secure).
+func (s *Server) resolve(r request) (target, source string) {
+	if r.uid != "" {
+		if e, ok := s.cache.Get(types.UID(r.uid)); ok {
+			return joinHostPort(e.PodIP, r.port), "cache"
+		}
+	}
+	// DNS form: <id>.<ns>.svc.<cluster-domain>:<port>
+	host := r.id + "." + r.namespace + ".svc." + s.clusterDomain
+	return joinHostPort(host, r.port), "dns"
+}
+
+// request is the parsed routing input.
+type request struct {
+	id        string
+	uid       string
+	namespace string
+	port      int
+}
+
+// readHeaders extracts the X-Sandbox-* values from an Envoy HeaderMap.
+// Missing namespace defaults to "default"; missing port defaults to 8888.
+// Invalid port (non-numeric) is signaled as port=0 so the caller can
+// reject with 400.
+func readHeaders(m *corev3.HeaderMap) request {
+	r := request{namespace: defaultSandboxNamespace, port: defaultSandboxPort}
+	if m == nil {
+		return r
+	}
+	for _, h := range m.Headers {
+		switch strings.ToLower(h.Key) {
+		case HeaderSandboxID:
+			r.id = headerString(h)
+		case HeaderSandboxUID:
+			r.uid = headerString(h)
+		case HeaderSandboxNamespace:
+			v := headerString(h)
+			if v != "" {
+				r.namespace = v
+			}
+		case HeaderSandboxPort:
+			v := headerString(h)
+			if v == "" {
+				continue
+			}
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				r.port = 0 // signals invalid to caller
+				continue
+			}
+			r.port = n
+		}
+	}
+	return r
+}
+
+// headerString returns the header's value as a string, preferring the
+// raw_value byte field (modern Envoy) and falling back to the legacy
+// string value.
+func headerString(h *corev3.HeaderValue) string {
+	if len(h.RawValue) > 0 {
+		return string(h.RawValue)
+	}
+	return h.Value
+}
+
+// validNamespace mirrors the Python router's namespace check:
+//
+//	namespace.replace("-", "").isalnum()
+//
+// At least one ASCII alphanumeric, only ASCII letters/digits/hyphens
+// otherwise. Empty input and hyphen-only input both rejected.
+func validNamespace(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasAlphanum := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9', c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z':
+			hasAlphanum = true
+		case c == '-':
+			// allowed
+		default:
+			return false
+		}
+	}
+	return hasAlphanum
+}
+
+// joinHostPort formats "host:port" without the IPv6 bracket dance —
+// our cache stores IPv4 addresses or DNS names, never bare IPv6 strings.
+// (Pod IPv6 support would need updating here.)
+func joinHostPort(host string, port int) string {
+	return host + ":" + strconv.Itoa(port)
+}
+
+// immediate builds an ImmediateResponse ProcessingResponse that ends the
+// request at the proxy with the given status code and JSON body. The
+// body shape matches the Python router's `{"detail": "..."}` format.
+func immediate(status int, body string) *extprocv3.ProcessingResponse {
+	return &extprocv3.ProcessingResponse{
+		Response: &extprocv3.ProcessingResponse_ImmediateResponse{
+			ImmediateResponse: &extprocv3.ImmediateResponse{
+				Status: &typev3.HttpStatus{Code: typev3.StatusCode(status)},
+				Headers: &extprocv3.HeaderMutation{
+					SetHeaders: []*corev3.HeaderValueOption{{
+						Header: &corev3.HeaderValue{
+							Key:      "content-type",
+							RawValue: []byte("application/json"),
+						},
+						AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+					}},
+				},
+				Body:    []byte(body),
+				Details: fmt.Sprintf("sandbox-router: %d", status),
+			},
+		},
+	}
+}

--- a/sandbox-router/internal/extproc/server.go
+++ b/sandbox-router/internal/extproc/server.go
@@ -238,20 +238,33 @@ func (s *Server) onRequestHeaders(_ context.Context, hdrs *extprocv3.HttpHeaders
 		"source", source,
 	)
 
+	mutation := &extprocv3.HeaderMutation{
+		SetHeaders: []*corev3.HeaderValueOption{{
+			Header: &corev3.HeaderValue{
+				Key:      HeaderOriginalDstHost,
+				RawValue: []byte(target),
+			},
+			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		}},
+	}
+	if r.upgrade {
+		// Strip Origin on upgrade so WebSocket backends that validate
+		// Origin == Host for CSRF protection (vscode-server, Jupyter,
+		// etc.) don't reject the upgrade with a 1006 close because the
+		// client-supplied Origin (router's external hostname) doesn't
+		// match the backend's own Host. Envoy normalizes header keys
+		// to lowercase, so "origin" — not "Origin" — is the key to
+		// remove. Mirrors the equivalent fix on the from-scratch Go
+		// router (PR #838, commit d04bfb5).
+		mutation.RemoveHeaders = append(mutation.RemoveHeaders, "origin")
+	}
+
 	return &extprocv3.ProcessingResponse{
 		Response: &extprocv3.ProcessingResponse_RequestHeaders{
 			RequestHeaders: &extprocv3.HeadersResponse{
 				Response: &extprocv3.CommonResponse{
-					Status: extprocv3.CommonResponse_CONTINUE,
-					HeaderMutation: &extprocv3.HeaderMutation{
-						SetHeaders: []*corev3.HeaderValueOption{{
-							Header: &corev3.HeaderValue{
-								Key:      HeaderOriginalDstHost,
-								RawValue: []byte(target),
-							},
-							AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
-						}},
-					},
+					Status:         extprocv3.CommonResponse_CONTINUE,
+					HeaderMutation: mutation,
 					// Route is recomputed after our mutation so Envoy picks
 					// the ORIGINAL_DST cluster with the new dst host.
 					ClearRouteCache: true,
@@ -283,6 +296,11 @@ type request struct {
 	uid       string
 	namespace string
 	port      int
+	// upgrade is true when the inbound request asked to switch
+	// protocols (Connection: Upgrade + Upgrade: <proto>, typically
+	// WebSocket). Used to trigger Origin stripping on the outbound
+	// request — see onRequestHeaders.
+	upgrade bool
 }
 
 // readHeaders extracts the X-Sandbox-* values from an Envoy HeaderMap.
@@ -294,6 +312,8 @@ func readHeaders(m *corev3.HeaderMap) request {
 	if m == nil {
 		return r
 	}
+	var hasConnectionUpgrade bool
+	var hasUpgradeValue bool
 	for _, h := range m.Headers {
 		switch strings.ToLower(h.Key) {
 		case HeaderSandboxID:
@@ -316,8 +336,26 @@ func readHeaders(m *corev3.HeaderMap) request {
 				continue
 			}
 			r.port = n
+		case "connection":
+			// RFC 7230 §6.7: Connection is a comma-separated list of
+			// option tokens. Check case-insensitively for an "upgrade"
+			// token, not equality, so values like "keep-alive, upgrade"
+			// are recognized.
+			for tok := range strings.SplitSeq(headerString(h), ",") {
+				if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
+					hasConnectionUpgrade = true
+					break
+				}
+			}
+		case "upgrade":
+			if headerString(h) != "" {
+				hasUpgradeValue = true
+			}
 		}
 	}
+	// True upgrade requires BOTH headers — matches the predicate
+	// httputil.ReverseProxy uses internally.
+	r.upgrade = hasConnectionUpgrade && hasUpgradeValue
 	return r
 }
 

--- a/sandbox-router/internal/extproc/server.go
+++ b/sandbox-router/internal/extproc/server.go
@@ -208,7 +208,15 @@ func (s *Server) onRequestHeaders(_ context.Context, hdrs *extprocv3.HttpHeaders
 	if r.id == "" {
 		return immediate(400, `{"detail":"X-Sandbox-ID header is required."}`)
 	}
-	if !validNamespace(r.namespace) {
+	// DNS-label validation on ID + namespace prevents DNS injection
+	// (e.g. id="foo.evil.com" interpolating extra components into
+	// "<id>.<ns>.svc.<cluster-domain>") and traversal-style inputs
+	// (e.g. id="foo/bar"). Matches the Python router's
+	// _is_valid_dns_label check and the same fix on PR #838.
+	if !validDNSLabel(r.id) {
+		return immediate(400, `{"detail":"Invalid sandbox ID format."}`)
+	}
+	if !validDNSLabel(r.namespace) {
 		return immediate(400, `{"detail":"Invalid namespace format."}`)
 	}
 	// TCP port range is [1, 65535]. Reject anything outside it (and the
@@ -246,6 +254,17 @@ func (s *Server) onRequestHeaders(_ context.Context, hdrs *extprocv3.HttpHeaders
 			},
 			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
 		}},
+		// Always strip Authorization on the way to the upstream.
+		// Identity-checking authorizers (TokenReview, JWT, etc.) sit in
+		// front of ext_proc and consume the bearer credential there;
+		// forwarding it to the sandbox would let the sandbox
+		// impersonate the caller against the K8s API or any other
+		// Bearer-protected service. Envoy normalizes header keys to
+		// lowercase, so "authorization" is the key to remove. Matches
+		// the same fix on the from-scratch Go router (PR #838) and the
+		// Python router, which strips Authorization right next to Host
+		// before forwarding.
+		RemoveHeaders: []string{"authorization"},
 	}
 	if r.upgrade {
 		// Strip Origin on upgrade so WebSocket backends that validate
@@ -369,29 +388,37 @@ func headerString(h *corev3.HeaderValue) string {
 	return h.Value
 }
 
-// validNamespace mirrors the Python router's namespace check:
+// validDNSLabel reports whether s is a syntactically valid DNS-1123
+// label. Mirrors the Python router's
 //
-//	namespace.replace("-", "").isalnum()
+//	^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$
 //
-// At least one ASCII alphanumeric, only ASCII letters/digits/hyphens
-// otherwise. Empty input and hyphen-only input both rejected.
-func validNamespace(s string) bool {
-	if s == "" {
+// regex with a 63-character cap. Applied to both X-Sandbox-ID and
+// X-Sandbox-Namespace before either gets interpolated into the DNS-
+// form upstream FQDN, so callers can't inject extra DNS components or
+// traversal sequences ("foo.evil.com", "foo/bar", etc.). Stricter
+// than the previous validNamespace: rejects uppercase, leading/
+// trailing hyphens, and anything over 63 chars — same shape K8s
+// itself enforces on Pod and Namespace names.
+func validDNSLabel(s string) bool {
+	if s == "" || len(s) > 63 {
 		return false
 	}
-	hasAlphanum := false
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {
-		case c >= '0' && c <= '9', c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z':
-			hasAlphanum = true
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'z':
 		case c == '-':
-			// allowed
+			// Hyphen is allowed only in the interior — not first or last.
+			if i == 0 || i == len(s)-1 {
+				return false
+			}
 		default:
 			return false
 		}
 	}
-	return hasAlphanum
+	return true
 }
 
 // joinHostPort formats "host:port", bracketing IPv6 literals per

--- a/sandbox-router/internal/extproc/server.go
+++ b/sandbox-router/internal/extproc/server.go
@@ -211,7 +211,13 @@ func (s *Server) onRequestHeaders(_ context.Context, hdrs *extprocv3.HttpHeaders
 	if !validNamespace(r.namespace) {
 		return immediate(400, `{"detail":"Invalid namespace format."}`)
 	}
-	if r.port < 1 || r.port == 0 {
+	// TCP port range is [1, 65535]. Reject anything outside it (and the
+	// 0 sentinel readHeaders sets on non-numeric input) before we hand
+	// the value to net.JoinHostPort — an out-of-range port would
+	// produce a syntactically valid but semantically junk
+	// x-envoy-original-dst-host (e.g. "10.0.0.1:99999") that Envoy
+	// would reject downstream with a less actionable error.
+	if r.port < 1 || r.port > 65535 {
 		return immediate(400, `{"detail":"Invalid port format."}`)
 	}
 

--- a/sandbox-router/internal/extproc/server.go
+++ b/sandbox-router/internal/extproc/server.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strconv"
 	"strings"
 
@@ -151,7 +152,7 @@ func (s *Server) onRequestHeaders(_ context.Context, hdrs *extprocv3.HttpHeaders
 	if !validNamespace(r.namespace) {
 		return immediate(400, `{"detail":"Invalid namespace format."}`)
 	}
-	if r.port == 0 {
+	if r.port < 1 || r.port == 0 {
 		return immediate(400, `{"detail":"Invalid port format."}`)
 	}
 
@@ -290,11 +291,14 @@ func validNamespace(s string) bool {
 	return hasAlphanum
 }
 
-// joinHostPort formats "host:port" without the IPv6 bracket dance —
-// our cache stores IPv4 addresses or DNS names, never bare IPv6 strings.
-// (Pod IPv6 support would need updating here.)
+// joinHostPort formats "host:port", bracketing IPv6 literals per
+// RFC 3986. Sandbox Pods can have IPv6 PodIPs on dual-stack or
+// IPv6-only clusters (Pod.Status.PodIP is the primary address, which
+// can be v4 or v6); without brackets, Envoy's x-envoy-original-dst-host
+// parser would treat the trailing ":port" as part of the address and
+// reject the value.
 func joinHostPort(host string, port int) string {
-	return host + ":" + strconv.Itoa(port)
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 // immediate builds an ImmediateResponse ProcessingResponse that ends the

--- a/sandbox-router/internal/extproc/server.go
+++ b/sandbox-router/internal/extproc/server.go
@@ -113,6 +113,13 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 			return err
 		}
 		resp := s.handle(stream.Context(), req)
+		if resp == nil {
+			// Unknown ProcessingRequest phase (newer Envoy variant we
+			// don't recognize). Skipping the Send keeps the stream open
+			// and lets Envoy decide what to do; sending a wrong-phase
+			// reply would abort it.
+			continue
+		}
 		if err := stream.Send(resp); err != nil {
 			return err
 		}
@@ -122,21 +129,73 @@ func (s *Server) Process(stream extprocv3.ExternalProcessor_ProcessServer) error
 // handle is the side-effect-free part of Process. Returns the response to
 // send back to Envoy. Header decisions never need to abort the stream —
 // validation failures come back as ImmediateResponse, not stream errors.
+//
+// Phases other than REQUEST_HEADERS return a phase-matched CONTINUE: the
+// ext_proc spec requires the ProcessingResponse oneof variant to match
+// the ProcessingRequest oneof variant (a ResponseBody request answered
+// with a RequestHeaders envelope is a protocol violation that aborts
+// the stream). The Envoy processing_mode config should have suppressed
+// these phases at the source, but we stay protocol-correct in case it
+// drifts.
 func (s *Server) handle(ctx context.Context, req *extprocv3.ProcessingRequest) *extprocv3.ProcessingResponse {
 	switch r := req.Request.(type) {
 	case *extprocv3.ProcessingRequest_RequestHeaders:
 		return s.onRequestHeaders(ctx, r.RequestHeaders)
 	default:
-		// Any other phase (request body / response headers / etc.) — just
-		// continue. Envoy's processing_mode config should have prevented
-		// these from being sent at all.
+		return continueFor(req)
+	}
+}
+
+// continueFor returns a CONTINUE-equivalent ProcessingResponse whose
+// oneof variant matches req's. Used as the no-op reply for off-mode
+// phases. TrailersResponse carries no CommonResponse field (its only
+// payload is an optional HeaderMutation), so its CONTINUE-equivalent
+// is an empty TrailersResponse — Envoy treats absent HeaderMutation as
+// "no change, proceed". Returns nil for unknown oneof variants (newer
+// Envoy phases we don't know about); Process drops nil responses
+// rather than sending a phase-mismatched envelope.
+func continueFor(req *extprocv3.ProcessingRequest) *extprocv3.ProcessingResponse {
+	common := &extprocv3.CommonResponse{Status: extprocv3.CommonResponse_CONTINUE}
+
+	switch req.Request.(type) {
+	case *extprocv3.ProcessingRequest_RequestHeaders:
 		return &extprocv3.ProcessingResponse{
 			Response: &extprocv3.ProcessingResponse_RequestHeaders{
-				RequestHeaders: &extprocv3.HeadersResponse{
-					Response: &extprocv3.CommonResponse{Status: extprocv3.CommonResponse_CONTINUE},
-				},
+				RequestHeaders: &extprocv3.HeadersResponse{Response: common},
 			},
 		}
+	case *extprocv3.ProcessingRequest_ResponseHeaders:
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseHeaders{
+				ResponseHeaders: &extprocv3.HeadersResponse{Response: common},
+			},
+		}
+	case *extprocv3.ProcessingRequest_RequestBody:
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_RequestBody{
+				RequestBody: &extprocv3.BodyResponse{Response: common},
+			},
+		}
+	case *extprocv3.ProcessingRequest_ResponseBody:
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseBody{
+				ResponseBody: &extprocv3.BodyResponse{Response: common},
+			},
+		}
+	case *extprocv3.ProcessingRequest_RequestTrailers:
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_RequestTrailers{
+				RequestTrailers: &extprocv3.TrailersResponse{},
+			},
+		}
+	case *extprocv3.ProcessingRequest_ResponseTrailers:
+		return &extprocv3.ProcessingResponse{
+			Response: &extprocv3.ProcessingResponse_ResponseTrailers{
+				ResponseTrailers: &extprocv3.TrailersResponse{},
+			},
+		}
+	default:
+		return nil
 	}
 }
 

--- a/sandbox-router/internal/extproc/server_test.go
+++ b/sandbox-router/internal/extproc/server_test.go
@@ -199,17 +199,71 @@ func TestHandle_InvalidNamespaceRejected(t *testing.T) {
 }
 
 func TestHandle_InvalidPortRejected(t *testing.T) {
-	s, _ := newServer(t)
-	resp := s.handle(context.Background(), reqHeaders(map[string]string{
-		HeaderSandboxID:   "alpha",
-		HeaderSandboxPort: "abc",
-	}))
-	ir := resp.GetImmediateResponse()
-	if ir == nil || ir.Status.Code != 400 {
-		t.Fatalf("expected 400 immediate; got: %+v", resp)
+	// Port must fall in [1, 65535]. Anything else gets rejected with a
+	// 400 immediate before we hand the value to net.JoinHostPort, so a
+	// bogus value can't ride along into x-envoy-original-dst-host and
+	// surface as a less actionable Envoy error.
+	cases := []struct {
+		name string
+		port string
+	}{
+		{"non-numeric", "abc"},
+		{"empty-after-trim", " "},
+		{"zero", "0"},
+		{"negative", "-1"},
+		{"way negative", "-99999"},
+		{"just over 65535", "65536"},
+		{"big number", "100000"},
+		{"max int32", "2147483647"},
 	}
-	if !strings.Contains(string(ir.Body), "port") {
-		t.Errorf("body should mention port: %s", ir.Body)
+	s, _ := newServer(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := s.handle(context.Background(), reqHeaders(map[string]string{
+				HeaderSandboxID:   "alpha",
+				HeaderSandboxPort: tc.port,
+			}))
+			ir := resp.GetImmediateResponse()
+			if ir == nil || ir.Status.Code != 400 {
+				t.Fatalf("port=%q: expected 400 immediate; got: %+v", tc.port, resp)
+			}
+			if !strings.Contains(string(ir.Body), "port") {
+				t.Errorf("port=%q: body should mention port: %s", tc.port, ir.Body)
+			}
+		})
+	}
+}
+
+func TestHandle_PortBoundariesAccepted(t *testing.T) {
+	// The smallest and largest legal TCP ports both make it through.
+	s, stub := newServer(t)
+	uid := types.UID("boundary-uid")
+	stub[uid] = cache.Entry{PodIP: "10.0.0.1"}
+	for _, port := range []string{"1", "65535"} {
+		t.Run(port, func(t *testing.T) {
+			resp := s.handle(context.Background(), reqHeaders(map[string]string{
+				HeaderSandboxID:   "alpha",
+				HeaderSandboxUID:  string(uid),
+				HeaderSandboxPort: port,
+			}))
+			if ir := resp.GetImmediateResponse(); ir != nil {
+				t.Fatalf("port %s: unexpected immediate %d / %s", port, ir.Status.Code, ir.Body)
+			}
+			rh := resp.GetRequestHeaders()
+			if rh == nil {
+				t.Fatalf("port %s: expected RequestHeaders mutation; got %+v", port, resp)
+			}
+			want := "10.0.0.1:" + port
+			got := ""
+			for _, h := range rh.Response.HeaderMutation.SetHeaders {
+				if h.Header.Key == HeaderOriginalDstHost {
+					got = string(h.Header.RawValue)
+				}
+			}
+			if got != want {
+				t.Fatalf("port %s: dst host got %q want %q", port, got, want)
+			}
+		})
 	}
 }
 

--- a/sandbox-router/internal/extproc/server_test.go
+++ b/sandbox-router/internal/extproc/server_test.go
@@ -270,8 +270,44 @@ func TestReadHeaders_AcceptsBothRawAndStringValues(t *testing.T) {
 }
 
 func TestJoinHostPort(t *testing.T) {
-	if got := joinHostPort("10.0.0.1", 8888); got != "10.0.0.1:8888" {
-		t.Errorf("joinHostPort got %q", got)
+	cases := []struct {
+		name string
+		host string
+		port int
+		want string
+	}{
+		{"ipv4", "10.0.0.1", 8888, "10.0.0.1:8888"},
+		{"dns", "alpha.default.svc.cluster.local", 8888, "alpha.default.svc.cluster.local:8888"},
+		// IPv6 literals must be bracketed per RFC 3986, otherwise the
+		// trailing colon-port is ambiguous with the address itself. Pod
+		// IPs on dual-stack / IPv6-only clusters surface as bare IPv6
+		// strings in Pod.Status.PodIP.
+		{"ipv6 loopback", "::1", 8888, "[::1]:8888"},
+		{"ipv6 link-local", "fe80::1", 9090, "[fe80::1]:9090"},
+		{"ipv6 full", "2001:db8::1", 8888, "[2001:db8::1]:8888"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinHostPort(tc.host, tc.port); got != tc.want {
+				t.Errorf("joinHostPort(%q, %d) = %q, want %q", tc.host, tc.port, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolve_IPv6PodIPGetsBracketed(t *testing.T) {
+	s, stub := newServer(t)
+	uid := types.UID("v6-uid")
+	stub[uid] = cache.Entry{PodIP: "2001:db8::42"}
+
+	target, source := s.resolve(request{
+		id: "alpha", uid: string(uid), namespace: "default", port: 8888,
+	})
+	if target != "[2001:db8::42]:8888" {
+		t.Errorf("target: got %q want [2001:db8::42]:8888", target)
+	}
+	if source != "cache" {
+		t.Errorf("source: got %q want cache", source)
 	}
 }
 

--- a/sandbox-router/internal/extproc/server_test.go
+++ b/sandbox-router/internal/extproc/server_test.go
@@ -445,3 +445,95 @@ func TestResolve_PrefersCacheOverDNS(t *testing.T) {
 		t.Errorf("source: got %q want cache", source)
 	}
 }
+
+// removeHeadersFrom extracts the RemoveHeaders list from a successful
+// HeadersResponse.
+func removeHeadersFrom(resp *extprocv3.ProcessingResponse) []string {
+	hr := resp.GetRequestHeaders()
+	if hr == nil || hr.Response == nil || hr.Response.HeaderMutation == nil {
+		return nil
+	}
+	return hr.Response.HeaderMutation.RemoveHeaders
+}
+
+func TestHandle_StripsOriginOnUpgrade(t *testing.T) {
+	s, stub := newServer(t)
+	uid := types.UID("ws-uid")
+	stub[uid] = cache.Entry{PodIP: "10.0.0.7"}
+
+	// True WebSocket upgrade: BOTH Connection: Upgrade AND a non-empty
+	// Upgrade header. Envoy normalizes header keys to lowercase, so
+	// "origin" — not "Origin" — is the key we must remove.
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:  "alpha",
+		HeaderSandboxUID: string(uid),
+		"Connection":     "keep-alive, Upgrade",
+		"Upgrade":        "websocket",
+		"Origin":         "https://router.example.com",
+	}))
+	removed := removeHeadersFrom(resp)
+	found := false
+	for _, h := range removed {
+		if h == "origin" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected RemoveHeaders to contain \"origin\"; got %v", removed)
+	}
+	// And the dst-host mutation must still be there — we're adding,
+	// not replacing the existing mutation.
+	if dst, ok := originalDstHostFrom(resp); !ok || dst != "10.0.0.7:8888" {
+		t.Fatalf("dst-host mutation lost: got %q (ok=%v)", dst, ok)
+	}
+}
+
+func TestHandle_NonUpgradePreservesOrigin(t *testing.T) {
+	// Guard against the strip leaking into normal HTTP — would break
+	// CORS preflights and any backend that uses Origin on
+	// non-WebSocket traffic.
+	s, stub := newServer(t)
+	uid := types.UID("plain-uid")
+	stub[uid] = cache.Entry{PodIP: "10.0.0.8"}
+
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:  "alpha",
+		HeaderSandboxUID: string(uid),
+		"Origin":         "https://client.example.com",
+		// no Connection / Upgrade headers
+	}))
+	for _, h := range removeHeadersFrom(resp) {
+		if h == "origin" {
+			t.Fatalf("Origin must not be stripped on non-upgrade; got RemoveHeaders=%v", removeHeadersFrom(resp))
+		}
+	}
+}
+
+func TestReadHeaders_UpgradeDetection(t *testing.T) {
+	// Locks in the predicate: an upgrade is recognized iff BOTH
+	// Connection contains an upgrade token AND Upgrade is non-empty.
+	// Matches httputil.ReverseProxy's internal check on the
+	// from-scratch router so behavior is consistent across PRs.
+	cases := []struct {
+		name string
+		hdrs map[string]string
+		want bool
+	}{
+		{"both present", map[string]string{"Connection": "Upgrade", "Upgrade": "websocket"}, true},
+		{"connection list with upgrade token", map[string]string{"Connection": "keep-alive, Upgrade", "Upgrade": "websocket"}, true},
+		{"case-insensitive scheme", map[string]string{"Connection": "upgrade", "Upgrade": "WebSocket"}, true},
+		{"missing Connection", map[string]string{"Upgrade": "websocket"}, false},
+		{"missing Upgrade", map[string]string{"Connection": "Upgrade"}, false},
+		{"connection without upgrade token", map[string]string{"Connection": "keep-alive", "Upgrade": "websocket"}, false},
+		{"empty Upgrade value", map[string]string{"Connection": "Upgrade", "Upgrade": ""}, false},
+		{"neither", map[string]string{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readHeaders(hdrs(tc.hdrs).Headers).upgrade
+			if got != tc.want {
+				t.Fatalf("got upgrade=%v want %v (hdrs=%v)", got, tc.want, tc.hdrs)
+			}
+		})
+	}
+}

--- a/sandbox-router/internal/extproc/server_test.go
+++ b/sandbox-router/internal/extproc/server_test.go
@@ -16,6 +16,7 @@ package extproc
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -215,19 +216,83 @@ func TestHandle_InvalidPortRejected(t *testing.T) {
 // TestHandle_NonRequestHeadersPhasePassesThrough confirms we don't fail
 // the stream when Envoy is misconfigured to call us for body/response
 // phases — we just CONTINUE.
-func TestHandle_NonRequestHeadersPhasePassesThrough(t *testing.T) {
+// TestHandle_PhaseMatchedContinue exercises the protocol-correctness
+// guarantee: the ProcessingResponse oneof variant must match the
+// ProcessingRequest oneof variant for every phase Envoy can send.
+// Sending the wrong variant (e.g. a RequestHeaders envelope in reply
+// to a RequestBody request) is a protocol violation that aborts the
+// ext_proc stream and therefore the user's request.
+func TestHandle_PhaseMatchedContinue(t *testing.T) {
 	s, _ := newServer(t)
-	resp := s.handle(context.Background(), &extprocv3.ProcessingRequest{
-		Request: &extprocv3.ProcessingRequest_ResponseHeaders{
-			ResponseHeaders: hdrs(nil),
+
+	cases := []struct {
+		name string
+		req  *extprocv3.ProcessingRequest
+		// pick returns the matching variant from the response; nil
+		// means the test failed the variant check.
+		pick func(*extprocv3.ProcessingResponse) any
+	}{
+		{
+			name: "ResponseHeaders → ResponseHeaders",
+			req: &extprocv3.ProcessingRequest{
+				Request: &extprocv3.ProcessingRequest_ResponseHeaders{ResponseHeaders: hdrs(nil)},
+			},
+			pick: func(r *extprocv3.ProcessingResponse) any { return r.GetResponseHeaders() },
 		},
-	})
-	hr := resp.GetRequestHeaders()
-	if hr == nil {
-		t.Fatalf("expected CONTINUE shaped response")
+		{
+			name: "RequestBody → RequestBody",
+			req: &extprocv3.ProcessingRequest{
+				Request: &extprocv3.ProcessingRequest_RequestBody{RequestBody: &extprocv3.HttpBody{}},
+			},
+			pick: func(r *extprocv3.ProcessingResponse) any { return r.GetRequestBody() },
+		},
+		{
+			name: "ResponseBody → ResponseBody",
+			req: &extprocv3.ProcessingRequest{
+				Request: &extprocv3.ProcessingRequest_ResponseBody{ResponseBody: &extprocv3.HttpBody{}},
+			},
+			pick: func(r *extprocv3.ProcessingResponse) any { return r.GetResponseBody() },
+		},
+		{
+			name: "RequestTrailers → RequestTrailers",
+			req: &extprocv3.ProcessingRequest{
+				Request: &extprocv3.ProcessingRequest_RequestTrailers{RequestTrailers: &extprocv3.HttpTrailers{}},
+			},
+			pick: func(r *extprocv3.ProcessingResponse) any { return r.GetRequestTrailers() },
+		},
+		{
+			name: "ResponseTrailers → ResponseTrailers",
+			req: &extprocv3.ProcessingRequest{
+				Request: &extprocv3.ProcessingRequest_ResponseTrailers{ResponseTrailers: &extprocv3.HttpTrailers{}},
+			},
+			pick: func(r *extprocv3.ProcessingResponse) any { return r.GetResponseTrailers() },
+		},
 	}
-	if hr.Response.HeaderMutation != nil {
-		t.Errorf("no mutation should be set for non-RequestHeaders phase")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := s.handle(context.Background(), tc.req)
+			if resp == nil {
+				t.Fatalf("nil response for known phase")
+			}
+			// Guard: a wrong-variant response would have GetRequestHeaders
+			// non-nil for, say, the RequestBody case. Assert the matching
+			// variant is set AND that no other variant leaked in.
+			matched := tc.pick(resp)
+			if matched == nil || reflect.ValueOf(matched).IsNil() {
+				t.Fatalf("phase-matched variant missing on %T; got %+v", tc.req.Request, resp.Response)
+			}
+		})
+	}
+}
+
+// TestHandle_UnknownPhaseReturnsNil documents the contract for unknown
+// (future) ProcessingRequest oneof variants: handle returns nil and the
+// Process loop drops the message rather than sending a wrong-phase
+// reply that would abort the stream.
+func TestHandle_UnknownPhaseReturnsNil(t *testing.T) {
+	if got := continueFor(&extprocv3.ProcessingRequest{Request: nil}); got != nil {
+		t.Fatalf("unknown oneof should yield nil ProcessingResponse, got %+v", got)
 	}
 }
 

--- a/sandbox-router/internal/extproc/server_test.go
+++ b/sandbox-router/internal/extproc/server_test.go
@@ -198,6 +198,35 @@ func TestHandle_InvalidNamespaceRejected(t *testing.T) {
 	}
 }
 
+func TestHandle_InvalidIDRejected(t *testing.T) {
+	// Mirrors the Python router's DNS-label check on sandbox_id. Without
+	// this, a caller could interpolate extra DNS components into the
+	// upstream FQDN via the DNS form ("<id>.<ns>.svc.<cluster-domain>").
+	cases := map[string]string{
+		"dot in id (would inject extra DNS components)": "foo.evil.com",
+		"slash in id (traversal flavor)":                "foo/bar",
+		"underscore in id":                              "foo_bar",
+		"uppercase":                                     "FooBar",
+		"leading hyphen":                                "-foo",
+		"trailing hyphen":                               "foo-",
+	}
+	s, _ := newServer(t)
+	for name, id := range cases {
+		t.Run(name, func(t *testing.T) {
+			resp := s.handle(context.Background(), reqHeaders(map[string]string{
+				HeaderSandboxID: id,
+			}))
+			ir := resp.GetImmediateResponse()
+			if ir == nil || ir.Status.Code != 400 {
+				t.Fatalf("id=%q: expected 400 immediate; got: %+v", id, resp)
+			}
+			if !strings.Contains(string(ir.Body), "Invalid sandbox ID") {
+				t.Errorf("id=%q: body should mention Invalid sandbox ID: %s", id, ir.Body)
+			}
+		})
+	}
+}
+
 func TestHandle_InvalidPortRejected(t *testing.T) {
 	// Port must fall in [1, 65535]. Anything else gets rejected with a
 	// 400 immediate before we hand the value to net.JoinHostPort, so a
@@ -350,26 +379,42 @@ func TestHandle_UnknownPhaseReturnsNil(t *testing.T) {
 	}
 }
 
-func TestValidNamespace(t *testing.T) {
+func TestValidDNSLabel(t *testing.T) {
+	// Stricter than the previous validNamespace: rejects uppercase,
+	// leading/trailing hyphens, and labels > 63 chars. Same shape as
+	// RFC 1123 / K8s' own DNS-label rules and the Python router's
+	// _is_valid_dns_label regex.
 	cases := map[string]bool{
-		"default": true,
-		"prod":    true,
-		"my-ns":   true,
-		"my-ns-1": true,
-		"MY-NS":   true,
-		"a":       true,
-		"":        false,
-		"-":       false,
-		"---":     false,
-		"my_ns":   false,
-		"my.ns":   false,
-		" ns":     false,
-		"ns ":     false,
+		// accepted
+		"default":               true,
+		"prod":                  true,
+		"my-ns":                 true,
+		"my-ns-1":               true,
+		"a":                     true,
+		"abc123":                true,
+		"1abc":                  true, // leading digit OK in RFC 1123 (vs the older 952)
+		strings.Repeat("a", 63): true,
+
+		// rejected — character class
+		"MY-NS":   false, // uppercase
+		"my_ns":   false, // underscore
+		"my.ns":   false, // dot would inject extra DNS components
+		"foo/bar": false, // slash, traversal flavor
+		" ns":     false, // leading space
+		"ns ":     false, // trailing space
 		"bad!":    false,
+
+		// rejected — structure
+		"":                      false, // empty
+		"-":                     false, // single hyphen
+		"---":                   false, // hyphens only
+		"-x":                    false, // leading hyphen
+		"x-":                    false, // trailing hyphen
+		strings.Repeat("a", 64): false, // exceeds 63-char cap
 	}
 	for in, want := range cases {
-		if got := validNamespace(in); got != want {
-			t.Errorf("validNamespace(%q) = %v, want %v", in, got, want)
+		if got := validDNSLabel(in); got != want {
+			t.Errorf("validDNSLabel(%q) = %v, want %v", in, got, want)
 		}
 	}
 }
@@ -506,6 +551,45 @@ func TestHandle_NonUpgradePreservesOrigin(t *testing.T) {
 		if h == "origin" {
 			t.Fatalf("Origin must not be stripped on non-upgrade; got RemoveHeaders=%v", removeHeadersFrom(resp))
 		}
+	}
+}
+
+// TestHandle_AlwaysStripsAuthorization is the regression test for the
+// privilege-escalation hazard the Python router avoids by stripping
+// Authorization. When the router is fronted by an identity-checking
+// authorizer (TokenReview, JWT, etc.) the caller's bearer credential
+// is meant for the router, not the sandbox. Forwarding it would let
+// the sandbox impersonate the caller against the K8s API or any
+// other Bearer-protected service. The strip applies to both upgrade
+// and non-upgrade paths, so we assert it on each.
+func TestHandle_AlwaysStripsAuthorization(t *testing.T) {
+	s, stub := newServer(t)
+	uid := types.UID("auth-uid")
+	stub[uid] = cache.Entry{PodIP: "10.0.0.9"}
+
+	for _, name := range []string{"non-upgrade", "upgrade"} {
+		t.Run(name, func(t *testing.T) {
+			hdrs := map[string]string{
+				HeaderSandboxID:  "alpha",
+				HeaderSandboxUID: string(uid),
+				"Authorization":  "Bearer should-not-leak",
+			}
+			if name == "upgrade" {
+				hdrs["Connection"] = "Upgrade"
+				hdrs["Upgrade"] = "websocket"
+			}
+			resp := s.handle(context.Background(), reqHeaders(hdrs))
+			found := false
+			for _, h := range removeHeadersFrom(resp) {
+				if h == "authorization" {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("%s: expected RemoveHeaders to contain \"authorization\"; got %v",
+					name, removeHeadersFrom(resp))
+			}
+		})
 	}
 }
 

--- a/sandbox-router/internal/extproc/server_test.go
+++ b/sandbox-router/internal/extproc/server_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extproc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extprocv3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/agent-sandbox/sandbox-router/internal/cache"
+)
+
+// stubCache satisfies Lookup with a fixed in-memory map. Lets tests drive
+// hit / miss behavior without spinning up an informer.
+type stubCache map[types.UID]cache.Entry
+
+func (s stubCache) Get(uid types.UID) (cache.Entry, bool) {
+	e, ok := s[uid]
+	return e, ok
+}
+
+// newServer builds a Server with a stub cache. Returns the server and
+// the stub so individual tests can mutate the map.
+func newServer(t *testing.T) (*Server, stubCache) {
+	t.Helper()
+	stub := stubCache{}
+	s, err := NewServer(Options{
+		Cache:         stub,
+		ClusterDomain: "cluster.local",
+		Log:           logr.Discard(),
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return s, stub
+}
+
+// hdrs builds an Envoy HttpHeaders message from a key→value map. Lower
+// cases keys to match Envoy's normalization.
+func hdrs(kv map[string]string) *extprocv3.HttpHeaders {
+	hm := &corev3.HeaderMap{}
+	for k, v := range kv {
+		hm.Headers = append(hm.Headers, &corev3.HeaderValue{
+			Key:      strings.ToLower(k),
+			RawValue: []byte(v),
+		})
+	}
+	return &extprocv3.HttpHeaders{Headers: hm}
+}
+
+// reqHeaders wraps hdrs into a ProcessingRequest of the RequestHeaders
+// phase, which is the only phase our handler actually does work on.
+func reqHeaders(kv map[string]string) *extprocv3.ProcessingRequest {
+	return &extprocv3.ProcessingRequest{
+		Request: &extprocv3.ProcessingRequest_RequestHeaders{
+			RequestHeaders: hdrs(kv),
+		},
+	}
+}
+
+// originalDstHostFrom extracts the value of the x-envoy-original-dst-host
+// header from a successful HeadersResponse, returning ("", false) if the
+// response is an ImmediateResponse or the mutation isn't present.
+func originalDstHostFrom(resp *extprocv3.ProcessingResponse) (string, bool) {
+	hr := resp.GetRequestHeaders()
+	if hr == nil {
+		return "", false
+	}
+	for _, h := range hr.Response.HeaderMutation.SetHeaders {
+		if h.Header.Key == HeaderOriginalDstHost {
+			return string(h.Header.RawValue), true
+		}
+	}
+	return "", false
+}
+
+func TestHandle_CacheHitSetsOriginalDstFromPodIP(t *testing.T) {
+	s, stub := newServer(t)
+	uid := types.UID("11111111-2222-3333-4444-555555555555")
+	stub[uid] = cache.Entry{PodIP: "10.0.0.7", SandboxName: "alpha", Namespace: "tenant-a"}
+
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:        "alpha",
+		HeaderSandboxUID:       string(uid),
+		HeaderSandboxNamespace: "tenant-a",
+		HeaderSandboxPort:      "9090",
+	}))
+
+	host, ok := originalDstHostFrom(resp)
+	if !ok {
+		t.Fatalf("expected header mutation; got: %+v", resp)
+	}
+	if host != "10.0.0.7:9090" {
+		t.Errorf("original-dst-host: got %q want %q", host, "10.0.0.7:9090")
+	}
+	if !resp.GetRequestHeaders().Response.ClearRouteCache {
+		t.Errorf("ClearRouteCache must be set so Envoy re-routes after our mutation")
+	}
+}
+
+func TestHandle_CacheMissFallsBackToDNS(t *testing.T) {
+	s, _ := newServer(t)
+
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:        "ghost",
+		HeaderSandboxUID:       "no-such-uid",
+		HeaderSandboxNamespace: "tenant-b",
+		HeaderSandboxPort:      "8888",
+	}))
+
+	host, ok := originalDstHostFrom(resp)
+	if !ok {
+		t.Fatalf("expected mutation, got: %+v", resp)
+	}
+	want := "ghost.tenant-b.svc.cluster.local:8888"
+	if host != want {
+		t.Errorf("DNS form: got %q want %q", host, want)
+	}
+}
+
+func TestHandle_NoUIDStillRoutesViaDNS(t *testing.T) {
+	s, _ := newServer(t)
+
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:        "alpha",
+		HeaderSandboxNamespace: "default",
+	}))
+
+	host, ok := originalDstHostFrom(resp)
+	if !ok {
+		t.Fatalf("expected mutation, got: %+v", resp)
+	}
+	if host != "alpha.default.svc.cluster.local:8888" {
+		t.Errorf("DNS form with default port: got %q", host)
+	}
+}
+
+func TestHandle_DefaultsAppliedForNamespaceAndPort(t *testing.T) {
+	s, _ := newServer(t)
+
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID: "alpha",
+	}))
+	host, _ := originalDstHostFrom(resp)
+	if host != "alpha.default.svc.cluster.local:8888" {
+		t.Errorf("defaults: got %q", host)
+	}
+}
+
+func TestHandle_MissingSandboxIDReturnsImmediate400(t *testing.T) {
+	s, _ := newServer(t)
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{}))
+
+	ir := resp.GetImmediateResponse()
+	if ir == nil {
+		t.Fatalf("expected ImmediateResponse, got: %+v", resp)
+	}
+	if ir.Status.Code != 400 {
+		t.Errorf("status: got %d want 400", ir.Status.Code)
+	}
+	if !strings.Contains(string(ir.Body), "X-Sandbox-ID") {
+		t.Errorf("body should mention X-Sandbox-ID: %s", ir.Body)
+	}
+}
+
+func TestHandle_InvalidNamespaceRejected(t *testing.T) {
+	s, _ := newServer(t)
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:        "alpha",
+		HeaderSandboxNamespace: "bad namespace!",
+	}))
+	ir := resp.GetImmediateResponse()
+	if ir == nil || ir.Status.Code != 400 {
+		t.Fatalf("expected 400 immediate; got: %+v", resp)
+	}
+	if !strings.Contains(string(ir.Body), "namespace") {
+		t.Errorf("body should mention namespace: %s", ir.Body)
+	}
+}
+
+func TestHandle_InvalidPortRejected(t *testing.T) {
+	s, _ := newServer(t)
+	resp := s.handle(context.Background(), reqHeaders(map[string]string{
+		HeaderSandboxID:   "alpha",
+		HeaderSandboxPort: "abc",
+	}))
+	ir := resp.GetImmediateResponse()
+	if ir == nil || ir.Status.Code != 400 {
+		t.Fatalf("expected 400 immediate; got: %+v", resp)
+	}
+	if !strings.Contains(string(ir.Body), "port") {
+		t.Errorf("body should mention port: %s", ir.Body)
+	}
+}
+
+// TestHandle_NonRequestHeadersPhasePassesThrough confirms we don't fail
+// the stream when Envoy is misconfigured to call us for body/response
+// phases — we just CONTINUE.
+func TestHandle_NonRequestHeadersPhasePassesThrough(t *testing.T) {
+	s, _ := newServer(t)
+	resp := s.handle(context.Background(), &extprocv3.ProcessingRequest{
+		Request: &extprocv3.ProcessingRequest_ResponseHeaders{
+			ResponseHeaders: hdrs(nil),
+		},
+	})
+	hr := resp.GetRequestHeaders()
+	if hr == nil {
+		t.Fatalf("expected CONTINUE shaped response")
+	}
+	if hr.Response.HeaderMutation != nil {
+		t.Errorf("no mutation should be set for non-RequestHeaders phase")
+	}
+}
+
+func TestValidNamespace(t *testing.T) {
+	cases := map[string]bool{
+		"default": true,
+		"prod":    true,
+		"my-ns":   true,
+		"my-ns-1": true,
+		"MY-NS":   true,
+		"a":       true,
+		"":        false,
+		"-":       false,
+		"---":     false,
+		"my_ns":   false,
+		"my.ns":   false,
+		" ns":     false,
+		"ns ":     false,
+		"bad!":    false,
+	}
+	for in, want := range cases {
+		if got := validNamespace(in); got != want {
+			t.Errorf("validNamespace(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestReadHeaders_AcceptsBothRawAndStringValues(t *testing.T) {
+	hm := &corev3.HeaderMap{Headers: []*corev3.HeaderValue{
+		{Key: HeaderSandboxID, RawValue: []byte("from-raw")},
+		{Key: HeaderSandboxNamespace, Value: "from-string"},
+	}}
+	r := readHeaders(hm)
+	if r.id != "from-raw" {
+		t.Errorf("RawValue not honored: got %q", r.id)
+	}
+	if r.namespace != "from-string" {
+		t.Errorf("legacy Value not honored: got %q", r.namespace)
+	}
+}
+
+func TestJoinHostPort(t *testing.T) {
+	if got := joinHostPort("10.0.0.1", 8888); got != "10.0.0.1:8888" {
+		t.Errorf("joinHostPort got %q", got)
+	}
+}
+
+func TestResolve_PrefersCacheOverDNS(t *testing.T) {
+	s, stub := newServer(t)
+	uid := types.UID("aaaa-bbbb")
+	stub[uid] = cache.Entry{PodIP: "10.20.30.40"}
+
+	target, source := s.resolve(request{
+		id: "alpha", uid: string(uid), namespace: "default", port: 8888,
+	})
+	if target != "10.20.30.40:8888" {
+		t.Errorf("target: got %q", target)
+	}
+	if source != "cache" {
+		t.Errorf("source: got %q want cache", source)
+	}
+}


### PR DESCRIPTION
**Status:** draft / RFC. Posted for discussion alongside #838 (from-scratch Go router). Not asking for review-to-merge — looking for a steer on whether the Envoy + ext_proc shape is interesting enough to pursue as v2 or post-v1 evolution.

## What this is

An alternative implementation of [KEP-NNNN](https://github.com/kubernetes-sigs/agent-sandbox/pull/758) that keeps the KEP's three core mechanisms (informer-backed UID→PodIP map, direct Pod IP dispatch, drift handling) in Go but delegates **everything else** (TLS, mTLS, rate limit, circuit breaker, retries, access logs, tracing, WAF, JWT) to Envoy.

The Go service is a single ext_proc gRPC server (~300 lines + cache) that owns the K8s-aware state. Envoy handles the data plane.

## Architecture

```
client ──► Envoy listener (:8080)
            │
            ├── HTTP filter: ext_proc
            │     │
            │     │  gRPC ProcessingRequest (RequestHeaders)
            │     ▼
            │   ext-proc-sandbox-router service
            │     │  - K8s Pod informer (labeled sandbox-name-hash)
            │     │  - In-memory UID → PodIP map
            │     │  - Reads X-Sandbox-UID + X-Sandbox-ID etc.
            │     │  - Returns header mutation:
            │     │    x-envoy-original-dst-host = <PodIP>:<port>
            │     │    (or DNS form on cache miss)
            │     ▼
            │   gRPC ProcessingResponse (HeaderMutation + ClearRouteCache)
            │
            └── HTTP filter: router → ORIGINAL_DST cluster
                                       (reads x-envoy-original-dst-host)
                ─────► sandbox Pod
```

Per-request cost: one in-cluster gRPC round-trip (~sub-ms) plus the Pod-IP dispatch.

## KEP requirements → status

| KEP item | Status | Notes |
|---|---|---|
| Informer watching sandbox Pods | ✅ | Same `cache` code as the from-scratch router |
| UID → PodIP in-memory map | ✅ | Shared between both prototypes |
| Direct dispatch, bypass Service | ✅ | Envoy ORIGINAL_DST cluster reads `x-envoy-original-dst-host` |
| `X-Sandbox-UID` request shape | ✅ | |
| Active cache invalidation on connection error | ✅ | Envoy outlier detection ejects 5xx-returning Pod IPs |
| Hybrid DNS fallback (cache miss) | ✅ | ext_proc returns DNS form when UID isn't cached |
| Sync period | ✅ | Standard 10m informer resync |
| Strict input validation | ✅ | Performed in ext_proc handler |
| TokenReview integration | ❌ | Deferred — drops in as an `ext_authz` filter or sibling ext_proc, not yet wired |
| TLS termination / mTLS | ✅✅ | Envoy native (the from-scratch router has to implement this) |

## Comparison with the from-scratch Go router (#838)

| Concern | From-scratch Go (#838) | Envoy + ext_proc (this) |
|---|---|---|
| TLS / mTLS | Custom (~400 LOC + fsnotify hot-reload) | Envoy native |
| Rate limit | Not implemented | `local_ratelimit` filter (config-only) |
| Circuit breaker | Not implemented | Envoy outlier detection (built in) |
| Retries | Custom retry transport (~150 LOC) | Envoy retry policy + hedged retries |
| Access logs | Custom middleware (~150 LOC) | Envoy access log (config-only) |
| Tracing | Custom OTel middleware (~100 LOC) | Envoy OTel native |
| Custom Go LOC | ~5,000 | ~300 |
| K8s API surface | Same informer | Same informer |
| Operational footprint | One Go binary | Envoy + Go service (two Deployments) |
| TokenReview | Implemented (#838) | Deferred |

## Validated

- Unit tests for cache + ext_proc handler.
- Standalone load harness at `cmd/load-test/` exercising real `Server` + real `Cache` (fake K8s client) — single replica sustains **~38k req/s** at 5k sandboxes with 80% cache hit, no errors, p50 1.4ms / p99 6.0ms. Bottleneck is gRPC machinery, not the cache.
- End-to-end run on kind: Envoy + ext_proc Deployments come up, `/healthz` returns 200, real sandbox Pods get routed via the cache, deleting a sandbox triggers outlier ejection within a few requests.

## Open questions

1. **Is the two-process operational model acceptable?** Trades ~5k LOC of Go for ~200 lines of Envoy YAML, but adds Envoy as a hard runtime dep. For OSS Kubernetes users without an existing Envoy footprint, this may be the wrong default. For users running a service mesh, it's nearly free.
2. **Should this replace #838 or coexist?** Two natural positions: (a) #838 ships as v1 (simpler operational story, no Envoy dep), this ships as v2 / opt-in for users who want the enterprise feature set; (b) this is the long-term answer and #838 is the bridge while Envoy adoption catches up.
3. **TokenReview path.** Two options here: an `ext_authz` filter pointing at a small authn extension of this same service (clean, separates concerns), or a second ext_proc filter sharing the same Go process (one fewer Deployment). Either works; preferences welcome.
4. **UID source.** Same question as #838 — the KEP says "Sandbox CRD UID (read from Pod labels)" but the controller doesn't stamp UID as a label. Both prototypes read it from `Pod.metadata.ownerReferences`. Want me to file a small controller change to also stamp `agents.x-k8s.io/sandbox-uid`?

Happy to close this out if the direction is clearly "stay all-Go" — the work was worth it as a comparison data point either way.