### PR TITLE
sdk: support dynamic timeout propagation in sandbox router

### DIFF
--- a/clients/go/sandbox/commands_test.go
+++ b/clients/go/sandbox/commands_test.go
@@ -112,6 +112,42 @@ func TestRun_PropagatesTimeoutHeaderFromContextDeadline(t *testing.T) {
 	}
 }
 
+func TestRun_TimeoutHeaderCappedByPerAttemptTimeout(t *testing.T) {
+	var timeoutHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timeoutHeader = r.Header.Get(headerSandboxTimeout)
+		_ = json.NewEncoder(w).Encode(ExecutionResult{
+			Stdout:   "ok\n",
+			Stderr:   "",
+			ExitCode: 0,
+		})
+	}))
+	defer server.Close()
+
+	c := newReadyTestSandbox(server.URL)
+	c.connector.mu.Lock()
+	c.connector.perAttemptTimeout = 2 * time.Second
+	c.connector.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := c.Run(ctx, "echo ok")
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if timeoutHeader == "" {
+		t.Fatal("expected X-Sandbox-Timeout header to be set")
+	}
+	seconds, err := strconv.ParseFloat(timeoutHeader, 64)
+	if err != nil {
+		t.Fatalf("failed to parse timeout header %q: %v", timeoutHeader, err)
+	}
+	if seconds <= 0 || seconds > 2.1 {
+		t.Fatalf("expected propagated timeout to be within (0, 2.1], got %f", seconds)
+	}
+}
+
 func TestRun_ExitCodeDefault_EmptyJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/clients/go/sandbox/commands_test.go
+++ b/clients/go/sandbox/commands_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -76,6 +77,38 @@ func TestRun_Success(t *testing.T) {
 	}
 	if result.Stderr != "" {
 		t.Errorf("expected empty stderr, got %q", result.Stderr)
+	}
+}
+
+func TestRun_PropagatesTimeoutHeaderFromContextDeadline(t *testing.T) {
+	var timeoutHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timeoutHeader = r.Header.Get(headerSandboxTimeout)
+		_ = json.NewEncoder(w).Encode(ExecutionResult{
+			Stdout:   "ok\n",
+			Stderr:   "",
+			ExitCode: 0,
+		})
+	}))
+	defer server.Close()
+
+	c := newReadyTestSandbox(server.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.Run(ctx, "echo ok")
+	if err != nil {
+		t.Fatalf("Run() error: %v", err)
+	}
+	if timeoutHeader == "" {
+		t.Fatal("expected X-Sandbox-Timeout header to be set")
+	}
+	seconds, err := strconv.ParseFloat(timeoutHeader, 64)
+	if err != nil {
+		t.Fatalf("failed to parse timeout header %q: %v", timeoutHeader, err)
+	}
+	if seconds <= 0 || seconds > 5.1 {
+		t.Fatalf("expected propagated timeout to be within (0, 5.1], got %f", seconds)
 	}
 }
 

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -286,7 +286,11 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		if deadline, ok := ctx.Deadline(); ok {
 			remaining := time.Until(deadline)
 			if remaining > 0 {
-				req.Header.Set(headerSandboxTimeout, strconv.FormatFloat(remaining.Seconds(), 'f', -1, 64))
+				timeout := remaining
+				if c.perAttemptTimeout > 0 && c.perAttemptTimeout < timeout {
+					timeout = c.perAttemptTimeout
+				}
+				req.Header.Set(headerSandboxTimeout, strconv.FormatFloat(timeout.Seconds(), 'f', -1, 64))
 			}
 		}
 		req.Header.Set(headerRequestID, reqID)

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -283,6 +283,12 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		req.Header.Set(headerSandboxID, sandboxID)
 		req.Header.Set(headerSandboxNamespace, namespace)
 		req.Header.Set(headerSandboxPort, strconv.Itoa(port))
