### PR TITLE
chore: replace deprecated utcnow call

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -25,7 +25,7 @@ def _get_version_build_args():
     import datetime
     git_version = utils.git_describe()
     git_sha = utils.git_sha()
-    build_date = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    build_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     return [
         f"--build-arg=GIT_VERSION={git_version}",
         f"--build-arg=GIT_SHA={git_sha}",


### PR DESCRIPTION
Apparently `datetime.datetime.now(datetime.UTC)` is now the way.
