### PR TITLE
examples/sandboxed-tools: refactor tools into their own package

### DIFF
--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -7,28 +7,55 @@ By keeping the sandbox lifetime scoped strictly to the duration of a tool call, 
 ## Architecture & Key Concepts
 
 1. **Minimal OpenAI-Compatible Client (`pkg/llm`)**: A lightweight Go client built on `net/http` without a third-party OpenAI SDK that interacts with OpenAI-compatible API endpoints (such as the Gemini API via its OpenAI compatibility layer). It supports function calling (tools) and tool call responses.
-2. **Ephemeral Sandbox Execution**: When the LLM requests a tool call (e.g., `run_command`), the application provisions a temporary sandbox directly using the low-level `agentsclientset`, executes the requested command via the Pod "exec" API, and immediately deletes the `Sandbox` resource.
+2. **Ephemeral Sandbox Execution**: When the LLM requests a tool call, the application provisions a temporary sandbox directly using the low-level `agentsclientset`, executes the requested tool, and immediately deletes the `Sandbox` resource once execution completes.
+3. **Session Persistence via Snapshots**: To maintain continuity across different turns of a conversation, the application automatically snapshots the sandbox's home directory (`/home/clawtainer` by default) before deleting the sandbox.
+   - These snapshots are saved as local tarball files on the host machine under `~/.local/sandboxed-tools/<session>/fs/backup-*.tar.gz`.
+   - When a new tool call is made, the application creates a fresh sandbox and automatically restores the latest snapshot into `/home/clawtainer` before executing the tool.
+   - Only the last 5 backups are retained per session; older backups are automatically pruned.
+
+## Command-Line Arguments (CLI Options)
+
+The application accepts the following command-line flags:
+
+| Flag | Description | Default / Fallback |
+| :--- | :--- | :--- |
+| `-session` | **Required**. A unique alphanumeric name (max 40 characters) to identify this agent session and store/restore its filesystem snapshots. | None |
+| `-namespace`| The Kubernetes namespace where sandbox pods are created. | `default` (overrides `SANDBOX_NAMESPACE` env var) |
+| `-image` | The container image used for the temporary sandbox pod. | `debian:bookworm-slim` (overrides `SANDBOX_IMAGE` env var) |
+| `-homedir` | The directory inside the sandbox that is persisted via snapshot/restore. | `/home/clawtainer` (overrides `SANDBOX_HOME_DIR` env var) |
 
 ## Configuration
 
-The application is configured via environment variables:
+The application is configured via environment variables (usually for API keys and endpoint configuration):
 
-| Variable | Description | Default |
+| Variable | Description | Default / Fallback |
 | :--- | :--- | :--- |
 | `GEMINI_API_KEY` | Your Gemini API key (or `OPENAI_API_KEY`). | **Required** |
 | `OPENAI_BASE_URL` | The base URL for the OpenAI-compatible API. | `https://generativelanguage.googleapis.com/v1beta/openai` |
 | `OPENAI_MODEL` | The model name to use for chat completions (or `MODEL`). | `gemini-3.5-flash` |
-| `SANDBOX_IMAGE` | The container image used for the temporary sandbox pod. | `debian:bookworm-slim` |
-| `SANDBOX_NAMESPACE`| The Kubernetes namespace where sandboxes are created. | `default` |
+| `SANDBOX_IMAGE` | Fallback container image if `-image` flag is not set. | `debian:bookworm-slim` |
+| `SANDBOX_NAMESPACE`| Fallback Kubernetes namespace if `-namespace` flag is not set. | `default` |
+| `SANDBOX_HOME_DIR` | Fallback persisted directory if `-homedir` flag is not set. | `/home/clawtainer` |
+
+## Available Tools
+
+The LLM has access to a powerful suite of tools configured in the registry (`pkg/tools`):
+
+* **`run_command`**: Executes an arbitrary shell command inside the sandbox container, returning `stdout`, `stderr`, and the `exit_code`.
+* **`ls`**: Lists the files and directories inside a specific folder (defaults to the current directory).
+* **`read`**: Reads the full contents of a file from the sandbox.
+* **`write`**: Writes specified content to a file, automatically creating parent directories if they do not exist and overwriting the file if it does.
 
 ## Running the Example
