### PR TITLE
feat: warmpool selection strategy

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -230,6 +230,10 @@ type SandboxStatus struct {
 	// A pod may have multiple IPs in dual-stack clusters.
 	// +optional
 	PodIPs []string `json:"podIPs,omitempty"`
+
+	// nodeName is the name of the node where the underlying pod is scheduled.
+	// +optional
+	NodeName string `json:"nodeName,omitempty"`
 }
 
 // +genclient

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -237,9 +237,11 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 	if pod == nil {
 		sandbox.Status.PodIPs = nil
+		sandbox.Status.NodeName = ""
 	} else {
 		sandbox.Status.LabelSelector = fmt.Sprintf("%s=%s", sandboxLabel, NameHash(sandbox.Name))
 		sandbox.Status.PodIPs = podIPsFromStatus(pod.Status.PodIPs)
+		sandbox.Status.NodeName = pod.Spec.NodeName
 	}
 
 	// Reconcile Service

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -566,6 +566,7 @@ func TestReconcile(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "test-container"}},
+						NodeName:   "node-1",
 					},
 					Status: corev1.PodStatus{
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}, {IP: "fd00::5"}},
@@ -589,6 +590,7 @@ func TestReconcile(t *testing.T) {
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				PodIPs:        []string{"10.244.0.5", "fd00::5"},
+				NodeName:      "node-1",
 				Conditions: []metav1.Condition{
 					{
 						Type:               "Ready",
@@ -634,6 +636,7 @@ func TestReconcile(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "test-container"}},
+						NodeName:   "node-2",
 					},
 					Status: corev1.PodStatus{
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}},
@@ -654,6 +657,7 @@ func TestReconcile(t *testing.T) {
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				PodIPs:        []string{"10.244.0.5"},
+				NodeName:      "node-2",
 				Conditions: []metav1.Condition{
 					{
 						Type:               "Ready",

--- a/docs/api.md
+++ b/docs/api.md
@@ -185,6 +185,7 @@ _Appears in:_
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_ | conditions defines the status conditions array |  | Optional: \{\} <br /> |
 | `selector` _string_ | selector is the label selector for pods. |  | Optional: \{\} <br /> |
 | `podIPs` _string array_ | podIPs are the IP addresses of the underlying pod.<br />A pod may have multiple IPs in dual-stack clusters. |  | Optional: \{\} <br /> |
+| `nodeName` _string_ | nodeName is the name of the node where the underlying pod is scheduled. |  | Optional: \{\} <br /> |
 
 
 #### ShutdownPolicy

--- a/extensions/controllers/queue/simple_sandbox_queue.go
+++ b/extensions/controllers/queue/simple_sandbox_queue.go
@@ -28,6 +28,7 @@ type SandboxKey types.NamespacedName
 type SandboxQueue interface {
 	Add(warmPoolName string, item SandboxKey)
 	Get(warmPoolName string) (SandboxKey, bool)
+	GetWithStrategy(warmPoolName string, pick func([]SandboxKey) (SandboxKey, bool)) (SandboxKey, bool)
 	RemoveQueue(warmPoolName string)
 	RemoveItem(warmPoolName string, item SandboxKey)
 }
@@ -56,6 +57,15 @@ func (s *SimpleSandboxQueue) Get(warmPoolName string) (SandboxKey, bool) {
 		return SandboxKey{}, false
 	}
 	return q.(*synchronizedQueue).Pop()
+}
+
+// GetWithStrategy pops an item from the specific warm pool's queue using a custom strategy.
+func (s *SimpleSandboxQueue) GetWithStrategy(warmPoolName string, pick func([]SandboxKey) (SandboxKey, bool)) (SandboxKey, bool) {
+	q, ok := s.queues.Load(warmPoolName)
+	if !ok {
+		return SandboxKey{}, false
+	}
+	return q.(*synchronizedQueue).PopWithStrategy(pick)
 }
 
 // RemoveItem deletes a specific sandbox from a warm pool's queue.
@@ -139,8 +149,55 @@ func (q *synchronizedQueue) Pop() (SandboxKey, bool) {
 	return item, true
 }
 
+// PopWithStrategy applies the strategy function to pick an item from the queue,
+// removes it thread-safely, and returns it.
+func (q *synchronizedQueue) PopWithStrategy(pick func([]SandboxKey) (SandboxKey, bool)) (SandboxKey, bool) {
+	for {
+		q.mu.Lock()
+		if len(q.items) == 0 {
+			q.mu.Unlock()
+			return SandboxKey{}, false
+		}
+
+		// Snapshot the queue items
+		snapshot := make([]SandboxKey, len(q.items))
+		copy(snapshot, q.items)
+		q.mu.Unlock()
+
+		key, ok := pick(snapshot)
+		if !ok {
+			return SandboxKey{}, false
+		}
+
+		q.mu.Lock()
+		// Verify the key is still present in the queue
+		if _, exists := q.set[key]; !exists {
+			// The picked key was concurrently popped by another goroutine.
+			// Unlock and retry snapshot and pick.
+			q.mu.Unlock()
+			continue
+		}
+
+		// Find the picked key in q.items and remove it
+		for i, k := range q.items {
+			if k == key {
+				// Shift left and clear the tail slot
+				last := len(q.items) - 1
+				copy(q.items[i:], q.items[i+1:])
+				q.items[last] = SandboxKey{}
+				q.items = q.items[:last]
+				break
+			}
+		}
+		delete(q.set, key)
+		q.mu.Unlock()
+
+		return key, true
+	}
+}
+
 // RemoveQueue completely deletes a warm pool's queue from the sync.Map
-// to prevent memory leaks when WarmPools are deleted.
+// to prevent memory leaks when SandboxTemplates or WarmPools are deleted.
 func (s *SimpleSandboxQueue) RemoveQueue(warmPoolName string) {
 	s.queues.Delete(warmPoolName)
 }

--- a/extensions/controllers/queue/simple_sandbox_queue_test.go
+++ b/extensions/controllers/queue/simple_sandbox_queue_test.go
@@ -131,3 +131,50 @@ func TestSimpleSandboxQueue_RemoveQueue_MemoryLeakFix(t *testing.T) {
 		t.Errorf("Expected queue to be completely removed, but it still existed")
 	}
 }
+
+func TestSimpleSandboxQueue_GetWithStrategy(t *testing.T) {
+	q := NewSimpleSandboxQueue()
+	hash := "template-hash-1"
+
+	key1 := SandboxKey{Namespace: "default", Name: "sb-1"}
+	key2 := SandboxKey{Namespace: "default", Name: "sb-2"}
+	key3 := SandboxKey{Namespace: "default", Name: "sb-3"}
+
+	q.Add(hash, key1)
+	q.Add(hash, key2)
+	q.Add(hash, key3)
+
+	// Custom strategy to pick key2 specifically
+	pickKey2 := func(items []SandboxKey) (SandboxKey, bool) {
+		for _, item := range items {
+			if item.Name == "sb-2" {
+				return item, true
+			}
+		}
+		return SandboxKey{}, false
+	}
+
+	// Pop with strategy
+	got, ok := q.GetWithStrategy(hash, pickKey2)
+	if !ok || got != key2 {
+		t.Errorf("Expected to pick %v, got %v (ok: %v)", key2, got, ok)
+	}
+
+	// First standard pop should be key1 (since key2 was removed)
+	got1, _ := q.Get(hash)
+	if got1 != key1 {
+		t.Errorf("Expected first remaining item to be %v, got %v", key1, got1)
+	}
+
+	// Second standard pop should be key3
+	got3, _ := q.Get(hash)
+	if got3 != key3 {
+		t.Errorf("Expected second remaining item to be %v, got %v", key3, got3)
+	}
+
+	// Queue should now be empty
+	_, ok3 := q.Get(hash)
+	if ok3 {
+		t.Errorf("Expected queue to be empty, but got an item")
+	}
+}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -611,16 +611,37 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 		}
 	}()
 
