### PR TITLE
copy template labels into sandbox

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1015,6 +1015,16 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		}
 	}
 
+	// Propagate the template's resource-level labels onto the Sandbox. The
+	// SandboxTemplate is the only place to set Sandbox labels, so copy them here
+	// as a base. System/claim-identity labels applied below take precedence.
+	for k, v := range template.Labels {
+		if sandbox.Labels == nil {
+			sandbox.Labels = make(map[string]string)
+		}
+		sandbox.Labels[k] = v
+	}
+
 	// Propagate claim identity labels for discovery and NetworkPolicy targeting.
 	// Fork extension: also write SandboxIDLabel onto the top-level Sandbox metadata
 	// (KEP-0174 only propagates to pod template labels; platform's informer reads

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1015,15 +1015,8 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		}
 	}
 
-	// Propagate the template's resource-level labels onto the Sandbox. The
-	// SandboxTemplate is the only place to set Sandbox labels, so copy them here
-	// as a base. System/claim-identity labels applied below take precedence.
-	for k, v := range template.Labels {
-		if sandbox.Labels == nil {
-			sandbox.Labels = make(map[string]string)
-		}
-		sandbox.Labels[k] = v
-	}
+	// Propagate template labels, but system/claim-identity labels take precedence.
+	sandbox.Labels = maps.Clone(template.Labels)
 
 	// Propagate claim identity labels for discovery and NetworkPolicy targeting.
 	// Fork extension: also write SandboxIDLabel onto the top-level Sandbox metadata

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1728,6 +1728,75 @@ func TestCreateSandboxPropagatesVolumeClaimTemplates(t *testing.T) {
 	}
 }
 
+func TestCreateSandboxPropagatesTemplateLabels(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "label-claim"
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: types.UID(claimName)},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "label-warmpool"},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "label-warmpool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "label-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "label-template",
+			Namespace: "default",
+			Labels: map[string]string{
+				"team":                           "platform",
+				"environment":                    "prod",
+				extensionsv1beta1.SandboxIDLabel: "should-be-overridden",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "test"}},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, warmPool, template).
+		WithStatusSubresource(claim).Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile failed: %v", err)
+	}
+
+	sandbox := &sandboxv1beta1.Sandbox{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: claimName, Namespace: "default"}, sandbox); err != nil {
+		t.Fatalf("Failed to get sandbox: %v", err)
+	}
+
+	if val := sandbox.Labels["team"]; val != "platform" {
+		t.Errorf("expected template label team=platform on sandbox, got %q", val)
+	}
+	if val := sandbox.Labels["environment"]; val != "prod" {
+		t.Errorf("expected template label environment=prod on sandbox, got %q", val)
+	}
+	// System/claim-identity labels must take precedence over template labels.
+	if val := sandbox.Labels[extensionsv1beta1.SandboxIDLabel]; val != string(claim.UID) {
+		t.Errorf("expected claim-identity label to override template value, got %q", val)
+	}
+}
+
 func TestSandboxClaimSandboxAdoption(t *testing.T) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
template is missing a way to set labels on the sandbox,
so I'd propose to inherit the labels from the template
we need this for auditing and general discoverability and owner-attribution

```release-note
sandboxes now inherit labels from their sandboxtemplate
```
TODO: `ready-for-review`