### PR TITLE
feat: add GitHub issue templates for bugs, features, and epics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,37 @@
+name: Bug Report
+description: Report a bug encountered while using agent-sandbox
+labels: ["kind/bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! 
+        If this is a security vulnerability, please do NOT open a public issue. Instead, follow our [Security Policy](https://github.com/kubernetes-sigs/agent-sandbox/security/policy).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Please provide as much information as possible. What did you do, what happened, and what did you expect to happen?
+      placeholder: Tell us what you saw and what you expected to see.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce it (as minimally and precisely as possible)?
+      description: Provide steps to reproduce the issue, including sample manifests or code snippets if applicable.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Please provide the agent-sandbox version you are using.
+      placeholder: e.g., vX.Y.Z or commit hash
+    validations:
+      required: true
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Anything else we need to know?
+      description: Additional context, logs, or related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a Vulnerability
+    url: https://github.com/kubernetes-sigs/agent-sandbox/security/policy
+    about: Please report security vulnerabilities privately following our security policy.
+  - name: Support Request / Questions (Slack)
+    url: https://kubernetes.slack.com/messages/agent-sandbox
+    about: Join the #agent-sandbox channel on Kubernetes Slack for real-time discussions and support.
+  - name: GitHub Discussions
+    url: https://github.com/kubernetes-sigs/agent-sandbox/discussions
+    about: Ask questions and discuss ideas with the community on GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,46 @@
+name: Epic / Umbrella Issue (Maintainers Only)
+description: FOR PROJECT MAINTAINERS ONLY. Track large multi-part roadmap initiatives.
+labels: ["kind/feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!WARNING]
+        > **This template is strictly for project maintainers to track approved roadmap initiatives.** 
+        > If you are a community contributor requesting a new feature, please use the **Feature Request** template instead. Unsolicited community epics will be closed.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary / Goal
+      description: Provide a high-level summary of the initiative and what success looks like.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / Value
+      description: Why is this initiative necessary? What value does it provide to users or maintainers?
+    validations:
+      required: true
+  - type: textarea
+    id: breakdown
+    attributes:
+      label: Work Breakdown / Tasks
+      description: Provide a checklist of child issues, PRs, or sub-tasks required to complete this epic.
+      value: |
+        - [ ] Task 1 (#issue)
+        - [ ] Task 2 (#issue)
+        - [ ] Docs update (#issue)
+    validations:
+      required: true
+  - type: input
+    id: milestone
+    attributes:
+      label: Target Milestone / Release
+      description: Which milestone or release is this epic targeted for?
+      placeholder: e.g., v0.5.0 (Beta) or Q3 2026
+  - type: textarea
+    id: anything-else
+    attributes:
+      label: Additional Context
+      description: Any related KEPs, design docs, diagrams, or roadmap links.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,22 @@
+name: Feature Request
+description: Propose a new feature or enhancement for agent-sandbox
+labels: ["kind/feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to propose a new feature or enhancement!
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: A clear and concise description of the feature or enhancement you would like to see implemented.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this needed?
+      description: Describe the underlying problem, use case, or motivation for adding this feature.
+    validations:
+      required: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds structured YAML issue templates for `agent-sandbox` to standardize community bug reports, feature requests, and maintainer epics.

Specifically, this adds:
1. `config.yml`: Configures contact links for Security Policy, Kubernetes Slack (`#agent-sandbox`), and GitHub Discussions, while keeping blank issues enabled (`blank_issues_enabled: true`).
2. `bug-report.yml`: A succinct bug report form requesting reproduction steps and the `agent-sandbox` version (`vX.Y.Z`).
3. `feature-request.yml`: An enhancement tracking form aligned with Kubernetes KEP/enhancement standards, asking "What would you like to be added?" and "Why is this needed?".
4. `epic.yml`: A maintainer epic tracking form with a prominent `(Maintainers Only)` disclaimer, task checklist, and milestone field.

#### Which issue(s) this PR is related to:
NONE

#### Release Note
```release-note
NONE
```