+
+Make sure your Kubernetes cluster is running and accessible via your active `kubeconfig` context.
 
 ```bash
 # Set your API key
 export GEMINI_API_KEY="your-api-key-here"
 
-# Run the chat interface
-go run ./examples/sandboxed-tools/main.go
+# Run the chat interface, specifying a session name
+go run ./examples/sandboxed-tools/main.go -session myfirstsession
 ```
 
 ## Example Session
@@ -36,25 +63,35 @@ go run ./examples/sandboxed-tools/main.go
 ```
 ================================================================================
 Welcome to the Sandboxed Tools example!
+Session Name: myfirstsession (Namespace: default)
+Sandbox Image: debian:bookworm-slim
 Using LLM Base URL: https://generativelanguage.googleapis.com/v1beta/openai (Model: gemini-3.5-flash)
-Sandbox Image: debian:bookworm-slim (Namespace: default)
 Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,
              and is immediately deleted afterward.
 Type your message (or '/exit' or '/quit' to quit):
 ================================================================================
 
-User> What is the current kernel version and uptime of the sandbox?
+User> Create a greeting file with 'Hello from Sandbox' under my home directory, then list the files there.
 
-[Tool Execution] LLM requested tool "run_command" with command: "uname -r && uptime"
-I0522 12:00:00.123456   12345 main.go:448] launching sandbox for tool execution...
-I0522 12:00:05.123456   12345 main.go:462] executing command in sandbox sandbox.name="sandbox-tool-abcde" command="uname -r && uptime"
-I0522 12:00:06.123456   12345 main.go:465] deleting sandbox sandbox.name="sandbox-tool-abcde"
-[Tool Result] stdout:
-6.1.0
- 12:00:05 up  1:23,  0 users,  load average: 0.00, 0.00, 0.00
-stderr:
+I0530 12:00:00.123456   12345 main.go:744] launching sandbox for tool execution...
+I0530 12:00:05.123456   12345 main.go:759] restoring filesystem to sandbox... sandbox.name="sandbox-tool-abcde"
+I0530 12:00:05.124000   12345 registry.go:72] llm invoking tool tool.name="write" tool.arguments="{\"content\":\"Hello from Sandbox\",\"path\":\"/home/clawtainer/greeting.txt\"}"
+I0530 12:00:05.125000   12345 write_file.go:67] creating directory in sandbox dir="/home/clawtainer"
+I0530 12:00:05.500000   12345 write_file.go:75] writing file in sandbox path="/home/clawtainer/greeting.txt"
+I0530 12:00:06.123456   12345 main.go:790] snapshotting filesystem from sandbox... sandbox.name="sandbox-tool-abcde"
+I0530 12:00:06.200000   12345 main.go:445] saved filesystem state to new backup backup="/home/user/.local/sandboxed-tools/myfirstsession/fs/backup-20260530T120006.tar.gz"
+I0530 12:00:06.201000   12345 main.go:798] deleting sandbox sandbox.name="sandbox-tool-abcde"
 
-exit_code: 0
+I0530 12:00:06.300000   12345 main.go:744] launching sandbox for tool execution...
+I0530 12:00:11.300000   12345 main.go:759] restoring filesystem to sandbox... sandbox.name="sandbox-tool-fghij"
+I0530 12:00:11.301000   12345 main.go:378] restoring filesystem from latest backup backup="/home/user/.local/sandboxed-tools/myfirstsession/fs/backup-20260530T120006.tar.gz"
+I0530 12:00:11.305000   12345 registry.go:72] llm invoking tool tool.name="ls" tool.arguments="{\"path\":\"/home/clawtainer\"}"
+I0530 12:00:11.306000   12345 list_files.go:56] listing files in sandbox path="/home/clawtainer"
+I0530 12:00:12.100000   12345 main.go:790] snapshotting filesystem from sandbox... sandbox.name="sandbox-tool-fghij"
+I0530 12:00:12.150000   12345 main.go:445] saved filesystem state to new backup backup="/home/user/.local/sandboxed-tools/myfirstsession/fs/backup-20260530T120012.tar.gz"
+I0530 12:00:12.151000   12345 main.go:798] deleting sandbox sandbox.name="sandbox-tool-fghij"
 
-Agent> The sandbox is running kernel version 6.1.0 and has been up for 1 hour and 23 minutes.
+Agent> I have created the file `greeting.txt` inside `/home/clawtainer` containing the message 'Hello from Sandbox'.
+When I listed the files inside `/home/clawtainer`, I found:
+- greeting.txt
 ```

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -46,6 +45,7 @@ import (
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	agentsclientset "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
 )
 
 func main() {
@@ -224,40 +224,10 @@ readyLoop:
 	return nil
 }
 
