### PR TITLE
fix: add dynamic bearer token patch for Kubernetes Python client 36.0…

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -52,9 +52,14 @@ class AsyncK8sHelper:
                 config.load_incluster_config()
             except config.ConfigException:
                 await config.load_kube_config()
+            # Import patch utility and keep token keys in sync for v36.0.0+ support
+            from .utils import patch_k8s_config
+            patch_k8s_config(client)
+
             self._api_client = client.ApiClient()
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
+
             self._initialized = True
 
     async def create_sandbox_claim(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -52,11 +52,12 @@ class AsyncK8sHelper:
                 config.load_incluster_config()
             except config.ConfigException:
                 await config.load_kube_config()
+            c = client.Configuration.get_default_copy()
             # Import patch utility and keep token keys in sync for v36.0.0+ support
             from .utils import patch_k8s_config
-            patch_k8s_config(client)
+            patch_k8s_config(c)
 
-            self._api_client = client.ApiClient()
+            self._api_client = client.ApiClient(configuration=c)
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -37,6 +37,10 @@ class K8sHelper:
             config.load_incluster_config()
         except config.ConfigException:
             config.load_kube_config()
+        # Import patch utility and keep token keys in sync for v36.0.0+ support
+        from .utils import patch_k8s_config
+        patch_k8s_config(client)
+
         self.custom_objects_api = client.CustomObjectsApi()
         self.core_v1_api = client.CoreV1Api()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -37,12 +37,14 @@ class K8sHelper:
             config.load_incluster_config()
         except config.ConfigException:
             config.load_kube_config()
+        c = client.Configuration.get_default_copy()
         # Import patch utility and keep token keys in sync for v36.0.0+ support
         from .utils import patch_k8s_config
-        patch_k8s_config(client)
+        patch_k8s_config(c)
 
-        self.custom_objects_api = client.CustomObjectsApi()
-        self.core_v1_api = client.CoreV1Api()
+        self.api_client = client.ApiClient(configuration=c)
+        self.custom_objects_api = client.CustomObjectsApi(self.api_client)
+        self.core_v1_api = client.CoreV1Api(self.api_client)
 
     def create_sandbox_claim(self, name: str, template: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None, warmpool: str | None = None):
         """Creates a SandboxClaim custom resource."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -212,22 +212,19 @@ class TestAsyncK8sHelperWaitForSandboxReady(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
-class MockConfig(MagicMock):
-    ConfigException = Exception
-
-
 class TestAsyncK8sHelperInitPatch(unittest.IsolatedAsyncioTestCase):
 
     @patch("k8s_agent_sandbox.utils.patch_k8s_config")
     @patch("k8s_agent_sandbox.async_k8s_helper.client.CoreV1Api")
     @patch("k8s_agent_sandbox.async_k8s_helper.client.CustomObjectsApi")
     @patch("k8s_agent_sandbox.async_k8s_helper.client.ApiClient")
-    @patch("k8s_agent_sandbox.async_k8s_helper.config", new_callable=MockConfig)
-    async def test_ensure_initialized_calls_patch_k8s_config(self, mock_config, mock_api_client_cls, mock_api_cls, mock_core_cls, mock_patch):
-        from k8s_agent_sandbox.async_k8s_helper import client
-        helper = AsyncK8sHelper()
-        await helper._ensure_initialized()
-        mock_patch.assert_called_once_with(client)
+    async def test_ensure_initialized_calls_patch_k8s_config(self, mock_api_client_cls, mock_api_cls, mock_core_cls, mock_patch):
+        with patch("k8s_agent_sandbox.async_k8s_helper.config.load_incluster_config") as mock_load_incluster, \
+             patch("k8s_agent_sandbox.async_k8s_helper.config.load_kube_config") as mock_load_kube:
+            from k8s_agent_sandbox.async_k8s_helper import client
+            helper = AsyncK8sHelper()
+            await helper._ensure_initialized()
+            mock_patch.assert_called_once_with(client)
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -221,8 +221,6 @@ class TestAsyncK8sHelperInitPatch(unittest.IsolatedAsyncioTestCase):
     async def test_ensure_initialized_calls_patch_k8s_config(self, mock_api_client_cls, mock_api_cls, mock_core_cls, mock_patch):
         with patch("k8s_agent_sandbox.async_k8s_helper.config.load_incluster_config") as mock_load_incluster, \
              patch("k8s_agent_sandbox.async_k8s_helper.config.load_kube_config") as mock_load_kube:
-            import k8s_agent_sandbox.utils
-            k8s_agent_sandbox.utils._is_patched = False
             from k8s_agent_sandbox.async_k8s_helper import client
             helper = AsyncK8sHelper()
             await helper._ensure_initialized()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -221,10 +221,9 @@ class TestAsyncK8sHelperInitPatch(unittest.IsolatedAsyncioTestCase):
     async def test_ensure_initialized_calls_patch_k8s_config(self, mock_api_client_cls, mock_api_cls, mock_core_cls, mock_patch):
         with patch("k8s_agent_sandbox.async_k8s_helper.config.load_incluster_config") as mock_load_incluster, \
              patch("k8s_agent_sandbox.async_k8s_helper.config.load_kube_config") as mock_load_kube:
-            from k8s_agent_sandbox.async_k8s_helper import client
             helper = AsyncK8sHelper()
             await helper._ensure_initialized()
-            mock_patch.assert_called_once_with(client)
+            mock_patch.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -212,5 +212,23 @@ class TestAsyncK8sHelperWaitForSandboxReady(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
+class MockConfig(MagicMock):
+    ConfigException = Exception
+
+
+class TestAsyncK8sHelperInitPatch(unittest.IsolatedAsyncioTestCase):
+
+    @patch("k8s_agent_sandbox.utils.patch_k8s_config")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.CustomObjectsApi")
+    @patch("k8s_agent_sandbox.async_k8s_helper.client.ApiClient")
+    @patch("k8s_agent_sandbox.async_k8s_helper.config", new_callable=MockConfig)
+    async def test_ensure_initialized_calls_patch_k8s_config(self, mock_config, mock_api_client_cls, mock_api_cls, mock_core_cls, mock_patch):
+        from k8s_agent_sandbox.async_k8s_helper import client
+        helper = AsyncK8sHelper()
+        await helper._ensure_initialized()
+        mock_patch.assert_called_once_with(client)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -221,6 +221,8 @@ class TestAsyncK8sHelperInitPatch(unittest.IsolatedAsyncioTestCase):
     async def test_ensure_initialized_calls_patch_k8s_config(self, mock_api_client_cls, mock_api_cls, mock_core_cls, mock_patch):
         with patch("k8s_agent_sandbox.async_k8s_helper.config.load_incluster_config") as mock_load_incluster, \
              patch("k8s_agent_sandbox.async_k8s_helper.config.load_kube_config") as mock_load_kube:
+            import k8s_agent_sandbox.utils
+            k8s_agent_sandbox.utils._is_patched = False
             from k8s_agent_sandbox.async_k8s_helper import client
             helper = AsyncK8sHelper()
             await helper._ensure_initialized()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
@@ -1,0 +1,183 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the bearer token synchronization and patching utility logic.
+
+This module tests that K8s client config modifications correctly propagate changes between
+`authorization` and `BearerToken` key definitions to support correct auth in the client SDK.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from k8s_agent_sandbox.utils import _sync_k8s_bearer_token, patch_k8s_config
+
+
+class FakeConfiguration:
+    _default = None
+
+    def __init__(self):
+        self.api_key = {}
+        self.api_key_prefix = {}
+        self.refresh_api_key_hook = None
+
+    @classmethod
+    def get_default_copy(cls):
+        if cls._default is None:
+            return FakeConfiguration()
+        copy_cfg = FakeConfiguration()
+        copy_cfg.api_key = dict(cls._default.api_key)
+        copy_cfg.api_key_prefix = dict(cls._default.api_key_prefix)
+        copy_cfg.refresh_api_key_hook = cls._default.refresh_api_key_hook
+        return copy_cfg
+
+    @classmethod
+    def set_default(cls, c):
+        cls._default = c
+
+
+class FakeClientModule:
+    def __init__(self):
+        self.Configuration = FakeConfiguration
+
+    def set_default(self, c):
+        self.Configuration.set_default(c)
+
+    def get_default_copy(self):
+        return self.Configuration.get_default_copy()
+
+
+class TestBearerTokenPatch(unittest.TestCase):
+
+    def setUp(self):
+        FakeConfiguration._default = None
+
+
+    def test_sync_bearer_token_from_authorization(self):
+        config = FakeConfiguration()
+        config.api_key["authorization"] = "bearer-token-123"
+        config.api_key_prefix["authorization"] = "Bearer"
+
+        _sync_k8s_bearer_token(config)
+
+        self.assertEqual(config.api_key["BearerToken"], "bearer-token-123")
+        self.assertEqual(config.api_key_prefix["BearerToken"], "Bearer")
+        self.assertEqual(config.api_key["authorization"], "bearer-token-123")
+        self.assertEqual(config.api_key_prefix["authorization"], "Bearer")
+
+    def test_sync_bearer_token_from_bearer_token(self):
+        config = FakeConfiguration()
+        config.api_key["BearerToken"] = "bearer-token-456"
+        config.api_key_prefix["BearerToken"] = "Bearer"
+
+        _sync_k8s_bearer_token(config)
+
+        self.assertEqual(config.api_key["authorization"], "bearer-token-456")
+        self.assertEqual(config.api_key_prefix["authorization"], "Bearer")
+        self.assertEqual(config.api_key["BearerToken"], "bearer-token-456")
+        self.assertEqual(config.api_key_prefix["BearerToken"], "Bearer")
+
+    def test_patch_k8s_config_wraps_refresh_hook_and_avoids_nesting(self):
+        client_module = FakeClientModule()
+        config = FakeConfiguration()
+        
+        # Original refresh hook
+        mock_orig_hook = MagicMock()
+        def orig_hook(cfg):
+            cfg.api_key["authorization"] = "refreshed-token"
+            mock_orig_hook(cfg)
+        
+        config.refresh_api_key_hook = orig_hook
+        client_module.set_default(config)
+
+        # First patch
+        patch_k8s_config(client_module)
+        patched_config = client_module.get_default_copy()
+        
+        self.assertIsNotNone(patched_config.refresh_api_key_hook)
+        self.assertNotEqual(patched_config.refresh_api_key_hook, orig_hook)
+
+        # Trigger refresh hook and verify it syncs BearerToken
+        test_cfg = FakeConfiguration()
+        test_cfg.api_key = {"authorization": "old-token"}
+        patched_config.refresh_api_key_hook(test_cfg)
+        
+        mock_orig_hook.assert_called_once_with(test_cfg)
+        self.assertEqual(test_cfg.api_key["authorization"], "refreshed-token")
+        self.assertEqual(test_cfg.api_key["BearerToken"], "refreshed-token")
+
+        # Second patch - should NOT wrap again
+        second_hook = patched_config.refresh_api_key_hook
+        client_module.set_default(patched_config)
+        patch_k8s_config(client_module)
+        
+        third_config = client_module.get_default_copy()
+        self.assertEqual(third_config.refresh_api_key_hook, second_hook)
+
+    def test_sync_bearer_token_empty_config(self):
+        config = FakeConfiguration()
+        _sync_k8s_bearer_token(config)
+        self.assertEqual(config.api_key, {})
+        self.assertEqual(config.api_key_prefix, {})
+
+    def test_patch_k8s_config_with_none_hook(self):
+        client_module = FakeClientModule()
+        config = FakeConfiguration()
+        config.refresh_api_key_hook = None
+        client_module.set_default(config)
+
+        patch_k8s_config(client_module)
+        patched_config = client_module.get_default_copy()
+        self.assertIsNone(patched_config.refresh_api_key_hook)
+
+    def test_sync_bearer_token_when_both_keys_exist_but_differ_after_refresh(self):
+        config = FakeConfiguration()
+        # 1. Initial state (only authorization set)
+        config.api_key["authorization"] = "initial-token"
+        
+        # 2. First sync - populates both keys and sets state
+        _sync_k8s_bearer_token(config)
+        self.assertEqual(config.api_key["authorization"], "initial-token")
+        self.assertEqual(config.api_key["BearerToken"], "initial-token")
+
+        # 3. Simulate a token refresh hook that updates only 'authorization'
+        config.api_key["authorization"] = "refreshed-token"
+
+        # 4. Run sync again - it must detect the update and propagate it to 'BearerToken'!
+        _sync_k8s_bearer_token(config)
+        self.assertEqual(config.api_key["authorization"], "refreshed-token")
+        self.assertEqual(config.api_key["BearerToken"], "refreshed-token")
+
+    def test_sync_bearer_token_when_both_keys_exist_but_differ_after_refresh_bearer_primary(self):
+        config = FakeConfiguration()
+        # 1. Initial state (only BearerToken set)
+        config.api_key["BearerToken"] = "initial-token"
+        
+        # 2. First sync - populates both keys and sets state
+        _sync_k8s_bearer_token(config)
+        self.assertEqual(config.api_key["authorization"], "initial-token")
+        self.assertEqual(config.api_key["BearerToken"], "initial-token")
+
+        # 3. Simulate a token refresh hook that updates only 'BearerToken'
+        config.api_key["BearerToken"] = "refreshed-token"
+
+        # 4. Run sync again - it must detect the update and propagate it to 'authorization'!
+        _sync_k8s_bearer_token(config)
+        self.assertEqual(config.api_key["authorization"], "refreshed-token")
+        self.assertEqual(config.api_key["BearerToken"], "refreshed-token")
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
@@ -62,6 +62,8 @@ class TestBearerTokenPatch(unittest.TestCase):
 
     def setUp(self):
         FakeConfiguration._default = None
+        import k8s_agent_sandbox.utils
+        k8s_agent_sandbox.utils._is_patched = False
 
 
     def test_sync_bearer_token_from_authorization(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
@@ -47,15 +47,7 @@ class FakeConfiguration:
         cls._default = c
 
 
-class FakeClientModule:
-    def __init__(self):
-        self.Configuration = FakeConfiguration
 
-    def set_default(self, c):
-        self.Configuration.set_default(c)
-
-    def get_default_copy(self):
-        return self.Configuration.get_default_copy()
 
 
 class TestBearerTokenPatch(unittest.TestCase):
@@ -89,7 +81,6 @@ class TestBearerTokenPatch(unittest.TestCase):
         self.assertEqual(config.api_key_prefix["BearerToken"], "Bearer")
 
     def test_patch_k8s_config_wraps_refresh_hook_and_avoids_nesting(self):
-        client_module = FakeClientModule()
         config = FakeConfiguration()
         
         # Original refresh hook
@@ -99,31 +90,26 @@ class TestBearerTokenPatch(unittest.TestCase):
             mock_orig_hook(cfg)
         
         config.refresh_api_key_hook = orig_hook
-        client_module.set_default(config)
 
         # First patch
-        patch_k8s_config(client_module)
-        patched_config = client_module.get_default_copy()
+        patch_k8s_config(config)
+        first_hook = config.refresh_api_key_hook
         
-        self.assertIsNotNone(patched_config.refresh_api_key_hook)
-        self.assertNotEqual(patched_config.refresh_api_key_hook, orig_hook)
+        self.assertIsNotNone(first_hook)
+        self.assertNotEqual(first_hook, orig_hook)
 
         # Trigger refresh hook and verify it syncs BearerToken
         test_cfg = FakeConfiguration()
         test_cfg.api_key = {"authorization": "old-token"}
-        patched_config.refresh_api_key_hook(test_cfg)
+        first_hook(test_cfg)
         
         mock_orig_hook.assert_called_once_with(test_cfg)
         self.assertEqual(test_cfg.api_key["authorization"], "refreshed-token")
         self.assertEqual(test_cfg.api_key["BearerToken"], "refreshed-token")
 
         # Second patch - should NOT wrap again
-        second_hook = patched_config.refresh_api_key_hook
-        client_module.set_default(patched_config)
-        patch_k8s_config(client_module)
-        
-        third_config = client_module.get_default_copy()
-        self.assertEqual(third_config.refresh_api_key_hook, second_hook)
+        patch_k8s_config(config)
+        self.assertEqual(config.refresh_api_key_hook, first_hook)
 
     def test_sync_bearer_token_empty_config(self):
         config = FakeConfiguration()
@@ -132,14 +118,11 @@ class TestBearerTokenPatch(unittest.TestCase):
         self.assertEqual(config.api_key_prefix, {})
 
     def test_patch_k8s_config_with_none_hook(self):
-        client_module = FakeClientModule()
         config = FakeConfiguration()
         config.refresh_api_key_hook = None
-        client_module.set_default(config)
 
-        patch_k8s_config(client_module)
-        patched_config = client_module.get_default_copy()
-        self.assertIsNone(patched_config.refresh_api_key_hook)
+        patch_k8s_config(config)
+        self.assertIsNone(config.refresh_api_key_hook)
 
     def test_sync_bearer_token_when_both_keys_exist_but_differ_after_refresh(self):
         config = FakeConfiguration()
@@ -189,7 +172,6 @@ class TestBearerTokenPatch(unittest.TestCase):
         self.assertEqual(getattr(config, "_last_known_bearer_token"), "new-token")
 
     def test_patch_k8s_config_pre_synchronizes_before_refresh_hook_execution(self):
-        client_module = FakeClientModule()
         config = FakeConfiguration()
         config.api_key["authorization"] = "pre-hook-token"
 
@@ -202,21 +184,17 @@ class TestBearerTokenPatch(unittest.TestCase):
             cfg.api_key["authorization"] = "post-hook-token"
 
         config.refresh_api_key_hook = orig_hook
-        client_module.set_default(config)
 
-        patch_k8s_config(client_module)
-        patched_config = client_module.get_default_copy()
+        patch_k8s_config(config)
+        patched_hook = config.refresh_api_key_hook
 
         test_cfg = FakeConfiguration()
         test_cfg.api_key = {"authorization": "pre-hook-token"}
-        patched_config.refresh_api_key_hook(test_cfg)
+        patched_hook(test_cfg)
 
         self.assertTrue(hook_called)
         self.assertEqual(test_cfg.api_key["authorization"], "post-hook-token")
         self.assertEqual(test_cfg.api_key["BearerToken"], "post-hook-token")
-
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
@@ -62,8 +62,6 @@ class TestBearerTokenPatch(unittest.TestCase):
 
     def setUp(self):
         FakeConfiguration._default = None
-        import k8s_agent_sandbox.utils
-        k8s_agent_sandbox.utils._is_patched = False
 
 
     def test_sync_bearer_token_from_authorization(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_bearer_token_patch.py
@@ -177,6 +177,45 @@ class TestBearerTokenPatch(unittest.TestCase):
         self.assertEqual(config.api_key["authorization"], "refreshed-token")
         self.assertEqual(config.api_key["BearerToken"], "refreshed-token")
 
+    def test_sync_both_keys_exist_but_differ_no_last_known_prefers_bearer_token(self):
+        config = FakeConfiguration()
+        config.api_key["authorization"] = "stale-token"
+        config.api_key["BearerToken"] = "new-token"
+
+        _sync_k8s_bearer_token(config)
+
+        self.assertEqual(config.api_key["authorization"], "new-token")
+        self.assertEqual(config.api_key["BearerToken"], "new-token")
+        self.assertEqual(getattr(config, "_last_known_bearer_token"), "new-token")
+
+    def test_patch_k8s_config_pre_synchronizes_before_refresh_hook_execution(self):
+        client_module = FakeClientModule()
+        config = FakeConfiguration()
+        config.api_key["authorization"] = "pre-hook-token"
+
+        hook_called = False
+        def orig_hook(cfg):
+            nonlocal hook_called
+            hook_called = True
+            # Verify that BearerToken has been pre-synchronized BEFORE the hook runs!
+            self.assertEqual(cfg.api_key.get("BearerToken"), "pre-hook-token")
+            cfg.api_key["authorization"] = "post-hook-token"
+
+        config.refresh_api_key_hook = orig_hook
+        client_module.set_default(config)
+
+        patch_k8s_config(client_module)
+        patched_config = client_module.get_default_copy()
+
+        test_cfg = FakeConfiguration()
+        test_cfg.api_key = {"authorization": "pre-hook-token"}
+        patched_config.refresh_api_key_hook(test_cfg)
+
+        self.assertTrue(hook_called)
+        self.assertEqual(test_cfg.api_key["authorization"], "post-hook-token")
+        self.assertEqual(test_cfg.api_key["BearerToken"], "post-hook-token")
+
+
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -204,8 +204,6 @@ class TestK8sHelperInitPatch(unittest.TestCase):
     def test_init_calls_patch_k8s_config(self, mock_api_cls, mock_core_cls, mock_patch):
         with patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config"), \
              patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config"):
-            import k8s_agent_sandbox.utils
-            k8s_agent_sandbox.utils._is_patched = False
             from k8s_agent_sandbox.k8s_helper import client
             K8sHelper()
             mock_patch.assert_called_once_with(client)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -19,9 +19,13 @@ from k8s_agent_sandbox.k8s_helper import K8sHelper
 from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
 
 
+class MockConfig(MagicMock):
+    ConfigException = Exception
+
+
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
-@patch("k8s_agent_sandbox.k8s_helper.config")
+@patch("k8s_agent_sandbox.k8s_helper.config", new_callable=MockConfig)
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
     def test_labels_and_annotations_coexist_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
@@ -129,7 +133,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
-@patch("k8s_agent_sandbox.k8s_helper.config")
+@patch("k8s_agent_sandbox.k8s_helper.config", new_callable=MockConfig)
 class TestK8sHelperResolveSandboxName(unittest.TestCase):
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
@@ -180,6 +184,18 @@ class TestK8sHelperResolveSandboxName(unittest.TestCase):
             helper.resolve_sandbox_name("test-claim", "default", timeout=5)
             
         self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
+
+
+class TestK8sHelperInitPatch(unittest.TestCase):
+
+    @patch("k8s_agent_sandbox.utils.patch_k8s_config")
+    @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+    @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+    @patch("k8s_agent_sandbox.k8s_helper.config", new_callable=MockConfig)
+    def test_init_calls_patch_k8s_config(self, mock_config, mock_api_cls, mock_core_cls, mock_patch):
+        from k8s_agent_sandbox.k8s_helper import client
+        K8sHelper()
+        mock_patch.assert_called_once_with(client)
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -204,6 +204,8 @@ class TestK8sHelperInitPatch(unittest.TestCase):
     def test_init_calls_patch_k8s_config(self, mock_api_cls, mock_core_cls, mock_patch):
         with patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config"), \
              patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config"):
+            import k8s_agent_sandbox.utils
+            k8s_agent_sandbox.utils._is_patched = False
             from k8s_agent_sandbox.k8s_helper import client
             K8sHelper()
             mock_patch.assert_called_once_with(client)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -19,16 +19,21 @@ from k8s_agent_sandbox.k8s_helper import K8sHelper
 from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
 
 
-class MockConfig(MagicMock):
-    ConfigException = Exception
-
-
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
-@patch("k8s_agent_sandbox.k8s_helper.config", new_callable=MockConfig)
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
-    def test_labels_and_annotations_coexist_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
+    def setUp(self):
+        self.load_incluster_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config")
+        self.load_kube_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config")
+        self.mock_load_incluster = self.load_incluster_patcher.start()
+        self.mock_load_kube = self.load_kube_patcher.start()
+
+    def tearDown(self):
+        self.load_incluster_patcher.stop()
+        self.load_kube_patcher.stop()
+
+    def test_labels_and_annotations_coexist_in_manifest(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -44,7 +49,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         self.assertEqual(body["metadata"]["annotations"], {"opentelemetry.io/trace-context": "trace-data"})
         self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent", "team": "platform"})
 
-    def test_labels_only_no_annotations(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_labels_only_no_annotations(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -58,7 +63,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         self.assertEqual(body["metadata"]["annotations"], {})
         self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent"})
 
-    def test_no_labels_no_annotations(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_no_labels_no_annotations(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -69,7 +74,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         self.assertEqual(body["metadata"]["annotations"], {})
         self.assertNotIn("labels", body["metadata"])
 
-    def test_lifecycle_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_lifecycle_included_in_manifest(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -86,7 +91,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         self.assertEqual(body["spec"]["lifecycle"], lifecycle)
         self.assertEqual(body["spec"]["sandboxTemplateRef"]["name"], "test-template")
 
-    def test_no_lifecycle_omits_key(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_no_lifecycle_omits_key(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -96,7 +101,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertNotIn("lifecycle", body["spec"])
 
-    def test_create_claim_with_warmpool_none(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_create_claim_with_warmpool_none(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -108,7 +113,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["spec"]["warmpool"], "none")
 
-    def test_create_claim_with_specific_warmpool(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_create_claim_with_specific_warmpool(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -120,7 +125,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["spec"]["warmpool"], "custom-pool")
 
-    def test_create_claim_warmpool_omitted(self, mock_config, mock_api_cls, mock_core_cls):
+    def test_create_claim_warmpool_omitted(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api
 
@@ -133,11 +138,20 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
-@patch("k8s_agent_sandbox.k8s_helper.config", new_callable=MockConfig)
 class TestK8sHelperResolveSandboxName(unittest.TestCase):
 
+    def setUp(self):
+        self.load_incluster_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config")
+        self.load_kube_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config")
+        self.mock_load_incluster = self.load_incluster_patcher.start()
+        self.mock_load_kube = self.load_kube_patcher.start()
+
+    def tearDown(self):
+        self.load_incluster_patcher.stop()
+        self.load_kube_patcher.stop()
+
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
-    def test_resolve_sandbox_name_template_not_found(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+    def test_resolve_sandbox_name_template_not_found(self, mock_watch_class, mock_api_cls, mock_core_cls):
         mock_watch = MagicMock()
         mock_event = {
             "type": "MODIFIED",
@@ -166,7 +180,7 @@ class TestK8sHelperResolveSandboxName(unittest.TestCase):
         self.assertIn("Template 'non-existent-template' not found", str(context.exception))
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
-    def test_resolve_sandbox_name_deleted_event(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+    def test_resolve_sandbox_name_deleted_event(self, mock_watch_class, mock_api_cls, mock_core_cls):
         mock_watch = MagicMock()
         mock_event = {
             "type": "DELETED",
@@ -191,11 +205,12 @@ class TestK8sHelperInitPatch(unittest.TestCase):
     @patch("k8s_agent_sandbox.utils.patch_k8s_config")
     @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
     @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
-    @patch("k8s_agent_sandbox.k8s_helper.config", new_callable=MockConfig)
-    def test_init_calls_patch_k8s_config(self, mock_config, mock_api_cls, mock_core_cls, mock_patch):
-        from k8s_agent_sandbox.k8s_helper import client
-        K8sHelper()
-        mock_patch.assert_called_once_with(client)
+    def test_init_calls_patch_k8s_config(self, mock_api_cls, mock_core_cls, mock_patch):
+        with patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config"), \
+             patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config"):
+            from k8s_agent_sandbox.k8s_helper import client
+            K8sHelper()
+            mock_patch.assert_called_once_with(client)
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -204,9 +204,8 @@ class TestK8sHelperInitPatch(unittest.TestCase):
     def test_init_calls_patch_k8s_config(self, mock_api_cls, mock_core_cls, mock_patch):
         with patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config"), \
              patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config"):
-            from k8s_agent_sandbox.k8s_helper import client
             K8sHelper()
-            mock_patch.assert_called_once_with(client)
+            mock_patch.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -24,14 +24,12 @@ from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNo
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
     def setUp(self):
-        self.load_incluster_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config")
-        self.load_kube_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config")
-        self.mock_load_incluster = self.load_incluster_patcher.start()
-        self.mock_load_kube = self.load_kube_patcher.start()
-
-    def tearDown(self):
-        self.load_incluster_patcher.stop()
-        self.load_kube_patcher.stop()
+        load_incluster_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config")
+        load_kube_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config")
+        self.mock_load_incluster = load_incluster_patcher.start()
+        self.mock_load_kube = load_kube_patcher.start()
+        self.addCleanup(load_incluster_patcher.stop)
+        self.addCleanup(load_kube_patcher.stop)
 
     def test_labels_and_annotations_coexist_in_manifest(self, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
@@ -141,14 +139,12 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 class TestK8sHelperResolveSandboxName(unittest.TestCase):
 
     def setUp(self):
-        self.load_incluster_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config")
-        self.load_kube_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config")
-        self.mock_load_incluster = self.load_incluster_patcher.start()
-        self.mock_load_kube = self.load_kube_patcher.start()
-
-    def tearDown(self):
-        self.load_incluster_patcher.stop()
-        self.load_kube_patcher.stop()
+        load_incluster_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_incluster_config")
+        load_kube_patcher = patch("k8s_agent_sandbox.k8s_helper.config.load_kube_config")
+        self.mock_load_incluster = load_incluster_patcher.start()
+        self.mock_load_kube = load_kube_patcher.start()
+        self.addCleanup(load_incluster_patcher.stop)
+        self.addCleanup(load_kube_patcher.stop)
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
     def test_resolve_sandbox_name_template_not_found(self, mock_watch_class, mock_api_cls, mock_core_cls):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py
@@ -31,7 +31,6 @@ from k8s_agent_sandbox.sandbox_client import SandboxClient
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
-@patch("k8s_agent_sandbox.k8s_helper.config")
 @patch("k8s_agent_sandbox.sandbox_client.K8sHelper")
 class TestLifecycleIntegration(unittest.TestCase):
     """End-to-end integration: SandboxClient -> K8sHelper -> manifest body.
@@ -42,7 +41,7 @@ class TestLifecycleIntegration(unittest.TestCase):
     """
 
     def test_create_sandbox_with_shutdown_produces_lifecycle_in_manifest(
-        self, MockClientK8sHelper, mock_config, mock_api_cls, mock_core_cls
+        self, MockClientK8sHelper, mock_api_cls, mock_core_cls
     ):
         """Full path: create_sandbox(shutdown_after_seconds=300) embeds
         spec.lifecycle in the K8s API call body."""
@@ -88,7 +87,7 @@ class TestLifecycleIntegration(unittest.TestCase):
         self.assertEqual(body["spec"]["sandboxTemplateRef"]["name"], "my-template")
 
     def test_create_sandbox_without_shutdown_omits_lifecycle_in_manifest(
-        self, MockClientK8sHelper, mock_config, mock_api_cls, mock_core_cls
+        self, MockClientK8sHelper, mock_api_cls, mock_core_cls
     ):
         """Full path: create_sandbox() without shutdown_after_seconds
         produces no spec.lifecycle."""
@@ -119,7 +118,7 @@ class TestLifecycleIntegration(unittest.TestCase):
         self.assertEqual(body["spec"]["sandboxTemplateRef"]["name"], "my-template")
 
     def test_invalid_shutdown_never_reaches_k8s_api(
-        self, MockClientK8sHelper, mock_config, mock_api_cls, mock_core_cls
+        self, MockClientK8sHelper, mock_api_cls, mock_core_cls
     ):
         """Validation fires before any K8s API call."""
         mock_api = MagicMock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -91,7 +91,7 @@ def _sync_k8s_bearer_token(config_obj):
                 d["authorization"] = bearer_val
                 setattr(config_obj, last_known_attr, bearer_val)
             else:
-                preferred = auth_val if auth_val is not None else bearer_val
+                preferred = bearer_val if bearer_val is not None else auth_val
                 d["authorization"] = preferred
                 d["BearerToken"] = preferred
                 setattr(config_obj, last_known_attr, preferred)
@@ -115,6 +115,7 @@ def patch_k8s_config(client_module):
         orig_hook = c.refresh_api_key_hook
         if orig_hook is not None and not getattr(orig_hook, "_is_patched_for_bearer_token", False):
             def new_hook(cfg):
+                _sync_k8s_bearer_token(cfg)
                 orig_hook(cfg)
                 _sync_k8s_bearer_token(cfg)
             new_hook._is_patched_for_bearer_token = True
@@ -122,5 +123,8 @@ def patch_k8s_config(client_module):
         client_module.Configuration.set_default(c)
     except Exception as e:
         import logging
-        logging.debug(f"Failed to patch default Kubernetes configuration: {e}")
+        logging.warning(
+            "Failed to patch default Kubernetes configuration; bearer token compatibility workaround was not applied.",
+            exc_info=True,
+        )
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -17,7 +17,6 @@ from functools import wraps
 import threading
 
 _patch_lock = threading.Lock()
-_is_patched = False
 
 
 def _safe_setattr(obj, attr, val):
@@ -117,21 +116,21 @@ def _sync_k8s_bearer_token(config_obj):
 
 def patch_k8s_config(client_module):
     """Patches the active default configuration and refresh hook of a Kubernetes client module to keep token keys synchronized."""
-    global _is_patched
-    if _is_patched:
+    if not hasattr(client_module, "Configuration"):
         return
     with _patch_lock:
-        if _is_patched:
-            return
-        if not hasattr(client_module, "Configuration"):
-            return
         try:
             c = client_module.Configuration.get_default_copy()
             if c is None:
                 return
-            _sync_k8s_bearer_token(c)
+            if getattr(c, "_is_patched_for_bearer_token", False):
+                return
             orig_hook = c.refresh_api_key_hook
-            if orig_hook is not None and not getattr(orig_hook, "_is_patched_for_bearer_token", False):
+            if orig_hook is not None and getattr(orig_hook, "_is_patched_for_bearer_token", False):
+                return
+
+            _sync_k8s_bearer_token(c)
+            if orig_hook is not None:
                 @wraps(orig_hook)
                 def new_hook(cfg):
                     _sync_k8s_bearer_token(cfg)
@@ -141,8 +140,9 @@ def patch_k8s_config(client_module):
                         _sync_k8s_bearer_token(cfg)
                 new_hook._is_patched_for_bearer_token = True
                 c.refresh_api_key_hook = new_hook
+
+            _safe_setattr(c, "_is_patched_for_bearer_token", True)
             client_module.Configuration.set_default(c)
-            _is_patched = True
         except Exception:
             import logging
             logging.warning(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime, timedelta, timezone
+from functools import wraps
 
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
@@ -114,14 +115,17 @@ def patch_k8s_config(client_module):
         _sync_k8s_bearer_token(c)
         orig_hook = c.refresh_api_key_hook
         if orig_hook is not None and not getattr(orig_hook, "_is_patched_for_bearer_token", False):
+            @wraps(orig_hook)
             def new_hook(cfg):
                 _sync_k8s_bearer_token(cfg)
-                orig_hook(cfg)
-                _sync_k8s_bearer_token(cfg)
+                try:
+                    orig_hook(cfg)
+                finally:
+                    _sync_k8s_bearer_token(cfg)
             new_hook._is_patched_for_bearer_token = True
             c.refresh_api_key_hook = new_hook
         client_module.Configuration.set_default(c)
-    except Exception as e:
+    except Exception:
         import logging
         logging.warning(
             "Failed to patch default Kubernetes configuration; bearer token compatibility workaround was not applied.",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -14,9 +14,7 @@
 
 from datetime import datetime, timedelta, timezone
 from functools import wraps
-import threading
 
-_patch_lock = threading.Lock()
 
 
 def _safe_setattr(obj, attr, val):
@@ -114,39 +112,34 @@ def _sync_k8s_bearer_token(config_obj):
         sync_dict(config_obj.api_key_prefix, "_last_known_bearer_token_prefix")
 
 
-def patch_k8s_config(client_module):
-    """Patches the active default configuration and refresh hook of a Kubernetes client module to keep token keys synchronized."""
-    if not hasattr(client_module, "Configuration"):
+def patch_k8s_config(c):
+    """Patches a specific Configuration instance to keep token keys synchronized."""
+    if c is None:
         return
-    with _patch_lock:
-        try:
-            c = client_module.Configuration.get_default_copy()
-            if c is None:
-                return
-            if getattr(c, "_is_patched_for_bearer_token", False):
-                return
-            orig_hook = c.refresh_api_key_hook
-            if orig_hook is not None and getattr(orig_hook, "_is_patched_for_bearer_token", False):
-                return
+    if getattr(c, "_is_patched_for_bearer_token", False):
+        return
+    orig_hook = c.refresh_api_key_hook
+    if orig_hook is not None and getattr(orig_hook, "_is_patched_for_bearer_token", False):
+        return
 
-            _sync_k8s_bearer_token(c)
-            if orig_hook is not None:
-                @wraps(orig_hook)
-                def new_hook(cfg):
+    try:
+        _sync_k8s_bearer_token(c)
+        if orig_hook is not None:
+            @wraps(orig_hook)
+            def new_hook(cfg):
+                _sync_k8s_bearer_token(cfg)
+                try:
+                    orig_hook(cfg)
+                finally:
                     _sync_k8s_bearer_token(cfg)
-                    try:
-                        orig_hook(cfg)
-                    finally:
-                        _sync_k8s_bearer_token(cfg)
-                new_hook._is_patched_for_bearer_token = True
-                c.refresh_api_key_hook = new_hook
+            new_hook._is_patched_for_bearer_token = True
+            c.refresh_api_key_hook = new_hook
 
-            _safe_setattr(c, "_is_patched_for_bearer_token", True)
-            client_module.Configuration.set_default(c)
-        except Exception:
-            import logging
-            logging.warning(
-                "Failed to patch default Kubernetes configuration; bearer token compatibility workaround was not applied.",
-                exc_info=True,
-            )
+        _safe_setattr(c, "_is_patched_for_bearer_token", True)
+    except Exception:
+        import logging
+        logging.warning(
+            "Failed to patch default Kubernetes configuration; bearer token compatibility workaround was not applied.",
+            exc_info=True,
+        )
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -14,6 +14,17 @@
 
 from datetime import datetime, timedelta, timezone
 from functools import wraps
+import threading
+
+_patch_lock = threading.Lock()
+_is_patched = False
+
+
+def _safe_setattr(obj, attr, val):
+    try:
+        setattr(obj, attr, val)
+    except AttributeError:
+        pass
 
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
@@ -73,29 +84,29 @@ def _sync_k8s_bearer_token(config_obj):
 
         if auth_val == bearer_val:
             # Already in sync! Update state tracker.
-            setattr(config_obj, last_known_attr, auth_val)
+            _safe_setattr(config_obj, last_known_attr, auth_val)
             return
 
         # Propagate the field that was actually modified
         if auth_val != last_known and bearer_val == last_known:
             d["BearerToken"] = auth_val
-            setattr(config_obj, last_known_attr, auth_val)
+            _safe_setattr(config_obj, last_known_attr, auth_val)
         elif bearer_val != last_known and auth_val == last_known:
             d["authorization"] = bearer_val
-            setattr(config_obj, last_known_attr, bearer_val)
+            _safe_setattr(config_obj, last_known_attr, bearer_val)
         else:
             # Initial load or fallback synchronization
             if auth_val is not None and bearer_val is None:
                 d["BearerToken"] = auth_val
-                setattr(config_obj, last_known_attr, auth_val)
+                _safe_setattr(config_obj, last_known_attr, auth_val)
             elif bearer_val is not None and auth_val is None:
                 d["authorization"] = bearer_val
-                setattr(config_obj, last_known_attr, bearer_val)
+                _safe_setattr(config_obj, last_known_attr, bearer_val)
             else:
                 preferred = bearer_val if bearer_val is not None else auth_val
                 d["authorization"] = preferred
                 d["BearerToken"] = preferred
-                setattr(config_obj, last_known_attr, preferred)
+                _safe_setattr(config_obj, last_known_attr, preferred)
 
     if getattr(config_obj, "api_key", None) is not None:
         sync_dict(config_obj.api_key, "_last_known_bearer_token")
@@ -106,29 +117,36 @@ def _sync_k8s_bearer_token(config_obj):
 
 def patch_k8s_config(client_module):
     """Patches the active default configuration and refresh hook of a Kubernetes client module to keep token keys synchronized."""
-    if not hasattr(client_module, "Configuration"):
+    global _is_patched
+    if _is_patched:
         return
-    try:
-        c = client_module.Configuration.get_default_copy()
-        if c is None:
+    with _patch_lock:
+        if _is_patched:
             return
-        _sync_k8s_bearer_token(c)
-        orig_hook = c.refresh_api_key_hook
-        if orig_hook is not None and not getattr(orig_hook, "_is_patched_for_bearer_token", False):
-            @wraps(orig_hook)
-            def new_hook(cfg):
-                _sync_k8s_bearer_token(cfg)
-                try:
-                    orig_hook(cfg)
-                finally:
+        if not hasattr(client_module, "Configuration"):
+            return
+        try:
+            c = client_module.Configuration.get_default_copy()
+            if c is None:
+                return
+            _sync_k8s_bearer_token(c)
+            orig_hook = c.refresh_api_key_hook
+            if orig_hook is not None and not getattr(orig_hook, "_is_patched_for_bearer_token", False):
+                @wraps(orig_hook)
+                def new_hook(cfg):
                     _sync_k8s_bearer_token(cfg)
-            new_hook._is_patched_for_bearer_token = True
-            c.refresh_api_key_hook = new_hook
-        client_module.Configuration.set_default(c)
-    except Exception:
-        import logging
-        logging.warning(
-            "Failed to patch default Kubernetes configuration; bearer token compatibility workaround was not applied.",
-            exc_info=True,
-        )
+                    try:
+                        orig_hook(cfg)
+                    finally:
+                        _sync_k8s_bearer_token(cfg)
+                new_hook._is_patched_for_bearer_token = True
+                c.refresh_api_key_hook = new_hook
+            client_module.Configuration.set_default(c)
+            _is_patched = True
+        except Exception:
+            import logging
+            logging.warning(
+                "Failed to patch default Kubernetes configuration; bearer token compatibility workaround was not applied.",
+                exc_info=True,
+            )
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -43,3 +43,84 @@ def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[
         "shutdownTime": shutdown_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "shutdownPolicy": "Delete",
     }
+
+
+# TODO: This compatibility patch is a workaround for a permanent token auth format
+# transition in the upstream kubernetes-client/python library (v36.0.0+), which uses
+# the dictionary key 'BearerToken' instead of 'authorization' inside 'api_key'.
+#
+# We preserve backward compatibility with older packages (<36.0.0) where only
+# 'authorization' is valid, and keep both keys synchronized under dynamic refreshes.
+#
+# Once we are sufficiently in the future (e.g., 6-12 months) and decide to bump
+# the minimum supported version of 'kubernetes' to a post-v36 release that natively
+# sets up 'BearerToken' properly, this compatibility logic can be safely dropped:
+#   - Remove '_sync_k8s_bearer_token' and 'patch_k8s_config' helpers from 'utils.py'.
+#   - Remove the patch calls from 'k8s_helper.py' and 'async_k8s_helper.py'.
+#   - Delete the dedicated 'test_bearer_token_patch.py' unit and init test classes.
+def _sync_k8s_bearer_token(config_obj):
+    """Synchronizes 'authorization' and 'BearerToken' keys/prefixes in configuration dictionaries."""
+    if config_obj is None:
+        return
+
+    def sync_dict(d, last_known_attr):
+        if d is None:
+            return
+        auth_val = d.get("authorization")
+        bearer_val = d.get("BearerToken")
+        last_known = getattr(config_obj, last_known_attr, None)
+
+        if auth_val == bearer_val:
+            # Already in sync! Update state tracker.
+            setattr(config_obj, last_known_attr, auth_val)
+            return
+
+        # Propagate the field that was actually modified
+        if auth_val != last_known and bearer_val == last_known:
+            d["BearerToken"] = auth_val
+            setattr(config_obj, last_known_attr, auth_val)
+        elif bearer_val != last_known and auth_val == last_known:
+            d["authorization"] = bearer_val
+            setattr(config_obj, last_known_attr, bearer_val)
+        else:
+            # Initial load or fallback synchronization
+            if auth_val is not None and bearer_val is None:
+                d["BearerToken"] = auth_val
+                setattr(config_obj, last_known_attr, auth_val)
+            elif bearer_val is not None and auth_val is None:
+                d["authorization"] = bearer_val
+                setattr(config_obj, last_known_attr, bearer_val)
+            else:
+                preferred = auth_val if auth_val is not None else bearer_val
+                d["authorization"] = preferred
+                d["BearerToken"] = preferred
+                setattr(config_obj, last_known_attr, preferred)
+
+    if getattr(config_obj, "api_key", None) is not None:
+        sync_dict(config_obj.api_key, "_last_known_bearer_token")
+
+    if getattr(config_obj, "api_key_prefix", None) is not None:
+        sync_dict(config_obj.api_key_prefix, "_last_known_bearer_token_prefix")
+
+
+def patch_k8s_config(client_module):
+    """Patches the active default configuration and refresh hook of a Kubernetes client module to keep token keys synchronized."""
+    if not hasattr(client_module, "Configuration"):
+        return
+    try:
+        c = client_module.Configuration.get_default_copy()
+        if c is None:
+            return
+        _sync_k8s_bearer_token(c)
+        orig_hook = c.refresh_api_key_hook
+        if orig_hook is not None and not getattr(orig_hook, "_is_patched_for_bearer_token", False):
+            def new_hook(cfg):
+                orig_hook(cfg)
+                _sync_k8s_bearer_token(cfg)
+            new_hook._is_patched_for_bearer_token = True
+            c.refresh_api_key_hook = new_hook
+        client_module.Configuration.set_default(c)
+    except Exception as e:
+        import logging
+        logging.debug(f"Failed to patch default Kubernetes configuration: {e}")
+

--- a/test/e2e/clients/python/incluster_test_script.py
+++ b/test/e2e/clients/python/incluster_test_script.py
@@ -44,7 +44,8 @@ def run_incluster_test(template_name, namespace):
             addr_info = socket.getaddrinfo(dns_name, None)
             resolved_ips = [info[4][0] for info in addr_info if info[4]]
             print(f"Successfully resolved direct DNS {dns_name} to IPs: {resolved_ips}")
-            assert resolved_ips, "DNS resolution returned no IPs"
+            if not resolved_ips:
+                raise RuntimeError("DNS resolution returned no IPs")
         except socket.gaierror as e:
             raise RuntimeError(f"Direct cluster DNS resolution failed for hostname {dns_name}: {e}") from e
 
@@ -52,8 +53,10 @@ def run_incluster_test(template_name, namespace):
         res = sandbox.commands.run("echo 'Hello from In-Cluster!'")
         print(f"Stdout: {res.stdout}")
         print(f"Stderr: {res.stderr}")
-        assert "Hello from In-Cluster!" in res.stdout, f"Unexpected stdout: {res.stdout}"
-        assert res.exit_code == 0, f"Unexpected exit code: {res.exit_code}"
+        if "Hello from In-Cluster!" not in res.stdout:
+            raise RuntimeError(f"Unexpected stdout: {res.stdout}")
+        if res.exit_code != 0:
+            raise RuntimeError(f"Unexpected exit code: {res.exit_code}")
         print("In-cluster compatibility and direct DNS routing E2E test completed successfully!")
     finally:
         if sandbox is not None:

--- a/test/e2e/clients/python/incluster_test_script.py
+++ b/test/e2e/clients/python/incluster_test_script.py
@@ -1,0 +1,65 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import logging
+import socket
+from k8s_agent_sandbox import SandboxClient
+from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
+
+logging.basicConfig(level=logging.INFO)
+
+def run_incluster_test(template_name, namespace):
+    print(f"\n==================================================")
+    print(f"Starting In-Cluster Compatibility and Direct DNS Routing E2E Test in namespace {namespace}...")
+    print(f"==================================================")
+    
+    # Use standard default connection config (Cluster DNS)
+    config = SandboxInClusterConnectionConfig()
+    client = SandboxClient(connection_config=config)
+    
+    print(f"Creating sandbox from template '{template_name}'...")
+    sandbox = client.create_sandbox(
+        template=template_name,
+        namespace=namespace,
+        warmpool="none",
+    )
+    try:
+        # Explicit DNS Resolution test on target service hostname
+        dns_name = f"{sandbox.sandbox_id}.{namespace}.svc.cluster.local"
+        print(f"Resolving direct DNS name inside the cluster: {dns_name}...")
+        try:
+            resolved_ip = socket.gethostbyname(dns_name)
+            print(f"Successfully resolved direct DNS {dns_name} to IP: {resolved_ip}")
+            assert resolved_ip, "DNS resolution returned an empty IP"
+        except socket.gaierror as e:
+            raise RuntimeError(f"Direct cluster DNS resolution failed for hostname {dns_name}: {e}") from e
+
+        print("Executing test command inside sandbox...")
+        res = sandbox.commands.run("echo 'Hello from In-Cluster!'")
+        print(f"Stdout: {res.stdout}")
+        print(f"Stderr: {res.stderr}")
+        assert "Hello from In-Cluster!" in res.stdout, f"Unexpected stdout: {res.stdout}"
+        assert res.exit_code == 0, f"Unexpected exit code: {res.exit_code}"
+        print("In-cluster compatibility and direct DNS routing E2E test completed successfully!")
+    finally:
+        print("Terminating sandbox...")
+        sandbox.terminate()
+        client.delete_all()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: incluster_test_script.py <template_name> <namespace>")
+        sys.exit(1)
+    run_incluster_test(sys.argv[1], sys.argv[2])

--- a/test/e2e/clients/python/incluster_test_script.py
+++ b/test/e2e/clients/python/incluster_test_script.py
@@ -29,20 +29,22 @@ def run_incluster_test(template_name, namespace):
     config = SandboxInClusterConnectionConfig()
     client = SandboxClient(connection_config=config)
     
-    print(f"Creating sandbox from template '{template_name}'...")
-    sandbox = client.create_sandbox(
-        template=template_name,
-        namespace=namespace,
-        warmpool="none",
-    )
+    sandbox = None
     try:
+        print(f"Creating sandbox from template '{template_name}'...")
+        sandbox = client.create_sandbox(
+            template=template_name,
+            namespace=namespace,
+            warmpool="none",
+        )
         # Explicit DNS Resolution test on target service hostname
         dns_name = f"{sandbox.sandbox_id}.{namespace}.svc.cluster.local"
         print(f"Resolving direct DNS name inside the cluster: {dns_name}...")
         try:
-            resolved_ip = socket.gethostbyname(dns_name)
-            print(f"Successfully resolved direct DNS {dns_name} to IP: {resolved_ip}")
-            assert resolved_ip, "DNS resolution returned an empty IP"
+            addr_info = socket.getaddrinfo(dns_name, None)
+            resolved_ips = [info[4][0] for info in addr_info if info[4]]
+            print(f"Successfully resolved direct DNS {dns_name} to IPs: {resolved_ips}")
+            assert resolved_ips, "DNS resolution returned no IPs"
         except socket.gaierror as e:
             raise RuntimeError(f"Direct cluster DNS resolution failed for hostname {dns_name}: {e}") from e
 
@@ -54,8 +56,9 @@ def run_incluster_test(template_name, namespace):
         assert res.exit_code == 0, f"Unexpected exit code: {res.exit_code}"
         print("In-cluster compatibility and direct DNS routing E2E test completed successfully!")
     finally:
-        print("Terminating sandbox...")
-        sandbox.terminate()
+        if sandbox is not None:
+            print("Terminating sandbox...")
+            sandbox.terminate()
         client.delete_all()
 
 if __name__ == "__main__":

--- a/test/e2e/clients/python/test_incluster_compatibility.py
+++ b/test/e2e/clients/python/test_incluster_compatibility.py
@@ -72,15 +72,27 @@ metadata:
   name: incluster-test-sa
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: incluster-test-role
+rules:
+- apiGroups: ["extensions.agents.x-k8s.io"]
+  resources: ["sandboxclaims"]
+  verbs: ["create", "get", "list", "watch", "delete"]
+- apiGroups: ["agents.x-k8s.io"]
+  resources: ["sandboxes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: incluster-test-admin-binding
+  name: incluster-test-role-binding
 subjects:
 - kind: ServiceAccount
   name: incluster-test-sa
 roleRef:
-  kind: ClusterRole
-  name: cluster-admin
+  kind: Role
+  name: incluster-test-role
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1

--- a/test/e2e/clients/python/test_incluster_compatibility.py
+++ b/test/e2e/clients/python/test_incluster_compatibility.py
@@ -64,6 +64,8 @@ def sandbox_template(tc, temp_namespace):
 def test_incluster_compatibility_both_versions(tc, temp_namespace, sandbox_template):
     """Verifies that the Python SDK in-cluster mode works correctly under both older (v35.0.0) and newer (v36.0.0) kubernetes client versions."""
     
+    DEFAULT_POD_EXEC_TIMEOUT = int(os.environ.get("POD_EXEC_TIMEOUT", "120"))
+
     # 1. Create RBAC and Pod manifests
     manifest = f"""
 apiVersion: v1
@@ -177,14 +179,16 @@ spec:
     subprocess.run(["kubectl", "cp", str(TEST_SCRIPT_PATH), f"{temp_namespace}/py-sdk-incluster-test:/app/incluster_test_script.py"], check=True, env=env, timeout=30)
 
     # Helper function to run a command inside the Pod
-    def exec_in_pod(cmd_list):
+    def exec_in_pod(cmd_list, timeout=None):
+        if timeout is None:
+            timeout = DEFAULT_POD_EXEC_TIMEOUT
         try:
             res = subprocess.run(
                 ["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--"] + cmd_list,
                 capture_output=True,
                 text=True,
                 env=env,
-                timeout=120,
+                timeout=timeout,
             )
         except subprocess.TimeoutExpired as e:
             print(f"CMD TIMEOUT: {' '.join(cmd_list)}")
@@ -197,20 +201,26 @@ spec:
         print(f"Stdout:\n{res.stdout}")
         if res.stderr:
             print(f"Stderr:\n{res.stderr}")
-        assert res.returncode == 0, f"Command failed with exit code {res.returncode}"
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"Command failed with exit code {res.returncode}.\n"
+                f"Command: {' '.join(cmd_list)}\n"
+                f"Stdout:\n{res.stdout}\n"
+                f"Stderr:\n{res.stderr}"
+            )
 
     # 3. Install the SDK package in editable mode
     print("Installing python SDK in editable mode inside the pod...")
