### PR TITLE
feat: propagate sandbox-template-ref-hash label to SandboxTemplate and adopted Sandboxes

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -357,14 +357,24 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 			if mergedMeta.Labels == nil {
 				mergedMeta.Labels = make(map[string]string)
 			}
+			templateHash := SandboxTemplateRefHash(template.Name)
 			mergedMeta.Labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
-			mergedMeta.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
+			mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
 
 			if err := r.mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
 				return nil, err
 			}
 
-			if !equality.Semantic.DeepEqual(&mergedMeta, &sandbox.Spec.PodTemplate.ObjectMeta) {
+			needsUpdate := !equality.Semantic.DeepEqual(&mergedMeta, &sandbox.Spec.PodTemplate.ObjectMeta)
+			if sandbox.Labels[sandboxTemplateRefHash] != templateHash {
+				if sandbox.Labels == nil {
+					sandbox.Labels = make(map[string]string)
+				}
+				sandbox.Labels[sandboxTemplateRefHash] = templateHash
+				needsUpdate = true
+			}
+
+			if needsUpdate {
 				logger.Info("Updating sandbox metadata to match claim", "claim", claim.Name, "sandbox", sandbox.Name)
 				sandbox.Spec.PodTemplate.ObjectMeta = mergedMeta
 				if err := r.Update(ctx, sandbox); err != nil {
@@ -737,7 +747,6 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 
 	// Remove warm pool labels so the sandbox no longer appears in warm pool queries
 	delete(adopted.Labels, warmPoolSandboxLabel)
-	delete(adopted.Labels, sandboxTemplateRefHash)
 	delete(adopted.Labels, v1beta1.SandboxPodTemplateHashLabel)
 	if adopted.Labels == nil {
 		adopted.Labels = make(map[string]string)
@@ -778,6 +787,12 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	template, templateErr := r.getTemplate(ctx, claim)
 	if templateHash == "" && template != nil {
 		templateHash = SandboxTemplateRefHash(template.Name)
+	}
+
+	// Keep the template ref hash on the adopted sandbox's top-level labels so
+	// discovery by template hash keeps working after adoption.
+	if templateHash != "" {
+		adopted.Labels[sandboxTemplateRefHash] = templateHash
 	}
 
 	if templateErr == nil && template != nil {
@@ -1021,6 +1036,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	// Sandbox.metadata.labels).
 	sandbox.Labels = ensureClaimIdentityLabels(sandbox.Labels, claim)
 	sandbox.Labels[v1beta1.SandboxLaunchTypeLabel] = v1beta1.SandboxLaunchTypeCold
+	sandbox.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(sandbox.Spec.PodTemplate.ObjectMeta.Labels, claim)
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -742,7 +742,6 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	// Take a snapshot of the sandbox BEFORE we mutate it to generate a clean JSON Patch.
 	originalAdopted := adopted.DeepCopy()
 
-	// Save templateHash before deleting it
 	templateHash := adopted.Labels[sandboxTemplateRefHash]
 
 	// Remove warm pool labels so the sandbox no longer appears in warm pool queries
@@ -783,10 +782,12 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	adopted.Labels = ensureClaimIdentityLabels(adopted.Labels, claim)
 	adopted.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(adopted.Spec.PodTemplate.ObjectMeta.Labels, claim)
 
-	// Fetch the template to construct the mergedMeta that reconcileActive will build.
+	// Resolve the template hash and metadata used by reconcileActive.
 	template, templateErr := r.getTemplate(ctx, claim)
 	if templateHash == "" && template != nil {
 		templateHash = SandboxTemplateRefHash(template.Name)
+	} else if templateHash == "" && templateErr != nil {
+		log.FromContext(ctx).V(1).Info("Unable to set template ref hash label during adoption because template lookup failed", "sandbox", adopted.Name, "claim", claim.Name, "error", templateErr.Error())
 	}
 
 	// Keep the template ref hash on the adopted sandbox's top-level labels so
@@ -1034,11 +1035,12 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	// Fork extension: also write SandboxIDLabel onto the top-level Sandbox metadata
 	// (KEP-0174 only propagates to pod template labels; platform's informer reads
 	// Sandbox.metadata.labels).
+	templateHash := SandboxTemplateRefHash(template.Name)
 	sandbox.Labels = ensureClaimIdentityLabels(sandbox.Labels, claim)
 	sandbox.Labels[v1beta1.SandboxLaunchTypeLabel] = v1beta1.SandboxLaunchTypeCold
-	sandbox.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
+	sandbox.Labels[sandboxTemplateRefHash] = templateHash
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels = ensureClaimIdentityLabels(sandbox.Spec.PodTemplate.ObjectMeta.Labels, claim)
-	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(template.Name)
+	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = templateHash
 
 	if err := r.mergePodMetadata(&sandbox.Spec.PodTemplate.ObjectMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
 		return nil, err

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -439,7 +439,14 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			expectedCondition: metav1.Condition{
 				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "SandboxNotReady", Message: "Sandbox is not ready",
 			},
-			validateSandbox: validateSandboxHasDefaultAutomountToken,
+			validateSandbox: func(t *testing.T, sandbox *sandboxv1beta1.Sandbox, template *extensionsv1beta1.SandboxTemplate) {
+				validateSandboxHasDefaultAutomountToken(t, sandbox, template)
+
+				expectedHash := SandboxTemplateRefHash(template.Name)
+				if val := sandbox.Labels[sandboxTemplateRefHash]; val != expectedHash {
+					t.Errorf("expected Sandbox metadata to have label %q=%q, got %q", sandboxTemplateRefHash, expectedHash, val)
+				}
+			},
 		},
 		{
 			name:             "sandbox exists but template is not found",
@@ -491,6 +498,11 @@ func TestSandboxClaimReconcile(t *testing.T) {
 				Message: "Sandbox is not ready",
 			},
 			validateSandbox: func(t *testing.T, sandbox *sandboxv1beta1.Sandbox, _ *extensionsv1beta1.SandboxTemplate) {
+				expectedHash := SandboxTemplateRefHash("test-template")
+				if val := sandbox.Labels[sandboxTemplateRefHash]; val != expectedHash {
+					t.Errorf("expected Sandbox metadata to have label %q=%q, got %q", sandboxTemplateRefHash, expectedHash, val)
+				}
+
 				// Verify DNS Bypass is successfully injected
 				if sandbox.Spec.PodTemplate.Spec.DNSPolicy != corev1.DNSNone {
 					t.Errorf("Expected DNSPolicy to be 'None', got %q", sandbox.Spec.PodTemplate.Spec.DNSPolicy)
@@ -2127,8 +2139,9 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				if _, exists := adoptedSandbox.Labels[warmPoolSandboxLabel]; exists {
 					t.Errorf("expected warm pool label to be removed from adopted sandbox")
 				}
-				if _, exists := adoptedSandbox.Labels[sandboxTemplateRefHash]; exists {
-					t.Errorf("expected template ref label to be removed from adopted sandbox")
+				expectedTemplateHash := SandboxTemplateRefHash(template.Name)
+				if val := adoptedSandbox.Labels[sandboxTemplateRefHash]; val != expectedTemplateHash {
+					t.Errorf("expected adopted sandbox to retain template ref label %q=%q, got %q", sandboxTemplateRefHash, expectedTemplateHash, val)
 				}
 				if val := adoptedSandbox.Labels[sandboxv1beta1.SandboxLaunchTypeLabel]; val != sandboxv1beta1.SandboxLaunchTypeWarm {
 					t.Errorf("expected adopted sandbox to have launch type label %q, got %q; labels=%v", sandboxv1beta1.SandboxLaunchTypeWarm, val, adoptedSandbox.Labels)

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -64,6 +64,10 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	ctx, end := r.Tracer.StartSpan(ctx, template, "ReconcileSandboxTemplate", nil)
 	defer end()
 
+	if err := r.ensureTemplateRefHashLabel(ctx, template); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if !template.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
 	}
@@ -151,6 +155,28 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	logger.Info("Successfully created shared NetworkPolicy", "name", npName)
 	return ctrl.Result{}, nil
+}
+
+func (r *SandboxTemplateReconciler) ensureTemplateRefHashLabel(ctx context.Context, template *extensionsv1beta1.SandboxTemplate) error {
+	if !template.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	expectedHash := SandboxTemplateRefHash(template.Name)
+	if template.Labels[sandboxTemplateRefHash] == expectedHash {
+		return nil
+	}
+
+	original := template.DeepCopy()
+	if template.Labels == nil {
+		template.Labels = make(map[string]string)
+	}
+	template.Labels[sandboxTemplateRefHash] = expectedHash
+
+	if err := r.Patch(ctx, template, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("failed to label sandbox template %q with template ref hash: %w", client.ObjectKeyFromObject(template), err)
+	}
+	return nil
 }
 
 // buildDefaultNetworkPolicySpec generates the "Secure by Default" network policy.

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -228,6 +228,19 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 			if val := updatedTemplate.Labels[sandboxTemplateRefHash]; val != expectedTemplateHash {
 				t.Errorf("expected SandboxTemplate to have label %q=%q, got %q", sandboxTemplateRefHash, expectedTemplateHash, val)
 			}
+
+			resourceVersion := updatedTemplate.ResourceVersion
+			_, err = reconciler.Reconcile(context.Background(), req)
+			if err != nil {
+				t.Fatalf("second reconcile: (%v)", err)
+			}
+			var relabeledTemplate extensionsv1beta1.SandboxTemplate
+			if err := client.Get(context.Background(), req.NamespacedName, &relabeledTemplate); err != nil {
+				t.Fatalf("get sandbox template after second reconcile: %v", err)
+			}
+			if relabeledTemplate.ResourceVersion != resourceVersion {
+				t.Errorf("expected second reconcile to leave SandboxTemplate resourceVersion unchanged, got %q, want %q", relabeledTemplate.ResourceVersion, resourceVersion)
+			}
 		})
 	}
 }

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -219,6 +219,15 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 			if tc.expectNetworkPolicy && tc.validateNetworkPolicy != nil {
 				tc.validateNetworkPolicy(t, &np)
 			}
+
+			var updatedTemplate extensionsv1beta1.SandboxTemplate
+			if err := client.Get(context.Background(), req.NamespacedName, &updatedTemplate); err != nil {
+				t.Fatalf("get sandbox template: %v", err)
+			}
+			expectedTemplateHash := SandboxTemplateRefHash(tc.templateToReconcile.Name)
+			if val := updatedTemplate.Labels[sandboxTemplateRefHash]; val != expectedTemplateHash {
+				t.Errorf("expected SandboxTemplate to have label %q=%q, got %q", sandboxTemplateRefHash, expectedTemplateHash, val)
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Closes #843. Adds the `agents.x-k8s.io/sandbox-template-ref-hash` label to two surfaces it was missing so clients can resolve the `SandboxTemplate` <-> `Sandbox` relationship through a single label selector:

1. `SandboxTemplate.metadata.labels` - the template now self-labels with its own ref hash during reconcile, mirroring how `Deployment` self-labels with `pod-template-hash`. Idempotent: the patch is a no-op when the label is already correct, so steady-state reconciles do not self-trigger.
2. `Sandbox.metadata.labels` on adopted and cold-path Sandboxes - `completeAdoption` no longer deletes the hash label after warm-pool adoption (the `warmPoolSandboxLabel` deletion at the same site is what actually excludes the sandbox from warm-pool queries; the template-ref-hash deletion was redundant per the issue's reviewer note). `reconcileActive` and `createSandbox` now also write the hash onto top-level `sandbox.Labels` so cold-path-created Sandboxes carry it. Warm-pool-created Sandboxes already had it via `sandboxwarmpool_controller.go:329-333`.

After this PR, `kubectl get sandbox -l agents.x-k8s.io/sandbox-template-ref-hash=<hash>` returns every Sandbox spawned by a given template - warm-pool, cold-path, and adopted - without clients needing to recompute the hash themselves.

The hash function `SandboxTemplateRefHash` already exists ([utils.go](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/extensions/controllers/utils.go), added in #763 by @lauragalbraith) and produces an 8-char deterministic hash. This change reuses it.

This aligns with the [`k8s-api-conventions` agent skill's "Label Values" guidance](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/.agents/skills/k8s-api-conventions/SKILL.md): when resource names can exceed the 63-char label limit, hash-based labels are the recommended pattern.

#### Which issue(s) this PR is related to:

Fixes #843
Ref #342 (parent discussion about the 63-character label-limit constraint)

#### Release Note

```release-note
SandboxTemplate now self-labels with `agents.x-k8s.io/sandbox-template-ref-hash`, and the same label is preserved on adopted Sandboxes and propagated to top-level metadata on cold-path-created Sandboxes. Clients can use a single label selector to resolve the SandboxTemplate <-> Sandbox relationship.
```

#### Testing

- New assertion in `sandboxtemplate_controller_test.go` covers the SandboxTemplate self-labeling for both Managed and Unmanaged NetworkPolicy paths.
- New assertions in `sandboxclaim_controller_test.go` cover cold-path-created Sandboxes carrying the label on top-level metadata.
- The existing adoption assertion at line 1865-1870 was inverted: it previously required the label be removed; it now requires the label be present with `SandboxTemplateRefHash(template.Name)`.
- `make all` passes locally.

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed template reference hash persistence for adopted and newly created sandboxes
  * Improved sandbox metadata reconciliation by consistently computing template hashes across labels
  * Enhanced template reconciliation idempotency

* **Tests**
  * Added validation of sandbox template reference hash labels during adoption and creation
  * Verified idempotent reconciliation behavior for templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->