+		if deadline, ok := ctx.Deadline(); ok {
+			remaining := time.Until(deadline)
+			if remaining > 0 {
+				req.Header.Set(headerSandboxTimeout, strconv.FormatFloat(remaining.Seconds(), 'f', -1, 64))
+			}
+		}
 		req.Header.Set(headerRequestID, reqID)
 		if podIP != "" {
 			req.Header.Set(headerSandboxPodIP, podIP)

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -24,6 +24,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -502,6 +503,17 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 	}
 	if _, ok := capturedHeaders[http.CanonicalHeaderKey(headerSandboxPodIP)]; ok {
 		t.Errorf("expected header %s to be absent, but it was present", headerSandboxPodIP)
+	}
+	timeoutHeader := headers.Get(headerSandboxTimeout)
+	if timeoutHeader == "" {
+		t.Fatalf("expected %s to be set", headerSandboxTimeout)
+	}
+	seconds, err := strconv.ParseFloat(timeoutHeader, 64)
+	if err != nil {
+		t.Fatalf("failed to parse timeout header %q: %v", timeoutHeader, err)
+	}
+	if seconds <= 0 {
+		t.Fatalf("expected propagated timeout to be positive, got %f", seconds)
 	}
 }
 

--- a/clients/go/sandbox/types.go
+++ b/clients/go/sandbox/types.go
@@ -34,6 +34,7 @@ const (
 	headerSandboxNamespace = "X-Sandbox-Namespace"
 	headerSandboxPort      = "X-Sandbox-Port"
 	headerSandboxPodIP     = "X-Sandbox-Pod-IP"
+	headerSandboxTimeout   = "X-Sandbox-Timeout"
 	headerRequestID        = "X-Request-ID"
 )
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -167,6 +167,9 @@ class AsyncSandboxConnector:
             headers["X-Sandbox-ID"] = self.id
             headers["X-Sandbox-Namespace"] = self.namespace
             headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
+            timeout = kwargs.get("timeout")
+            if timeout is not None:
+                headers["X-Sandbox-Timeout"] = str(timeout)
             if self._get_pod_ip and not self._pod_ip_auth_failed:
                 if not self._pod_ip_resolved:
                     try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -47,7 +47,7 @@ def _router_timeout_header_value(timeout) -> str | None:
     else:
         return None
 
-    if not math.isfinite(value) or value <= 0:
+    if value is None or not math.isfinite(value) or value <= 0:
         return None
     return str(value)
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import logging
+import math
 from typing import Callable, Awaitable
 
 import httpx
@@ -33,6 +34,22 @@ from .models import (
 RETRYABLE_STATUS_CODES = {500, 502, 503, 504}
 MAX_RETRIES = 5
 BACKOFF_FACTOR = 0.5
+
+
+def _router_timeout_header_value(timeout) -> str | None:
+    value = None
+    if isinstance(timeout, bool):
+        return None
+    if isinstance(timeout, (int, float)):
+        value = timeout
+    elif isinstance(timeout, httpx.Timeout):
+        value = timeout.read
+    else:
+        return None
+
+    if not math.isfinite(value) or value <= 0:
+        return None
+    return str(value)
 
 
 class AsyncSandboxConnector:
@@ -167,9 +184,9 @@ class AsyncSandboxConnector:
             headers["X-Sandbox-ID"] = self.id
             headers["X-Sandbox-Namespace"] = self.namespace
             headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
-            timeout = kwargs.get("timeout")
-            if timeout is not None:
-                headers["X-Sandbox-Timeout"] = str(timeout)
+            timeout_header = _router_timeout_header_value(kwargs.get("timeout"))
+            if timeout_header is not None:
+                headers["X-Sandbox-Timeout"] = timeout_header
             if self._get_pod_ip and not self._pod_ip_auth_failed:
                 if not self._pod_ip_resolved:
                     try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -364,6 +364,9 @@ class SandboxConnector:
                 headers["X-Sandbox-ID"] = self.id
                 headers["X-Sandbox-Namespace"] = self.namespace
                 headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
+                timeout = kwargs.get("timeout")
+                if timeout is not None:
+                    headers["X-Sandbox-Timeout"] = str(timeout)
                 if self._get_pod_ip and not self._pod_ip_auth_failed:
                     if not self._pod_ip_resolved:
                         try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -52,7 +52,7 @@ def _router_timeout_header_value(timeout) -> str | None:
     else:
         return None
 
-    if not math.isfinite(value) or value <= 0:
+    if value is None or not math.isfinite(value) or value <= 0:
         return None
     return str(value)
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import math
 import socket
 import subprocess
 import time
@@ -36,6 +37,25 @@ from .exceptions import (
 )
 
 ROUTER_SERVICE_NAME = "svc/sandbox-router-svc"
+
+
+def _router_timeout_header_value(timeout) -> str | None:
+    value = None
+    if isinstance(timeout, bool):
+        return None
+    if isinstance(timeout, (int, float)):
+        value = timeout
+    elif isinstance(timeout, tuple):
+        if len(timeout) == 0:
+            return None
+        value = timeout[-1]
+    else:
+        return None
+
+    if not math.isfinite(value) or value <= 0:
+        return None
+    return str(value)
+
 
 class ConnectionStrategy(ABC):
     """Abstract base class for connection strategies."""
@@ -364,9 +384,9 @@ class SandboxConnector:
                 headers["X-Sandbox-ID"] = self.id
                 headers["X-Sandbox-Namespace"] = self.namespace
                 headers["X-Sandbox-Port"] = str(self.connection_config.server_port)
-                timeout = kwargs.get("timeout")
-                if timeout is not None:
-                    headers["X-Sandbox-Timeout"] = str(timeout)
+                timeout_header = _router_timeout_header_value(kwargs.get("timeout"))
+                if timeout_header is not None:
+                    headers["X-Sandbox-Timeout"] = timeout_header
                 if self._get_pod_ip and not self._pod_ip_auth_failed:
                     if not self._pod_ip_resolved:
                         try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -357,6 +357,44 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         )
         self.assertTrue(connector._inject_router_headers)
 
