### PR TITLE
refactor(controllers): rename iterators from k, and propagate list errors in reconcilePod

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -694,8 +694,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		client.InNamespace(sandbox.Namespace),
 		client.MatchingFields{podSandboxNameHashIndex: nameHash},
 	); err != nil {
-		logger.Error(err, "Failed to list pods")
-		return nil, fmt.Errorf("pod list failed: %w", err)
+		return nil, fmt.Errorf("failed to list pods for sandbox %s/%s (%s=%q): %w", sandbox.Namespace, sandbox.Name, podSandboxNameHashIndex, nameHash, err)
 	}
 
 	if len(podList.Items) > 1 {
@@ -986,23 +985,23 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	propagatedLabelsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedLabelsAnnotation]
 	if propagatedLabelsStr != "" {
 		propagatedLabels := strings.SplitSeq(propagatedLabelsStr, ",")
-		for k := range propagatedLabels {
-			if k == "" {
+		for labelKey := range propagatedLabels {
+			if labelKey == "" {
 				continue
 			}
-			if isSystemLabel(k) {
-				if k == sandboxLabel {
+			if isSystemLabel(labelKey) {
+				if labelKey == sandboxLabel {
 					continue
 				}
-				if _, exists := pod.Labels[k]; exists {
-					delete(pod.Labels, k)
+				if _, exists := pod.Labels[labelKey]; exists {
+					delete(pod.Labels, labelKey)
 					updated = true
-					logger.V(1).Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
+					logger.V(4).Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", labelKey)
 				}
 				continue
 			}
-			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Labels[k]; !ok {
-				delete(pod.Labels, k)
+			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Labels[labelKey]; !ok {
+				delete(pod.Labels, labelKey)
 				updated = true
 			}
 		}
@@ -1051,22 +1050,22 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	propagatedAnnotationsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation]
 	if propagatedAnnotationsStr != "" {
 		propagatedAnnotations := strings.SplitSeq(propagatedAnnotationsStr, ",")
-		for k := range propagatedAnnotations {
-			if k == "" {
+		for annotationKey := range propagatedAnnotations {
+			if annotationKey == "" {
 				continue
 			}
-			if isSystemAnnotation(k) {
-				if isControllerManagedPodAnnotation(k) {
+			if isSystemAnnotation(annotationKey) {
+				if isControllerManagedPodAnnotation(annotationKey) {
 					continue
 				}
-				if _, exists := pod.Annotations[k]; exists {
-					delete(pod.Annotations, k)
+				if _, exists := pod.Annotations[annotationKey]; exists {
+					delete(pod.Annotations, annotationKey)
 					updated = true
 				}
 				continue
 			}
-			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[k]; !ok {
-				delete(pod.Annotations, k)
+			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[annotationKey]; !ok {
+				delete(pod.Annotations, annotationKey)
 				updated = true
 			}
 		}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -35,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
@@ -2128,6 +2129,41 @@ func TestReconcilePod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcilePod_ListError(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+	nameHash := "test-hash"
+	listErr := errors.New("simulated list error")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+				return listErr
+			},
+		}).
+		Build()
+
+	r := SandboxReconciler{
+		Client:        fakeClient,
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+	require.Error(t, err)
+	assert.Nil(t, pod)
+	require.ErrorIs(t, err, listErr)
+	assert.Contains(t, err.Error(), "failed to list pods for sandbox test-ns/test-sandbox")
+	assert.Contains(t, err.Error(), podSandboxNameHashIndex+"=\"test-hash\"")
 }
 
 func TestReconcileService(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR addresses two refactoring nits in `controllers/sandbox_controller.go` to improve, maintainability, and error hygiene:

1. **Descriptive Loop Iterators**: Renames the generic iterator variable `k` to `labelKey` and `annotationKey` inside the split loops in `updatePodMetadata`, making the iteration logic clear and more understable.
3. **Robust Error Propagation**: Modifies `reconcilePod` to bubble up pod list errors returned by `r.List` as properly wrapped errors  `fmt.Errorf("failed to list pods for sandbox %s/%s with label selector %s: %w", sandbox.Namespace, sandbox.Name, labelSelector, err)` instead of swallowing them.


#### Which issue(s) this PR is related to: NA
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```
<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when Pod listing fails, now including the affected Sandbox namespace/name and the pod label selector details.
  * Refreshed propagated Pod metadata cleanup for labels and annotations to better preserve controller-managed entries while removing unauthorized or outdated metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->