### PR TITLE
fix: python runtime example path

### DIFF
--- a/examples/python-runtime-sandbox/main.py
+++ b/examples/python-runtime-sandbox/main.py
@@ -91,7 +91,14 @@ async def upload_file(file: UploadFile = File(...)):
     """
     try:
         logging.info(f"--- UPLOAD_FILE CALLED: Attempting to save '{file.filename}' ---")
-        file_path = os.path.join("/app", file.filename)
+        
+        try:
+            file_path = get_safe_path(file.filename)
+        except ValueError:
+            return JSONResponse(
+                status_code=403,
+                content={"message": "Access denied"}
+            )
         
         with open(file_path, "wb") as f:
             f.write(await file.read())

--- a/examples/python-runtime-sandbox/tester.py
+++ b/examples/python-runtime-sandbox/tester.py
@@ -157,6 +157,80 @@ def test_absolute_path_traversal(base_url):
         print(f"An error occurred during absolute path traversal check: {e}")
         sys.exit(1)
 
+def test_upload(base_url):
+    """
+    Tests the upload endpoint with a safe filename, verifies the file
+    exists, downloads the content to verify correctness, and cleans up.
+    """
+    filename = 'test_upload.txt'
+    file_content = b'Hello world from upload test'
+    
+    url_upload = f"{base_url}/upload"
+    files = {'file': (filename, file_content)}
+    
+    try:
+        print(f"\n--- Testing Upload endpoint ---")
+        print(f"Sending POST request to {url_upload}")
+        response = requests.post(url_upload, files=files)
+        response.raise_for_status()
+        
+        print("Upload successful!")
+        print("Response JSON:", response.json())
+        assert response.status_code == 200
+        assert "uploaded successfully" in response.json()["message"]
+        
+        # 1. Verify file exists
+        url_exists = f"{base_url}/exists/{filename}"
+        print(f"Checking if file exists via GET {url_exists}")
+        response_exists = requests.get(url_exists)
+        response_exists.raise_for_status()
+        assert response_exists.json()["exists"] is True
+        print("File existence verified successfully!")
+        
+        # 2. Download the file and verify content
+        url_download = f"{base_url}/download/{filename}"
+        print(f"Downloading file via GET {url_download}")
+        response_download = requests.get(url_download)
+        response_download.raise_for_status()
+        assert response_download.content == file_content
+        print("Downloaded file content verified successfully!")
+        
+        # 3. Clean up the uploaded file
+        url_execute = f"{base_url}/execute"
+        print(f"Cleaning up uploaded file via POST {url_execute}")
+        payload = {"command": f"rm {filename}"}
+        response_execute = requests.post(url_execute, json=payload)
+        response_execute.raise_for_status()
+        print("File cleanup completed successfully!")
+        
+    except (requests.exceptions.RequestException, AssertionError) as e:
+        print(f"An error occurred during upload verification: {e}")
+        sys.exit(1)
+
+def test_upload_path_traversal(base_url):
+    """
+    Tests that uploading a file with an unsafe filename is blocked.
+    """
+    url = f"{base_url}/upload"
+    # Try to upload using a path traversal filename
+    files = {'file': ('../../unsafe_upload.txt', b'malicious payload')}
+    
+    try:
+        print(f"\n--- Testing Upload Path Traversal ---")
+        print(f"Sending POST request to {url} with unsafe filename")
+        response = requests.post(url, files=files)
+        
+        print(f"Response status code: {response.status_code}")
+        print("Response JSON:", response.json())
+        
+        assert response.status_code == 403
+        assert "Access denied" in response.json()["message"]
+        print("Upload path traversal blocked successfully!")
+        
+    except (requests.exceptions.RequestException, AssertionError) as e:
+        print(f"An error occurred during upload path traversal check: {e}")
+        sys.exit(1)
+
 if __name__ == "__main__":
     if len(sys.argv) != 3:
         print("Usage: python tester.py <server_ip> <server_port>")
@@ -172,3 +246,5 @@ if __name__ == "__main__":
     test_exists(base_url)
     test_path_traversal(base_url)
     test_absolute_path_traversal(base_url)
+    test_upload(base_url)
+    test_upload_path_traversal(base_url)


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

This PR aligns the `/upload` endpoint in the `python-runtime-sandbox` example with the other file management endpoints (`/download`, `/list`, `/exists`) to ensure consistent path validation behavior. 
Specifically, the `/upload` endpoint now validates that the destination path lies within the designated `/app` directory by leveraging the existing `get_safe_path` helper, rather than joining the user-provided filename directly.
Additionally, the integration test suite in `tester.py` has been updated to cover the `/upload` endpoint, verifying both typical upload operations and path validation enforcement.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->