-// ExecutionResult holds the captured stdout, stderr, and exit code of a command.
-type ExecutionResult struct {
-	// Stdout contains the captured standard output.
-	// This is only populated if ExecOptions.Stdout was nil.
-	Stdout string
-
-	// Stderr contains the captured standard error.
-	// This is only populated if ExecOptions.Stderr was nil.
-	Stderr string
-
-	// ExitCode is the exit status returned by the command.
-	ExitCode int
-}
-
-// ExecOptions contains the options for executing a command inside the sandbox container.
-type ExecOptions struct {
-	// Command is the process name and arguments to run (e.g. []string{"sh", "-c", "uname -a"}).
-	Command []string
-
-	// Stdin is an optional reader to pipe into the command's standard input.
-	Stdin io.Reader
-
-	// Stdout is an optional writer where standard output will be written.
-	// If nil, Stdout will be captured internally and returned as a string in the ExecutionResult.
-	Stdout io.Writer
-
-	// Stderr is an optional writer where standard error will be written.
-	// If nil, Stderr will be captured internally and returned as a string in the ExecutionResult.
-	Stderr io.Writer
-}
-
-// Exec executes a command inside the sandbox container with specified options.
-// If Stdout or Stderr are nil in ExecOptions, they are captured internally and returned in the ExecutionResult.
-func (s *Sandbox) Exec(ctx context.Context, opts ExecOptions) (*ExecutionResult, error) {
+// ExecCommand executes a command inside the sandbox container with specified options.
+// If Stdout or Stderr are nil in tools.ExecCommandOptions, they are captured internally and returned in the tools.ExecCommandResult.
+// If the command returns a non-zero exit code, that is _not_ treated as an error; the exit code is returned in the result.
+func (s *Sandbox) ExecCommand(ctx context.Context, opts tools.ExecCommandOptions) (*tools.ExecCommandResult, error) {
 	coreClient := s.session.client.coreClient
 	restConfig := s.session.client.restConfig
 
@@ -315,7 +285,7 @@ func (s *Sandbox) Exec(ctx context.Context, opts ExecOptions) (*ExecutionResult,
 		}
 	}
 
-	res := &ExecutionResult{
+	res := &tools.ExecCommandResult{
 		ExitCode: exitCode,
 	}
 	if opts.Stdout == nil {
@@ -326,14 +296,6 @@ func (s *Sandbox) Exec(ctx context.Context, opts ExecOptions) (*ExecutionResult,
 	}
 
 	return res, nil
-}
-
-// Run executes a shell command in the sandbox pod.
-func (s *Sandbox) Run(ctx context.Context, command string) (*ExecutionResult, error) {
-	opts := ExecOptions{
-		Command: []string{"sh", "-c", command},
-	}
-	return s.Exec(ctx, opts)
 }
 
 // getBackupDir gets the backup directory for the session.
@@ -421,11 +383,11 @@ func (s *Sandbox) RestoreFS(ctx context.Context) error {
 	}
 	defer f.Close()
 
-	opts := ExecOptions{
+	opts := tools.ExecCommandOptions{
 		Command: []string{"tar", "-zxf", "-", "-C", s.session.HomeDir},
 		Stdin:   f,
 	}
-	res, err := s.Exec(ctx, opts)
+	res, err := s.ExecCommand(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to execute restore: %w", err)
 	}
@@ -455,11 +417,21 @@ func (s *Sandbox) SnapshotFS(ctx context.Context) error {
 	}
 	defer backupFile.Close()
 
-	opts := ExecOptions{
+	// Clean up the temp file if something goes wrong
+	shouldDeleteTempFile := true
+	defer func() {
+		if shouldDeleteTempFile {
+			if err := os.Remove(tmpFilename); err != nil {
+				log.Error(err, "unable to remove temporary backup file")
+			}
+		}
+	}()
+
+	opts := tools.ExecCommandOptions{
 		Command: []string{"tar", "-zcf", "-", "-C", s.session.HomeDir, "."},
 		Stdout:  backupFile,
 	}
-	res, err := s.Exec(ctx, opts)
+	res, err := s.ExecCommand(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to execute snapshot: %w", err)
 	}
@@ -475,6 +447,9 @@ func (s *Sandbox) SnapshotFS(ctx context.Context) error {
 	if err := os.Rename(tmpFilename, backupFilename); err != nil {
 		return fmt.Errorf("failed to rename temp backup file to final path: %w", err)
 	}
+
+	// Don't delete the temp file; we successfully created the backup
+	shouldDeleteTempFile = false
 
 	// Prune backups, keeping only the last 5
 	if err := s.session.PruneBackups(ctx, 5); err != nil {
@@ -665,8 +640,23 @@ func run(ctx context.Context, opts RunOptions) error {
 		modelName = "gemini-3.5-flash"
 	}
 
+	if opts.HomeDir == "" {
+		return fmt.Errorf("homeDir must not be empty")
+	}
+
+	if opts.SessionName == "" {
+		return fmt.Errorf("sessionName is required")
+	}
+
+	// We require the session name to contain only alphanumeric characters.
+	// We could be more liberal, but we want to err on the side of caution for now.
 	if !isAlphaNumeric(opts.SessionName) {
 		return fmt.Errorf("invalid session name %q: must be alphanumeric", opts.SessionName)
+	}
+
+	// Limit length; erring on the side of caution.
+	if len(opts.SessionName) > 40 {
+		return fmt.Errorf("invalid session name %q: must be at most 40 characters", opts.SessionName)
 	}
 
 	llmClient, err := llm.NewClient(baseURL, apiKey)
@@ -689,40 +679,36 @@ func run(ctx context.Context, opts RunOptions) error {
 		}
 	}()
 
+	toolsRegistry := tools.NewRegistry()
+	toolsRegistry.Add(&tools.RunCommand{})
+
+	toolsRegistry.Add(&tools.ListFilesTool{})
+	toolsRegistry.Add(&tools.ReadFileTool{})
+	toolsRegistry.Add(&tools.WriteFileTool{})
+
+	llmTools := toolsRegistry.All()
+
 	session := &Session{
-		Name:   opts.SessionName,
-		client: sandboxClient,
+		Name:    opts.SessionName,
+		client:  sandboxClient,
+		HomeDir: opts.HomeDir,
 	}
 
-	runCmdTool := llm.Tool{
-		Type: "function",
-		Function: llm.ToolFunction{
-			Name:        "run_command",
-			Description: "Executes a shell command inside a sandbox and returns the stdout and stderr.",
-			Parameters: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"command": map[string]any{
-						"type":        "string",
-						"description": "The shell command to execute",
-					},
-				},
-				"required": []string{"command"},
-			},
-		},
-	}
+	systemPrompt := "You are a helpful AI assistant with access to a sandboxed environment. " +
+		"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
+		"Always explain what you are doing."
 
 	messages := []llm.Message{
 		{
-			Role: "system",
-			Content: "You are a helpful AI assistant with access to a sandboxed environment. " +
-				"You can use the run_command tool to execute shell commands to answer user questions or perform tasks. " +
-				"Always explain what you are doing.",
+			Role:    "system",
+			Content: &systemPrompt,
 		},
 	}
 
 	fmt.Println("================================================================================")
 	fmt.Println("Welcome to the Sandboxed Tools example!")
+	fmt.Printf("Session Name: %s (Namespace: %s)\n", opts.SessionName, opts.Namespace)
+	fmt.Printf("Sandbox Image: %s\n", opts.Image)
 	fmt.Printf("Using LLM Base URL: %s (Model: %s)\n", baseURL, modelName)
 	fmt.Println("Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,")
 	fmt.Println("             and is immediately deleted afterward.")
@@ -750,13 +736,13 @@ func run(ctx context.Context, opts RunOptions) error {
 			break
 		}
 
-		messages = append(messages, llm.Message{Role: "user", Content: input})
+		messages = append(messages, llm.Message{Role: "user", Content: &input})
 
 		for {
 			req := llm.ChatCompletionRequest{
 				Model:    modelName,
 				Messages: messages,
-				Tools:    []llm.Tool{runCmdTool},
+				Tools:    llmTools,
 			}
 
 			resp, err := llmClient.CreateChatCompletion(ctx, req)
@@ -774,102 +760,69 @@ func run(ctx context.Context, opts RunOptions) error {
 			messages = append(messages, msg)
 
 			if len(msg.ToolCalls) == 0 {
-				fmt.Printf("\nAgent> %s\n", msg.Content)
+				fmt.Printf("\nAgent> %s\n", valueOf(msg.Content))
 				break
 			}
 
+			log.Info("launching sandbox for tool execution...")
+
+			sb, err := session.CreateSandbox(ctx, opts.Image, opts.Namespace)
+			if err != nil {
+				return fmt.Errorf("failed to create sandbox: %w", err)
+			}
+
+			if err := sb.WaitForReady(ctx); err != nil {
+				log.Error(err, "sandbox not ready")
+				_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
+				return err
+			}
+
+			log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
+
+			log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
+			if err := sb.RestoreFS(ctx); err != nil {
+				log.Error(err, "failed to restore filesystem; starting with a fresh sandbox instead", "sandbox.name", sb.SandboxName())
+			}
+
+			shouldSnapshot := true
+
 			for _, tc := range msg.ToolCalls {
-				if tc.Function.Name == "run_command" {
-					var args struct {
-						Command string `json:"command"`
-					}
-					if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
-						fmt.Printf("[Tool Error] Failed to parse arguments: %v\n", err)
-						messages = append(messages, llm.Message{
-							Role:       "tool",
-							ToolCallID: tc.ID,
-							Content:    fmt.Sprintf("Failed to parse arguments: %v", err),
-						})
-						continue
-					}
+				// TODO: Add a timeout to the tool execution?
+				result, err := toolsRegistry.Call(ctx, sb, tc)
 
-					fmt.Printf("\n[Tool Execution] LLM requested tool %q with command: %q\n", tc.Function.Name, args.Command)
-					log.Info("launching sandbox for tool execution...")
+				// We don't snapshot if there was an error, but we do snapshot if the tool just
+				// returned a non-zero exit code.
+				if err != nil {
+					shouldSnapshot = false
+				}
 
-					sb, err := session.CreateSandbox(ctx, opts.Image, opts.Namespace)
-					if err != nil {
-						fmt.Printf("[Sandbox Error] Failed to create sandbox: %v\n", err)
-						messages = append(messages, llm.Message{
-							Role:       "tool",
-							ToolCallID: tc.ID,
-							Content:    fmt.Sprintf("Sandbox creation failed: %v", err),
-						})
-						continue
-					}
-
-					if err := sb.WaitForReady(ctx); err != nil {
-						log.Error(err, "sandbox not ready")
-						_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
-						return err
-					}
-
-					log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
-
-					log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
-					if err := sb.RestoreFS(ctx); err != nil {
-						log.Error(err, "failed to restore filesystem", "sandbox.name", sb.SandboxName())
-						_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
-						messages = append(messages, llm.Message{
-							Role:       "tool",
-							ToolCallID: tc.ID,
-							Content:    fmt.Sprintf("Filesystem restore failed: %v", err),
-						})
-						continue
-					}
-
-					log.Info("executing command in sandbox", "sandbox.name", sb.SandboxName(), "command", args.Command)
-					// TODO: Add a timeout to the tool execution?
-					res, err := sb.Run(ctx, args.Command)
-
-					// We don't snapshot if there was an error, but we do snapshot if the tool just
-					// returned a non-zero exit code.
-					if err == nil {
-						log.Info("snapshotting filesystem from sandbox...", "sandbox.name", sb.SandboxName())
-						if err := sb.SnapshotFS(ctx); err != nil {
-							// Maybe this should be surfaced as an error ... but let's deal with this
-							// when we cache the sandbox.
-							log.Error(err, "failed to snapshot filesystem")
-						}
-					}
-
-					log.Info("deleting sandbox", "sandbox.name", sb.SandboxName())
-					if deleteErr := sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb); deleteErr != nil {
-						log.Error(deleteErr, "failed to delete sandbox", "sandbox.name", sb.SandboxName())
-					} else {
-						log.V(1).Info("sandbox deleted successfully.", "sandbox.name", sb.SandboxName())
-					}
-
-					var toolResult string
-					if err != nil {
-						toolResult = fmt.Sprintf("Execution error: %v", err)
-					} else {
-						toolResult = fmt.Sprintf("stdout:\n%s\nstderr:\n%s\nexit_code: %d", res.Stdout, res.Stderr, res.ExitCode)
-					}
-					fmt.Printf("[Tool Result] %s\n", toolResult)
-
+				if err != nil {
+					log.Error(err, "error calling tool", "tool", tc.Function.Name)
+					content := fmt.Sprintf("Error calling tool %q: %v", tc.Function.Name, err)
 					messages = append(messages, llm.Message{
 						Role:       "tool",
 						ToolCallID: tc.ID,
-						Content:    toolResult,
+						Content:    &content,
 					})
 				} else {
-					fmt.Printf("[Tool Error] Unknown tool requested: %s\n", tc.Function.Name)
-					messages = append(messages, llm.Message{
-						Role:       "tool",
-						ToolCallID: tc.ID,
-						Content:    fmt.Sprintf("Unknown tool %q", tc.Function.Name),
-					})
+					messages = append(messages, result)
 				}
+			}
+
+			if shouldSnapshot {
+				log.Info("snapshotting filesystem from sandbox...", "sandbox.name", sb.SandboxName())
+				if err := sb.SnapshotFS(ctx); err != nil {
+					// Maybe this should be surfaced as an error ... but let's deal with this
+					// when we cache the sandbox.
+					log.Error(err, "failed to snapshot filesystem")
+				}
+			}
+
+			log.Info("deleting sandbox", "sandbox.name", sb.SandboxName())
+			if deleteErr := sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb); deleteErr != nil {
+				log.Error(deleteErr, "failed to delete sandbox", "sandbox.name", sb.SandboxName())
+			} else {
+				log.V(1).Info("sandbox deleted successfully.", "sandbox.name", sb.SandboxName())
 			}
 		}
 	}
@@ -892,4 +845,14 @@ func isAlphaNumeric(s string) bool {
 		}
 	}
 	return true
