### PR TITLE
Implement revised KEP 119 for persisting Suspended condition.

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -29,8 +29,14 @@ const (
 	SandboxConditionSuspended ConditionType = "Suspended"
 	// SandboxReasonSuspendedPodTerminated indicates that the pod has been terminated.
 	SandboxReasonSuspendedPodTerminated = "PodTerminated"
-	// SandboxReasonSuspendedPodNotTerminated indicates the pod has not been terminated yet.
-	SandboxReasonSuspendedPodNotTerminated = "PodNotTerminated"
+	// SandboxReasonSuspendedPodTerminating indicates the pod is in the process of termination.
+	SandboxReasonSuspendedPodTerminating = "PodTerminating"
+	// SandboxReasonSuspendedPodResuming indicates the sandbox resumption is requested and the pod is being provisioned.
+	SandboxReasonSuspendedPodResuming = "PodResuming"
+	// SandboxReasonSuspendedPodProvisioning indicates the first time pod provisioning (separate from waking from a suspend).
+	SandboxReasonSuspendedPodProvisioning = "PodProvisioning"
+	// SandboxReasonSuspendedPodProvisioned indicates the pod object has been created in the cluster and the sandbox is active.
+	SandboxReasonSuspendedPodProvisioned = "PodProvisioned"
 
 	// SandboxConditionReady indicates readiness for Sandbox.
 	SandboxConditionReady ConditionType = "Ready"

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -280,27 +280,48 @@ func (r *SandboxReconciler) computeConditions(sandbox *sandboxv1beta1.Sandbox, e
 }
 
 func (r *SandboxReconciler) computeSuspendedCondition(sandbox *sandboxv1beta1.Sandbox, pod *corev1.Pod) *metav1.Condition {
-	isSuspended := sandbox.Spec.OperatingMode == sandboxv1beta1.SandboxOperatingModeSuspended
-	if !isSuspended {
-		return nil
-	}
+	desiresSuspension := sandbox.Spec.OperatingMode == sandboxv1beta1.SandboxOperatingModeSuspended
+	existingSuspendedCond := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionSuspended))
 
-	suspended := metav1.Condition{
+	// Initialize the condition container (keep the condition present once initialized)
+	suspended := &metav1.Condition{
 		Type:               string(sandboxv1beta1.SandboxConditionSuspended),
 		ObservedGeneration: sandbox.Generation,
 	}
-	if pod == nil {
-		// Mark Suspended condition as True
-		suspended.Status = metav1.ConditionTrue
-		suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodTerminated
-		suspended.Message = "Pod has been terminated. Sandbox is not operational."
+
+	if desiresSuspension {
+		if pod == nil {
+			// Stable State: Fully Suspended
+			suspended.Status = metav1.ConditionTrue
+			suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodTerminated
+			suspended.Message = "Pod has been successfully terminated. Sandbox is fully suspended."
+		} else {
+			// Transient State: In the process of scaling down
+			suspended.Status = metav1.ConditionFalse
+			suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodTerminating
+			suspended.Message = "Sandbox suspension requested. Pod is in the process of termination."
+		}
 	} else {
-		suspended.Status = metav1.ConditionFalse
-		suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodNotTerminated
-		suspended.Message = "Pod has not been terminated. Sandbox is operational."
+		// The spec wants it RUNNING
+		if pod == nil {
+			// Differentiate between a brand-new Sandbox and one waking up from suspension
+			suspended.Status = metav1.ConditionFalse
+			if existingSuspendedCond != nil && (existingSuspendedCond.Status == metav1.ConditionTrue || existingSuspendedCond.Reason == sandboxv1beta1.SandboxReasonSuspendedPodTerminating) {
+				suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodResuming
+				suspended.Message = "Sandbox resumption requested. Pod is being provisioned."
+			} else {
+				suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodProvisioning
+				suspended.Message = "Pod is provisioning."
+			}
+		} else {
+			// The pod exists. We do not track granular pod health here; Ready condition does that.
+			suspended.Status = metav1.ConditionFalse
+			suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodProvisioned
+			suspended.Message = "Sandbox is active and the underlying Pod has been provisioned."
+		}
 	}
 
-	return &suspended
+	return suspended
 }
 
 func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1beta1.Sandbox, err error, svc *corev1.Service, pod *corev1.Pod) metav1.Condition {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -91,6 +91,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     nil,
 			pod:     nil,
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioning", Message: "Pod is provisioning."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod does not exist; Service does not exist"},
 			},
 		},