+	var sandboxList v1beta1.SandboxList
+	if err := r.List(ctx, &sandboxList, client.InNamespace(claim.Namespace)); err != nil {
+		logger.Error(err, "Failed to list sandboxes for smart selection node counting")
+		return nil, queue.SandboxKey{}, err
+	}
+
+	nodeCounts := make(map[string]int)
+	sbMap := make(map[string]*v1beta1.Sandbox)
+	for i := range sandboxList.Items {
+		sb := &sandboxList.Items[i]
+		sbMap[sb.Name] = sb
+		if _, isWarm := sb.Labels[warmPoolSandboxLabel]; !isWarm {
+			if sb.Status.NodeName != "" {
+				nodeCounts[sb.Status.NodeName]++
+			}
+		}
+	}
+
+	selector := &smartSelector{
+		claim:      claim,
+		sbMap:      sbMap,
+		nodeCounts: nodeCounts,
+	}
+
 	for {
-		adoptedKey, ok := r.WarmSandboxQueue.Get(claim.Spec.WarmPoolRef.Name)
+		adoptedKey, ok := r.WarmSandboxQueue.GetWithStrategy(claim.Spec.WarmPoolRef.Name, selector.pick)
 		if !ok {
 			return nil, queue.SandboxKey{}, nil
 		}
 
-		// 1. Hand the Kubernetes client the empty bucket
 		adopted := &v1beta1.Sandbox{}
-
-		// 2. Fetch from the Informer Cache
 		err := r.Get(ctx, client.ObjectKey{Namespace: adoptedKey.Namespace, Name: adoptedKey.Name}, adopted)
 		if err != nil {
 			if k8errors.IsNotFound(err) {
@@ -635,8 +656,6 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 
 		if err := verifySandboxCandidate(adopted, claim); err != nil {
 			logger.V(1).Info("sandbox candidate can't be adopted", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name, "reason", err.Error())
-			// If it's a good sandbox just in the wrong namespace,
-			// add it to the skipped list so the defer block puts it back.
 			if errors.Is(err, ErrCrossNamespaceAdoption) {
 				skipped = append(skipped, adoptedKey)
 			}
@@ -1732,4 +1751,85 @@ func getWarmPoolName(obj metav1.Object) string {
 		}
 	}
 	return ""
+}
+
+type smartSelector struct {
+	claim      *extensionsv1beta1.SandboxClaim
+	sbMap      map[string]*v1beta1.Sandbox
+	nodeCounts map[string]int
+}
+
+func (s *smartSelector) pick(keys []queue.SandboxKey) (queue.SandboxKey, bool) {
+	var bestKey queue.SandboxKey
+	var bestSandbox *v1beta1.Sandbox
+	found := false
+
+	for _, key := range keys {
+		// Upfront filter mismatching namespaces to avoid map lookup
+		if key.Namespace != s.claim.Namespace {
+			continue
+		}
+
+		sb, exists := s.sbMap[key.Name]
+		if !exists {
+			// The sandbox doesn't exist in cache/cluster or r.List failed.
+			// Pop it to either discard it (if deleted) or perform a direct Get fallback.
+			return key, true
+		}
+
+		if err := verifySandboxCandidate(sb, s.claim); err != nil {
+			// The sandbox is invalid. Pop it to discard it.
+			return key, true
+		}
+
+		if !found {
+			bestKey = key
+			bestSandbox = sb
+			found = true
+			continue
+		}
+
+		sbReady := isSandboxReady(sb)
+		bestReady := isSandboxReady(bestSandbox)
+
+		if sbReady != bestReady {
+			if sbReady {
+				bestKey = key
+				bestSandbox = sb
+			}
+			continue
+		}
+
+		sbNode := sb.Status.NodeName
+		bestNode := bestSandbox.Status.NodeName
+
+		if sbNode == "" && bestNode != "" {
+			continue
+		}
+		if sbNode != "" && bestNode == "" {
+			bestKey = key
+			bestSandbox = sb
+			continue
+		}
+
+		if sbNode != "" && bestNode != "" && sbNode != bestNode {
+			sbCount := s.nodeCounts[sbNode]
+			bestCount := s.nodeCounts[bestNode]
+			if sbCount < bestCount {
+				bestKey = key
+				bestSandbox = sb
+				continue
+			}
+			if sbCount > bestCount {
+				continue
+			}
+		}
+
+		if sb.CreationTimestamp.Before(&bestSandbox.CreationTimestamp) {
+			bestKey = key
+			bestSandbox = sb
+		}
+	}
+
+	return bestKey, found
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1935,7 +1935,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: true,
 		},
 		{
-			name: "adopts sandboxes from queue regardless of ready state",
+			name: "adopts ready sandboxes from queue prioritizing ready state",
 			existingObjects: []client.Object{
 				template,
 				claim,
@@ -1944,7 +1944,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				createWarmPoolSandbox("young-ready", metav1.Now(), true),
 			},
 			expectSandboxAdoption:   true,
-			expectedAdoptedSandbox:  "not-ready",
+			expectedAdoptedSandbox:  "middle-ready",
 			expectNewSandboxCreated: false,
 		},
 		{
@@ -2008,7 +2008,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				createWarmPoolSandbox("pool-sb-2", metav1.Now(), true),
 			},
 			expectSandboxAdoption:   true,
-			expectedAdoptedSandbox:  "pool-sb-2",
+			expectedAdoptedSandbox:  "pool-sb-1",
 			expectNewSandboxCreated: false,
 			simulateConflicts:       1, // Fail update on the first sandbox, succeed on the second
 		},
@@ -3883,4 +3883,272 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 	err = isAdoptable(ownedByClaimSandbox)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not managed by warm pool")
+}
+
+func TestSandboxClaimAdoptionStrategy(t *testing.T) {
+	scheme := newScheme(t)
+
+	createWarmPoolSandboxWithNode := func(name string, creationTime metav1.Time, ready bool, nodeName string) *sandboxv1beta1.Sandbox {
+		conditionStatus := metav1.ConditionFalse
+		if ready {
+			conditionStatus = metav1.ConditionTrue
+		}
+		poolNameHash := sandboxcontrollers.NameHash("test-pool")
+		return &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         "default",
+				CreationTimestamp: creationTime,
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   poolNameHash,
+					sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+						Kind:       "SandboxWarmPool",
+						Name:       "test-pool",
+						UID:        "warmpool-uid",
+						Controller: ptr.To(true), // nolint:modernize
+					},
+				},
+			},
+			Spec: sandboxv1beta1.SandboxSpec{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}},
+					},
+				},
+			},
+			Status: sandboxv1beta1.SandboxStatus{
+				NodeName: nodeName,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(sandboxv1beta1.SandboxConditionReady),
+						Status: conditionStatus,
+						Reason: "DependenciesReady",
+					},
+				},
+			},
+		}
+	}
+
+	createClaim := func(name string) *extensionsv1beta1.SandboxClaim {
+		return &extensionsv1beta1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				UID:       types.UID(name + "-uid"),
+			},
+			Spec: extensionsv1beta1.SandboxClaimSpec{
+				WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{
+					Name: "test-pool",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name                   string
+		existingSandboxes      []*sandboxv1beta1.Sandbox
+		otherObjects           []client.Object
+		expectedAdoptedSandbox string
+	}{
+		{
+			name: "picks oldest ready sandbox",
+			existingSandboxes: []*sandboxv1beta1.Sandbox{
+				createWarmPoolSandboxWithNode("sb-young-ready", metav1.Now(), true, "node-1"),
+				createWarmPoolSandboxWithNode("sb-old-ready", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true, "node-2"),
+				createWarmPoolSandboxWithNode("sb-old-not-ready", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}, false, "node-3"),
+			},
+			expectedAdoptedSandbox: "sb-old-ready",
+		},
+		{
+			name: "picks sandbox on the node with fewest active sandboxes",
+			existingSandboxes: []*sandboxv1beta1.Sandbox{
+				createWarmPoolSandboxWithNode("sb-node1-ready", metav1.Now(), true, "node-1"),
+				createWarmPoolSandboxWithNode("sb-node2-ready", metav1.Now(), true, "node-2"),
+			},
+			otherObjects: []client.Object{
+				&sandboxv1beta1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "active-sb-node1",
+						Namespace: "default",
+						Labels:    map[string]string{}, // No warmPoolSandboxLabel -> active
+					},
+					Status: sandboxv1beta1.SandboxStatus{
+						NodeName: "node-1",
+					},
+				},
+			},
+			expectedAdoptedSandbox: "sb-node2-ready",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			template := &extensionsv1beta1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+				Spec: extensionsv1beta1.SandboxTemplateSpec{
+					PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}},
+				},
+			}
+
+			claim := createClaim("test-claim")
+
+			warmPool := &extensionsv1beta1.SandboxWarmPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: "default",
+					UID:       "warmpool-uid",
+				},
+				Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+					TemplateRef: extensionsv1beta1.SandboxTemplateRef{
+						Name: "test-template",
+					},
+				},
+			}
+
+			var allObjects []client.Object
+			allObjects = append(allObjects, template, claim, warmPool)
+			allObjects = append(allObjects, tc.otherObjects...)
+			for _, sb := range tc.existingSandboxes {
+				allObjects = append(allObjects, sb)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(allObjects...).
+				WithStatusSubresource(claim).
+				Build()
+
+			warmSandboxQueue := queue.NewSimpleSandboxQueue()
+			for _, sb := range tc.existingSandboxes {
+				key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name}
+				warmSandboxQueue.Add("test-pool", key)
+			}
+
+			reconciler := &SandboxClaimReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				Recorder:         events.NewFakeRecorder(10),
+				WarmSandboxQueue: warmSandboxQueue,
+				Tracer:           asmetrics.NewNoOp(),
+			}
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+			_, err := reconciler.Reconcile(context.Background(), req)
+			require.NoError(t, err)
+
+			var adoptedSandbox sandboxv1beta1.Sandbox
+			err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: tc.expectedAdoptedSandbox}, &adoptedSandbox)
+			require.NoError(t, err)
+
+			controllerRef := metav1.GetControllerOf(&adoptedSandbox)
+			require.NotNil(t, controllerRef)
+			require.Equal(t, claim.UID, controllerRef.UID)
+		})
+	}
+}
+
+func TestSmartSelector(t *testing.T) {
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+
+	createSandbox := func(name, ns, node string, ready bool) *sandboxv1beta1.Sandbox {
+		status := sandboxv1beta1.SandboxStatus{NodeName: node}
+		if ready {
+			status.Conditions = []metav1.Condition{{
+				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}}
+		}
+		return &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ns,
+				Labels: map[string]string{
+					warmPoolSandboxLabel:   sandboxcontrollers.NameHash("test-pool"),
+					sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+					Kind:       "SandboxWarmPool",
+					Name:       "test-pool",
+					UID:        "warmpool-uid",
+					Controller: new(true),
+				}},
+			},
+			Status: status,
+		}
+	}
+
+	t.Run("ignores keys from different namespaces", func(t *testing.T) {
+		selector := &smartSelector{
+			claim:      claim,
+			sbMap:      map[string]*sandboxv1beta1.Sandbox{},
+			nodeCounts: map[string]int{},
+		}
+		keys := []queue.SandboxKey{
+			{Namespace: "other-ns", Name: "sb-1"},
+		}
+		_, ok := selector.pick(keys)
+		require.False(t, ok)
+	})
+
+	t.Run("returns key, true when sandbox does not exist in sbMap to clean queue", func(t *testing.T) {
+		selector := &smartSelector{
+			claim:      claim,
+			sbMap:      map[string]*sandboxv1beta1.Sandbox{}, // Empty map
+			nodeCounts: map[string]int{},
+		}
+		keys := []queue.SandboxKey{
+			{Namespace: "default", Name: "sb-deleted"},
+		}
+		picked, ok := selector.pick(keys)
+		require.True(t, ok)
+		require.Equal(t, "sb-deleted", picked.Name)
+	})
+
+	t.Run("returns key, true when sandbox fails validation to clean queue", func(t *testing.T) {
+		sbInvalid := createSandbox("sb-invalid", "default", "", false)
+		// Make it invalid by removing the warm pool label
+		sbInvalid.Labels = map[string]string{}
+
+		selector := &smartSelector{
+			claim: claim,
+			sbMap: map[string]*sandboxv1beta1.Sandbox{
+				"sb-invalid": sbInvalid,
+			},
+			nodeCounts: map[string]int{},
+		}
+		keys := []queue.SandboxKey{
+			{Namespace: "default", Name: "sb-invalid"},
+		}
+		picked, ok := selector.pick(keys)
+		require.True(t, ok)
+		require.Equal(t, "sb-invalid", picked.Name)
+	})
+
+	t.Run("picks ready sandbox over unready", func(t *testing.T) {
+		sbUnready := createSandbox("sb-unready", "default", "node-1", false)
+		sbReady := createSandbox("sb-ready", "default", "node-2", true)
+
+		selector := &smartSelector{
+			claim: claim,
+			sbMap: map[string]*sandboxv1beta1.Sandbox{
+				"sb-unready": sbUnready,
+				"sb-ready":   sbReady,
+			},
+			nodeCounts: map[string]int{},
+		}
+		keys := []queue.SandboxKey{
+			{Namespace: "default", Name: "sb-unready"},
+			{Namespace: "default", Name: "sb-ready"},
+		}
+		picked, ok := selector.pick(keys)
+		require.True(t, ok)
+		require.Equal(t, "sb-ready", picked.Name)
+	})
 }

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3997,6 +3997,8 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeName:
+                type: string
               podIPs:
                 items:
                   type: string

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3997,6 +3997,8 @@ spec:
                   - type
                   type: object
                 type: array
