### PR TITLE
chore: bump golang to 1.26.3, create skill

### DIFF
--- a/.agents/skills/bump-go-version/SKILL.md
+++ b/.agents/skills/bump-go-version/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: bump-go-version
+description: Bumps the Go version to the latest release across go.mod, tools.mod, and Dockerfiles.
+---
+
+# Bump Go Version Skill
+
+## Purpose
+This skill guides AI agents to update the Go version used throughout the `agent-sandbox` repository to the latest stable Go release. It ensures consistency across Go module definitions (`go.mod`, `tools.mod`, `toolchain`) and container image base layers (`Dockerfile`).
+
+## Instructions
+
+1.  **Determine the Latest Go Version**:
+    *   Run the helper script provided with this skill to fetch the latest stable Go release version string (e.g., `go1.26.3`). Execute this from the repository root:
+        ```bash
+        ./.agents/skills/bump-go-version/scripts/get-latest-go
+        ```
+    *   Note the exact version strings needed:
+        *   For `go mod edit -go`, use the numeric format `1.x.y` (e.g., `1.26.3`).
+        *   For `go mod edit -toolchain`, use the `go1.x.y` format (e.g., `go1.26.3`).
+        *   For `Dockerfiles`, identify the corresponding official `golang` image tag (e.g., `golang:1.26.3`).
+
+2.  **Locate Target Files and Context**:
+    *   Run the helper script provided with this skill to locate all relevant files and inspect their current `FROM`, `go`, and `toolchain` lines. Execute this from the repository root:
+        ```bash
+        ./.agents/skills/bump-go-version/scripts/find-files
+        ```
+    *   The script will output the list of all `go.mod`, `tools.mod`, and `Dockerfile*` files in the repository along with their current version directives. (Note: `site/go.mod` is automatically excluded by the script).
+
+3.  **Update Go Module Directives**:
+    *   By default, **only update the `toolchain` directive** in each `go.mod` and `tools.mod` file using `go mod edit`. Do not update the `go` language version directive by default, as bumping the minimum language version forces that requirement onto all downstream consumers of our modules.
+    *   Example (Default Workflow):
+        ```bash
+        go mod edit -toolchain=go1.26.3 go.mod
+        go mod edit -toolchain=go1.26.3 tools.mod
+        ```
+    *   *Optional Language Version Bump*: If the user explicitly requests bumping the Go language version (e.g., when adopting new language features), update the `go` directive using `go mod edit -go=1.x` (specifying only the major/minor version, e.g., `1.26`, without a patch version).
+        ```bash
+        go mod edit -go=1.26 go.mod
+        ```
+    *   *CRITICAL NOTE*: **Do NOT update or modify `site/go.mod`**. `site/go.mod` is a Hugo theme configuration file, not a Go code module, and modifying it or running Go tools against it will break the documentation build.
+
+4.  **Update Dockerfiles**:
+    *   For each `Dockerfile` (or `Dockerfile.*`) identified by the script, inspect the file for any `FROM golang:<version>` or `FROM --platform=$BUILDPLATFORM golang:<version>` lines.
+    *   Update the version tag to match the latest Go release (e.g., change `golang:1.26.2` to `golang:1.26.3`).
+    *   Do not modify other base images (e.g., `debian`, `distroless`) unless specifically required.
+
+5.  **Verify and Test**:
+    *   After updating the files, run `go mod tidy` in directories containing `go.mod` files to verify module resolution and clean up dependencies.
+    *   *CRITICAL NOTE*: **Do NOT run `go mod tidy` inside `site/`**. Running Go's native `go mod tidy` in the Hugo site directory will fail or strip theme dependencies.
+    *   Run `make all` (which includes lint(ing), building, and unit testing) from the repository root to ensure the project builds and tests pass successfully with the new Go version.
+    *   Ensure no unintended formatting changes or unrelated modifications are introduced.
+
+## Helper Scripts
+- [`scripts/get-latest-go`](scripts/get-latest-go): Fetches the latest stable Go release version string.
+- [`scripts/find-files`](scripts/find-files): Scans the repository and outputs all `go.mod`, `tools.mod`, and `Dockerfile` files along with their current version context lines (excluding `site/go.mod`).
+
+## References
+- [Go Release History](https://go.dev/doc/devel/release)
+- Project rules (as documented in [`AGENTS.md`](../../../AGENTS.md) and [`CONTRIBUTING.md`](../../../CONTRIBUTING.md))

--- a/.agents/skills/bump-go-version/SKILL.md
+++ b/.agents/skills/bump-go-version/SKILL.md
@@ -16,7 +16,7 @@ This skill guides AI agents to update the Go version used throughout the `agent-
         ./.agents/skills/bump-go-version/scripts/get-latest-go
         ```
     *   Note the exact version strings needed:
-        *   For `go mod edit -go`, use the numeric format `1.x.y` (e.g., `1.26.3`).
+        *   For `go mod edit -go`, use the numeric format `1.x` (e.g., `1.26`).  This is the language version and should not specify a patch version.
         *   For `go mod edit -toolchain`, use the `go1.x.y` format (e.g., `go1.26.3`).
         *   For `Dockerfiles`, identify the corresponding official `golang` image tag (e.g., `golang:1.26.3`).
 

--- a/.agents/skills/bump-go-version/scripts/find-files
+++ b/.agents/skills/bump-go-version/scripts/find-files
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+def get_git_files():
+    try:
+        repo_root = subprocess.check_output(['git', 'rev-parse', '--show-toplevel'], text=True).strip()
+        os.chdir(repo_root)
+        files = subprocess.check_output(['git', 'ls-files'], text=True).splitlines()
+        return files
+    except subprocess.CalledProcessError as e:
+        print(f"Error running git command: {e}", file=sys.stderr)
+        sys.exit(1)
+
+def main():
+    files = get_git_files()
+    
+    print("=== Dockerfile FROM lines ===")
+    dockerfiles = sorted([f for f in files if 'Dockerfile' in f])
+    for f in dockerfiles:
+        print(f"{f}:")
+        has_from = False
+        try:
+            with open(f, 'r', encoding='utf-8') as fp:
+                for line in fp:
+                    if line.startswith('FROM '):
+                        print(f"  {line.strip()}")
+                        has_from = True
+        except Exception as e:
+            print(f"  (error reading file: {e})")
+        if not has_from:
+            print("  (no FROM lines found)")
+
+    print("\n=== go.mod / tools.mod go and toolchain lines ===")
+    # Exclude site/go.mod because Hugo manages it as a theme module, which breaks standard Go tooling
+    mod_files = sorted([f for f in files if f.endswith('.mod') and f != 'site/go.mod'])
+    for f in mod_files:
+        print(f"{f}:")
+        has_lines = False
+        try:
+            with open(f, 'r', encoding='utf-8') as fp:
+                for line in fp:
+                    if line.startswith('go ') or line.startswith('toolchain '):
+                        print(f"  {line.strip()}")
+                        has_lines = True
+        except Exception as e:
+            print(f"  (error reading file: {e})")
+        if not has_lines:
+            print("  (no go or toolchain directives found)")
+
+if __name__ == '__main__':
+    main()

--- a/.agents/skills/bump-go-version/scripts/get-latest-go
+++ b/.agents/skills/bump-go-version/scripts/get-latest-go
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import urllib.request
+import urllib.error
+
+def main():
+    url = "https://go.dev/VERSION?m=text"
+    try:
+        # Set a reasonable timeout to ensure robust fetching
+        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+        with urllib.request.urlopen(req, timeout=10) as response:
+            content = response.read().decode('utf-8')
+            # The first line contains the version string e.g., go1.26.3
+            first_line = content.splitlines()[0].strip()
+            print(first_line)
+    except urllib.error.URLError as e:
+        print(f"Error fetching Go version from {url}: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build go binaries
 # See https://github.com/golang/go/issues/69255#issuecomment-2523276831
-FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
 
 # Declare TARGETARCH to make it available in this build stage
 ARG TARGETARCH

--- a/dev/tools/go.mod
+++ b/dev/tools/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/agent-sandbox/dev/tools
 
 go 1.26.2
 
+toolchain go1.26.3
+
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	golang.org/x/perf/cmd/benchstat

--- a/dev/tools/go.mod
+++ b/dev/tools/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox/dev/tools
 
-go 1.26.2
+go 1.26
 
 toolchain go1.26.3
 

--- a/examples/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our golang binaries in a separate stage to keep the final image small.
-FROM golang:1.26.2 AS builder
+FROM golang:1.26.3 AS builder
 
 WORKDIR /src
 

--- a/examples/chrome-sandbox/go.mod
+++ b/examples/chrome-sandbox/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/agent-sandbox/examples/chrome-sandbox
 
 go 1.26.2
 
+toolchain go1.26.3
+
 require k8s.io/klog/v2 v2.140.0
 
 require github.com/go-logr/logr v1.4.2 // indirect

--- a/examples/chrome-sandbox/go.mod
+++ b/examples/chrome-sandbox/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox/examples/chrome-sandbox
 
-go 1.26.2
+go 1.26
 
 toolchain go1.26.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox
 
-go 1.26.2
+go 1.26
 
 toolchain go1.26.3
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/agent-sandbox
 
 go 1.26.2
 
+toolchain go1.26.3
+
 require (
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-logr/logr v1.4.3

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/kubernetes-sigs/agent-sandbox
 
 go 1.26.2
 
-toolchain go1.26.3
+require github.com/google/docsy v0.12.0 // indirect

--- a/site/go.mod
+++ b/site/go.mod
@@ -2,4 +2,4 @@ module github.com/kubernetes-sigs/agent-sandbox
 
 go 1.26.2
 
-require github.com/google/docsy v0.12.0 // indirect
+toolchain go1.26.3

--- a/tools.mod
+++ b/tools.mod
@@ -2,6 +2,8 @@ module sigs.k8s.io/agent-sandbox
 
 go 1.25.7
 
+toolchain go1.26.3
+
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/tools.mod
+++ b/tools.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/agent-sandbox
 
-go 1.25.7
+go 1.26
 
 toolchain go1.26.3
 


### PR DESCRIPTION
- **chore: create skill to bump golang version**
  The golang version in tools.mod was lagging, and this might have been confusing Copilot reviews.
  

- **chore: update go to 1.26.3**
  This is using our new skill
  

- **chore: use major versions in go.mod go directives**
  The go directive specifies the language version; we just want the latest major (or and older major for compatability with older go versions)
  
  The toolchain specifies the actual version to build with, we want the latest minor.
  