### PR TITLE
fix: adding namespace selector for sandbox router

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -83,7 +83,7 @@ Use `APIURL` to bypass discovery entirely. Useful for:
 
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
-    APIURL: "http://sandbox-router-svc.default.svc.cluster.local:8080",
+    APIURL: "http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080",
 })
 if err != nil { log.Fatal(err) }
 defer client.DeleteAll(ctx)
@@ -335,5 +335,5 @@ go test ./clients/go/sandbox/ -tags=integration -v -timeout=300s \
 
 # Direct URL mode
 go test ./clients/go/sandbox/ -tags=integration -v -timeout=300s \
-    -args --api-url=http://sandbox-router:8080
+    -args --api-url=http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080
 ```

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -202,7 +202,7 @@ from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
 
 client = SandboxClient(
     connection_config=SandboxDirectConnectionConfig(
-       api_url="http://sandbox-router-svc.default.svc.cluster.local:8080"
+       api_url="http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080"
     )
 )
 
@@ -251,7 +251,7 @@ from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
 
 async def main():
     config = SandboxDirectConnectionConfig(
-        api_url="http://sandbox-router-svc.default.svc.cluster.local:8080"
+        api_url="http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080"
     )
 
     async with AsyncSandboxClient(connection_config=config) as client:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -155,7 +155,7 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                     "kubectl", "port-forward",
                     ROUTER_SERVICE_NAME,
                     f"{local_port}:8080",
-                    "-n", self.namespace
+                    "-n", self.config.router_namespace
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Literal, Union
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 class ExecutionResult(BaseModel):
     """A structured object for holding the result of a command execution."""
@@ -44,6 +45,14 @@ class SandboxLocalTunnelConnectionConfig(BaseModel):
     """Configuration for connecting via kubectl port-forward."""
     port_forward_ready_timeout: int = 30  # Timeout in seconds to wait for port-forward to be ready.
     server_port: int = 8888  # Port the sandbox container listens on.
+    router_namespace: str = "agent-sandbox-system"  # Namespace where the Router service resides.
+
+    @field_validator("router_namespace")
+    @classmethod
+    def validate_namespace(cls, v: str) -> str:
+        if not re.match(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", v):
+            raise ValueError("Invalid Kubernetes namespace name format")
+        return v
 
 class SandboxInClusterConnectionConfig(BaseModel):
     """Configuration for direct in-cluster connection to the sandbox pod, bypassing the router.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -692,5 +692,30 @@ class TestSandboxClientInClusterConfig(unittest.TestCase):
         self.assertNotIn('pod_ip', call_kwargs)
 
 
+from pydantic import ValidationError
+
+class TestConnectionConfigValidation(unittest.TestCase):
+    def test_valid_router_namespace(self):
+        valid_namespaces = ["default", "agent-sandbox-system", "my-namespace-123", "kube-system"]
+        for ns in valid_namespaces:
+            config = SandboxLocalTunnelConnectionConfig(router_namespace=ns)
+            self.assertEqual(config.router_namespace, ns)
+
+    def test_invalid_router_namespace(self):
+        invalid_namespaces = [
+            "-invalid",        # starts with hyphen
+            "invalid-",        # ends with hyphen
+            "Uppercase",       # contains uppercase letters
+            "ns_with_under",   # contains underscore
+            "ns;echo",         # command injection attempt
+            "ns|sh",           # pipe attempt
+            "ns&rm",           # ampersand attempt
+            "",                # empty namespace
+        ]
+        for ns in invalid_namespaces:
+            with self.assertRaises(ValidationError):
+                SandboxLocalTunnelConnectionConfig(router_namespace=ns)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/sandbox-router/README.md
+++ b/clients/python/agentic-sandbox-client/sandbox-router/README.md
@@ -62,7 +62,7 @@ previous step, and then apply the manifest.
 
 ```bash
 sed -i "s|\${ROUTER_IMAGE}|$SANDBOX_ROUTER_IMG|g" sandbox_router.yaml
