### PR TITLE
examples/sandboxed-tools: persist sessions across invocations

### DIFF
--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -58,6 +58,15 @@ export GEMINI_API_KEY="your-api-key-here"
 go run ./examples/sandboxed-tools/main.go -session myfirstsession
 ```
 
+## Session Persistence & Resuming Sessions
+
+By default, `sandboxed-tools` creates and resumes a session named `default`. You can specify a custom session name with the `-session` flag to run multiple independent sessions.  (Currently the session name is restricted to 40 characters at most, and only alphanumeric characters.)
+
+### How it Works
+1. **Message History**: Chat history (including system prompts, user inputs, assistant replies, and tool calls/results) is saved in real-time to a JSONL file at `~/.local/sandboxed-tools/<session-name>/sessions/latest.jsonl`.
+2. **Resuming Existing Sessions**: When starting `sandboxed-tools` with a specific session name, it automatically loads the message history from the JSONL file, prints a visual summary of your previous conversation, and continues seamlessly from where you left off.
+3. **Filesystem Backups**: Sandbox filesystem states (contents of `/home/clawtainer`) are backed up in the session-specific folder `~/.local/sandboxed-tools/<session-name>/fs`. When a sandbox launches, the latest backup tarball is restored automatically, preserving your files and environment state across tool executions and session restarts!
+
 ## Example Session
 
 ```

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -45,6 +45,7 @@ import (
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	agentsclientset "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/sessions"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
 )
 
