### PR TITLE
fix(api): mark Sandbox.spec.volumeClaimTemplates immutable via CEL

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -188,6 +188,8 @@ type SandboxBlueprint struct {
 }
 
 // SandboxSpec defines the desired state of Sandbox.
+// volumeClaimTemplates is immutable after creation.
+// +kubebuilder:validation:XValidation:rule="has(self.volumeClaimTemplates) == has(oldSelf.volumeClaimTemplates) && (!has(self.volumeClaimTemplates) || self.volumeClaimTemplates == oldSelf.volumeClaimTemplates)",message="volumeClaimTemplates is immutable"
 type SandboxSpec struct {
 	// The following markers will use OpenAPI v3 schema to validate the value
 	// More info: https://book.kubebuilder.io/reference/markers/crd-validation.html

--- a/docs/api.md
+++ b/docs/api.md
@@ -362,6 +362,7 @@ _Appears in:_
 
 
 SandboxSpec defines the desired state of Sandbox.
+volumeClaimTemplates is immutable after creation.
 
 
 

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3961,6 +3961,11 @@ spec:
             required:
             - podTemplate
             type: object
+            x-kubernetes-validations:
+            - message: volumeClaimTemplates is immutable
+              rule: has(self.volumeClaimTemplates) == has(oldSelf.volumeClaimTemplates)
+                && (!has(self.volumeClaimTemplates) || self.volumeClaimTemplates ==
+                oldSelf.volumeClaimTemplates)
           status:
             properties:
               conditions:

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3961,6 +3961,11 @@ spec:
             required:
             - podTemplate
             type: object
+            x-kubernetes-validations:
+            - message: volumeClaimTemplates is immutable
+              rule: has(self.volumeClaimTemplates) == has(oldSelf.volumeClaimTemplates)
+                && (!has(self.volumeClaimTemplates) || self.volumeClaimTemplates ==
+                oldSelf.volumeClaimTemplates)
           status:
             properties:
               conditions:

--- a/test/e2e/volumeclaimtemplate_test.go
+++ b/test/e2e/volumeclaimtemplate_test.go
@@ -128,3 +128,54 @@ func TestSandboxVolumeClaimTemplates(t *testing.T) {
 	}
 	require.True(t, found, "expected pod to have a 'data' volume backed by PVC")
 }
+
+func TestSandboxVolumeClaimTemplatesImmutable(t *testing.T) {
+	vct := sandboxv1beta1.PersistentVolumeClaimTemplate{
+		EmbeddedObjectMetadata: sandboxv1beta1.EmbeddedObjectMetadata{Name: "data"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}},
+		},
+	}
+	pausePod := sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "pause", Image: "registry.k8s.io/pause:3.10"}}}}
+
+	cases := []struct {
+		name    string
+		initial []sandboxv1beta1.PersistentVolumeClaimTemplate
+		mutate  func([]sandboxv1beta1.PersistentVolumeClaimTemplate) []sandboxv1beta1.PersistentVolumeClaimTemplate
+	}{
+		{"set→modified-set", []sandboxv1beta1.PersistentVolumeClaimTemplate{vct}, func(v []sandboxv1beta1.PersistentVolumeClaimTemplate) []sandboxv1beta1.PersistentVolumeClaimTemplate {
+			return append(v, vct)
+		}},
+		{"unset→set", nil, func(_ []sandboxv1beta1.PersistentVolumeClaimTemplate) []sandboxv1beta1.PersistentVolumeClaimTemplate {
+			return []sandboxv1beta1.PersistentVolumeClaimTemplate{vct}
+		}},
+		{"set→unset", []sandboxv1beta1.PersistentVolumeClaimTemplate{vct}, func(_ []sandboxv1beta1.PersistentVolumeClaimTemplate) []sandboxv1beta1.PersistentVolumeClaimTemplate {
+			return nil
+		}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tc := framework.NewTestContext(t)
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("sandbox-vct-immutable-%d", time.Now().UnixNano())}}
+			require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+
+			sb := &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "vct-immutable", Namespace: ns.Name},
+				Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+					PodTemplate:          pausePod,
+					VolumeClaimTemplates: c.initial,
+				}},
+			}
+			require.NoError(t, tc.CreateWithCleanup(t.Context(), sb))
+
+			latest := &sandboxv1beta1.Sandbox{}
+			require.NoError(t, tc.Get(t.Context(), types.NamespacedName{Name: sb.Name, Namespace: ns.Name}, latest))
+			latest.Spec.VolumeClaimTemplates = c.mutate(latest.Spec.VolumeClaimTemplates)
+
+			err := tc.Update(t.Context(), latest)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "volumeClaimTemplates is immutable")
+		})
+	}
+}


### PR DESCRIPTION
Add an XValidation immutability rule on Sandbox `volumeClaimTemplates` (placed on the parent rather than the field so the transition rule can observe presence on both old and new objects) so the API server enforces immutability for all three transitions: set to modified set, unset to set, and set to unset. The previous rule on the optional field was skipped when the field was absent in either the old or new object, leaving two gaps.

This aligns Sandbox with the StatefulSet immutability contract and prevents controller reconciliation failures or orphaned PVCs caused by post-creation mutations.

fixes #727

**Changes**

- \`api/v1beta1/sandbox_types.go\`: move XValidation marker to \`SandboxSpec\` with \`has()\` checks covering all transitions
- \`k8s/crds/agents.x-k8s.io_sandboxes.yaml\`: regenerated via \`go generate ./...\`
- \`helm/crds/agents.x-k8s.io_sandboxes.yaml\`: regenerated via \`go generate ./...\`
- \`docs/api.md\`: regenerated via \`make generate-api-docs\`
- \`test/e2e/volumeclaimtemplate_test.go\`: added table-driven e2e tests for all three rejection cases

#### Release Note

```release-note
`Sandbox.spec.volumeClaimTemplates` is now immutable after creation. Attempts to add, modify, or remove it during an update are rejected by the API server. Previously, the field could be mutated but changes were silently ignored by the controller, causing spec/PVC drift. Creates, no-op updates, and existing objects are unaffected.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced immutability for Sandbox `volumeClaimTemplates` after creation.
  * Attempts to add, modify, or remove `volumeClaimTemplates` during updates are now rejected with a validation error (“volumeClaimTemplates is immutable”).

* **Tests**
  * Added end-to-end coverage verifying immutability for `volumeClaimTemplates` update scenarios (set→modified, unset→set, set→unset).

* **Documentation**
  * Updated API documentation to explicitly note that `volumeClaimTemplates` cannot be changed after creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->