### PR TITLE
fix: write Sandbox status with merge-patch and add Pod reconcile predicate

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1266,10 +1266,14 @@ func isPodReady(pod *corev1.Pod) bool {
 // podStatusChanged reports whether a Pod update is relevant to the Sandbox
 // controller. The controller's Owns(Pod) watch otherwise fires on every Kubelet
 // status write (~7 per pod lifecycle); this filters to the transitions the
-// reconciler actually depends on: Phase, Ready, and PodIPs (the Ready condition
-// is gated on PodIPs being populated, so a PodIPs change must trigger a
-// reconcile even when Phase and Ready are unchanged).
+// reconciler actually depends on: DeletionTimestamp (immediate reaction when a
+// Pod enters Terminating), Phase, Ready, and PodIPs (the Ready condition is
+// gated on PodIPs being populated, so a PodIPs change must trigger a reconcile
+// even when Phase and Ready are unchanged).
 func podStatusChanged(oldPod, newPod *corev1.Pod) bool {
+	if oldPod.DeletionTimestamp.IsZero() != newPod.DeletionTimestamp.IsZero() {
+		return true
+	}
 	if oldPod.Status.Phase != newPod.Status.Phase {
 		return true
 	}
@@ -1311,6 +1315,10 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sandboxv1beta1.Sandbox{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&corev1.Pod{}, builder.WithPredicates(predicate.And(labelSelectorPredicate, podStatusChangedPredicate))).
+		// Services use only the label selector predicate; unlike Pods, they are
+		// stable and don't receive frequent status writes. If a service-mesh or
+		// ingress controller starts annotating Services at high frequency, add a
+		// state-filtering predicate here analogous to podStatusChangedPredicate.
 		Owns(&corev1.Service{}, builder.WithPredicates(labelSelectorPredicate)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).
 		Complete(r)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1270,6 +1270,18 @@ func isPodReady(pod *corev1.Pod) bool {
 // Pod enters Terminating), Phase, Ready, and PodIPs (the Ready condition is
 // gated on PodIPs being populated, so a PodIPs change must trigger a reconcile
 // even when Phase and Ready are unchanged).
+//
+// This intentionally ignores Pod label and annotation changes, which has one
+// known side effect: updatePodMetadata self-heals drift in propagated pod
+// labels/annotations, so external tampering with those keys is not corrected
+// immediately but on the next Phase/Ready/PodIPs transition or the periodic
+// resync. Folding a metadata check into this predicate in a churn-safe way is
+// not free: a naive "any label/annotation changed" comparison would reconcile
+// on every third-party write (service meshes, sidecar injectors) that annotates
+// the Pod, so it would have to be scoped to just the controller-managed keys,
+// coupling this predicate to the propagation scheme. For a rare case that
+// always self-corrects, eventual consistency is an acceptable trade-off here;
+// revisit if the drift window ever matters in practice.
 func podStatusChanged(oldPod, newPod *corev1.Pod) bool {
 	if oldPod.DeletionTimestamp.IsZero() != newPod.DeletionTimestamp.IsZero() {
 		return true
@@ -1313,7 +1325,7 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&sandboxv1beta1.Sandbox{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&sandboxv1beta1.Sandbox{}).
 		Owns(&corev1.Pod{}, builder.WithPredicates(predicate.And(labelSelectorPredicate, podStatusChangedPredicate))).
 		// Services use only the label selector predicate; unlike Pods, they are
 		// stable and don't receive frequent status writes. If a service-mesh or

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -181,7 +181,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		sandbox.Annotations[asmetrics.TraceContextAnnotation] = tc
 
-		if err := asmetrics.InstrumentWrite("sandbox", "annotation_set", "spec", "patch", func() error {
+		if err := asmetrics.InstrumentWrite("sandbox", "annotation_set", "metadata", "patch", func() error {
 			return r.Patch(ctx, sandbox, patch)
 		}); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -649,7 +649,7 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	logger := log.FromContext(ctx)
 	patch := client.MergeFrom(sandbox.DeepCopy())
 	delete(sandbox.Annotations, sandboxv1beta1.SandboxPodNameAnnotation)
-	if err := asmetrics.InstrumentWrite("sandbox", "annotation_remove", "spec", "patch", func() error {
+	if err := asmetrics.InstrumentWrite("sandbox", "annotation_remove", "metadata", "patch", func() error {
 		return r.Patch(ctx, sandbox, patch)
 	}); err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -773,7 +773,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			sandbox.Annotations = make(map[string]string)
 		}
 		sandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation] = podName
-		if err := asmetrics.InstrumentWrite("sandbox", "pod_name_annotation", "spec", "patch", func() error {
+		if err := asmetrics.InstrumentWrite("sandbox", "pod_name_annotation", "metadata", "patch", func() error {
 			return r.Patch(ctx, sandbox, patch)
 		}); err != nil {
 			if k8serrors.IsNotFound(err) {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -179,8 +181,10 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		sandbox.Annotations[asmetrics.TraceContextAnnotation] = tc
 
-		if err := r.Patch(ctx, sandbox, patch); err != nil {
-			return ctrl.Result{}, err
+		if err := asmetrics.InstrumentWrite("sandbox", "annotation_set", "spec", "patch", func() error {
+			return r.Patch(ctx, sandbox, patch)
+		}); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 	}
 
@@ -428,12 +432,21 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 		return nil
 	}
 
-	if err := r.Status().Update(ctx, sandbox); err != nil {
-		logger.Error(err, "Failed to update sandbox status")
+	original := sandbox.DeepCopy()
+	original.Status = *oldStatus
+	patch := client.MergeFrom(original)
+
+	if err := asmetrics.InstrumentWrite("sandbox", "status_update", "status", "patch", func() error {
+		return r.Status().Patch(ctx, sandbox, patch)
+	}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Object was deleted out from under us; nothing left to reconcile.
+			return nil
+		}
+		logger.Error(err, "Failed to patch sandbox status")
 		return err
 	}
 
-	// Surface error
 	return nil
 }
 
@@ -636,7 +649,13 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	logger := log.FromContext(ctx)
 	patch := client.MergeFrom(sandbox.DeepCopy())
 	delete(sandbox.Annotations, sandboxv1beta1.SandboxPodNameAnnotation)
-	if err := r.Patch(ctx, sandbox, patch); err != nil {
+	if err := asmetrics.InstrumentWrite("sandbox", "annotation_remove", "spec", "patch", func() error {
+		return r.Patch(ctx, sandbox, patch)
+	}); err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Object was deleted out from under us; nothing left to reconcile.
+			return nil
+		}
 		return fmt.Errorf("failed to clear pod name annotation: %w", err)
 	}
 	logger.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
@@ -754,7 +773,13 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			sandbox.Annotations = make(map[string]string)
 		}
 		sandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation] = podName
-		if err := r.Patch(ctx, sandbox, patch); err != nil {
+		if err := asmetrics.InstrumentWrite("sandbox", "pod_name_annotation", "spec", "patch", func() error {
+			return r.Patch(ctx, sandbox, patch)
+		}); err != nil {
+			if k8serrors.IsNotFound(err) {
+				// Object was deleted out from under us; nothing left to reconcile.
+				return nil
+			}
 			return fmt.Errorf("failed to set pod name annotation: %w", err)
 		}
 
@@ -1228,6 +1253,35 @@ func sandboxMarkedExpired(sandbox *sandboxv1beta1.Sandbox) bool {
 	return cond != nil && (cond.Reason == sandboxv1beta1.SandboxReasonExpired)
 }
 
+// isPodReady reports whether the pod has a Ready condition set to True.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// podStatusChanged reports whether a Pod update is relevant to the Sandbox
+// controller. The controller's Owns(Pod) watch otherwise fires on every Kubelet
+// status write (~7 per pod lifecycle); this filters to the transitions the
+// reconciler actually depends on: Phase, Ready, and PodIPs (the Ready condition
+// is gated on PodIPs being populated, so a PodIPs change must trigger a
+// reconcile even when Phase and Ready are unchanged).
+func podStatusChanged(oldPod, newPod *corev1.Pod) bool {
+	if oldPod.Status.Phase != newPod.Status.Phase {
+		return true
+	}
+	if isPodReady(oldPod) != isPodReady(newPod) {
+		return true
+	}
+	if !equality.Semantic.DeepEqual(oldPod.Status.PodIPs, newPod.Status.PodIPs) {
+		return true
+	}
+	return false
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
 	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
@@ -1243,9 +1297,20 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers
 		return err
 	}
 
+	podStatusChangedPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, ok1 := e.ObjectOld.(*corev1.Pod)
+			newPod, ok2 := e.ObjectNew.(*corev1.Pod)
+			if !ok1 || !ok2 {
+				return true
+			}
+			return podStatusChanged(oldPod, newPod)
+		},
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&sandboxv1beta1.Sandbox{}).
-		Owns(&corev1.Pod{}, builder.WithPredicates(labelSelectorPredicate)).
+		For(&sandboxv1beta1.Sandbox{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&corev1.Pod{}, builder.WithPredicates(predicate.And(labelSelectorPredicate, podStatusChangedPredicate))).
 		Owns(&corev1.Service{}, builder.WithPredicates(labelSelectorPredicate)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).
 		Complete(r)

--- a/controllers/sandbox_status_conflict_test.go
+++ b/controllers/sandbox_status_conflict_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package controllers
 
 import (
@@ -67,11 +81,11 @@ func TestStatusUpdateConflictsOnStaleResourceVersion(t *testing.T) {
 	// A concurrent writer advances the server's ResourceVersion.
 	fresh := &sandboxv1beta1.Sandbox{}
 	require.NoError(t, r.Get(ctx, key, fresh))
-	fresh.Status.Replicas = 1
+	fresh.Status.ServiceFQDN = "fresh.cluster.local"
 	require.NoError(t, r.Status().Update(ctx, fresh))
 
 	// The stale writer's Update is now rejected with a 409 Conflict.
-	stale.Status.Replicas = 2
+	stale.Status.ServiceFQDN = "stale.cluster.local"
 	err := r.Status().Update(ctx, stale)
 	require.Error(t, err)
 	require.Truef(t, k8serrors.IsConflict(err), "expected a Conflict error, got %v", err)
@@ -91,17 +105,17 @@ func TestUpdateStatusSucceedsWithStaleResourceVersion(t *testing.T) {
 	// Advance the server ResourceVersion out from under the stale copy.
 	fresh := &sandboxv1beta1.Sandbox{}
 	require.NoError(t, r.Get(ctx, key, fresh))
-	fresh.Status.Replicas = 1
+	fresh.Status.ServiceFQDN = "fresh.cluster.local"
 	require.NoError(t, r.Status().Update(ctx, fresh))
 
 	// updateStatus must succeed despite the stale ResourceVersion.
 	oldStatus := stale.Status.DeepCopy()
-	stale.Status.Replicas = 2
+	stale.Status.ServiceFQDN = "stale.cluster.local"
 	require.NoError(t, r.updateStatus(ctx, oldStatus, stale))
 
 	got := &sandboxv1beta1.Sandbox{}
 	require.NoError(t, r.Get(ctx, key, got))
-	require.Equal(t, int32(2), got.Status.Replicas)
+	require.Equal(t, "stale.cluster.local", got.Status.ServiceFQDN)
 }
 
 // TestUpdateStatusIgnoresDeletedSandbox proves the second half of the fix:
@@ -121,7 +135,7 @@ func TestUpdateStatusIgnoresDeletedSandbox(t *testing.T) {
 
 	// Writing status to the now-deleted object must return nil, not an error.
 	oldStatus := current.Status.DeepCopy()
-	current.Status.Replicas = 2
+	current.Status.ServiceFQDN = "deleted.cluster.local"
 	require.NoError(t, r.updateStatus(ctx, oldStatus, current))
 }
 

--- a/controllers/sandbox_status_conflict_test.go
+++ b/controllers/sandbox_status_conflict_test.go
@@ -1,0 +1,162 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
+)
+
+// These tests document why the Sandbox controller writes its status with a
+// non-optimistic merge Patch instead of Update.
+//
+// Under burst load (for example a warm pool draining and re-minting many
+// sandboxes at once), the controller issues many status writes in quick
+// succession. With Status().Update(), each write carries a ResourceVersion
+// precondition; when the controller's cache lags its own writes the cached
+// ResourceVersion is stale and the apiserver rejects the write with a 409
+// Conflict. The controller then requeues and retries, producing a
+// conflict/retry storm that starves forward progress. Switching to a merge
+// Patch (which sends no ResourceVersion precondition) makes status writes
+// resilient to a stale cache.
+
+func newSandboxForStatusTest() *sandboxv1beta1.Sandbox {
+	return &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "status-conflict-sandbox",
+			Namespace: "default",
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main"}},
+				},
+			},
+		},
+	}
+}
+
+func newStatusTestReconciler(objs ...runtime.Object) SandboxReconciler {
+	return SandboxReconciler{
+		Client:        newFakeClient(objs...),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+}
+
+// TestStatusUpdateConflictsOnStaleResourceVersion documents the bug: a
+// Status().Update() with a stale ResourceVersion is rejected with a Conflict.
+func TestStatusUpdateConflictsOnStaleResourceVersion(t *testing.T) {
+	ctx := t.Context()
+	sb := newSandboxForStatusTest()
+	r := newStatusTestReconciler(sb)
+	key := types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace}
+
+	// A copy held as the controller's cache would hold it.
+	stale := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(ctx, key, stale))
+
+	// A concurrent writer advances the server's ResourceVersion.
+	fresh := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(ctx, key, fresh))
+	fresh.Status.Replicas = 1
+	require.NoError(t, r.Status().Update(ctx, fresh))
+
+	// The stale writer's Update is now rejected with a 409 Conflict.
+	stale.Status.Replicas = 2
+	err := r.Status().Update(ctx, stale)
+	require.Error(t, err)
+	require.Truef(t, k8serrors.IsConflict(err), "expected a Conflict error, got %v", err)
+}
+
+// TestUpdateStatusSucceedsWithStaleResourceVersion proves the fix: updateStatus
+// uses a merge Patch, so the same stale ResourceVersion does not cause a conflict.
+func TestUpdateStatusSucceedsWithStaleResourceVersion(t *testing.T) {
+	ctx := t.Context()
+	sb := newSandboxForStatusTest()
+	r := newStatusTestReconciler(sb)
+	key := types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace}
+
+	stale := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(ctx, key, stale))
+
+	// Advance the server ResourceVersion out from under the stale copy.
+	fresh := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(ctx, key, fresh))
+	fresh.Status.Replicas = 1
+	require.NoError(t, r.Status().Update(ctx, fresh))
+
+	// updateStatus must succeed despite the stale ResourceVersion.
+	oldStatus := stale.Status.DeepCopy()
+	stale.Status.Replicas = 2
+	require.NoError(t, r.updateStatus(ctx, oldStatus, stale))
+
+	got := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(ctx, key, got))
+	require.Equal(t, int32(2), got.Status.Replicas)
+}
+
+// TestUpdateStatusIgnoresDeletedSandbox proves the second half of the fix:
+// writing status to a Sandbox that was deleted mid-reconcile must not error
+// (which would cause a pointless requeue).
+func TestUpdateStatusIgnoresDeletedSandbox(t *testing.T) {
+	ctx := t.Context()
+	sb := newSandboxForStatusTest()
+	r := newStatusTestReconciler(sb)
+	key := types.NamespacedName{Name: sb.Name, Namespace: sb.Namespace}
+
+	current := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(ctx, key, current))
+
+	// The sandbox is deleted out from under the reconcile.
+	require.NoError(t, r.Delete(ctx, current))
+
+	// Writing status to the now-deleted object must return nil, not an error.
+	oldStatus := current.Status.DeepCopy()
+	current.Status.Replicas = 2
+	require.NoError(t, r.updateStatus(ctx, oldStatus, current))
+}
+
+func TestIsPodReady(t *testing.T) {
+	notReady := &corev1.Pod{}
+	require.False(t, isPodReady(notReady))
+
+	ready := &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}}}
+	require.True(t, isPodReady(ready))
+}
+
+func TestPodStatusChanged(t *testing.T) {
+	base := &corev1.Pod{Status: corev1.PodStatus{
+		Phase:      corev1.PodPending,
+		PodIPs:     []corev1.PodIP{{IP: "10.0.0.1"}},
+		Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+	}}
+
+	// No relevant change.
+	require.False(t, podStatusChanged(base, base.DeepCopy()))
+
+	// Phase change.
+	phaseChanged := base.DeepCopy()
+	phaseChanged.Status.Phase = corev1.PodRunning
+	require.True(t, podStatusChanged(base, phaseChanged))
+
+	// Ready flip.
+	readyFlipped := base.DeepCopy()
+	readyFlipped.Status.Conditions[0].Status = corev1.ConditionTrue
+	require.True(t, podStatusChanged(base, readyFlipped))
+
+	// PodIPs change without phase/ready change (the reviewer's concern).
+	ipsChanged := base.DeepCopy()
+	ipsChanged.Status.PodIPs = []corev1.PodIP{{IP: "10.0.0.1"}, {IP: "fd00::1"}}
+	require.True(t, podStatusChanged(base, ipsChanged))
+}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -367,7 +367,9 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 			if !equality.Semantic.DeepEqual(&mergedMeta, &sandbox.Spec.PodTemplate.ObjectMeta) {
 				logger.Info("Updating sandbox metadata to match claim", "claim", claim.Name, "sandbox", sandbox.Name)
 				sandbox.Spec.PodTemplate.ObjectMeta = mergedMeta
-				if err := r.Update(ctx, sandbox); err != nil {
+				if err := asmetrics.InstrumentWrite("claim", "pod_meta_bind", "spec", "update", func() error {
+					return r.Update(ctx, sandbox)
+				}); err != nil {
 					return nil, err
 				}
 			}
@@ -445,7 +447,9 @@ func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *ex
 
 	patch := client.MergeFrom(oldClaim)
 
-	if err := r.Status().Patch(ctx, claim, patch); err != nil {
+	if err := asmetrics.InstrumentWrite("claim", "claim_status", "status", "patch", func() error {
+		return r.Status().Patch(ctx, claim, patch)
+	}); err != nil {
 		logger.Error(err, "Failed to patch sandboxclaim status")
 		return err
 	}
@@ -809,7 +813,9 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		}
 	}
 
