### PR TITLE
fix(e2e/framework): retry MustUpdateObject on conflict

### DIFF
--- a/test/e2e/framework/client.go
+++ b/test/e2e/framework/client.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	sandboxextensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
@@ -108,22 +109,22 @@ func (cl *ClusterClient) Update(ctx context.Context, obj client.Object) error {
 }
 
 // MustUpdateObject updates the specified object, using the provided updateFunc to modify
-// the object.  This ensures that we always update the latest version of the object from the cluster.
-// In future we might support automatic retries on optimistic-concurrency "misses".
+// the object. It fetches the latest version before each attempt and retries automatically
+// on optimistic-concurrency conflicts.
 func MustUpdateObject[T client.Object](cl *ClusterClient, obj T, updateFunc func(obj T)) {
 	cl.Helper()
 
 	ctx := cl.Context()
-
 	id := types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}
-	latest := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(T)
-	if err := cl.Get(ctx, id, latest); err != nil {
-		cl.Fatalf("MustUpdateObject: failed to get latest %T (%s): %v", obj, id.String(), err)
-	}
 
-	updateFunc(latest)
-
-	if err := cl.Update(ctx, latest); err != nil {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(T)
+		if err := cl.Get(ctx, id, latest); err != nil {
+			return err
+		}
+		updateFunc(latest)
+		return cl.Update(ctx, latest)
+	}); err != nil {
 		cl.Fatalf("MustUpdateObject: failed to update %T (%s): %v", obj, id.String(), err)
 	}
 }

--- a/test/e2e/framework/client_test.go
+++ b/test/e2e/framework/client_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	"sigs.k8s.io/agent-sandbox/controllers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestMustUpdateObjectRetriesOnConflict(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+	}
+
+	updateAttempts := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(controllers.Scheme).
+		WithObjects(sandbox).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateAttempts++
+				if updateAttempts == 1 {
+					return k8serrors.NewConflict(
+						schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+						obj.GetName(),
+						fmt.Errorf("simulated concurrent modification"),
+					)
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	cl := &ClusterClient{
+		T:      t,
+		client: fakeClient,
+	}
+
+	MustUpdateObject(cl, sandbox, func(s *sandboxv1beta1.Sandbox) {
+		if s.Labels == nil {
+			s.Labels = make(map[string]string)
+		}
+		s.Labels["test-key"] = "test-value"
+	})
+
+	if updateAttempts != 2 {
+		t.Errorf("expected 2 update attempts (1 conflict + 1 success), got %d", updateAttempts)
+	}
+
+	updated := &sandboxv1beta1.Sandbox{}
+	if err := fakeClient.Get(t.Context(), types.NamespacedName{Name: "test-sandbox", Namespace: "default"}, updated); err != nil {
+		t.Fatalf("failed to get sandbox after update: %v", err)
+	}
+	if updated.Labels["test-key"] != "test-value" {
+		t.Errorf("label not persisted after conflict retry, got labels: %v", updated.Labels)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
MustUpdateObject did a single Get followed by Update with no retry, so any concurrent controller write between the two would fail the test with an optimistic concurrency error. Wrap both in retry.RetryOnConflict so the framework handles these races automatically.

Adds a unit test that injects a conflict on the first Update and verifies the retry succeeds and the change is persisted.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes: #892

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->