### PR TITLE
refactor(test): mutate test manifests structurally instead of using sed

### DIFF
--- a/clients/python/agentic-sandbox-client/gateway-kind/run-test-kind.sh
+++ b/clients/python/agentic-sandbox-client/gateway-kind/run-test-kind.sh
@@ -84,7 +84,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-cd "$REPO_ROOT/clients/python/agentic-sandbox-client/gateway-kind"
+cd "$REPO_ROOT/clients/python/agentic-sandbox-client"
 echo "========= $0 - Running the Python client tester... ========="
 python3 ./test_client.py --gateway-name kind-gateway
 echo "========= $0 - Finished running the Python client with gateway and router tester. ========="

--- a/clients/python/agentic-sandbox-client/gateway-kind/run-test-kind.sh
+++ b/clients/python/agentic-sandbox-client/gateway-kind/run-test-kind.sh
@@ -38,42 +38,41 @@ echo "Using image tag: $IMAGE_TAG"
 export SANDBOX_ROUTER_IMG="kind.local/sandbox-router:${IMAGE_TAG}"
 export SANDBOX_PYTHON_RUNTIME_IMG="kind.local/python-runtime-sandbox:${IMAGE_TAG}"
 
+# Start virtual environment and install dependencies first so we have yaml library available
+echo "Starting virtual environment for Python client and install agentic sandbox client..."
+cd "$REPO_ROOT/clients/python/agentic-sandbox-client"
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+
 # following develop guide to make and deploy agent-sandbox to kind cluster
-cd $REPO_ROOT
+cd "$REPO_ROOT"
 make build
 make deploy-kind EXTENSIONS=true
 make deploy-cloud-provider-kind
 
-cd clients/python/agentic-sandbox-client/gateway-kind
+cd "$REPO_ROOT/clients/python/agentic-sandbox-client/gateway-kind"
 echo "Applying CRD for template - Sandbox claim will be applied by the sandbox client in python code"
-sed -i "s|IMAGE_PLACEHOLDER|${SANDBOX_PYTHON_RUNTIME_IMG}|g" python-sandbox-template.yaml
-kubectl apply -f python-sandbox-template.yaml
+python3 "$REPO_ROOT/dev/tools/mutate_yaml.py" template python-sandbox-template.yaml --image "${SANDBOX_PYTHON_RUNTIME_IMG}" | kubectl apply -f -
 
-
-cd ../sandbox-router
+cd "$REPO_ROOT/clients/python/agentic-sandbox-client/sandbox-router"
 echo "Applying CRD for router template"
-sed -i "s|\${ROUTER_IMAGE}|${SANDBOX_ROUTER_IMG}|g" sandbox_router.yaml
-sed -i 's|value: "false"|value: "true"|g' sandbox_router.yaml
-kubectl apply -f sandbox_router.yaml
+python3 "$REPO_ROOT/dev/tools/mutate_yaml.py" router sandbox_router.yaml --image "${SANDBOX_ROUTER_IMG}" --allow-unauthenticated | kubectl apply -f -
 kubectl rollout status deployment/sandbox-router-deployment --timeout=60s
 
-
-cd ../gateway-kind
+cd "$REPO_ROOT/clients/python/agentic-sandbox-client/gateway-kind"
 echo "Setting up Cloud Provider Kind Gateway in the kind cluster..."
 echo "Applying Gateway configuration..."
 kubectl apply -f gateway-kind.yaml
 kubectl wait --for=condition=Programmed=True gateway/kind-gateway --timeout=60s
 
