### PR TITLE
WIP feat(vap): support trusted init-containers

### DIFF
--- a/examples/policy/vap/README.md
+++ b/examples/policy/vap/README.md
@@ -50,7 +50,7 @@ To verify the policy is active, try creating a non-compliant sandbox.
 1. Compliant Sandbox (Should Succeed):
 
 ```yaml
-apiVersion: agents.x-k8s.io/v1alpha1
+apiVersion: agents.x-k8s.io/v1beta1
 kind: Sandbox
 metadata:
   name: secure-sandbox
@@ -120,7 +120,7 @@ spec:
 Since there's no `runtimeClassName` specified, the VAP will reject the creation of the Sandbox resource. 
 
 ```yaml
-apiVersion: agents.x-k8s.io/v1alpha1
+apiVersion: agents.x-k8s.io/v1beta1
 kind: Sandbox
 metadata:
   name: insecure-sandbox
@@ -155,7 +155,7 @@ Attempt to create a Sandbox with a secure main container but a privileged init c
 
 **Manifest (`bad-init.yaml`):**
 ```yaml
-apiVersion: agents.x-k8s.io/v1alpha1
+apiVersion: agents.x-k8s.io/v1beta1
 kind: Sandbox
 metadata:
   name: side-door-attack

--- a/examples/policy/vap/policy_test.go
+++ b/examples/policy/vap/policy_test.go
@@ -471,10 +471,7 @@ func TestSecureSandboxVAP(t *testing.T) {
 			expectAllowed: false,
 		},
 		{
-			// K8s 1.28+ sidecar containers (restartPolicy: Always) run for the entire pod
-			// lifetime. A trusted init container with elevated caps that stays alive during
-			// agent execution creates an intra-pod escalation path.
-			name:        "Violation: Trusted init container uses restartPolicy Always (sidecar)",
+			name:        "Success: Trusted init container with restartPolicy Always is permitted",
 			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init"},
 			mutateSpec: func(spec *corev1.PodSpec) {
 				restartAlways := corev1.ContainerRestartPolicyAlways
@@ -498,7 +495,7 @@ func TestSecureSandboxVAP(t *testing.T) {
 					},
 				}
 			},
-			expectAllowed: false,
+			expectAllowed: true,
 		},
 		{
 			name:        "Violation: Trusted init container is privileged",

--- a/examples/policy/vap/policy_test.go
+++ b/examples/policy/vap/policy_test.go
@@ -105,6 +105,7 @@ func TestSecureSandboxVAP(t *testing.T) {
 	// 4. Test Scenarios
 	tests := []struct {
 		name          string
+		annotations   map[string]string // sandbox-level annotations (e.g. trusted-init-containers)
 		mutateSpec    func(spec *corev1.PodSpec) // Function to inject the vulnerability
 		expectAllowed bool
 	}{
@@ -321,13 +322,214 @@ func TestSecureSandboxVAP(t *testing.T) {
 			},
 			expectAllowed: false,
 		},
+
+		// --- 6. Trusted Init Container Annotation ---
+		{
+			name:        "Success: Trusted init container adds allowed caps and runs as root",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:  "sidecar-init",
+						Image: "us.gcr.io/snap-mesh-images/sidecar-init:latest",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW", "NET_BIND_SERVICE", "SETUID", "SETGID"},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: true,
+		},
+		{
+			name:        "Success: Multiple trusted init containers declared",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init,auth-init"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:  "sidecar-init",
+						Image: "us.gcr.io/snap-mesh-images/sidecar-init:latest",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+					{
+						Name:  "auth-init",
+						Image: "us.gcr.io/security-mesh-images/auth-init:latest",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: ptr.To(true),
+							Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("50m"),
+								corev1.ResourceMemory: parserQuantity("64Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "Violation: Init container adds caps without being declared trusted",
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:  "sneaky-init",
+						Image: "attacker/image:latest",
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: ptr.To(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_ADMIN"},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
+		{
+			name:        "Success: Trusted init container may add any capability",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:  "sidecar-init",
+						Image: "us.gcr.io/snap-mesh-images/sidecar-init:latest",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW", "SYS_ADMIN"},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: true,
+		},
+		{
+			name:        "Violation: Trusted init container does not drop ALL",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:  "sidecar-init",
+						Image: "us.gcr.io/snap-mesh-images/sidecar-init:latest",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"NET_ADMIN"},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
+		{
+			name:        "Violation: Annotation names a main container as trusted",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "test"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.Containers[0].SecurityContext.Capabilities.Add = []corev1.Capability{"NET_ADMIN"}
+			},
+			expectAllowed: false,
+		},
+		{
+			// K8s 1.28+ sidecar containers (restartPolicy: Always) run for the entire pod
+			// lifetime. A trusted init container with elevated caps that stays alive during
+			// agent execution creates an intra-pod escalation path.
+			name:        "Violation: Trusted init container uses restartPolicy Always (sidecar)",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				restartAlways := corev1.ContainerRestartPolicyAlways
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:          "sidecar-init",
+						Image:         "us.gcr.io/snap-mesh-images/sidecar-init:latest",
+						RestartPolicy: &restartAlways,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
+		{
+			name:        "Violation: Trusted init container is privileged",
+			annotations: map[string]string{"agents.x-k8s.io/trusted-init-containers": "sidecar-init"},
+			mutateSpec: func(spec *corev1.PodSpec) {
+				spec.InitContainers = []corev1.Container{
+					{
+						Name:  "sidecar-init",
+						Image: "us.gcr.io/snap-mesh-images/sidecar-init:latest",
+						SecurityContext: &corev1.SecurityContext{
+							Privileged:   ptr.To(true),
+							Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    parserQuantity("100m"),
+								corev1.ResourceMemory: parserQuantity("128Mi"),
+							},
+						},
+					},
+				}
+			},
+			expectAllowed: false,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// DeepCopy the secure spec to start fresh every time
 			sandbox := &sandboxv1beta1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-sandbox", Namespace: "default", Annotations: tc.annotations},
 				Spec: sandboxv1beta1.SandboxSpec{
 					PodTemplate: sandboxv1beta1.PodTemplate{
 						Spec: *secureSpec.DeepCopy(),

--- a/examples/policy/vap/secure-sandbox-policy.yaml
+++ b/examples/policy/vap/secure-sandbox-policy.yaml
@@ -54,16 +54,6 @@ spec:
         )
       message: "Security Violation: 'agents.x-k8s.io/trusted-init-containers' may only name init containers. Main and ephemeral containers cannot be trusted."
 
-    # 0b. Trusted Init Annotation Safety — no sidecar (continuous) init containers.
-    # K8s 1.28+ allows init containers with restartPolicy: Always, which run for the
-    # entire pod lifetime alongside main containers. A trusted init container with
-    # elevated capabilities that stays alive during agent execution creates an
-    # intra-pod escalation path. Trusted init containers must run to completion and exit.
-    - expression: >-
-        variables.trustedInitContainers.all(c,
-          !has(c.restartPolicy) || c.restartPolicy != 'Always'
-        )
-      message: "Security Violation: Trusted init containers must not use 'restartPolicy: Always'. Sidecar (continuous) init containers cannot be granted elevated capabilities as they remain alive during agent execution."
 
     # 1. Runtime Isolation
     - expression: "has(object.spec.podTemplate.spec.runtimeClassName) && object.spec.podTemplate.spec.runtimeClassName == 'gvisor'"

--- a/examples/policy/vap/secure-sandbox-policy.yaml
+++ b/examples/policy/vap/secure-sandbox-policy.yaml
@@ -7,7 +7,7 @@ spec:
   matchConstraints:
     resourceRules:
     - apiGroups:   ["agents.x-k8s.io"]
-      apiVersions: ["v1beta1"]
+      apiVersions: ["v1alpha1", "v1beta1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["sandboxes"]
 

--- a/examples/policy/vap/secure-sandbox-policy.yaml
+++ b/examples/policy/vap/secure-sandbox-policy.yaml
@@ -7,48 +7,88 @@ spec:
   matchConstraints:
     resourceRules:
     - apiGroups:   ["agents.x-k8s.io"]
-      apiVersions: ["v1alpha1"]
+      apiVersions: ["v1beta1"]
       operations:  ["CREATE", "UPDATE"]
       resources:   ["sandboxes"]
-  
-  # Define a variable to check ALL container types: containers, initContainers, and ephemeralContainers.
+
   variables:
+    # All containers across all list types — used by rules that apply universally.
     - name: allContainers
       expression: >-
         object.spec.podTemplate.spec.containers +
         (has(object.spec.podTemplate.spec.initContainers) ? object.spec.podTemplate.spec.initContainers : []) +
         (has(object.spec.podTemplate.spec.ephemeralContainers) ? object.spec.podTemplate.spec.ephemeralContainers : [])
 
+    # Operator-declared trusted init container names, sourced from annotation:
+    #   agents.x-k8s.io/trusted-init-containers: "sidecar-init,other-init"
+    # Only init containers may be named here — the policy enforces this explicitly.
+    # Trusted init containers are exempt from: capability adds (constrained allowlist) and runAsNonRoot.
+    # All other rules (privileged, hostNetwork, hostPID, procMount, etc.) remain unconditional.
+    - name: trustedInitNames
+      expression: >-
+        (has(object.metadata.annotations) &&
+         'agents.x-k8s.io/trusted-init-containers' in object.metadata.annotations)
+        ? object.metadata.annotations['agents.x-k8s.io/trusted-init-containers'].split(',')
+        : []
+
+    - name: trustedInitContainers
+      expression: >-
+        (has(object.spec.podTemplate.spec.initContainers) ? object.spec.podTemplate.spec.initContainers : [])
+          .filter(c, c.name in variables.trustedInitNames)
+
+    - name: untrustedInitContainers
+      expression: >-
+        (has(object.spec.podTemplate.spec.initContainers) ? object.spec.podTemplate.spec.initContainers : [])
+          .filter(c, !(c.name in variables.trustedInitNames))
+
   validations:
+    # 0a. Trusted Init Annotation Safety — no main or ephemeral containers.
+    # Prevent operators from declaring a main or ephemeral container as trusted.
+    # Since K8s enforces unique names across all container lists, this closes the
+    # only possible bypass: a user cannot name a main container the same as an init container.
+    - expression: >-
+        variables.trustedInitNames.all(name,
+          !object.spec.podTemplate.spec.containers.exists(c, c.name == name) &&
+          (!(has(object.spec.podTemplate.spec.ephemeralContainers)) ||
+           !object.spec.podTemplate.spec.ephemeralContainers.exists(c, c.name == name))
+        )
+      message: "Security Violation: 'agents.x-k8s.io/trusted-init-containers' may only name init containers. Main and ephemeral containers cannot be trusted."
+
+    # 0b. Trusted Init Annotation Safety — no sidecar (continuous) init containers.
+    # K8s 1.28+ allows init containers with restartPolicy: Always, which run for the
+    # entire pod lifetime alongside main containers. A trusted init container with
+    # elevated capabilities that stays alive during agent execution creates an
+    # intra-pod escalation path. Trusted init containers must run to completion and exit.
+    - expression: >-
+        variables.trustedInitContainers.all(c,
+          !has(c.restartPolicy) || c.restartPolicy != 'Always'
+        )
+      message: "Security Violation: Trusted init containers must not use 'restartPolicy: Always'. Sidecar (continuous) init containers cannot be granted elevated capabilities as they remain alive during agent execution."
+
     # 1. Runtime Isolation
-    # All sandboxes must use gVisor to prevent container escape.
     - expression: "has(object.spec.podTemplate.spec.runtimeClassName) && object.spec.podTemplate.spec.runtimeClassName == 'gvisor'"
       message: "Security Violation: All Sandboxes must use 'runtimeClassName: gvisor'"
 
     # 2. Network Isolation (Metadata Server Protection)
-    # Host networking allows access to 169.254.169.254 (Node Metadata). This must be blocked.
     - expression: "!has(object.spec.podTemplate.spec.hostNetwork) || object.spec.podTemplate.spec.hostNetwork == false"
       message: "Security Violation: 'hostNetwork: true' is strictly prohibited. Sandboxes must be isolated from the node network."
 
     # 3. Identity Isolation (K8s API Access)
-    # Sandboxes must not mount K8s ServiceAccount tokens to prevent API abuse.
     - expression: "has(object.spec.podTemplate.spec.automountServiceAccountToken) && object.spec.podTemplate.spec.automountServiceAccountToken == false"
       message: "Security Violation: 'automountServiceAccountToken' must be explicitly set to 'false'. Sandbox workloads are not permitted to access the K8s API."
 
-    # 4. Privilege Escalation Prevention
-    # Privileged containers break isolation boundaries.
+    # 4. Privilege Escalation Prevention — unconditional, no exemptions.
     - expression: >-
-        variables.allContainers.all(c, 
-           !has(c.securityContext) || 
+        variables.allContainers.all(c,
+           !has(c.securityContext) ||
            !has(c.securityContext.privileged) ||
            c.securityContext.privileged == false
         )
       message: "Security Violation: Privileged containers are not allowed (checked in containers, initContainers, and ephemeralContainers)."
 
-    # 5. Capabilities Hardening (Defense in Depth)
-    # Drop ALL capabilities.
+    # 5. Capabilities Hardening — all containers must drop ALL, no exemptions.
     - expression: >-
-        variables.allContainers.all(c, 
+        variables.allContainers.all(c,
            has(c.securityContext) &&
            has(c.securityContext.capabilities) &&
            has(c.securityContext.capabilities.drop) &&
@@ -56,86 +96,112 @@ spec:
         )
       message: "Security Violation: All containers must explicitly drop 'ALL' capabilities in securityContext."
 
-    # 6. DoS Protection (Resource Limits)
-    # Prevent noisy neighbors by enforcing memory/cpu limits.
+    # 6. DoS Protection (Resource Limits) — unconditional.
     - expression: >-
-        variables.allContainers.all(c, 
-           has(c.resources) && 
-           has(c.resources.limits) && 
-           has(c.resources.limits.memory) && 
+        variables.allContainers.all(c,
+           has(c.resources) &&
+           has(c.resources.limits) &&
+           has(c.resources.limits.memory) &&
            has(c.resources.limits.cpu)
         )
       message: "Security Violation: All containers must define resource limits (cpu and memory) to prevent DoS."
 
-    # 7. Root User Restriction
-    # Containers must not run as root. Checks Pod-level inheritance and Container-level overrides.
+    # 7. Root User Restriction — main containers and untrusted init containers only.
+    # Trusted init containers may run as root (needed for iptables setup); they exit
+    # before any untrusted code runs so there is no ongoing intra-pod threat.
+    # runAsNonRoot is a hard NO for main containers regardless of any annotation.
     - expression: >-
-        variables.allContainers.all(c, 
+        object.spec.podTemplate.spec.containers.all(c,
           (has(c.securityContext) && has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == true) ||
-          ((!has(c.securityContext) || !has(c.securityContext.runAsNonRoot)) && 
-           has(object.spec.podTemplate.spec.securityContext) && 
-           has(object.spec.podTemplate.spec.securityContext.runAsNonRoot) && 
+          ((!has(c.securityContext) || !has(c.securityContext.runAsNonRoot)) &&
+           has(object.spec.podTemplate.spec.securityContext) &&
+           has(object.spec.podTemplate.spec.securityContext.runAsNonRoot) &&
            object.spec.podTemplate.spec.securityContext.runAsNonRoot == true)
         )
-      message: "Security Violation: Pods or Containers must set 'runAsNonRoot: true', and containers cannot override it to false."
+      message: "Security Violation: Main containers must set 'runAsNonRoot: true'. Root is not permitted in main containers."
+
+    - expression: >-
+        variables.untrustedInitContainers.all(c,
+          (has(c.securityContext) && has(c.securityContext.runAsNonRoot) && c.securityContext.runAsNonRoot == true) ||
+          ((!has(c.securityContext) || !has(c.securityContext.runAsNonRoot)) &&
+           has(object.spec.podTemplate.spec.securityContext) &&
+           has(object.spec.podTemplate.spec.securityContext.runAsNonRoot) &&
+           object.spec.podTemplate.spec.securityContext.runAsNonRoot == true)
+        )
+      message: "Security Violation: Init containers must set 'runAsNonRoot: true', or be declared in 'agents.x-k8s.io/trusted-init-containers'."
 
     # 8. Identity Isolation (Projected Volumes)
-    # Blocks manual mounting of ServiceAccount tokens, ClusterTrustBundles, and PodCertificates.
     - expression: >-
         !has(object.spec.podTemplate.spec.volumes) ||
-        !object.spec.podTemplate.spec.volumes.exists(v, 
-           has(v.projected) && 
-           has(v.projected.sources) && 
+        !object.spec.podTemplate.spec.volumes.exists(v,
+           has(v.projected) &&
+           has(v.projected.sources) &&
            v.projected.sources.exists(s, has(s.serviceAccountToken) || has(s.clusterTrustBundle) || has(s.podCertificate))
         )
       message: "Security Violation: Projected Service Account Tokens, ClusterTrustBundles, and PodCertificates are prohibited."
 
     # 9. Filesystem Isolation (HostPath)
-    # HostPath volumes allow attackers to access the underlying node filesystem.
     - expression: >-
         !has(object.spec.podTemplate.spec.volumes) ||
         !object.spec.podTemplate.spec.volumes.exists(v, has(v.hostPath))
       message: "Security Violation: HostPath volumes are strictly prohibited. You cannot mount host directories."
-    
-    # 10. Capabilities Hardening (No Adds)
-    # Prevent adding dangerous capabilities back after dropping them.
+
+    # 10a. Capabilities — no adds on main containers or ephemeral containers, ever.
     - expression: >-
-        variables.allContainers.all(c, 
+        object.spec.podTemplate.spec.containers.all(c,
+           !has(c.securityContext) ||
+           !has(c.securityContext.capabilities) ||
+           !has(c.securityContext.capabilities.add) ||
+           size(c.securityContext.capabilities.add) == 0
+        ) &&
+        (!(has(object.spec.podTemplate.spec.ephemeralContainers)) ||
+         object.spec.podTemplate.spec.ephemeralContainers.all(c,
+           !has(c.securityContext) ||
+           !has(c.securityContext.capabilities) ||
+           !has(c.securityContext.capabilities.add) ||
+           size(c.securityContext.capabilities.add) == 0
+        ))
+      message: "Security Violation: Capabilities.add must be empty on main and ephemeral containers."
+
+    # 10b. Capabilities — no adds on untrusted init containers.
+    - expression: >-
+        variables.untrustedInitContainers.all(c,
            !has(c.securityContext) ||
            !has(c.securityContext.capabilities) ||
            !has(c.securityContext.capabilities.add) ||
            size(c.securityContext.capabilities.add) == 0
         )
-      message: "Security Violation: Capabilities.add must be empty. You cannot add capabilities."
-    
-    # 11. Process & IPC Isolation
-    # Prevent sharing PID/IPC namespaces with the host.
+      message: "Security Violation: Capabilities.add must be empty. Declare the init container in 'agents.x-k8s.io/trusted-init-containers' to allow capability adds."
+
+    # 10c. Capabilities — trusted init containers may add any capability.
+    # The operator has explicitly declared trust via the annotation. The only hard
+    # constraint is rule 0b: they must not use restartPolicy: Always, ensuring they
+    # run to completion and exit before the agent workload starts.
+
+    # 11. Process & IPC Isolation — unconditional.
     - expression: >-
-        (!has(object.spec.podTemplate.spec.hostPID) || object.spec.podTemplate.spec.hostPID == false) && 
+        (!has(object.spec.podTemplate.spec.hostPID) || object.spec.podTemplate.spec.hostPID == false) &&
         (!has(object.spec.podTemplate.spec.hostIPC) || object.spec.podTemplate.spec.hostIPC == false)
       message: "Security Violation: 'hostPID' and 'hostIPC' must be false."
 
-    # 12. Network Isolation (HostPort)
-    # Binding to a host port allows bypassing network policy and claiming node resources.
+    # 12. Network Isolation (HostPort) — unconditional.
     - expression: >-
-        variables.allContainers.all(c, 
-          !has(c.ports) || 
+        variables.allContainers.all(c,
+          !has(c.ports) ||
           c.ports.all(p, !has(p.hostPort))
         )
       message: "Security Violation: 'hostPort' usage is prohibited."
 
-    # 13. Kernel Hardening (Sysctls)
-    # Prevent modifying kernel parameters.
+    # 13. Kernel Hardening (Sysctls) — unconditional.
     - expression: >-
         !has(object.spec.podTemplate.spec.securityContext) ||
         !has(object.spec.podTemplate.spec.securityContext.sysctls) ||
         size(object.spec.podTemplate.spec.securityContext.sysctls) == 0
       message: "Security Violation: Custom 'sysctls' are prohibited."
 
-    # 14. Filesystem Hardening (ProcMount)
-    # Prevent unmasking /proc paths (which could leak host info).
+    # 14. Filesystem Hardening (ProcMount) — unconditional.
     - expression: >-
-        variables.allContainers.all(c, 
+        variables.allContainers.all(c,
            !has(c.securityContext) ||
            !has(c.securityContext.procMount) ||
            c.securityContext.procMount == 'Default'
@@ -143,20 +209,18 @@ spec:
       message: "Security Violation: 'procMount' must be 'Default' (Unmasked is prohibited)."
 
     # 15. GKE Scheduling (Node Selector)
-    # Ensure the workload lands on a node capable of running gVisor.
     - expression: >-
-        has(object.spec.podTemplate.spec.nodeSelector) && 
-        'sandbox.gke.io/runtime' in object.spec.podTemplate.spec.nodeSelector && 
+        has(object.spec.podTemplate.spec.nodeSelector) &&
+        'sandbox.gke.io/runtime' in object.spec.podTemplate.spec.nodeSelector &&
         object.spec.podTemplate.spec.nodeSelector['sandbox.gke.io/runtime'] == 'gvisor'
       message: "Scheduling Violation: Sandboxes must be scheduled on gVisor nodes (nodeSelector 'sandbox.gke.io/runtime: gvisor')."
 
     # 16. GKE Scheduling (Tolerations)
-    # Ensure the workload can tolerate the gVisor taint.
     - expression: >-
-         has(object.spec.podTemplate.spec.tolerations) &&
-         object.spec.podTemplate.spec.tolerations.exists(t, 
-           t.key == 'sandbox.gke.io/runtime' && 
-           t.value == 'gvisor' && 
-           t.effect == 'NoSchedule'
-         )
+        has(object.spec.podTemplate.spec.tolerations) &&
+        object.spec.podTemplate.spec.tolerations.exists(t,
+          t.key == 'sandbox.gke.io/runtime' &&
+          t.value == 'gvisor' &&
+          t.effect == 'NoSchedule'
+        )
       message: "Scheduling Violation: Sandboxes must tolerate the gVisor taint ('sandbox.gke.io/runtime=gvisor:NoSchedule')."


### PR DESCRIPTION
#### What this PR does / why we need it:

The existing `secure-sandbox-policy` VAP applies a blanket prohibition on
`capabilities.add` across all containers, including init containers. This
blocks legitimate use cases where a trusted init container needs elevated
capabilities to perform one-time setup before the agent workload starts —
the most common example being a mesh sidecar init container that manipulates
iptables to intercept egress traffic.

This PR introduces an opt-in annotation,
`agents.x-k8s.io/trusted-init-containers`, that allows operators to declare
specific init containers as trusted for elevated capability adds and root
execution. The policy enforces strict invariants around this exemption to
prevent it from being misused as a privilege escalation path:

- Named containers must be init containers — main and ephemeral containers
  cannot be declared trusted (enforced by explicit CEL guard)
- All unconditional rules remain in force for trusted init containers:
  `privileged`, `hostNetwork`, `hostPID`, `hostIPC`, `drop: ALL`,
  `procMount`, `hostPort`, `sysctls`
- `runAsNonRoot` is relaxed only for trusted init containers, not main
  containers — running the agent workload as root is explicitly not supported
  given the intra-pod threat model (shared `/proc`, shared volumes, shared
  network namespace)

Also fixes `apiVersions` to match both `v1alpha1` and `v1beta1` so the
policy covers clusters mid-migration between API versions.

#### Which issue(s) this PR is related to:

<!-- None yet — please link if a tracking issue exists -->

#### Release Note

```release-note
Added `agents.x-k8s.io/trusted-init-containers` annotation to the
secure-sandbox VAP example, allowing operators to exempt specific init
containers from capability and runAsNonRoot restrictions for use cases
such as mesh traffic interception via iptables.All other
policy rules remain unconditional.
```