-    exec_in_pod(["env", "SETUPTOOLS_SCM_PRETEND_VERSION=0.1.0", "pip", "install", "-e", "/app"])
+    exec_in_pod(["env", "SETUPTOOLS_SCM_PRETEND_VERSION=0.1.0", "pip", "install", "-e", "/app"], timeout=240)
 
     # 4. PATH A: Test compatibility with kubernetes==35.0.0
     print("\n--- [PATH A] Testing compatibility with kubernetes==35.0.0 ---")
-    exec_in_pod(["pip", "install", "kubernetes==35.0.0"])
+    exec_in_pod(["pip", "install", "kubernetes==35.0.0"], timeout=240)
     exec_in_pod(["python", "/app/incluster_test_script.py", sandbox_template, temp_namespace])
     print("[PATH A] Passed!")
 
     # 5. PATH B: Test compatibility with kubernetes==36.0.0 (or current latest)
     print("\n--- [PATH B] Testing compatibility with kubernetes==36.0.0 ---")
-    exec_in_pod(["pip", "install", "kubernetes==36.0.0"])
+    exec_in_pod(["pip", "install", "kubernetes==36.0.0"], timeout=240)
     exec_in_pod(["python", "/app/incluster_test_script.py", sandbox_template, temp_namespace])
     print("[PATH B] Passed!")