@@ -100,6 +101,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     &corev1.Service{},
 			pod:     nil,
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioning", Message: "Pod is provisioning."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod does not exist; Service Exists"},
 			},
 		},
@@ -109,6 +111,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     &corev1.Service{},
 			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioned", Message: "Sandbox is active and the underlying Pod has been provisioned."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
 			},
 		},
@@ -126,6 +129,7 @@ func TestComputeConditions(t *testing.T) {
 				},
 			},
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioned", Message: "Sandbox is active and the underlying Pod has been provisioned."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Running but not Ready; Service Exists"},
 			},
 		},
@@ -145,6 +149,7 @@ func TestComputeConditions(t *testing.T) {
 				},
 			},
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioned", Message: "Sandbox is active and the underlying Pod has been provisioned."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Ready but has no podIPs yet; Service Exists"},
 			},
 		},
@@ -161,7 +166,7 @@ func TestComputeConditions(t *testing.T) {
 				},
 			},
 			expectedConditions: []metav1.Condition{
-				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodNotTerminated", Message: "Pod has not been terminated. Sandbox is operational."},
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodTerminating", Message: "Sandbox suspension requested. Pod is in the process of termination."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "SandboxSuspended", Message: "Sandbox is suspending"},
 			},
 		},
@@ -171,16 +176,21 @@ func TestComputeConditions(t *testing.T) {
 			svc:     &corev1.Service{},
 			pod:     nil,
 			expectedConditions: []metav1.Condition{
-				{Type: "Suspended", Status: "True", ObservedGeneration: gen, Reason: "PodTerminated", Message: "Pod has been terminated. Sandbox is not operational."},
+				{Type: "Suspended", Status: "True", ObservedGeneration: gen, Reason: "PodTerminated", Message: "Pod has been successfully terminated. Sandbox is fully suspended."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "SandboxSuspended", Message: "Sandbox is suspended"},
 			},
 		},
 		{
-			name:    "8. Resuming - Pod missing",
-			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
-			svc:     &corev1.Service{},
-			pod:     nil,
+			name: "8. Resuming - Pod missing",
+			sandbox: func() *sandboxv1beta1.Sandbox {
+				sb := sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning)
+				sb.Status.Conditions = []metav1.Condition{{Type: "Suspended", Status: "True"}}
+				return sb
+			}(),
+			svc: &corev1.Service{},
+			pod: nil,
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodResuming", Message: "Sandbox resumption requested. Pod is being provisioned."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod does not exist; Service Exists"},
 			},
 		},
@@ -190,6 +200,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     &corev1.Service{},
 			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}},
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioned", Message: "Sandbox is active and the underlying Pod has been provisioned."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Unknown; Service Exists"},
 			},
 		},
@@ -199,6 +210,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     &corev1.Service{},
 			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodFailed}},
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioned", Message: "Sandbox is active and the underlying Pod has been provisioned."},
 				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodFailed", Message: "Pod failed"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Failed; Service Exists"},
 			},
@@ -209,6 +221,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     &corev1.Service{},
 			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodSucceeded}},
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioned", Message: "Sandbox is active and the underlying Pod has been provisioned."},
 				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodSucceeded", Message: "Pod completed successfully"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Succeeded; Service Exists"},
 			},