-kubectl apply -f sandbox_router.yaml
+kubectl apply -n agent-sandbox-system -f sandbox_router.yaml
 ```
 
 ### Deploy the Gateway

--- a/examples/policy/network-policy-management/README.md
+++ b/examples/policy/network-policy-management/README.md
@@ -43,7 +43,7 @@ This is designed for running untrusted code safely:
 
 **Ingress (Incoming Traffic)**
 
-- **Allowed:**  Traffic is only allowed from the designated [Sandbox Router](../../../clients/python/agentic-sandbox-client/sandbox-router) (`app: sandbox-router`). The router must run in the template’s namespace for the secure default to work. 
+- **Allowed:**  Traffic is only allowed from the designated [Sandbox Router](../../../clients/python/agentic-sandbox-client/sandbox-router) (`app: sandbox-router`) residing in the `"agent-sandbox-system"` system namespace.
 
 - **Blocked:** All other internal cluster traffic and external ingress is explicitly denied.
 
@@ -127,7 +127,10 @@ spec:
 
       # 2. Re-allow the standard Sandbox Router (required if you override defaults)
       - from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-sandbox-system
+          podSelector:
             matchLabels:
               app: sandbox-router
 
@@ -188,7 +191,10 @@ spec:
     ingress:
       # Re-allow the standard Sandbox Router
       - from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: agent-sandbox-system
+          podSelector:
             matchLabels:
               app: sandbox-router
     egress:

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -181,7 +181,7 @@ Open `clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml` 
 ```bash
 envsubst '${ROUTER_IMAGE}' \
     < clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml \
-    | kubectl apply -n agent-sandbox-demo -f -
+    | kubectl apply -n agent-sandbox-system -f -
 ```
 
 ### 7.3 Verify WarmPool
@@ -209,13 +209,13 @@ python-warmpool-fghij     1/1     Running   0          15s
 
 ```bash
 # Check router pods
-kubectl get pods -l app=sandbox-router
+kubectl get pods -l app=sandbox-router -n agent-sandbox-system
 
 # Check router service
-kubectl get svc sandbox-router-svc
+kubectl get svc sandbox-router-svc -n agent-sandbox-system
 
 # Test router health
-kubectl port-forward svc/sandbox-router-svc 8080:8080 &
+kubectl port-forward svc/sandbox-router-svc 8080:8080 -n agent-sandbox-system &
 PF_PID=$!
 sleep 2
 curl http://localhost:8080/healthz

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -155,6 +155,21 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 // buildDefaultNetworkPolicySpec generates the "Secure by Default" network policy.
 func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPolicySpec {
+	peers := []networkingv1.NetworkPolicyPeer{
+		{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "agent-sandbox-system",
+				},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "sandbox-router",
+				},
+			},
+		},
+	}
+
 	return networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -168,15 +183,7 @@ func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPoli
 		// 1. INGRESS: Allow traffic only from the Sandbox Router
 		Ingress: []networkingv1.NetworkPolicyIngressRule{
 			{
-				From: []networkingv1.NetworkPolicyPeer{
-					{
-						PodSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app": "sandbox-router",
-							},
-						},
-					},
-				},
+				From: peers,
 			},
 		},
 		// 2. EGRESS: Secure Default Configuration

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -107,8 +107,16 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 				if len(np.Spec.PolicyTypes) != 2 {
 					t.Errorf("Expected 2 PolicyTypes, got %d", len(np.Spec.PolicyTypes))
 				}