--- a/test/e2e/clients/python/test_incluster_compatibility.py
+++ b/test/e2e/clients/python/test_incluster_compatibility.py
@@ -53,10 +53,12 @@ def get_image_prefix(env_var="IMAGE_PREFIX", default="kind.local/"):
 @pytest.fixture(scope="function")
 def sandbox_template(tc, temp_namespace):
     """Deploys the sandbox template into the test namespace"""
+    from string import Template
     image_tag = get_image_tag()
     image_prefix = get_image_prefix()
     with open(TEMPLATE_YAML_PATH, "r") as f:
-        manifest = f.read().format(image_prefix=image_prefix, image_tag=image_tag)
+        template = Template(f.read())
+        manifest = template.substitute(image_prefix=image_prefix, image_tag=image_tag)
     tc.apply_manifest_text(manifest, namespace=temp_namespace)
     return "python-sdk-test-template"
 

--- a/test/e2e/clients/python/test_incluster_compatibility.py
+++ b/test/e2e/clients/python/test_incluster_compatibility.py
@@ -135,7 +135,7 @@ spec:
         env["KUBECONFIG"] = tc.kubeconfig_path
 
     # Copy files
-    subprocess.run(["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "mkdir", "-p", "/app"], check=True, env=env)
+    subprocess.run(["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "mkdir", "-p", "/app"], check=True, env=env, timeout=30)
     
     # Copy SDK directory recursively by tar-ing it (standard work-around for copying whole dirs with kubectl) using safe pipelining
     tar_proc = subprocess.Popen(
@@ -155,8 +155,18 @@ spec:
         env=env,
     )
     tar_proc.stdout.close()
-    stdout, stderr = k_proc.communicate()
-    tar_rc = tar_proc.wait()
+    try:
+        stdout, stderr = k_proc.communicate(timeout=60)
+        tar_rc = tar_proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        tar_proc.kill()
+        k_proc.kill()
+        tar_proc.wait()
+        stdout, stderr = k_proc.communicate()
+        raise TimeoutError(
+            f"Tar copy operation timed out. stdout: {stdout.decode() if stdout else ''}, stderr: {stderr.decode() if stderr else ''}"
+        ) from None
+
     if tar_rc != 0 or k_proc.returncode != 0:
         raise RuntimeError(
             f"Tar copy failed. tar exit code: {tar_rc}, "
@@ -164,11 +174,25 @@ spec:
         )
 
     # Copy the script itself
-    subprocess.run(["kubectl", "cp", str(TEST_SCRIPT_PATH), f"{temp_namespace}/py-sdk-incluster-test:/app/incluster_test_script.py"], check=True, env=env)
+    subprocess.run(["kubectl", "cp", str(TEST_SCRIPT_PATH), f"{temp_namespace}/py-sdk-incluster-test:/app/incluster_test_script.py"], check=True, env=env, timeout=30)
 
     # Helper function to run a command inside the Pod
     def exec_in_pod(cmd_list):
-        res = subprocess.run(["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--"] + cmd_list, capture_output=True, text=True, env=env)
+        try:
+            res = subprocess.run(
+                ["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--"] + cmd_list,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired as e:
+            print(f"CMD TIMEOUT: {' '.join(cmd_list)}")
+            if e.stdout:
+                print(f"Stdout (before timeout):\n{e.stdout.decode() if isinstance(e.stdout, bytes) else e.stdout}")
+            if e.stderr:
+                print(f"Stderr (before timeout):\n{e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr}")
+            raise
         print(f"CMD: {' '.join(cmd_list)}")
         print(f"Stdout:\n{res.stdout}")
         if res.stderr:

--- a/test/e2e/clients/python/test_incluster_compatibility.py
+++ b/test/e2e/clients/python/test_incluster_compatibility.py
@@ -1,0 +1,180 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import subprocess
+import time
+from test.e2e.clients.python.framework.context import TestContext
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+TEST_MANIFESTS_DIR = REPO_ROOT / "test" / "e2e" / "clients" / "python" / "test_manifests"
+TEMPLATE_YAML_PATH = TEST_MANIFESTS_DIR / "sandbox_template.yaml"
+SDK_PATH = REPO_ROOT / "clients" / "python" / "agentic-sandbox-client"
+TEST_SCRIPT_PATH = REPO_ROOT / "test" / "e2e" / "clients" / "python" / "incluster_test_script.py"
+
+
+@pytest.fixture(scope="module")
+def tc():
+    """Provides the required kubernetes api for E2E tests"""
+    context = TestContext()
+    yield context
+
+
+@pytest.fixture(scope="function")
+def temp_namespace(tc):
+    """Creates and yields a temporary namespace for testing"""
+    namespace = tc.create_temp_namespace(prefix="py-sdk-incluster-")
+    yield namespace
+    tc.delete_namespace(namespace)
+
+
+def get_image_tag(env_var="IMAGE_TAG", default="latest"):
+    return os.environ.get(env_var, default)
+
+
+def get_image_prefix(env_var="IMAGE_PREFIX", default="kind.local/"):
+    return os.environ.get(env_var, default)
+
+
+@pytest.fixture(scope="function")
+def sandbox_template(tc, temp_namespace):
+    """Deploys the sandbox template into the test namespace"""
+    image_tag = get_image_tag()
+    image_prefix = get_image_prefix()
+    with open(TEMPLATE_YAML_PATH, "r") as f:
+        manifest = f.read().format(image_prefix=image_prefix, image_tag=image_tag)
+    tc.apply_manifest_text(manifest, namespace=temp_namespace)
+    return "python-sdk-test-template"
+
+
+def test_incluster_compatibility_both_versions(tc, temp_namespace, sandbox_template):
+    """Verifies that the Python SDK in-cluster mode works correctly under both older (v35.0.0) and newer (v36.0.0) kubernetes client versions."""
+    
+    # 1. Create RBAC and Pod manifests
+    manifest = f"""
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: incluster-test-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: incluster-test-admin-binding
+subjects:
+- kind: ServiceAccount
+  name: incluster-test-sa
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: py-sdk-incluster-test
+spec:
+  serviceAccountName: incluster-test-sa
+  containers:
+  - name: test-runner
+    image: python:3.11-slim
+    command: ["sleep", "3600"]
+"""
+    print("Applying service account, role binding and test pod...")
+    tc.apply_manifest_text(manifest, namespace=temp_namespace)
+    
+    from kubernetes.client.exceptions import ApiException
+
+    # Wait for Pod to be running
+    print("Waiting for test pod to start...")
+    core_v1 = tc.get_core_v1_api()
+    timeout = time.monotonic() + 120
+    while time.monotonic() < timeout:
+        try:
+            pod = core_v1.read_namespaced_pod(name="py-sdk-incluster-test", namespace=temp_namespace)
+            if pod.status.phase == "Running":
+                print("Test pod is running!")
+                break
+        except ApiException as e:
+            if e.status != 404:
+                raise
+        time.sleep(2)
+    else:
+        pytest.fail("Test pod failed to start within timeout.")
+
+    # 2. Copy the SDK codebase and script into the Pod
+    print("Copying python SDK files to the pod...")
+    env = os.environ.copy()
+    if tc.kubeconfig_path:
+        env["KUBECONFIG"] = tc.kubeconfig_path
+
+    # Copy files
+    subprocess.run(["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "mkdir", "-p", "/app"], check=True, env=env)
+    
+    # Copy SDK directory recursively by tar-ing it (standard work-around for copying whole dirs with kubectl) using safe pipelining
+    tar_proc = subprocess.Popen(
+        ["tar", "-cf", "-", "-C", str(SDK_PATH), "."],
+        stdout=subprocess.PIPE,
+        env=env,
+    )
+    kubectl_cmd = [
+        "kubectl", "exec", "-i", "-n", temp_namespace, "py-sdk-incluster-test",
+        "--", "tar", "-xf", "-", "-C", "/app"
+    ]
+    k_proc = subprocess.Popen(
+        kubectl_cmd,
+        stdin=tar_proc.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    tar_proc.stdout.close()
+    stdout, stderr = k_proc.communicate()
+    tar_rc = tar_proc.wait()
+    if tar_rc != 0 or k_proc.returncode != 0:
+        raise RuntimeError(
+            f"Tar copy failed. tar exit code: {tar_rc}, "
+            f"kubectl exit code: {k_proc.returncode}, stderr: {stderr.decode()}"
+        )
+
+    # Copy the script itself
+    subprocess.run(["kubectl", "cp", str(TEST_SCRIPT_PATH), f"{temp_namespace}/py-sdk-incluster-test:/app/incluster_test_script.py"], check=True, env=env)
+
+    # Helper function to run a command inside the Pod
+    def exec_in_pod(cmd_list):
+        res = subprocess.run(["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--"] + cmd_list, capture_output=True, text=True, env=env)
+        print(f"CMD: {' '.join(cmd_list)}")
+        print(f"Stdout:\n{res.stdout}")
+        if res.stderr:
+            print(f"Stderr:\n{res.stderr}")
+        assert res.returncode == 0, f"Command failed with exit code {res.returncode}"
+
+    # 3. Install the SDK package in editable mode
+    print("Installing python SDK in editable mode inside the pod...")
+    exec_in_pod(["env", "SETUPTOOLS_SCM_PRETEND_VERSION=0.1.0", "pip", "install", "-e", "/app"])
+
+    # 4. PATH A: Test compatibility with kubernetes==35.0.0
+    print("\n--- [PATH A] Testing compatibility with kubernetes==35.0.0 ---")
+    exec_in_pod(["pip", "install", "kubernetes==35.0.0"])
+    exec_in_pod(["python", "/app/incluster_test_script.py", sandbox_template, temp_namespace])
+    print("[PATH A] Passed!")
+
+    # 5. PATH B: Test compatibility with kubernetes==36.0.0 (or current latest)
+    print("\n--- [PATH B] Testing compatibility with kubernetes==36.0.0 ---")
+    exec_in_pod(["pip", "install", "kubernetes==36.0.0"])
+    exec_in_pod(["python", "/app/incluster_test_script.py", sandbox_template, temp_namespace])
+    print("[PATH B] Passed!")

--- a/test/e2e/clients/python/test_incluster_compatibility.py
+++ b/test/e2e/clients/python/test_incluster_compatibility.py
@@ -139,6 +139,37 @@ spec:
     # Copy files
     subprocess.run(["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "mkdir", "-p", "/app"], check=True, env=env, timeout=30)
     
+    # Ensure tar is available in the pod container (required for kubectl cp / tar pipelines)
+    print("Checking if tar is installed in the pod...")
+    check_tar = subprocess.run(
+        ["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "which", "tar"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    if check_tar.returncode != 0:
+        print("tar not found in the pod container. Attempting self-healing install via apt-get...")
+        try:
+            subprocess.run(
+                ["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "apt-get", "update"],
+                check=True,
+                env=env,
+                timeout=60,
+            )
+            subprocess.run(
+                ["kubectl", "exec", "-n", temp_namespace, "py-sdk-incluster-test", "--", "apt-get", "install", "-y", "tar"],
+                check=True,
+                env=env,
+                timeout=60,
+            )
+            print("tar successfully installed in the pod container!")
+        except Exception as e:
+            raise RuntimeError(
+                f"tar command is missing in the pod container, and self-healing installation failed. "
+                f"E2E files copy cannot proceed. Error: {e}"
+            ) from e
+    
     # Copy SDK directory recursively by tar-ing it (standard work-around for copying whole dirs with kubectl) using safe pipelining
     tar_proc = subprocess.Popen(
         ["tar", "-cf", "-", "-C", str(SDK_PATH), "."],

--- a/test/e2e/clients/python/test_manifests/sandbox_template.yaml
+++ b/test/e2e/clients/python/test_manifests/sandbox_template.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: python-sandbox
-        image: {image_prefix}python-runtime-sandbox:{image_tag}
+        image: ${image_prefix}python-runtime-sandbox:${image_tag}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8888

--- a/test/e2e/clients/python/test_manifests/sandbox_template.yaml
+++ b/test/e2e/clients/python/test_manifests/sandbox_template.yaml
@@ -3,6 +3,8 @@ kind: SandboxTemplate
 metadata:
   name: python-sdk-test-template
 spec:
+  service: true
+  networkPolicyManagement: Unmanaged
   podTemplate:
     metadata:
       labels:


### PR DESCRIPTION
Upstream kubernetes client package version 36.0.0 contains a breaking change where API client classes search for token values under the key 'BearerToken' instead of 'authorization' inside the Configuration api_key mapping. This causes all standard in-cluster clients (which configure tokens via the legacy 'authorization' key) to fail to send authentication headers, returning 401/403.

This change:

- Implements a state-tracking '_sync_k8s_bearer_token' helper in 'utils.py' to bidirectionally synchronize dynamic key-token updates (and prefixes) on Configuration instances and dynamic token-refresh events.

- Adds 'patch_k8s_config' to initialize the patch and safely wrap the default 'refresh_api_key_hook' without creating recursive execution chains.

- Patches both 'K8sHelper' and 'AsyncK8sHelper' early in their constructor execution sequences before instantiating API classes, ensuring their respective ApiClient instances inherit the correct configurations.

- Introduces robust Python unit test suites ('test_bearer_token_patch.py' and helper initialization tests) verifying safe and successful token synchronization.

- Creates a live, in-cluster E2E compatibility test suite ('test_incluster_compatibility.py') validating direct DNS cluster routing against both 'kubernetes==35.0.0' and 'kubernetes==36.0.0' inside a running Kind environment.

#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #846
#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
Fixes a critical, in-cluster connection failure (401 Unauthorized / 403 Forbidden error) in the Python SDK when running alongside modern versions of the upstream kubernetes package (version 36.0.0 and newer). This fix preserves full backward compatibility with older package versions (such as v35.0.0 and earlier) and dynamic token-refresh mechanisms.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->