### PR TITLE
fix: correct heading rendering in include-file shortcode

### DIFF
--- a/site/layouts/shortcodes/include-file.html
+++ b/site/layouts/shortcodes/include-file.html
@@ -2,7 +2,7 @@
 {{- $md := resources.Get $file -}}
 
 {{/* Remove first heading */}}
-{{- $content := replaceRE `(\s*#[^\n$]*\n*)` "" $md.Content 1 -}}
+{{- $content := replaceRE `(?m)^#[^\n]*\n*` "" $md.Content 1 -}}
 
 {{/* Get the current page's section path */}}
 {{- $pagePath := .Page.RelPermalink -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
The short code used regex `\s*#[^\n$]*\n*` to strip the first heading which also consumed surrounding blank lines. This caused headings to render inline with preceding paragraph text on the Getting Started > Overview page

fixed by replacing the regex with `#[^\n]*\n?` to match only the heading line itself

<img width="1450" height="799" alt="image" src="https://github.com/user-attachments/assets/4d6a2492-8ded-473b-9611-d43c65693b1d" />


#### Which issue(s) this PR is related to:
Fixes #884 


#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->