-				if len(np.Spec.Ingress) != 1 || np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app"] != "sandbox-router" {
-					t.Errorf("Expected Default Ingress rule to target sandbox-router")
+				if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].From) != 1 {
+					t.Fatalf("Expected Default Ingress rule to contain exactly 1 peer source, got %d", len(np.Spec.Ingress[0].From))
+				}
+				peer1 := np.Spec.Ingress[0].From[0]
+				if peer1.PodSelector == nil || peer1.NamespaceSelector == nil {
+					t.Fatalf("Expected both PodSelector and NamespaceSelector to be non-nil")
+				}
+				if peer1.PodSelector.MatchLabels["app"] != "sandbox-router" ||
+					peer1.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "agent-sandbox-system" {
+					t.Errorf("Expected first Ingress peer to target sandbox-router in agent-sandbox-system namespace")
 				}
 				if len(np.Spec.Egress) != 1 {
 					t.Fatalf("Expected 1 Default Egress rule, got %d", len(np.Spec.Egress))

--- a/test/e2e/clients/python/test_e2e_python_sdk.py
+++ b/test/e2e/clients/python/test_e2e_python_sdk.py
@@ -18,7 +18,10 @@ from test.e2e.clients.python.framework.context import TestContext
 import pytest
 import yaml
 from k8s_agent_sandbox import SandboxClient
-from k8s_agent_sandbox.models import SandboxGatewayConnectionConfig
+from k8s_agent_sandbox.models import (
+    SandboxGatewayConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
+)
 
 TEST_MANIFESTS_DIR = "test/e2e/clients/python/test_manifests"
 TEMPLATE_YAML_PATH = os.path.join(TEST_MANIFESTS_DIR, "sandbox_template.yaml")
@@ -154,7 +157,8 @@ def run_sdk_tests(sandbox):
 
 def test_python_sdk_router_mode(tc, temp_namespace, sandbox_template, deploy_router, sandbox_coldpool):
     """Tests the Python SDK in Sandbox Router (Developer/Tunnel) mode without warmpool."""
-    client = SandboxClient()
+    config = SandboxLocalTunnelConnectionConfig(router_namespace=temp_namespace)
+    client = SandboxClient(connection_config=config)
     try:
         sandbox = client.create_sandbox(
             warmpool=sandbox_coldpool,
@@ -174,7 +178,8 @@ def test_python_sdk_router_mode_warmpool(
     tc, temp_namespace, sandbox_template, deploy_router, sandbox_warmpool
 ):
     """Tests the Python SDK in Sandbox Router mode with warmpool."""
-    client = SandboxClient()
+    config = SandboxLocalTunnelConnectionConfig(router_namespace=temp_namespace)
+    client = SandboxClient(connection_config=config)
     try:
         sandbox = client.create_sandbox(
             warmpool=sandbox_warmpool,

--- a/test/e2e/clients/python/test_manifests/sandbox_template.yaml
+++ b/test/e2e/clients/python/test_manifests/sandbox_template.yaml
@@ -3,6 +3,19 @@ kind: SandboxTemplate
 metadata:
   name: python-sdk-test-template
 spec:
+  networkPolicyManagement: Managed
+  networkPolicy:
+    ingress:
+      - from:
+        - podSelector:
+            matchLabels:
+              app: sandbox-router
+    egress:
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
   podTemplate:
     metadata:
       labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

Refactors the default `NetworkPolicy` generated by the `SandboxTemplate` controller to strictly scope ingress rules to the `"agent-sandbox-system"` namespace, improving the robustness and accuracy of the default isolation model.
**Context & Robustness Improvement:**
Previously, the `SandboxTemplate` controller generated a template-level `NetworkPolicy` allowing ingress from any pod in the local namespace matching the label `app: sandbox-router`. In centralized production environments, the legitimate router always runs in the central system namespace (`agent-sandbox-system`). 
This PR tightens the default firewall boundaries by removing the local namespace fallback. Ingress is now strictly scoped and permitted **only** from the designated `sandbox-router` residing in the system namespace (`agent-sandbox-system`), preventing unauthorized or accidental direct-pod connections from other workloads within the tenant namespace.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
**Upgrade Sequence:** Upon upgrading the controller, the reconciler will automatically identify drift on existing shared template `NetworkPolicies` and immediately update their ingress rules to restrict traffic only to the `"agent-sandbox-system"` namespace. 
**To avoid service interruption:** If you have existing deployments running the `sandbox-router` in a namespace other than `"agent-sandbox-system"`, operators must migrate and deploy the `sandbox-router` inside `"agent-sandbox-system"` **prior to or in tandem with** upgrading the controller.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->