+              nodeName:
+                type: string
               podIPs:
                 items:
                   type: string

--- a/test/e2e/framework/predicates/sandbox.go
+++ b/test/e2e/framework/predicates/sandbox.go
@@ -57,7 +57,7 @@ func (s *sandboxHasStatusPredicate) Matches(obj client.Object) (bool, error) {
 	}
 	opts := []cmp.Option{
 		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
-		cmpopts.IgnoreFields(sandboxv1beta1.SandboxStatus{}, "PodIPs"),
+		cmpopts.IgnoreFields(sandboxv1beta1.SandboxStatus{}, "PodIPs", "NodeName"),
 	}
 	if diff := cmp.Diff(s.WantStatus, sandbox.Status, opts...); diff != "" {
 		return false, nil


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR introduces a unified smart sandbox selection strategy for warm pool adoption. Based on review feedback, we eliminated the configurable `adoptionStrategy` field from `SandboxTemplate` to simplify the user-facing API. The controller now automatically applies this smart strategy by default.

**Changes:**

*   **Sandbox API Update (`SandboxStatus.NodeName`):**
    *   Added `nodeName` string to `SandboxStatus` to track the name of the node where the underlying sandbox pod is scheduled. This allows controllers to inspect workload distribution dynamically.
    *   Regenerated deepcopy files and CRDs.

*   **Smart Sandbox Selection Strategy (`smartSelector`):**
    *   The controller automatically adopts sandboxes from the warm pool using a decoupled, package-level selection strategy:
        *   **Readiness Priority:** Prioritizes ready sandboxes over unready ones to ensure instant workload availability.
        *   **Node Work Spread:** Prioritizes spreading workloads across different GKE/Kubernetes nodes by preferring candidate sandboxes on the node with the fewest active workloads (using the new `nodeName` status field).
        *   **Oldest Ready Fallback:** Resolves ties (equal node workloads or unready candidates) by choosing the oldest created sandbox (FIFO fallback).

*   **Queue Self-Cleaning & Fallback:**
    *   If a sandbox key in the queue is deleted/ghost (doesn't exist in the cluster) or fails candidate validation (e.g. missing warmpool labels or incorrect template hash), the selector immediately returns `key, true` to pop and discard it from the memory queue.
    *   Propagates transient `r.List` API server errors immediately rather than silently falling back to a cold-start, ensuring correct controller requeuing.

*   **Thread-Safe Queue Pops with Retry Loop:**
    *   Extended `SimpleSandboxQueue` and `synchronizedQueue` to support `GetWithStrategy` and `PopWithStrategy` operations.
    *   Implemented a retry loop inside `PopWithStrategy` to safely handle concurrency race conditions: if another goroutine pops the selected key during selection, the pop retries with a fresh snapshot rather than failing.

*   **Performance & API Alignment:**
    *   Aligned queue keying to use `warmPoolName` instead of `templateHash` to follow the v1beta1 API model. Partitioning the queues per warm pool prevents evaluating candidates from other warm pools.
    *   Added upfront namespace filtering in the smart selector before calling `r.Get` to save expensive Kubernetes API round-trips.
    *   Updated API definitions in `extensions/api/v1beta1/sandboxtemplate_types.go`, regenerated `docs/api.md`, and updated all generated deepcopy files and CRDs.

*   **Unit Testing:**
    *   Added a comprehensive unit test suite `TestSmartSelector` in `extensions/controllers/sandboxclaim_controller_test.go` covering readiness prioritization, node spreading, namespace filtering, and queue cleaning/deletion logic.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #491
Ref <issue link> (issue in a different repository)
-->

Fixes #491

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
- **api/v1beta1**: Added `NodeName` to `SandboxStatus` to expose the scheduled node name of the underlying sandbox pod.
- **extensions/controllers**: Implemented a unified smart sandbox selection strategy for warm pool adoption. The strategy automatically prioritizes ready sandboxes, spreads workloads across nodes, and falls back to creation-time tie-breaking.
- **extensions/queue**: Extended `SimpleSandboxQueue` to support thread-safe strategic queue pops (`GetWithStrategy`) with built-in retry protection against concurrent pop race conditions.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

Generated by Overseer (powered by the gemini model).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox status now exposes the node name where the underlying pod is scheduled.
  * Warm-pool queue supports strategy-aware retrieval for targeted sandbox selection.

* **Behavioral Improvements**
  * Adoption now prefers ready sandboxes and balances allocations across nodes.

* **Documentation**
  * API docs and CRDs updated to include the new Sandbox status `nodeName` field.

* **Tests**
  * Added and updated unit and e2e tests covering adoption selection and status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->