### PR TITLE
Sanitizes OpenTelemetry trace attribute `sandbox.command` 

### DIFF
--- a/clients/go/sandbox/commands.go
+++ b/clients/go/sandbox/commands.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/trace"
@@ -56,7 +57,7 @@ func (c *Commands) Run(ctx context.Context, command string, opts ...CallOption) 
 		maxAttempts = 1 // safe default: no retries for non-idempotent commands
 	}
 	ctx = withLifecycleSpan(ctx, c.lifecycleCtx())
-	ctx, span := startSpan(ctx, c.tracer, c.svcName, "run", AttrCommand.String(command))
+	ctx, span := startSpan(ctx, c.tracer, c.svcName, "run", AttrCommandExecutable.String(commandExecutable(command)))
 	defer func() { span.End() }()
 
 	payload, err := json.Marshal(map[string]string{"command": command})
@@ -95,3 +96,12 @@ func (c *Commands) Run(ctx context.Context, command string, opts ...CallOption) 
 	c.log.V(1).Info("run completed", "exitCode", result.ExitCode)
 	return &result, nil
 }
+
+func commandExecutable(command string) string {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+

--- a/clients/go/sandbox/commands.go
+++ b/clients/go/sandbox/commands.go
@@ -99,9 +99,15 @@ func (c *Commands) Run(ctx context.Context, command string, opts ...CallOption) 
 
 func commandExecutable(command string) string {
 	fields := strings.Fields(command)
-	if len(fields) == 0 {
-		return ""
+	for _, field := range fields {
+		// Skip leading inline environment variables (e.g., KEY=VALUE)
+		if strings.Contains(field, "=") {
+			continue
+		}
+		// Extract base executable name (strip directory paths)
+		parts := strings.Split(field, "/")
+		return parts[len(parts)-1]
 	}
-	return fields[0]
+	return ""
 }
 

--- a/clients/go/sandbox/commands.go
+++ b/clients/go/sandbox/commands.go
@@ -98,8 +98,8 @@ func (c *Commands) Run(ctx context.Context, command string, opts ...CallOption) 
 }
 
 func commandExecutable(command string) string {
-	fields := strings.Fields(command)
-	for _, field := range fields {
+	fields := strings.FieldsSeq(command)
+	for field := range fields {
 		// Skip leading inline environment variables (e.g., KEY=VALUE)
 		if strings.Contains(field, "=") {
 			continue
@@ -110,4 +110,3 @@ func commandExecutable(command string) string {
 	}
 	return ""
 }
-

--- a/clients/go/sandbox/tracing.go
+++ b/clients/go/sandbox/tracing.go
@@ -33,7 +33,7 @@ import (
 // Span attribute keys in the sandbox.* namespace.
 var (
 	AttrClaimName        = attribute.Key("sandbox.claim.name")
-	AttrCommand          = attribute.Key("sandbox.command")
+	AttrCommandExecutable = attribute.Key("sandbox.command.executable")
 	AttrExitCode         = attribute.Key("sandbox.exit_code")
 	AttrFilePath         = attribute.Key("sandbox.file.path")
 	AttrFileSize         = attribute.Key("sandbox.file.size")

--- a/clients/go/sandbox/tracing.go
+++ b/clients/go/sandbox/tracing.go
@@ -32,16 +32,16 @@ import (
 
 // Span attribute keys in the sandbox.* namespace.
 var (
-	AttrClaimName        = attribute.Key("sandbox.claim.name")
+	AttrClaimName         = attribute.Key("sandbox.claim.name")
 	AttrCommandExecutable = attribute.Key("sandbox.command.executable")
-	AttrExitCode         = attribute.Key("sandbox.exit_code")
-	AttrFilePath         = attribute.Key("sandbox.file.path")
-	AttrFileSize         = attribute.Key("sandbox.file.size")
-	AttrFileCount        = attribute.Key("sandbox.file.count")
-	AttrFileExists       = attribute.Key("sandbox.file.exists")
-	AttrGatewayName      = attribute.Key("sandbox.gateway.name")
-	AttrGatewayNamespace = attribute.Key("sandbox.gateway.namespace")
-	AttrRequestID        = attribute.Key("sandbox.request_id")
+	AttrExitCode          = attribute.Key("sandbox.exit_code")
+	AttrFilePath          = attribute.Key("sandbox.file.path")
+	AttrFileSize          = attribute.Key("sandbox.file.size")
+	AttrFileCount         = attribute.Key("sandbox.file.count")
+	AttrFileExists        = attribute.Key("sandbox.file.exists")
+	AttrGatewayName       = attribute.Key("sandbox.gateway.name")
+	AttrGatewayNamespace  = attribute.Key("sandbox.gateway.namespace")
+	AttrRequestID         = attribute.Key("sandbox.request_id")
 )
 
 // NewTracerProvider creates a TracerProvider with an OTLP/gRPC exporter.

--- a/clients/go/sandbox/tracing_test.go
+++ b/clients/go/sandbox/tracing_test.go
@@ -484,3 +484,40 @@ func assertSpanAttrBool(t *testing.T, span tracetest.SpanStub, key string, want 
 	}
 	t.Errorf("span %s: missing attribute %s", span.Name, key)
 }
+
+func TestCommandExecutable(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    string
+	}{
+		{
+			name:    "simple command",
+			command: "echo hello",
+			want:    "echo",
+		},
+		{
+			name:    "command with path",
+			command: "/usr/bin/python3 -c 'print()'",
+			want:    "python3",
+		},
+		{
+			name:    "command with leading env vars",
+			command: "API_KEY=secret_token TOKEN=xyz ./run.sh --arg",
+			want:    "run.sh",
+		},
+		{
+			name:    "empty command",
+			command: "  ",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := commandExecutable(tt.command); got != tt.want {
+				t.Errorf("commandExecutable(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/clients/go/sandbox/tracing_test.go
+++ b/clients/go/sandbox/tracing_test.go
@@ -520,4 +520,3 @@ func TestCommandExecutable(t *testing.T) {
 		})
 	}
 }
-

--- a/clients/go/sandbox/tracing_test.go
+++ b/clients/go/sandbox/tracing_test.go
@@ -253,7 +253,7 @@ func TestTracingLifecycleAndOperations(t *testing.T) {
 	}
 
 	// Verify Run attributes
-	assertSpanAttr(t, spanByName["test-svc.run"], "sandbox.command", "echo hello")
+	assertSpanAttr(t, spanByName["test-svc.run"], "sandbox.command.executable", "echo")
 	assertSpanAttrInt(t, spanByName["test-svc.run"], "sandbox.exit_code", 0)
 
 	// Verify Write attributes

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/async_command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/async_command_executor.py
@@ -31,7 +31,8 @@ class AsyncCommandExecutor:
     async def run(self, command: str, timeout: int = 60) -> ExecutionResult:
         span = trace.get_current_span()
         if span.is_recording():
-            span.set_attribute("sandbox.command", command)
+            executable = command.split()[0] if command and command.split() else ""
+            span.set_attribute("sandbox.command.executable", executable)
 
         payload = {"command": command}
         response = await self.connector.send_request(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/async_command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/async_command_executor.py
@@ -17,6 +17,18 @@ from k8s_agent_sandbox.models import ExecutionResult
 from k8s_agent_sandbox.trace_manager import async_trace_span, trace
 
 
+def _extract_executable(command: str) -> str:
+    if not command:
+        return ""
+    for field in command.split():
+        # Skip leading inline environment variables (e.g., KEY=VALUE)
+        if "=" in field:
+            continue
+        # Extract base executable name (strip directory paths)
+        return field.split("/")[-1]
+    return ""
+
+
 class AsyncCommandExecutor:
     """
     Handles async execution of commands within the sandbox.
@@ -31,7 +43,7 @@ class AsyncCommandExecutor:
     async def run(self, command: str, timeout: int = 60) -> ExecutionResult:
         span = trace.get_current_span()
         if span.is_recording():
-            executable = command.split()[0] if command and command.split() else ""
+            executable = _extract_executable(command)
             span.set_attribute("sandbox.command.executable", executable)
 
         payload = {"command": command}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
@@ -17,6 +17,18 @@ from k8s_agent_sandbox.connector import SandboxConnector
 from k8s_agent_sandbox.models import ExecutionResult
 from k8s_agent_sandbox.trace_manager import trace_span, trace
 
+def _extract_executable(command: str) -> str:
+    if not command:
+        return ""
+    for field in command.split():
+        # Skip leading inline environment variables (e.g., KEY=VALUE)
+        if "=" in field:
+            continue
+        # Extract base executable name (strip directory paths)
+        return field.split("/")[-1]
+    return ""
+
+
 class CommandExecutor:
     """
     Handles execution of commands within the sandbox.
@@ -30,7 +42,7 @@ class CommandExecutor:
     def run(self, command: str, timeout: int = 60) -> ExecutionResult:
         span = trace.get_current_span()
         if span.is_recording():
-            executable = command.split()[0] if command and command.split() else ""
+            executable = _extract_executable(command)
             span.set_attribute("sandbox.command.executable", executable)
 
         payload = {"command": command}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/command_executor.py
@@ -30,7 +30,8 @@ class CommandExecutor:
     def run(self, command: str, timeout: int = 60) -> ExecutionResult:
         span = trace.get_current_span()
         if span.is_recording():
-            span.set_attribute("sandbox.command", command)
+            executable = command.split()[0] if command and command.split() else ""
+            span.set_attribute("sandbox.command.executable", executable)
 
         payload = {"command": command}
         response = self.connector.send_request(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_command_executor.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from k8s_agent_sandbox.commands.command_executor import CommandExecutor, _extract_executable
+from k8s_agent_sandbox.commands.async_command_executor import AsyncCommandExecutor
+from k8s_agent_sandbox.models import ExecutionResult
+
+
+class TestCommandExecutor(unittest.TestCase):
+
+    def test_extract_executable(self):
+        tests = [
+            ("echo hello", "echo"),
+            ("/usr/bin/python3 -c 'print()'", "python3"),
+            ("API_KEY=secret_token TOKEN=xyz ./run.sh --arg", "run.sh"),
+            ("  ", ""),
+            ("", ""),
+        ]
+        for command, expected in tests:
+            with self.subTest(command=command):
+                self.assertEqual(_extract_executable(command), expected)
+
+    @patch("k8s_agent_sandbox.commands.command_executor.trace")
+    def test_sync_executor_logs_executable(self, mock_trace):
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = mock_span
+
+        mock_connector = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "stdout": "hello",
+            "stderr": "",
+            "exit_code": 0
+        }
+        mock_connector.send_request.return_value = mock_response
+
+        executor = CommandExecutor(mock_connector, MagicMock(), "sandbox-client")
+        result = executor.run("API_KEY=123 /usr/bin/python3 my_script.py")
+
+        mock_span.set_attribute.assert_any_call("sandbox.command.executable", "python3")
+        mock_span.set_attribute.assert_any_call("sandbox.exit_code", 0)
+        self.assertEqual(result.stdout, "hello")
+
+
+class TestAsyncCommandExecutor(unittest.IsolatedAsyncioTestCase):
+
+    @patch("k8s_agent_sandbox.commands.async_command_executor.trace")
+    async def test_async_executor_logs_executable(self, mock_trace):
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = mock_span
+
+        mock_connector = MagicMock()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "stdout": "hello_async",
+            "stderr": "",
+            "exit_code": 0
+        }
+        
+        async def async_send(*args, **kwargs):
+            return mock_response
+        mock_connector.send_request = async_send
+
+        executor = AsyncCommandExecutor(mock_connector, MagicMock(), "sandbox-client")
+        result = await executor.run("API_KEY=123 /usr/bin/python3 my_script.py")
+
+        mock_span.set_attribute.assert_any_call("sandbox.command.executable", "python3")
+        mock_span.set_attribute.assert_any_call("sandbox.exit_code", 0)
+        self.assertEqual(result.stdout, "hello_async")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sanitizes OpenTelemetry trace attribute `sandbox.command` to prevent sensitive data exposure. Instead of logging the raw unsanitized command string containing potentially sensitive arguments (like tokens, passwords, or API keys), it now extracts and logs only the base executable name of the command under the new attribute key `sandbox.command.executable`. This fix is applied to both the Python SDK (sync and async command executors) and the Go SDK clients.

#### Which issue(s) this PR is related to:
n/a

#### Release Note
```release-note
Security fix: Sanitize raw command trace logging to log only the executable name under `sandbox.command.executable` instead of the full command string, avoiding potential sensitive data exposure.
```