### PR TITLE
fix: protect system-reserved Pod labels and annotations from tenant override

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -475,12 +475,30 @@ func isSystemAnnotation(key string) bool {
 		key == asmetrics.TraceContextAnnotation
 }
 
+// warmPoolTrackingLabels are the system-prefixed labels that trusted extension
+// controllers (warm pool / claim) set on a Sandbox and that must be propagated to the
+// backing Pod. Centralized here so the create and adoption paths stay in sync.
+var warmPoolTrackingLabels = []string{
+	warmPoolSandboxLabel,
+	sandboxTemplateRefHashLabel,
+	sandboxv1beta1.SandboxPodTemplateHashLabel,
+}
+
 // isAllowedSystemLabel reports whether a system-prefixed label is a tracking label
 // that trusted controllers are permitted to set on a Sandbox and have propagated to
 // the backing Pod.
 func isAllowedSystemLabel(key string) bool {
+	return slices.Contains(warmPoolTrackingLabels, key)
+}
+
+// isControllerManagedPodAnnotation reports whether a system-reserved annotation is one
+// the controller itself sets on a Pod, and therefore must not be scrubbed during
+// cleanup of previously-propagated annotations.
+func isControllerManagedPodAnnotation(key string) bool {
 	switch key {
-	case warmPoolSandboxLabel, sandboxTemplateRefHashLabel, sandboxv1beta1.SandboxPodTemplateHashLabel:
+	case sandboxv1beta1.SandboxPropagatedLabelsAnnotation,
+		sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation,
+		asmetrics.TraceContextAnnotation:
 		return true
 	default:
 		return false
@@ -491,8 +509,17 @@ func isAllowedSystemLabel(key string) bool {
 // extension controller (warm pool or claim). Only controller-managed Sandboxes may
 // propagate the warm-pool tracking labels to their Pods; this prevents a tenant from
 // spoofing those labels via a directly-created Sandbox.
+//
+// We require a controller owner reference (controller=true) under the extensions API
+// group. This assumes the OwnerReferencesPermissionEnforcement admission plugin is
+// active, so a tenant cannot attach a controller ownerRef pointing at an object they
+// are not permitted to delete. Verifying that the referenced owner actually exists and
+// matches ref.UID would harden this further and is left as a follow-up.
 func sandboxManagedByExtensionController(sandbox *sandboxv1beta1.Sandbox) bool {
 	for _, ref := range sandbox.OwnerReferences {
+		if ref.Controller == nil || !*ref.Controller {
+			continue
+		}
 		if !strings.HasPrefix(ref.APIVersion, "extensions.agents.x-k8s.io/") {
 			continue
 		}
@@ -863,7 +890,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
 	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
 	if sandboxManagedByExtensionController(sandbox) {
-		for _, key := range []string{warmPoolSandboxLabel, sandboxTemplateRefHashLabel, sandboxv1beta1.SandboxPodTemplateHashLabel} {
+		for _, key := range warmPoolTrackingLabels {
 			if v, ok := sandbox.Labels[key]; ok {
 				podLabels[key] = v
 			}
@@ -963,14 +990,6 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
 		if isSystemLabel(k) {
 			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate", "pod", pod.Name, "key", k)
-			// Remove a value a tenant may have managed to inject on an adopted pod.
-			if !isAllowedSystemLabel(k) {
-				if _, exists := pod.Labels[k]; exists {
-					delete(pod.Labels, k)
-					updated = true
-					logger.Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
-				}
-			}
 			continue
 		}
 		if pod.Labels[k] != v {
@@ -981,20 +1000,35 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	}
 	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
 	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
-	if sandboxManagedByExtensionController(sandbox) {
-		for _, key := range []string{warmPoolSandboxLabel, sandboxTemplateRefHashLabel, sandboxv1beta1.SandboxPodTemplateHashLabel} {
+	extensionManaged := sandboxManagedByExtensionController(sandbox)
+	if extensionManaged {
+		for _, key := range warmPoolTrackingLabels {
 			if v, ok := sandbox.Labels[key]; ok && pod.Labels[key] != v {
 				pod.Labels[key] = v
 				updated = true
 			}
 		}
 	}
-	// Handle deletion of labels
+	// Handle deletion of labels removed from the template. System keys recorded in the
+	// propagated list by an older (vulnerable) controller are also scrubbed, except the
+	// controller-owned name-hash label and, on extension-managed Sandboxes, the allowed
+	// tracking labels.
 	propagatedLabelsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedLabelsAnnotation]
 	if propagatedLabelsStr != "" {
 		propagatedLabels := strings.SplitSeq(propagatedLabelsStr, ",")
 		for k := range propagatedLabels {
-			if k == "" || isSystemLabel(k) {
+			if k == "" {
+				continue
+			}
+			if isSystemLabel(k) {
+				if k == sandboxLabel || (extensionManaged && isAllowedSystemLabel(k)) {
+					continue
+				}
+				if _, exists := pod.Labels[k]; exists {
+					delete(pod.Labels, k)
+					updated = true
+					logger.Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
+				}
 				continue
 			}
 			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Labels[k]; !ok {
@@ -1021,12 +1055,24 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 			managedAnnotationKeys = append(managedAnnotationKeys, k)
 		}
 	}
-	// Handle deletion of annotations
+	// Handle deletion of annotations. System annotations that an older controller may
+	// have recorded in the propagated list are scrubbed, except those the controller
+	// itself manages on the Pod.
 	propagatedAnnotationsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation]
 	if propagatedAnnotationsStr != "" {
 		propagatedAnnotations := strings.SplitSeq(propagatedAnnotationsStr, ",")
 		for k := range propagatedAnnotations {
-			if k == "" || isSystemAnnotation(k) {
+			if k == "" {
+				continue
+			}
+			if isSystemAnnotation(k) {
+				if isControllerManagedPodAnnotation(k) {
+					continue
+				}
+				if _, exists := pod.Annotations[k]; exists {
+					delete(pod.Annotations, k)
+					updated = true
+				}
 				continue
 			}
 			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[k]; !ok {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -57,6 +58,8 @@ const (
 	// avoid an import cycle.
 	warmPoolSandboxLabel        = "agents.x-k8s.io/warm-pool-sandbox"
 	sandboxTemplateRefHashLabel = "agents.x-k8s.io/sandbox-template-ref-hash"
+
+	extensionsAgentsGroup = "extensions.agents.x-k8s.io"
 )
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
@@ -475,20 +478,29 @@ func isSystemAnnotation(key string) bool {
 		key == asmetrics.TraceContextAnnotation
 }
 
-// warmPoolTrackingLabels are the system-prefixed labels that trusted extension
-// controllers (warm pool / claim) set on a Sandbox and that must be propagated to the
-// backing Pod. Centralized here so the create and adoption paths stay in sync.
-var warmPoolTrackingLabels = []string{
-	warmPoolSandboxLabel,
-	sandboxTemplateRefHashLabel,
-	sandboxv1beta1.SandboxPodTemplateHashLabel,
+// warmPoolTrackingLabelSet is the allowlist of system-prefixed labels that trusted
+// extension controllers (warm pool / claim) set on a Sandbox and that must be
+// propagated to the backing Pod. A map avoids accidental mutation via append on a
+// shared slice and keeps membership checks O(1).
+var warmPoolTrackingLabelSet = map[string]struct{}{
+	warmPoolSandboxLabel:                       {},
+	sandboxTemplateRefHashLabel:                {},
+	sandboxv1beta1.SandboxPodTemplateHashLabel: {},
+}
+
+// extensionControllerOwnerKinds are the extension owner kinds that may authorize
+// warm-pool tracking label propagation.
+var extensionControllerOwnerKinds = map[string]struct{}{
+	"SandboxWarmPool": {},
+	"SandboxClaim":    {},
 }
 
 // isAllowedSystemLabel reports whether a system-prefixed label is a tracking label
 // that trusted controllers are permitted to set on a Sandbox and have propagated to
 // the backing Pod.
 func isAllowedSystemLabel(key string) bool {
-	return slices.Contains(warmPoolTrackingLabels, key)
+	_, ok := warmPoolTrackingLabelSet[key]
+	return ok
 }
 
 // isControllerManagedPodAnnotation reports whether a system-reserved annotation is one
@@ -520,10 +532,11 @@ func sandboxManagedByExtensionController(sandbox *sandboxv1beta1.Sandbox) bool {
 		if ref.Controller == nil || !*ref.Controller {
 			continue
 		}
-		if !strings.HasPrefix(ref.APIVersion, "extensions.agents.x-k8s.io/") {
+		gv, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil || gv.Group != extensionsAgentsGroup {
 			continue
 		}
-		if ref.Kind == "SandboxWarmPool" || ref.Kind == "SandboxClaim" {
+		if _, ok := extensionControllerOwnerKinds[ref.Kind]; ok {
 			return true
 		}
 	}
@@ -890,7 +903,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
 	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
 	if sandboxManagedByExtensionController(sandbox) {
-		for _, key := range warmPoolTrackingLabels {
+		for key := range warmPoolTrackingLabelSet {
 			if v, ok := sandbox.Labels[key]; ok {
 				podLabels[key] = v
 			}
@@ -1003,7 +1016,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	// longer carries a given label) so stale or spoofed tracking labels cannot persist
 	// across ownership/label transitions.
 	extensionManaged := sandboxManagedByExtensionController(sandbox)
-	for _, key := range warmPoolTrackingLabels {
+	for key := range warmPoolTrackingLabelSet {
 		if v, ok := sandbox.Labels[key]; extensionManaged && ok {
 			if pod.Labels[key] != v {
 				pod.Labels[key] = v
@@ -1034,7 +1047,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 				if _, exists := pod.Labels[k]; exists {
 					delete(pod.Labels, k)
 					updated = true
-					logger.Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
+					logger.V(1).Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
 				}
 				continue
 			}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -50,16 +49,6 @@ const (
 	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
-
-	// warmPoolSandboxLabel and sandboxTemplateRefHashLabel are tracking labels under
-	// the system prefix that trusted extension controllers (e.g. the warm pool
-	// controller) set on a Sandbox and expect to be propagated to the backing Pod.
-	// They are mirrored here (rather than imported from the extensions package) to
-	// avoid an import cycle.
-	warmPoolSandboxLabel        = "agents.x-k8s.io/warm-pool-sandbox"
-	sandboxTemplateRefHashLabel = "agents.x-k8s.io/sandbox-template-ref-hash"
-
-	extensionsAgentsGroup = "extensions.agents.x-k8s.io"
 )
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
@@ -478,31 +467,6 @@ func isSystemAnnotation(key string) bool {
 		key == asmetrics.TraceContextAnnotation
 }
 
-// warmPoolTrackingLabelSet is the allowlist of system-prefixed labels that trusted
-// extension controllers (warm pool / claim) set on a Sandbox and that must be
-// propagated to the backing Pod. A map avoids accidental mutation via append on a
-// shared slice and keeps membership checks O(1).
-var warmPoolTrackingLabelSet = map[string]struct{}{
-	warmPoolSandboxLabel:                       {},
-	sandboxTemplateRefHashLabel:                {},
-	sandboxv1beta1.SandboxPodTemplateHashLabel: {},
-}
-
-// extensionControllerOwnerKinds are the extension owner kinds that may authorize
-// warm-pool tracking label propagation.
-var extensionControllerOwnerKinds = map[string]struct{}{
-	"SandboxWarmPool": {},
-	"SandboxClaim":    {},
-}
-
-// isAllowedSystemLabel reports whether a system-prefixed label is a tracking label
-// that trusted controllers are permitted to set on a Sandbox and have propagated to
-// the backing Pod.
-func isAllowedSystemLabel(key string) bool {
-	_, ok := warmPoolTrackingLabelSet[key]
-	return ok
-}
-
 // isControllerManagedPodAnnotation reports whether a system-reserved annotation is one
 // the controller itself sets on a Pod, and therefore must not be scrubbed during
 // cleanup of previously-propagated annotations.
@@ -515,32 +479,6 @@ func isControllerManagedPodAnnotation(key string) bool {
 	default:
 		return false
 	}
-}
-
-// sandboxManagedByExtensionController reports whether the Sandbox is owned by a trusted
-// extension controller (warm pool or claim). Only controller-managed Sandboxes may
-// propagate the warm-pool tracking labels to their Pods; this prevents a tenant from
-// spoofing those labels via a directly-created Sandbox.
-//
-// We require a controller owner reference (controller=true) under the extensions API
-// group. This assumes the OwnerReferencesPermissionEnforcement admission plugin is
-// active, so a tenant cannot attach a controller ownerRef pointing at an object they
-// are not permitted to delete. Verifying that the referenced owner actually exists and
-// matches ref.UID would harden this further and is left as a follow-up.
-func sandboxManagedByExtensionController(sandbox *sandboxv1beta1.Sandbox) bool {
-	for _, ref := range sandbox.OwnerReferences {
-		if ref.Controller == nil || !*ref.Controller {
-			continue
-		}
-		gv, err := schema.ParseGroupVersion(ref.APIVersion)
-		if err != nil || gv.Group != extensionsAgentsGroup {
-			continue
-		}
-		if _, ok := extensionControllerOwnerKinds[ref.Kind]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Service, error) {
@@ -900,15 +838,6 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	}
 	// Assign system-owned labels after merging user input so they cannot be overridden.
 	podLabels[sandboxLabel] = nameHash
-	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
-	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
-	if sandboxManagedByExtensionController(sandbox) {
-		for key := range warmPoolTrackingLabelSet {
-			if v, ok := sandbox.Labels[key]; ok {
-				podLabels[key] = v
-			}
-		}
-	}
 
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
@@ -1011,28 +940,9 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		}
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
-	// Keep the warm-pool tracking labels in sync: propagate them from the Sandbox CR for
-	// controller-managed Sandboxes, and remove them otherwise (or when the Sandbox no
-	// longer carries a given label) so stale or spoofed tracking labels cannot persist
-	// across ownership/label transitions.
-	extensionManaged := sandboxManagedByExtensionController(sandbox)
-	for key := range warmPoolTrackingLabelSet {
-		if v, ok := sandbox.Labels[key]; extensionManaged && ok {
-			if pod.Labels[key] != v {
-				pod.Labels[key] = v
-				updated = true
-			}
-			continue
-		}
-		if _, exists := pod.Labels[key]; exists {
-			delete(pod.Labels, key)
-			updated = true
-		}
-	}
 	// Handle deletion of labels removed from the template. System keys recorded in the
 	// propagated list by an older (vulnerable) controller are also scrubbed, except the
-	// controller-owned name-hash label and, on extension-managed Sandboxes, the allowed
-	// tracking labels.
+	// controller-owned name-hash label.
 	propagatedLabelsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedLabelsAnnotation]
 	if propagatedLabelsStr != "" {
 		propagatedLabels := strings.SplitSeq(propagatedLabelsStr, ",")
@@ -1041,7 +951,7 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 				continue
 			}
 			if isSystemLabel(k) {
-				if k == sandboxLabel || (extensionManaged && isAllowedSystemLabel(k)) {
+				if k == sandboxLabel {
 					continue
 				}
 				if _, exists := pod.Labels[k]; exists {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -450,31 +450,35 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
+// hasSystemReservedPrefix reports whether a key uses a label/annotation prefix
+// reserved for the sandbox system or its extensions.
+func hasSystemReservedPrefix(key string) bool {
+	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
+		strings.HasPrefix(key, "extensions.agents.x-k8s.io/")
+}
+
 // isSystemLabel reports whether a label key is reserved for the sandbox system.
 // Such keys must never be settable through a user-supplied PodTemplate, otherwise a
 // tenant could override security-critical labels (e.g. the headless Service selector
 // label) and hijack another Sandbox's network traffic.
 func isSystemLabel(key string) bool {
-	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
-		strings.HasPrefix(key, "extensions.agents.x-k8s.io/")
+	return hasSystemReservedPrefix(key)
 }
 
 // isSystemAnnotation reports whether an annotation key is reserved for the sandbox
 // system and therefore must not be settable through a user-supplied PodTemplate.
 func isSystemAnnotation(key string) bool {
-	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
-		strings.HasPrefix(key, "extensions.agents.x-k8s.io/") ||
+	return hasSystemReservedPrefix(key) ||
 		key == asmetrics.TraceContextAnnotation
 }
 
 // isControllerManagedPodAnnotation reports whether a system-reserved annotation is one
-// the controller itself sets on a Pod, and therefore must not be scrubbed during
-// cleanup of previously-propagated annotations.
+// the core controller itself sets on a Pod during metadata reconciliation, and
+// therefore must not be scrubbed during cleanup of previously-propagated annotations.
 func isControllerManagedPodAnnotation(key string) bool {
 	switch key {
 	case sandboxv1beta1.SandboxPropagatedLabelsAnnotation,
-		sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation,
-		asmetrics.TraceContextAnnotation:
+		sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation:
 		return true
 	default:
 		return false

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -49,6 +49,14 @@ const (
 	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
+
+	// warmPoolSandboxLabel and sandboxTemplateRefHashLabel are tracking labels under
+	// the system prefix that trusted extension controllers (e.g. the warm pool
+	// controller) set on a Sandbox and expect to be propagated to the backing Pod.
+	// They are mirrored here (rather than imported from the extensions package) to
+	// avoid an import cycle.
+	warmPoolSandboxLabel        = "agents.x-k8s.io/warm-pool-sandbox"
+	sandboxTemplateRefHashLabel = "agents.x-k8s.io/sandbox-template-ref-hash"
 )
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
@@ -450,6 +458,51 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
+// isSystemLabel reports whether a label key is reserved for the sandbox system.
+// Such keys must never be settable through a user-supplied PodTemplate, otherwise a
+// tenant could override security-critical labels (e.g. the headless Service selector
+// label) and hijack another Sandbox's network traffic.
+func isSystemLabel(key string) bool {
+	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
+		strings.HasPrefix(key, "extensions.agents.x-k8s.io/")
+}
+
+// isSystemAnnotation reports whether an annotation key is reserved for the sandbox
+// system and therefore must not be settable through a user-supplied PodTemplate.
+func isSystemAnnotation(key string) bool {
+	return strings.HasPrefix(key, "agents.x-k8s.io/") ||
+		strings.HasPrefix(key, "extensions.agents.x-k8s.io/") ||
+		key == asmetrics.TraceContextAnnotation
+}
+
+// isAllowedSystemLabel reports whether a system-prefixed label is a tracking label
+// that trusted controllers are permitted to set on a Sandbox and have propagated to
+// the backing Pod.
+func isAllowedSystemLabel(key string) bool {
+	switch key {
+	case warmPoolSandboxLabel, sandboxTemplateRefHashLabel, sandboxv1beta1.SandboxPodTemplateHashLabel:
+		return true
+	default:
+		return false
+	}
+}
+
+// sandboxManagedByExtensionController reports whether the Sandbox is owned by a trusted
+// extension controller (warm pool or claim). Only controller-managed Sandboxes may
+// propagate the warm-pool tracking labels to their Pods; this prevents a tenant from
+// spoofing those labels via a directly-created Sandbox.
+func sandboxManagedByExtensionController(sandbox *sandboxv1beta1.Sandbox) bool {
+	for _, ref := range sandbox.OwnerReferences {
+		if !strings.HasPrefix(ref.APIVersion, "extensions.agents.x-k8s.io/") {
+			continue
+		}
+		if ref.Kind == "SandboxWarmPool" || ref.Kind == "SandboxClaim" {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Service, error) {
 	logger := log.FromContext(ctx)
 	desired := sandbox.Spec.Service
@@ -770,7 +823,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			// No additional action needed — label applied below.
 		}
 
-		metadataUpdated := r.updatePodMetadata(pod, sandbox, nameHash)
+		metadataUpdated := r.updatePodMetadata(ctx, pod, sandbox, nameHash)
 		if metadataUpdated || needsUpdate {
 			if err := r.Patch(ctx, pod, patch); err != nil {
 				return nil, fmt.Errorf("failed to patch pod: %w", err)
@@ -793,18 +846,38 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 
 	// Create new Pod
 	logger.Info("Creating a new Pod", "Pod.Namespace", sandbox.Namespace, "Pod.Name", sandbox.Name)
-	podLabels := map[string]string{
-		sandboxLabel: nameHash,
-	}
+	podLabels := make(map[string]string, len(sandbox.Spec.PodTemplate.ObjectMeta.Labels)+1)
 
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		// Never let a user-supplied template set system-reserved labels.
+		if isSystemLabel(k) {
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate", "key", k)
+			continue
+		}
 		podLabels[k] = v
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
+	// Assign system-owned labels after merging user input so they cannot be overridden.
+	podLabels[sandboxLabel] = nameHash
+	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
+	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
+	if sandboxManagedByExtensionController(sandbox) {
+		for _, key := range []string{warmPoolSandboxLabel, sandboxTemplateRefHashLabel, sandboxv1beta1.SandboxPodTemplateHashLabel} {
+			if v, ok := sandbox.Labels[key]; ok {
+				podLabels[key] = v
+			}
+		}
+	}
+
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+		// Never let a user-supplied template set system-reserved annotations.
+		if isSystemAnnotation(k) {
+			logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate", "key", k)
+			continue
+		}
 		annotations[k] = v
 		managedAnnotationKeys = append(managedAnnotationKeys, k)
 	}
@@ -874,7 +947,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	return pod, nil
 }
 
-func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv1beta1.Sandbox, nameHash string) bool {
+func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.Pod, sandbox *sandboxv1beta1.Sandbox, nameHash string) bool {
+	logger := log.FromContext(ctx)
 	updated := false
 	if pod.Labels == nil {
 		pod.Labels = make(map[string]string)
@@ -883,21 +957,44 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 		pod.Labels[sandboxLabel] = nameHash
 		updated = true
 	}
-	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption)
+	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption),
+	// skipping system-reserved keys so a user-supplied template cannot override them.
 	var managedLabelKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Labels {
+		if isSystemLabel(k) {
+			logger.V(1).Info("Ignoring system-reserved label in Sandbox PodTemplate", "pod", pod.Name, "key", k)
+			// Remove a value a tenant may have managed to inject on an adopted pod.
+			if !isAllowedSystemLabel(k) {
+				if _, exists := pod.Labels[k]; exists {
+					delete(pod.Labels, k)
+					updated = true
+					logger.Info("Removed unauthorized system label from Pod", "pod", pod.Name, "key", k)
+				}
+			}
+			continue
+		}
 		if pod.Labels[k] != v {
 			pod.Labels[k] = v
 			updated = true
 		}
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
+	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
+	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
+	if sandboxManagedByExtensionController(sandbox) {
+		for _, key := range []string{warmPoolSandboxLabel, sandboxTemplateRefHashLabel, sandboxv1beta1.SandboxPodTemplateHashLabel} {
+			if v, ok := sandbox.Labels[key]; ok && pod.Labels[key] != v {
+				pod.Labels[key] = v
+				updated = true
+			}
+		}
+	}
 	// Handle deletion of labels
 	propagatedLabelsStr := pod.Annotations[sandboxv1beta1.SandboxPropagatedLabelsAnnotation]
 	if propagatedLabelsStr != "" {
 		propagatedLabels := strings.SplitSeq(propagatedLabelsStr, ",")
 		for k := range propagatedLabels {
-			if k == "" {
+			if k == "" || isSystemLabel(k) {
 				continue
 			}
 			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Labels[k]; !ok {
@@ -913,6 +1010,10 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 			pod.Annotations = make(map[string]string)
 		}
 		for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
+			if isSystemAnnotation(k) {
+				logger.V(1).Info("Ignoring system-reserved annotation in Sandbox PodTemplate", "pod", pod.Name, "key", k)
+				continue
+			}
 			if pod.Annotations[k] != v {
 				pod.Annotations[k] = v
 				updated = true
@@ -925,7 +1026,7 @@ func (r *SandboxReconciler) updatePodMetadata(pod *corev1.Pod, sandbox *sandboxv
 	if propagatedAnnotationsStr != "" {
 		propagatedAnnotations := strings.SplitSeq(propagatedAnnotationsStr, ",")
 		for k := range propagatedAnnotations {
-			if k == "" {
+			if k == "" || isSystemAnnotation(k) {
 				continue
 			}
 			if _, ok := sandbox.Spec.PodTemplate.ObjectMeta.Annotations[k]; !ok {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -998,15 +998,22 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		}
 		managedLabelKeys = append(managedLabelKeys, k)
 	}
-	// Propagate trusted warm-pool tracking labels from the Sandbox CR, but only for
-	// controller-managed Sandboxes so tenants cannot spoof them on a self-created Sandbox.
+	// Keep the warm-pool tracking labels in sync: propagate them from the Sandbox CR for
+	// controller-managed Sandboxes, and remove them otherwise (or when the Sandbox no
+	// longer carries a given label) so stale or spoofed tracking labels cannot persist
+	// across ownership/label transitions.
 	extensionManaged := sandboxManagedByExtensionController(sandbox)
-	if extensionManaged {
-		for _, key := range warmPoolTrackingLabels {
-			if v, ok := sandbox.Labels[key]; ok && pod.Labels[key] != v {
+	for _, key := range warmPoolTrackingLabels {
+		if v, ok := sandbox.Labels[key]; extensionManaged && ok {
+			if pod.Labels[key] != v {
 				pod.Labels[key] = v
 				updated = true
 			}
+			continue
+		}
+		if _, exists := pod.Labels[key]; exists {
+			delete(pod.Labels, key)
+			updated = true
 		}
 	}
 	// Handle deletion of labels removed from the template. System keys recorded in the

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1298,57 +1298,15 @@ func TestReconcilePod(t *testing.T) {
 			},
 		},
 		{
-			name: "propagates warm-pool tracking labels for an extension-managed Sandbox",
+			name: "does not propagate system labels from Sandbox metadata to Pod",
 			sandbox: &sandboxv1beta1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandboxName,
 					Namespace: sandboxNs,
 					UID:       sandboxUID,
-					Labels:    map[string]string{"agents.x-k8s.io/warm-pool-sandbox": "pool-hash"},
-					OwnerReferences: []metav1.OwnerReference{{
-						APIVersion: "extensions.agents.x-k8s.io/v1beta1",
-						Kind:       "SandboxWarmPool",
-						Name:       "wp",
-						UID:        "wp-uid",
-						Controller: new(true),
-					}},
-				},
-				Spec: sandboxv1beta1.SandboxSpec{
-					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
-					PodTemplate: sandboxv1beta1.PodTemplate{
-						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
-						ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
-					},
-				},
-			},
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            sandboxName,
-					Namespace:       sandboxNs,
-					ResourceVersion: "1",
 					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
-						"custom-label":                      "label-val",
 					},
-					Annotations: map[string]string{
-						"agents.x-k8s.io/propagated-labels": "custom-label",
-					},
-					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
-				},
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
-			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
-		},
-		{
-			name: "does not propagate warm-pool tracking labels for a tenant-owned Sandbox",
-			sandbox: &sandboxv1beta1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      sandboxName,
-					Namespace: sandboxNs,
-					UID:       sandboxUID,
-					// Tenant sets the tracking label directly but is not extension-managed.
-					Labels: map[string]string{"agents.x-k8s.io/warm-pool-sandbox": "pool-hash"},
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
 					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
@@ -1369,48 +1327,6 @@ func TestReconcilePod(t *testing.T) {
 					},
 					Annotations: map[string]string{
 						"agents.x-k8s.io/propagated-labels": "custom-label",
-					},
-					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
-				},
-				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
-			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
-		},
-		{
-			name: "removes stale warm-pool tracking label when Sandbox is not extension-managed",
-			initialObjs: []runtime.Object{
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            sandboxName,
-						Namespace:       sandboxNs,
-						ResourceVersion: "1",
-						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": nameHash,
-							"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
-							"custom-label":                      "label-val",
-						},
-						Annotations: map[string]string{
-							"agents.x-k8s.io/propagated-labels": "custom-label",
-						},
-						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
-					},
-					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
-				},
-			},
-			sandbox: sandboxObj,
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            sandboxName,
-					Namespace:       sandboxNs,
-					ResourceVersion: "2",
-					Labels: map[string]string{
-						"agents.x-k8s.io/sandbox-name-hash": nameHash,
-						"custom-label":                      "label-val",
-					},
-					Annotations: map[string]string{
-						"custom-annotation":                      "anno-val",
-						"agents.x-k8s.io/propagated-labels":      "custom-label",
-						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -285,6 +285,7 @@ func TestResolvePodName(t *testing.T) {
 func TestReconcile(t *testing.T) {
 	sandboxName := "sandbox-name"
 	sandboxNs := "sandbox-ns"
+	nameHash := NameHash(sandboxName)
 	testCases := []struct {
 		name                 string
 		initialObjs          []runtime.Object
@@ -314,7 +315,7 @@ func TestReconcile(t *testing.T) {
 			},
 			// Verify Sandbox status
 			wantStatus: sandboxv1beta1.SandboxStatus{
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				Conditions: []metav1.Condition{
 					{
 						Type:               "Ready",
@@ -333,7 +334,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -366,7 +367,7 @@ func TestReconcile(t *testing.T) {
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -385,7 +386,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
@@ -404,13 +405,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						ClusterIP: "None",
 					},
@@ -461,7 +462,7 @@ func TestReconcile(t *testing.T) {
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450", // Pre-computed hash of "sandbox-name"
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -480,7 +481,7 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 							"custom-label":                      "label-val",
 						},
 						Annotations: map[string]string{
@@ -516,13 +517,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						ClusterIP: "None",
 					},
@@ -533,7 +534,7 @@ func TestReconcile(t *testing.T) {
 						Name:      "my-pvc-sandbox-name",
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 							"custom-label":                      "label-val",
 						},
 						Annotations:     map[string]string{"custom-annotation": "anno-val"},
@@ -559,7 +560,7 @@ func TestReconcile(t *testing.T) {
 						Name:      sandboxName,
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash":  "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
 							sandboxv1beta1.SandboxAdoptableLabel: "true",
 						},
 					},
@@ -586,7 +587,7 @@ func TestReconcile(t *testing.T) {
 			wantStatus: sandboxv1beta1.SandboxStatus{
 				Service:       sandboxName,
 				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				PodIPs:        []string{"10.244.0.5", "fd00::5"},
 				Conditions: []metav1.Condition{
 					{
@@ -606,13 +607,13 @@ func TestReconcile(t *testing.T) {
 						Namespace:       sandboxNs,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash": "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						},
 						ClusterIP: "None",
 					},
@@ -627,7 +628,7 @@ func TestReconcile(t *testing.T) {
 						Name:      sandboxName,
 						Namespace: sandboxNs,
 						Labels: map[string]string{
-							"agents.x-k8s.io/sandbox-name-hash":  "ab179450",
+							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
 							sandboxv1beta1.SandboxAdoptableLabel: "true",
 						},
 					},
@@ -651,7 +652,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			wantStatus: sandboxv1beta1.SandboxStatus{
-				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=ab179450",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
 				PodIPs:        []string{"10.244.0.5"},
 				Conditions: []metav1.Condition{
 					{
@@ -1181,6 +1182,62 @@ func TestReconcilePod(t *testing.T) {
 							Name: "test-container",
 						},
 					},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name: "drops user-supplied system-reserved labels and annotations to prevent hijacking",
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "test-container"}},
+						},
+						ObjectMeta: sandboxv1beta1.PodMetadata{
+							Labels: map[string]string{
+								// Attacker attempts to hijack another Sandbox's routing label
+								// and to spoof an extensions-prefixed system label.
+								"agents.x-k8s.io/sandbox-name-hash":          "malicious-hijacked-hash",
+								"extensions.agents.x-k8s.io/warm-pool-spoof": "evil",
+								"custom-label": "label-val",
+							},
+							Annotations: map[string]string{
+								"agents.x-k8s.io/pod-name":       "malicious-pod-name",
+								asmetrics.TraceContextAnnotation: "spoofed-trace",
+								"custom-annotation":              "anno-val",
+							},
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						// System label is set by the controller, not the attacker's value.
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
 			wantSandboxAnnotations: map[string]string{

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1298,6 +1298,127 @@ func TestReconcilePod(t *testing.T) {
 			},
 		},
 		{
+			name: "propagates warm-pool tracking labels for an extension-managed Sandbox",
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Labels:    map[string]string{"agents.x-k8s.io/warm-pool-sandbox": "pool-hash"},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+						Kind:       "SandboxWarmPool",
+						Name:       "wp",
+						UID:        "wp-uid",
+						Controller: new(true),
+					}},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/propagated-labels": "custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+		},
+		{
+			name: "does not propagate warm-pool tracking labels for a tenant-owned Sandbox",
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					// Tenant sets the tracking label directly but is not extension-managed.
+					Labels: map[string]string{"agents.x-k8s.io/warm-pool-sandbox": "pool-hash"},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/propagated-labels": "custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+		},
+		{
+			name: "removes stale warm-pool tracking label when Sandbox is not extension-managed",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+							"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+							"custom-label":                      "label-val",
+						},
+						Annotations: map[string]string{
+							"agents.x-k8s.io/propagated-labels": "custom-label",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				},
+			},
+			sandbox: sandboxObj,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+		},
+		{
 			name: "delete pod if mode is Suspended",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1245,6 +1245,59 @@ func TestReconcilePod(t *testing.T) {
 			},
 		},
 		{
+			name: "scrubs stale system labels/annotations recorded by an older controller",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+							"custom-label":                      "label-val",
+							// A system label an older controller propagated and recorded.
+							"agents.x-k8s.io/evil": "x",
+						},
+						Annotations: map[string]string{
+							"custom-annotation": "anno-val",
+							// Older controller recorded system keys in the propagated lists.
+							"agents.x-k8s.io/propagated-labels":      "custom-label,agents.x-k8s.io/evil",
+							"agents.x-k8s.io/propagated-annotations": "custom-annotation,agents.x-k8s.io/pod-name",
+							"agents.x-k8s.io/pod-name":               "leftover",
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
 			name: "delete pod if mode is Suspended",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1262,8 +1262,9 @@ func TestReconcilePod(t *testing.T) {
 							"custom-annotation": "anno-val",
 							// Older controller recorded system keys in the propagated lists.
 							"agents.x-k8s.io/propagated-labels":      "custom-label,agents.x-k8s.io/evil",
-							"agents.x-k8s.io/propagated-annotations": "custom-annotation,agents.x-k8s.io/pod-name",
+							"agents.x-k8s.io/propagated-annotations": "custom-annotation,agents.x-k8s.io/pod-name,opentelemetry.io/trace-context",
 							"agents.x-k8s.io/pod-name":               "leftover",
+							asmetrics.TraceContextAnnotation:         "spoofed-trace",
 						},
 						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 					},

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -1,0 +1,68 @@
+# Threat Model: System Label and Annotation Protection
+
+This document describes a privilege/isolation threat that arises from propagating
+user-controlled `PodTemplate` metadata onto the Pods that the Sandbox controller
+manages, and the controls that mitigate it.
+
+## Background
+
+A `Sandbox` lets a tenant supply a `spec.podTemplate`, including arbitrary
+`metadata.labels` and `metadata.annotations`. The controller propagates that
+metadata to the backing Pod so tenants can organize and select their workloads.
+
+The controller and its extensions also rely on a set of **system-reserved**
+label and annotation keys to implement core behavior:
+
+- `agents.x-k8s.io/sandbox-name-hash` — the selector label used by the per-Sandbox
+  headless `Service`. Traffic for a Sandbox is routed to the Pod(s) carrying the
+  matching value.
+- `agents.x-k8s.io/sandbox-pod-template-hash`,
+  `agents.x-k8s.io/warm-pool-sandbox`,
+  `agents.x-k8s.io/sandbox-template-ref-hash` — tracking labels set by the warm
+  pool / claim controllers.
+- `agents.x-k8s.io/pod-name`, `agents.x-k8s.io/sandbox-template-ref`,
+  `agents.x-k8s.io/propagated-labels`, `agents.x-k8s.io/propagated-annotations`,
+  and `opentelemetry.io/trace-context` — controller-managed annotations.
+
+## Threat
+
+**Spoofing / cross-tenant traffic hijack via reserved-key injection.**
+
+If user-supplied template metadata is propagated verbatim, a tenant can set a
+system-reserved key to a value of their choosing. The highest-impact case is the
+Service selector label:
+
+1. Tenant A creates `Sandbox A`; its Service selects Pods labeled
+   `agents.x-k8s.io/sandbox-name-hash=<hash(A)>`.
+2. Tenant B (malicious) creates `Sandbox B` with
+   `spec.podTemplate.metadata.labels["agents.x-k8s.io/sandbox-name-hash"] = <hash(A)>`.
+3. Tenant B's Pod now also matches Sandbox A's Service selector, so traffic
+   intended for Sandbox A can be delivered to the attacker's Pod
+   (a network-isolation bypass / traffic-hijack primitive).
+
+Related abuses: forging the warm-pool tracking labels to influence
+adoption/pooling decisions, or overwriting controller-managed annotations such
+as `agents.x-k8s.io/pod-name`.
+
+## Mitigations
+
+The controller treats any label/annotation key under `agents.x-k8s.io/` or
+`extensions.agents.x-k8s.io/` (and the trace-context annotation) as
+**system-reserved** and never lets user-supplied `PodTemplate` metadata set them:
+
+- **Create path (`reconcilePod`)** and **adoption path (`updatePodMetadata`)**
+  filter out system-reserved keys from the user template before applying them.
+- The Service selector label `agents.x-k8s.io/sandbox-name-hash` is assigned by
+  the controller **after** merging user labels, so it cannot be overridden.
+- On adoption, any unauthorized system label already present on a Pod is removed.
+- The warm-pool tracking labels are **only** propagated for Sandboxes that are
+  owned by a trusted extension controller (`SandboxWarmPool` / `SandboxClaim`),
+  so a tenant cannot spoof them via a directly-created Sandbox.
+
+## Out of scope
+
+- The value of the name hash is still derived with FNV-1a. The label-protection
+  controls above hold regardless of the hash algorithm; strengthening the hash
+  (e.g. to a truncated SHA-256) is tracked separately.
+- Network policy is the primary, defense-in-depth control for tenant isolation;
+  this mitigation removes a control-plane bypass of the Service-based routing.

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -56,10 +56,9 @@ The core controller treats any label/annotation key under `agents.x-k8s.io/` or
 - On adoption/update, system-reserved keys that an older (vulnerable) controller
   recorded in the `propagated-labels` / `propagated-annotations` lists are scrubbed
   from the Pod — except the controller-owned name-hash label and the
-  controller-managed annotations (`propagated-labels`, `propagated-annotations`,
-  and the trace-context annotation). Combined with always (re)setting the
-  name-hash label to the controller's value, this prevents a stale or spoofed
-  Service-selector label from surviving adoption.
+  controller-managed annotations (`propagated-labels`, `propagated-annotations`).
+  Combined with always (re)setting the name-hash label to the controller's value,
+  this prevents a stale or spoofed Service-selector label from surviving adoption.
 - System labels on `Sandbox.metadata.labels` are **not** copied to Pods by the
   core controller. Only non-system keys from `spec.podTemplate` are propagated.
 

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -54,10 +54,19 @@ The controller treats any label/annotation key under `agents.x-k8s.io/` or
   filter out system-reserved keys from the user template before applying them.
 - The Service selector label `agents.x-k8s.io/sandbox-name-hash` is assigned by
   the controller **after** merging user labels, so it cannot be overridden.
-- On adoption, any unauthorized system label already present on a Pod is removed.
+- On adoption/update, system-reserved keys that an older (vulnerable) controller
+  recorded in the `propagated-labels` / `propagated-annotations` lists are scrubbed
+  from the Pod — except the controller-owned name-hash label, the allowed tracking
+  labels on extension-managed Sandboxes, and the controller-managed annotations
+  (`propagated-labels`, `propagated-annotations`, and the trace-context annotation).
+  Combined with always (re)setting the name-hash label to the controller's value,
+  this prevents a stale or spoofed Service-selector label from surviving adoption.
 - The warm-pool tracking labels are **only** propagated for Sandboxes that are
-  owned by a trusted extension controller (`SandboxWarmPool` / `SandboxClaim`),
-  so a tenant cannot spoof them via a directly-created Sandbox.
+  owned by a trusted extension controller (`SandboxWarmPool` / `SandboxClaim`) via a
+  *controller* owner reference. This assumes the
+  `OwnerReferencesPermissionEnforcement` admission plugin is active so a tenant
+  cannot attach such an owner reference to an object they cannot delete; verifying
+  the owner object's existence and UID would harden this further.
 
 ## Out of scope
 

--- a/docs/security/threat_model.md
+++ b/docs/security/threat_model.md
@@ -7,22 +7,22 @@ manages, and the controls that mitigate it.
 ## Background
 
 A `Sandbox` lets a tenant supply a `spec.podTemplate`, including arbitrary
-`metadata.labels` and `metadata.annotations`. The controller propagates that
+`metadata.labels` and `metadata.annotations`. The core controller propagates that
 metadata to the backing Pod so tenants can organize and select their workloads.
 
-The controller and its extensions also rely on a set of **system-reserved**
-label and annotation keys to implement core behavior:
+The controller also relies on a set of **system-reserved** label and annotation
+keys to implement core behavior:
 
 - `agents.x-k8s.io/sandbox-name-hash` — the selector label used by the per-Sandbox
   headless `Service`. Traffic for a Sandbox is routed to the Pod(s) carrying the
   matching value.
-- `agents.x-k8s.io/sandbox-pod-template-hash`,
-  `agents.x-k8s.io/warm-pool-sandbox`,
-  `agents.x-k8s.io/sandbox-template-ref-hash` — tracking labels set by the warm
-  pool / claim controllers.
-- `agents.x-k8s.io/pod-name`, `agents.x-k8s.io/sandbox-template-ref`,
-  `agents.x-k8s.io/propagated-labels`, `agents.x-k8s.io/propagated-annotations`,
+- `agents.x-k8s.io/propagated-labels`, `agents.x-k8s.io/propagated-annotations`,
   and `opentelemetry.io/trace-context` — controller-managed annotations.
+
+Extension controllers (warm pool, claim) may set additional system-prefixed labels
+on the **Sandbox CR** (`metadata.labels`, `spec.podTemplate`, etc.). The core
+Sandbox reconciler does not propagate those to Pods; extension controllers own
+that lifecycle separately.
 
 ## Threat
 
@@ -40,13 +40,12 @@ Service selector label:
    intended for Sandbox A can be delivered to the attacker's Pod
    (a network-isolation bypass / traffic-hijack primitive).
 
-Related abuses: forging the warm-pool tracking labels to influence
-adoption/pooling decisions, or overwriting controller-managed annotations such
-as `agents.x-k8s.io/pod-name`.
+Related abuses: forging system-prefixed labels or overwriting controller-managed
+annotations such as `agents.x-k8s.io/pod-name`.
 
 ## Mitigations
 
-The controller treats any label/annotation key under `agents.x-k8s.io/` or
+The core controller treats any label/annotation key under `agents.x-k8s.io/` or
 `extensions.agents.x-k8s.io/` (and the trace-context annotation) as
 **system-reserved** and never lets user-supplied `PodTemplate` metadata set them:
 
@@ -56,20 +55,19 @@ The controller treats any label/annotation key under `agents.x-k8s.io/` or
   the controller **after** merging user labels, so it cannot be overridden.
 - On adoption/update, system-reserved keys that an older (vulnerable) controller
   recorded in the `propagated-labels` / `propagated-annotations` lists are scrubbed
-  from the Pod — except the controller-owned name-hash label, the allowed tracking
-  labels on extension-managed Sandboxes, and the controller-managed annotations
-  (`propagated-labels`, `propagated-annotations`, and the trace-context annotation).
-  Combined with always (re)setting the name-hash label to the controller's value,
-  this prevents a stale or spoofed Service-selector label from surviving adoption.
-- The warm-pool tracking labels are **only** propagated for Sandboxes that are
-  owned by a trusted extension controller (`SandboxWarmPool` / `SandboxClaim`) via a
-  *controller* owner reference. This assumes the
-  `OwnerReferencesPermissionEnforcement` admission plugin is active so a tenant
-  cannot attach such an owner reference to an object they cannot delete; verifying
-  the owner object's existence and UID would harden this further.
+  from the Pod — except the controller-owned name-hash label and the
+  controller-managed annotations (`propagated-labels`, `propagated-annotations`,
+  and the trace-context annotation). Combined with always (re)setting the
+  name-hash label to the controller's value, this prevents a stale or spoofed
+  Service-selector label from surviving adoption.
+- System labels on `Sandbox.metadata.labels` are **not** copied to Pods by the
+  core controller. Only non-system keys from `spec.podTemplate` are propagated.
 
 ## Out of scope
 
+- Extension controllers manage their own labels on Sandbox CRs and may patch Pod
+  metadata through separate reconciliation paths. The core controller intentionally
+  does not encode extension owner-reference or warm-pool tracking logic.
 - The value of the name hash is still derived with FNV-1a. The label-protection
   controls above hold regardless of the hash algorithm; strengthening the hash
   (e.g. to a truncated SHA-256) is tracked separately.


### PR DESCRIPTION
## Summary

A Sandbox's `spec.podTemplate` metadata was propagated verbatim to the backing Pod, including system-reserved keys. A tenant could set `agents.x-k8s.io/sandbox-name-hash` in their template to match another Sandbox's headless Service selector and hijack its traffic, or forge system-prefixed labels / controller-managed annotations.

This PR makes the **core** controller treat any `agents.x-k8s.io/` or `extensions.agents.x-k8s.io/` label/annotation key (plus the trace-context annotation) as system-reserved and filter it out of user-supplied PodTemplate metadata on both the create (`reconcilePod`) and adoption (`updatePodMetadata`) paths:

- The `sandbox-name-hash` label is assigned *after* merging user labels, so it can never be overridden.
- Stale system-reserved keys that an older controller recorded in the `propagated-labels` / `propagated-annotations` lists are scrubbed on adoption/update.
- System labels on `Sandbox.metadata.labels` are **not** copied to Pods — extension controllers own their own Sandbox CR lifecycle.

Adds security regression tests and documents the threat in `docs/security/threat_model.md`.

**Relationship to #784:** #784 (merged) requires `agents.x-k8s.io/adoptable: "true"` before adopting unowned Pod/Service/PVC resources. This PR closes the complementary gap where tenants could still *inject* system-reserved keys through `spec.podTemplate`. The core controller intentionally does **not** add extension ownerRef or warm-pool tracking logic.

**Scope note:** FNV-1a name hash is **unchanged**; SHA-256 strengthening remains a follow-up PR.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./controllers/...`
- [x] `go test ./controllers/...`
- [ ] CI presubmits