+}
+
+// valueOf is a helper that safely gets a value from a pointer,
+// if the pointer is nil it returns the default (zero) value.
+func valueOf[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
 }

--- a/examples/sandboxed-tools/pkg/llm/client.go
+++ b/examples/sandboxed-tools/pkg/llm/client.go
@@ -43,8 +43,14 @@ type ChatCompletionRequest struct {
 
 // Message represents a single chat message in the conversation history.
 type Message struct {
-	Role             string     `json:"role"`
-	Content          string     `json:"content,omitempty"`
+	// Role is the role of the message sender, identifying the "speaker".
+	// Common values: "user", "assistant", "system".
+	Role string `json:"role"`
+
+	// Content is the content of the message.
+	// This is a pointer, because some models expect an empty string to be passed.
+	Content *string `json:"content,omitempty"`
+
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string     `json:"tool_call_id,omitempty"`
 	ThoughtSignature string     `json:"thought_signature,omitempty"`

--- a/examples/sandboxed-tools/pkg/tools/interface.go
+++ b/examples/sandboxed-tools/pkg/tools/interface.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"io"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// Tool is the interface for all LLM-callable tools.
+type Tool interface {
+	Schema() llm.Tool
+	Run(ctx context.Context, sandbox Sandbox) (llm.Message, error)
+}
+
+// Sandbox represents the interface for running commands in a sandbox.
+type Sandbox interface {
+	// ExecCommand executes a command inside the sandbox container with specified options.
+	// If Stdout or Stderr are nil in tools.ExecCommandOptions, they are captured internally and returned in the tools.ExecCommandResult.
+	// If the command returns a non-zero exit code, that is _not_ treated as an error; the exit code is returned in the result.
+	ExecCommand(ctx context.Context, opts ExecCommandOptions) (*ExecCommandResult, error)
+}
+
+// ExecCommandResult holds the result of running a command in the sandbox.
+type ExecCommandResult struct {
+	// Stdout contains the captured standard output.
+	// This is only populated if ExecCommandOptions.Stdout was nil.
+	Stdout string
+
+	// Stderr contains the captured standard error.
+	// This is only populated if ExecCommandOptions.Stderr was nil.
+	Stderr string
+
+	// ExitCode is the exit status returned by the command.
+	ExitCode int
+}
+
+// ExecCommandOptions holds the options for running a command in the sandbox.
+type ExecCommandOptions struct {
+
+	// Command is the process name and arguments to run (e.g. []string{"sh", "-c", "uname -a"}).
+	Command []string
+
+	// Stdin is an optional reader to pipe into the command's standard input.
+	Stdin io.Reader
+
+	// Stdout is an optional writer where standard output will be written.
+	// If nil, Stdout will be captured internally and returned as a string in the ExecCommandResult.
+	Stdout io.Writer
+
+	// Stderr is an optional writer where standard error will be written.
+	// If nil, Stderr will be captured internally and returned as a string in the ExecCommandResult.
+	Stderr io.Writer
+}

--- a/examples/sandboxed-tools/pkg/tools/list_files.go
+++ b/examples/sandboxed-tools/pkg/tools/list_files.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// ListFilesTool is a tool that lists files in the sandbox.
+// OpenClaw uses "ls" defined at https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/tools/ls.ts
+type ListFilesTool struct {
+	Path string `json:"path"`
+}
+
+func (t *ListFilesTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "ls",
+			Description: "List files in a directory.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Directory to list (default: current directory)",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *ListFilesTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	path := t.Path
+	if path == "" {
+		path = "."
+	}
+	log.Info("listing files in sandbox", "path", path)
+	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		// The -- separator makes execution more robust e.g. if path is "--help"
+		Command: []string{"ls", "-p", "--", path},
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	content := res.Stdout
+
+	if res.ExitCode != 0 {
+		content = fmt.Sprintf("Failed to list %q:\nstdout:\n%s\nstderr:\n%s\nexit_code: %d", path, res.Stdout, res.Stderr, res.ExitCode)
+	}
+
+	result := llm.Message{
+		Content: &content,
+	}
+
+	return result, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/read_file.go
+++ b/examples/sandboxed-tools/pkg/tools/read_file.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// ReadFileTool is a tool that reads file contents from the sandbox.
+type ReadFileTool struct {
+	Path string `json:"path"`
+}
+
+func (t *ReadFileTool) Schema() llm.Tool {
+	// Area of future investigation: do the models favor certain names (e.g. antigravity uses view_file)
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "read",
+			Description: "Read the contents of a file.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Path to the file to read (relative or absolute)",
+					},
+				},
+				"required": []string{"path"},
+			},
+		},
+	}
+}
+
+func (t *ReadFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	if t.Path == "" {
+		return llm.Message{}, errors.New("path is required")
+	}
+
+	log.Info("reading file in sandbox", "path", t.Path)
+	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		// The -- separator makes execution more robust e.g. if path is "--help"
+		Command: []string{"cat", "--", t.Path},
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	content := res.Stdout
+
+	if res.ExitCode != 0 {
+		content = fmt.Sprintf("Failed to read %q:\nstdout:\n%s\nstderr:\n%s\nexit_code: %d", t.Path, res.Stdout, res.Stderr, res.ExitCode)
+	}
+
+	result := llm.Message{
+		Content: &content,
+	}
+
+	return result, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/registry.go
+++ b/examples/sandboxed-tools/pkg/tools/registry.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// Registry keeps track of available tools and handles their invocations.
+type Registry struct {
+	tools map[string]Tool
+}
+
+// NewRegistry initializes a new tool registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		tools: make(map[string]Tool),
+	}
+}
+
+// Add registers a new tool.
+func (r *Registry) Add(tool Tool) {
+	if tool == nil {
+		panic("registered tool must not be nil")
+	}
+	if reflect.TypeOf(tool).Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("registered tool %T must be a pointer", tool))
+	}
+	schema := tool.Schema()
+	name := schema.Function.Name
+	r.tools[name] = tool
+}
+
+// All returns schemas for all registered tools.
+func (r *Registry) All() []llm.Tool {
+	var list []llm.Tool
+	for _, tool := range r.tools {
+		list = append(list, tool.Schema())
+	}
+	slices.SortFunc(list, func(a, b llm.Tool) int {
+		if a.Function.Name < b.Function.Name {
+			return -1
+		}
+		if a.Function.Name > b.Function.Name {
+			return 1
+		}
+		return 0
+	})
+	return list
+}
+
+// Call executes a tool call inside the provided sandbox and returns the LLM tool response message.
+func (r *Registry) Call(ctx context.Context, sandbox Sandbox, tc llm.ToolCall) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	log.Info("llm invoking tool", "tool.name", tc.Function.Name)
+
+	tool := r.tools[tc.Function.Name]
+	if tool == nil {
+		return llm.Message{}, fmt.Errorf("tool %q not found", tc.Function.Name)
+	}
+
+	toolType := reflect.TypeOf(tool).Elem()
+	toolInvocation := reflect.New(toolType).Interface().(Tool)
+
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), toolInvocation); err != nil {
+		return llm.Message{}, fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	res, err := toolInvocation.Run(ctx, sandbox)
+	if err != nil {
+		return llm.Message{}, fmt.Errorf("failed to run tool: %w", err)
+	}
+
+	log.Info("tool result", "tool.name", tc.Function.Name)
+
+	// Populate some default values so the tools don't all have to do it.
+	if res.Role == "" {
+		res.Role = "tool"
+	}
+	res.ToolCallID = tc.ID
+	return res, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/run_command.go
+++ b/examples/sandboxed-tools/pkg/tools/run_command.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// RunCommand is a tool that runs shell commands in the sandbox.
+type RunCommand struct {
+	Command string `json:"command"`
+}
+
+func (t *RunCommand) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "run_command",
+			Description: "Executes a shell command inside a sandbox and returns the stdout and stderr.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command": map[string]any{
+						"type":        "string",
+						"description": "The shell command to execute",
+					},
+				},
+				"required": []string{"command"},
+			},
+		},
+	}
+}
+
+func (t *RunCommand) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	log.Info("executing command in sandbox", "command", t.Command)
+	// TODO: Add a timeout to the tool execution?
+	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"sh", "-c", t.Command},
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	content := fmt.Sprintf("stdout:\n%s\nstderr:\n%s\nexit_code: %d", res.Stdout, res.Stderr, res.ExitCode)
+
+	return llm.Message{
+		Content: &content,
+	}, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/write_file.go
+++ b/examples/sandboxed-tools/pkg/tools/write_file.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// WriteFileTool is a tool that writes content to a file in the sandbox.
+// OpenClaw uses "write" defined at https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/tools/write.ts
+type WriteFileTool struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func (t *WriteFileTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "write",
+			Description: "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Path to the file to write (relative or absolute)",
+					},
+					"content": map[string]any{
+						"type":        "string",
+						"description": "Content to write to the file",
+					},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+	}
+}
+
+func (t *WriteFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	p := t.Path
+	if p == "" {
+		return llm.Message{}, fmt.Errorf("path is required")
+	}
+
+	dir := filepath.Dir(p)
+	log.Info("creating directory in sandbox", "dir", dir)
+	if _, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		// The -- separator makes execution more robust e.g. if path is "--help"
+		Command: []string{"mkdir", "-p", "--", dir},
+	}); err != nil {
+		return llm.Message{}, fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	log.Info("writing file in sandbox", "path", p)
+	response, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		// We use cat instead of tee, to avoid echoing the file
+		Command: []string{"sh", "-c", "cat > \"$1\"", "--", p},
+		Stdin:   bytes.NewBufferString(t.Content),
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	content := fmt.Sprintf("Wrote file %q", p)
+	if response.ExitCode != 0 {
+		content = fmt.Sprintf("failed to write file %q:\nstdout:\n%s\nstderr:\n%s\nexit_code: %d", p, response.Stdout, response.Stderr, response.ExitCode)
+	}
+
+	result := llm.Message{
+		Content: &content,
+	}
+	return result, nil
+}


### PR DESCRIPTION
- **examples/sandboxed-tools: refactor tools into their own package**
  This lets us add more tools in a reasonable way, as most claw-style systems use a handful of tools.
  