+    async def test_timeout_header_is_sent_for_router_requests(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        await connector.send_request("GET", "health", timeout=123)
+
+        _, call_kwargs = connector.client.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123")
+
+    async def test_timeout_header_is_not_sent_for_in_cluster_requests(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        await connector.send_request("GET", "health", timeout=123)
+
+        _, call_kwargs = connector.client.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-Timeout", sent_headers)
+
 
 class AsyncSandboxHandler(BaseHTTPRequestHandler):
     """Minimal handler for async connector HTTP tests."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -376,6 +376,44 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         sent_headers = call_kwargs.get("headers", {})
         self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123")
 
+    async def test_timeout_object_uses_read_timeout_for_router_requests(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        await connector.send_request("GET", "health", timeout=httpx.Timeout(123.0))
+
+        _, call_kwargs = connector.client.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123.0")
+
+    async def test_unsupported_timeout_does_not_send_header(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        await connector.send_request("GET", "health", timeout=object())
+
+        _, call_kwargs = connector.client.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-Timeout", sent_headers)
+
     async def test_timeout_header_is_not_sent_for_in_cluster_requests(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)
         connector = AsyncSandboxConnector(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -367,6 +367,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         )
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.raise_for_status.return_value = None
         connector.client.request = AsyncMock(return_value=mock_response)
 
@@ -386,6 +387,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         )
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.raise_for_status.return_value = None
         connector.client.request = AsyncMock(return_value=mock_response)
 
@@ -394,6 +396,26 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         _, call_kwargs = connector.client.request.call_args
         sent_headers = call_kwargs.get("headers", {})
         self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123.0")
+
+    async def test_timeout_object_without_read_timeout_does_not_send_header(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        mock_response = AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.is_redirect = False
+        mock_response.raise_for_status.return_value = None
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        await connector.send_request("GET", "health", timeout=httpx.Timeout(None))
+
+        _, call_kwargs = connector.client.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-Timeout", sent_headers)
 
     async def test_unsupported_timeout_does_not_send_header(self):
         config = SandboxDirectConnectionConfig(api_url="http://router")
@@ -405,6 +427,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         )
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.raise_for_status.return_value = None
         connector.client.request = AsyncMock(return_value=mock_response)
 
@@ -424,6 +447,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         )
         mock_response = AsyncMock(spec=httpx.Response)
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.raise_for_status.return_value = None
         connector.client.request = AsyncMock(return_value=mock_response)
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -194,6 +194,30 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
         self.assertIn("X-Sandbox-Namespace", sent_headers)
         self.assertIn("X-Sandbox-Port", sent_headers)
 
+    def test_timeout_header_is_sent_for_router_requests(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute", timeout=123)
+
+        _, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123")
+
+    def test_timeout_header_is_not_sent_for_in_cluster_requests(self):
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+        strategy = InClusterConnectionStrategy("my-sb", "my-ns", config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute", timeout=123)
+
+        _, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-Timeout", sent_headers)
+
     def test_in_cluster_url_is_pod_dns(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)
         strategy = InClusterConnectionStrategy("my-sb", "my-ns", config)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -218,6 +218,18 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
         sent_headers = call_kwargs.get("headers", {})
         self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123")
 
+    def test_timeout_tuple_without_read_timeout_does_not_send_header(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute", timeout=(5, None))
+
+        _, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-Timeout", sent_headers)
+
     def test_unsupported_timeout_does_not_send_header(self):
         config = SandboxDirectConnectionConfig(api_url="http://router")
         strategy = DirectConnectionStrategy(config)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -206,6 +206,30 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
         sent_headers = call_kwargs.get("headers", {})
         self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123")
 
+    def test_timeout_tuple_uses_last_value_for_router_requests(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute", timeout=(3, 123))
+
+        _, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertEqual(sent_headers.get("X-Sandbox-Timeout"), "123")
+
+    def test_unsupported_timeout_does_not_send_header(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        strategy = DirectConnectionStrategy(config)
+        connector, mock_session = self._make_connector_with_strategy(strategy, config)
+        mock_session.request.return_value = self._mock_ok_response()
+
+        connector.send_request("GET", "/execute", timeout=object())
+
+        _, call_kwargs = mock_session.request.call_args
+        sent_headers = call_kwargs.get("headers", {})
+        self.assertNotIn("X-Sandbox-Timeout", sent_headers)
+
     def test_timeout_header_is_not_sent_for_in_cluster_requests(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)
         strategy = InClusterConnectionStrategy("my-sb", "my-ns", config)

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 
+import math
 import os
+import ipaddress
 import re
 import secrets
-import ipaddress
 
 import httpx
 from fastapi import FastAPI, Request, HTTPException
@@ -33,6 +34,7 @@ DEFAULT_SANDBOX_PORT = 8888
 DEFAULT_NAMESPACE = "default"
 DEFAULT_PROXY_TIMEOUT = 180.0
 DEFAULT_CLUSTER_DOMAIN = "cluster.local"
+MAX_REQUEST_TIMEOUT = 3600.0
 
 
 def _get_proxy_timeout() -> float:
@@ -75,9 +77,10 @@ def _get_request_timeout(request: Request) -> float:
             f"falling back to {proxy_timeout}s"
         )
         return proxy_timeout
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0 or value > MAX_REQUEST_TIMEOUT:
         print(
-            f"WARNING: X-Sandbox-Timeout must be positive, got {value}, "
+            f"WARNING: X-Sandbox-Timeout must be finite and within "
+            f"(0, {MAX_REQUEST_TIMEOUT}], got {value}, "
             f"falling back to {proxy_timeout}s"
         )
         return proxy_timeout

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -63,6 +63,27 @@ def _get_cluster_domain() -> str:
     return cluster_domain
 
 
+def _get_request_timeout(request: Request) -> float:
+    raw = request.headers.get("X-Sandbox-Timeout")
+    if raw is None:
+        return proxy_timeout
+    try:
+        value = float(raw)
+    except (ValueError, TypeError):
+        print(
+            f"WARNING: Invalid X-Sandbox-Timeout='{raw}', "
+            f"falling back to {proxy_timeout}s"
+        )
+        return proxy_timeout
+    if value <= 0:
+        print(
+            f"WARNING: X-Sandbox-Timeout must be positive, got {value}, "
+            f"falling back to {proxy_timeout}s"
+        )
+        return proxy_timeout
+    return value
+
+
 cluster_domain = _get_cluster_domain()
 
 DNS_LABEL_REGEX = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
@@ -173,6 +194,7 @@ async def proxy_request(request: Request, full_path: str):
     print(f"Proxying request for sandbox '{sandbox_id}' to URL: {target_url}")
 
     try:
+        timeout = _get_request_timeout(request)
         headers = {
             key: value
             for (key, value) in request.headers.items()
@@ -186,7 +208,8 @@ async def proxy_request(request: Request, full_path: str):
             content=request.stream()
         )
 
-        resp = await client.send(req, stream=True)
+        # Allow a request-level timeout to override the router's default timeout.
+        resp = await client.send(req, stream=True, timeout=timeout)
 
         async def stream_generator():
             try:

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -34,7 +34,6 @@ DEFAULT_SANDBOX_PORT = 8888
 DEFAULT_NAMESPACE = "default"
 DEFAULT_PROXY_TIMEOUT = 180.0
 DEFAULT_CLUSTER_DOMAIN = "cluster.local"
-MAX_REQUEST_TIMEOUT = 3600.0
 
 
 def _get_proxy_timeout() -> float:
@@ -77,11 +76,16 @@ def _get_request_timeout(request: Request) -> float:
             f"falling back to {proxy_timeout}s"
         )
         return proxy_timeout
-    if not math.isfinite(value) or value <= 0 or value > MAX_REQUEST_TIMEOUT:
+    if not math.isfinite(value) or value <= 0:
         print(
-            f"WARNING: X-Sandbox-Timeout must be finite and within "
-            f"(0, {MAX_REQUEST_TIMEOUT}], got {value}, "
+            f"WARNING: X-Sandbox-Timeout must be finite and positive, got {value}, "
             f"falling back to {proxy_timeout}s"
+        )
+        return proxy_timeout
+    if value > proxy_timeout:
+        print(
+            f"WARNING: X-Sandbox-Timeout={value} exceeds configured "
+            f"proxy timeout {proxy_timeout}s; capping to {proxy_timeout}s"
         )
         return proxy_timeout
     return value
@@ -204,15 +208,18 @@ async def proxy_request(request: Request, full_path: str):
             if key.lower() not in {"host", "authorization"}
         }
 
+        # Request-level timeouts are attached via HTTPX request extensions.
+        # The effective value is capped by the router's configured proxy timeout.
+        # https://www.python-httpx.org/advanced/extensions/
         req = client.build_request(
             method=request.method,
             url=target_url,
             headers=headers,
-            content=request.stream()
+            content=request.stream(),
+            timeout=timeout,
         )
 
-        # Allow a request-level timeout to override the router's default timeout.
-        resp = await client.send(req, stream=True, timeout=timeout)
+        resp = await client.send(req, stream=True)
 
         async def stream_generator():
             try:
@@ -233,7 +240,16 @@ async def proxy_request(request: Request, full_path: str):
             status_code=502,
             detail=f"Could not connect to the backend sandbox: {sandbox_id}",
         )
+    except httpx.TimeoutException as e:
+        print(
+            f"ERROR: Request to sandbox at {target_url} timed out. Error: {e}")
+        raise HTTPException(
+            status_code=504,
+            detail=f"Timed out waiting for the backend sandbox: {sandbox_id}",
+        ) from e
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         raise HTTPException(
-            status_code=500, detail="An internal error occurred in the proxy.")
+            status_code=500,
+            detail="An internal error occurred in the proxy.",
+        ) from e

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -216,7 +216,7 @@ async def proxy_request(request: Request, full_path: str):
             url=target_url,
             headers=headers,
             content=request.stream(),
-            timeout=timeout,
+            timeout=httpx.Timeout(timeout, connect=min(timeout, 5.0)),
         )
 
         resp = await client.send(req, stream=True)

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -317,6 +317,42 @@ class TestProxyTimeout:
             importlib.reload(sandbox_router)
             assert sandbox_router.proxy_timeout == 180.0
 
+    def test_request_header_overrides_proxy_timeout(self, client):
+        async def capture_send(req, **kwargs):
+            capture_send.timeout = kwargs.get("timeout")
+            raise httpx.ConnectError("stop here")
+
+        capture_send.timeout = None
+        with patch.object(sandbox_router.client, "send", side_effect=capture_send):
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Timeout": "600",
+                },
+            )
+
+        assert resp.status_code == 502
+        assert capture_send.timeout == 600.0
+
+    def test_invalid_request_header_falls_back_to_default_timeout(self, client):
+        async def capture_send(req, **kwargs):
+            capture_send.timeout = kwargs.get("timeout")
+            raise httpx.ConnectError("stop here")
+
+        capture_send.timeout = None
+        with patch.object(sandbox_router.client, "send", side_effect=capture_send):
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Timeout": "invalid",
+                },
+            )
+
+        assert resp.status_code == 502
+        assert capture_send.timeout == sandbox_router.proxy_timeout
+
 
 class TestProxyRouting:
     def test_connect_error_returns_502(self, client):

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -353,6 +353,42 @@ class TestProxyTimeout:
         assert resp.status_code == 502
         assert capture_send.timeout == sandbox_router.proxy_timeout
 
+    def test_non_finite_request_header_falls_back_to_default_timeout(self, client):
+        async def capture_send(req, **kwargs):
+            capture_send.timeout = kwargs.get("timeout")
+            raise httpx.ConnectError("stop here")
+
+        capture_send.timeout = None
+        with patch.object(sandbox_router.client, "send", side_effect=capture_send):
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Timeout": "inf",
+                },
+            )
+
+        assert resp.status_code == 502
+        assert capture_send.timeout == sandbox_router.proxy_timeout
+
+    def test_oversized_request_header_falls_back_to_default_timeout(self, client):
+        async def capture_send(req, **kwargs):
+            capture_send.timeout = kwargs.get("timeout")
+            raise httpx.ConnectError("stop here")
+
+        capture_send.timeout = None
+        with patch.object(sandbox_router.client, "send", side_effect=capture_send):
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Timeout": "3601",
+                },
+            )
+
+        assert resp.status_code == 502
+        assert capture_send.timeout == sandbox_router.proxy_timeout
+
 
 class TestProxyRouting:
     def test_connect_error_returns_502(self, client):

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -317,9 +317,9 @@ class TestProxyTimeout:
             importlib.reload(sandbox_router)
             assert sandbox_router.proxy_timeout == 180.0
 
-    def test_request_header_overrides_proxy_timeout(self, client):
+    def test_request_header_below_proxy_timeout_overrides_default(self, client):
         async def capture_send(req, **kwargs):
-            capture_send.timeout = kwargs.get("timeout")
+            capture_send.timeout = req.extensions.get("timeout")
             raise httpx.ConnectError("stop here")
 
         capture_send.timeout = None
@@ -328,16 +328,17 @@ class TestProxyTimeout:
                 "/execute",
                 headers={
                     "X-Sandbox-ID": "my-sandbox",
-                    "X-Sandbox-Timeout": "600",
+                    "X-Sandbox-Timeout": "60",
                 },
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout == 600.0
+        assert capture_send.timeout["connect"] == 60.0
+        assert capture_send.timeout["read"] == 60.0
 
     def test_invalid_request_header_falls_back_to_default_timeout(self, client):
         async def capture_send(req, **kwargs):
-            capture_send.timeout = kwargs.get("timeout")
+            capture_send.timeout = req.extensions.get("timeout")
             raise httpx.ConnectError("stop here")
 
         capture_send.timeout = None
@@ -351,11 +352,12 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
     def test_non_finite_request_header_falls_back_to_default_timeout(self, client):
         async def capture_send(req, **kwargs):
-            capture_send.timeout = kwargs.get("timeout")
+            capture_send.timeout = req.extensions.get("timeout")
             raise httpx.ConnectError("stop here")
 
         capture_send.timeout = None
@@ -369,11 +371,15 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
-    def test_oversized_request_header_falls_back_to_default_timeout(self, client):
+    @pytest.mark.parametrize("timeout_value", ["0", "-1"])
+    def test_non_positive_request_header_falls_back_to_default_timeout(
+        self, client, timeout_value
+    ):
         async def capture_send(req, **kwargs):
-            capture_send.timeout = kwargs.get("timeout")
+            capture_send.timeout = req.extensions.get("timeout")
             raise httpx.ConnectError("stop here")
 
         capture_send.timeout = None
@@ -382,12 +388,32 @@ class TestProxyTimeout:
                 "/execute",
                 headers={
                     "X-Sandbox-ID": "my-sandbox",
-                    "X-Sandbox-Timeout": "3601",
+                    "X-Sandbox-Timeout": timeout_value,
                 },
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
+
+    def test_request_header_above_proxy_timeout_is_capped(self, client):
+        async def capture_send(req, **kwargs):
+            capture_send.timeout = req.extensions.get("timeout")
+            raise httpx.ConnectError("stop here")
+
+        capture_send.timeout = None
+        with patch.object(sandbox_router.client, "send", side_effect=capture_send):
+            resp = client.post(
+                "/execute",
+                headers={
+                    "X-Sandbox-ID": "my-sandbox",
+                    "X-Sandbox-Timeout": "600",
+                },
+            )
+
+        assert resp.status_code == 502
+        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
 
 class TestProxyRouting:
@@ -406,6 +432,22 @@ class TestProxyRouting:
             )
             assert resp.status_code == 502
             assert "unreachable-sandbox" in resp.json()["detail"]
+
+    def test_timeout_error_returns_504(self, client):
+        """When the target sandbox times out, the router should return 504."""
+        with patch.object(
+            sandbox_router.client,
+            "send",
+            new_callable=AsyncMock,
+            side_effect=httpx.TimeoutException("timed out"),
+        ):
+            resp = client.post(
+                "/execute",
+                headers={"X-Sandbox-ID": "slow-sandbox"},
+                content=b'{"command": "sleep 999"}',
+            )
+            assert resp.status_code == 504
+            assert "slow-sandbox" in resp.json()["detail"]
 
     def test_target_url_construction(self, client):
         """Verify the router builds the correct internal DNS URL."""

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -333,7 +333,7 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout["connect"] == 60.0
+        assert capture_send.timeout["connect"] == 5.0
         assert capture_send.timeout["read"] == 60.0
 
     def test_invalid_request_header_falls_back_to_default_timeout(self, client):
@@ -352,7 +352,7 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == min(sandbox_router.proxy_timeout, 5.0)
         assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
     def test_non_finite_request_header_falls_back_to_default_timeout(self, client):
@@ -371,7 +371,7 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == min(sandbox_router.proxy_timeout, 5.0)
         assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
     @pytest.mark.parametrize("timeout_value", ["0", "-1"])
@@ -393,7 +393,7 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == min(sandbox_router.proxy_timeout, 5.0)
         assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
     def test_request_header_above_proxy_timeout_is_capped(self, client):
@@ -412,7 +412,7 @@ class TestProxyTimeout:
             )
 
         assert resp.status_code == 502
-        assert capture_send.timeout["connect"] == sandbox_router.proxy_timeout
+        assert capture_send.timeout["connect"] == min(sandbox_router.proxy_timeout, 5.0)
         assert capture_send.timeout["read"] == sandbox_router.proxy_timeout
 
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Propagates client-side request timeouts to the sandbox-router so long-running sandbox operations are not prematurely terminated by the router's default proxy timeout.

Today, SDK calls can accept a longer timeout (for example `sandbox.commands.run(..., timeout=600)`), but that timeout is only enforced client-side. When requests are routed through `sandbox-router`, the router still applies its own default proxy timeout, which can terminate long-running requests early with `504 Gateway Timeout`.

This PR adds support for request-level timeout propagation by:
- teaching `sandbox-router` to accept `X-Sandbox-Timeout` and use it as a per-request proxy timeout override
- updating the Python sync and async SDK connectors to inject `X-Sandbox-Timeout`
- updating the Go SDK connector to propagate the remaining request deadline through the same header
- adding tests for router behavior and SDK header propagation

#### Which issue(s) this PR is related to:
Fixes #820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go and Python clients now propagate request timeouts via an HTTP header so downstream services and the router can honor client deadlines and enforce per-attempt caps.
  * Router applies per-request timeout selection, falls back to configured proxy timeout for invalid/missing values, and caps excessive values; backend timeouts are surfaced as 504 responses.

* **Tests**
  * Added and expanded tests validating timeout header propagation, router timeout selection/capping, and timeout-related response behavior across clients and proxy paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->