@@ -220,6 +233,7 @@ func TestComputeConditions(t *testing.T) {
 			svc:     nil,
 			pod:     nil,
 			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodProvisioning", Message: "Pod is provisioning."},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: something went wrong"},
 			},
 		},
@@ -316,6 +330,13 @@ func TestReconcile(t *testing.T) {
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
 				Conditions: []metav1.Condition{
 					{
+						Type:               "Suspended",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "PodProvisioned",
+						Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+					},
+					{
 						Type:               "Ready",
 						Status:             "False",
 						ObservedGeneration: 1,
@@ -367,6 +388,13 @@ func TestReconcile(t *testing.T) {
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 1,
+						Reason:             "PodProvisioned",
+						Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+					},
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
 						Status:             metav1.ConditionFalse,
@@ -462,6 +490,13 @@ func TestReconcile(t *testing.T) {
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
 				Conditions: []metav1.Condition{
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 1,
+						Reason:             "PodProvisioned",
+						Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+					},
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
 						Status:             metav1.ConditionFalse,
@@ -588,6 +623,13 @@ func TestReconcile(t *testing.T) {
 				PodIPs:        []string{"10.244.0.5", "fd00::5"},
 				Conditions: []metav1.Condition{
 					{
+						Type:               "Suspended",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "PodProvisioned",
+						Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+					},
+					{
 						Type:               "Ready",
 						Status:             "True",
 						ObservedGeneration: 1,
@@ -651,6 +693,13 @@ func TestReconcile(t *testing.T) {
 				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
 				PodIPs:        []string{"10.244.0.5"},
 				Conditions: []metav1.Condition{
+					{
+						Type:               "Suspended",
+						Status:             "False",
+						ObservedGeneration: 1,
+						Reason:             "PodProvisioned",
+						Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+					},
 					{
 						Type:               "Ready",
 						Status:             "True",
@@ -2625,6 +2674,6 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 
 	var got sandboxv1beta1.Sandbox
 	require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: sbName, Namespace: sbNs}, &got))
-	require.Len(t, got.Status.Conditions, 1,
+	require.Len(t, got.Status.Conditions, 2,
 		"conditions slice must not grow across %d reconcile iterations — controller must upsert not append", iters)
 }

--- a/docs/keps/119-sandbox-suspended-state/README.md
+++ b/docs/keps/119-sandbox-suspended-state/README.md
@@ -47,54 +47,6 @@ The controller evaluates the hierarchy top-down. The `Suspended` condition remai
 | **Resuming** | `False` | `PodResuming` | nil (Recreating) | **`False`** | `DependenciesNotReady` | Transient State: Sandbox resumption requested. Recreation of underlying workload is in progress. |
 | **Operational** | `False` | `PodProvisioned` | non-nil (Active) | **`True` / `False`** | `DependenciesReady` / `DependenciesNotReady` | Stable State: Sandbox is active and the underlying Pod has been provisioned. Note: The Pod might be Pending or Failed; we rely on `Ready` and `Finished` to track specific Pod health. |
 
-## Controller Implementation
-
-The state transitions map cleanly to a level-based evaluation of desired state (`OperatingMode`) against physical state (Pod existence):
-
-```go
-func (r *SandboxReconciler) computeSuspendedCondition(
-    sandbox *sandboxv1beta1.Sandbox, 
-    pod *corev1.Pod,
-) *metav1.Condition {
-    
-    desiresSuspension := sandbox.Spec.OperatingMode == sandboxv1beta1.SandboxOperatingModeSuspended
-    existingSuspendedCond := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionSuspended))
-
-    // Initialize the condition container (keep the condition present once initialized)
-    suspended := &metav1.Condition{
-        Type:               string(sandboxv1beta1.SandboxConditionSuspended),
-        ObservedGeneration: sandbox.Generation,
-    }
-
-    if desiresSuspension {
-        if pod == nil {
-            // Stable State: Fully Suspended
-            suspended.Status = metav1.ConditionTrue
-            suspended.Reason = sandboxv1beta1.SandboxReasonSuspendedPodTerminated
-            suspended.Message = "Pod has been successfully terminated. Sandbox is fully suspended."
-        } else {
-            // Transient State: In the process of scaling down
-            suspended.Status = metav1.ConditionFalse
-            suspended.Reason = "PodTerminating"
-            suspended.Message = "Sandbox suspension requested. Active workloads are being de-provisioned."
-        }
-    } else {
-        // The spec wants it RUNNING
-        if pod == nil {
-            // Differentiate between a brand-new Sandbox and one waking up from suspension
-            suspended.Status = metav1.ConditionFalse
-        } else {
-            // Stable State: The pod exists. We do not track granular pod health here.
-            suspended.Status = metav1.ConditionFalse
-            suspended.Reason = "PodProvisioned"
-            suspended.Message = "Sandbox is active and the underlying Pod has been provisioned."
-        }
-    }
-
-    return suspended
-}
-```
-
 ## Usage Examples
 
 Standard Kubernetes tooling can now interact with the sandbox state natively and reliably using both states of the condition:

--- a/docs/keps/119-sandbox-suspended-state/README.md
+++ b/docs/keps/119-sandbox-suspended-state/README.md
@@ -5,7 +5,6 @@
 - [Condition Hierarchy](#condition-hierarchy)
     - [1. <code>Suspended</code>](#1-suspended)
     - [2. <code>Ready</code> (Root Condition)](#2-ready-root-condition)
-- [Controller Implementation](#controller-implementation)
 - [Usage Examples](#usage-examples)
 - [Alternatives Considered](#alternatives-considered)
     - [1. Retaining the Legacy <code>status.phase</code> Field](#1-retaining-the-legacy-statusphase-field)

--- a/docs/keps/119-sandbox-suspended-state/README.md
+++ b/docs/keps/119-sandbox-suspended-state/README.md
@@ -27,7 +27,7 @@ The Sandbox state is determined by multiple distinct layers.
 #### 1. `Suspended`
 This condition explicitly tracks whether the sandbox environment is currently paused or hibernated. 
 * **Status: True** – The Sandbox is no longer actively executing workloads due to a suspension request. The `Reason` field specifies how it is suspended (`PodTerminated`).
-* **Status: False** – The Sandbox is active, running, or in a transient lifecycle phase (`PodTerminating`, `PodResuming`, `PodRunning`). `lastTransitionTime` is updated only when the status flips between `True` and `False`, and is retained while the status remains `False` even if the reason/message changes.
+* **Status: False** – The Sandbox is active, running, or in a transient lifecycle phase (`PodProvisioning`, `PodTerminating`, `PodResuming`, `PodProvisioned`). `lastTransitionTime` is updated only when the status flips between `True` and `False`, and is retained while the status remains `False` even if the reason/message changes.
 * **Ready Impact:** The moment a suspension is requested (e.g., `spec.operatingMode: Suspended`), the `Ready` condition immediately transitions to `False` with the reason `SandboxSuspended`. It holds this reason through the entire suspending phase and remains that way once fully suspended.
 
 #### 2. `Ready` (Root Condition)
@@ -45,7 +45,7 @@ The controller evaluates the hierarchy top-down. The `Suspended` condition remai
 | **Suspending** | `False` | `PodTerminating` | non-nil (Deleting) | **`False`** | `SandboxSuspended` | Transient State: Sandbox suspension requested. Active workloads are being de-provisioned. |
 | **Suspended** | `True` | `PodTerminated` | nil (Fully deleted) | **`False`** | `SandboxSuspended` | Stable State: Pod has been successfully terminated. Sandbox is fully suspended. |
 | **Resuming** | `False` | `PodResuming` | nil (Recreating) | **`False`** | `DependenciesNotReady` | Transient State: Sandbox resumption requested. Recreation of underlying workload is in progress. |
-| **Operational** | `False` | `PodRunning` | non-nil (Active) | **`True`** | `DependenciesReady` | Stable State: Sandbox is active and the underlying Pod is running. |
+| **Operational** | `False` | `PodProvisioned` | non-nil (Active) | **`True` / `False`** | `DependenciesReady` / `DependenciesNotReady` | Stable State: Sandbox is active and the underlying Pod has been provisioned. Note: The Pod might be Pending or Failed; we rely on `Ready` and `Finished` to track specific Pod health. |
 
 ## Controller Implementation
 
@@ -83,18 +83,11 @@ func (r *SandboxReconciler) computeSuspendedCondition(
         if pod == nil {
             // Differentiate between a brand-new Sandbox and one waking up from suspension
             suspended.Status = metav1.ConditionFalse
-            if existingSuspendedCond != nil && existingSuspendedCond.Status == metav1.ConditionTrue {
-                suspended.Reason = "PodResuming"
-                suspended.Message = "Sandbox resumption requested. Recreation of underlying workload is in progress."
-            } else {
-                suspended.Reason = "Provisioning"
-                suspended.Message = "Sandbox is provisioning."
-            }
         } else {
-            // Stable State: The pod exists and is active.
+            // Stable State: The pod exists. We do not track granular pod health here.
             suspended.Status = metav1.ConditionFalse
-            suspended.Reason = "PodRunning"
-            suspended.Message = "Sandbox is active and the underlying Pod is running."
+            suspended.Reason = "PodProvisioned"
+            suspended.Message = "Sandbox is active and the underlying Pod has been provisioned."
         }
     }
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -82,6 +82,13 @@ func TestSimpleSandbox(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodProvisioned,
+					Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,

--- a/test/e2e/mode_test.go
+++ b/test/e2e/mode_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
 
-func TestSandboxOperatingMode(t *testing.T) {
+func TestSandboxSuspendResumeCycleWithOperatingMode(t *testing.T) {
 	tc := framework.NewTestContext(t)
 
 	// Set up a namespace
@@ -40,13 +40,20 @@ func TestSandboxOperatingMode(t *testing.T) {
 	require.NoError(t, tc.CreateWithCleanup(t.Context(), sandboxObj))
 
 	nameHash := NameHash(sandboxObj.Name)
-	// Assert Sandbox object status reconciles as expected
+	// 1. Assert Sandbox object status reconciles as expected for default running mode
 	p := []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1beta1.SandboxStatus{
 			Service:       "my-sandbox",
 			ServiceFQDN:   fmt.Sprintf("my-sandbox.%s.svc.cluster.local", ns.Name),
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
+				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodProvisioned,
+					Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+				},
 				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
@@ -69,12 +76,12 @@ func TestSandboxOperatingMode(t *testing.T) {
 	service.Namespace = ns.Name
 	tc.MustExist(service)
 
-	// Set operating mode to suspended
+	// 2. Set operating mode to suspended
 	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1beta1.Sandbox) {
 		obj.Spec.OperatingMode = sandboxv1beta1.SandboxOperatingModeSuspended
 	})
 
-	// Wait for sandbox status to reflect new state
+	// Wait for sandbox status to reflect suspended state
 	p = []predicates.ObjectPredicate{
 		predicates.SandboxHasStatus(sandboxv1beta1.SandboxStatus{
 			Service:       "my-sandbox",
@@ -82,18 +89,18 @@ func TestSandboxOperatingMode(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 2,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodTerminated,
+					Message:            "Pod has been successfully terminated. Sandbox is fully suspended.",
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionFalse,
 					ObservedGeneration: 2,
 					Reason:             sandboxv1beta1.SandboxReasonSuspended,
 					Message:            "Sandbox is suspended",
-				},
-				{
-					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
-					Status:             metav1.ConditionTrue,
-					ObservedGeneration: 2,
-					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodTerminated,
-					Message:            "Pod has been terminated. Sandbox is not operational.",
 				},
 			},
 		}),
@@ -101,5 +108,43 @@ func TestSandboxOperatingMode(t *testing.T) {
 	tc.MustWaitForObject(sandboxObj, p...)
 	// Verify Pod is deleted but Service still exists
 	require.NoError(t, tc.WaitForObjectNotFound(t.Context(), pod))
+	tc.MustMatchPredicates(service, predicates.NotDeleted())
+
+	// 3. Resume the sandbox
+	framework.MustUpdateObject(tc.ClusterClient, sandboxObj, func(obj *sandboxv1beta1.Sandbox) {
+		obj.Spec.OperatingMode = sandboxv1beta1.SandboxOperatingModeRunning
+	})
+
+	// Wait for sandbox status to reflect resumed state
+	p = []predicates.ObjectPredicate{
+		predicates.SandboxHasStatus(sandboxv1beta1.SandboxStatus{
+			Service:       "my-sandbox",
+			ServiceFQDN:   fmt.Sprintf("my-sandbox.%s.svc.cluster.local", ns.Name),
+			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 3,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodProvisioned,
+					Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+				},
+				{
+					Type:               "Ready",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 3,
+					Reason:             sandboxv1beta1.SandboxReasonDependenciesReady,
+					Message:            "Pod is Ready; Service Exists",
+				},
+			},
+		}),
+	}
+	tc.MustWaitForObject(sandboxObj, p...)
+
+	// Assert Pod exists again
+	pod = &corev1.Pod{}
+	pod.Name = "my-sandbox"
+	pod.Namespace = ns.Name
+	tc.MustExist(pod)
 	tc.MustMatchPredicates(service, predicates.NotDeleted())
 }

--- a/test/e2e/shutdown_test.go
+++ b/test/e2e/shutdown_test.go
@@ -48,6 +48,13 @@ func TestSandboxShutdownTime(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodProvisioned,
+					Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,
@@ -82,6 +89,13 @@ func TestSandboxShutdownTime(t *testing.T) {
 			Service:     "",
 			ServiceFQDN: "",
 			Conditions: []metav1.Condition{
+				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodProvisioned,
+					Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+				},
 				{
 					Type:               string(sandboxv1beta1.SandboxConditionReady),
 					Status:             metav1.ConditionFalse,

--- a/test/e2e/volumeclaimtemplate_test.go
+++ b/test/e2e/volumeclaimtemplate_test.go
@@ -83,6 +83,13 @@ func TestSandboxVolumeClaimTemplates(t *testing.T) {
 			LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 			Conditions: []metav1.Condition{
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionSuspended),
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodProvisioned,
+					Message:            "Sandbox is active and the underlying Pod has been provisioned.",
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR introduces more detailed tracking for the `Suspended` condition in the Sandbox API. Instead of relying on a simple binary state, the Suspended condition will now use fine-grained reasons to accurately reflect the exact phase of the underlying Pod during a suspend or resume operation.

**Key Changes:**

1. Added the following `SandboxConditionSuspended` reasons:

      a. **Suspend Reason**
      `PodTerminating`: Indicates the sandbox suspension request is received and the controller is currently in the process of terminating the pod.
      `PodTerminated`: Indicates the sandbox is fully suspended and the underlying pod has been entirely removed.
      
     b.  **Resume Reason**
      `PodResuming`: Indicates that a resumption was requested (operating mode changed back to running after previously suspended) and a new pod is being provisioned.
      `PodProvisioned`: Indicates the sandbox is active and the pod is provisioned.
      
      c. **First time Pod Provisioning Reason**
      `PodProvisioning`: Indicates the sandbox is active and the pod is being provisioned for the first time. (separate from waking up from a suspend)

2. Added the suspend resume lifecycle test in `mode_test.go` E2E.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes-sigs/agent-sandbox/issues/873

#### Release Note
```release-note
Provides granular tracking of Suspended condition.
```
