### PR TITLE
.github/copilot-instructions.md: add Project Toolchain, Lint Policy, …

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,8 +20,6 @@ If the repo's lint gate (`make lint-go` and `make lint-api`, which wrap `./dev/t
 **Scope of Review:**
 
 Focus on substantive findings tied to the lines the PR actually changes — logic bugs, security issues, controller-runtime misuse, API/contract breaks, missing tests for the new behavior. In particular:
-
-- Do **not** comment on lines that are unchanged by the diff unless they materially interact with a changed line (e.g. the change breaks an invariant the surrounding code assumed).
 - Do **not** flag style issues in pre-existing code that the PR happens to move or re-format mechanically.
 
 When in doubt between flagging a marginal nit and staying silent: stay silent. Each comment costs the contributor attention, and a noisy review erodes the signal of the substantive findings.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,31 @@ You are an expert code reviewer, experienced with Kubernetes and `controller-run
 **Context:**
 `agent-sandbox` is a Kubernetes controller designed for managing isolated, stateful, singleton workloads (like AI agent runtimes).
 
+**Project Toolchain & Versions:**
+
+The Go toolchain version targeted by this repository is the value of the `go` directive in `go.mod` at the head of the PR's base branch. Defer to that value as the authoritative target. Do **not** suggest lowering the targeted Go version, dropping support for newer language features that compile cleanly under it, or adding compatibility shims for older toolchains the repo has already moved past. If a PR introduces a `go` bump, evaluate the bump on its own merits (motivation, blast radius) — not by pattern-matching to "older is safer". Treat the version set in `go.mod` as a deliberate maintainer decision unless the PR is itself changing it.
+
+**Lint Policy:**
+
+This repository's binding style and correctness gate is whatever lint config exists at the head of the PR's base branch (e.g. `.golangci.yml`, `.golangci.yaml`, or absence of one). If the repo has not opted into a particular linter or stylistic rule, do **not** introduce that rule via review comments. Bias toward stylistic suggestions only when:
+
+- the rule is enforced by the repo's existing lint config, **or**
+- the change introduces a clear bug (not a clear style preference), **or**
+- the file already follows a local convention and the new code visibly diverges from it.
+
+If `go vet`, `go build`, and `go test` all pass and no lint config flags the line, treat residual style as author preference rather than a review-blocking concern.
+
+**Scope of Review:**
+
+Focus on substantive findings tied to the lines the PR actually changes — logic bugs, security issues, controller-runtime misuse, API/contract breaks, missing tests for the new behavior. In particular:
+
+- Do **not** repeat the same finding across multiple files when one comment with a file list suffices.
+- Do **not** comment on lines that are unchanged by the diff unless they materially interact with a changed line (e.g. the change breaks an invariant the surrounding code assumed).
+- Do **not** flag style issues in pre-existing code that the PR happens to move or re-format mechanically.
+- Prefer one consolidated comment per concern over multiple sub-comments restating the same point.
+
+When in doubt between flagging a marginal nit and staying silent: stay silent. Each comment costs the contributor attention, and a noisy review erodes the signal of the substantive findings.
+
 **Your Mission:**
 
 1. **Analyze Logic & Correctness:** Identify logical errors, race conditions, memory leaks, or unhandled edge cases, especially within controller reconciliation loops.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,22 +9,20 @@ The Go toolchain version targeted by this repository is the value of the `go` di
 
 **Lint Policy:**
 
-This repository's binding style and correctness gate is whatever lint config exists at the head of the PR's base branch (e.g. `.golangci.yml`, `.golangci.yaml`, or absence of one). If the repo has not opted into a particular linter or stylistic rule, do **not** introduce that rule via review comments. Bias toward stylistic suggestions only when:
+This repository's binding style and correctness gate is whatever lint config exists at the head of the PR's base branch (e.g. `.golangci.yml`, `.golangci.yaml`, `.golangci-kal.yml`, or absence of one). If the repo has not opted into a particular linter or stylistic rule, do **not** introduce that rule via review comments. Bias toward stylistic suggestions only when:
 
 - the rule is enforced by the repo's existing lint config, **or**
 - the change introduces a clear bug (not a clear style preference), **or**
 - the file already follows a local convention and the new code visibly diverges from it.
 
-If `go vet`, `go build`, and `go test` all pass and no lint config flags the line, treat residual style as author preference rather than a review-blocking concern.
+If the repo's lint gate (`make lint-go` and `make lint-api`, which wrap `./dev/tools/lint-*`) and `go test` all pass and no lint config flags the line, treat residual style as author preference rather than a review-blocking concern.
 
 **Scope of Review:**
 
 Focus on substantive findings tied to the lines the PR actually changes — logic bugs, security issues, controller-runtime misuse, API/contract breaks, missing tests for the new behavior. In particular:
 
-- Do **not** repeat the same finding across multiple files when one comment with a file list suffices.
 - Do **not** comment on lines that are unchanged by the diff unless they materially interact with a changed line (e.g. the change breaks an invariant the surrounding code assumed).
 - Do **not** flag style issues in pre-existing code that the PR happens to move or re-format mechanically.
-- Prefer one consolidated comment per concern over multiple sub-comments restating the same point.
 
 When in doubt between flagging a marginal nit and staying silent: stay silent. Each comment costs the contributor attention, and a noisy review erodes the signal of the substantive findings.
 


### PR DESCRIPTION
This PR adds three sections to .github/copilot-instructions.md — **Project Toolchain & Versions**, **Lint Policy**, and **Scope of Review** — to shape Copilot's review posture as the repo matures. The existing Context / Mission / Conventions / CLA Reminder / Tone sections are unchanged; the three new sections sit between Context and Mission so they frame the reviewer's posture before the per-task checklist.

The three sections are descriptive, not prescriptive — they tell the bot **where to look for the truth** (go.mod, .golangci*.yml, the diff itself) rather than baking specific versions or rules into the instructions, so the file doesn't go stale when those change.

**Why these three:** recent review threads on this repo show a few recurring patterns the current instructions don't directly speak to. A few concrete examples:

**#810 (rapid-burst HPA test)** — Copilot left two separate comments flagging the same Warmpool vs WarmPool capitalization across two files (templates/cluster-loader-hpa.yaml:10 and rapid-burst-test.yaml:147). One consolidated comment with a file list would have communicated the same finding; the duplication dilutes the substantive findings in the same review. The new **Scope of Review** section codifies "one consolidated comment per concern."

**#851 (utcnow → now(UTC))** — A 2-line change attracted a Copilot comment arguing the repo's Python target is 3.10 and datetime.UTC is 3.11+, asking to revert to an older-toolchain-compatible form. The PR was merged as-is. This is the kind of "stay on older toolchain" comment **Project Toolchain & Versions** is meant to bound — if the repo's binding version (in pyproject.toml / go.mod / equivalent) targets 3.11+, the bot should defer to that rather than re-litigate it per-PR.

**#798 (parallel WarmPool controller)** — Three Copilot comments on one file, all stylistic (rename an unused callback param to _, two docstring-vs-implementation mismatches). The substantive controller-correctness question (slowStartBatch error aggregation semantics) was raised correctly, but bundled with two polish notes that could have ridden on a follow-up. **Scope of Review**'s "when in doubt between a marginal nit and silence, prefer silence" guidance is aimed at this — the cost per comment is contributor attention, and substantive findings get diluted by adjacent polish.

The patterns share a shape: the bot pattern-matches to a generic style/version heuristic without checking what this repo has actually opted into. The three sections re-anchor each pattern on a per-repo source of truth.

**What is NOT in this PR:**
No change to Mission, Conventions, CLA Reminder, or Tone.
No new Go style opinions — Lint Policy explicitly defers to .golangci.yml (which the repo does not currently have).
No targeting of any specific past review thread — the framing is forward-looking and the examples above are illustrative.

**Verification:**
git apply --check clean against main HEAD.
Markdown renders correctly.
File length goes from 24 lines to 50 lines.

---

#### Which issue(s) this PR is related to:

No tracking issue — proactive improvement based on observed Copilot review-thread patterns on this repo. Examples cited above (#810, #851, #798) for illustration; the change is not specifically scoped to any of them.

#### Release Note
release-note
NONE