@@ -411,7 +412,7 @@ func (s *Sandbox) SnapshotFS(ctx context.Context) error {
 	backupFilename := filepath.Join(dir, fmt.Sprintf("backup-%s.tar.gz", timestamp))
 	tmpFilename := backupFilename + ".tmp"
 
-	backupFile, err := os.OpenFile(tmpFilename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	backupFile, err := os.OpenFile(tmpFilename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create backup file %s: %w", tmpFilename, err)
 	}
@@ -600,6 +601,11 @@ type RunOptions struct {
 }
 
 func (o *RunOptions) InitDefaults() {
+	o.SessionName = os.Getenv("SESSION_NAME")
+	if o.SessionName == "" {
+		o.SessionName = "default"
+	}
+
 	o.Image = os.Getenv("SANDBOX_IMAGE")
 	if o.Image == "" {
 		o.Image = "debian:bookworm-slim"
@@ -648,15 +654,8 @@ func run(ctx context.Context, opts RunOptions) error {
 		return fmt.Errorf("sessionName is required")
 	}
 
-	// We require the session name to contain only alphanumeric characters.
-	// We could be more liberal, but we want to err on the side of caution for now.
-	if !isAlphaNumeric(opts.SessionName) {
-		return fmt.Errorf("invalid session name %q: must be alphanumeric", opts.SessionName)
-	}
-
-	// Limit length; erring on the side of caution.
-	if len(opts.SessionName) > 40 {
-		return fmt.Errorf("invalid session name %q: must be at most 40 characters", opts.SessionName)
+	if err := sessions.ValidateSessionName(opts.SessionName); err != nil {
+		return fmt.Errorf("invalid sessionName %q: %w", opts.SessionName, err)
 	}
 
 	llmClient, err := llm.NewClient(baseURL, apiKey)
@@ -688,6 +687,13 @@ func run(ctx context.Context, opts RunOptions) error {
 
 	llmTools := toolsRegistry.All()
 
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	sessionsDir := filepath.Join(homeDir, ".local", "sandboxed-tools")
+	sessionStore := sessions.NewFileStore(sessionsDir)
+
 	session := &Session{
 		Name:    opts.SessionName,
 		client:  sandboxClient,
@@ -698,22 +704,38 @@ func run(ctx context.Context, opts RunOptions) error {
 		"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
 		"Always explain what you are doing."
 
-	messages := []llm.Message{
-		{
-			Role:    "system",
-			Content: &systemPrompt,
-		},
+	messages, err := sessionStore.LoadSession(ctx, opts.SessionName)
+	if err != nil {
+		return fmt.Errorf("failed to load session: %w", err)
 	}
 
-	fmt.Println("================================================================================")
-	fmt.Println("Welcome to the Sandboxed Tools example!")
-	fmt.Printf("Session Name: %s (Namespace: %s)\n", opts.SessionName, opts.Namespace)
-	fmt.Printf("Sandbox Image: %s\n", opts.Image)
-	fmt.Printf("Using LLM Base URL: %s (Model: %s)\n", baseURL, modelName)
-	fmt.Println("Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,")
-	fmt.Println("             and is immediately deleted afterward.")
-	fmt.Println("Type your message (or '/exit' or '/quit' to quit):")
-	fmt.Println("================================================================================")
+	if len(messages) == 0 {
+		sysMsg := llm.Message{
+			Role:    "system",
+			Content: &systemPrompt,
+		}
+		messages = []llm.Message{sysMsg}
+		if err := sessionStore.AppendMessages(ctx, opts.SessionName, sysMsg); err != nil {
+			return fmt.Errorf("failed to persist system prompt: %w", err)
+		}
+
+		fmt.Println("================================================================================")
+		fmt.Println("Welcome to the Sandboxed Tools example!")
+		fmt.Printf("Session Name: %s\n", opts.SessionName)
+		fmt.Println("Type your message (or '/exit' or '/quit' to quit):")
+		fmt.Println("================================================================================")
+	} else {
+		fmt.Println("================================================================================")
+		fmt.Printf("Resumed session %q with %d messages in history:\n", opts.SessionName, len(messages))
+		fmt.Println("================================================================================")
+		for _, msg := range messages {
+			if msg.Role == "user" {
+				fmt.Printf("User> %s\n", valueOf(msg.Content))
+			} else if msg.Role == "assistant" && msg.Content != nil && *msg.Content != "" {
+				fmt.Printf("Agent> %s\n", *msg.Content)
+			}
+		}
+	}
 
 	for {
 		fmt.Print("\nUser> ")
@@ -736,7 +758,11 @@ func run(ctx context.Context, opts RunOptions) error {
 			break
 		}
 
-		messages = append(messages, llm.Message{Role: "user", Content: &input})
+		userMsg := llm.Message{Role: "user", Content: &input}
+		messages = append(messages, userMsg)
+		if err := sessionStore.AppendMessages(ctx, opts.SessionName, userMsg); err != nil {
+			return fmt.Errorf("failed to persist user message: %w", err)
+		}
 
 		for {
 			req := llm.ChatCompletionRequest{
@@ -758,6 +784,9 @@ func run(ctx context.Context, opts RunOptions) error {
 
 			msg := resp.Choices[0].Message
 			messages = append(messages, msg)
+			if err := sessionStore.AppendMessages(ctx, opts.SessionName, msg); err != nil {
+				return fmt.Errorf("failed to persist assistant message: %w", err)
+			}
 
 			if len(msg.ToolCalls) == 0 {
 				fmt.Printf("\nAgent> %s\n", valueOf(msg.Content))
@@ -796,16 +825,21 @@ func run(ctx context.Context, opts RunOptions) error {
 					shouldSnapshot = false
 				}
 
+				var toolMsg llm.Message
 				if err != nil {
 					log.Error(err, "error calling tool", "tool", tc.Function.Name)
 					content := fmt.Sprintf("Error calling tool %q: %v", tc.Function.Name, err)
-					messages = append(messages, llm.Message{
+					toolMsg = llm.Message{
 						Role:       "tool",
 						ToolCallID: tc.ID,
 						Content:    &content,
-					})
+					}
 				} else {
-					messages = append(messages, result)
+					toolMsg = result
+				}
+				messages = append(messages, toolMsg)
+				if err := sessionStore.AppendMessages(ctx, opts.SessionName, toolMsg); err != nil {
+					return fmt.Errorf("failed to persist tool response: %w", err)
 				}
 			}
 
@@ -828,23 +862,6 @@ func run(ctx context.Context, opts RunOptions) error {
 	}
 
 	return nil
-}
-
-// isAlphaNumeric returns true if the string is purely alphanumeric.
-func isAlphaNumeric(s string) bool {
-	if len(s) == 0 {
-		return false
-	}
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r >= 'A' && r <= 'Z':
-		case r >= '0' && r <= '9':
-		default:
-			return false
-		}
-	}
-	return true
 }
 
 // valueOf is a helper that safely gets a value from a pointer,

--- a/examples/sandboxed-tools/pkg/sessions/id.go
+++ b/examples/sandboxed-tools/pkg/sessions/id.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessions
+
+import "fmt"
+
+// ValidateSessionName validates that the session name is valid.
+// We use session names in kubernetes and in filesystem paths,
+// so we limit the characters allowed (alphanumeric) and the length (max 40 characters).
+func ValidateSessionName(sessionName string) error {
+	// We require the session name to contain only alphanumeric characters.
+	// We could be more liberal, but we want to err on the side of caution for now.
+	if !isAlphaNumeric(sessionName) {
+		return fmt.Errorf("session name must be alphanumeric")
+	}
+
+	// Limit length; erring on the side of caution.
+	if len(sessionName) > 40 {
+		return fmt.Errorf("session name must be no more than 40 characters long")
+	}
+
+	return nil
+}
+
+// isAlphaNumeric returns true if the string is purely alphanumeric.
+func isAlphaNumeric(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/examples/sandboxed-tools/pkg/sessions/store.go
+++ b/examples/sandboxed-tools/pkg/sessions/store.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// Store defines the interface for chat session persistence.
+type Store interface {
+	// LoadSession retrieves all messages for the given session ID.
+	// If the session does not exist, it returns a nil slice and no error.
+	LoadSession(ctx context.Context, sessionID string) ([]llm.Message, error)
+
+	// AppendMessages appends a set of messages to the session's history.
+	AppendMessages(ctx context.Context, sessionID string, messages ...llm.Message) error
+}
+
+// FileStore is a JSONL implementation of the Store interface.
+type FileStore struct {
+	basedir string
+}
+
+var _ Store = &FileStore{}
+
+// NewFileStore creates a new FileStore with the given base directory.
+func NewFileStore(dir string) *FileStore {
+	return &FileStore{
+		basedir: dir,
+	}
+}
+
+// ensureDir ensures that the session directory exists.
+func (s *FileStore) ensureDir(sessionID string) error {
+	dir := filepath.Join(s.basedir, sessionID, "sessions")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create session directory %s: %w", dir, err)
+	}
+	return nil
+}
+
+// LoadSession reads all messages from the JSONL session file.
+func (s *FileStore) LoadSession(ctx context.Context, sessionID string) ([]llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	if err := ValidateSessionName(sessionID); err != nil {
+		return nil, err
+	}
+	p := filepath.Join(s.basedir, sessionID, "sessions", "latest.jsonl")
+	log.V(2).Info("loading session", "path", p)
+	file, err := os.Open(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open session file %s: %w", p, err)
+	}
+	defer file.Close()
+
+	var messages []llm.Message
+	decoder := json.NewDecoder(file)
+	for {
+		var msg llm.Message
+		if err := decoder.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to decode message from session file: %w", err)
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, nil
+}
+
+// AppendMessages marshals and appends a set of messages to the session file.
+func (s *FileStore) AppendMessages(ctx context.Context, sessionID string, messages ...llm.Message) error {
+	log := klog.FromContext(ctx)
+
+	if err := ValidateSessionName(sessionID); err != nil {
+		return err
+	}
+
+	if err := s.ensureDir(sessionID); err != nil {
+		return err
+	}
+
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	for _, msg := range messages {
+		if err := enc.Encode(msg); err != nil {
+			return fmt.Errorf("failed to marshal message to json: %w", err)
+		}
+
+		// Note: json.Encoder automatically adds a \n character, no need to add it manually
+	}
+
+	p := filepath.Join(s.basedir, sessionID, "sessions", "latest.jsonl")
+	log.V(2).Info("appending to session", "path", p)
+	file, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open session file %s: %w", p, err)
+	}
+	defer file.Close()
+
+	if _, err := b.WriteTo(file); err != nil {
+		return fmt.Errorf("failed to write messages to session file: %w", err)
+	}
+
+	return nil
+}

--- a/examples/sandboxed-tools/pkg/sessions/store_test.go
+++ b/examples/sandboxed-tools/pkg/sessions/store_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessions
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+func TestFileStore(t *testing.T) {
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "sessions-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	store := NewFileStore(tempDir)
+
+	sessionID := "testsession123"
+
+	// 1. Load non-existent session
+	msgs, err := store.LoadSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession failed for non-existent session: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected empty messages, got %d", len(msgs))
+	}
+
+	// 2. Append a message
+	sysPrompt := "You are a helpful assistant."
+	msg1 := llm.Message{
+		Role:    "system",
+		Content: &sysPrompt,
+	}
+	if err := store.AppendMessages(ctx, sessionID, msg1); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	// 3. Load and assert msg1
+	msgs, err = store.LoadSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession failed: %v", err)
+	}
+	if diff := cmp.Diff([]llm.Message{msg1}, msgs); diff != "" {
+		t.Errorf("messages mismatch (-want +got):\n%s", diff)
+	}
+
+	// 4. Append more messages (user and assistant with tool calls)
+	userPrompt := "list files"
+	msg2 := llm.Message{
+		Role:    "user",
+		Content: &userPrompt,
+	}
+	if err := store.AppendMessages(ctx, sessionID, msg2); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	toolCall := llm.ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: llm.FunctionCall{
+			Name:      "list_files",
+			Arguments: `{"path": "."}`,
+		},
+	}
+	msg3 := llm.Message{
+		Role:      "assistant",
+		ToolCalls: []llm.ToolCall{toolCall},
+	}
+
+	toolResult := "file1.txt\nfile2.txt"
+	msg4 := llm.Message{
+		Role:       "tool",
+		ToolCallID: "call_1",
+		Content:    &toolResult,
+	}
+	if err := store.AppendMessages(ctx, sessionID, msg3, msg4); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	// 5. Load and assert everything
+	msgs, err = store.LoadSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession failed: %v", err)
+	}
+	wantMsgs := []llm.Message{msg1, msg2, msg3, msg4}
+	if diff := cmp.Diff(wantMsgs, msgs); diff != "" {
+		t.Errorf("messages mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
- **examples/sandboxed-tools: persist sessions across invocations**
  This means we don't have to start again every time.
  
  Format is jsonl in the local filesystem;
  an interface means that a server could use a database instead.
  