-cd ../
-
-
 # Cleanup function
 cleanup() {
     echo "Cleaning up virtual environment..."
-    deactivate 
-    rm -rf .venv
+    deactivate || true
+    rm -rf "$REPO_ROOT/clients/python/agentic-sandbox-client/.venv"
 
-    cd $REPO_ROOT
+    cd "$REPO_ROOT"
     echo "Cleaning up cloud provider kind..."
     make kill-cloud-provider-kind
     
@@ -83,17 +82,12 @@ cleanup() {
     echo "Cleanup completed."
 }
 
+trap cleanup EXIT
 
-echo "Starting virtual environment for Python client and install agentic sandbox client..."
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -e .
-
-
+cd "$REPO_ROOT/clients/python/agentic-sandbox-client/gateway-kind"
 echo "========= $0 - Running the Python client tester... ========="
 python3 ./test_client.py --gateway-name kind-gateway
 echo "========= $0 - Finished running the Python client with gateway and router tester. ========="
 
-trap cleanup EXIT
-
 echo "Test finished."
+

--- a/dev/tools/mutate_yaml.py
+++ b/dev/tools/mutate_yaml.py
@@ -45,16 +45,22 @@ def mutate_router(file_path, image, allow_unauthenticated):
                     if c.get("name") == "router":
                         if image:
                             c["image"] = image
+                        env_mutated = False
                         for env_var in c.get("env", []):
                             if env_var.get("name") == "ALLOW_UNAUTHENTICATED_ROUTER":
                                 env_var["value"] = "true" if allow_unauthenticated else "false"
+                                env_mutated = True
+                        if allow_unauthenticated and not env_mutated:
+                            print("Error: ALLOW_UNAUTHENTICATED_ROUTER env var not found in router container", file=sys.stderr)
+                            sys.exit(1)
                         mutated = True
             except (KeyError, TypeError) as e:
                 print(f"Error parsing/mutating router YAML structure: {e}", file=sys.stderr)
                 sys.exit(1)
                 
     if not mutated:
-        print("Warning: sandbox-router-deployment Deployment not found in YAML documents", file=sys.stderr)
+        print("Error: sandbox-router-deployment Deployment not found in YAML documents", file=sys.stderr)
+        sys.exit(1)
         
     yaml.safe_dump_all(docs, sys.stdout)
 

--- a/dev/tools/mutate_yaml.py
+++ b/dev/tools/mutate_yaml.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+import yaml
+
+def mutate_template(file_path, image):
+    with open(file_path, "r") as f:
+        data = yaml.safe_load(f)
+    
+    try:
+        # Safely traverse and set the image field
+        containers = data["spec"]["podTemplate"]["spec"]["containers"]
+        if containers:
+            containers[0]["image"] = image
+    except (KeyError, TypeError, IndexError) as e:
+        print(f"Error parsing/mutating template YAML structure: {e}", file=sys.stderr)
+        sys.exit(1)
+        
+    yaml.safe_dump(data, sys.stdout)
+
+def mutate_router(file_path, image, allow_unauthenticated):
+    with open(file_path, "r") as f:
+        docs = list(yaml.safe_load_all(f))
+        
+    mutated = False
+    for doc in docs:
+        if doc and doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name") == "sandbox-router-deployment":
+            try:
+                containers = doc["spec"]["template"]["spec"]["containers"]
+                for c in containers:
+                    if c.get("name") == "router":
+                        if image:
+                            c["image"] = image
+                        for env_var in c.get("env", []):
+                            if env_var.get("name") == "ALLOW_UNAUTHENTICATED_ROUTER":
+                                env_var["value"] = "true" if allow_unauthenticated else "false"
+                        mutated = True
+            except (KeyError, TypeError) as e:
+                print(f"Error parsing/mutating router YAML structure: {e}", file=sys.stderr)
+                sys.exit(1)
+                
+    if not mutated:
+        print("Warning: sandbox-router-deployment Deployment not found in YAML documents", file=sys.stderr)
+        
+    yaml.safe_dump_all(docs, sys.stdout)
+
+def main():
+    parser = argparse.ArgumentParser(description="Mutate template and router YAML manifests structurally.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    
+    template_parser = subparsers.add_parser("template", help="Mutate SandboxTemplate manifest")
+    template_parser.add_argument("file", help="Path to the template YAML file")
+    template_parser.add_argument("--image", required=True, help="New image to set in the template container")
+    
+    router_parser = subparsers.add_parser("router", help="Mutate SandboxRouter manifest")
+    router_parser.add_argument("file", help="Path to the router deployment YAML file")
+    router_parser.add_argument("--image", help="New image to set in the router container")
+    router_parser.add_argument("--allow-unauthenticated", action="store_true", help="Enable unauthenticated router mode")
+    
+    args = parser.parse_args()
+    
+    if args.command == "template":
+        mutate_template(args.file, args.image)
+    elif args.command == "router":
+        mutate_router(args.file, args.image, args.allow_unauthenticated)
+
+if __name__ == "__main__":
+    main()

--- a/test/e2e/clients/python/test_e2e_python_sdk.py
+++ b/test/e2e/clients/python/test_e2e_python_sdk.py
@@ -67,9 +67,20 @@ def deploy_router(tc, temp_namespace):
     print(f"Using router image: {router_image}")
 
     with open(ROUTER_YAML_PATH, "r") as f:
-        manifest = f.read().replace("${ROUTER_IMAGE}", router_image)
-        # Enable unauthenticated mode for local E2E test execution
-        manifest = manifest.replace('value: "false"', 'value: "true"')
+        docs = list(yaml.safe_load_all(f))
+
+    for doc in docs:
+        if doc and doc.get("kind") == "Deployment" and doc.get("metadata", {}).get("name") == "sandbox-router-deployment":
+            containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+            for c in containers:
+                if c.get("name") == "router":
+                    c["image"] = router_image
+                    env_vars = c.get("env", [])
+                    for env_var in env_vars:
+                        if env_var.get("name") == "ALLOW_UNAUTHENTICATED_ROUTER":
+                            env_var["value"] = "true"
+
+    manifest = yaml.safe_dump_all(docs)
 
     print(f"Applying router manifest to namespace: {temp_namespace}")
     tc.apply_manifest_text(manifest, namespace=temp_namespace)


### PR DESCRIPTION
### What this PR does / why we need it
This PR addresses feedback from Barney in PR 755 by replacing fragile string replacements and `sed` mutations with robust structural YAML parsing and path-based updates. 

Specifically, the following changes were made:
- **Added a Python utility:** A new utility `dev/tools/mutate_yaml.py` has been introduced to parse and update template and router manifests structurally.
- **Updated shell script:** `run-test-kind.sh` now uses `mutate_yaml.py` to modify manifests on the fly without changing source files in-place.
- **Improved E2E tests:** `test_e2e_python_sdk.py` has been updated to use `yaml.safe_load_all` for structured path-based updates.

### Which issue(s) this PR is related to
Follow up on https://github.com/kubernetes-sigs/agent-sandbox/pull/755#issuecomment-4580223080

### Release Note
```release-note
Refactored manifest mutation in tests to use structural YAML parsing instead of string-based replacements for better robustness.
```