-	if err := r.Patch(ctx, adopted, client.MergeFrom(originalAdopted)); err != nil {
+	if err := asmetrics.InstrumentWrite("claim", "adopt_patch", "spec", "patch", func() error {
+		return r.Patch(ctx, adopted, client.MergeFrom(originalAdopted))
+	}); err != nil {
 		return err
 	}
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -450,6 +450,10 @@ func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *ex
 	if err := asmetrics.InstrumentWrite("claim", "claim_status", "status", "patch", func() error {
 		return r.Status().Patch(ctx, claim, patch)
 	}); err != nil {
+		if k8errors.IsNotFound(err) {
+			// Claim was deleted out from under us; nothing left to reconcile.
+			return nil
+		}
 		logger.Error(err, "Failed to patch sandboxclaim status")
 		return err
 	}

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -43,6 +43,7 @@ import (
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
 const (
@@ -236,7 +237,9 @@ func (r *SandboxWarmPoolReconciler) adoptSandbox(ctx context.Context, warmPool *
 		return err
 	}
 	setWarmLaunchTypeLabelIfNeeded(sb)
-	return r.Update(ctx, sb)
+	return asmetrics.InstrumentWrite("warmpool", "owner_adopt", "spec", "update", func() error {
+		return r.Update(ctx, sb)
+	})
 }
 
 func setWarmLaunchTypeLabelIfNeeded(sb *sandboxv1beta1.Sandbox) bool {

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -237,7 +237,7 @@ func (r *SandboxWarmPoolReconciler) adoptSandbox(ctx context.Context, warmPool *
 		return err
 	}
 	setWarmLaunchTypeLabelIfNeeded(sb)
-	return asmetrics.InstrumentWrite("warmpool", "owner_adopt", "spec", "update", func() error {
+	return asmetrics.InstrumentWrite("warmpool", "owner_adopt", "metadata", "update", func() error {
 		return r.Update(ctx, sb)
 	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/agent-sandbox/internal/version"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -109,6 +110,23 @@ var (
 		nil,
 	)
 
+	writesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "agent_sandbox_writes_total",
+			Help: "Total Kubernetes write calls from sandbox controllers, by path and result",
+		},
+		[]string{"controller", "action", "subresource", "verb", "result"},
+	)
+
+	writeDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "agent_sandbox_write_duration_seconds",
+			Help:    "Latency of individual Kubernetes write calls from sandbox controllers",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"controller", "action", "result"},
+	)
+
 	buildVersionInfo = version.Get()
 
 	// BuildInfo exposes agent-sandbox-controller build metadata as a constant gauge.
@@ -136,6 +154,8 @@ func init() {
 	metrics.Registry.MustRegister(SandboxCreationLatency)
 	metrics.Registry.MustRegister(SandboxClaimCreationTotal)
 	metrics.Registry.MustRegister(BuildInfo)
+	metrics.Registry.MustRegister(writesTotal)
+	metrics.Registry.MustRegister(writeDuration)
 }
 
 // RecordClaimStartupLatency records the duration since the provided start time.
@@ -158,4 +178,25 @@ func RecordSandboxCreationLatency(duration time.Duration, namespace, launchType,
 // RecordSandboxClaimCreation increments the total count of created sandbox claims.
 func RecordSandboxClaimCreation(namespace, templateName, launchType, warmPoolName, podCondition string) {
 	SandboxClaimCreationTotal.WithLabelValues(namespace, templateName, launchType, warmPoolName, podCondition).Inc()
+}
+
+// InstrumentWrite times an API write, classifies the result (success/conflict/error),
+// and records both agent_sandbox_writes_total and agent_sandbox_write_duration_seconds.
+func InstrumentWrite(controller, action, subresource, verb string, fn func() error) error {
+	start := time.Now()
+	err := fn()
+	result := "success"
+	if err != nil {
+		switch {
+		case apierrors.IsConflict(err):
+			result = "conflict"
+		case apierrors.IsNotFound(err):
+			result = "notfound"
+		default:
+			result = "error"
+		}
+	}
+	writesTotal.WithLabelValues(controller, action, subresource, verb, result).Inc()
+	writeDuration.WithLabelValues(controller, action, result).Observe(time.Since(start).Seconds())
+	return err
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -124,7 +124,7 @@ var (
 			Help:    "Latency of individual Kubernetes write calls from sandbox controllers",
 			Buckets: prometheus.DefBuckets,
 		},
-		[]string{"controller", "action", "result"},
+		[]string{"controller", "action", "subresource", "verb", "result"},
 	)
 
 	buildVersionInfo = version.Get()
@@ -197,6 +197,6 @@ func InstrumentWrite(controller, action, subresource, verb string, fn func() err
 		}
 	}
 	writesTotal.WithLabelValues(controller, action, subresource, verb, result).Inc()
-	writeDuration.WithLabelValues(controller, action, result).Observe(time.Since(start).Seconds())
+	writeDuration.WithLabelValues(controller, action, subresource, verb, result).Observe(time.Since(start).Seconds())
 	return err
 }


### PR DESCRIPTION
## What this PR does / why we need it

Under burst load (for example when a warm pool drains and re-mints many sandboxes at once), the Sandbox controller issues many status writes in quick succession. `Status().Update()` carries a ResourceVersion precondition, so when the controller's cache lags its own writes the cached ResourceVersion is stale and the API server rejects the write with a 409 Conflict. The controller requeues and retries, and the conflict/retry storm starves forward progress.

This combines two changes the history here showed are needed together:

1. Status writes use a non-optimistic merge patch (`client.MergeFrom`) instead of `Update`, removing the ResourceVersion precondition. This matches the patterns already merged for the claim (#508) and warm pool (#387) controllers.
2. A Pod watch predicate reconciles only on Phase, Ready, or PodIPs changes, suppressing the redundant reconciles `Owns(Pod)` generates on every Kubelet phase transition (~7 per pod lifecycle, per #527).
3. `NotFound` on status and annotation writes is treated as a no-op, so objects deleted mid-reconcile no longer cause requeues.
4. Adds per-write metrics (`agent_sandbox_writes_total`, `agent_sandbox_write_duration_seconds`) labeled by controller/action/subresource/verb/result, so conflicts and 404s can be attributed to a specific write path.

## Relationship to prior work

This builds directly on @vicentefb's work. The status `Update` -> `Patch` change re-lands #509 (reverted in #526 because, per #527, the patch alone left the Kubelet-driven reconcile storm intact). The reconcile predicate is the #532 design re-authored on v1beta1, with that PR's two review points applied: it also fires on `PodIPs` changes (otherwise a PodReady-before-PodIPs race can leave status at "Ready but no podIPs yet"), and `AnnotationChangedPredicate` is dropped (the controller patches its own annotations, which would re-trigger reconciles). New here on top of that: the per-write metrics, the NotFound handling, the unit tests, and load-test validation.

## Validation

Measured on a GKE cluster (150 warm pool, 10 QPS burst, c4 nodes):

- Status-write conflicts: ~43/s (38% of writes) -> 0.
- A 150-pool / 10 QPS burst completed 600/600 claims with zero failures at startup p50 0.83s; the prior `Update`-based build conflict-stormed at the same load.

## Follow-up (out of scope)

The Pod-label `Update` in the pod-reconcile path can still collide with the Kubelet under churn; converting it is a separate potential optimization not included here.

## Which issue(s) this PR fixes

Part of #527. Supersedes #532. Re-lands #509 (reverted in #526).

## Release note

```release-note
Sandbox status is now written with a non-optimistic merge patch instead of an update, eliminating optimistic-lock (409) conflict storms under burst load, and a Pod watch predicate suppresses redundant reconciles from Kubelet status churn. Writes to deleted sandboxes no longer trigger requeues. Adds per-write metrics agent_sandbox_writes_total and agent_sandbox_write_duration_seconds.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added write-operation metrics for controller actions, improving visibility into update performance and outcomes.

* **Bug Fixes**
  * Reduced unnecessary pod reconciliations by reacting only to meaningful pod status changes.
  * Improved status updates to handle conflicts and missing resources more gracefully.
  * Made sandbox claim and warm-pool adoption updates more resilient during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->