### PR TITLE
fix(extensions): reject unowned sandboxes in isAdoptable to prevent warm pool poisoning

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1668,7 +1668,10 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	}
 
 	controllerRef := metav1.GetControllerOf(candidate)
-	if controllerRef != nil && controllerRef.Kind != "SandboxWarmPool" {
+	if controllerRef == nil {
+		return fmt.Errorf("sandbox is unowned and cannot be safely adopted")
+	}
+	if controllerRef.Kind != "SandboxWarmPool" {
 		return fmt.Errorf("sandbox is not managed by warm pool. Controller: %v", controllerRef)
 	}
 	return nil

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1669,10 +1669,10 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 
 	controllerRef := metav1.GetControllerOf(candidate)
 	if controllerRef == nil {
-		return fmt.Errorf("sandbox is unowned and cannot be safely adopted")
+		return fmt.Errorf("sandbox %s/%s is unowned and cannot be safely adopted", candidate.Namespace, candidate.Name)
 	}
-	if controllerRef.Kind != "SandboxWarmPool" {
-		return fmt.Errorf("sandbox is not managed by warm pool. Controller: %v", controllerRef)
+	if controllerRef.APIVersion != extensionsv1beta1.GroupVersion.String() || controllerRef.Kind != "SandboxWarmPool" {
+		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
 	}
 	return nil
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3263,9 +3263,10 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				warmPoolSandboxLabel:   "pool-hash-123",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
 				Kind:       "SandboxWarmPool",
 				Name:       "test-warmpool",
-				Controller: new(true),
+				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
 	}
@@ -3280,9 +3281,10 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				warmPoolSandboxLabel:   "pool-hash-123",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
 				Kind:       "SandboxWarmPool",
 				Name:       "test-warmpool",
-				Controller: new(true),
+				Controller: ptr.To(true), // nolint:modernize
 			}},
 		},
 	}
@@ -3842,9 +3844,6 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 				sandboxTemplateRefHash: templateHash,
 			},
 		},
-		Spec: sandboxv1beta1.SandboxSpec{
-			PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}},
-		},
 	}
 
 	// 3. Verify it is rejected
@@ -3860,7 +3859,7 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 			Kind:       "SandboxWarmPool",
 			Name:       "test-pool",
 			UID:        "pool-uid-123",
-			Controller: new(true),
+			Controller: ptr.To(true), // nolint:modernize
 		},
 	}
 
@@ -3876,7 +3875,7 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 			Kind:       "SandboxClaim",
 			Name:       "test-claim",
 			UID:        "claim-uid-123",
-			Controller: new(true),
+			Controller: ptr.To(true), // nolint:modernize
 		},
 	}
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2056,6 +2056,20 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 			expectNewSandboxCreated: false,
 		},
+		{
+			name: "rejects unowned sandboxes with mock labels",
+			existingObjects: []client.Object{
+				template,
+				claim,
+				func() client.Object {
+					sb := createWarmPoolSandbox("unowned-sb", metav1.Now(), true)
+					sb.OwnerReferences = nil
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:   false,
+			expectNewSandboxCreated: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -3249,8 +3263,9 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				warmPoolSandboxLabel:   "pool-hash-123",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				Kind: "SandboxWarmPool",
-				Name: "test-warmpool",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-warmpool",
+				Controller: new(true),
 			}},
 		},
 	}
@@ -3265,8 +3280,9 @@ func TestVerifySandboxCandidate_NamespaceIsolation(t *testing.T) {
 				warmPoolSandboxLabel:   "pool-hash-123",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				Kind: "SandboxWarmPool",
-				Name: "test-warmpool",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-warmpool",
+				Controller: new(true),
 			}},
 		},
 	}
@@ -3809,4 +3825,63 @@ func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
 
 	require.NotContains(t, updatedClaim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
 	require.Equal(t, "adopted-sb-legacy", updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+}
+
+func TestIsAdoptable_RejectsUnowned(t *testing.T) {
+	// 1. Create a warm pool template hash
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	templateHash := sandboxcontrollers.NameHash("test-template")
+
+	// 2. Mock an unowned Sandbox (no OwnerReferences)
+	unownedSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unowned-sandbox",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: templateHash,
+			},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}},
+		},
+	}
+
+	// 3. Verify it is rejected
+	err := isAdoptable(unownedSandbox)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unowned")
+
+	// 4. Mock an owned Sandbox (pointing to SandboxWarmPool)
+	ownedSandbox := unownedSandbox.DeepCopy()
+	ownedSandbox.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+			Kind:       "SandboxWarmPool",
+			Name:       "test-pool",
+			UID:        "pool-uid-123",
+			Controller: new(true),
+		},
+	}
+
+	// 5. Verify it is accepted
+	err = isAdoptable(ownedSandbox)
+	require.NoError(t, err)
+
+	// 6. Mock an owned Sandbox pointing to a different kind (e.g. SandboxClaim, which is NOT WarmPool)
+	ownedByClaimSandbox := unownedSandbox.DeepCopy()
+	ownedByClaimSandbox.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+			Kind:       "SandboxClaim",
+			Name:       "test-claim",
+			UID:        "claim-uid-123",
+			Controller: new(true),
+		},
+	}
+
+	// 7. Verify it is rejected
+	err = isAdoptable(ownedByClaimSandbox)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not managed by warm pool")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes the `SandboxClaim` controller could adopt unowned `Sandbox` resources. Previously, the `isAdoptable` function only checked if an existing controller reference was specifically not a `SandboxWarmPool`. This allowed unowned sandboxes to be added to the warm pool queue and subsequently adopted by legitimate users.

By intercepting these environments, it could exfiltrate data or falsify outputs, compromising the sandbox security boundary.

The fix introduces an explicit check to ensure that a `Sandbox` has a valid controller reference before adoption.

**Changes:**
*   Modified `extensions/controllers/sandboxclaim_controller.go` to reject unowned sandboxes in the `isAdoptable` function.
*   Added unit tests in `extensions/controllers/sandboxclaim_controller_test.go` to verify that unowned sandboxes are rejected and legitimate owned sandboxes are still accepted.

