### PR TITLE
feat: go client pod extension support

### DIFF
--- a/clients/go/gke_extensions/snapshots/client.go
+++ b/clients/go/gke_extensions/snapshots/client.go
@@ -1,0 +1,160 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+
+	sandbox "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+// crdDiscoverer is satisfied by discovery.DiscoveryInterface and any test fake.
+type crdDiscoverer interface {
+	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
+}
+
+// PodSnapshotClient wraps sandbox.Client and returns SandboxWithSnapshotSupport
+// instances. It validates at construction time that the GKE Pod Snapshot CRD
+// is installed on the cluster.
+type PodSnapshotClient struct {
+	inner *sandbox.Client
+	k8s   *sandbox.K8sHelper
+	log   logr.Logger
+	opts  sandbox.Options
+}
+
+// NewPodSnapshotClient creates a PodSnapshotClient. It fails immediately if the
+// PodSnapshot CRD (podsnapshot.gke.io/v1) is not installed and accessible on
+// the cluster.
+func NewPodSnapshotClient(ctx context.Context, opts sandbox.Options) (*PodSnapshotClient, error) {
+	// Build a shared K8sHelper so that both the inner sandbox.Client and the
+	// snapshot wrappers share a single set of Kubernetes clients.
+	k8s, err := sandbox.NewK8sHelper(opts.RestConfig, opts.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("snapshots: failed to initialise Kubernetes clients: %w", err)
+	}
+
+	dc, err := discovery.NewDiscoveryClientForConfig(k8s.RestConfig)
+	if err != nil {
+		return nil, fmt.Errorf("snapshots: failed to create discovery client: %w", err)
+	}
+
+	if err := checkSnapshotCRDInstalled(dc, opts.Logger); err != nil {
+		return nil, err
+	}
+
+	opts.K8sHelper = k8s
+	inner, err := sandbox.NewClient(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("snapshots: failed to create sandbox client: %w", err)
+	}
+
+	return &PodSnapshotClient{
+		inner: inner,
+		k8s:   k8s,
+		log:   opts.Logger,
+		opts:  opts,
+	}, nil
+}
+
+// CreateSandbox provisions a new sandbox and wraps it with snapshot support.
+func (c *PodSnapshotClient) CreateSandbox(ctx context.Context, template, namespace string) (*SandboxWithSnapshotSupport, error) {
+	sb, err := c.inner.CreateSandbox(ctx, template, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	return NewSandboxWithSnapshotSupport(sb, sb, c.k8s, namespace, c.log), nil
+}
+
+// GetSandbox re-attaches to an existing sandbox by claim name and wraps it
+// with snapshot support.
+func (c *PodSnapshotClient) GetSandbox(ctx context.Context, claimName, namespace string) (*SandboxWithSnapshotSupport, error) {
+	sb, err := c.inner.GetSandbox(ctx, claimName, namespace)
+	if err != nil {
+		return nil, err
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+	return NewSandboxWithSnapshotSupport(sb, sb, c.k8s, namespace, c.log), nil
+}
+
+// DeleteSandbox closes the handle (if tracked) and deletes the underlying claim.
+func (c *PodSnapshotClient) DeleteSandbox(ctx context.Context, claimName, namespace string) error {
+	return c.inner.DeleteSandbox(ctx, claimName, namespace)
+}
+
+// DeleteAll closes and deletes all tracked sandboxes. Best-effort.
+func (c *PodSnapshotClient) DeleteAll(ctx context.Context) {
+	c.inner.DeleteAll(ctx)
+}
+
+// EnableAutoCleanup registers SIGINT/SIGTERM handlers to call DeleteAll.
+// The returned stop function deregisters the handlers.
+func (c *PodSnapshotClient) EnableAutoCleanup() func() {
+	return c.inner.EnableAutoCleanup()
+}
+
+// checkSnapshotCRDInstalled uses the discovery API to verify that
+// podsnapshot.gke.io/v1 is available on the cluster.
+func checkSnapshotCRDInstalled(dc crdDiscoverer, log logr.Logger) error {
+	groupVersion := PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion
+	resources, err := dc.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		if k8serrors.IsNotFound(err) || isGroupNotFound(err) {
+			return fmt.Errorf("%w: %s API group not found on cluster", ErrCRDNotInstalled, groupVersion)
+		}
+		if k8serrors.IsForbidden(err) {
+			// RBAC may prohibit discovery; assume the CRD exists and let
+			// subsequent operations surface permission errors.
+			log.Info("discovery check for PodSnapshot CRD returned 403; assuming CRD is installed", "warning", err.Error())
+			return nil
+		}
+		return fmt.Errorf("snapshots: checking for PodSnapshot CRD: %w", err)
+	}
+
+	for _, r := range resources.APIResources {
+		if r.Kind == "PodSnapshot" {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: PodSnapshot resource not found in %s", ErrCRDNotInstalled, groupVersion)
+}
+
+// isGroupNotFound returns true when the discovery client wraps a "group not found"
+// error that is not surfaced as a standard k8s 404.
+func isGroupNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	// discovery.ErrGroupDiscoveryFailed wraps per-group errors.
+	if derr, ok := err.(*discovery.ErrGroupDiscoveryFailed); ok {
+		for _, gerr := range derr.Groups {
+			if k8serrors.IsNotFound(gerr) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/clients/go/gke_extensions/snapshots/client.go
+++ b/clients/go/gke_extensions/snapshots/client.go
@@ -132,12 +132,22 @@ func checkSnapshotCRDInstalled(dc crdDiscoverer, log logr.Logger) error {
 		return fmt.Errorf("snapshots: checking for PodSnapshot CRD: %w", err)
 	}
 
+	snapshotFound, triggerFound := false, false
 	for _, r := range resources.APIResources {
-		if r.Kind == "PodSnapshot" {
-			return nil
+		switch r.Kind {
+		case "PodSnapshot":
+			snapshotFound = true
+		case "PodSnapshotManualTrigger":
+			triggerFound = true
 		}
 	}
-	return fmt.Errorf("%w: PodSnapshot resource not found in %s", ErrCRDNotInstalled, groupVersion)
+	if !snapshotFound {
+		return fmt.Errorf("%w: PodSnapshot resource not found in %s", ErrCRDNotInstalled, groupVersion)
+	}
+	if !triggerFound {
+		return fmt.Errorf("%w: PodSnapshotManualTrigger resource not found in %s", ErrCRDNotInstalled, groupVersion)
+	}
+	return nil
 }
 
 // isGroupNotFound returns true when the discovery client wraps a "group not found"

--- a/clients/go/gke_extensions/snapshots/client.go
+++ b/clients/go/gke_extensions/snapshots/client.go
@@ -38,7 +38,6 @@ type PodSnapshotClient struct {
 	inner *sandbox.Client
 	k8s   *sandbox.K8sHelper
 	log   logr.Logger
-	opts  sandbox.Options
 }
 
 // NewPodSnapshotClient creates a PodSnapshotClient. It fails immediately if the
@@ -71,7 +70,6 @@ func NewPodSnapshotClient(ctx context.Context, opts sandbox.Options) (*PodSnapsh
 		inner: inner,
 		k8s:   k8s,
 		log:   opts.Logger,
-		opts:  opts,
 	}, nil
 }
 

--- a/clients/go/gke_extensions/snapshots/client_test.go
+++ b/clients/go/gke_extensions/snapshots/client_test.go
@@ -17,6 +17,7 @@ package snapshots
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -155,4 +156,33 @@ func TestIsGroupNotFound_ErrGroupDiscoveryFailed_NonNotFound(t *testing.T) {
 	if isGroupNotFound(derr) {
 		t.Error("expected false when ErrGroupDiscoveryFailed wraps a non-404 error")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 6: PodSnapshotClient.opts field removed
+// ---------------------------------------------------------------------------
+
+func TestPodSnapshotClient_StructFields(t *testing.T) {
+	// Guard against accidental re-introduction of the opts field using reflection
+	// so a keyed literal that silently omits fields does not hide regressions.
+	typ := reflect.TypeOf(PodSnapshotClient{})
+	for i := 0; i < typ.NumField(); i++ {
+		if typ.Field(i).Name == "opts" {
+			t.Errorf("PodSnapshotClient must not have an 'opts' field (removed as dead state)")
+		}
+	}
+	// Ensure the expected fields are still present.
+	expected := map[string]bool{"inner": false, "k8s": false, "log": false}
+	for i := 0; i < typ.NumField(); i++ {
+		if _, ok := expected[typ.Field(i).Name]; ok {
+			expected[typ.Field(i).Name] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("expected field %q to exist on PodSnapshotClient", name)
+		}
+	}
+	// Silence unused logr.Discard reference.
+	_ = logr.Discard()
 }

--- a/clients/go/gke_extensions/snapshots/client_test.go
+++ b/clients/go/gke_extensions/snapshots/client_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -82,6 +83,18 @@ func TestCheckSnapshotCRDInstalled_KindMissing(t *testing.T) {
 	err := checkSnapshotCRDInstalled(dc, logr.Discard())
 	if !errors.Is(err, ErrCRDNotInstalled) {
 		t.Errorf("expected ErrCRDNotInstalled when PodSnapshot kind absent, got %v", err)
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_TriggerMissing(t *testing.T) {
+	// PodSnapshot present but PodSnapshotManualTrigger absent → ErrCRDNotInstalled.
+	dc := &fakeCRDDiscoverer{resources: apiResourceList("PodSnapshot")}
+	err := checkSnapshotCRDInstalled(dc, logr.Discard())
+	if !errors.Is(err, ErrCRDNotInstalled) {
+		t.Errorf("expected ErrCRDNotInstalled when PodSnapshotManualTrigger absent, got %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "PodSnapshotManualTrigger") {
+		t.Errorf("error message should mention PodSnapshotManualTrigger, got %v", err)
 	}
 }
 

--- a/clients/go/gke_extensions/snapshots/client_test.go
+++ b/clients/go/gke_extensions/snapshots/client_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+// ---------------------------------------------------------------------------
+// fakeCRDDiscoverer
+// ---------------------------------------------------------------------------
+
+type fakeCRDDiscoverer struct {
+	resources *metav1.APIResourceList
+	err       error
+}
+
+func (f *fakeCRDDiscoverer) ServerResourcesForGroupVersion(_ string) (*metav1.APIResourceList, error) {
+	return f.resources, f.err
+}
+
+func apiResourceList(kinds ...string) *metav1.APIResourceList {
+	list := &metav1.APIResourceList{}
+	for _, k := range kinds {
+		list.APIResources = append(list.APIResources, metav1.APIResource{Kind: k})
+	}
+	return list
+}
+
+// ---------------------------------------------------------------------------
+// checkSnapshotCRDInstalled
+// ---------------------------------------------------------------------------
+
+func TestCheckSnapshotCRDInstalled_Found(t *testing.T) {
+	dc := &fakeCRDDiscoverer{resources: apiResourceList("PodSnapshot", "PodSnapshotManualTrigger")}
+	if err := checkSnapshotCRDInstalled(dc, logr.Discard()); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_NotFound(t *testing.T) {
+	notFound := k8serrors.NewNotFound(schema.GroupResource{Group: PodSnapshotAPIGroup}, "")
+	dc := &fakeCRDDiscoverer{err: notFound}
+	err := checkSnapshotCRDInstalled(dc, logr.Discard())
+	if !errors.Is(err, ErrCRDNotInstalled) {
+		t.Errorf("expected ErrCRDNotInstalled, got %v", err)
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_Forbidden(t *testing.T) {
+	forbidden := k8serrors.NewForbidden(schema.GroupResource{Group: PodSnapshotAPIGroup}, "", fmt.Errorf("access denied"))
+	dc := &fakeCRDDiscoverer{err: forbidden}
+	// 403 → assume installed, return nil
+	if err := checkSnapshotCRDInstalled(dc, logr.Discard()); err != nil {
+		t.Errorf("expected nil for forbidden, got %v", err)
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_KindMissing(t *testing.T) {
+	dc := &fakeCRDDiscoverer{resources: apiResourceList("SomeOtherKind")}
+	err := checkSnapshotCRDInstalled(dc, logr.Discard())
+	if !errors.Is(err, ErrCRDNotInstalled) {
+		t.Errorf("expected ErrCRDNotInstalled when PodSnapshot kind absent, got %v", err)
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_EmptyResourceList(t *testing.T) {
+	dc := &fakeCRDDiscoverer{resources: &metav1.APIResourceList{}}
+	err := checkSnapshotCRDInstalled(dc, logr.Discard())
+	if !errors.Is(err, ErrCRDNotInstalled) {
+		t.Errorf("expected ErrCRDNotInstalled for empty resource list, got %v", err)
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_OtherError(t *testing.T) {
+	dc := &fakeCRDDiscoverer{err: fmt.Errorf("connection refused")}
+	err := checkSnapshotCRDInstalled(dc, logr.Discard())
+	if err == nil {
+		t.Error("expected error for generic API failure")
+	}
+	if errors.Is(err, ErrCRDNotInstalled) {
+		t.Error("generic connection error should not be wrapped as ErrCRDNotInstalled")
+	}
+}
+
+func TestCheckSnapshotCRDInstalled_GroupDiscoveryFailed_NotFound(t *testing.T) {
+	notFound := k8serrors.NewNotFound(schema.GroupResource{Group: PodSnapshotAPIGroup}, "")
+	discoveryErr := &discovery.ErrGroupDiscoveryFailed{
+		Groups: map[schema.GroupVersion]error{
+			{Group: PodSnapshotAPIGroup, Version: PodSnapshotAPIVersion}: notFound,
+		},
+	}
+	dc := &fakeCRDDiscoverer{err: discoveryErr}
+	err := checkSnapshotCRDInstalled(dc, logr.Discard())
+	if !errors.Is(err, ErrCRDNotInstalled) {
+		t.Errorf("expected ErrCRDNotInstalled for ErrGroupDiscoveryFailed wrapping 404, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isGroupNotFound
+// ---------------------------------------------------------------------------
+
+func TestIsGroupNotFound_Nil(t *testing.T) {
+	if isGroupNotFound(nil) {
+		t.Error("expected false for nil error")
+	}
+}
+
+func TestIsGroupNotFound_NonDiscoveryError(t *testing.T) {
+	if isGroupNotFound(fmt.Errorf("unrelated error")) {
+		t.Error("expected false for non-discovery error")
+	}
+}
+
+func TestIsGroupNotFound_ErrGroupDiscoveryFailed_With404(t *testing.T) {
+	notFound := k8serrors.NewNotFound(schema.GroupResource{}, "")
+	derr := &discovery.ErrGroupDiscoveryFailed{
+		Groups: map[schema.GroupVersion]error{
+			{Group: "foo", Version: "v1"}: notFound,
+		},
+	}
+	if !isGroupNotFound(derr) {
+		t.Error("expected true when ErrGroupDiscoveryFailed wraps a 404")
+	}
+}
+
+func TestIsGroupNotFound_ErrGroupDiscoveryFailed_NonNotFound(t *testing.T) {
+	forbidden := k8serrors.NewForbidden(schema.GroupResource{}, "", fmt.Errorf("denied"))
+	derr := &discovery.ErrGroupDiscoveryFailed{
+		Groups: map[schema.GroupVersion]error{
+			{Group: "foo", Version: "v1"}: forbidden,
+		},
+	}
+	if isGroupNotFound(derr) {
+		t.Error("expected false when ErrGroupDiscoveryFailed wraps a non-404 error")
+	}
+}

--- a/clients/go/gke_extensions/snapshots/client_test.go
+++ b/clients/go/gke_extensions/snapshots/client_test.go
@@ -165,17 +165,17 @@ func TestIsGroupNotFound_ErrGroupDiscoveryFailed_NonNotFound(t *testing.T) {
 func TestPodSnapshotClient_StructFields(t *testing.T) {
 	// Guard against accidental re-introduction of the opts field using reflection
 	// so a keyed literal that silently omits fields does not hide regressions.
-	typ := reflect.TypeOf(PodSnapshotClient{})
-	for i := 0; i < typ.NumField(); i++ {
-		if typ.Field(i).Name == "opts" {
+	typ := reflect.TypeFor[PodSnapshotClient]()
+	for f := range typ.Fields() {
+		if f.Name == "opts" {
 			t.Errorf("PodSnapshotClient must not have an 'opts' field (removed as dead state)")
 		}
 	}
 	// Ensure the expected fields are still present.
 	expected := map[string]bool{"inner": false, "k8s": false, "log": false}
-	for i := 0; i < typ.NumField(); i++ {
-		if _, ok := expected[typ.Field(i).Name]; ok {
-			expected[typ.Field(i).Name] = true
+	for f := range typ.Fields() {
+		if _, ok := expected[f.Name]; ok {
+			expected[f.Name] = true
 		}
 	}
 	for name, found := range expected {

--- a/clients/go/gke_extensions/snapshots/doc.go
+++ b/clients/go/gke_extensions/snapshots/doc.go
@@ -1,0 +1,90 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package snapshots is a Go client extension for interacting with the GKE Pod
+// Snapshot feature from within the agent-sandbox framework. It allows Go users
+// to trigger snapshots of a running sandbox and restore a new sandbox from a
+// recently created snapshot — mirroring the functionality of the Python client
+// at clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots.
+//
+// # Main types
+//
+//   - [PodSnapshotClient] — the top-level entry point. Wraps [sandbox.Client]
+//     and validates at construction time that the GKE Pod Snapshot CRDs are
+//     installed. All sandboxes it creates are [SandboxWithSnapshotSupport].
+//
+//   - [SandboxWithSnapshotSupport] — wraps a sandbox handle with snapshot
+//     lifecycle operations: Suspend, Resume, IsRestoredFromSnapshot, IsActive.
+//
+//   - [SnapshotEngine] — low-level engine for Create / List / Delete / DeleteAll
+//     operations against PodSnapshot and PodSnapshotManualTrigger CRDs.
+//
+// # Cluster prerequisites
+//
+// GKE Pod Snapshots require:
+//
+//  1. A GKE Standard cluster running gVisor (version ≥ 1.35.2-gke.1842000).
+//
+//  2. The PodSnapshotStorageConfig and PodSnapshotPolicy CRDs installed and
+//     configured with a GCS bucket and appropriate IAM permissions.
+//
+//  3. A PodSnapshotPolicy whose snapshotGroupingRules include the
+//     "agents.x-k8s.io/sandbox-name-hash" label. Example:
+//
+//     apiVersion: podsnapshot.gke.io/v1
+//     kind: PodSnapshotPolicy
+//     metadata:
+//     name: my-policy
+//     namespace: default
+//     spec:
+//     storageConfigName: my-storage-config
+//     selector:
+//     matchLabels:
+//     app: agent-sandbox-workload
+//     triggerConfig:
+//     type: manual
+//     postCheckpoint: resume
+//     snapshotGroupingRules:
+//     groupByLabelValue:
+//     labels: ["agents.x-k8s.io/sandbox-name-hash"]
+//     groupRetentionPolicy:
+//     maxSnapshotCountPerGroup: 3
+//
+// # Usage
+//
+//	client, err := snapshots.NewPodSnapshotClient(ctx, sandbox.Options{
+//	    RestConfig: restConfig,
+//	    Logger:     logger,
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer client.DeleteAll(ctx)
+//
+//	sb, err := client.CreateSandbox(ctx, "my-template", "default")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Take a manual snapshot.
+//	resp := sb.Snapshots().Create(ctx, "my-snapshot", 3*time.Minute)
+//	if resp.Success {
+//	    fmt.Println("snapshot UID:", resp.SnapshotUID)
+//	}
+//
+//	// Suspend (optionally snapshots first) and later resume.
+//	suspendResp := sb.Suspend(ctx, true, 3*time.Minute)
+//	resumeResp  := sb.Resume(ctx, 3*time.Minute)
+//	fmt.Println("restored from snapshot:", resumeResp.RestoredFromSnapshot)
+package snapshots

--- a/clients/go/gke_extensions/snapshots/engine.go
+++ b/clients/go/gke_extensions/snapshots/engine.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	sandbox "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
 )
@@ -37,29 +36,27 @@ import (
 type SnapshotEngine struct {
 	namespace          string
 	dynClient          dynamic.Interface
-	coreClient         corev1client.CoreV1Interface
-	getPodName         func() (string, error)
-	getSandboxNameHash func() (string, error)
+	getPodName         func(ctx context.Context) (string, error)
+	getSandboxNameHash func(ctx context.Context) (string, error)
 	log                logr.Logger
 
-	mu                   sync.Mutex
+	mu                    sync.Mutex
 	createdManualTriggers []string
 }
 
 // NewSnapshotEngine creates a SnapshotEngine backed by the provided K8sHelper.
 // getPodName and getSandboxNameHash are callbacks that resolve dynamic identity
-// values; they may be called on every operation.
+// values; ctx is forwarded from each engine operation to the callbacks.
 func NewSnapshotEngine(
 	namespace string,
 	k8s *sandbox.K8sHelper,
-	getPodName func() (string, error),
-	getSandboxNameHash func() (string, error),
+	getPodName func(ctx context.Context) (string, error),
+	getSandboxNameHash func(ctx context.Context) (string, error),
 	log logr.Logger,
 ) *SnapshotEngine {
 	return &SnapshotEngine{
 		namespace:          namespace,
 		dynClient:          k8s.DynamicClient,
-		coreClient:         k8s.CoreClient,
 		getPodName:         getPodName,
 		getSandboxNameHash: getSandboxNameHash,
 		log:                log,
@@ -71,7 +68,7 @@ func NewSnapshotEngine(
 func (e *SnapshotEngine) Create(ctx context.Context, triggerName string, timeout time.Duration) SnapshotResponse {
 	safeName := sanitizeTriggerName(triggerName)
 
-	podName, err := e.getPodName()
+	podName, err := e.getPodName(ctx)
 	if err != nil || podName == "" {
 		return SnapshotResponse{
 			Success:     false,
@@ -138,7 +135,7 @@ func (e *SnapshotEngine) Create(ctx context.Context, triggerName string, timeout
 
 // List returns snapshots matching the filter, sorted newest-first.
 func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSnapshotResult {
-	podName, err := e.getPodName()
+	podName, err := e.getPodName(ctx)
 	if err != nil || podName == "" {
 		return ListSnapshotResult{
 			Success:     false,
@@ -147,7 +144,7 @@ func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSn
 		}
 	}
 
-	hash, err := e.getSandboxNameHash()
+	hash, err := e.getSandboxNameHash(ctx)
 	if err != nil || hash == "" {
 		return ListSnapshotResult{
 			Success:     false,
@@ -158,11 +155,15 @@ func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSn
 
 	labelSelector := SandboxNameHashLabel + "=" + hash
 	if len(filter.GroupingLabels) > 0 {
-		var parts []string
-		for k, v := range filter.GroupingLabels {
-			parts = append(parts, k+"="+v)
+		// Sort keys for a deterministic selector string.
+		keys := make([]string, 0, len(filter.GroupingLabels))
+		for k := range filter.GroupingLabels {
+			keys = append(keys, k)
 		}
-		labelSelector += "," + strings.Join(parts, ",")
+		sort.Strings(keys)
+		for _, k := range keys {
+			labelSelector += "," + k + "=" + filter.GroupingLabels[k]
+		}
 	}
 
 	e.log.Info("listing snapshots", "labelSelector", labelSelector)
@@ -261,7 +262,7 @@ func (e *SnapshotEngine) DeleteAll(ctx context.Context, deleteBy string, labelVa
 }
 
 // DeleteManualTriggers cleans up PodSnapshotManualTrigger resources created by
-// this engine. Best-effort with up to maxRetries attempts.
+// this engine. Best-effort with up to maxRetries attempts; respects ctx cancellation.
 func (e *SnapshotEngine) DeleteManualTriggers(ctx context.Context) {
 	const maxRetries = 3
 	const retryDelay = time.Second
@@ -288,10 +289,15 @@ func (e *SnapshotEngine) DeleteManualTriggers(ctx context.Context) {
 		}
 		remaining = failed
 		if len(remaining) > 0 && attempt < maxRetries {
-			time.Sleep(retryDelay)
+			select {
+			case <-ctx.Done():
+				goto done
+			case <-time.After(retryDelay):
+			}
 		}
 	}
 
+done:
 	e.mu.Lock()
 	e.createdManualTriggers = remaining
 	e.mu.Unlock()
@@ -393,14 +399,31 @@ func (e *SnapshotEngine) executeDeletion(
 
 // sanitizeTriggerName converts an arbitrary string to a valid Kubernetes
 // resource name and appends a timestamp+UUID suffix for uniqueness.
+// Output always matches [a-z0-9]([-a-z0-9]*[a-z0-9])? and is ≤ 63 chars.
 func sanitizeTriggerName(name string) string {
 	safe := strings.ToLower(name)
-	safe = strings.ReplaceAll(safe, "_", "-")
-	// "-YYYYMMDD-HHMMSS-xxxxxxxx" is 25 chars; leave 38 for the base
+
+	// Replace every character that is not [a-z0-9-] with a dash.
+	var b strings.Builder
+	for _, r := range safe {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	safe = b.String()
+
+	// Collapse consecutive dashes produced by replacements.
+	for strings.Contains(safe, "--") {
+		safe = strings.ReplaceAll(safe, "--", "-")
+	}
+
+	// "-YYYYMMDD-HHMMSS-xxxxxxxx" is 25 chars; leave 38 for the base.
 	if len(safe) > 38 {
 		safe = safe[:38]
 	}
-	safe = strings.TrimRight(safe, "-")
+	safe = strings.Trim(safe, "-")
 	if safe == "" {
 		safe = "snap"
 	}

--- a/clients/go/gke_extensions/snapshots/engine.go
+++ b/clients/go/gke_extensions/snapshots/engine.go
@@ -69,11 +69,19 @@ func (e *SnapshotEngine) Create(ctx context.Context, triggerName string, timeout
 	safeName := sanitizeTriggerName(triggerName)
 
 	podName, err := e.getPodName(ctx)
-	if err != nil || podName == "" {
+	if err != nil {
 		return SnapshotResponse{
 			Success:     false,
 			TriggerName: safeName,
-			ErrorReason: fmt.Sprintf("pod name not available: %v", err),
+			ErrorReason: fmt.Sprintf("failed to get pod name: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+	if podName == "" {
+		return SnapshotResponse{
+			Success:     false,
+			TriggerName: safeName,
+			ErrorReason: "pod name is not yet available; ensure the sandbox is open and running",
 			ErrorCode:   ErrorCode,
 		}
 	}

--- a/clients/go/gke_extensions/snapshots/engine.go
+++ b/clients/go/gke_extensions/snapshots/engine.go
@@ -17,7 +17,7 @@ package snapshots
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -79,14 +79,14 @@ func (e *SnapshotEngine) Create(ctx context.Context, triggerName string, timeout
 	}
 
 	manifest := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 			"kind":       PodSnapshotTriggerKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      safeName,
 				"namespace": e.namespace,
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"targetPod": podName,
 			},
 		},
@@ -153,18 +153,23 @@ func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSn
 		}
 	}
 
-	labelSelector := SandboxNameHashLabel + "=" + hash
+	var sb strings.Builder
+	sb.WriteString(SandboxNameHashLabel + "=" + hash)
 	if len(filter.GroupingLabels) > 0 {
 		// Sort keys for a deterministic selector string.
 		keys := make([]string, 0, len(filter.GroupingLabels))
 		for k := range filter.GroupingLabels {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		for _, k := range keys {
-			labelSelector += "," + k + "=" + filter.GroupingLabels[k]
+			sb.WriteByte(',')
+			sb.WriteString(k)
+			sb.WriteByte('=')
+			sb.WriteString(filter.GroupingLabels[k])
 		}
 	}
+	labelSelector := sb.String()
 
 	e.log.Info("listing snapshots", "labelSelector", labelSelector)
 
@@ -185,7 +190,7 @@ func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSn
 		conditions, _, _ := unstructured.NestedSlice(item.Object, "status", "conditions")
 		isReady := false
 		for _, raw := range conditions {
-			cond, ok := raw.(map[string]interface{})
+			cond, ok := raw.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -225,8 +230,8 @@ func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSn
 		})
 	}
 
-	sort.Slice(details, func(i, j int) bool {
-		return details[i].CreationTimestamp.After(details[j].CreationTimestamp)
+	slices.SortFunc(details, func(a, b SnapshotDetail) int {
+		return b.CreationTimestamp.Compare(a.CreationTimestamp)
 	})
 
 	e.log.Info("found snapshots", "count", len(details))

--- a/clients/go/gke_extensions/snapshots/engine.go
+++ b/clients/go/gke_extensions/snapshots/engine.go
@@ -1,0 +1,410 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	sandbox "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+// SnapshotEngine manages PodSnapshot CRUD operations for a sandbox.
+type SnapshotEngine struct {
+	namespace          string
+	dynClient          dynamic.Interface
+	coreClient         corev1client.CoreV1Interface
+	getPodName         func() (string, error)
+	getSandboxNameHash func() (string, error)
+	log                logr.Logger
+
+	mu                   sync.Mutex
+	createdManualTriggers []string
+}
+
+// NewSnapshotEngine creates a SnapshotEngine backed by the provided K8sHelper.
+// getPodName and getSandboxNameHash are callbacks that resolve dynamic identity
+// values; they may be called on every operation.
+func NewSnapshotEngine(
+	namespace string,
+	k8s *sandbox.K8sHelper,
+	getPodName func() (string, error),
+	getSandboxNameHash func() (string, error),
+	log logr.Logger,
+) *SnapshotEngine {
+	return &SnapshotEngine{
+		namespace:          namespace,
+		dynClient:          k8s.DynamicClient,
+		coreClient:         k8s.CoreClient,
+		getPodName:         getPodName,
+		getSandboxNameHash: getSandboxNameHash,
+		log:                log,
+	}
+}
+
+// Create takes a snapshot of the sandbox pod. triggerName is sanitised and
+// made unique; timeout controls how long to wait for the snapshot to complete.
+func (e *SnapshotEngine) Create(ctx context.Context, triggerName string, timeout time.Duration) SnapshotResponse {
+	safeName := sanitizeTriggerName(triggerName)
+
+	podName, err := e.getPodName()
+	if err != nil || podName == "" {
+		return SnapshotResponse{
+			Success:     false,
+			TriggerName: safeName,
+			ErrorReason: fmt.Sprintf("pod name not available: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	manifest := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       PodSnapshotTriggerKind,
+			"metadata": map[string]interface{}{
+				"name":      safeName,
+				"namespace": e.namespace,
+			},
+			"spec": map[string]interface{}{
+				"targetPod": podName,
+			},
+		},
+	}
+
+	created, err := e.dynClient.Resource(triggerGVR).Namespace(e.namespace).Create(ctx, manifest, metav1.CreateOptions{})
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to create PodSnapshotManualTrigger: %v", err)
+		if k8serrors.IsForbidden(err) {
+			errMsg += "; check that the service account has RBAC permission to create PodSnapshotManualTrigger resources"
+		}
+		e.log.Error(err, "failed to create snapshot trigger", "trigger", safeName)
+		return SnapshotResponse{
+			Success:     false,
+			TriggerName: safeName,
+			ErrorReason: errMsg,
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	e.mu.Lock()
+	e.createdManualTriggers = append(e.createdManualTriggers, safeName)
+	e.mu.Unlock()
+
+	resourceVersion := created.GetResourceVersion()
+
+	result, err := waitForSnapshotCompleted(ctx, e.dynClient, e.namespace, safeName, resourceVersion, timeout, e.log)
+	if err != nil {
+		e.log.Error(err, "snapshot creation failed", "trigger", safeName)
+		return SnapshotResponse{
+			Success:     false,
+			TriggerName: safeName,
+			ErrorReason: err.Error(),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	return SnapshotResponse{
+		Success:           true,
+		TriggerName:       safeName,
+		SnapshotUID:       result.SnapshotUID,
+		SnapshotTimestamp: result.SnapshotTimestamp,
+		ErrorCode:         SuccessCode,
+	}
+}
+
+// List returns snapshots matching the filter, sorted newest-first.
+func (e *SnapshotEngine) List(ctx context.Context, filter SnapshotFilter) ListSnapshotResult {
+	podName, err := e.getPodName()
+	if err != nil || podName == "" {
+		return ListSnapshotResult{
+			Success:     false,
+			ErrorReason: "pod name not available",
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	hash, err := e.getSandboxNameHash()
+	if err != nil || hash == "" {
+		return ListSnapshotResult{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("sandbox name hash not available: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	labelSelector := SandboxNameHashLabel + "=" + hash
+	if len(filter.GroupingLabels) > 0 {
+		var parts []string
+		for k, v := range filter.GroupingLabels {
+			parts = append(parts, k+"="+v)
+		}
+		labelSelector += "," + strings.Join(parts, ",")
+	}
+
+	e.log.Info("listing snapshots", "labelSelector", labelSelector)
+
+	list, err := e.dynClient.Resource(snapshotGVR).Namespace(e.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		e.log.Error(err, "failed to list snapshots")
+		return ListSnapshotResult{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("failed to list PodSnapshots: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	var details []SnapshotDetail
+	for _, item := range list.Items {
+		conditions, _, _ := unstructured.NestedSlice(item.Object, "status", "conditions")
+		isReady := false
+		for _, raw := range conditions {
+			cond, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if cond["type"] == "Ready" && cond["status"] == "True" {
+				isReady = true
+				break
+			}
+		}
+		if filter.ReadyOnly && !isReady {
+			continue
+		}
+
+		annotations := item.GetAnnotations()
+		sourcePod := "Unknown"
+		if annotations != nil {
+			if p, ok := annotations[PodSnapshotPodAnnotation]; ok {
+				sourcePod = p
+			}
+		}
+
+		ts := item.GetCreationTimestamp()
+		var creationTS time.Time
+		if !ts.IsZero() {
+			creationTS = ts.Time
+		}
+
+		status := "NotReady"
+		if isReady {
+			status = "Ready"
+		}
+
+		details = append(details, SnapshotDetail{
+			SnapshotUID:       item.GetName(),
+			SourcePod:         sourcePod,
+			CreationTimestamp: creationTS,
+			Status:            status,
+		})
+	}
+
+	sort.Slice(details, func(i, j int) bool {
+		return details[i].CreationTimestamp.After(details[j].CreationTimestamp)
+	})
+
+	e.log.Info("found snapshots", "count", len(details))
+	return ListSnapshotResult{
+		Success:   true,
+		Snapshots: details,
+		ErrorCode: SuccessCode,
+	}
+}
+
+// Delete deletes a single snapshot by UID and waits for confirmation.
+func (e *SnapshotEngine) Delete(ctx context.Context, snapshotUID string, timeout time.Duration) DeleteSnapshotResult {
+	return e.executeDeletion(ctx, snapshotUID, "", nil, timeout)
+}
+
+// DeleteAll deletes snapshots matching the given strategy.
+// deleteBy must be "all" (delete every snapshot for this sandbox) or "labels"
+// (delete snapshots matching labelValue).
+func (e *SnapshotEngine) DeleteAll(ctx context.Context, deleteBy string, labelValue map[string]string, timeout time.Duration) (DeleteSnapshotResult, error) {
+	switch deleteBy {
+	case "all":
+		e.log.Info("deleting all snapshots for this sandbox")
+		return e.executeDeletion(ctx, "", "global", nil, timeout), nil
+	case "labels":
+		if len(labelValue) == 0 {
+			return DeleteSnapshotResult{}, fmt.Errorf("labelValue must be non-empty when deleteBy=labels")
+		}
+		e.log.Info("deleting snapshots matching labels", "labels", labelValue)
+		return e.executeDeletion(ctx, "", "", labelValue, timeout), nil
+	default:
+		return DeleteSnapshotResult{}, fmt.Errorf("unsupported deleteBy value %q; must be \"all\" or \"labels\"", deleteBy)
+	}
+}
+
+// DeleteManualTriggers cleans up PodSnapshotManualTrigger resources created by
+// this engine. Best-effort with up to maxRetries attempts.
+func (e *SnapshotEngine) DeleteManualTriggers(ctx context.Context) {
+	const maxRetries = 3
+	const retryDelay = time.Second
+
+	e.mu.Lock()
+	remaining := make([]string, len(e.createdManualTriggers))
+	copy(remaining, e.createdManualTriggers)
+	e.mu.Unlock()
+
+	for attempt := 1; attempt <= maxRetries && len(remaining) > 0; attempt++ {
+		var failed []string
+		for _, name := range remaining {
+			err := e.dynClient.Resource(triggerGVR).Namespace(e.namespace).Delete(ctx, name, metav1.DeleteOptions{})
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					e.log.V(1).Info("trigger already deleted", "trigger", name)
+					continue
+				}
+				e.log.Error(err, "failed to delete trigger", "trigger", name, "attempt", attempt, "maxRetries", maxRetries)
+				failed = append(failed, name)
+			} else {
+				e.log.Info("deleted snapshot trigger", "trigger", name)
+			}
+		}
+		remaining = failed
+		if len(remaining) > 0 && attempt < maxRetries {
+			time.Sleep(retryDelay)
+		}
+	}
+
+	e.mu.Lock()
+	e.createdManualTriggers = remaining
+	e.mu.Unlock()
+
+	if len(remaining) > 0 {
+		e.log.Info("leaked PodSnapshotManualTrigger resources require manual cleanup",
+			"count", len(remaining), "triggers", remaining)
+	}
+}
+
+func (e *SnapshotEngine) executeDeletion(
+	ctx context.Context,
+	snapshotUID string,
+	scope string,
+	labels map[string]string,
+	timeout time.Duration,
+) DeleteSnapshotResult {
+	var toDelete []string
+
+	switch {
+	case snapshotUID != "":
+		toDelete = []string{snapshotUID}
+	case scope == "global":
+		result := e.List(ctx, SnapshotFilter{ReadyOnly: false})
+		if !result.Success {
+			return DeleteSnapshotResult{
+				Success:     false,
+				ErrorReason: "failed to list snapshots before deletion: " + result.ErrorReason,
+				ErrorCode:   ErrorCode,
+			}
+		}
+		for _, s := range result.Snapshots {
+			toDelete = append(toDelete, s.SnapshotUID)
+		}
+	case len(labels) > 0:
+		result := e.List(ctx, SnapshotFilter{ReadyOnly: false, GroupingLabels: labels})
+		if !result.Success {
+			return DeleteSnapshotResult{
+				Success:     false,
+				ErrorReason: "failed to list snapshots before deletion: " + result.ErrorReason,
+				ErrorCode:   ErrorCode,
+			}
+		}
+		for _, s := range result.Snapshots {
+			toDelete = append(toDelete, s.SnapshotUID)
+		}
+	}
+
+	if len(toDelete) == 0 {
+		e.log.Info("no snapshots found to delete")
+		return DeleteSnapshotResult{Success: true, ErrorCode: SuccessCode}
+	}
+
+	var deleted []string
+	var errs []string
+
+	for _, uid := range toDelete {
+		err := e.dynClient.Resource(snapshotGVR).Namespace(e.namespace).Delete(ctx, uid, metav1.DeleteOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				e.log.V(1).Info("snapshot already deleted", "uid", uid)
+				deleted = append(deleted, uid)
+				continue
+			}
+			msg := fmt.Sprintf("failed to delete snapshot %q: %v", uid, err)
+			e.log.Error(err, "failed to delete snapshot", "uid", uid)
+			errs = append(errs, msg)
+			continue
+		}
+
+		if err := waitForSnapshotDeletion(ctx, e.dynClient, e.namespace, uid, timeout, e.log); err != nil {
+			msg := fmt.Sprintf("timed out waiting for snapshot %q deletion: %v", uid, err)
+			e.log.Info(msg)
+			errs = append(errs, msg)
+			continue
+		}
+		deleted = append(deleted, uid)
+	}
+
+	if len(errs) > 0 {
+		errMsg := strings.Join(errs, "; ")
+		if len(deleted) > 0 {
+			errMsg = fmt.Sprintf("partial failure: deleted %d/%d snapshots; %s", len(deleted), len(toDelete), errMsg)
+		}
+		return DeleteSnapshotResult{
+			Success:          false,
+			DeletedSnapshots: deleted,
+			ErrorReason:      errMsg,
+			ErrorCode:        ErrorCode,
+		}
+	}
+
+	return DeleteSnapshotResult{
+		Success:          true,
+		DeletedSnapshots: deleted,
+		ErrorCode:        SuccessCode,
+	}
+}
+
+// sanitizeTriggerName converts an arbitrary string to a valid Kubernetes
+// resource name and appends a timestamp+UUID suffix for uniqueness.
+func sanitizeTriggerName(name string) string {
+	safe := strings.ToLower(name)
+	safe = strings.ReplaceAll(safe, "_", "-")
+	// "-YYYYMMDD-HHMMSS-xxxxxxxx" is 25 chars; leave 38 for the base
+	if len(safe) > 38 {
+		safe = safe[:38]
+	}
+	safe = strings.TrimRight(safe, "-")
+	if safe == "" {
+		safe = "snap"
+	}
+	ts := time.Now().UTC().Format("20060102-150405")
+	suffix := uuid.New().String()[:8]
+	return fmt.Sprintf("%s-%s-%s", safe, ts, suffix)
+}

--- a/clients/go/gke_extensions/snapshots/engine_test.go
+++ b/clients/go/gke_extensions/snapshots/engine_test.go
@@ -35,16 +35,16 @@ import (
 // Helpers
 // ---------------------------------------------------------------------------
 
-func newTestEngine(dynCS *fakedynamic.FakeDynamicClient, podName, hash string) *SnapshotEngine {
+func newTestEngine(dynCS *fakedynamic.FakeDynamicClient) *SnapshotEngine {
 	return &SnapshotEngine{
 		namespace: "default",
 		dynClient: dynCS,
 		log:       logr.Discard(),
 		getPodName: func(_ context.Context) (string, error) {
-			return podName, nil
+			return "my-pod", nil
 		},
 		getSandboxNameHash: func(_ context.Context) (string, error) {
-			return hash, nil
+			return "abc123", nil
 		},
 	}
 }
@@ -61,21 +61,21 @@ func newDynClient(extra ...runtime.Object) *fakedynamic.FakeDynamicClient {
 }
 
 func makeSnapshot(name, hashLabel string, ready bool) *unstructured.Unstructured {
-	status := map[string]interface{}{}
+	status := map[string]any{}
 	if ready {
-		status["conditions"] = []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "True"},
+		status["conditions"] = []any{
+			map[string]any{"type": "Ready", "status": "True"},
 		}
 	}
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 			"kind":       "PodSnapshot",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":              name,
 				"namespace":         "default",
 				"creationTimestamp": "2026-01-01T00:00:00Z",
-				"labels":            map[string]interface{}{SandboxNameHashLabel: hashLabel},
+				"labels":            map[string]any{SandboxNameHashLabel: hashLabel},
 			},
 			"status": status,
 		},
@@ -108,7 +108,7 @@ func TestSanitizeTriggerName(t *testing.T) {
 				t.Error("trigger name must not be empty")
 			}
 			for _, ch := range result {
-				if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-') {
+				if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '-' {
 					t.Errorf("invalid character %q in trigger name %q", ch, result)
 				}
 			}
@@ -160,7 +160,7 @@ func TestSnapshotEngine_List_AllReady(t *testing.T) {
 	snap1 := makeSnapshot("snap-1", "abc123", true)
 	snap2 := makeSnapshot("snap-2", "abc123", false)
 	dynCS := newDynClient(snap1, snap2)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: true})
 
@@ -179,7 +179,7 @@ func TestSnapshotEngine_List_IncludeNotReady(t *testing.T) {
 	snap1 := makeSnapshot("snap-1", "abc123", true)
 	snap2 := makeSnapshot("snap-2", "abc123", false)
 	dynCS := newDynClient(snap1, snap2)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: false})
 
@@ -232,11 +232,11 @@ func TestSnapshotEngine_List_NoHash(t *testing.T) {
 func TestSnapshotEngine_Delete_Success(t *testing.T) {
 	snap := makeSnapshot("snap-1", "abc123", true)
 	dynCS := newDynClient(snap)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	// Inject a watch that immediately returns DELETED.
 	snapWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() {
 			snapWatcher.Delete(snap)
 		}()
@@ -254,7 +254,7 @@ func TestSnapshotEngine_Delete_Success(t *testing.T) {
 
 func TestSnapshotEngine_Delete_AlreadyGone(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	// Object doesn't exist; waitForSnapshotDeletion first GETs the object to check.
 	// The GET will return 404, so deletion is considered successful immediately.
@@ -270,17 +270,17 @@ func TestSnapshotEngine_Delete_AlreadyGone(t *testing.T) {
 
 func TestSnapshotEngine_DeleteManualTriggers(t *testing.T) {
 	trigger := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 			"kind":       PodSnapshotTriggerKind,
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name":      "my-trigger",
 				"namespace": "default",
 			},
 		},
 	}
 	dynCS := newDynClient(trigger)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 	eng.createdManualTriggers = []string{"my-trigger"}
 
 	eng.DeleteManualTriggers(context.Background())
@@ -292,7 +292,7 @@ func TestSnapshotEngine_DeleteManualTriggers(t *testing.T) {
 
 func TestSnapshotEngine_DeleteManualTriggers_AlreadyGone(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 	eng.createdManualTriggers = []string{"ghost-trigger"}
 
 	eng.DeleteManualTriggers(context.Background())
@@ -309,24 +309,24 @@ func TestSnapshotEngine_DeleteManualTriggers_AlreadyGone(t *testing.T) {
 
 func TestSnapshotEngine_Create_Success(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	// Inject a watch reactor that immediately fires MODIFIED with completion status.
 	trigWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() {
 			completedTrigger := &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 					"kind":       PodSnapshotTriggerKind,
-					"metadata": map[string]interface{}{
+					"metadata": map[string]any{
 						"name":      "snap",
 						"namespace": "default",
 					},
-					"status": map[string]interface{}{
-						"snapshotCreated": map[string]interface{}{"name": "snap-uid-123"},
-						"conditions": []interface{}{
-							map[string]interface{}{
+					"status": map[string]any{
+						"snapshotCreated": map[string]any{"name": "snap-uid-123"},
+						"conditions": []any{
+							map[string]any{
 								"type":               "Triggered",
 								"status":             "True",
 								"reason":             "Complete",
@@ -355,19 +355,19 @@ func TestSnapshotEngine_Create_Success(t *testing.T) {
 
 func TestSnapshotEngine_Create_Failure(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	trigWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() {
 			failedTrigger := &unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 					"kind":       PodSnapshotTriggerKind,
-					"metadata": map[string]interface{}{"name": "snap", "namespace": "default"},
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+					"metadata":   map[string]any{"name": "snap", "namespace": "default"},
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":    "Triggered",
 								"status":  "False",
 								"reason":  "Failed",
@@ -390,10 +390,10 @@ func TestSnapshotEngine_Create_Failure(t *testing.T) {
 
 func TestSnapshotEngine_Create_Timeout(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	// Return a watcher that never fires.
-	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		return true, watch.NewFake(), nil
 	})
 
@@ -412,7 +412,7 @@ func TestSnapshotEngine_Create_Timeout(t *testing.T) {
 
 func TestSnapshotEngine_DeleteAll_Empty(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result, err := eng.DeleteAll(context.Background(), "all", nil, 5*time.Second)
 	if err != nil {
@@ -428,7 +428,7 @@ func TestSnapshotEngine_DeleteAll_Empty(t *testing.T) {
 
 func TestSnapshotEngine_DeleteAll_InvalidStrategy(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	_, err := eng.DeleteAll(context.Background(), "unknown", nil, 5*time.Second)
 	if err == nil {
@@ -438,7 +438,7 @@ func TestSnapshotEngine_DeleteAll_InvalidStrategy(t *testing.T) {
 
 func TestSnapshotEngine_DeleteAll_ByLabelsRequiresLabels(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	_, err := eng.DeleteAll(context.Background(), "labels", nil, 5*time.Second)
 	if err == nil {
@@ -471,10 +471,10 @@ func TestSnapshotEngine_Create_EmptyPodName(t *testing.T) {
 
 func TestSnapshotEngine_Create_APIError(t *testing.T) {
 	dynCS := newDynClient()
-	dynCS.PrependReactor("create", "podsnapshotmanualtriggers", func(action ktesting.Action) (bool, runtime.Object, error) {
+	dynCS.PrependReactor("create", "podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("server error")
 	})
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	resp := eng.Create(context.Background(), "test", 5*time.Second)
 	if resp.Success {
@@ -493,7 +493,7 @@ func TestSnapshotEngine_Create_APIError(t *testing.T) {
 func TestSnapshotEngine_List_WithGroupingLabels(t *testing.T) {
 	snap := makeSnapshot("snap-1", "abc123", true)
 	dynCS := newDynClient(snap)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result := eng.List(context.Background(), SnapshotFilter{
 		ReadyOnly:      true,
@@ -509,10 +509,10 @@ func TestSnapshotEngine_List_WithGroupingLabels(t *testing.T) {
 
 func TestSnapshotEngine_List_APIError(t *testing.T) {
 	dynCS := newDynClient()
-	dynCS.PrependReactor("list", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+	dynCS.PrependReactor("list", "podsnapshots", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("network error")
 	})
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: false})
 	if result.Success {
@@ -523,11 +523,11 @@ func TestSnapshotEngine_List_APIError(t *testing.T) {
 func TestSnapshotEngine_List_WithPodAnnotation(t *testing.T) {
 	snap := makeSnapshot("snap-1", "abc123", true)
 	// Add the pod annotation.
-	annotations := map[string]interface{}{PodSnapshotPodAnnotation: "origin-pod-xyz"}
-	snap.Object["metadata"].(map[string]interface{})["annotations"] = annotations
+	annotations := map[string]any{PodSnapshotPodAnnotation: "origin-pod-xyz"}
+	snap.Object["metadata"].(map[string]any)["annotations"] = annotations
 
 	dynCS := newDynClient(snap)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: false})
 	if !result.Success {
@@ -548,11 +548,11 @@ func TestSnapshotEngine_List_WithPodAnnotation(t *testing.T) {
 func TestSnapshotEngine_DeleteAll_ByLabels_Success(t *testing.T) {
 	snap := makeSnapshot("snap-1", "abc123", true)
 	dynCS := newDynClient(snap)
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	// Inject DELETED event so waitForSnapshotDeletion sees it gone immediately.
 	snapWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() { snapWatcher.Delete(snap) }()
 		return true, snapWatcher, nil
 	})
@@ -573,10 +573,10 @@ func TestSnapshotEngine_DeleteAll_ByLabels_Success(t *testing.T) {
 func TestSnapshotEngine_DeleteManualTriggers_RetryAndLeak(t *testing.T) {
 	dynCS := newDynClient()
 	// Always fail with a non-404 error so retries are exhausted.
-	dynCS.PrependReactor("delete", "podsnapshotmanualtriggers", func(action ktesting.Action) (bool, runtime.Object, error) {
+	dynCS.PrependReactor("delete", "podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("server unavailable")
 	})
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 	eng.createdManualTriggers = []string{"trigger-1"}
 
 	eng.DeleteManualTriggers(context.Background())
@@ -595,10 +595,10 @@ func TestSnapshotEngine_executeDeletion_DeleteAPIError(t *testing.T) {
 	snap := makeSnapshot("snap-1", "abc123", true)
 	dynCS := newDynClient(snap)
 	// Fail delete with a non-404 error.
-	dynCS.PrependReactor("delete", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+	dynCS.PrependReactor("delete", "podsnapshots", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("forbidden")
 	})
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	result := eng.executeDeletion(context.Background(), "snap-1", "", nil, 5*time.Second)
 	if result.Success {
@@ -617,18 +617,18 @@ func TestSnapshotEngine_executeDeletion_PartialFailure(t *testing.T) {
 	// snap-1 deletes successfully; snap-2 gets a DELETED event.
 	// snap-1: let the first delete succeed; snap-2: return an error.
 	callCount := 0
-	dynCS.PrependReactor("delete", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+	dynCS.PrependReactor("delete", "podsnapshots", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		callCount++
 		if callCount == 1 {
 			return true, nil, fmt.Errorf("network error for snap-1")
 		}
 		return false, nil, nil // let snap-2 go through default handling
 	})
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	// For snap-2: inject a DELETED watch event.
 	snapWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() { snapWatcher.Delete(snap2) }()
 		return true, snapWatcher, nil
 	})
@@ -656,7 +656,7 @@ func assertValidK8sName(t *testing.T, result string) {
 		t.Error("name must not be empty")
 	}
 	for _, ch := range result {
-		if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-') {
+		if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '-' {
 			t.Errorf("invalid char %q in %q", ch, result)
 		}
 	}
@@ -712,23 +712,22 @@ func TestSanitizeTriggerName_OnlyInvalidChars(t *testing.T) {
 	assertValidK8sName(t, result)
 }
 
-
 // ---------------------------------------------------------------------------
 // Issue 4: deterministic GroupingLabels label selector
 // ---------------------------------------------------------------------------
 
 func TestSnapshotEngine_List_GroupingLabelsDeterministic(t *testing.T) {
 	dynCS := newDynClient()
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 
 	var selectors []string
-	dynCS.PrependReactor("list", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
-		la := action.(ktesting.ListAction)
+	dynCS.PrependReactor("list", "podsnapshots", func(a ktesting.Action) (bool, runtime.Object, error) {
+		la := a.(ktesting.ListAction)
 		selectors = append(selectors, la.GetListRestrictions().Labels.String())
 		return true, &unstructured.UnstructuredList{}, nil
 	})
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		eng.List(context.Background(), SnapshotFilter{
 			ReadyOnly:      false,
 			GroupingLabels: map[string]string{"env": "prod", "team": "platform", "app": "agent"},
@@ -753,10 +752,10 @@ func TestSnapshotEngine_List_GroupingLabelsDeterministic(t *testing.T) {
 func TestDeleteManualTriggers_CtxCancelDuringRetry(t *testing.T) {
 	dynCS := newDynClient()
 	// Always fail with a non-404 error to force retries.
-	dynCS.PrependReactor("delete", "podsnapshotmanualtriggers", func(action ktesting.Action) (bool, runtime.Object, error) {
+	dynCS.PrependReactor("delete", "podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("server unavailable")
 	})
-	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng := newTestEngine(dynCS)
 	eng.createdManualTriggers = []string{"trigger-1"}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/clients/go/gke_extensions/snapshots/engine_test.go
+++ b/clients/go/gke_extensions/snapshots/engine_test.go
@@ -467,6 +467,33 @@ func TestSnapshotEngine_Create_EmptyPodName(t *testing.T) {
 	if resp.Success {
 		t.Error("expected failure when pod name is empty")
 	}
+	if !strings.Contains(resp.ErrorReason, "not yet available") {
+		t.Errorf("expected 'not yet available' in error reason, got %q", resp.ErrorReason)
+	}
+}
+
+func TestSnapshotEngine_Create_PodNameError(t *testing.T) {
+	dynCS := newDynClient()
+	eng := &SnapshotEngine{
+		namespace: "default",
+		dynClient: dynCS,
+		log:       logr.Discard(),
+		getPodName: func(_ context.Context) (string, error) {
+			return "", fmt.Errorf("pod lookup failed")
+		},
+		getSandboxNameHash: func(_ context.Context) (string, error) { return "abc123", nil },
+	}
+
+	resp := eng.Create(context.Background(), "test", 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when getPodName returns error")
+	}
+	if !strings.Contains(resp.ErrorReason, "failed to get pod name") {
+		t.Errorf("expected 'failed to get pod name' in error reason, got %q", resp.ErrorReason)
+	}
+	if !strings.Contains(resp.ErrorReason, "pod lookup failed") {
+		t.Errorf("expected underlying error text in reason, got %q", resp.ErrorReason)
+	}
 }
 
 func TestSnapshotEngine_Create_APIError(t *testing.T) {

--- a/clients/go/gke_extensions/snapshots/engine_test.go
+++ b/clients/go/gke_extensions/snapshots/engine_test.go
@@ -1,0 +1,643 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func newTestEngine(dynCS *fakedynamic.FakeDynamicClient, podName, hash string) *SnapshotEngine {
+	return &SnapshotEngine{
+		namespace: "default",
+		dynClient: dynCS,
+		log:       logr.Discard(),
+		getPodName: func() (string, error) {
+			return podName, nil
+		},
+		getSandboxNameHash: func() (string, error) {
+			return hash, nil
+		},
+	}
+}
+
+func newDynClient(extra ...runtime.Object) *fakedynamic.FakeDynamicClient {
+	return fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			triggerGVR:  "PodSnapshotManualTriggerList",
+			snapshotGVR: "PodSnapshotList",
+		},
+		extra...,
+	)
+}
+
+func makeSnapshot(name, hashLabel string, ready bool) *unstructured.Unstructured {
+	status := map[string]interface{}{}
+	if ready {
+		status["conditions"] = []interface{}{
+			map[string]interface{}{"type": "Ready", "status": "True"},
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       "PodSnapshot",
+			"metadata": map[string]interface{}{
+				"name":              name,
+				"namespace":         "default",
+				"creationTimestamp": "2026-01-01T00:00:00Z",
+				"labels":            map[string]interface{}{SandboxNameHashLabel: hashLabel},
+			},
+			"status": status,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeTriggerName
+// ---------------------------------------------------------------------------
+
+func TestSanitizeTriggerName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"simple", "my-trigger"},
+		{"underscores", "my_trigger"},
+		{"uppercase", "MY_TRIGGER"},
+		{"empty", ""},
+		{"long", "this-is-a-very-long-trigger-name-that-should-be-truncated-to-fit-k8s-limits"},
+		{"all dashes", "---"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sanitizeTriggerName(tc.input)
+			if len(result) > 63 {
+				t.Errorf("trigger name too long: %d chars: %s", len(result), result)
+			}
+			if result == "" {
+				t.Error("trigger name must not be empty")
+			}
+			for _, ch := range result {
+				if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-') {
+					t.Errorf("invalid character %q in trigger name %q", ch, result)
+				}
+			}
+		})
+	}
+}
+
+// TestSanitizeTriggerName_BaseCapAt38 verifies the 38-char truncation rule.
+// The suffix "-YYYYMMDD-HHMMSS-xxxxxxxx" is exactly 25 chars, so a base
+// longer than 38 chars must be truncated to 38, yielding a 63-char total.
+func TestSanitizeTriggerName_BaseCapAt38(t *testing.T) {
+	// 50 lowercase letters — well over the 38-char base limit.
+	longBase := "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx"
+	result := sanitizeTriggerName(longBase)
+
+	// Total must be exactly 63 chars: 38 (base) + 25 (suffix).
+	if len(result) != 63 {
+		t.Errorf("expected total length 63, got %d: %q", len(result), result)
+	}
+
+	// The base portion (everything before the first timestamp dash) must be
+	// exactly 38 chars. The suffix format is "-YYYYMMDD-HHMMSS-xxxxxxxx",
+	// so split on the first occurrence of "-2" (the timestamp prefix).
+	// More robustly: count that the result starts with 38 chars of the base.
+	if result[:38] != longBase[:38] {
+		t.Errorf("base not correctly truncated to 38 chars: got prefix %q", result[:38])
+	}
+}
+
+// TestSanitizeTriggerName_ExactlyAtLimit verifies that a base of exactly 38
+// chars is kept as-is (not trimmed further).
+func TestSanitizeTriggerName_ExactlyAtLimit(t *testing.T) {
+	base38 := "abcdefghijklmnopqrstuvwxyzabcdefghijkl" // exactly 38 chars
+	result := sanitizeTriggerName(base38)
+
+	if len(result) != 63 {
+		t.Errorf("expected total length 63, got %d: %q", len(result), result)
+	}
+	if result[:38] != base38 {
+		t.Errorf("38-char base was unexpectedly modified: got prefix %q", result[:38])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.List
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_List_AllReady(t *testing.T) {
+	snap1 := makeSnapshot("snap-1", "abc123", true)
+	snap2 := makeSnapshot("snap-2", "abc123", false)
+	dynCS := newDynClient(snap1, snap2)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: true})
+
+	if !result.Success {
+		t.Fatalf("expected success, got error: %s", result.ErrorReason)
+	}
+	if len(result.Snapshots) != 1 {
+		t.Fatalf("expected 1 ready snapshot, got %d", len(result.Snapshots))
+	}
+	if result.Snapshots[0].SnapshotUID != "snap-1" {
+		t.Errorf("expected snap-1, got %s", result.Snapshots[0].SnapshotUID)
+	}
+}
+
+func TestSnapshotEngine_List_IncludeNotReady(t *testing.T) {
+	snap1 := makeSnapshot("snap-1", "abc123", true)
+	snap2 := makeSnapshot("snap-2", "abc123", false)
+	dynCS := newDynClient(snap1, snap2)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: false})
+
+	if !result.Success {
+		t.Fatalf("expected success, got error: %s", result.ErrorReason)
+	}
+	if len(result.Snapshots) != 2 {
+		t.Fatalf("expected 2 snapshots, got %d", len(result.Snapshots))
+	}
+}
+
+func TestSnapshotEngine_List_NoPodName(t *testing.T) {
+	dynCS := newDynClient()
+	eng := &SnapshotEngine{
+		namespace:  "default",
+		dynClient:  dynCS,
+		log:        logr.Discard(),
+		getPodName: func() (string, error) { return "", nil },
+		getSandboxNameHash: func() (string, error) {
+			return "abc123", nil
+		},
+	}
+
+	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: true})
+	if result.Success {
+		t.Error("expected failure when pod name is empty")
+	}
+}
+
+func TestSnapshotEngine_List_NoHash(t *testing.T) {
+	dynCS := newDynClient()
+	eng := &SnapshotEngine{
+		namespace:          "default",
+		dynClient:          dynCS,
+		log:                logr.Discard(),
+		getPodName:         func() (string, error) { return "my-pod", nil },
+		getSandboxNameHash: func() (string, error) { return "", nil },
+	}
+
+	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: true})
+	if result.Success {
+		t.Error("expected failure when sandbox name hash is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.Delete
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_Delete_Success(t *testing.T) {
+	snap := makeSnapshot("snap-1", "abc123", true)
+	dynCS := newDynClient(snap)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	// Inject a watch that immediately returns DELETED.
+	snapWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			snapWatcher.Delete(snap)
+		}()
+		return true, snapWatcher, nil
+	})
+
+	result := eng.Delete(context.Background(), "snap-1", 5*time.Second)
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.ErrorReason)
+	}
+	if len(result.DeletedSnapshots) != 1 || result.DeletedSnapshots[0] != "snap-1" {
+		t.Errorf("unexpected deleted snapshots: %v", result.DeletedSnapshots)
+	}
+}
+
+func TestSnapshotEngine_Delete_AlreadyGone(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	// Object doesn't exist; waitForSnapshotDeletion first GETs the object to check.
+	// The GET will return 404, so deletion is considered successful immediately.
+	result := eng.Delete(context.Background(), "nonexistent", 5*time.Second)
+	if !result.Success {
+		t.Fatalf("expected success for already-deleted snapshot, got: %s", result.ErrorReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.DeleteManualTriggers
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_DeleteManualTriggers(t *testing.T) {
+	trigger := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       PodSnapshotTriggerKind,
+			"metadata": map[string]interface{}{
+				"name":      "my-trigger",
+				"namespace": "default",
+			},
+		},
+	}
+	dynCS := newDynClient(trigger)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng.createdManualTriggers = []string{"my-trigger"}
+
+	eng.DeleteManualTriggers(context.Background())
+
+	if len(eng.createdManualTriggers) != 0 {
+		t.Errorf("expected createdManualTriggers to be empty, got %v", eng.createdManualTriggers)
+	}
+}
+
+func TestSnapshotEngine_DeleteManualTriggers_AlreadyGone(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng.createdManualTriggers = []string{"ghost-trigger"}
+
+	eng.DeleteManualTriggers(context.Background())
+
+	// A 404 is silently ignored; no remaining triggers.
+	if len(eng.createdManualTriggers) != 0 {
+		t.Errorf("expected empty triggers after 404, got %v", eng.createdManualTriggers)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.Create (watch-based)
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_Create_Success(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	// Inject a watch reactor that immediately fires MODIFIED with completion status.
+	trigWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			completedTrigger := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+					"kind":       PodSnapshotTriggerKind,
+					"metadata": map[string]interface{}{
+						"name":      "snap",
+						"namespace": "default",
+					},
+					"status": map[string]interface{}{
+						"snapshotCreated": map[string]interface{}{"name": "snap-uid-123"},
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":               "Triggered",
+								"status":             "True",
+								"reason":             "Complete",
+								"lastTransitionTime": "2026-01-01T00:00:00Z",
+							},
+						},
+					},
+				},
+			}
+			trigWatcher.Modify(completedTrigger)
+		}()
+		return true, trigWatcher, nil
+	})
+
+	resp := eng.Create(context.Background(), "test-snapshot", 5*time.Second)
+	if !resp.Success {
+		t.Fatalf("expected success, got: %s", resp.ErrorReason)
+	}
+	if resp.SnapshotUID != "snap-uid-123" {
+		t.Errorf("expected snapshotUID=snap-uid-123, got %q", resp.SnapshotUID)
+	}
+	if len(eng.createdManualTriggers) != 1 {
+		t.Errorf("expected 1 tracked trigger, got %d", len(eng.createdManualTriggers))
+	}
+}
+
+func TestSnapshotEngine_Create_Failure(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	trigWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			failedTrigger := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+					"kind":       PodSnapshotTriggerKind,
+					"metadata": map[string]interface{}{"name": "snap", "namespace": "default"},
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":    "Triggered",
+								"status":  "False",
+								"reason":  "Failed",
+								"message": "out of disk space",
+							},
+						},
+					},
+				},
+			}
+			trigWatcher.Modify(failedTrigger)
+		}()
+		return true, trigWatcher, nil
+	})
+
+	resp := eng.Create(context.Background(), "test-snapshot", 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure for failed snapshot")
+	}
+}
+
+func TestSnapshotEngine_Create_Timeout(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	// Return a watcher that never fires.
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+		return true, watch.NewFake(), nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	resp := eng.Create(ctx, "test-snapshot", 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure on timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.DeleteAll
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_DeleteAll_Empty(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result, err := eng.DeleteAll(context.Background(), "all", nil, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.ErrorReason)
+	}
+	if len(result.DeletedSnapshots) != 0 {
+		t.Errorf("expected no deletions, got %v", result.DeletedSnapshots)
+	}
+}
+
+func TestSnapshotEngine_DeleteAll_InvalidStrategy(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	_, err := eng.DeleteAll(context.Background(), "unknown", nil, 5*time.Second)
+	if err == nil {
+		t.Error("expected error for unknown deleteBy strategy")
+	}
+}
+
+func TestSnapshotEngine_DeleteAll_ByLabelsRequiresLabels(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	_, err := eng.DeleteAll(context.Background(), "labels", nil, 5*time.Second)
+	if err == nil {
+		t.Error("expected error when deleteBy=labels but no labelValue")
+	}
+
+	// Provide metav1 timestamp import check.
+	_ = metav1.Now()
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.Create — error paths
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_Create_EmptyPodName(t *testing.T) {
+	dynCS := newDynClient()
+	eng := &SnapshotEngine{
+		namespace:          "default",
+		dynClient:          dynCS,
+		log:                logr.Discard(),
+		getPodName:         func() (string, error) { return "", nil },
+		getSandboxNameHash: func() (string, error) { return "abc123", nil },
+	}
+
+	resp := eng.Create(context.Background(), "test", 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when pod name is empty")
+	}
+}
+
+func TestSnapshotEngine_Create_APIError(t *testing.T) {
+	dynCS := newDynClient()
+	dynCS.PrependReactor("create", "podsnapshotmanualtriggers", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("server error")
+	})
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	resp := eng.Create(context.Background(), "test", 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure on API error creating trigger")
+	}
+	// Trigger name should still be returned for debugging.
+	if resp.TriggerName == "" {
+		t.Error("TriggerName should be set even on failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.List — additional paths
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_List_WithGroupingLabels(t *testing.T) {
+	snap := makeSnapshot("snap-1", "abc123", true)
+	dynCS := newDynClient(snap)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result := eng.List(context.Background(), SnapshotFilter{
+		ReadyOnly:      true,
+		GroupingLabels: map[string]string{"env": "prod"},
+	})
+
+	// The fake dynamic client ignores label selectors, so we just verify the
+	// call succeeds and returns structurally valid results.
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.ErrorReason)
+	}
+}
+
+func TestSnapshotEngine_List_APIError(t *testing.T) {
+	dynCS := newDynClient()
+	dynCS.PrependReactor("list", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("network error")
+	})
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: false})
+	if result.Success {
+		t.Error("expected failure on list API error")
+	}
+}
+
+func TestSnapshotEngine_List_WithPodAnnotation(t *testing.T) {
+	snap := makeSnapshot("snap-1", "abc123", true)
+	// Add the pod annotation.
+	annotations := map[string]interface{}{PodSnapshotPodAnnotation: "origin-pod-xyz"}
+	snap.Object["metadata"].(map[string]interface{})["annotations"] = annotations
+
+	dynCS := newDynClient(snap)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: false})
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.ErrorReason)
+	}
+	if len(result.Snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(result.Snapshots))
+	}
+	if result.Snapshots[0].SourcePod != "origin-pod-xyz" {
+		t.Errorf("expected SourcePod=origin-pod-xyz, got %q", result.Snapshots[0].SourcePod)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.DeleteAll — "labels" path
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_DeleteAll_ByLabels_Success(t *testing.T) {
+	snap := makeSnapshot("snap-1", "abc123", true)
+	dynCS := newDynClient(snap)
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	// Inject DELETED event so waitForSnapshotDeletion sees it gone immediately.
+	snapWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() { snapWatcher.Delete(snap) }()
+		return true, snapWatcher, nil
+	})
+
+	result, err := eng.DeleteAll(context.Background(), "labels", map[string]string{"env": "test"}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got: %s", result.ErrorReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotEngine.DeleteManualTriggers — retry/leak paths
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_DeleteManualTriggers_RetryAndLeak(t *testing.T) {
+	dynCS := newDynClient()
+	// Always fail with a non-404 error so retries are exhausted.
+	dynCS.PrependReactor("delete", "podsnapshotmanualtriggers", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("server unavailable")
+	})
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng.createdManualTriggers = []string{"trigger-1"}
+
+	eng.DeleteManualTriggers(context.Background())
+
+	// After maxRetries exhausted, trigger should be reported as leaked.
+	if len(eng.createdManualTriggers) == 0 {
+		t.Error("expected trigger to remain in createdManualTriggers after exhausting retries")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// executeDeletion — delete API error and partial failure
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_executeDeletion_DeleteAPIError(t *testing.T) {
+	snap := makeSnapshot("snap-1", "abc123", true)
+	dynCS := newDynClient(snap)
+	// Fail delete with a non-404 error.
+	dynCS.PrependReactor("delete", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("forbidden")
+	})
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	result := eng.executeDeletion(context.Background(), "snap-1", "", nil, 5*time.Second)
+	if result.Success {
+		t.Error("expected failure when delete API returns error")
+	}
+	if result.ErrorReason == "" {
+		t.Error("ErrorReason should be set")
+	}
+}
+
+func TestSnapshotEngine_executeDeletion_PartialFailure(t *testing.T) {
+	snap1 := makeSnapshot("snap-1", "abc123", true)
+	snap2 := makeSnapshot("snap-2", "abc123", true)
+	dynCS := newDynClient(snap1, snap2)
+
+	// snap-1 deletes successfully; snap-2 gets a DELETED event.
+	// snap-1: let the first delete succeed; snap-2: return an error.
+	callCount := 0
+	dynCS.PrependReactor("delete", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		if callCount == 1 {
+			return true, nil, fmt.Errorf("network error for snap-1")
+		}
+		return false, nil, nil // let snap-2 go through default handling
+	})
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	// For snap-2: inject a DELETED watch event.
+	snapWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() { snapWatcher.Delete(snap2) }()
+		return true, snapWatcher, nil
+	})
+
+	result := eng.executeDeletion(context.Background(), "", "global", nil, 5*time.Second)
+	// At least one error and at least one deletion: partial failure.
+	if result.Success {
+		t.Error("expected partial failure result")
+	}
+	if len(result.DeletedSnapshots) == 0 {
+		t.Error("expected at least one successfully deleted snapshot in partial failure")
+	}
+}

--- a/clients/go/gke_extensions/snapshots/engine_test.go
+++ b/clients/go/gke_extensions/snapshots/engine_test.go
@@ -17,6 +17,7 @@ package snapshots
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,10 +40,10 @@ func newTestEngine(dynCS *fakedynamic.FakeDynamicClient, podName, hash string) *
 		namespace: "default",
 		dynClient: dynCS,
 		log:       logr.Discard(),
-		getPodName: func() (string, error) {
+		getPodName: func(_ context.Context) (string, error) {
 			return podName, nil
 		},
-		getSandboxNameHash: func() (string, error) {
+		getSandboxNameHash: func(_ context.Context) (string, error) {
 			return hash, nil
 		},
 	}
@@ -196,8 +197,8 @@ func TestSnapshotEngine_List_NoPodName(t *testing.T) {
 		namespace:  "default",
 		dynClient:  dynCS,
 		log:        logr.Discard(),
-		getPodName: func() (string, error) { return "", nil },
-		getSandboxNameHash: func() (string, error) {
+		getPodName: func(_ context.Context) (string, error) { return "", nil },
+		getSandboxNameHash: func(_ context.Context) (string, error) {
 			return "abc123", nil
 		},
 	}
@@ -214,8 +215,8 @@ func TestSnapshotEngine_List_NoHash(t *testing.T) {
 		namespace:          "default",
 		dynClient:          dynCS,
 		log:                logr.Discard(),
-		getPodName:         func() (string, error) { return "my-pod", nil },
-		getSandboxNameHash: func() (string, error) { return "", nil },
+		getPodName:         func(_ context.Context) (string, error) { return "my-pod", nil },
+		getSandboxNameHash: func(_ context.Context) (string, error) { return "", nil },
 	}
 
 	result := eng.List(context.Background(), SnapshotFilter{ReadyOnly: true})
@@ -458,8 +459,8 @@ func TestSnapshotEngine_Create_EmptyPodName(t *testing.T) {
 		namespace:          "default",
 		dynClient:          dynCS,
 		log:                logr.Discard(),
-		getPodName:         func() (string, error) { return "", nil },
-		getSandboxNameHash: func() (string, error) { return "abc123", nil },
+		getPodName:         func(_ context.Context) (string, error) { return "", nil },
+		getSandboxNameHash: func(_ context.Context) (string, error) { return "abc123", nil },
 	}
 
 	resp := eng.Create(context.Background(), "test", 5*time.Second)
@@ -639,5 +640,137 @@ func TestSnapshotEngine_executeDeletion_PartialFailure(t *testing.T) {
 	}
 	if len(result.DeletedSnapshots) == 0 {
 		t.Error("expected at least one successfully deleted snapshot in partial failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 1: sanitizeTriggerName — invalid character stripping
+// ---------------------------------------------------------------------------
+
+func assertValidK8sName(t *testing.T, result string) {
+	t.Helper()
+	if len(result) > 63 {
+		t.Errorf("name too long (%d): %q", len(result), result)
+	}
+	if result == "" {
+		t.Error("name must not be empty")
+	}
+	for _, ch := range result {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-') {
+			t.Errorf("invalid char %q in %q", ch, result)
+		}
+	}
+	if result[0] == '-' || result[len(result)-1] == '-' {
+		t.Errorf("name must not start or end with dash: %q", result)
+	}
+}
+
+func TestSanitizeTriggerName_Space(t *testing.T) {
+	result := sanitizeTriggerName("my trigger")
+	assertValidK8sName(t, result)
+}
+
+func TestSanitizeTriggerName_Dot(t *testing.T) {
+	result := sanitizeTriggerName("snap.v2")
+	assertValidK8sName(t, result)
+	if !strings.Contains(result, "snap") || !strings.Contains(result, "v2") {
+		t.Errorf("expected base to contain snap and v2, got %q", result)
+	}
+}
+
+func TestSanitizeTriggerName_Slash(t *testing.T) {
+	result := sanitizeTriggerName("ns/pod")
+	assertValidK8sName(t, result)
+}
+
+func TestSanitizeTriggerName_AtSign(t *testing.T) {
+	result := sanitizeTriggerName("user@domain")
+	assertValidK8sName(t, result)
+}
+
+func TestSanitizeTriggerName_Mixed(t *testing.T) {
+	result := sanitizeTriggerName("My Trigger/v2.0@host")
+	assertValidK8sName(t, result)
+}
+
+func TestSanitizeTriggerName_ConsecutiveDashes(t *testing.T) {
+	// underscores → dashes, then consecutive dashes must be collapsed
+	result := sanitizeTriggerName("a__b")
+	assertValidK8sName(t, result)
+	if strings.Contains(result, "--") {
+		t.Errorf("consecutive dashes not collapsed: %q", result)
+	}
+}
+
+func TestSanitizeTriggerName_LeadingInvalidChars(t *testing.T) {
+	result := sanitizeTriggerName("...abc")
+	assertValidK8sName(t, result)
+}
+
+func TestSanitizeTriggerName_OnlyInvalidChars(t *testing.T) {
+	result := sanitizeTriggerName("@@@")
+	assertValidK8sName(t, result)
+}
+
+
+// ---------------------------------------------------------------------------
+// Issue 4: deterministic GroupingLabels label selector
+// ---------------------------------------------------------------------------
+
+func TestSnapshotEngine_List_GroupingLabelsDeterministic(t *testing.T) {
+	dynCS := newDynClient()
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+
+	var selectors []string
+	dynCS.PrependReactor("list", "podsnapshots", func(action ktesting.Action) (bool, runtime.Object, error) {
+		la := action.(ktesting.ListAction)
+		selectors = append(selectors, la.GetListRestrictions().Labels.String())
+		return true, &unstructured.UnstructuredList{}, nil
+	})
+
+	for i := 0; i < 10; i++ {
+		eng.List(context.Background(), SnapshotFilter{
+			ReadyOnly:      false,
+			GroupingLabels: map[string]string{"env": "prod", "team": "platform", "app": "agent"},
+		})
+	}
+
+	if len(selectors) == 0 {
+		t.Fatal("no list calls recorded")
+	}
+	first := selectors[0]
+	for i, sel := range selectors[1:] {
+		if sel != first {
+			t.Errorf("call %d produced different selector: got %q, want %q", i+1, sel, first)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 5: DeleteManualTriggers respects context cancellation during retry sleep
+// ---------------------------------------------------------------------------
+
+func TestDeleteManualTriggers_CtxCancelDuringRetry(t *testing.T) {
+	dynCS := newDynClient()
+	// Always fail with a non-404 error to force retries.
+	dynCS.PrependReactor("delete", "podsnapshotmanualtriggers", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("server unavailable")
+	})
+	eng := newTestEngine(dynCS, "my-pod", "abc123")
+	eng.createdManualTriggers = []string{"trigger-1"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel the context right away so the retry sleep is interrupted.
+	cancel()
+
+	start := time.Now()
+	eng.DeleteManualTriggers(ctx)
+	elapsed := time.Since(start)
+
+	// With a cancelled context the retry sleep should be skipped.
+	// Allow generous margin — should complete in well under 1 second.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("DeleteManualTriggers blocked too long with cancelled ctx: %v (want < 500ms)", elapsed)
 	}
 }

--- a/clients/go/gke_extensions/snapshots/sandbox.go
+++ b/clients/go/gke_extensions/snapshots/sandbox.go
@@ -61,6 +61,15 @@ func NewSandboxWithSnapshotSupport(
 	}
 }
 
+// IsActive reports whether the sandbox handle is ready for communication and
+// the snapshot engine has been initialised.
+// Mirrors Python's SandboxWithSnapshotSupport.is_active().
+func (s *SandboxWithSnapshotSupport) IsActive() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.Handle.IsReady() && s.engine != nil
+}
+
 // Snapshots returns the SnapshotEngine for this sandbox, initialising it lazily.
 func (s *SandboxWithSnapshotSupport) Snapshots() *SnapshotEngine {
 	s.mu.Lock()
@@ -236,8 +245,7 @@ func (s *SandboxWithSnapshotSupport) Resume(ctx context.Context, timeout time.Du
 	}
 	s.log.Info("sandbox scaled to 1 replica", "sandbox", s.Info.SandboxName())
 
-	podName := s.Info.PodName()
-	if !waitForPodReady(ctx, s.k8s.CoreClient, s.namespace, podName, timeout, s.log) {
+	if !waitForPodReady(ctx, s.k8s.CoreClient, s.namespace, s.Info.PodName, timeout, s.log) {
 		s.log.Info("timed out waiting for pod to become ready", "sandbox", s.Info.SandboxName())
 		return ResumeResponse{
 			Success:     false,

--- a/clients/go/gke_extensions/snapshots/sandbox.go
+++ b/clients/go/gke_extensions/snapshots/sandbox.go
@@ -52,14 +52,13 @@ func NewSandboxWithSnapshotSupport(
 	namespace string,
 	log logr.Logger,
 ) *SandboxWithSnapshotSupport {
-	s := &SandboxWithSnapshotSupport{
+	return &SandboxWithSnapshotSupport{
 		Handle:    handle,
 		Info:      info,
 		k8s:       k8s,
 		namespace: namespace,
 		log:       log,
 	}
-	return s
 }
 
 // Snapshots returns the SnapshotEngine for this sandbox, initialising it lazily.
@@ -70,15 +69,15 @@ func (s *SandboxWithSnapshotSupport) Snapshots() *SnapshotEngine {
 		s.engine = NewSnapshotEngine(
 			s.namespace,
 			s.k8s,
-			func() (string, error) {
+			func(ctx context.Context) (string, error) {
 				name := s.Info.PodName()
 				if name == "" {
 					return "", fmt.Errorf("pod name not yet available; ensure the sandbox is open")
 				}
 				return name, nil
 			},
-			func() (string, error) {
-				return s.resolveSandboxNameHash()
+			func(ctx context.Context) (string, error) {
+				return s.resolveSandboxNameHash(ctx)
 			},
 			s.log,
 		)
@@ -137,7 +136,9 @@ func (s *SandboxWithSnapshotSupport) Suspend(ctx context.Context, snapshotBefore
 	}
 
 	// Pre-resolve sandbox name hash while the sandbox is still running.
-	if _, err := s.resolveSandboxNameHash(); err != nil {
+	// The hash must be cached before scaling to 0 replicas, since the
+	// Sandbox CR's status.selector may be cleared once the pod terminates.
+	if _, err := s.resolveSandboxNameHash(ctx); err != nil {
 		s.log.Error(err, "cannot suspend: failed to resolve sandbox name hash")
 		return SuspendResponse{
 			Success:     false,
@@ -289,8 +290,9 @@ func (s *SandboxWithSnapshotSupport) Close(ctx context.Context) error {
 }
 
 // resolveSandboxNameHash fetches (and caches) the sandbox-name-hash label value
-// from the Sandbox CR's status.selector field.
-func (s *SandboxWithSnapshotSupport) resolveSandboxNameHash() (string, error) {
+// from the Sandbox CR's status.selector field. The provided ctx is forwarded to
+// the Kubernetes API call so that caller timeouts and cancellation are respected.
+func (s *SandboxWithSnapshotSupport) resolveSandboxNameHash(ctx context.Context) (string, error) {
 	s.mu.Lock()
 	if s.snapshotHash != "" {
 		h := s.snapshotHash
@@ -299,7 +301,7 @@ func (s *SandboxWithSnapshotSupport) resolveSandboxNameHash() (string, error) {
 	}
 	s.mu.Unlock()
 
-	sb, err := s.k8s.AgentsClient.Sandboxes(s.namespace).Get(context.Background(), s.Info.SandboxName(), metav1.GetOptions{})
+	sb, err := s.k8s.AgentsClient.Sandboxes(s.namespace).Get(ctx, s.Info.SandboxName(), metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("getting sandbox CR: %w", err)
 	}

--- a/clients/go/gke_extensions/snapshots/sandbox.go
+++ b/clients/go/gke_extensions/snapshots/sandbox.go
@@ -193,6 +193,11 @@ func (s *SandboxWithSnapshotSupport) Suspend(ctx context.Context, snapshotBefore
 	}
 	s.log.Info("sandbox scaled to 0 replicas", "sandbox", s.Info.SandboxName())
 
+	if podName == "" {
+		s.log.Info("pod name was unknown at suspend time; skipping termination wait", "sandbox", s.Info.SandboxName())
+		return SuspendResponse{Success: true, SnapshotResponse: snapshotResp, ErrorCode: SuccessCode}
+	}
+
 	if waitForPodTermination(ctx, s.k8s.CoreClient, s.namespace, podName, podUID, timeout, s.log) {
 		s.log.Info("sandbox pod terminated", "sandbox", s.Info.SandboxName())
 		return SuspendResponse{

--- a/clients/go/gke_extensions/snapshots/sandbox.go
+++ b/clients/go/gke_extensions/snapshots/sandbox.go
@@ -230,8 +230,16 @@ func (s *SandboxWithSnapshotSupport) Resume(ctx context.Context, timeout time.Du
 
 	// Capture the latest snapshot UID before scaling up to compare after resume.
 	listResult := s.Snapshots().List(ctx, SnapshotFilter{ReadyOnly: true})
+	if !listResult.Success {
+		s.log.Error(nil, "failed to list snapshots before resume", "reason", listResult.ErrorReason)
+		return ResumeResponse{
+			Success:     false,
+			ErrorReason: "failed to list snapshots: " + listResult.ErrorReason,
+			ErrorCode:   ErrorCode,
+		}
+	}
 	var latestSnapshotUID string
-	if listResult.Success && len(listResult.Snapshots) > 0 {
+	if len(listResult.Snapshots) > 0 {
 		latestSnapshotUID = listResult.Snapshots[0].SnapshotUID
 	}
 
@@ -316,13 +324,17 @@ func (s *SandboxWithSnapshotSupport) resolveSandboxNameHash(ctx context.Context)
 
 	// LabelSelector format: "agents.x-k8s.io/sandbox-name-hash=<value>"
 	sel := sb.Status.LabelSelector
+	if sel == "" {
+		return "", fmt.Errorf("sandbox %q has no status.selector yet; ensure the sandbox is running", s.Info.SandboxName())
+	}
 	if key, val, found := strings.Cut(sel, "="); found && key == SandboxNameHashLabel && val != "" {
 		s.mu.Lock()
 		s.snapshotHash = val
 		s.mu.Unlock()
 		return val, nil
 	}
-	return "", nil
+	return "", fmt.Errorf("sandbox %q status.selector %q does not contain expected label %q",
+		s.Info.SandboxName(), sel, SandboxNameHashLabel)
 }
 
 // setReplicas patches spec.replicas on the Sandbox CR.

--- a/clients/go/gke_extensions/snapshots/sandbox.go
+++ b/clients/go/gke_extensions/snapshots/sandbox.go
@@ -1,0 +1,333 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	sandbox "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+// SandboxWithSnapshotSupport wraps a sandbox.Handle and sandbox.Info with
+// GKE Pod Snapshot lifecycle operations (suspend, resume, snapshot CRUD).
+type SandboxWithSnapshotSupport struct {
+	sandbox.Handle
+	sandbox.Info
+
+	k8s       *sandbox.K8sHelper
+	namespace string
+	log       logr.Logger
+
+	mu           sync.Mutex
+	snapshotHash string // cached sandbox-name-hash value
+	engine       *SnapshotEngine
+}
+
+// NewSandboxWithSnapshotSupport wraps an existing sandbox handle with snapshot support.
+// handle and info are typically the same *sandbox.Sandbox.
+func NewSandboxWithSnapshotSupport(
+	handle sandbox.Handle,
+	info sandbox.Info,
+	k8s *sandbox.K8sHelper,
+	namespace string,
+	log logr.Logger,
+) *SandboxWithSnapshotSupport {
+	s := &SandboxWithSnapshotSupport{
+		Handle:    handle,
+		Info:      info,
+		k8s:       k8s,
+		namespace: namespace,
+		log:       log,
+	}
+	return s
+}
+
+// Snapshots returns the SnapshotEngine for this sandbox, initialising it lazily.
+func (s *SandboxWithSnapshotSupport) Snapshots() *SnapshotEngine {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.engine == nil {
+		s.engine = NewSnapshotEngine(
+			s.namespace,
+			s.k8s,
+			func() (string, error) {
+				name := s.Info.PodName()
+				if name == "" {
+					return "", fmt.Errorf("pod name not yet available; ensure the sandbox is open")
+				}
+				return name, nil
+			},
+			func() (string, error) {
+				return s.resolveSandboxNameHash()
+			},
+			s.log,
+		)
+	}
+	return s.engine
+}
+
+// IsSuspended reports whether the sandbox is currently suspended (spec.replicas == 0).
+func (s *SandboxWithSnapshotSupport) IsSuspended(ctx context.Context) (bool, error) {
+	sb, err := s.k8s.AgentsClient.Sandboxes(s.namespace).Get(ctx, s.Info.SandboxName(), metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("checking suspend state: %w", err)
+	}
+	if sb.Spec.Replicas != nil && *sb.Spec.Replicas == 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// IsRestoredFromSnapshot checks whether the sandbox pod was restored from snapshotUID.
+func (s *SandboxWithSnapshotSupport) IsRestoredFromSnapshot(ctx context.Context, snapshotUID string) RestoreCheckResult {
+	if snapshotUID == "" {
+		return RestoreCheckResult{
+			Success:     false,
+			ErrorReason: "snapshotUID cannot be empty",
+			ErrorCode:   ErrorCode,
+		}
+	}
+	podName := s.Info.PodName()
+	if podName == "" {
+		return RestoreCheckResult{
+			Success:     false,
+			ErrorReason: "pod name not found; ensure sandbox is open",
+			ErrorCode:   ErrorCode,
+		}
+	}
+	return checkPodRestoredFromSnapshot(ctx, s.k8s.CoreClient, s.namespace, podName, snapshotUID, s.log)
+}
+
+// Suspend suspends the sandbox by scaling it to zero replicas.
+// If snapshotBeforeSuspend is true, a snapshot is created first.
+// timeout controls how long to wait for the pod to terminate.
+func (s *SandboxWithSnapshotSupport) Suspend(ctx context.Context, snapshotBeforeSuspend bool, timeout time.Duration) SuspendResponse {
+	suspended, err := s.IsSuspended(ctx)
+	if err != nil {
+		s.log.Error(err, "failed to check suspend state before suspend")
+		return SuspendResponse{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("failed to check suspend state: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+	if suspended {
+		s.log.Info("sandbox is already suspended", "sandbox", s.Info.SandboxName())
+		return SuspendResponse{Success: true, ErrorCode: SuccessCode}
+	}
+
+	// Pre-resolve sandbox name hash while the sandbox is still running.
+	if _, err := s.resolveSandboxNameHash(); err != nil {
+		s.log.Error(err, "cannot suspend: failed to resolve sandbox name hash")
+		return SuspendResponse{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("failed to resolve sandbox name hash: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	var snapshotResp *SnapshotResponse
+	if snapshotBeforeSuspend {
+		triggerName := "suspend-" + s.Info.SandboxName()
+		resp := s.Snapshots().Create(ctx, triggerName, timeout)
+		if !resp.Success {
+			s.log.Error(nil, "snapshot before suspend failed", "reason", resp.ErrorReason)
+			return SuspendResponse{
+				Success:          false,
+				SnapshotResponse: &resp,
+				ErrorReason:      "snapshot failed: " + resp.ErrorReason,
+				ErrorCode:        ErrorCode,
+			}
+		}
+		snapshotResp = &resp
+	}
+
+	// Capture pod UID before scaling down so we can detect termination.
+	podName := s.Info.PodName()
+	podUID := ""
+	if podName != "" {
+		pod, err := s.k8s.CoreClient.Pods(s.namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err == nil {
+			podUID = string(pod.UID)
+		}
+	}
+
+	if err := s.setReplicas(ctx, 0); err != nil {
+		s.log.Error(err, "failed to scale sandbox to 0")
+		return SuspendResponse{
+			Success:          false,
+			SnapshotResponse: snapshotResp,
+			ErrorReason:      fmt.Sprintf("failed to scale down sandbox: %v", err),
+			ErrorCode:        ErrorCode,
+		}
+	}
+	s.log.Info("sandbox scaled to 0 replicas", "sandbox", s.Info.SandboxName())
+
+	if waitForPodTermination(ctx, s.k8s.CoreClient, s.namespace, podName, podUID, timeout, s.log) {
+		s.log.Info("sandbox pod terminated", "sandbox", s.Info.SandboxName())
+		return SuspendResponse{
+			Success:          true,
+			SnapshotResponse: snapshotResp,
+			ErrorCode:        SuccessCode,
+		}
+	}
+
+	s.log.Info("timed out waiting for pod termination", "sandbox", s.Info.SandboxName())
+	return SuspendResponse{
+		Success:          false,
+		SnapshotResponse: snapshotResp,
+		ErrorReason:      "timed out waiting for pod to terminate",
+		ErrorCode:        ErrorCode,
+	}
+}
+
+// Resume resumes the sandbox by scaling it to one replica.
+// timeout controls how long to wait for the pod to become ready.
+func (s *SandboxWithSnapshotSupport) Resume(ctx context.Context, timeout time.Duration) ResumeResponse {
+	suspended, err := s.IsSuspended(ctx)
+	if err != nil {
+		s.log.Error(err, "failed to check suspend state before resume")
+		return ResumeResponse{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("failed to check suspend state: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+	if !suspended {
+		s.log.Info("sandbox is already running (not suspended)", "sandbox", s.Info.SandboxName())
+		return ResumeResponse{Success: true, ErrorCode: SuccessCode}
+	}
+
+	// Capture the latest snapshot UID before scaling up to compare after resume.
+	listResult := s.Snapshots().List(ctx, SnapshotFilter{ReadyOnly: true})
+	var latestSnapshotUID string
+	if listResult.Success && len(listResult.Snapshots) > 0 {
+		latestSnapshotUID = listResult.Snapshots[0].SnapshotUID
+	}
+
+	if err := s.setReplicas(ctx, 1); err != nil {
+		s.log.Error(err, "failed to scale sandbox to 1")
+		return ResumeResponse{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("failed to scale up sandbox: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+	s.log.Info("sandbox scaled to 1 replica", "sandbox", s.Info.SandboxName())
+
+	podName := s.Info.PodName()
+	if !waitForPodReady(ctx, s.k8s.CoreClient, s.namespace, podName, timeout, s.log) {
+		s.log.Info("timed out waiting for pod to become ready", "sandbox", s.Info.SandboxName())
+		return ResumeResponse{
+			Success:     false,
+			SnapshotUID: latestSnapshotUID,
+			ErrorReason: "timed out waiting for pod to become ready",
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	if latestSnapshotUID == "" {
+		s.log.Info("no previous snapshots found; pod started fresh", "sandbox", s.Info.SandboxName())
+		return ResumeResponse{
+			Success:              true,
+			RestoredFromSnapshot: false,
+			ErrorCode:            SuccessCode,
+		}
+	}
+
+	restoreCheck := s.IsRestoredFromSnapshot(ctx, latestSnapshotUID)
+	if restoreCheck.Success {
+		s.log.Info("sandbox restored from snapshot", "sandbox", s.Info.SandboxName(), "snapshotUID", latestSnapshotUID)
+		return ResumeResponse{
+			Success:              true,
+			RestoredFromSnapshot: true,
+			SnapshotUID:          latestSnapshotUID,
+			ErrorCode:            SuccessCode,
+		}
+	}
+
+	s.log.Error(nil, "pod ready but not restored from snapshot", "reason", restoreCheck.ErrorReason)
+	return ResumeResponse{
+		Success:              false,
+		RestoredFromSnapshot: false,
+		SnapshotUID:          latestSnapshotUID,
+		ErrorReason:          "pod ready but not restored from snapshot: " + restoreCheck.ErrorReason,
+		ErrorCode:            ErrorCode,
+	}
+}
+
+// Close cleans up snapshot trigger resources and then closes the underlying sandbox.
+func (s *SandboxWithSnapshotSupport) Close(ctx context.Context) error {
+	s.mu.Lock()
+	eng := s.engine
+	s.mu.Unlock()
+
+	if eng != nil {
+		eng.DeleteManualTriggers(ctx)
+	}
+	return s.Handle.Close(ctx)
+}
+
+// resolveSandboxNameHash fetches (and caches) the sandbox-name-hash label value
+// from the Sandbox CR's status.selector field.
+func (s *SandboxWithSnapshotSupport) resolveSandboxNameHash() (string, error) {
+	s.mu.Lock()
+	if s.snapshotHash != "" {
+		h := s.snapshotHash
+		s.mu.Unlock()
+		return h, nil
+	}
+	s.mu.Unlock()
+
+	sb, err := s.k8s.AgentsClient.Sandboxes(s.namespace).Get(context.Background(), s.Info.SandboxName(), metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("getting sandbox CR: %w", err)
+	}
+
+	// LabelSelector format: "agents.x-k8s.io/sandbox-name-hash=<value>"
+	sel := sb.Status.LabelSelector
+	if idx := strings.Index(sel, "="); idx >= 0 {
+		key := sel[:idx]
+		val := sel[idx+1:]
+		if key == SandboxNameHashLabel && val != "" {
+			s.mu.Lock()
+			s.snapshotHash = val
+			s.mu.Unlock()
+			return val, nil
+		}
+	}
+	return "", nil
+}
+
+// setReplicas patches spec.replicas on the Sandbox CR.
+func (s *SandboxWithSnapshotSupport) setReplicas(ctx context.Context, replicas int32) error {
+	patch := fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas)
+	_, err := s.k8s.AgentsClient.Sandboxes(s.namespace).Patch(
+		ctx,
+		s.Info.SandboxName(),
+		k8stypes.MergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+	)
+	return err
+}

--- a/clients/go/gke_extensions/snapshots/sandbox.go
+++ b/clients/go/gke_extensions/snapshots/sandbox.go
@@ -69,7 +69,7 @@ func (s *SandboxWithSnapshotSupport) Snapshots() *SnapshotEngine {
 		s.engine = NewSnapshotEngine(
 			s.namespace,
 			s.k8s,
-			func(ctx context.Context) (string, error) {
+			func(_ context.Context) (string, error) {
 				name := s.Info.PodName()
 				if name == "" {
 					return "", fmt.Errorf("pod name not yet available; ensure the sandbox is open")
@@ -308,15 +308,11 @@ func (s *SandboxWithSnapshotSupport) resolveSandboxNameHash(ctx context.Context)
 
 	// LabelSelector format: "agents.x-k8s.io/sandbox-name-hash=<value>"
 	sel := sb.Status.LabelSelector
-	if idx := strings.Index(sel, "="); idx >= 0 {
-		key := sel[:idx]
-		val := sel[idx+1:]
-		if key == SandboxNameHashLabel && val != "" {
-			s.mu.Lock()
-			s.snapshotHash = val
-			s.mu.Unlock()
-			return val, nil
-		}
+	if key, val, found := strings.Cut(sel, "="); found && key == SandboxNameHashLabel && val != "" {
+		s.mu.Lock()
+		s.snapshotHash = val
+		s.mu.Unlock()
+		return val, nil
 	}
 	return "", nil
 }

--- a/clients/go/gke_extensions/snapshots/sandbox_test.go
+++ b/clients/go/gke_extensions/snapshots/sandbox_test.go
@@ -1,0 +1,687 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	fakeagents "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
+	sandbox "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal sandbox.Handle + sandbox.Info stub for testing
+// ---------------------------------------------------------------------------
+
+type stubHandle struct {
+	closeErr error
+	closed   bool
+}
+
+func (s *stubHandle) Open(_ context.Context) error      { return nil }
+func (s *stubHandle) Close(_ context.Context) error     { s.closed = true; return s.closeErr }
+func (s *stubHandle) Disconnect(_ context.Context) error { return nil }
+func (s *stubHandle) IsReady() bool                     { return true }
+func (s *stubHandle) Run(_ context.Context, _ string, _ ...sandbox.CallOption) (*sandbox.ExecutionResult, error) {
+	return nil, nil
+}
+func (s *stubHandle) Write(_ context.Context, _ string, _ []byte, _ ...sandbox.CallOption) error {
+	return nil
+}
+func (s *stubHandle) Read(_ context.Context, _ string, _ ...sandbox.CallOption) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubHandle) List(_ context.Context, _ string, _ ...sandbox.CallOption) ([]sandbox.FileEntry, error) {
+	return nil, nil
+}
+func (s *stubHandle) Exists(_ context.Context, _ string, _ ...sandbox.CallOption) (bool, error) {
+	return false, nil
+}
+
+type stubInfo struct {
+	claimName   string
+	sandboxName string
+	podName     string
+	annotations map[string]string
+}
+
+func (s *stubInfo) ClaimName() string            { return s.claimName }
+func (s *stubInfo) SandboxName() string          { return s.sandboxName }
+func (s *stubInfo) PodName() string              { return s.podName }
+func (s *stubInfo) Annotations() map[string]string { return s.annotations }
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func newTestK8sHelper(agentsCS *fakeagents.Clientset, dynCS *fakedynamic.FakeDynamicClient, kubeCS *fakekube.Clientset) *sandbox.K8sHelper {
+	return &sandbox.K8sHelper{
+		AgentsClient: agentsCS.AgentsV1beta1(),
+		DynamicClient: dynCS,
+		CoreClient:    kubeCS.CoreV1(),
+		Log:           logr.Discard(),
+	}
+}
+
+func newTestSandboxWrapper(
+	sandboxName, podName string,
+	agentsCS *fakeagents.Clientset,
+	dynCS *fakedynamic.FakeDynamicClient,
+	kubeCS *fakekube.Clientset,
+) *SandboxWithSnapshotSupport {
+	handle := &stubHandle{}
+	info := &stubInfo{
+		claimName:   "my-claim",
+		sandboxName: sandboxName,
+		podName:     podName,
+	}
+	k8s := newTestK8sHelper(agentsCS, dynCS, kubeCS)
+	return NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
+}
+
+func makeAgentsClientset(sb *sandboxv1beta1.Sandbox) *fakeagents.Clientset { //nolint:staticcheck
+	cs := fakeagents.NewSimpleClientset() //nolint:staticcheck
+	if sb != nil {
+		_, err := cs.AgentsV1beta1().Sandboxes(sb.Namespace).Create(
+			context.Background(), sb, metav1.CreateOptions{})
+		if err != nil {
+			panic("test setup: failed to create sandbox in fake clientset: " + err.Error())
+		}
+	}
+	return cs
+}
+
+func makeSandbox(name string, replicas int32, selector string) *sandboxv1beta1.Sandbox {
+	r := replicas
+	return &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			Replicas: &r,
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{},
+			},
+		},
+		Status: sandboxv1beta1.SandboxStatus{
+			LabelSelector: selector,
+		},
+	}
+}
+
+func newTestDynClient() *fakedynamic.FakeDynamicClient {
+	return fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			triggerGVR:  "PodSnapshotManualTriggerList",
+			snapshotGVR: "PodSnapshotList",
+		},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// IsSuspended
+// ---------------------------------------------------------------------------
+
+func TestIsSuspended_True(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=abc123")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	suspended, err := wrapper.IsSuspended(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !suspended {
+		t.Error("expected sandbox to be suspended (replicas=0)")
+	}
+}
+
+func TestIsSuspended_False(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=abc123")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	suspended, err := wrapper.IsSuspended(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if suspended {
+		t.Error("expected sandbox to be running (replicas=1)")
+	}
+}
+
+func TestIsSuspended_NilReplicas(t *testing.T) {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sandbox", Namespace: "default"},
+		Spec: sandboxv1beta1.SandboxSpec{
+			Replicas:    nil, // unset → default 1
+			PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{}},
+		},
+	}
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	suspended, err := wrapper.IsSuspended(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if suspended {
+		t.Error("expected not suspended when replicas is nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveSandboxNameHash
+// ---------------------------------------------------------------------------
+
+func TestResolveSandboxNameHash_Success(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=hash42")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	hash, err := wrapper.resolveSandboxNameHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "hash42" {
+		t.Errorf("expected hash42, got %q", hash)
+	}
+}
+
+func TestResolveSandboxNameHash_Caches(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=cached")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	h1, _ := wrapper.resolveSandboxNameHash()
+	// Delete from k8s so a second call that hits the API would fail.
+	agentsCS.AgentsV1beta1().Sandboxes("default").Delete(context.Background(), "my-sandbox", metav1.DeleteOptions{}) //nolint:errcheck
+	h2, err := wrapper.resolveSandboxNameHash()
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("expected cached value %q, got %q", h1, h2)
+	}
+}
+
+func TestResolveSandboxNameHash_EmptySelector(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	hash, err := wrapper.resolveSandboxNameHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "" {
+		t.Errorf("expected empty hash, got %q", hash)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsRestoredFromSnapshot
+// ---------------------------------------------------------------------------
+
+func TestIsRestoredFromSnapshot_EmptyUID(t *testing.T) {
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod",
+		makeAgentsClientset(nil), newTestDynClient(), fakekube.NewSimpleClientset())
+
+	result := wrapper.IsRestoredFromSnapshot(context.Background(), "")
+	if result.Success {
+		t.Error("expected failure for empty snapshotUID")
+	}
+}
+
+func TestIsRestoredFromSnapshot_NoPod(t *testing.T) {
+	info := &stubInfo{sandboxName: "my-sandbox", podName: ""}
+	handle := &stubHandle{}
+	k8s := newTestK8sHelper(makeAgentsClientset(nil), newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
+
+	result := wrapper.IsRestoredFromSnapshot(context.Background(), "snap-123")
+	if result.Success {
+		t.Error("expected failure when pod name is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Close delegates cleanup to engine and underlying handle
+// ---------------------------------------------------------------------------
+
+func TestClose_DelegatesAndCleansUp(t *testing.T) {
+	handle := &stubHandle{}
+	info := &stubInfo{sandboxName: "my-sandbox", podName: "my-pod"}
+	k8s := newTestK8sHelper(makeAgentsClientset(nil), newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
+
+	// Initialise the engine so it's non-nil on Close.
+	_ = wrapper.Snapshots()
+
+	if err := wrapper.Close(context.Background()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !handle.closed {
+		t.Error("expected underlying handle.Close() to be called")
+	}
+}
+
+func TestClose_PropagatesHandleError(t *testing.T) {
+	wantErr := errors.New("close failed")
+	handle := &stubHandle{closeErr: wantErr}
+	info := &stubInfo{sandboxName: "my-sandbox", podName: "my-pod"}
+	k8s := newTestK8sHelper(makeAgentsClientset(nil), newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
+
+	if err := wrapper.Close(context.Background()); !errors.Is(err, wantErr) {
+		t.Errorf("expected close error %v, got %v", wantErr, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Suspend / Resume (basic state check)
+// ---------------------------------------------------------------------------
+
+func TestSuspend_AlreadySuspended(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
+	if !resp.Success {
+		t.Errorf("expected success when already suspended, got: %s", resp.ErrorReason)
+	}
+}
+
+func TestResume_AlreadyRunning(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if !resp.Success {
+		t.Errorf("expected success when already running, got: %s", resp.ErrorReason)
+	}
+}
+
+func TestSuspend_ScalesDownAndWaitsForTermination(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	agentsCS := makeAgentsClientset(sb)
+	// Pod doesn't exist → termination is immediate.
+	kubeCS := fakekube.NewSimpleClientset()
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+
+	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
+	if !resp.Success {
+		t.Fatalf("expected success, got: %s", resp.ErrorReason)
+	}
+
+	// Verify sandbox was patched to replicas=0.
+	updated, err := agentsCS.AgentsV1beta1().Sandboxes("default").Get(context.Background(), "my-sandbox", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting sandbox after suspend: %v", err)
+	}
+	if updated.Spec.Replicas == nil || *updated.Spec.Replicas != 0 {
+		t.Errorf("expected replicas=0 after suspend, got %v", updated.Spec.Replicas)
+	}
+}
+
+func TestResume_ScalesUpAndWaitsForReady(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	agentsCS := makeAgentsClientset(sb)
+
+	// Pod exists and is Ready.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+
+	// No snapshots exist → skip restore verification.
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if !resp.Success {
+		t.Fatalf("expected success, got: %s", resp.ErrorReason)
+	}
+	if resp.RestoredFromSnapshot {
+		t.Error("expected RestoredFromSnapshot=false when no snapshots exist")
+	}
+
+	// Verify sandbox was patched to replicas=1.
+	updated, err := agentsCS.AgentsV1beta1().Sandboxes("default").Get(context.Background(), "my-sandbox", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting sandbox after resume: %v", err)
+	}
+	if updated.Spec.Replicas == nil || *updated.Spec.Replicas != 1 {
+		t.Errorf("expected replicas=1 after resume, got %v", updated.Spec.Replicas)
+	}
+}
+
+func TestSuspend_FailsWhenHashNotResolvable(t *testing.T) {
+	// Sandbox CR has empty selector → hash unavailable.
+	sb := makeSandbox("my-sandbox", 1, "")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
+	// Empty hash is allowed (returns "" without error); suspend should still
+	// proceed unless the hash lookup itself errors.
+	// We just verify no panic and the state is consistent.
+	_ = resp
+}
+
+func TestResume_Timeout(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	agentsCS := makeAgentsClientset(sb)
+
+	// Pod is not ready.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	resp := wrapper.Resume(ctx, 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure on pod ready timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Suspend — error paths
+// ---------------------------------------------------------------------------
+
+func TestSuspend_IsSuspendedError(t *testing.T) {
+	// No sandbox CR → IsSuspended returns not-found error.
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when sandbox CR does not exist")
+	}
+}
+
+func TestSuspend_SetReplicasError(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=h1")
+	agentsCS := makeAgentsClientset(sb)
+	// Make patch fail.
+	agentsCS.PrependReactor("patch", "sandboxes", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("patch forbidden")
+	})
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when setReplicas returns error")
+	}
+}
+
+func TestSuspend_WithSnapshotSuccess(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=h1")
+	agentsCS := makeAgentsClientset(sb)
+	dynCS := newTestDynClient()
+
+	// Snapshot trigger watch fires with completion.
+	trigWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			trigWatcher.Modify(&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+					"kind":       PodSnapshotTriggerKind,
+					"metadata":   map[string]interface{}{"name": "t", "namespace": "default"},
+					"status": map[string]interface{}{
+						"snapshotCreated": map[string]interface{}{"name": "snap-uid"},
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":               "Triggered",
+								"status":             "True",
+								"reason":             "Complete",
+								"lastTransitionTime": "2026-01-01T00:00:00Z",
+							},
+						},
+					},
+				},
+			})
+		}()
+		return true, trigWatcher, nil
+	})
+
+	// Pod doesn't exist → termination is immediate.
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS, fakekube.NewSimpleClientset())
+
+	resp := wrapper.Suspend(context.Background(), true, 5*time.Second)
+	if !resp.Success {
+		t.Fatalf("expected success with snapshot, got: %s", resp.ErrorReason)
+	}
+	if resp.SnapshotResponse == nil {
+		t.Error("expected SnapshotResponse to be set")
+	}
+}
+
+func TestSuspend_WithSnapshotFail(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=h1")
+	agentsCS := makeAgentsClientset(sb)
+	dynCS := newTestDynClient()
+
+	// Snapshot trigger watch fires with failure.
+	trigWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			trigWatcher.Modify(&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{"name": "t", "namespace": "default"},
+					"status": map[string]interface{}{
+						"conditions": []interface{}{
+							map[string]interface{}{
+								"type":    "Triggered",
+								"status":  "False",
+								"reason":  "Failed",
+								"message": "out of memory",
+							},
+						},
+					},
+				},
+			})
+		}()
+		return true, trigWatcher, nil
+	})
+
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS, fakekube.NewSimpleClientset())
+
+	resp := wrapper.Suspend(context.Background(), true, 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when snapshot creation fails")
+	}
+	if resp.SnapshotResponse == nil {
+		t.Error("expected SnapshotResponse to be populated on failure")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Resume — error paths and snapshot restoration
+// ---------------------------------------------------------------------------
+
+func TestResume_IsSuspendedError(t *testing.T) {
+	// No sandbox CR.
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when sandbox CR does not exist")
+	}
+}
+
+func TestResume_SetReplicasError(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=h1")
+	agentsCS := makeAgentsClientset(sb)
+	agentsCS.PrependReactor("patch", "sandboxes", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("patch error")
+	})
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when setReplicas returns error")
+	}
+}
+
+func TestResume_WithSnapshotRestored(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=h1")
+	agentsCS := makeAgentsClientset(sb)
+	dynCS := newTestDynClient()
+
+	// Seed a ready snapshot so List returns it.
+	snap := makeSnapshot("snap-uid-1", "h1", true)
+	dynCS2 := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			triggerGVR:  "PodSnapshotManualTriggerList",
+			snapshotGVR: "PodSnapshotList",
+		},
+		snap,
+	)
+	_ = dynCS
+
+	// Pod is ready AND has PodRestored=True with correct UID.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: "PodRestored", Status: corev1.ConditionTrue, Message: "restored from snap-uid-1"},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS2, kubeCS)
+
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if !resp.Success {
+		t.Fatalf("expected success, got: %s", resp.ErrorReason)
+	}
+	if !resp.RestoredFromSnapshot {
+		t.Error("expected RestoredFromSnapshot=true")
+	}
+	if resp.SnapshotUID != "snap-uid-1" {
+		t.Errorf("expected SnapshotUID=snap-uid-1, got %q", resp.SnapshotUID)
+	}
+}
+
+func TestResume_WithSnapshotNotRestored(t *testing.T) {
+	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=h1")
+	agentsCS := makeAgentsClientset(sb)
+
+	snap := makeSnapshot("snap-uid-1", "h1", true)
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			triggerGVR:  "PodSnapshotManualTriggerList",
+			snapshotGVR: "PodSnapshotList",
+		},
+		snap,
+	)
+
+	// Pod is ready but PodRestored condition is absent (fresh start).
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS, kubeCS)
+
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when restore check fails")
+	}
+	if resp.RestoredFromSnapshot {
+		t.Error("expected RestoredFromSnapshot=false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsRestoredFromSnapshot — delegates to checkPodRestoredFromSnapshot
+// ---------------------------------------------------------------------------
+
+func TestIsRestoredFromSnapshot_Delegated(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: "PodRestored", Status: corev1.ConditionTrue, Message: "from snap-xyz"},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+
+	result := wrapper.IsRestoredFromSnapshot(context.Background(), "snap-xyz")
+	if !result.Success {
+		t.Errorf("expected success: %s", result.ErrorReason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshots() — empty pod name propagates to engine
+// ---------------------------------------------------------------------------
+
+func TestSnapshots_EmptyPodName_PropagatesError(t *testing.T) {
+	info := &stubInfo{sandboxName: "my-sandbox", podName: ""}
+	handle := &stubHandle{}
+	k8s := newTestK8sHelper(makeAgentsClientset(nil), newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
+
+	resp := wrapper.Snapshots().Create(context.Background(), "test", 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when pod name is empty")
+	}
+}

--- a/clients/go/gke_extensions/snapshots/sandbox_test.go
+++ b/clients/go/gke_extensions/snapshots/sandbox_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -239,12 +240,21 @@ func TestResolveSandboxNameHash_EmptySelector(t *testing.T) {
 	agentsCS := makeAgentsClientset(sb)
 	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
-	hash, err := wrapper.resolveSandboxNameHash(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	_, err := wrapper.resolveSandboxNameHash(context.Background())
+	if err == nil {
+		t.Error("expected error when status.selector is empty")
 	}
-	if hash != "" {
-		t.Errorf("expected empty hash, got %q", hash)
+}
+
+func TestResolveSandboxNameHash_ErrorOnMalformedSelector(t *testing.T) {
+	// Selector contains the wrong label key; expected label is absent.
+	sb := makeSandbox(1, "some-other-label=abc123")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	_, err := wrapper.resolveSandboxNameHash(context.Background())
+	if err == nil {
+		t.Error("expected error when selector does not contain the expected label")
 	}
 }
 
@@ -391,16 +401,17 @@ func TestResume_ScalesUpAndWaitsForReady(t *testing.T) {
 }
 
 func TestSuspend_FailsWhenHashNotResolvable(t *testing.T) {
-	// Sandbox CR has empty selector → hash unavailable.
+	// Sandbox CR has empty selector → resolveSandboxNameHash returns an error.
 	sb := makeSandbox(1, "")
 	agentsCS := makeAgentsClientset(sb)
 	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
-	// Empty hash is allowed (returns "" without error); suspend should still
-	// proceed unless the hash lookup itself errors.
-	if resp.ErrorCode != SuccessCode {
-		t.Errorf("expected SuccessCode, got %d: %s", resp.ErrorCode, resp.ErrorReason)
+	if resp.Success {
+		t.Error("expected failure when sandbox-name-hash cannot be resolved")
+	}
+	if resp.ErrorCode != ErrorCode {
+		t.Errorf("expected ErrorCode, got %d", resp.ErrorCode)
 	}
 }
 
@@ -567,6 +578,25 @@ func TestResume_SetReplicasError(t *testing.T) {
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if resp.Success {
 		t.Error("expected failure when setReplicas returns error")
+	}
+}
+
+func TestResume_FailsWhenListFails(t *testing.T) {
+	// Sandbox is suspended (replicas=0) but has empty selector → List will fail
+	// because resolveSandboxNameHash returns an error.
+	sb := makeSandbox(0, "")
+	agentsCS := makeAgentsClientset(sb)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	resp := wrapper.Resume(context.Background(), 5*time.Second)
+	if resp.Success {
+		t.Error("expected failure when snapshot list fails")
+	}
+	if resp.ErrorCode != ErrorCode {
+		t.Errorf("expected ErrorCode, got %d", resp.ErrorCode)
+	}
+	if !strings.Contains(resp.ErrorReason, "failed to list snapshots") {
+		t.Errorf("expected 'failed to list snapshots' in reason, got %q", resp.ErrorReason)
 	}
 }
 
@@ -758,28 +788,25 @@ func TestResolveSandboxNameHash_CacheHitSkipsAPICall(t *testing.T) {
 	}
 }
 
-// TestSuspend_CtxCancelledBeforeHashResolve verifies Suspend exits with error
-// when the sandbox CR does not exist (which triggers hash resolution failure).
+// TestSuspend_CtxCancelledBeforeHashResolve verifies Suspend exits quickly when
+// hash resolution fails (empty selector) regardless of ctx cancellation state.
 func TestSuspend_CtxCancelledBeforeHashResolve(t *testing.T) {
-	// Sandbox is running (replicas=1) but no CR → hash resolution fails.
+	// Sandbox is running (replicas=1) with empty selector → resolveSandboxNameHash
+	// returns an error immediately, causing Suspend to fail fast.
 	sb := makeSandbox(1, "")
 	agentsCS := makeAgentsClientset(sb)
-
-	// Replace the sandbox so hash resolution fails (empty selector → returns "").
 	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
-	// The empty selector means hash = "" — Suspend should succeed (no error from hash
-	// resolution itself, since "" is a valid "not found" return). Test the overall
-	// control flow: when already-cancelled ctx is passed, IsSuspended should still
-	// work via the fake client which ignores ctx cancellation.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
-	// With a pre-cancelled context Suspend may or may not fail depending on how
-	// the fake client handles it; the key invariant we verify is that it does not hang.
 	start := time.Now()
-	_ = wrapper.Suspend(ctx, false, 10*time.Millisecond)
+	resp := wrapper.Suspend(ctx, false, 10*time.Millisecond)
 	if time.Since(start) > 2*time.Second {
 		t.Error("Suspend blocked too long with a cancelled context")
+	}
+	// Suspend must fail: either hash resolution error or ctx-cancelled IsSuspended.
+	if resp.Success {
+		t.Error("expected Suspend to fail when hash cannot be resolved")
 	}
 }

--- a/clients/go/gke_extensions/snapshots/sandbox_test.go
+++ b/clients/go/gke_extensions/snapshots/sandbox_test.go
@@ -49,7 +49,7 @@ type stubHandle struct {
 func (s *stubHandle) Open(_ context.Context) error       { return nil }
 func (s *stubHandle) Close(_ context.Context) error      { s.closed = true; return s.closeErr }
 func (s *stubHandle) Disconnect(_ context.Context) error { return nil }
-func (s *stubHandle) IsReady() bool                      { return true }
+func (s *stubHandle) IsReady() bool                      { return !s.closed }
 func (s *stubHandle) Run(_ context.Context, _ string, _ ...sandbox.CallOption) (*sandbox.ExecutionResult, error) {
 	return nil, nil
 }
@@ -683,6 +683,45 @@ func TestSnapshots_EmptyPodName_PropagatesError(t *testing.T) {
 	resp := wrapper.Snapshots().Create(context.Background(), "test", 5*time.Second)
 	if resp.Success {
 		t.Error("expected failure when pod name is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsActive
+// ---------------------------------------------------------------------------
+
+func TestIsActive_FalseBeforeEngineInit(t *testing.T) {
+	// A freshly constructed wrapper has no engine; IsActive must return false.
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	if wrapper.IsActive() {
+		t.Error("expected IsActive()=false before Snapshots() is called")
+	}
+}
+
+func TestIsActive_TrueAfterEngineInit(t *testing.T) {
+	// Calling Snapshots() lazily initialises the engine; IsActive must then return true.
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	_ = wrapper.Snapshots() // triggers engine init
+	if !wrapper.IsActive() {
+		t.Error("expected IsActive()=true after Snapshots() is called")
+	}
+}
+
+func TestIsActive_FalseAfterClose(t *testing.T) {
+	// After Close() the underlying handle is no longer ready; IsActive must return false.
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	_ = wrapper.Snapshots() // init engine so both conditions could be true
+
+	if err := wrapper.Close(context.Background()); err != nil {
+		t.Fatalf("Close returned unexpected error: %v", err)
+	}
+	if wrapper.IsActive() {
+		t.Error("expected IsActive()=false after Close()")
 	}
 }
 

--- a/clients/go/gke_extensions/snapshots/sandbox_test.go
+++ b/clients/go/gke_extensions/snapshots/sandbox_test.go
@@ -603,11 +603,10 @@ func TestResume_FailsWhenListFails(t *testing.T) {
 func TestResume_WithSnapshotRestored(t *testing.T) {
 	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
-	dynCS := newTestDynClient()
 
 	// Seed a ready snapshot so List returns it.
 	snap := makeSnapshot("snap-uid-1", "h1", true)
-	dynCS2 := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
 			triggerGVR:  "PodSnapshotManualTriggerList",
@@ -615,7 +614,6 @@ func TestResume_WithSnapshotRestored(t *testing.T) {
 		},
 		snap,
 	)
-	_ = dynCS
 
 	// Pod is ready AND has PodRestored=True with correct UID.
 	pod := &corev1.Pod{
@@ -628,7 +626,7 @@ func TestResume_WithSnapshotRestored(t *testing.T) {
 		},
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
-	wrapper := newTestSandboxWrapper(agentsCS, dynCS2, kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, dynCS, kubeCS)
 
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if !resp.Success {
@@ -808,5 +806,23 @@ func TestSuspend_CtxCancelledBeforeHashResolve(t *testing.T) {
 	// Suspend must fail: either hash resolution error or ctx-cancelled IsSuspended.
 	if resp.Success {
 		t.Error("expected Suspend to fail when hash cannot be resolved")
+	}
+}
+
+func TestSuspend_EmptyPodName_SkipsTerminationWait(t *testing.T) {
+	// Sandbox is running (replicas=1) with a valid selector, but the pod name is
+	// not yet populated. Suspend should scale down and return success immediately
+	// without making any pod API calls.
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	agentsCS := makeAgentsClientset(sb)
+
+	handle := &stubHandle{}
+	info := &stubInfo{claimName: "my-claim", sandboxName: "my-sandbox", podName: ""}
+	k8s := newTestK8sHelper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
+
+	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
+	if !resp.Success {
+		t.Fatalf("expected success when pod name is empty, got: %s", resp.ErrorReason)
 	}
 }

--- a/clients/go/gke_extensions/snapshots/sandbox_test.go
+++ b/clients/go/gke_extensions/snapshots/sandbox_test.go
@@ -209,7 +209,7 @@ func TestResolveSandboxNameHash_Success(t *testing.T) {
 	agentsCS := makeAgentsClientset(sb)
 	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
-	hash, err := wrapper.resolveSandboxNameHash()
+	hash, err := wrapper.resolveSandboxNameHash(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -223,10 +223,10 @@ func TestResolveSandboxNameHash_Caches(t *testing.T) {
 	agentsCS := makeAgentsClientset(sb)
 	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
-	h1, _ := wrapper.resolveSandboxNameHash()
+	h1, _ := wrapper.resolveSandboxNameHash(context.Background())
 	// Delete from k8s so a second call that hits the API would fail.
 	agentsCS.AgentsV1beta1().Sandboxes("default").Delete(context.Background(), "my-sandbox", metav1.DeleteOptions{}) //nolint:errcheck
-	h2, err := wrapper.resolveSandboxNameHash()
+	h2, err := wrapper.resolveSandboxNameHash(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error on second call: %v", err)
 	}
@@ -240,7 +240,7 @@ func TestResolveSandboxNameHash_EmptySelector(t *testing.T) {
 	agentsCS := makeAgentsClientset(sb)
 	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
-	hash, err := wrapper.resolveSandboxNameHash()
+	hash, err := wrapper.resolveSandboxNameHash(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -683,5 +683,64 @@ func TestSnapshots_EmptyPodName_PropagatesError(t *testing.T) {
 	resp := wrapper.Snapshots().Create(context.Background(), "test", 5*time.Second)
 	if resp.Success {
 		t.Error("expected failure when pod name is empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 3: resolveSandboxNameHash threads context correctly
+// ---------------------------------------------------------------------------
+
+// TestResolveSandboxNameHash_PropagatesNotFoundError verifies that resolveSandboxNameHash
+// returns an error when the Sandbox CR does not exist in the cluster.
+func TestResolveSandboxNameHash_PropagatesNotFoundError(t *testing.T) {
+	// No sandbox CR — the API call returns not-found, which becomes an error.
+	agentsCS := makeAgentsClientset(nil)
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	_, err := wrapper.resolveSandboxNameHash(context.Background())
+	if err == nil {
+		t.Error("expected error when sandbox CR not found")
+	}
+}
+
+func TestResolveSandboxNameHash_CacheHitSkipsAPICall(t *testing.T) {
+	agentsCS := makeAgentsClientset(nil) // no sandbox in cluster
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	// Pre-populate the cache — no API call should happen.
+	wrapper.snapshotHash = "pre-cached"
+
+	hash, err := wrapper.resolveSandboxNameHash(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hash != "pre-cached" {
+		t.Errorf("expected pre-cached, got %q", hash)
+	}
+}
+
+// TestSuspend_CtxCancelledBeforeHashResolve verifies Suspend exits with error
+// when the sandbox CR does not exist (which triggers hash resolution failure).
+func TestSuspend_CtxCancelledBeforeHashResolve(t *testing.T) {
+	// Sandbox is running (replicas=1) but no CR → hash resolution fails.
+	sb := makeSandbox("my-sandbox", 1, "")
+	agentsCS := makeAgentsClientset(sb)
+
+	// Replace the sandbox so hash resolution fails (empty selector → returns "").
+	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+
+	// The empty selector means hash = "" — Suspend should succeed (no error from hash
+	// resolution itself, since "" is a valid "not found" return). Test the overall
+	// control flow: when already-cancelled ctx is passed, IsSuspended should still
+	// work via the fake client which ignores ctx cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	// With a pre-cancelled context Suspend may or may not fail depending on how
+	// the fake client handles it; the key invariant we verify is that it does not hang.
+	start := time.Now()
+	_ = wrapper.Suspend(ctx, false, 10*time.Millisecond)
+	if time.Since(start) > 2*time.Second {
+		t.Error("Suspend blocked too long with a cancelled context")
 	}
 }

--- a/clients/go/gke_extensions/snapshots/sandbox_test.go
+++ b/clients/go/gke_extensions/snapshots/sandbox_test.go
@@ -33,8 +33,8 @@ import (
 	ktesting "k8s.io/client-go/testing"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
-	fakeagents "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
 	sandbox "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+	fakeagents "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
 )
 
 // ---------------------------------------------------------------------------
@@ -46,10 +46,10 @@ type stubHandle struct {
 	closed   bool
 }
 
-func (s *stubHandle) Open(_ context.Context) error      { return nil }
-func (s *stubHandle) Close(_ context.Context) error     { s.closed = true; return s.closeErr }
+func (s *stubHandle) Open(_ context.Context) error       { return nil }
+func (s *stubHandle) Close(_ context.Context) error      { s.closed = true; return s.closeErr }
 func (s *stubHandle) Disconnect(_ context.Context) error { return nil }
-func (s *stubHandle) IsReady() bool                     { return true }
+func (s *stubHandle) IsReady() bool                      { return true }
 func (s *stubHandle) Run(_ context.Context, _ string, _ ...sandbox.CallOption) (*sandbox.ExecutionResult, error) {
 	return nil, nil
 }
@@ -73,9 +73,9 @@ type stubInfo struct {
 	annotations map[string]string
 }
 
-func (s *stubInfo) ClaimName() string            { return s.claimName }
-func (s *stubInfo) SandboxName() string          { return s.sandboxName }
-func (s *stubInfo) PodName() string              { return s.podName }
+func (s *stubInfo) ClaimName() string              { return s.claimName }
+func (s *stubInfo) SandboxName() string            { return s.sandboxName }
+func (s *stubInfo) PodName() string                { return s.podName }
 func (s *stubInfo) Annotations() map[string]string { return s.annotations }
 
 // ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@ func (s *stubInfo) Annotations() map[string]string { return s.annotations }
 
 func newTestK8sHelper(agentsCS *fakeagents.Clientset, dynCS *fakedynamic.FakeDynamicClient, kubeCS *fakekube.Clientset) *sandbox.K8sHelper {
 	return &sandbox.K8sHelper{
-		AgentsClient: agentsCS.AgentsV1beta1(),
+		AgentsClient:  agentsCS.AgentsV1beta1(),
 		DynamicClient: dynCS,
 		CoreClient:    kubeCS.CoreV1(),
 		Log:           logr.Discard(),
@@ -92,7 +92,6 @@ func newTestK8sHelper(agentsCS *fakeagents.Clientset, dynCS *fakedynamic.FakeDyn
 }
 
 func newTestSandboxWrapper(
-	sandboxName, podName string,
 	agentsCS *fakeagents.Clientset,
 	dynCS *fakedynamic.FakeDynamicClient,
 	kubeCS *fakekube.Clientset,
@@ -100,8 +99,8 @@ func newTestSandboxWrapper(
 	handle := &stubHandle{}
 	info := &stubInfo{
 		claimName:   "my-claim",
-		sandboxName: sandboxName,
-		podName:     podName,
+		sandboxName: "my-sandbox",
+		podName:     "my-pod",
 	}
 	k8s := newTestK8sHelper(agentsCS, dynCS, kubeCS)
 	return NewSandboxWithSnapshotSupport(handle, info, k8s, "default", logr.Discard())
@@ -119,11 +118,11 @@ func makeAgentsClientset(sb *sandboxv1beta1.Sandbox) *fakeagents.Clientset { //n
 	return cs
 }
 
-func makeSandbox(name string, replicas int32, selector string) *sandboxv1beta1.Sandbox {
+func makeSandbox(replicas int32, selector string) *sandboxv1beta1.Sandbox {
 	r := replicas
 	return &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      "my-sandbox",
 			Namespace: "default",
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
@@ -153,9 +152,9 @@ func newTestDynClient() *fakedynamic.FakeDynamicClient {
 // ---------------------------------------------------------------------------
 
 func TestIsSuspended_True(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=abc123")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=abc123")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	suspended, err := wrapper.IsSuspended(context.Background())
 	if err != nil {
@@ -167,9 +166,9 @@ func TestIsSuspended_True(t *testing.T) {
 }
 
 func TestIsSuspended_False(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=abc123")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=abc123")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	suspended, err := wrapper.IsSuspended(context.Background())
 	if err != nil {
@@ -189,7 +188,7 @@ func TestIsSuspended_NilReplicas(t *testing.T) {
 		},
 	}
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	suspended, err := wrapper.IsSuspended(context.Background())
 	if err != nil {
@@ -205,9 +204,9 @@ func TestIsSuspended_NilReplicas(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestResolveSandboxNameHash_Success(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=hash42")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=hash42")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	hash, err := wrapper.resolveSandboxNameHash(context.Background())
 	if err != nil {
@@ -219,9 +218,9 @@ func TestResolveSandboxNameHash_Success(t *testing.T) {
 }
 
 func TestResolveSandboxNameHash_Caches(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=cached")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=cached")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	h1, _ := wrapper.resolveSandboxNameHash(context.Background())
 	// Delete from k8s so a second call that hits the API would fail.
@@ -236,9 +235,9 @@ func TestResolveSandboxNameHash_Caches(t *testing.T) {
 }
 
 func TestResolveSandboxNameHash_EmptySelector(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "")
+	sb := makeSandbox(1, "")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	hash, err := wrapper.resolveSandboxNameHash(context.Background())
 	if err != nil {
@@ -254,7 +253,7 @@ func TestResolveSandboxNameHash_EmptySelector(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIsRestoredFromSnapshot_EmptyUID(t *testing.T) {
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod",
+	wrapper := newTestSandboxWrapper(
 		makeAgentsClientset(nil), newTestDynClient(), fakekube.NewSimpleClientset())
 
 	result := wrapper.IsRestoredFromSnapshot(context.Background(), "")
@@ -313,9 +312,9 @@ func TestClose_PropagatesHandleError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSuspend_AlreadySuspended(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=hash1")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
 	if !resp.Success {
@@ -324,9 +323,9 @@ func TestSuspend_AlreadySuspended(t *testing.T) {
 }
 
 func TestResume_AlreadyRunning(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=hash1")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if !resp.Success {
@@ -335,11 +334,11 @@ func TestResume_AlreadyRunning(t *testing.T) {
 }
 
 func TestSuspend_ScalesDownAndWaitsForTermination(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=hash1")
 	agentsCS := makeAgentsClientset(sb)
 	// Pod doesn't exist → termination is immediate.
 	kubeCS := fakekube.NewSimpleClientset()
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), kubeCS)
 
 	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
 	if !resp.Success {
@@ -357,7 +356,7 @@ func TestSuspend_ScalesDownAndWaitsForTermination(t *testing.T) {
 }
 
 func TestResume_ScalesUpAndWaitsForReady(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=hash1")
 	agentsCS := makeAgentsClientset(sb)
 
 	// Pod exists and is Ready.
@@ -370,7 +369,7 @@ func TestResume_ScalesUpAndWaitsForReady(t *testing.T) {
 		},
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), kubeCS)
 
 	// No snapshots exist → skip restore verification.
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
@@ -393,19 +392,20 @@ func TestResume_ScalesUpAndWaitsForReady(t *testing.T) {
 
 func TestSuspend_FailsWhenHashNotResolvable(t *testing.T) {
 	// Sandbox CR has empty selector → hash unavailable.
-	sb := makeSandbox("my-sandbox", 1, "")
+	sb := makeSandbox(1, "")
 	agentsCS := makeAgentsClientset(sb)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
 	// Empty hash is allowed (returns "" without error); suspend should still
 	// proceed unless the hash lookup itself errors.
-	// We just verify no panic and the state is consistent.
-	_ = resp
+	if resp.ErrorCode != SuccessCode {
+		t.Errorf("expected SuccessCode, got %d: %s", resp.ErrorCode, resp.ErrorReason)
+	}
 }
 
 func TestResume_Timeout(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=hash1")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=hash1")
 	agentsCS := makeAgentsClientset(sb)
 
 	// Pod is not ready.
@@ -418,7 +418,7 @@ func TestResume_Timeout(t *testing.T) {
 		},
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), kubeCS)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -436,7 +436,7 @@ func TestResume_Timeout(t *testing.T) {
 func TestSuspend_IsSuspendedError(t *testing.T) {
 	// No sandbox CR → IsSuspended returns not-found error.
 	agentsCS := makeAgentsClientset(nil)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
 	if resp.Success {
@@ -445,13 +445,13 @@ func TestSuspend_IsSuspendedError(t *testing.T) {
 }
 
 func TestSuspend_SetReplicasError(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=h1")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
 	// Make patch fail.
-	agentsCS.PrependReactor("patch", "sandboxes", func(action ktesting.Action) (bool, runtime.Object, error) {
+	agentsCS.PrependReactor("patch", "sandboxes", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("patch forbidden")
 	})
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), false, 5*time.Second)
 	if resp.Success {
@@ -460,23 +460,23 @@ func TestSuspend_SetReplicasError(t *testing.T) {
 }
 
 func TestSuspend_WithSnapshotSuccess(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=h1")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
 	dynCS := newTestDynClient()
 
 	// Snapshot trigger watch fires with completion.
 	trigWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() {
 			trigWatcher.Modify(&unstructured.Unstructured{
-				Object: map[string]interface{}{
+				Object: map[string]any{
 					"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 					"kind":       PodSnapshotTriggerKind,
-					"metadata":   map[string]interface{}{"name": "t", "namespace": "default"},
-					"status": map[string]interface{}{
-						"snapshotCreated": map[string]interface{}{"name": "snap-uid"},
-						"conditions": []interface{}{
-							map[string]interface{}{
+					"metadata":   map[string]any{"name": "t", "namespace": "default"},
+					"status": map[string]any{
+						"snapshotCreated": map[string]any{"name": "snap-uid"},
+						"conditions": []any{
+							map[string]any{
 								"type":               "Triggered",
 								"status":             "True",
 								"reason":             "Complete",
@@ -491,7 +491,7 @@ func TestSuspend_WithSnapshotSuccess(t *testing.T) {
 	})
 
 	// Pod doesn't exist → termination is immediate.
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS, fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, dynCS, fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), true, 5*time.Second)
 	if !resp.Success {
@@ -503,20 +503,20 @@ func TestSuspend_WithSnapshotSuccess(t *testing.T) {
 }
 
 func TestSuspend_WithSnapshotFail(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 1, "agents.x-k8s.io/sandbox-name-hash=h1")
+	sb := makeSandbox(1, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
 	dynCS := newTestDynClient()
 
 	// Snapshot trigger watch fires with failure.
 	trigWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshotmanualtriggers", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() {
 			trigWatcher.Modify(&unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"metadata": map[string]interface{}{"name": "t", "namespace": "default"},
-					"status": map[string]interface{}{
-						"conditions": []interface{}{
-							map[string]interface{}{
+				Object: map[string]any{
+					"metadata": map[string]any{"name": "t", "namespace": "default"},
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
 								"type":    "Triggered",
 								"status":  "False",
 								"reason":  "Failed",
@@ -530,7 +530,7 @@ func TestSuspend_WithSnapshotFail(t *testing.T) {
 		return true, trigWatcher, nil
 	})
 
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS, fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, dynCS, fakekube.NewSimpleClientset())
 
 	resp := wrapper.Suspend(context.Background(), true, 5*time.Second)
 	if resp.Success {
@@ -548,7 +548,7 @@ func TestSuspend_WithSnapshotFail(t *testing.T) {
 func TestResume_IsSuspendedError(t *testing.T) {
 	// No sandbox CR.
 	agentsCS := makeAgentsClientset(nil)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if resp.Success {
@@ -557,12 +557,12 @@ func TestResume_IsSuspendedError(t *testing.T) {
 }
 
 func TestResume_SetReplicasError(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=h1")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
-	agentsCS.PrependReactor("patch", "sandboxes", func(action ktesting.Action) (bool, runtime.Object, error) {
+	agentsCS.PrependReactor("patch", "sandboxes", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("patch error")
 	})
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if resp.Success {
@@ -571,7 +571,7 @@ func TestResume_SetReplicasError(t *testing.T) {
 }
 
 func TestResume_WithSnapshotRestored(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=h1")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
 	dynCS := newTestDynClient()
 
@@ -598,7 +598,7 @@ func TestResume_WithSnapshotRestored(t *testing.T) {
 		},
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS2, kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, dynCS2, kubeCS)
 
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if !resp.Success {
@@ -613,7 +613,7 @@ func TestResume_WithSnapshotRestored(t *testing.T) {
 }
 
 func TestResume_WithSnapshotNotRestored(t *testing.T) {
-	sb := makeSandbox("my-sandbox", 0, "agents.x-k8s.io/sandbox-name-hash=h1")
+	sb := makeSandbox(0, "agents.x-k8s.io/sandbox-name-hash=h1")
 	agentsCS := makeAgentsClientset(sb)
 
 	snap := makeSnapshot("snap-uid-1", "h1", true)
@@ -636,7 +636,7 @@ func TestResume_WithSnapshotNotRestored(t *testing.T) {
 		},
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, dynCS, kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, dynCS, kubeCS)
 
 	resp := wrapper.Resume(context.Background(), 5*time.Second)
 	if resp.Success {
@@ -662,7 +662,7 @@ func TestIsRestoredFromSnapshot_Delegated(t *testing.T) {
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
 	agentsCS := makeAgentsClientset(nil)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), kubeCS)
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), kubeCS)
 
 	result := wrapper.IsRestoredFromSnapshot(context.Background(), "snap-xyz")
 	if !result.Success {
@@ -695,7 +695,7 @@ func TestSnapshots_EmptyPodName_PropagatesError(t *testing.T) {
 func TestResolveSandboxNameHash_PropagatesNotFoundError(t *testing.T) {
 	// No sandbox CR — the API call returns not-found, which becomes an error.
 	agentsCS := makeAgentsClientset(nil)
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	_, err := wrapper.resolveSandboxNameHash(context.Background())
 	if err == nil {
@@ -705,7 +705,7 @@ func TestResolveSandboxNameHash_PropagatesNotFoundError(t *testing.T) {
 
 func TestResolveSandboxNameHash_CacheHitSkipsAPICall(t *testing.T) {
 	agentsCS := makeAgentsClientset(nil) // no sandbox in cluster
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	// Pre-populate the cache — no API call should happen.
 	wrapper.snapshotHash = "pre-cached"
@@ -723,11 +723,11 @@ func TestResolveSandboxNameHash_CacheHitSkipsAPICall(t *testing.T) {
 // when the sandbox CR does not exist (which triggers hash resolution failure).
 func TestSuspend_CtxCancelledBeforeHashResolve(t *testing.T) {
 	// Sandbox is running (replicas=1) but no CR → hash resolution fails.
-	sb := makeSandbox("my-sandbox", 1, "")
+	sb := makeSandbox(1, "")
 	agentsCS := makeAgentsClientset(sb)
 
 	// Replace the sandbox so hash resolution fails (empty selector → returns "").
-	wrapper := newTestSandboxWrapper("my-sandbox", "my-pod", agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
+	wrapper := newTestSandboxWrapper(agentsCS, newTestDynClient(), fakekube.NewSimpleClientset())
 
 	// The empty selector means hash = "" — Suspend should succeed (no error from hash
 	// resolution itself, since "" is a valid "not found" return). Test the overall

--- a/clients/go/gke_extensions/snapshots/types.go
+++ b/clients/go/gke_extensions/snapshots/types.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	PodSnapshotAPIGroup      = "podsnapshot.gke.io"
+	PodSnapshotAPIVersion    = "v1"
+	PodSnapshotPlural        = "podsnapshots"
+	PodSnapshotTriggerPlural = "podsnapshotmanualtriggers"
+	PodSnapshotTriggerKind   = "PodSnapshotManualTrigger"
+
+	SandboxAPIGroup   = "agents.x-k8s.io"
+	SandboxAPIVersion = "v1beta1"
+	SandboxPlural     = "sandboxes"
+
+	SandboxNameHashLabel    = "agents.x-k8s.io/sandbox-name-hash"
+	PodSnapshotPodAnnotation = "podsnapshot.gke.io/origin-pod"
+)
+
+const (
+	SuccessCode = 0
+	ErrorCode   = 1
+)
+
+var (
+	ErrCRDNotInstalled = errors.New("Pod Snapshot Controller is not ready; install the PodSnapshotPolicy CRD before using this client")
+	ErrSnapshotTimeout = errors.New("snapshot creation timed out")
+	ErrSnapshotFailed  = errors.New("snapshot creation failed")
+)
+
+// SnapshotResponse is the result of a snapshot creation operation.
+type SnapshotResponse struct {
+	Success           bool
+	TriggerName       string
+	SnapshotUID       string
+	SnapshotTimestamp time.Time
+	ErrorReason       string
+	ErrorCode         int
+}
+
+// SnapshotDetail holds information about a single snapshot.
+type SnapshotDetail struct {
+	SnapshotUID       string
+	SourcePod         string
+	CreationTimestamp time.Time
+	Status            string
+}
+
+// ListSnapshotResult is the result of a list snapshots operation.
+type ListSnapshotResult struct {
+	Success     bool
+	Snapshots   []SnapshotDetail
+	ErrorReason string
+	ErrorCode   int
+}
+
+// DeleteSnapshotResult is the result of a delete snapshots operation.
+type DeleteSnapshotResult struct {
+	Success          bool
+	DeletedSnapshots []string
+	ErrorReason      string
+	ErrorCode        int
+}
+
+// SnapshotFilter controls which snapshots are returned by List.
+type SnapshotFilter struct {
+	// ReadyOnly excludes snapshots that are not yet in the Ready state.
+	ReadyOnly bool
+	// GroupingLabels are additional label selectors applied on top of the
+	// mandatory sandbox-name-hash selector.
+	GroupingLabels map[string]string
+}
+
+// SuspendResponse is the result of a suspend operation.
+type SuspendResponse struct {
+	Success          bool
+	SnapshotResponse *SnapshotResponse
+	ErrorReason      string
+	ErrorCode        int
+}
+
+// ResumeResponse is the result of a resume operation.
+type ResumeResponse struct {
+	Success              bool
+	RestoredFromSnapshot bool
+	SnapshotUID          string
+	ErrorReason          string
+	ErrorCode            int
+}
+
+// RestoreCheckResult is the result of an is-restored-from-snapshot check.
+type RestoreCheckResult struct {
+	Success     bool
+	ErrorReason string
+	ErrorCode   int
+}
+
+// snapshotResult is the internal result returned by waitForSnapshotCompleted.
+type snapshotResult struct {
+	SnapshotUID       string
+	SnapshotTimestamp time.Time
+}

--- a/clients/go/gke_extensions/snapshots/types.go
+++ b/clients/go/gke_extensions/snapshots/types.go
@@ -30,7 +30,7 @@ const (
 	SandboxAPIVersion = "v1beta1"
 	SandboxPlural     = "sandboxes"
 
-	SandboxNameHashLabel    = "agents.x-k8s.io/sandbox-name-hash"
+	SandboxNameHashLabel     = "agents.x-k8s.io/sandbox-name-hash"
 	PodSnapshotPodAnnotation = "podsnapshot.gke.io/origin-pod"
 )
 
@@ -40,7 +40,7 @@ const (
 )
 
 var (
-	ErrCRDNotInstalled = errors.New("Pod Snapshot Controller is not ready; install the PodSnapshotPolicy CRD before using this client")
+	ErrCRDNotInstalled = errors.New("pod snapshot controller is not ready; install the PodSnapshotPolicy CRD before using this client")
 	ErrSnapshotTimeout = errors.New("snapshot creation timed out")
 	ErrSnapshotFailed  = errors.New("snapshot creation failed")
 )

--- a/clients/go/gke_extensions/snapshots/utils.go
+++ b/clients/go/gke_extensions/snapshots/utils.go
@@ -130,7 +130,7 @@ var errNotYetComplete = errors.New("snapshot not yet complete")
 func extractSnapshotResult(obj *unstructured.Unstructured) (snapshotResult, error) {
 	conditions, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
 	for _, raw := range conditions {
-		cond, ok := raw.(map[string]interface{})
+		cond, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/clients/go/gke_extensions/snapshots/utils.go
+++ b/clients/go/gke_extensions/snapshots/utils.go
@@ -16,6 +16,7 @@ package snapshots
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -122,7 +123,9 @@ func drainTriggerWatch(ctx context.Context, watcher watch.Interface, triggerName
 	}
 }
 
-var errNotYetComplete = fmt.Errorf("snapshot not yet complete")
+// errNotYetComplete is a sentinel returned by extractSnapshotResult when the
+// trigger has not yet reached a terminal state.
+var errNotYetComplete = errors.New("snapshot not yet complete")
 
 func extractSnapshotResult(obj *unstructured.Unstructured) (snapshotResult, error) {
 	conditions, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")

--- a/clients/go/gke_extensions/snapshots/utils.go
+++ b/clients/go/gke_extensions/snapshots/utils.go
@@ -1,0 +1,344 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var (
+	triggerGVR = schema.GroupVersionResource{
+		Group:    PodSnapshotAPIGroup,
+		Version:  PodSnapshotAPIVersion,
+		Resource: PodSnapshotTriggerPlural,
+	}
+	snapshotGVR = schema.GroupVersionResource{
+		Group:    PodSnapshotAPIGroup,
+		Version:  PodSnapshotAPIVersion,
+		Resource: PodSnapshotPlural,
+	}
+)
+
+// waitForSnapshotCompleted watches the PodSnapshotManualTrigger until it
+// reports completion (Triggered=True/Complete) or failure.
+func waitForSnapshotCompleted(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace, triggerName, resourceVersion string,
+	timeout time.Duration,
+	log logr.Logger,
+) (snapshotResult, error) {
+	log.Info("waiting for snapshot manual trigger to complete", "trigger", triggerName)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	listOpts := metav1.ListOptions{
+		FieldSelector: "metadata.name=" + triggerName,
+	}
+	if resourceVersion != "" {
+		listOpts.ResourceVersion = resourceVersion
+	}
+
+	for {
+		watcher, err := dynClient.Resource(triggerGVR).Namespace(namespace).Watch(ctx, listOpts)
+		if err != nil {
+			if ctx.Err() != nil {
+				return snapshotResult{}, fmt.Errorf("%w: trigger %s: %w", ErrSnapshotTimeout, triggerName, ctx.Err())
+			}
+			return snapshotResult{}, fmt.Errorf("watching snapshot trigger %s: %w", triggerName, err)
+		}
+
+		result, done, watchErr := drainTriggerWatch(ctx, watcher, triggerName, log)
+		watcher.Stop()
+
+		if done {
+			return result, nil
+		}
+		if watchErr != nil {
+			return snapshotResult{}, watchErr
+		}
+		// Watch channel closed; re-establish.
+		log.V(1).Info("trigger watch closed, re-establishing", "trigger", triggerName)
+	}
+}
+
+func drainTriggerWatch(ctx context.Context, watcher watch.Interface, triggerName string, log logr.Logger) (snapshotResult, bool, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return snapshotResult{}, false, fmt.Errorf("%w: trigger %s", ErrSnapshotTimeout, triggerName)
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return snapshotResult{}, false, nil
+			}
+			switch event.Type {
+			case watch.Error:
+				log.V(1).Info("transient trigger watch error, re-listing", "error", event.Object)
+				return snapshotResult{}, false, nil
+			case watch.Deleted:
+				return snapshotResult{}, false, fmt.Errorf("%w: trigger %s was deleted before completion", ErrSnapshotFailed, triggerName)
+			case watch.Added, watch.Modified:
+				obj, ok := event.Object.(*unstructured.Unstructured)
+				if !ok {
+					continue
+				}
+				result, err := extractSnapshotResult(obj)
+				if err == errNotYetComplete {
+					continue
+				}
+				if err != nil {
+					return snapshotResult{}, false, fmt.Errorf("%w: %w", ErrSnapshotFailed, err)
+				}
+				log.Info("snapshot trigger completed", "trigger", triggerName, "snapshotUID", result.SnapshotUID)
+				return result, true, nil
+			}
+		}
+	}
+}
+
+var errNotYetComplete = fmt.Errorf("snapshot not yet complete")
+
+func extractSnapshotResult(obj *unstructured.Unstructured) (snapshotResult, error) {
+	conditions, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, raw := range conditions {
+		cond, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		typ, _ := cond["type"].(string)
+		status, _ := cond["status"].(string)
+		reason, _ := cond["reason"].(string)
+
+		if typ != "Triggered" {
+			continue
+		}
+		if status == "True" && reason == "Complete" {
+			uid, _, _ := unstructured.NestedString(obj.Object, "status", "snapshotCreated", "name")
+			tsStr, _ := cond["lastTransitionTime"].(string)
+			var ts time.Time
+			if tsStr != "" {
+				ts, _ = time.Parse(time.RFC3339, tsStr)
+			}
+			return snapshotResult{SnapshotUID: uid, SnapshotTimestamp: ts}, nil
+		}
+		if status == "False" && (reason == "Failed" || reason == "Error") {
+			msg, _ := cond["message"].(string)
+			return snapshotResult{}, fmt.Errorf("snapshot failed: %s", msg)
+		}
+	}
+	return snapshotResult{}, errNotYetComplete
+}
+
+// checkPodRestoredFromSnapshot reads the pod and verifies the PodRestored condition.
+func checkPodRestoredFromSnapshot(
+	ctx context.Context,
+	coreClient corev1client.CoreV1Interface,
+	namespace, podName, snapshotUID string,
+	log logr.Logger,
+) RestoreCheckResult {
+	pod, err := coreClient.Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		log.Error(err, "failed to check pod restore status", "pod", podName)
+		return RestoreCheckResult{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("failed to read pod: %v", err),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	if pod.Status.Conditions == nil {
+		return RestoreCheckResult{
+			Success:     false,
+			ErrorReason: "pod status or conditions not found",
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type != "PodRestored" {
+			continue
+		}
+		if cond.Status == corev1.ConditionTrue {
+			if strings.Contains(cond.Message, snapshotUID) {
+				return RestoreCheckResult{Success: true, ErrorCode: SuccessCode}
+			}
+			return RestoreCheckResult{
+				Success:     false,
+				ErrorReason: fmt.Sprintf("pod was not restored from snapshot %q; actual condition message: %q", snapshotUID, cond.Message),
+				ErrorCode:   ErrorCode,
+			}
+		}
+		return RestoreCheckResult{
+			Success:     false,
+			ErrorReason: fmt.Sprintf("restore attempted but pending or failed (status: %q, reason: %q, message: %q)", cond.Status, cond.Reason, cond.Message),
+			ErrorCode:   ErrorCode,
+		}
+	}
+
+	return RestoreCheckResult{
+		Success:     false,
+		ErrorReason: "pod was started as a fresh instance (no PodRestored condition found)",
+		ErrorCode:   ErrorCode,
+	}
+}
+
+// waitForSnapshotDeletion watches until the PodSnapshot is gone.
+func waitForSnapshotDeletion(
+	ctx context.Context,
+	dynClient dynamic.Interface,
+	namespace, snapshotUID string,
+	timeout time.Duration,
+	log logr.Logger,
+) error {
+	// Quick check: already deleted?
+	_, err := dynClient.Resource(snapshotGVR).Namespace(namespace).Get(ctx, snapshotUID, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.V(1).Info("snapshot already deleted", "uid", snapshotUID)
+			return nil
+		}
+		return fmt.Errorf("checking snapshot existence: %w", err)
+	}
+
+	log.Info("waiting for snapshot deletion", "uid", snapshotUID)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	listOpts := metav1.ListOptions{FieldSelector: "metadata.name=" + snapshotUID}
+
+	for {
+		watcher, err := dynClient.Resource(snapshotGVR).Namespace(namespace).Watch(ctx, listOpts)
+		if err != nil {
+			if ctx.Err() != nil {
+				return fmt.Errorf("timed out waiting for snapshot %s deletion", snapshotUID)
+			}
+			return fmt.Errorf("watching snapshot %s deletion: %w", snapshotUID, err)
+		}
+
+		done, watchErr := drainDeletionWatch(ctx, watcher, snapshotUID, log)
+		watcher.Stop()
+
+		if done {
+			return nil
+		}
+		if watchErr != nil {
+			return watchErr
+		}
+		log.V(1).Info("snapshot deletion watch closed, re-establishing", "uid", snapshotUID)
+	}
+}
+
+func drainDeletionWatch(ctx context.Context, watcher watch.Interface, snapshotUID string, log logr.Logger) (bool, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return false, fmt.Errorf("timed out waiting for snapshot %s deletion", snapshotUID)
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return false, nil
+			}
+			switch event.Type {
+			case watch.Deleted:
+				log.Info("snapshot deletion confirmed", "uid", snapshotUID)
+				return true, nil
+			case watch.Error:
+				log.V(1).Info("transient deletion watch error, re-listing", "error", event.Object)
+				return false, nil
+			}
+		}
+	}
+}
+
+// waitForPodTermination polls until the pod is gone or its UID changes.
+// Returns true if the pod terminated within the timeout.
+func waitForPodTermination(
+	ctx context.Context,
+	coreClient corev1client.CoreV1Interface,
+	namespace, podName, podUID string,
+	timeout time.Duration,
+	log logr.Logger,
+) bool {
+	log.Info("waiting for pod termination", "pod", podName, "uid", podUID, "timeout", timeout)
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		pod, err := coreClient.Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return true
+			}
+			log.Error(err, "error checking pod status during termination wait", "pod", podName)
+		} else if string(pod.UID) != podUID {
+			// A new pod took the name; old one has terminated.
+			return true
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	log.Info("timed out waiting for pod termination", "pod", podName)
+	return false
+}
+
+// waitForPodReady polls until the pod has Ready=True.
+// Returns true if the pod became ready within the timeout.
+func waitForPodReady(
+	ctx context.Context,
+	coreClient corev1client.CoreV1Interface,
+	namespace, podName string,
+	timeout time.Duration,
+	log logr.Logger,
+) bool {
+	log.Info("waiting for pod to become ready", "pod", podName, "timeout", timeout)
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		pod, err := coreClient.Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err == nil && pod.DeletionTimestamp == nil {
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					return true
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	log.Info("timed out waiting for pod to become ready", "pod", podName)
+	return false
+}

--- a/clients/go/gke_extensions/snapshots/utils.go
+++ b/clients/go/gke_extensions/snapshots/utils.go
@@ -222,6 +222,9 @@ func waitForSnapshotDeletion(
 	timeout time.Duration,
 	log logr.Logger,
 ) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	// Quick check: already deleted?
 	_, err := dynClient.Resource(snapshotGVR).Namespace(namespace).Get(ctx, snapshotUID, metav1.GetOptions{})
 	if err != nil {
@@ -233,8 +236,6 @@ func waitForSnapshotDeletion(
 	}
 
 	log.Info("waiting for snapshot deletion", "uid", snapshotUID)
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 
 	listOpts := metav1.ListOptions{FieldSelector: "metadata.name=" + snapshotUID}
 
@@ -318,7 +319,7 @@ func waitForPodTermination(
 		select {
 		case <-ctx.Done():
 			return false
-		case <-time.After(2 * time.Second):
+		case <-time.After(min(2*time.Second, time.Until(deadline))):
 		}
 	}
 
@@ -357,7 +358,7 @@ func waitForPodReady(
 		select {
 		case <-ctx.Done():
 			return false
-		case <-time.After(2 * time.Second):
+		case <-time.After(min(2*time.Second, time.Until(deadline))):
 		}
 	}
 

--- a/clients/go/gke_extensions/snapshots/utils.go
+++ b/clients/go/gke_extensions/snapshots/utils.go
@@ -314,23 +314,29 @@ func waitForPodTermination(
 }
 
 // waitForPodReady polls until the pod has Ready=True.
+// getPodName is called on every iteration so callers can supply a name that
+// may not yet be populated at call time (e.g. immediately after scale-up).
 // Returns true if the pod became ready within the timeout.
 func waitForPodReady(
 	ctx context.Context,
 	coreClient corev1client.CoreV1Interface,
-	namespace, podName string,
+	namespace string,
+	getPodName func() string,
 	timeout time.Duration,
 	log logr.Logger,
 ) bool {
-	log.Info("waiting for pod to become ready", "pod", podName, "timeout", timeout)
+	log.Info("waiting for pod to become ready", "timeout", timeout)
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
-		pod, err := coreClient.Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-		if err == nil && pod.DeletionTimestamp == nil {
-			for _, cond := range pod.Status.Conditions {
-				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-					return true
+		podName := getPodName()
+		if podName != "" {
+			pod, err := coreClient.Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err == nil && pod.DeletionTimestamp == nil {
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+						return true
+					}
 				}
 			}
 		}
@@ -342,6 +348,6 @@ func waitForPodReady(
 		}
 	}
 
-	log.Info("timed out waiting for pod to become ready", "pod", podName)
+	log.Info("timed out waiting for pod to become ready", "pod", getPodName())
 	return false
 }

--- a/clients/go/gke_extensions/snapshots/utils.go
+++ b/clients/go/gke_extensions/snapshots/utils.go
@@ -143,6 +143,9 @@ func extractSnapshotResult(obj *unstructured.Unstructured) (snapshotResult, erro
 		}
 		if status == "True" && reason == "Complete" {
 			uid, _, _ := unstructured.NestedString(obj.Object, "status", "snapshotCreated", "name")
+			if uid == "" {
+				return snapshotResult{}, fmt.Errorf("trigger completed but status.snapshotCreated.name is empty")
+			}
 			tsStr, _ := cond["lastTransitionTime"].(string)
 			var ts time.Time
 			if tsStr != "" {
@@ -252,6 +255,16 @@ func waitForSnapshotDeletion(
 		}
 		if watchErr != nil {
 			return watchErr
+		}
+		// Watch channel closed; check if already deleted before re-establishing to
+		// close the race between the initial Get() check and Watch() setup.
+		_, err = dynClient.Resource(snapshotGVR).Namespace(namespace).Get(ctx, snapshotUID, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("snapshot confirmed deleted after watch closed", "uid", snapshotUID)
+				return nil
+			}
+			// transient error — fall through to re-watch
 		}
 		log.V(1).Info("snapshot deletion watch closed, re-establishing", "uid", snapshotUID)
 	}

--- a/clients/go/gke_extensions/snapshots/utils_test.go
+++ b/clients/go/gke_extensions/snapshots/utils_test.go
@@ -274,7 +274,7 @@ func TestWaitForPodReady_Ready(t *testing.T) {
 		context.Background(),
 		kubeCS.CoreV1(),
 		"default",
-		"my-pod",
+		func() string { return "my-pod" },
 		5*time.Second,
 		logr.Discard(),
 	)
@@ -304,7 +304,7 @@ func TestWaitForPodReady_Timeout(t *testing.T) {
 		ctx,
 		kubeCS.CoreV1(),
 		"default",
-		"my-pod",
+		func() string { return "my-pod" },
 		5*time.Second,
 		logr.Discard(),
 	)
@@ -336,12 +336,50 @@ func TestWaitForPodReady_SkipsTerminating(t *testing.T) {
 		ctx,
 		kubeCS.CoreV1(),
 		"default",
-		"my-pod",
+		func() string { return "my-pod" },
 		5*time.Second,
 		logr.Discard(),
 	)
 	if done {
 		t.Error("expected false for terminating pod even if conditions say Ready")
+	}
+}
+
+func TestWaitForPodReady_EmptyNameEventuallyPopulates(t *testing.T) {
+	// Simulates the case where pod name is not yet known immediately after scale-up.
+	// The first call to getPodName returns ""; subsequent calls return "my-pod".
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	callCount := 0
+	getPodName := func() string {
+		callCount++
+		if callCount == 1 {
+			return "" // first iteration: name not yet assigned
+		}
+		return "my-pod"
+	}
+
+	done := waitForPodReady(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		getPodName,
+		10*time.Second,
+		logr.Discard(),
+	)
+	if !done {
+		t.Error("expected true when pod name eventually becomes available")
+	}
+	if callCount < 2 {
+		t.Errorf("expected at least 2 getPodName calls, got %d", callCount)
 	}
 }
 

--- a/clients/go/gke_extensions/snapshots/utils_test.go
+++ b/clients/go/gke_extensions/snapshots/utils_test.go
@@ -1,0 +1,573 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshots
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+// ---------------------------------------------------------------------------
+// checkPodRestoredFromSnapshot
+// ---------------------------------------------------------------------------
+
+func makePod(name string, conditions []corev1.PodCondition) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func TestCheckPodRestoredFromSnapshot_Success(t *testing.T) {
+	snapshotUID := "snap-123"
+	pod := makePod("my-pod", []corev1.PodCondition{
+		{
+			Type:    "PodRestored",
+			Status:  corev1.ConditionTrue,
+			Message: "restored from snapshot snap-123",
+		},
+	})
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	result := checkPodRestoredFromSnapshot(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		snapshotUID,
+		logr.Discard(),
+	)
+
+	if !result.Success {
+		t.Errorf("expected success, got error: %s", result.ErrorReason)
+	}
+}
+
+func TestCheckPodRestoredFromSnapshot_WrongUID(t *testing.T) {
+	pod := makePod("my-pod", []corev1.PodCondition{
+		{
+			Type:    "PodRestored",
+			Status:  corev1.ConditionTrue,
+			Message: "restored from snapshot other-uid",
+		},
+	})
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	result := checkPodRestoredFromSnapshot(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		"snap-123",
+		logr.Discard(),
+	)
+
+	if result.Success {
+		t.Error("expected failure when UID does not match")
+	}
+}
+
+func TestCheckPodRestoredFromSnapshot_NoCondition(t *testing.T) {
+	pod := makePod("my-pod", nil)
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	result := checkPodRestoredFromSnapshot(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		"snap-123",
+		logr.Discard(),
+	)
+
+	if result.Success {
+		t.Error("expected failure with no conditions")
+	}
+}
+
+func TestCheckPodRestoredFromSnapshot_FreshStart(t *testing.T) {
+	pod := makePod("my-pod", []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	})
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	result := checkPodRestoredFromSnapshot(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		"snap-123",
+		logr.Discard(),
+	)
+
+	if result.Success {
+		t.Error("expected failure (fresh start, no PodRestored condition)")
+	}
+}
+
+func TestCheckPodRestoredFromSnapshot_PodNotFound(t *testing.T) {
+	kubeCS := fakekube.NewSimpleClientset()
+
+	result := checkPodRestoredFromSnapshot(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"nonexistent",
+		"snap-123",
+		logr.Discard(),
+	)
+
+	if result.Success {
+		t.Error("expected failure when pod not found")
+	}
+}
+
+func TestCheckPodRestoredFromSnapshot_RestoreFailed(t *testing.T) {
+	pod := makePod("my-pod", []corev1.PodCondition{
+		{
+			Type:    "PodRestored",
+			Status:  corev1.ConditionFalse,
+			Reason:  "RestoreFailed",
+			Message: "snapshot not found",
+		},
+	})
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	result := checkPodRestoredFromSnapshot(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		"snap-123",
+		logr.Discard(),
+	)
+
+	if result.Success {
+		t.Error("expected failure when restore failed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForPodTermination
+// ---------------------------------------------------------------------------
+
+func TestWaitForPodTermination_AlreadyGone(t *testing.T) {
+	kubeCS := fakekube.NewSimpleClientset()
+
+	// Pod doesn't exist — should return true immediately.
+	done := waitForPodTermination(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"gone-pod",
+		"uid-1",
+		5*time.Second,
+		logr.Discard(),
+	)
+	if !done {
+		t.Error("expected true when pod is not found")
+	}
+}
+
+func TestWaitForPodTermination_UIDChanged(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "default",
+			UID:       "new-uid",
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	// Old UID is "old-uid"; current pod has "new-uid" → termination detected.
+	done := waitForPodTermination(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		"old-uid",
+		5*time.Second,
+		logr.Discard(),
+	)
+	if !done {
+		t.Error("expected true when pod UID changed")
+	}
+}
+
+func TestWaitForPodTermination_Timeout(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "default",
+			UID:       "same-uid",
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	done := waitForPodTermination(
+		ctx,
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		"same-uid",
+		5*time.Second,
+		logr.Discard(),
+	)
+	if done {
+		t.Error("expected false on timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForPodReady
+// ---------------------------------------------------------------------------
+
+func TestWaitForPodReady_Ready(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	done := waitForPodReady(
+		context.Background(),
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		5*time.Second,
+		logr.Discard(),
+	)
+	if !done {
+		t.Error("expected true for ready pod")
+	}
+}
+
+func TestWaitForPodReady_Timeout(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	done := waitForPodReady(
+		ctx,
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		5*time.Second,
+		logr.Discard(),
+	)
+	if done {
+		t.Error("expected false on timeout when pod is not ready")
+	}
+}
+
+func TestWaitForPodReady_SkipsTerminating(t *testing.T) {
+	now := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-pod",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	done := waitForPodReady(
+		ctx,
+		kubeCS.CoreV1(),
+		"default",
+		"my-pod",
+		5*time.Second,
+		logr.Discard(),
+	)
+	if done {
+		t.Error("expected false for terminating pod even if conditions say Ready")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractSnapshotResult
+// ---------------------------------------------------------------------------
+
+func TestExtractSnapshotResult_Complete(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"snapshotCreated": map[string]interface{}{"name": "snap-abc"},
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":               "Triggered",
+						"status":             "True",
+						"reason":             "Complete",
+						"lastTransitionTime": "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	result, err := extractSnapshotResult(obj)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SnapshotUID != "snap-abc" {
+		t.Errorf("expected snap-abc, got %s", result.SnapshotUID)
+	}
+}
+
+func TestExtractSnapshotResult_Failed(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":    "Triggered",
+						"status":  "False",
+						"reason":  "Failed",
+						"message": "disk full",
+					},
+				},
+			},
+		},
+	}
+	_, err := extractSnapshotResult(obj)
+	if err == nil || err == errNotYetComplete {
+		t.Error("expected non-nil error for failed snapshot")
+	}
+}
+
+func TestExtractSnapshotResult_NotYetComplete(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Triggered",
+						"status": "False",
+						"reason": "InProgress",
+					},
+				},
+			},
+		},
+	}
+	_, err := extractSnapshotResult(obj)
+	if err != errNotYetComplete {
+		t.Errorf("expected errNotYetComplete, got %v", err)
+	}
+}
+
+func init() {
+	// Force the compiler to keep the runtime import used only for test helpers.
+	_ = runtime.NewScheme()
+}
+
+// ---------------------------------------------------------------------------
+// drainDeletionWatch
+// ---------------------------------------------------------------------------
+
+func TestDrainDeletionWatch_Deleted(t *testing.T) {
+	watcher := watch.NewFake()
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "snap-1"}}}
+	go func() { watcher.Delete(obj) }()
+
+	done, err := drainDeletionWatch(context.Background(), watcher, "snap-1", logr.Discard())
+	if !done || err != nil {
+		t.Errorf("expected (true, nil), got (%v, %v)", done, err)
+	}
+}
+
+func TestDrainDeletionWatch_WatchError(t *testing.T) {
+	watcher := watch.NewFake()
+	go func() {
+		watcher.Error(&metav1.Status{Status: "Failure"})
+		watcher.Stop()
+	}()
+
+	done, err := drainDeletionWatch(context.Background(), watcher, "snap-1", logr.Discard())
+	// watch.Error causes re-list (done=false, err=nil).
+	if done || err != nil {
+		t.Errorf("expected (false, nil) on watch.Error, got (%v, %v)", done, err)
+	}
+}
+
+func TestDrainDeletionWatch_ChannelClosed(t *testing.T) {
+	watcher := watch.NewFake()
+	go func() { watcher.Stop() }()
+
+	done, err := drainDeletionWatch(context.Background(), watcher, "snap-1", logr.Discard())
+	if done || err != nil {
+		t.Errorf("expected (false, nil) on closed channel, got (%v, %v)", done, err)
+	}
+}
+
+func TestDrainDeletionWatch_ContextCancelled(t *testing.T) {
+	watcher := watch.NewFake() // never fires
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { cancel() }()
+
+	_, err := drainDeletionWatch(ctx, watcher, "snap-1", logr.Discard())
+	if err == nil {
+		t.Error("expected error when context is cancelled")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForSnapshotDeletion — watch path (snapshot exists, then DELETED)
+// ---------------------------------------------------------------------------
+
+func TestWaitForSnapshotDeletion_WatchPath(t *testing.T) {
+	snap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       "PodSnapshot",
+			"metadata":   map[string]interface{}{"name": "snap-1", "namespace": "default"},
+		},
+	}
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{snapshotGVR: "PodSnapshotList"},
+		snap,
+	)
+
+	snapWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+		go func() { snapWatcher.Delete(snap) }()
+		return true, snapWatcher, nil
+	})
+
+	err := waitForSnapshotDeletion(context.Background(), dynCS, "default", "snap-1", 5*time.Second, logr.Discard())
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// drainTriggerWatch — edge cases
+// ---------------------------------------------------------------------------
+
+func TestDrainTriggerWatch_Deleted(t *testing.T) {
+	watcher := watch.NewFake()
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "t"}}}
+	go func() { watcher.Delete(obj) }()
+
+	_, done, err := drainTriggerWatch(context.Background(), watcher, "t", logr.Discard())
+	if done {
+		t.Error("expected done=false for deleted trigger")
+	}
+	if err == nil {
+		t.Error("expected error (ErrSnapshotFailed) when trigger is deleted")
+	}
+}
+
+func TestDrainTriggerWatch_WatchError(t *testing.T) {
+	watcher := watch.NewFake()
+	go func() {
+		watcher.Error(&metav1.Status{Status: "Failure"})
+		watcher.Stop()
+	}()
+
+	_, done, err := drainTriggerWatch(context.Background(), watcher, "t", logr.Discard())
+	// watch.Error → re-list (done=false, err=nil).
+	if done || err != nil {
+		t.Errorf("expected (zero, false, nil) on watch.Error, got (%v, %v)", done, err)
+	}
+}
+
+func TestDrainTriggerWatch_ChannelClosed(t *testing.T) {
+	watcher := watch.NewFake()
+	go func() { watcher.Stop() }()
+
+	_, done, err := drainTriggerWatch(context.Background(), watcher, "t", logr.Discard())
+	if done || err != nil {
+		t.Errorf("expected (zero, false, nil) on closed channel, got (%v, %v)", done, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForPodTermination — non-404 API error is logged and loop continues
+// ---------------------------------------------------------------------------
+
+func TestWaitForPodTermination_APIError_ThenGone(t *testing.T) {
+	// First call returns a server error; second call returns 404 → terminated.
+	callCount := 0
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default", UID: "uid-old"},
+	}
+	kubeCS := fakekube.NewSimpleClientset(pod)
+	kubeCS.PrependReactor("get", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		if callCount == 1 {
+			return true, nil, fmt.Errorf("server error")
+		}
+		return false, nil, nil // let default (404 after deletion) handle it
+	})
+	// Delete the pod so the second (passthrough) call returns 404.
+	kubeCS.CoreV1().Pods("default").Delete(context.Background(), "my-pod", metav1.DeleteOptions{}) //nolint:errcheck
+
+	done := waitForPodTermination(
+		context.Background(), kubeCS.CoreV1(), "default", "my-pod", "uid-old",
+		5*time.Second, logr.Discard(),
+	)
+	if !done {
+		t.Error("expected true when pod eventually disappears after an API error")
+	}
+}

--- a/clients/go/gke_extensions/snapshots/utils_test.go
+++ b/clients/go/gke_extensions/snapshots/utils_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -433,6 +434,32 @@ func TestExtractSnapshotResult_Failed(t *testing.T) {
 	}
 }
 
+func TestExtractSnapshotResult_EmptyUID(t *testing.T) {
+	// Triggered=True/Complete but snapshotCreated.name is absent.
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"status": map[string]any{
+				// snapshotCreated intentionally omitted
+				"conditions": []any{
+					map[string]any{
+						"type":               "Triggered",
+						"status":             "True",
+						"reason":             "Complete",
+						"lastTransitionTime": "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		},
+	}
+	_, err := extractSnapshotResult(obj)
+	if err == nil {
+		t.Error("expected error when snapshotCreated.name is empty")
+	}
+	if err == errNotYetComplete {
+		t.Error("expected a real error, not errNotYetComplete")
+	}
+}
+
 func TestExtractSnapshotResult_NotYetComplete(t *testing.T) {
 	obj := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -513,6 +540,95 @@ func TestDrainDeletionWatch_ContextCancelled(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestWaitForSnapshotDeletion_WatchPath(t *testing.T) {
+	snap := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       "PodSnapshot",
+			"metadata":   map[string]any{"name": "snap-1", "namespace": "default"},
+		},
+	}
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{snapshotGVR: "PodSnapshotList"},
+		snap,
+	)
+
+	snapWatcher := watch.NewFake()
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
+		go func() { snapWatcher.Delete(snap) }()
+		return true, snapWatcher, nil
+	})
+
+	err := waitForSnapshotDeletion(context.Background(), dynCS, "default", "snap-1", 5*time.Second, logr.Discard())
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// waitForSnapshotDeletion — additional paths
+// ---------------------------------------------------------------------------
+
+func TestWaitForSnapshotDeletion_AlreadyDeleted(t *testing.T) {
+	// Object does not exist at all; initial Get() returns 404 → fast-path nil.
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{snapshotGVR: "PodSnapshotList"},
+	)
+
+	err := waitForSnapshotDeletion(context.Background(), dynCS, "default", "snap-1", 5*time.Second, logr.Discard())
+	if err != nil {
+		t.Errorf("expected nil error for already-deleted snapshot, got: %v", err)
+	}
+}
+
+func TestWaitForSnapshotDeletion_DeletedBeforeWatch(t *testing.T) {
+	// Simulate the TOCTOU race: snapshot exists when the initial Get() runs, but
+	// is deleted before the Watch fires any event. The watch channel closes without
+	// a DELETED event. The fix re-checks with Get() after the watch closes and finds
+	// 404, so it returns nil instead of re-establishing an endless watch loop.
+	//
+	// The reactor mutex prevents calling Delete() inside a watch reactor, so we
+	// simulate the deletion by having the second Get() call return NotFound.
+	snap := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       "PodSnapshot",
+			"metadata":   map[string]any{"name": "snap-1", "namespace": "default"},
+		},
+	}
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{snapshotGVR: "PodSnapshotList"},
+		snap,
+	)
+
+	// First Get() (initial existence check) passes through to the fake store.
+	// Second Get() (post-watch-close re-check) returns NotFound to simulate the race.
+	getCallCount := 0
+	dynCS.PrependReactor("get", "podsnapshots", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		getCallCount++
+		if getCallCount <= 1 {
+			return false, nil, nil // let default handler return the snap
+		}
+		return true, nil, k8serrors.NewNotFound(snapshotGVR.GroupResource(), "snap-1")
+	})
+
+	// Watch closes immediately with no DELETED event.
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
+		w := watch.NewFake()
+		go func() { w.Stop() }()
+		return true, w, nil
+	})
+
+	err := waitForSnapshotDeletion(context.Background(), dynCS, "default", "snap-1", 5*time.Second, logr.Discard())
+	if err != nil {
+		t.Errorf("expected nil when snapshot was deleted before watch fired, got: %v", err)
+	}
+}
+
+func TestWaitForSnapshotDeletion_DeletedDuringWatch(t *testing.T) {
+	// Happy-path regression: snapshot exists, watch fires DELETED → returns nil.
 	snap := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,

--- a/clients/go/gke_extensions/snapshots/utils_test.go
+++ b/clients/go/gke_extensions/snapshots/utils_test.go
@@ -37,10 +37,10 @@ import (
 // checkPodRestoredFromSnapshot
 // ---------------------------------------------------------------------------
 
-func makePod(name string, conditions []corev1.PodCondition) *corev1.Pod {
+func makePod(conditions []corev1.PodCondition) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      "my-pod",
 			Namespace: "default",
 		},
 		Status: corev1.PodStatus{
@@ -51,7 +51,7 @@ func makePod(name string, conditions []corev1.PodCondition) *corev1.Pod {
 
 func TestCheckPodRestoredFromSnapshot_Success(t *testing.T) {
 	snapshotUID := "snap-123"
-	pod := makePod("my-pod", []corev1.PodCondition{
+	pod := makePod([]corev1.PodCondition{
 		{
 			Type:    "PodRestored",
 			Status:  corev1.ConditionTrue,
@@ -75,7 +75,7 @@ func TestCheckPodRestoredFromSnapshot_Success(t *testing.T) {
 }
 
 func TestCheckPodRestoredFromSnapshot_WrongUID(t *testing.T) {
-	pod := makePod("my-pod", []corev1.PodCondition{
+	pod := makePod([]corev1.PodCondition{
 		{
 			Type:    "PodRestored",
 			Status:  corev1.ConditionTrue,
@@ -99,7 +99,7 @@ func TestCheckPodRestoredFromSnapshot_WrongUID(t *testing.T) {
 }
 
 func TestCheckPodRestoredFromSnapshot_NoCondition(t *testing.T) {
-	pod := makePod("my-pod", nil)
+	pod := makePod(nil)
 	kubeCS := fakekube.NewSimpleClientset(pod)
 
 	result := checkPodRestoredFromSnapshot(
@@ -117,7 +117,7 @@ func TestCheckPodRestoredFromSnapshot_NoCondition(t *testing.T) {
 }
 
 func TestCheckPodRestoredFromSnapshot_FreshStart(t *testing.T) {
-	pod := makePod("my-pod", []corev1.PodCondition{
+	pod := makePod([]corev1.PodCondition{
 		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 	})
 	kubeCS := fakekube.NewSimpleClientset(pod)
@@ -154,7 +154,7 @@ func TestCheckPodRestoredFromSnapshot_PodNotFound(t *testing.T) {
 }
 
 func TestCheckPodRestoredFromSnapshot_RestoreFailed(t *testing.T) {
-	pod := makePod("my-pod", []corev1.PodCondition{
+	pod := makePod([]corev1.PodCondition{
 		{
 			Type:    "PodRestored",
 			Status:  corev1.ConditionFalse,
@@ -351,11 +351,11 @@ func TestWaitForPodReady_SkipsTerminating(t *testing.T) {
 
 func TestExtractSnapshotResult_Complete(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"snapshotCreated": map[string]interface{}{"name": "snap-abc"},
-				"conditions": []interface{}{
-					map[string]interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
+				"snapshotCreated": map[string]any{"name": "snap-abc"},
+				"conditions": []any{
+					map[string]any{
 						"type":               "Triggered",
 						"status":             "True",
 						"reason":             "Complete",
@@ -376,10 +376,10 @@ func TestExtractSnapshotResult_Complete(t *testing.T) {
 
 func TestExtractSnapshotResult_Failed(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"conditions": []interface{}{
-					map[string]interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
 						"type":    "Triggered",
 						"status":  "False",
 						"reason":  "Failed",
@@ -397,10 +397,10 @@ func TestExtractSnapshotResult_Failed(t *testing.T) {
 
 func TestExtractSnapshotResult_NotYetComplete(t *testing.T) {
 	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"status": map[string]interface{}{
-				"conditions": []interface{}{
-					map[string]interface{}{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
 						"type":   "Triggered",
 						"status": "False",
 						"reason": "InProgress",
@@ -426,7 +426,7 @@ func init() {
 
 func TestDrainDeletionWatch_Deleted(t *testing.T) {
 	watcher := watch.NewFake()
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "snap-1"}}}
+	obj := &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "snap-1"}}}
 	go func() { watcher.Delete(obj) }()
 
 	done, err := drainDeletionWatch(context.Background(), watcher, "snap-1", logr.Discard())
@@ -476,10 +476,10 @@ func TestDrainDeletionWatch_ContextCancelled(t *testing.T) {
 
 func TestWaitForSnapshotDeletion_WatchPath(t *testing.T) {
 	snap := &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
 			"kind":       "PodSnapshot",
-			"metadata":   map[string]interface{}{"name": "snap-1", "namespace": "default"},
+			"metadata":   map[string]any{"name": "snap-1", "namespace": "default"},
 		},
 	}
 	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
@@ -489,7 +489,7 @@ func TestWaitForSnapshotDeletion_WatchPath(t *testing.T) {
 	)
 
 	snapWatcher := watch.NewFake()
-	dynCS.PrependWatchReactor("podsnapshots", func(action ktesting.Action) (bool, watch.Interface, error) {
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
 		go func() { snapWatcher.Delete(snap) }()
 		return true, snapWatcher, nil
 	})
@@ -506,7 +506,7 @@ func TestWaitForSnapshotDeletion_WatchPath(t *testing.T) {
 
 func TestDrainTriggerWatch_Deleted(t *testing.T) {
 	watcher := watch.NewFake()
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{"metadata": map[string]interface{}{"name": "t"}}}
+	obj := &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "t"}}}
 	go func() { watcher.Delete(obj) }()
 
 	_, done, err := drainTriggerWatch(context.Background(), watcher, "t", logr.Discard())
@@ -553,7 +553,7 @@ func TestWaitForPodTermination_APIError_ThenGone(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-pod", Namespace: "default", UID: "uid-old"},
 	}
 	kubeCS := fakekube.NewSimpleClientset(pod)
-	kubeCS.PrependReactor("get", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+	kubeCS.PrependReactor("get", "pods", func(_ ktesting.Action) (bool, runtime.Object, error) {
 		callCount++
 		if callCount == 1 {
 			return true, nil, fmt.Errorf("server error")

--- a/clients/go/gke_extensions/snapshots/utils_test.go
+++ b/clients/go/gke_extensions/snapshots/utils_test.go
@@ -654,6 +654,36 @@ func TestWaitForSnapshotDeletion_DeletedDuringWatch(t *testing.T) {
 	}
 }
 
+func TestWaitForSnapshotDeletion_Timeout(t *testing.T) {
+	// Snapshot exists and is never deleted; timeout should fire and return an error.
+	snap := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": PodSnapshotAPIGroup + "/" + PodSnapshotAPIVersion,
+			"kind":       "PodSnapshot",
+			"metadata":   map[string]any{"name": "snap-1", "namespace": "default"},
+		},
+	}
+	dynCS := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{snapshotGVR: "PodSnapshotList"},
+		snap,
+	)
+
+	// Watch that never sends any events.
+	dynCS.PrependWatchReactor("podsnapshots", func(_ ktesting.Action) (bool, watch.Interface, error) {
+		return true, watch.NewFake(), nil
+	})
+
+	start := time.Now()
+	err := waitForSnapshotDeletion(context.Background(), dynCS, "default", "snap-1", 50*time.Millisecond, logr.Discard())
+	if err == nil {
+		t.Error("expected a timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("function blocked far too long: %v", elapsed)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // drainTriggerWatch — edge cases
 // ---------------------------------------------------------------------------

--- a/clients/go/gke_extensions/snapshots/utils_test.go
+++ b/clients/go/gke_extensions/snapshots/utils_test.go
@@ -16,10 +16,10 @@ package snapshots
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
-
-	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -569,5 +569,28 @@ func TestWaitForPodTermination_APIError_ThenGone(t *testing.T) {
 	)
 	if !done {
 		t.Error("expected true when pod eventually disappears after an API error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Issue 7: errNotYetComplete uses errors.New (sentinel comparability)
+// ---------------------------------------------------------------------------
+
+func TestErrNotYetComplete_IsComparable(t *testing.T) {
+	if !errors.Is(errNotYetComplete, errNotYetComplete) {
+		t.Error("errNotYetComplete must be comparable to itself via errors.Is")
+	}
+}
+
+func TestErrNotYetComplete_IsNotWrapped(t *testing.T) {
+	if errors.Unwrap(errNotYetComplete) != nil {
+		t.Error("errNotYetComplete must not wrap another error (should use errors.New)")
+	}
+}
+
+func TestErrNotYetComplete_NotConfusedWithOtherErrors(t *testing.T) {
+	other := errors.New("snapshot not yet complete") // different instance
+	if errors.Is(errNotYetComplete, other) {
+		t.Error("errNotYetComplete must not match a different error with the same message")
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a Go client extension for GKE Pod Snapshots (clients/go/gke_extensions/snapshots/), mirroring the existing Python implementation. Enables Go consumers to create, list, and delete PodSnapshot CRDs, and to suspend/resume sandboxes using snapshots as checkpoints

#### Which issue(s) this PR is related to:
closes #538 
