### PR TITLE
Update validation of Sandbox label

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -830,7 +830,7 @@ func validateAdditionalPodMetadata(claimMeta *v1beta1.PodMetadata) error {
 		}
 
 		// Block spoofing of system components
-		if isLabel && strings.ToLower(key) == "app" && strings.ToLower(value) == "sandbox-router" {
+		if isLabel && strings.EqualFold(key, "app") && strings.EqualFold(value, "sandbox-router") {
 			return fmt.Errorf("restricted system label value: %q=%q is not allowed in AdditionalPodMetadata", key, value)
 		}
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -829,6 +829,11 @@ func validateAdditionalPodMetadata(claimMeta *v1beta1.PodMetadata) error {
 			return fmt.Errorf("restricted system domain: %q is not allowed in AdditionalPodMetadata", key)
 		}
 
+		// Block spoofing of system components
+		if isLabel && strings.ToLower(key) == "app" && strings.ToLower(value) == "sandbox-router" {
+			return fmt.Errorf("restricted system label value: %q=%q is not allowed in AdditionalPodMetadata", key, value)
+		}
+
 		// Validate label values (annotations have less restrictions)
 		if isLabel {
 			if errs := validation.IsValidLabelValue(value); len(errs) > 0 {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -632,6 +632,24 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "claim with spoofed router app label is rejected",
+			claimToReconcile: &extensionsv1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "claim-spoofed-app-label", Namespace: "default", UID: "uid-spoofed-app-label"},
+				Spec: extensionsv1beta1.SandboxClaimSpec{
+					TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"},
+					AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
+						Labels: map[string]string{"app": "sandbox-router"},
+					},
+				},
+			},
+			existingObjects: []client.Object{template},
+			expectSandbox:   false,
+			expectError:     false,
+			expectedCondition: metav1.Condition{
+				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "InvalidMetadata",
+			},
+		},
+		{
 			name:             "sandbox is created with injected environment variables from claim",
 			claimToReconcile: claimWithEnv,
 			existingObjects:  []client.Object{templateWithEnvOverride},

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -646,7 +646,10 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			expectSandbox:   false,
 			expectError:     false,
 			expectedCondition: metav1.Condition{
-				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "InvalidMetadata",
+				Type:    string(sandboxv1beta1.SandboxConditionReady),
+				Status:  metav1.ConditionFalse,
+				Reason:  "InvalidMetadata",
+				Message: "invalid additionalPodMetadata: failed to validate label \"app\": restricted system label value: \"app\"=\"sandbox-router\" is not allowed in AdditionalPodMetadata",
 			},
 		},
 		{
@@ -871,6 +874,9 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			if tc.expectedCondition.Reason == "ReconcilerError" || tc.expectedCondition.Reason == "InvalidMetadata" {
 				if condition.Reason != tc.expectedCondition.Reason {
 					t.Errorf("expected condition reason %q, got %q", tc.expectedCondition.Reason, condition.Reason)
+				}
+				if tc.expectedCondition.Message != "" && condition.Message != tc.expectedCondition.Message {
+					t.Errorf("expected condition message %q, got %q", tc.expectedCondition.Message, condition.Message)
 				}
 			} else {
 				if len(tc.expectedPodIPs) > 0 {


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR enhances the validation of the metadata in sandboxclaim. 
Specifically, it updates the `validateAdditionalPodMetadata` function in the `SandboxClaim` controller to block users from defining the `app=sandbox-router` label within their claims.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Ref bug(internal) - [b/511322145 ](https://b.corp.google.com/issues/511322145)

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->