### PR TITLE
WIP: examples/sandboxed-tools: managed images

### DIFF
--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -27,9 +27,21 @@ The application is configured via environment variables:
 # Set your API key
 export GEMINI_API_KEY="your-api-key-here"
 
-# Run the chat interface
+# Run the chat interface with the default session name ("default")
 go run ./examples/sandboxed-tools/main.go
+
+# Or specify a custom session name to resume/create a specific session
+go run ./examples/sandboxed-tools/main.go -session mysession
 ```
+
+## Session Persistence & Resuming Sessions
+
+By default, `sandboxed-tools` creates and resumes a session named `default`. You can specify a custom session name with the `-session` flag to run multiple independent sessions.
+
+### How it Works
+1. **Message History**: Chat history (including system prompts, user inputs, assistant replies, and tool calls/results) is saved in real-time to a JSONL file at `~/.local/sandboxed-tools/sessions/<session-name>.jsonl`.
+2. **Resuming Existing Sessions**: When starting `sandboxed-tools` with a specific session name, it automatically loads the message history from the JSONL file, prints a visual summary of your previous conversation, and continues seamlessly from where you left off.
+3. **Filesystem Backups**: Sandbox filesystem states (contents of `/home/clawtainer`) are backed up in the session-specific folder `~/.local/sandboxed-tools/<session-name>/fs`. When a sandbox launches, the latest backup tarball is restored automatically, preserving your files and environment state across tool executions and session restarts!
 
 ## Example Session
 

--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -34,14 +34,22 @@ go run ./examples/sandboxed-tools/main.go
 go run ./examples/sandboxed-tools/main.go -session mysession
 ```
 
-## Session Persistence & Resuming Sessions
+## Session Persistence, Warm Sandbox Reuse & Inactivity Expiry
 
-By default, `sandboxed-tools` creates and resumes a session named `default`. You can specify a custom session name with the `-session` flag to run multiple independent sessions.
+`sandboxed-tools` uses an advanced architectural design to balance **visual responsiveness**, **resource efficiency**, and **cluster-wide cleanup guarantees**:
 
-### How it Works
-1. **Message History**: Chat history (including system prompts, user inputs, assistant replies, and tool calls/results) is saved in real-time to a JSONL file at `~/.local/sandboxed-tools/sessions/<session-name>.jsonl`.
-2. **Resuming Existing Sessions**: When starting `sandboxed-tools` with a specific session name, it automatically loads the message history from the JSONL file, prints a visual summary of your previous conversation, and continues seamlessly from where you left off.
-3. **Filesystem Backups**: Sandbox filesystem states (contents of `/home/clawtainer`) are backed up in the session-specific folder `~/.local/sandboxed-tools/<session-name>/fs`. When a sandbox launches, the latest backup tarball is restored automatically, preserving your files and environment state across tool executions and session restarts!
+### 1. Warm Sandbox Reuse (Fast Execution)
+Instead of launching and deleting a sandbox on every single tool call, the application launches the sandbox Pod only on the **first tool call**. For subsequent tool calls within the same session, the application **reuses** the warm, active sandbox directly. This cuts execution overhead down from several seconds to milliseconds, keeping the agent loop incredibly fast.
+
+### 2. Kubernetes-Native Inactivity Expiry
+To prevent orphaned containers and resource leaks in your cluster, the application leverages the Sandbox's built-in **Lifecycle Spec**:
+- During creation, the sandbox is configured with a 5-minute inactivity lifetime: `Spec.Lifecycle.ShutdownTime` is set to `now + 5 minutes` and `Spec.Lifecycle.ShutdownPolicy` is set to `Delete`.
+- Every time a new tool is executed, the application automatically **extends the lifecycle** by updating the sandbox's `ShutdownTime` in Kubernetes to `now + 5 minutes`.
+- If no new tool calls are made for 5 minutes (e.g., because the CLI was closed, crashed, or left idle), the **Kubernetes controller automatically terminates the Pod and deletes the Sandbox resource**.
+
+### 3. Resuming & Local Filesystem Backups
+- **Message History**: Chat history is saved in real-time to a JSONL file at `~/.local/sandboxed-tools/sessions/<session-name>.jsonl`, and restored automatically on startup.
+- **Durable Backups**: Before the sandbox is cleaned up (on CLI exit or upon inactivity), the filesystem state of `/home/clawtainer` is archived to a timestamped backup at `~/.local/sandboxed-tools/<session-name>/fs`. If a session is resumed and the sandbox was already cleaned up by Kubernetes, a new sandbox is created and restored seamlessly from the latest local backup!
 
 ## Example Session
 

--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -32,6 +32,9 @@ go run ./examples/sandboxed-tools/main.go
 
 # Or specify a custom session name to resume/create a specific session
 go run ./examples/sandboxed-tools/main.go -session mysession
+
+# Run with the GKE service portal integration enabled to proxy external APIs securely with tokens
+go run ./examples/sandboxed-tools/main.go -service-portal
 ```
 
 ## Session Persistence, Warm Sandbox Reuse & Inactivity Expiry

--- a/examples/sandboxed-tools/cmd/tool-agent/apt.go
+++ b/examples/sandboxed-tools/cmd/tool-agent/apt.go
@@ -10,9 +10,63 @@ import (
 	"strings"
 )
 
+type AptGetUpdate struct {
+}
+
+// parseAptGetUpdate parses a command to check if it is an apt-get update command.
+func parseAptGetUpdate(args []string) *AptGetUpdate {
+	if len(args) == 2 && args[0] == "apt-get" && args[1] == "update" {
+		return &AptGetUpdate{}
+	}
+
+	return nil
+}
+
+func (c *AptGetUpdate) Run(ctx context.Context, opt RunOptions) error {
+	args := []string{"apt-get", "update"}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdin = nil
+	cmd.Stdout = opt.Stdout
+	cmd.Stderr = opt.Stderr
+	return cmd.Run()
+}
+
+func (c *AptGetUpdate) PostRun(ctx context.Context) error {
+	return nil
+}
+
 type AptGetInstall struct {
 	Packages []string
 	Yes      bool
+}
+
+// parseAptGetInstall parses a command to check if it is an apt-get install command.
+func parseAptGetInstall(args []string) *AptGetInstall {
+	if len(args) == 0 {
+		return nil
+	}
+
+	if len(args) >= 4 {
+		if args[0] == "apt-get" && args[1] == "install" && args[2] == "--yes" {
+			packageNames := args[3:]
+			allValid := true
+			for _, p := range packageNames {
+				if !isPackageName(p) {
+					allValid = false
+					break
+				}
+			}
+			if allValid {
+				return &AptGetInstall{
+					Packages: packageNames,
+					Yes:      true,
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *AptGetInstall) Run(ctx context.Context, opt RunOptions) error {

--- a/examples/sandboxed-tools/cmd/tool-agent/apt.go
+++ b/examples/sandboxed-tools/cmd/tool-agent/apt.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type AptGetInstall struct {
+	Packages []string
+	Yes      bool
+}
+
+func (c *AptGetInstall) Run(ctx context.Context, opt RunOptions) error {
+	args := []string{"apt-get", "install"}
+	if c.Yes {
+		args = append(args, "--yes")
+	}
+	args = append(args, c.Packages...)
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdin = nil
+	cmd.Stdout = opt.Stdout
+	cmd.Stderr = opt.Stderr
+	return cmd.Run()
+}
+
+func (c *AptGetInstall) PostRun(ctx context.Context) error {
+	return recordInstalledPackages(c.Packages)
+}
+
+// recordInstalledPackages reads the existing package list, deduplicates, and writes them back
+func recordInstalledPackages(packages []string) error {
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = "/home/clawtainer"
+	}
+
+	filePath := filepath.Join(home, ".installed-packages.txt")
+
+	existing := make(map[string]bool)
+	if data, err := os.ReadFile(filePath); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				existing[line] = true
+			}
+		}
+	}
+
+	for _, pkg := range packages {
+		existing[pkg] = true
+	}
+
+	var all []string
+	for pkg := range existing {
+		all = append(all, pkg)
+	}
+	sort.Strings(all)
+
+	var sb strings.Builder
+	for _, pkg := range all {
+		sb.WriteString(pkg)
+		sb.WriteString("\n")
+	}
+
+	if err := os.MkdirAll(home, 0755); err != nil {
+		return fmt.Errorf("failed to create home directory %s: %w", home, err)
+	}
+
+	if err := os.WriteFile(filePath, []byte(sb.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write installed packages list: %w", err)
+	}
+
+	return nil
+}

--- a/examples/sandboxed-tools/cmd/tool-agent/main.go
+++ b/examples/sandboxed-tools/cmd/tool-agent/main.go
@@ -1,0 +1,283 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/api/workloadapi"
+)
+
+const socketPath = "/var/run/tool-agent.sock"
+
+func main() {
+	log.Println("Starting tool-agent...")
+
+	// Handle standard shutdown signals
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	log := klog.FromContext(ctx)
+
+	// Ensure the parent directory of the socket exists
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for socket: %w", err)
+	}
+
+	// Remove any existing socket file
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing socket file: %w", err)
+	}
+
+	// Listen on Unix Domain Socket
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to listen on socket: %w", err)
+	}
+	defer listener.Close()
+
+	// Chmod socket so any user in the container can execute sudo via UDS
+	if err := os.Chmod(socketPath, 0666); err != nil {
+		return fmt.Errorf("failed to set socket permissions: %w", err)
+	}
+
+	log.Info("Listening on Unix Domain Socket", "path", socketPath)
+
+	// Accept connections in a goroutine to respect context cancellation
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					log.Error(err, "Failed to accept UDS connection")
+					continue
+				}
+			}
+			go func() {
+				udsConn := newUDSConnection(conn)
+				defer udsConn.Close()
+
+				handleConnection(ctx, udsConn)
+			}()
+		}
+	}()
+
+	// Wait for termination signal
+	<-ctx.Done()
+	log.Info("shutting down")
+	return nil
+}
+
+type udsConnection struct {
+	conn net.Conn
+
+	mu     sync.Mutex
+	writer *json.Encoder
+	reader *json.Decoder
+}
+
+func (c *udsConnection) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func newUDSConnection(conn net.Conn) *udsConnection {
+	c := &udsConnection{}
+	c.conn = conn
+
+	c.reader = json.NewDecoder(conn)
+	c.writer = json.NewEncoder(conn)
+
+	return c
+}
+
+func (c *udsConnection) Read(v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reader.Decode(v)
+}
+
+func (c *udsConnection) Write(v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.writer.Encode(v)
+}
+
+func (c *udsConnection) SendError(err error) {
+	_ = c.Write(workloadapi.SudoResponse{Error: err.Error()})
+}
+
+func handleConnection(ctx context.Context, conn *udsConnection) {
+	log := klog.FromContext(ctx)
+
+	var req workloadapi.SudoRequest
+	if err := conn.Read(&req); err != nil {
+		conn.SendError(fmt.Errorf("failed to decode request: %w", err))
+		return
+	}
+
+	if len(req.Command) == 0 {
+		conn.SendError(errors.New("request contains empty command"))
+		return
+	}
+
+	// Validate against the carefully curated allowlist of commands
+	parsed := parseAllowedCommand(req.Command)
+	if parsed == nil {
+		conn.SendError(fmt.Errorf("command not allowed: %v", req.Command))
+		return
+	}
+
+	log.Info("executing allowed command", "command", req.Command)
+
+	runOptions := RunOptions{}
+	runOptions.Stdout = &udsWriter{conn: conn, stream: "stdout"}
+	runOptions.Stderr = &udsWriter{conn: conn, stream: "stderr"}
+
+	err := parsed.Run(ctx, runOptions)
+	exitCode := 0
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			conn.SendError(fmt.Errorf("failed to start process: %w", err))
+			return
+		}
+	}
+
+	// Record installed packages to homedir upon successful execution of apt-get install
+	if exitCode == 0 {
+		if err := parsed.PostRun(ctx); err != nil {
+			log.Error(err, "error from post-run")
+		}
+	}
+
+	conn.Write(workloadapi.SudoResponse{ExitCode: &exitCode})
+}
+
+// parseAllowedCommand checks if the requested command is on the allowlist
+func parseAllowedCommand(args []string) Command {
+	if len(args) == 0 {
+		return nil
+	}
+
+	if v := parseAptGetInstall(args); v != nil {
+		return v
+	}
+
+	return nil
+}
+
+// isPackageName returns true if s is a valid package name, false otherwise
+// valid package names: contain only lowercase letters, numbers, hyphens, and underscores
+// They must start with a letter or number
+func isPackageName(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+				return false
+			}
+		} else {
+			if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// parseAptGetInstall parses a command to check if it is an apt-get install command.
+func parseAptGetInstall(args []string) *AptGetInstall {
+	if len(args) == 0 {
+		return nil
+	}
+
+	cmdName := filepath.Base(args[0])
+
+	switch cmdName {
+	// We start very strict
+	case "apt-get":
+		if len(args) >= 4 {
+			if args[1] == "install" && args[2] == "--yes" && isPackageName(args[3]) {
+				return &AptGetInstall{
+					Packages: args[3:],
+					Yes:      true,
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+type RunOptions struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+type Command interface {
+	Run(ctx context.Context, opt RunOptions) error
+	PostRun(ctx context.Context) error
+}
+
+// udsWriter streams standard output/error back to the UDS client in JSON-lines format
+type udsWriter struct {
+	conn   *udsConnection
+	stream string
+}
+
+func (w *udsWriter) Write(p []byte) (n int, err error) {
+	resp := workloadapi.SudoResponse{
+		Stream: w.stream,
+		Data:   string(p),
+	}
+
+	if err := w.conn.Write(resp); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/examples/sandboxed-tools/cmd/tool-agent/main.go
+++ b/examples/sandboxed-tools/cmd/tool-agent/main.go
@@ -205,6 +205,9 @@ func parseAllowedCommand(args []string) Command {
 	if v := parseAptGetInstall(args); v != nil {
 		return v
 	}
+	if v := parseAptGetUpdate(args); v != nil {
+		return v
+	}
 
 	return nil
 }
@@ -228,30 +231,6 @@ func isPackageName(s string) bool {
 		}
 	}
 	return true
-}
-
-// parseAptGetInstall parses a command to check if it is an apt-get install command.
-func parseAptGetInstall(args []string) *AptGetInstall {
-	if len(args) == 0 {
-		return nil
-	}
-
-	cmdName := filepath.Base(args[0])
-
-	switch cmdName {
-	// We start very strict
-	case "apt-get":
-		if len(args) >= 4 {
-			if args[1] == "install" && args[2] == "--yes" && isPackageName(args[3]) {
-				return &AptGetInstall{
-					Packages: args[3:],
-					Yes:      true,
-				}
-			}
-		}
-	}
-
-	return nil
 }
 
 type RunOptions struct {

--- a/examples/sandboxed-tools/cmd/tool-sudo/main.go
+++ b/examples/sandboxed-tools/cmd/tool-sudo/main.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/api/workloadapi"
+)
+
+const socketPath = "/var/run/tool-agent.sock"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: sudo <command> [args...]")
+		os.Exit(1)
+	}
+
+	// Handle standard shutdown signals
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	// Connect to the tool-agent Unix Domain Socket
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to connect to agent socket at %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	enc := json.NewEncoder(conn)
+	dec := json.NewDecoder(conn)
+
+	// Send the command line arguments as a Request
+	req := workloadapi.SudoRequest{
+		Command: os.Args[1:],
+	}
+	if err := enc.Encode(req); err != nil {
+		return fmt.Errorf("failed to send request to agent: %w", err)
+	}
+
+	// Stream responses in real-time
+	for {
+		var resp workloadapi.SudoResponse
+		if err := dec.Decode(&resp); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed to read response from agent: %w", err)
+		}
+
+		if resp.Error != "" {
+			fmt.Fprintf(os.Stderr, "%s\n", resp.Error)
+			os.Exit(1)
+		}
+
+		switch resp.Stream {
+		case "stdout":
+			_, _ = os.Stdout.Write([]byte(resp.Data))
+		case "stderr":
+			_, _ = os.Stderr.Write([]byte(resp.Data))
+		}
+
+		if resp.ExitCode != nil {
+			os.Exit(*resp.ExitCode)
+		}
+	}
+	return nil
+}

--- a/examples/sandboxed-tools/images/sandboxed-tools/Dockerfile
+++ b/examples/sandboxed-tools/images/sandboxed-tools/Dockerfile
@@ -1,0 +1,52 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build stage
+FROM golang:1.26.3 AS builder
+
+WORKDIR /workspace
+
+# Copy the Go modules manifests
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the entire project source
+COPY . .
+
+# Build tool-agent and tool-sudo binaries
+RUN CGO_ENABLED=0 GOOS=linux go build -o /tool-agent ./examples/sandboxed-tools/cmd/tool-agent
+RUN CGO_ENABLED=0 GOOS=linux go build -o /tool-sudo ./examples/sandboxed-tools/cmd/tool-sudo
+
+# Final runtime stage
+FROM debian:trixie-slim
+
+# Install basic packages and utility tools
+RUN apt-get update && apt-get install --yes \
+    curl \
+    ca-certificates \
+    util-linux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create the non-root clawtainer user (UID 1000)
+RUN useradd -u 1000 -m -s /bin/bash clawtainer
+
+# Copy the compiled binaries into standard system locations
+COPY --from=builder /tool-agent /tool-agent
+COPY --from=builder /tool-sudo /usr/bin/sudo
+
+# Make sure binaries have correct executable permissions
+RUN chmod +x /tool-agent && chmod +x /usr/bin/sudo
+
+# Run tool-agent as the primary PID 1 process running as root (UID 0)
+ENTRYPOINT ["/tool-agent"]

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -183,6 +184,27 @@ func (s *Sandbox) PodNamespacedName() types.NamespacedName {
 		Namespace: s.id.Namespace,
 		Name:      s.podName,
 	}
+}
+
+// ExtendLifecycle updates the ShutdownTime of the Sandbox in Kubernetes to now + inactivityTimeout.
+func (s *Sandbox) ExtendLifecycle(ctx context.Context, inactivityTimeout time.Duration) error {
+	agentsClient := s.session.client.agentsClient
+
+	// Fetch latest spec
+	latest, err := agentsClient.AgentsV1beta1().Sandboxes(s.id.Namespace).Get(ctx, s.id.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch latest sandbox spec to extend lifecycle: %w", err)
+	}
+
+	// Update ShutdownTime
+	latest.Spec.ShutdownTime = &metav1.Time{Time: time.Now().Add(inactivityTimeout)}
+
+	_, err = agentsClient.AgentsV1beta1().Sandboxes(s.id.Namespace).Update(ctx, latest, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update sandbox lifecycle: %w", err)
+	}
+
+	return nil
 }
 
 // WaitForReady polls the Sandbox resource until it becomes ready and resolves the underlying Pod name.
@@ -448,17 +470,20 @@ func (s *Sandbox) SnapshotFS(ctx context.Context) error {
 }
 
 // CreateSandbox creates a Sandbox resource.
-func (s *Session) CreateSandbox(ctx context.Context, image, namespace string) (*Sandbox, error) {
+func (s *Session) CreateSandbox(ctx context.Context, image, namespace string, inactivityTimeout time.Duration) (*Sandbox, error) {
 	agentsClient := s.client.agentsClient
 
-	// TODO: Use shutdownPolicy (and maybe cache the sandbox between tool calls)
-
+	policy := sandboxv1beta1.ShutdownPolicyDelete
 	sb := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "sandbox-tool-",
 			Namespace:    namespace,
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
+			Lifecycle: sandboxv1beta1.Lifecycle{
+				ShutdownTime:   &metav1.Time{Time: time.Now().Add(inactivityTimeout)},
+				ShutdownPolicy: &policy,
+			},
 			PodTemplate: sandboxv1beta1.PodTemplate{
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: new(false),
@@ -657,7 +682,19 @@ func run(ctx context.Context, opts RunOptions) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize sandbox client: %w", err)
 	}
+	var (
+		activeSandbox            *Sandbox
+		sandboxInactivityTimeout = 5 * time.Minute
+	)
+
 	defer func() {
+		if activeSandbox != nil {
+			log.Info("taking final snapshot before program exit...", "sandbox.name", activeSandbox.SandboxName())
+			if err := activeSandbox.SnapshotFS(context.WithoutCancel(ctx)); err != nil {
+				log.Error(err, "failed to take final snapshot on program exit")
+			}
+		}
+
 		if err := sandboxClient.DeleteAllSandboxes(context.WithoutCancel(ctx)); err != nil {
 			log.Error(err, "failed to delete all sandboxes")
 		}
@@ -708,8 +745,8 @@ func run(ctx context.Context, opts RunOptions) error {
 		fmt.Printf("Session Name: %s\n", opts.SessionName)
 		fmt.Printf("Sandbox Image: %s (Namespace: %s)\n", opts.Image, opts.Namespace)
 		fmt.Printf("Using LLM Base URL: %s (Model: %s)\n", baseURL, modelName)
-		fmt.Println("Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,")
-		fmt.Println("             and is immediately deleted afterward.")
+		fmt.Println("Key Concept: An Agent Sandbox is launched ONCE on the first tool call for warm reuse,")
+		fmt.Println("             and automatically deleted by the cluster after 5 minutes of inactivity.")
 		fmt.Println("Type your message (or '/exit' or '/quit' to quit):")
 		fmt.Println("================================================================================")
 	} else {
@@ -781,24 +818,80 @@ func run(ctx context.Context, opts RunOptions) error {
 				break
 			}
 
-			log.Info("launching sandbox for tool execution...")
+			sb := activeSandbox
 
-			sb, err := session.CreateSandbox(ctx, opts.Image, opts.Namespace)
-			if err != nil {
-				return fmt.Errorf("failed to create sandbox: %w", err)
+			if sb != nil {
+				// Check if the sandbox still exists in the cluster
+				_, err := sandboxClient.agentsClient.AgentsV1beta1().Sandboxes(sb.id.Namespace).Get(ctx, sb.id.Name, metav1.GetOptions{})
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						log.Info("Active sandbox was deleted or expired, will recreate it", "sandbox.name", sb.SandboxName())
+						activeSandbox = nil
+						sb = nil
+					} else {
+						return fmt.Errorf("failed to verify active sandbox status: %w", err)
+					}
+				}
 			}
 
-			if err := sb.WaitForReady(ctx); err != nil {
-				log.Error(err, "sandbox not ready")
-				_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
-				return err
-			}
+			if sb == nil {
+				log.Info("launching sandbox for tool execution...")
 
-			log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
+				var err error
+				sb, err = session.CreateSandbox(ctx, opts.Image, opts.Namespace, sandboxInactivityTimeout)
+				if err != nil {
+					return fmt.Errorf("failed to create sandbox: %w", err)
+				}
 
-			log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
-			if err := sb.RestoreFS(ctx); err != nil {
-				log.Error(err, "failed to restore filesystem; starting with a fresh sandbox instead", "sandbox.name", sb.SandboxName())
+				if err := sb.WaitForReady(ctx); err != nil {
+					log.Error(err, "sandbox not ready")
+					_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
+					return err
+				}
+
+				log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
+
+				log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
+				if err := sb.RestoreFS(ctx); err != nil {
+					log.Error(err, "failed to restore filesystem; starting with a fresh sandbox instead", "sandbox.name", sb.SandboxName())
+				}
+
+				activeSandbox = sb
+			} else {
+				log.Info("reusing active sandbox...", "sandbox.name", sb.SandboxName())
+				log.Info("extending sandbox lifecycle...", "sandbox.name", sb.SandboxName())
+				if err := sb.ExtendLifecycle(ctx, sandboxInactivityTimeout); err != nil {
+					if k8serrors.IsNotFound(err) {
+						log.Info("sandbox vanished while extending lifecycle, recreating...")
+						activeSandbox = nil
+						sb = nil
+
+						var recreateErr error
+						sb, recreateErr = session.CreateSandbox(ctx, opts.Image, opts.Namespace, sandboxInactivityTimeout)
+						if recreateErr != nil {
+							return fmt.Errorf("failed to recreate sandbox: %w", recreateErr)
+						}
+
+						if err := sb.WaitForReady(ctx); err != nil {
+							log.Error(err, "sandbox not ready")
+							_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
+							return err
+						}
+
+						log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
+
+						log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
+						if err := sb.RestoreFS(ctx); err != nil {
+							log.Error(err, "failed to restore filesystem", "sandbox.name", sb.SandboxName())
+							_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
+							return err
+						}
+
+						activeSandbox = sb
+					} else {
+						log.Error(err, "failed to extend sandbox lifecycle")
+					}
+				}
 			}
 
 			shouldSnapshot := true
@@ -834,17 +927,8 @@ func run(ctx context.Context, opts RunOptions) error {
 			if shouldSnapshot {
 				log.Info("snapshotting filesystem from sandbox...", "sandbox.name", sb.SandboxName())
 				if err := sb.SnapshotFS(ctx); err != nil {
-					// Maybe this should be surfaced as an error ... but let's deal with this
-					// when we cache the sandbox.
 					log.Error(err, "failed to snapshot filesystem")
 				}
-			}
-
-			log.Info("deleting sandbox", "sandbox.name", sb.SandboxName())
-			if deleteErr := sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb); deleteErr != nil {
-				log.Error(deleteErr, "failed to delete sandbox", "sandbox.name", sb.SandboxName())
-			} else {
-				log.V(1).Info("sandbox deleted successfully.", "sandbox.name", sb.SandboxName())
 			}
 		}
 	}

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -78,6 +78,8 @@ func main() {
 	flag.StringVar(&opts.Image, "image", opts.Image, "image")
 	flag.StringVar(&opts.HomeDir, "homedir", opts.HomeDir, "Home directory in the sandbox; this is currently the only directory that we persist with snapshot/restore.")
 	flag.BoolVar(&opts.EnableServicePortal, "service-portal", opts.EnableServicePortal, "Enable service-portal proxy sidecar and iptables configuration")
+	flag.StringVar(&opts.Entrypoint, "entrypoint", opts.Entrypoint, "Entrypoint override to run inside the sandbox container; defaults to empty string (do not override)")
+	flag.StringVar(&opts.User, "user", opts.User, "User to run commands as inside the sandbox container. If empty, runs as root.")
 	flag.Parse()
 
 	log := klog.FromContext(ctx)
@@ -159,6 +161,12 @@ type Session struct {
 
 	// EnableServicePortal adds the initContainer and sidecar container to the Sandbox pod template spec.
 	EnableServicePortal bool
+
+	// Entrypoint is the command override to run inside the sandbox container.
+	Entrypoint []string
+
+	// User is the operating system user to run commands as inside the sandbox container.
+	User string
 }
 
 // Sandbox represents an active sandbox instance.
@@ -276,6 +284,11 @@ func (s *Sandbox) ExecCommand(ctx context.Context, opts tools.ExecCommandOptions
 		stderr = &stderrBuf
 	}
 
+	cmd := opts.Command
+	if s.session.User != "" {
+		cmd = append([]string{"runuser", "-u", s.session.User, "--"}, opts.Command...)
+	}
+
 	req := coreClient.RESTClient().Post().
 		Resource("pods").
 		Name(podID.Name).
@@ -283,7 +296,7 @@ func (s *Sandbox) ExecCommand(ctx context.Context, opts tools.ExecCommandOptions
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: "sandbox",
-			Command:   opts.Command,
+			Command:   cmd,
 			Stdin:     opts.Stdin != nil,
 			Stdout:    true,
 			Stderr:    true,
@@ -496,7 +509,7 @@ func (s *Session) CreateSandbox(ctx context.Context, image, namespace string, in
 						{
 							Name:    "sandbox",
 							Image:   image,
-							Command: []string{"sleep", "infinity"},
+							Command: s.Entrypoint,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "home",
@@ -621,6 +634,12 @@ type RunOptions struct {
 
 	// EnableServicePortal enables the GKE service portal sidecar and iptables init container.
 	EnableServicePortal bool
+
+	// Entrypoint is the command override to run inside the sandbox container.
+	Entrypoint string
+
+	// User is the operating system user to run commands as inside the sandbox container.
+	User string
 }
 
 func (o *RunOptions) InitDefaults() {
@@ -642,6 +661,11 @@ func (o *RunOptions) InitDefaults() {
 	o.HomeDir = os.Getenv("SANDBOX_HOME_DIR")
 	if o.HomeDir == "" {
 		o.HomeDir = "/home/clawtainer"
+	}
+
+	o.User = os.Getenv("SANDBOX_USER")
+	if o.User == "" {
+		o.User = "clawtainer"
 	}
 }
 
@@ -728,11 +752,18 @@ func run(ctx context.Context, opts RunOptions) error {
 	sessionsDir := filepath.Join(homeDir, ".local", "sandboxed-tools", "sessions")
 	sessionStore := sessions.NewFileStore(sessionsDir)
 
+	var entrypoint []string
+	if opts.Entrypoint != "" {
+		entrypoint = strings.Fields(opts.Entrypoint)
+	}
+
 	session := &Session{
 		Name:                opts.SessionName,
 		client:              sandboxClient,
 		HomeDir:             opts.HomeDir,
 		EnableServicePortal: opts.EnableServicePortal,
+		Entrypoint:          entrypoint,
+		User:                opts.User,
 	}
 
 	messages, err := sessionStore.LoadSession(ctx, opts.SessionName)

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -46,6 +46,7 @@ import (
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	agentsclientset "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/sandboxes"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/sessions"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
 )
@@ -76,6 +77,7 @@ func main() {
 	flag.StringVar(&opts.Namespace, "namespace", opts.Namespace, "namespace")
 	flag.StringVar(&opts.Image, "image", opts.Image, "image")
 	flag.StringVar(&opts.HomeDir, "homedir", opts.HomeDir, "Home directory in the sandbox; this is currently the only directory that we persist with snapshot/restore.")
+	flag.BoolVar(&opts.EnableServicePortal, "service-portal", opts.EnableServicePortal, "Enable service-portal proxy sidecar and iptables configuration")
 	flag.Parse()
 
 	log := klog.FromContext(ctx)
@@ -154,6 +156,9 @@ type Session struct {
 	// HomeDir is the home directory; we mount a tmpfs volume here.
 	// We currently only snapshot and restore this directory.
 	HomeDir string
+
+	// EnableServicePortal adds the initContainer and sidecar container to the Sandbox pod template spec.
+	EnableServicePortal bool
 }
 
 // Sandbox represents an active sandbox instance.
@@ -476,8 +481,8 @@ func (s *Session) CreateSandbox(ctx context.Context, image, namespace string, in
 	policy := sandboxv1beta1.ShutdownPolicyDelete
 	sb := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "sandbox-tool-",
-			Namespace:    namespace,
+			Name:      s.Name,
+			Namespace: namespace,
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
 			Lifecycle: sandboxv1beta1.Lifecycle{
@@ -518,6 +523,10 @@ func (s *Session) CreateSandbox(ctx context.Context, image, namespace string, in
 				},
 			},
 		},
+	}
+
+	if s.EnableServicePortal {
+		sandboxes.AddServicePortal(sb, sandboxes.ServicePortalConfig{})
 	}
 
 	created, err := agentsClient.AgentsV1beta1().Sandboxes(namespace).Create(ctx, sb, metav1.CreateOptions{})
@@ -609,6 +618,9 @@ type RunOptions struct {
 	// HomeDir is the home directory inside the sandbox.
 	// This is currently the only path that we persist between execs in the sandbox.
 	HomeDir string
+
+	// EnableServicePortal enables the GKE service portal sidecar and iptables init container.
+	EnableServicePortal bool
 }
 
 func (o *RunOptions) InitDefaults() {
@@ -695,9 +707,9 @@ func run(ctx context.Context, opts RunOptions) error {
 			}
 		}
 
-		if err := sandboxClient.DeleteAllSandboxes(context.WithoutCancel(ctx)); err != nil {
-			log.Error(err, "failed to delete all sandboxes")
-		}
+		// if err := sandboxClient.DeleteAllSandboxes(context.WithoutCancel(ctx)); err != nil {
+		// 	log.Error(err, "failed to delete all sandboxes")
+		// }
 	}()
 
 	toolsRegistry := tools.NewRegistry()
@@ -717,8 +729,10 @@ func run(ctx context.Context, opts RunOptions) error {
 	sessionStore := sessions.NewFileStore(sessionsDir)
 
 	session := &Session{
-		Name:   opts.SessionName,
-		client: sandboxClient,
+		Name:                opts.SessionName,
+		client:              sandboxClient,
+		HomeDir:             opts.HomeDir,
+		EnableServicePortal: opts.EnableServicePortal,
 	}
 
 	messages, err := sessionStore.LoadSession(ctx, opts.SessionName)

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -45,6 +45,7 @@ import (
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	agentsclientset "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/sessions"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
 )
 
@@ -586,6 +587,11 @@ type RunOptions struct {
 }
 
 func (o *RunOptions) InitDefaults() {
+	o.SessionName = os.Getenv("SESSION_NAME")
+	if o.SessionName == "" {
+		o.SessionName = "default"
+	}
+
 	o.Image = os.Getenv("SANDBOX_IMAGE")
 	if o.Image == "" {
 		o.Image = "debian:bookworm-slim"
@@ -666,31 +672,58 @@ func run(ctx context.Context, opts RunOptions) error {
 
 	llmTools := toolsRegistry.All()
 
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	sessionsDir := filepath.Join(homeDir, ".local", "sandboxed-tools", "sessions")
+	sessionStore := sessions.NewFileStore(sessionsDir)
+
 	session := &Session{
 		Name:   opts.SessionName,
 		client: sandboxClient,
 	}
 
-	systemPrompt := "You are a helpful AI assistant with access to a sandboxed environment. " +
-		"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
-		"Always explain what you are doing."
-
-	messages := []llm.Message{
-		{
-			Role:    "system",
-			Content: &systemPrompt,
-		},
+	messages, err := sessionStore.LoadSession(ctx, opts.SessionName)
+	if err != nil {
+		return fmt.Errorf("failed to load session: %w", err)
 	}
 
-	fmt.Println("================================================================================")
-	fmt.Println("Welcome to the Sandboxed Tools example!")
-	fmt.Printf("Session Name: %s\n", opts.SessionName)
-	fmt.Printf("Sandbox Image: %s (Namespace: %s)\n", opts.Image, opts.Namespace)
-	fmt.Printf("Using LLM Base URL: %s (Model: %s)\n", baseURL, modelName)
-	fmt.Println("Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,")
-	fmt.Println("             and is immediately deleted afterward.")
-	fmt.Println("Type your message (or '/exit' or '/quit' to quit):")
-	fmt.Println("================================================================================")
+	if len(messages) == 0 {
+		systemPrompt := "You are a helpful AI assistant with access to a sandboxed environment. " +
+			"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
+			"Always explain what you are doing."
+
+		sysMsg := llm.Message{
+			Role:    "system",
+			Content: &systemPrompt,
+		}
+		messages = []llm.Message{sysMsg}
+		if err := sessionStore.AppendMessage(ctx, opts.SessionName, sysMsg); err != nil {
+			return fmt.Errorf("failed to persist system prompt: %w", err)
+		}
+
+		fmt.Println("================================================================================")
+		fmt.Println("Welcome to the Sandboxed Tools example!")
+		fmt.Printf("Session Name: %s\n", opts.SessionName)
+		fmt.Printf("Sandbox Image: %s (Namespace: %s)\n", opts.Image, opts.Namespace)
+		fmt.Printf("Using LLM Base URL: %s (Model: %s)\n", baseURL, modelName)
+		fmt.Println("Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,")
+		fmt.Println("             and is immediately deleted afterward.")
+		fmt.Println("Type your message (or '/exit' or '/quit' to quit):")
+		fmt.Println("================================================================================")
+	} else {
+		fmt.Println("================================================================================")
+		fmt.Printf("Resumed session %q with %d messages in history:\n", opts.SessionName, len(messages))
+		fmt.Println("================================================================================")
+		for _, msg := range messages {
+			if msg.Role == "user" {
+				fmt.Printf("User> %s\n", valueOf(msg.Content))
+			} else if msg.Role == "assistant" && msg.Content != nil && *msg.Content != "" {
+				fmt.Printf("Agent> %s\n", *msg.Content)
+			}
+		}
+	}
 
 	for {
 		fmt.Print("\nUser> ")
@@ -713,7 +746,11 @@ func run(ctx context.Context, opts RunOptions) error {
 			break
 		}
 
-		messages = append(messages, llm.Message{Role: "user", Content: &input})
+		userMsg := llm.Message{Role: "user", Content: &input}
+		messages = append(messages, userMsg)
+		if err := sessionStore.AppendMessage(ctx, opts.SessionName, userMsg); err != nil {
+			return fmt.Errorf("failed to persist user message: %w", err)
+		}
 
 		for {
 			req := llm.ChatCompletionRequest{
@@ -735,6 +772,9 @@ func run(ctx context.Context, opts RunOptions) error {
 
 			msg := resp.Choices[0].Message
 			messages = append(messages, msg)
+			if err := sessionStore.AppendMessage(ctx, opts.SessionName, msg); err != nil {
+				return fmt.Errorf("failed to persist assistant message: %w", err)
+			}
 
 			if len(msg.ToolCalls) == 0 {
 				fmt.Printf("\nAgent> %s\n", valueOf(msg.Content))
@@ -773,16 +813,21 @@ func run(ctx context.Context, opts RunOptions) error {
 					shouldSnapshot = false
 				}
 
+				var toolMsg llm.Message
 				if err != nil {
 					log.Error(err, "error calling tool", "tool", tc.Function.Name)
 					content := fmt.Sprintf("Error calling tool %q: %v", tc.Function.Name, err)
-					messages = append(messages, llm.Message{
+					toolMsg = llm.Message{
 						Role:       "tool",
 						ToolCallID: tc.ID,
 						Content:    &content,
-					})
+					}
 				} else {
-					messages = append(messages, result)
+					toolMsg = result
+				}
+				messages = append(messages, toolMsg)
+				if err := sessionStore.AppendMessage(ctx, opts.SessionName, toolMsg); err != nil {
+					return fmt.Errorf("failed to persist tool response: %w", err)
 				}
 			}
 

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -46,6 +45,7 @@ import (
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	agentsclientset "sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/tools"
 )
 
 func main() {
@@ -224,40 +224,9 @@ readyLoop:
 	return nil
 }
 
-// ExecutionResult holds the captured stdout, stderr, and exit code of a command.
-type ExecutionResult struct {
-	// Stdout contains the captured standard output.
-	// This is only populated if ExecOptions.Stdout was nil.
-	Stdout string
-
-	// Stderr contains the captured standard error.
-	// This is only populated if ExecOptions.Stderr was nil.
-	Stderr string
-
-	// ExitCode is the exit status returned by the command.
-	ExitCode int
-}
-
-// ExecOptions contains the options for executing a command inside the sandbox container.
-type ExecOptions struct {
-	// Command is the process name and arguments to run (e.g. []string{"sh", "-c", "uname -a"}).
-	Command []string
-
-	// Stdin is an optional reader to pipe into the command's standard input.
-	Stdin io.Reader
-
-	// Stdout is an optional writer where standard output will be written.
-	// If nil, Stdout will be captured internally and returned as a string in the ExecutionResult.
-	Stdout io.Writer
-
-	// Stderr is an optional writer where standard error will be written.
-	// If nil, Stderr will be captured internally and returned as a string in the ExecutionResult.
-	Stderr io.Writer
-}
-
-// Exec executes a command inside the sandbox container with specified options.
-// If Stdout or Stderr are nil in ExecOptions, they are captured internally and returned in the ExecutionResult.
-func (s *Sandbox) Exec(ctx context.Context, opts ExecOptions) (*ExecutionResult, error) {
+// ExecCommand executes a command inside the sandbox container with specified options.
+// If Stdout or Stderr are nil in tools.ExecCommandOptions, they are captured internally and returned in the tools.ExecCommandResult.
+func (s *Sandbox) ExecCommand(ctx context.Context, opts tools.ExecCommandOptions) (*tools.ExecCommandResult, error) {
 	coreClient := s.session.client.coreClient
 	restConfig := s.session.client.restConfig
 
@@ -315,7 +284,7 @@ func (s *Sandbox) Exec(ctx context.Context, opts ExecOptions) (*ExecutionResult,
 		}
 	}
 
-	res := &ExecutionResult{
+	res := &tools.ExecCommandResult{
 		ExitCode: exitCode,
 	}
 	if opts.Stdout == nil {
@@ -326,14 +295,6 @@ func (s *Sandbox) Exec(ctx context.Context, opts ExecOptions) (*ExecutionResult,
 	}
 
 	return res, nil
-}
-
-// Run executes a shell command in the sandbox pod.
-func (s *Sandbox) Run(ctx context.Context, command string) (*ExecutionResult, error) {
-	opts := ExecOptions{
-		Command: []string{"sh", "-c", command},
-	}
-	return s.Exec(ctx, opts)
 }
 
 // getBackupDir gets the backup directory for the session.
@@ -421,11 +382,11 @@ func (s *Sandbox) RestoreFS(ctx context.Context) error {
 	}
 	defer f.Close()
 
-	opts := ExecOptions{
+	opts := tools.ExecCommandOptions{
 		Command: []string{"tar", "-zxf", "-", "-C", s.session.HomeDir},
 		Stdin:   f,
 	}
-	res, err := s.Exec(ctx, opts)
+	res, err := s.ExecCommand(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to execute restore: %w", err)
 	}
@@ -455,11 +416,11 @@ func (s *Sandbox) SnapshotFS(ctx context.Context) error {
 	}
 	defer backupFile.Close()
 
-	opts := ExecOptions{
+	opts := tools.ExecCommandOptions{
 		Command: []string{"tar", "-zcf", "-", "-C", s.session.HomeDir, "."},
 		Stdout:  backupFile,
 	}
-	res, err := s.Exec(ctx, opts)
+	res, err := s.ExecCommand(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to execute snapshot: %w", err)
 	}
@@ -665,8 +626,15 @@ func run(ctx context.Context, opts RunOptions) error {
 		modelName = "gemini-3.5-flash"
 	}
 
+	// We require the session name to contain only alphanumeric characters.
+	// We could be more liberal, but we want to err on the side of caution for now.
 	if !isAlphaNumeric(opts.SessionName) {
 		return fmt.Errorf("invalid session name %q: must be alphanumeric", opts.SessionName)
+	}
+
+	// Limit length; erring on the side of caution.
+	if len(opts.SessionName) > 40 {
+		return fmt.Errorf("invalid session name %q: must be at most 40 characters", opts.SessionName)
 	}
 
 	llmClient, err := llm.NewClient(baseURL, apiKey)
@@ -689,40 +657,35 @@ func run(ctx context.Context, opts RunOptions) error {
 		}
 	}()
 
+	toolsRegistry := tools.NewRegistry()
+	toolsRegistry.Add(&tools.RunCommand{})
+
+	toolsRegistry.Add(&tools.ListFilesTool{})
+	toolsRegistry.Add(&tools.ReadFileTool{})
+	toolsRegistry.Add(&tools.WriteFileTool{})
+
+	llmTools := toolsRegistry.All()
+
 	session := &Session{
 		Name:   opts.SessionName,
 		client: sandboxClient,
 	}
 
-	runCmdTool := llm.Tool{
-		Type: "function",
-		Function: llm.ToolFunction{
-			Name:        "run_command",
-			Description: "Executes a shell command inside a sandbox and returns the stdout and stderr.",
-			Parameters: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"command": map[string]any{
-						"type":        "string",
-						"description": "The shell command to execute",
-					},
-				},
-				"required": []string{"command"},
-			},
-		},
-	}
+	systemPrompt := "You are a helpful AI assistant with access to a sandboxed environment. " +
+		"You can use the available tools (like run_command to execute shell commands, ls to list files, read to read files, and write to write files) to answer user questions or perform tasks. " +
+		"Always explain what you are doing."
 
 	messages := []llm.Message{
 		{
-			Role: "system",
-			Content: "You are a helpful AI assistant with access to a sandboxed environment. " +
-				"You can use the run_command tool to execute shell commands to answer user questions or perform tasks. " +
-				"Always explain what you are doing.",
+			Role:    "system",
+			Content: &systemPrompt,
 		},
 	}
 
 	fmt.Println("================================================================================")
 	fmt.Println("Welcome to the Sandboxed Tools example!")
+	fmt.Printf("Session Name: %s\n", opts.SessionName)
+	fmt.Printf("Sandbox Image: %s (Namespace: %s)\n", opts.Image, opts.Namespace)
 	fmt.Printf("Using LLM Base URL: %s (Model: %s)\n", baseURL, modelName)
 	fmt.Println("Key Concept: An Agent Sandbox is launched ONLY when a tool needs to be executed,")
 	fmt.Println("             and is immediately deleted afterward.")
@@ -750,13 +713,13 @@ func run(ctx context.Context, opts RunOptions) error {
 			break
 		}
 
-		messages = append(messages, llm.Message{Role: "user", Content: input})
+		messages = append(messages, llm.Message{Role: "user", Content: &input})
 
 		for {
 			req := llm.ChatCompletionRequest{
 				Model:    modelName,
 				Messages: messages,
-				Tools:    []llm.Tool{runCmdTool},
+				Tools:    llmTools,
 			}
 
 			resp, err := llmClient.CreateChatCompletion(ctx, req)
@@ -774,102 +737,69 @@ func run(ctx context.Context, opts RunOptions) error {
 			messages = append(messages, msg)
 
 			if len(msg.ToolCalls) == 0 {
-				fmt.Printf("\nAgent> %s\n", msg.Content)
+				fmt.Printf("\nAgent> %s\n", valueOf(msg.Content))
 				break
 			}
 
+			log.Info("launching sandbox for tool execution...")
+
+			sb, err := session.CreateSandbox(ctx, opts.Image, opts.Namespace)
+			if err != nil {
+				return fmt.Errorf("failed to create sandbox: %w", err)
+			}
+
+			if err := sb.WaitForReady(ctx); err != nil {
+				log.Error(err, "sandbox not ready")
+				_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
+				return err
+			}
+
+			log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
+
+			log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
+			if err := sb.RestoreFS(ctx); err != nil {
+				log.Error(err, "failed to restore filesystem; starting with a fresh sandbox instead", "sandbox.name", sb.SandboxName())
+			}
+
+			shouldSnapshot := true
+
 			for _, tc := range msg.ToolCalls {
-				if tc.Function.Name == "run_command" {
-					var args struct {
-						Command string `json:"command"`
-					}
-					if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
-						fmt.Printf("[Tool Error] Failed to parse arguments: %v\n", err)
-						messages = append(messages, llm.Message{
-							Role:       "tool",
-							ToolCallID: tc.ID,
-							Content:    fmt.Sprintf("Failed to parse arguments: %v", err),
-						})
-						continue
-					}
+				// TODO: Add a timeout to the tool execution?
+				result, err := toolsRegistry.Call(ctx, sb, tc)
 
-					fmt.Printf("\n[Tool Execution] LLM requested tool %q with command: %q\n", tc.Function.Name, args.Command)
-					log.Info("launching sandbox for tool execution...")
+				// We don't snapshot if there was an error, but we do snapshot if the tool just
+				// returned a non-zero exit code.
+				if err != nil {
+					shouldSnapshot = false
+				}
 
-					sb, err := session.CreateSandbox(ctx, opts.Image, opts.Namespace)
-					if err != nil {
-						fmt.Printf("[Sandbox Error] Failed to create sandbox: %v\n", err)
-						messages = append(messages, llm.Message{
-							Role:       "tool",
-							ToolCallID: tc.ID,
-							Content:    fmt.Sprintf("Sandbox creation failed: %v", err),
-						})
-						continue
-					}
-
-					if err := sb.WaitForReady(ctx); err != nil {
-						log.Error(err, "sandbox not ready")
-						_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
-						return err
-					}
-
-					log.V(1).Info("sandbox ready", "sandbox.name", sb.SandboxName())
-
-					log.Info("restoring filesystem to sandbox...", "sandbox.name", sb.SandboxName())
-					if err := sb.RestoreFS(ctx); err != nil {
-						log.Error(err, "failed to restore filesystem", "sandbox.name", sb.SandboxName())
-						_ = sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb)
-						messages = append(messages, llm.Message{
-							Role:       "tool",
-							ToolCallID: tc.ID,
-							Content:    fmt.Sprintf("Filesystem restore failed: %v", err),
-						})
-						continue
-					}
-
-					log.Info("executing command in sandbox", "sandbox.name", sb.SandboxName(), "command", args.Command)
-					// TODO: Add a timeout to the tool execution?
-					res, err := sb.Run(ctx, args.Command)
-
-					// We don't snapshot if there was an error, but we do snapshot if the tool just
-					// returned a non-zero exit code.
-					if err == nil {
-						log.Info("snapshotting filesystem from sandbox...", "sandbox.name", sb.SandboxName())
-						if err := sb.SnapshotFS(ctx); err != nil {
-							// Maybe this should be surfaced as an error ... but let's deal with this
-							// when we cache the sandbox.
-							log.Error(err, "failed to snapshot filesystem")
-						}
-					}
-
-					log.Info("deleting sandbox", "sandbox.name", sb.SandboxName())
-					if deleteErr := sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb); deleteErr != nil {
-						log.Error(deleteErr, "failed to delete sandbox", "sandbox.name", sb.SandboxName())
-					} else {
-						log.V(1).Info("sandbox deleted successfully.", "sandbox.name", sb.SandboxName())
-					}
-
-					var toolResult string
-					if err != nil {
-						toolResult = fmt.Sprintf("Execution error: %v", err)
-					} else {
-						toolResult = fmt.Sprintf("stdout:\n%s\nstderr:\n%s\nexit_code: %d", res.Stdout, res.Stderr, res.ExitCode)
-					}
-					fmt.Printf("[Tool Result] %s\n", toolResult)
-
+				if err != nil {
+					log.Error(err, "error calling tool", "tool", tc.Function.Name)
+					content := fmt.Sprintf("Error calling tool %q: %v", tc.Function.Name, err)
 					messages = append(messages, llm.Message{
 						Role:       "tool",
 						ToolCallID: tc.ID,
-						Content:    toolResult,
+						Content:    &content,
 					})
 				} else {
-					fmt.Printf("[Tool Error] Unknown tool requested: %s\n", tc.Function.Name)
-					messages = append(messages, llm.Message{
-						Role:       "tool",
-						ToolCallID: tc.ID,
-						Content:    fmt.Sprintf("Unknown tool %q", tc.Function.Name),
-					})
+					messages = append(messages, result)
 				}
+			}
+
+			if shouldSnapshot {
+				log.Info("snapshotting filesystem from sandbox...", "sandbox.name", sb.SandboxName())
+				if err := sb.SnapshotFS(ctx); err != nil {
+					// Maybe this should be surfaced as an error ... but let's deal with this
+					// when we cache the sandbox.
+					log.Error(err, "failed to snapshot filesystem")
+				}
+			}
+
+			log.Info("deleting sandbox", "sandbox.name", sb.SandboxName())
+			if deleteErr := sandboxClient.DeleteSandbox(context.WithoutCancel(ctx), sb); deleteErr != nil {
+				log.Error(deleteErr, "failed to delete sandbox", "sandbox.name", sb.SandboxName())
+			} else {
+				log.V(1).Info("sandbox deleted successfully.", "sandbox.name", sb.SandboxName())
 			}
 		}
 	}
@@ -892,4 +822,14 @@ func isAlphaNumeric(s string) bool {
 		}
 	}
 	return true
+}
+
+// valueOf is a helper that safely gets a value from a pointer,
+// if the pointer is nil it returns the default (zero) value.
+func valueOf[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
 }

--- a/examples/sandboxed-tools/pkg/api/workloadapi/sudo.go
+++ b/examples/sandboxed-tools/pkg/api/workloadapi/sudo.go
@@ -1,0 +1,14 @@
+package workloadapi
+
+// SudoRequest initiates a sudo operation
+type SudoRequest struct {
+	Command []string `json:"command"`
+}
+
+// SudoResponse is the streamed response for the progress of a sudo operation
+type SudoResponse struct {
+	Stream   string `json:"stream,omitempty"`
+	Data     string `json:"data,omitempty"`
+	ExitCode *int   `json:"exit_code,omitempty"`
+	Error    string `json:"error,omitempty"`
+}

--- a/examples/sandboxed-tools/pkg/llm/client.go
+++ b/examples/sandboxed-tools/pkg/llm/client.go
@@ -128,25 +128,60 @@ func (c *Client) CreateChatCompletion(ctx context.Context, req ChatCompletionReq
 	}
 	log.V(1).Info("making LLM request", "request", string(bodyBytes))
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("llm: failed to create http request: %w", err)
-	}
+	var resp *http.Response
+	var respBody []byte
 
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	maxAttempts := 5
+	backoff := 1 * time.Second
 
-	resp, err := c.httpClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("llm: http request failed: %w", err)
-	}
-	defer resp.Body.Close()
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			log.Info("retrying LLM request due to temporary error", "attempt", attempt, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("llm: failed to read response body: %w", err)
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, fmt.Errorf("llm: failed to create http request: %w", err)
+		}
+
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+		resp, err = c.httpClient.Do(httpReq)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if attempt < maxAttempts {
+				continue
+			}
+			return nil, fmt.Errorf("llm: http request failed: %w", err)
+		}
+
+		respBody, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			if attempt < maxAttempts {
+				continue
+			}
+			return nil, fmt.Errorf("llm: failed to read response body: %w", err)
+		}
+		log.V(1).Info("response from LLM", "status", resp.StatusCode, "body", string(respBody))
+
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+			if attempt < maxAttempts {
+				continue
+			}
+		}
+
+		break
 	}
-	log.V(1).Info("response from LLM", "status", resp.StatusCode, "body", string(respBody))
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("llm: api error (status %d): %s", resp.StatusCode, string(respBody))

--- a/examples/sandboxed-tools/pkg/llm/client.go
+++ b/examples/sandboxed-tools/pkg/llm/client.go
@@ -43,8 +43,10 @@ type ChatCompletionRequest struct {
 
 // Message represents a single chat message in the conversation history.
 type Message struct {
-	Role             string     `json:"role"`
-	Content          string     `json:"content,omitempty"`
+	Role string `json:"role"`
+	// Content is the content of the message.
+	// This is a pointer, because some models expect an empty string to be passed.
+	Content          *string    `json:"content,omitempty"`
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string     `json:"tool_call_id,omitempty"`
 	ThoughtSignature string     `json:"thought_signature,omitempty"`

--- a/examples/sandboxed-tools/pkg/sandboxes/serviceportals.go
+++ b/examples/sandboxed-tools/pkg/sandboxes/serviceportals.go
@@ -1,0 +1,295 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+// ServiceConfig defines configuration for a single proxied service.
+type ServiceConfig struct {
+	Name       string
+	TargetURL  string
+	Host       string
+	AuthHeader string
+
+	// The key inside the Secret containing the auth token
+	SecretKey string
+}
+
+// ServicePortalConfig defines the options for configuring the service-portal.
+type ServicePortalConfig struct {
+	// SecretName is the name of the Kubernetes Secret containing the API tokens.
+	// Defaults to "service-portal-configuration" if empty.
+	SecretName string
+
+	// InitImage is the image of the init container configuring iptables rules.
+	// Defaults to "images.local/init-iptables:latest" if empty.
+	InitImage string
+
+	// SidecarImage is the image of the service-portal proxy sidecar.
+	// Defaults to "images.local/all-in-one-portal:latest" if empty.
+	SidecarImage string
+
+	// // Services is a list of services to proxy.
+	// // If empty, defaults to DefaultServices.
+	// Services []ServiceConfig
+}
+
+// Can create a secret using
+// kubectl create secret generic service-portal-configuration   \
+//     --from-literal=GEMINI_API_KEY="${GEMINI_API_KEY}$"  \
+//     --from-literal=OPENAI_API_KEY="" \
+//     --from-literal=GITHUB_TOKEN=$(gh auth token)
+
+// // DefaultServices returns the default service-portal service configurations for Gemini and GitHub.
+// var DefaultServices = []ServiceConfig{
+// 	{
+// 		Name:       "gemini",
+// 		TargetURL:  "https://generativelanguage.googleapis.com",
+// 		Host:       "gemini.backend",
+// 		AuthHeader: "Authorization",
+// 		SecretKey:  "GEMINI_API_KEY",
+// 	},
+// 	{
+// 		Name:       "github",
+// 		TargetURL:  "https://api.github.com",
+// 		Host:       "github.backend",
+// 		AuthHeader: "Authorization",
+// 		SecretKey:  "GITHUB_TOKEN",
+// 	},
+// }
+
+// AddServicePortal injects the iptables initContainer, the service-portal proxy sidecar,
+// and configures hostAliases and securityContext on a Sandbox resource.
+func AddServicePortal(sb *sandboxv1beta1.Sandbox, config ServicePortalConfig) {
+	if config.SecretName == "" {
+		config.SecretName = "service-portal-configuration"
+	}
+	if config.InitImage == "" {
+		config.InitImage = "images.local/init-service-portals:latest"
+	}
+	if config.SidecarImage == "" {
+		config.SidecarImage = "images.local/all-in-one-portal:latest"
+	}
+	// if len(config.Services) == 0 {
+	// 	config.Services = DefaultServices
+	// }
+
+	podSpec := &sb.Spec.PodTemplate.Spec
+
+	// 1. Add HostAliases
+	// var hostnames []string
+	// for _, svc := range config.Services {
+	// 	hostnames = append(hostnames, svc.Host)
+	// }
+	// podSpec.HostAliases = append(podSpec.HostAliases, corev1.HostAlias{
+	// 	IP:        "8.8.8.8",
+	// 	Hostnames: hostnames,
+	// })
+
+	// 2. Add InitContainer
+	rootUser := int64(0)
+	rootGroup := int64(0)
+	initContainer := corev1.Container{
+		Name:            "init-iptables",
+		Image:           config.InitImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Env: []corev1.EnvVar{
+			{
+				Name:  "PROXY_PORT",
+				Value: "8080",
+			},
+			{
+				Name:  "PROXY_HTTPS_PORT",
+				Value: "8443",
+			},
+			{
+				Name:  "PROXY_UID",
+				Value: "1337",
+			},
+			{
+				Name:  "INTERCEPT_PORTS",
+				Value: "80,443",
+			},
+			{
+				Name:  "CHOWN_UID",
+				Value: "1337",
+			},
+			{
+				Name:  "CHOWN_GID",
+				Value: "1337",
+			},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"NET_ADMIN"},
+			},
+			RunAsUser:  &rootUser,
+			RunAsGroup: &rootGroup,
+			Privileged: new(false),
+		},
+	}
+
+	initContainer.VolumeMounts = []corev1.VolumeMount{
+		{
+			Name:      "ca-cert",
+			MountPath: "/etc/service-portal/ca",
+		},
+		{
+			Name:      "ca-key",
+			MountPath: "/etc/service-portal/ca-private",
+		},
+	}
+	podSpec.InitContainers = append(podSpec.InitContainers, initContainer)
+
+	// 3. Prepare Sidecar Container
+	var sidecarEnv []corev1.EnvVar
+	// var serviceNames []string
+	// for _, svc := range config.Services {
+	// 	serviceNames = append(serviceNames, svc.Name)
+	// }
+	// sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+	// 	Name:  "SERVICE_NAMES",
+	// 	Value: strings.Join(serviceNames, ","),
+	// })
+
+	// for _, svc := range config.Services {
+	// 	prefix := strings.ToUpper(svc.Name)
+	// 	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+	// 		Name:  prefix + "_TARGET_URL",
+	// 		Value: svc.TargetURL,
+	// 	})
+	// 	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+	// 		Name:  prefix + "_HOST",
+	// 		Value: svc.Host,
+	// 	})
+	// 	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+	// 		Name:  prefix + "_AUTH_HEADER",
+	// 		Value: svc.AuthHeader,
+	// 	})
+	// 	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+	// 		Name: prefix + "_AUTH_TOKEN",
+	// 		ValueFrom: &corev1.EnvVarSource{
+	// 			SecretKeyRef: &corev1.SecretKeySelector{
+	// 				LocalObjectReference: corev1.LocalObjectReference{
+	// 					Name: config.SecretName,
+	// 				},
+	// 				Key: svc.SecretKey,
+	// 			},
+	// 		},
+	// 	})
+	// }
+
+	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+		Name:  "RULES_DIR",
+		Value: "/secrets/service-portals-config",
+	})
+
+	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+		Name:  "CA_CERT_PATH",
+		Value: "/etc/service-portal/ca-private/tls.crt",
+	})
+	sidecarEnv = append(sidecarEnv, corev1.EnvVar{
+		Name:  "CA_KEY_PATH",
+		Value: "/etc/service-portal/ca-private/tls.key",
+	})
+
+	proxyUser := int64(1337)
+	proxyGroup := int64(1337)
+	falseVal := false
+	trueVal := true
+	sidecarContainer := corev1.Container{
+		Name:  "service-portal-sidecar",
+		Image: config.SidecarImage,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &proxyUser,
+			RunAsGroup:               &proxyGroup,
+			AllowPrivilegeEscalation: &falseVal,
+			ReadOnlyRootFilesystem:   &trueVal,
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: 8080,
+				Name:          "proxy",
+			},
+		},
+		Env: sidecarEnv,
+	}
+
+	sidecarContainer.VolumeMounts = append(sidecarContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      "service-portals-config",
+		MountPath: "/secrets/service-portals-config",
+		ReadOnly:  true,
+	})
+
+	sidecarContainer.VolumeMounts = append(sidecarContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      "ca-key",
+		MountPath: "/etc/service-portal/ca-private",
+		ReadOnly:  true,
+	})
+
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "service-portals-config",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: config.SecretName,
+			},
+		},
+	})
+
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "ca-cert",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+	})
+
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "ca-key",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium: corev1.StorageMediumMemory,
+			},
+		},
+	})
+
+	podSpec.Containers = append(podSpec.Containers, sidecarContainer)
+
+	// 4. Update main/sandbox container's securityContext as a best practice
+	for i, container := range podSpec.Containers {
+		if container.Name == "sandbox" {
+			container := &podSpec.Containers[i]
+			if container.SecurityContext == nil {
+				container.SecurityContext = &corev1.SecurityContext{}
+			}
+			container.SecurityContext.RunAsNonRoot = &trueVal
+			if container.SecurityContext.RunAsUser == nil {
+				userVal := int64(1000)
+				container.SecurityContext.RunAsUser = &userVal
+			}
+			container.SecurityContext.AllowPrivilegeEscalation = &falseVal
+
+			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+				Name:      "ca-cert",
+				MountPath: "/etc/service-portal/ca",
+				ReadOnly:  true,
+			})
+		}
+	}
+}

--- a/examples/sandboxed-tools/pkg/sandboxes/serviceportals.go
+++ b/examples/sandboxed-tools/pkg/sandboxes/serviceportals.go
@@ -44,6 +44,10 @@ type ServicePortalConfig struct {
 	// Defaults to "images.local/all-in-one-portal:latest" if empty.
 	SidecarImage string
 
+	// RunSandboxAsNonRoot specifies whether to force the sandbox container to run as non-root.
+	// Defaults to false.
+	RunSandboxAsNonRoot bool
+
 	// // Services is a list of services to proxy.
 	// // If empty, defaults to DefaultServices.
 	// Services []ServiceConfig
@@ -275,15 +279,17 @@ func AddServicePortal(sb *sandboxv1beta1.Sandbox, config ServicePortalConfig) {
 	for i, container := range podSpec.Containers {
 		if container.Name == "sandbox" {
 			container := &podSpec.Containers[i]
-			if container.SecurityContext == nil {
-				container.SecurityContext = &corev1.SecurityContext{}
+			if config.RunSandboxAsNonRoot {
+				if container.SecurityContext == nil {
+					container.SecurityContext = &corev1.SecurityContext{}
+				}
+				container.SecurityContext.RunAsNonRoot = &trueVal
+				if container.SecurityContext.RunAsUser == nil {
+					userVal := int64(1000)
+					container.SecurityContext.RunAsUser = &userVal
+				}
+				container.SecurityContext.AllowPrivilegeEscalation = &falseVal
 			}
-			container.SecurityContext.RunAsNonRoot = &trueVal
-			if container.SecurityContext.RunAsUser == nil {
-				userVal := int64(1000)
-				container.SecurityContext.RunAsUser = &userVal
-			}
-			container.SecurityContext.AllowPrivilegeEscalation = &falseVal
 
 			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 				Name:      "ca-cert",

--- a/examples/sandboxed-tools/pkg/sandboxes/serviceportals_test.go
+++ b/examples/sandboxed-tools/pkg/sandboxes/serviceportals_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxes
+
+import (
+	"slices"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+func TestAddServicePortal(t *testing.T) {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sandbox",
+			Namespace: "default",
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "sandbox",
+							Image: "debian:bookworm-slim",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	AddServicePortal(sb, ServicePortalConfig{})
+
+	podSpec := &sb.Spec.PodTemplate.Spec
+
+	// Verify HostAliases
+	if len(podSpec.HostAliases) != 1 {
+		t.Fatalf("expected 1 host alias, got %d", len(podSpec.HostAliases))
+	}
+	if podSpec.HostAliases[0].IP != "8.8.8.8" {
+		t.Errorf("expected IP 8.8.8.8, got %s", podSpec.HostAliases[0].IP)
+	}
+	expectedHosts := map[string]bool{"gemini.backend": true, "github.backend": true}
+	for _, host := range podSpec.HostAliases[0].Hostnames {
+		if !expectedHosts[host] {
+			t.Errorf("unexpected hostname: %s", host)
+		}
+	}
+
+	// Verify InitContainers
+	if len(podSpec.InitContainers) != 1 {
+		t.Fatalf("expected 1 init container, got %d", len(podSpec.InitContainers))
+	}
+	initContainer := podSpec.InitContainers[0]
+	if initContainer.Name != "init-iptables" {
+		t.Errorf("expected init container name 'init-iptables', got '%s'", initContainer.Name)
+	}
+	if initContainer.Image != "init-iptables:latest" {
+		t.Errorf("expected init container image 'init-iptables:latest', got '%s'", initContainer.Image)
+	}
+	if initContainer.SecurityContext == nil || initContainer.SecurityContext.Capabilities == nil {
+		t.Fatalf("init container SecurityContext or Capabilities is nil")
+	}
+	if !slices.Contains(initContainer.SecurityContext.Capabilities.Add, "NET_ADMIN") {
+		t.Errorf("init container missing NET_ADMIN capability")
+	}
+
+	// Verify Containers
+	if len(podSpec.Containers) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(podSpec.Containers))
+	}
+
+	// Sandbox container
+	sandboxContainer := podSpec.Containers[0]
+	if sandboxContainer.Name != "sandbox" {
+		t.Errorf("expected first container to be 'sandbox', got '%s'", sandboxContainer.Name)
+	}
+	if sandboxContainer.SecurityContext == nil {
+		t.Fatalf("sandbox container SecurityContext is nil")
+	}
+	if sandboxContainer.SecurityContext.RunAsNonRoot == nil || !*sandboxContainer.SecurityContext.RunAsNonRoot {
+		t.Errorf("expected RunAsNonRoot to be true")
+	}
+	if sandboxContainer.SecurityContext.RunAsUser == nil || *sandboxContainer.SecurityContext.RunAsUser != 1000 {
+		t.Errorf("expected RunAsUser to be 1000")
+	}
+	if sandboxContainer.SecurityContext.AllowPrivilegeEscalation == nil || *sandboxContainer.SecurityContext.AllowPrivilegeEscalation {
+		t.Errorf("expected AllowPrivilegeEscalation to be false")
+	}
+
+	// Sidecar container
+	sidecarContainer := podSpec.Containers[1]
+	if sidecarContainer.Name != "service-portal-sidecar" {
+		t.Errorf("expected second container to be 'service-portal-sidecar', got '%s'", sidecarContainer.Name)
+	}
+	if sidecarContainer.Image != "all-in-one-portal:latest" {
+		t.Errorf("expected sidecar container image 'all-in-one-portal:latest', got '%s'", sidecarContainer.Image)
+	}
+	if sidecarContainer.SecurityContext == nil {
+		t.Fatalf("sidecar container SecurityContext is nil")
+	}
+	if sidecarContainer.SecurityContext.RunAsUser == nil || *sidecarContainer.SecurityContext.RunAsUser != 1337 {
+		t.Errorf("expected sidecar RunAsUser to be 1337")
+	}
+	if sidecarContainer.SecurityContext.RunAsGroup == nil || *sidecarContainer.SecurityContext.RunAsGroup != 1337 {
+		t.Errorf("expected sidecar RunAsGroup to be 1337")
+	}
+	if sidecarContainer.SecurityContext.AllowPrivilegeEscalation == nil || *sidecarContainer.SecurityContext.AllowPrivilegeEscalation {
+		t.Errorf("expected sidecar AllowPrivilegeEscalation to be false")
+	}
+	if sidecarContainer.SecurityContext.ReadOnlyRootFilesystem == nil || !*sidecarContainer.SecurityContext.ReadOnlyRootFilesystem {
+		t.Errorf("expected sidecar ReadOnlyRootFilesystem to be true")
+	}
+
+	// Verify Env
+	envMap := make(map[string]string)
+	for _, env := range sidecarContainer.Env {
+		if env.ValueFrom == nil {
+			envMap[env.Name] = env.Value
+		}
+	}
+	if envMap["SERVICE_NAMES"] != "gemini,github" {
+		t.Errorf("expected SERVICE_NAMES env to be 'gemini,github', got '%s'", envMap["SERVICE_NAMES"])
+	}
+	if envMap["GEMINI_TARGET_URL"] != "https://generativelanguage.googleapis.com" {
+		t.Errorf("expected GEMINI_TARGET_URL, got '%s'", envMap["GEMINI_TARGET_URL"])
+	}
+	if envMap["GEMINI_HOST"] != "gemini.backend" {
+		t.Errorf("expected GEMINI_HOST, got '%s'", envMap["GEMINI_HOST"])
+	}
+	if envMap["GITHUB_TARGET_URL"] != "https://api.github.com" {
+		t.Errorf("expected GITHUB_TARGET_URL, got '%s'", envMap["GITHUB_TARGET_URL"])
+	}
+	if envMap["GITHUB_HOST"] != "github.backend" {
+		t.Errorf("expected GITHUB_HOST, got '%s'", envMap["GITHUB_HOST"])
+	}
+}

--- a/examples/sandboxed-tools/pkg/sessions/store.go
+++ b/examples/sandboxed-tools/pkg/sessions/store.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// Store defines the interface for chat session persistence.
+type Store interface {
+	// LoadSession retrieves all messages for the given session ID.
+	// If the session does not exist, it returns a nil slice and no error.
+	LoadSession(ctx context.Context, sessionID string) ([]llm.Message, error)
+
+	// AppendMessage appends a single message to the session's history.
+	AppendMessage(ctx context.Context, sessionID string, message llm.Message) error
+}
+
+// FileStore is a JSONL implementation of the Store interface.
+type FileStore struct {
+	dir string
+}
+
+// NewFileStore creates a new FileStore with the given base directory.
+func NewFileStore(dir string) *FileStore {
+	return &FileStore{
+		dir: dir,
+	}
+}
+
+// ensureDir ensures that the session directory exists.
+func (s *FileStore) ensureDir() error {
+	if err := os.MkdirAll(s.dir, 0700); err != nil {
+		return fmt.Errorf("failed to create session directory %s: %w", s.dir, err)
+	}
+	return nil
+}
+
+// LoadSession reads all messages from the JSONL session file.
+func (s *FileStore) LoadSession(ctx context.Context, sessionID string) ([]llm.Message, error) {
+	filename := filepath.Join(s.dir, sessionID+".jsonl")
+	file, err := os.Open(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open session file %s: %w", filename, err)
+	}
+	defer file.Close()
+
+	var messages []llm.Message
+	decoder := json.NewDecoder(file)
+	for {
+		var msg llm.Message
+		if err := decoder.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("failed to decode message from session file: %w", err)
+		}
+		messages = append(messages, msg)
+	}
+
+	return messages, nil
+}
+
+// AppendMessage marshals and appends a single message to the session file.
+func (s *FileStore) AppendMessage(ctx context.Context, sessionID string, msg llm.Message) error {
+	if err := s.ensureDir(); err != nil {
+		return err
+	}
+
+	filename := filepath.Join(s.dir, sessionID+".jsonl")
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open session file %s: %w", filename, err)
+	}
+	defer file.Close()
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message to json: %w", err)
+	}
+
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("failed to write message to session file: %w", err)
+	}
+
+	return nil
+}

--- a/examples/sandboxed-tools/pkg/sessions/store_test.go
+++ b/examples/sandboxed-tools/pkg/sessions/store_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sessions
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+func TestFileStore(t *testing.T) {
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "sessions-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	store := NewFileStore(tempDir)
+
+	sessionID := "test-session-123"
+
+	// 1. Load non-existent session
+	msgs, err := store.LoadSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession failed for non-existent session: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("expected empty messages, got %d", len(msgs))
+	}
+
+	// 2. Append a message
+	sysPrompt := "You are a helpful assistant."
+	msg1 := llm.Message{
+		Role:    "system",
+		Content: &sysPrompt,
+	}
+	if err := store.AppendMessage(ctx, sessionID, msg1); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	// 3. Load and assert msg1
+	msgs, err = store.LoadSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" || msgs[0].Content == nil || *msgs[0].Content != sysPrompt {
+		t.Errorf("loaded message does not match: %+v", msgs[0])
+	}
+
+	// 4. Append more messages (user and assistant with tool calls)
+	userPrompt := "list files"
+	msg2 := llm.Message{
+		Role:    "user",
+		Content: &userPrompt,
+	}
+	if err := store.AppendMessage(ctx, sessionID, msg2); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	toolCall := llm.ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: llm.FunctionCall{
+			Name:      "list_files",
+			Arguments: `{"path": "."}`,
+		},
+	}
+	msg3 := llm.Message{
+		Role:      "assistant",
+		ToolCalls: []llm.ToolCall{toolCall},
+	}
+	if err := store.AppendMessage(ctx, sessionID, msg3); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	toolResult := "file1.txt\nfile2.txt"
+	msg4 := llm.Message{
+		Role:       "tool",
+		ToolCallID: "call_1",
+		Content:    &toolResult,
+	}
+	if err := store.AppendMessage(ctx, sessionID, msg4); err != nil {
+		t.Fatalf("AppendMessage failed: %v", err)
+	}
+
+	// 5. Load and assert everything
+	msgs, err = store.LoadSession(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("LoadSession failed: %v", err)
+	}
+	if len(msgs) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(msgs))
+	}
+
+	if msgs[1].Role != "user" || msgs[1].Content == nil || *msgs[1].Content != userPrompt {
+		t.Errorf("message 2 mismatch: %+v", msgs[1])
+	}
+	if msgs[2].Role != "assistant" || len(msgs[2].ToolCalls) != 1 || msgs[2].ToolCalls[0].ID != "call_1" {
+		t.Errorf("message 3 mismatch: %+v", msgs[2])
+	}
+	if msgs[3].Role != "tool" || msgs[3].ToolCallID != "call_1" || msgs[3].Content == nil || *msgs[3].Content != toolResult {
+		t.Errorf("message 4 mismatch: %+v", msgs[3])
+	}
+}

--- a/examples/sandboxed-tools/pkg/tools/interface.go
+++ b/examples/sandboxed-tools/pkg/tools/interface.go
@@ -35,11 +35,11 @@ type Sandbox interface {
 // ExecCommandResult holds the result of running a command in the sandbox.
 type ExecCommandResult struct {
 	// Stdout contains the captured standard output.
-	// This is only populated if ExecOptions.Stdout was nil.
+	// This is only populated if ExecCommandOptions.Stdout was nil.
 	Stdout string
 
 	// Stderr contains the captured standard error.
-	// This is only populated if ExecOptions.Stderr was nil.
+	// This is only populated if ExecCommandOptions.Stderr was nil.
 	Stderr string
 
 	// ExitCode is the exit status returned by the command.
@@ -56,10 +56,10 @@ type ExecCommandOptions struct {
 	Stdin io.Reader
 
 	// Stdout is an optional writer where standard output will be written.
-	// If nil, Stdout will be captured internally and returned as a string in the ExecutionResult.
+	// If nil, Stdout will be captured internally and returned as a string in the ExecCommandResult.
 	Stdout io.Writer
 
 	// Stderr is an optional writer where standard error will be written.
-	// If nil, Stderr will be captured internally and returned as a string in the ExecutionResult.
+	// If nil, Stderr will be captured internally and returned as a string in the ExecCommandResult.
 	Stderr io.Writer
 }

--- a/examples/sandboxed-tools/pkg/tools/interface.go
+++ b/examples/sandboxed-tools/pkg/tools/interface.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"io"
+
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// Tool is the interface for all LLM-callable tools.
+type Tool interface {
+	Schema() llm.Tool
+	Run(ctx context.Context, sandbox Sandbox) (llm.Message, error)
+}
+
+// Sandbox represents the interface for running commands in a sandbox.
+type Sandbox interface {
+	ExecCommand(ctx context.Context, opts ExecCommandOptions) (*ExecCommandResult, error)
+}
+
+// ExecCommandResult holds the result of running a command in the sandbox.
+type ExecCommandResult struct {
+	// Stdout contains the captured standard output.
+	// This is only populated if ExecOptions.Stdout was nil.
+	Stdout string
+
+	// Stderr contains the captured standard error.
+	// This is only populated if ExecOptions.Stderr was nil.
+	Stderr string
+
+	// ExitCode is the exit status returned by the command.
+	ExitCode int
+}
+
+// ExecCommandOptions holds the options for running a command in the sandbox.
+type ExecCommandOptions struct {
+
+	// Command is the process name and arguments to run (e.g. []string{"sh", "-c", "uname -a"}).
+	Command []string
+
+	// Stdin is an optional reader to pipe into the command's standard input.
+	Stdin io.Reader
+
+	// Stdout is an optional writer where standard output will be written.
+	// If nil, Stdout will be captured internally and returned as a string in the ExecutionResult.
+	Stdout io.Writer
+
+	// Stderr is an optional writer where standard error will be written.
+	// If nil, Stderr will be captured internally and returned as a string in the ExecutionResult.
+	Stderr io.Writer
+}

--- a/examples/sandboxed-tools/pkg/tools/list_files.go
+++ b/examples/sandboxed-tools/pkg/tools/list_files.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// ListFilesTool is a tool that lists files in the sandbox.
+// OpenClaw uses "ls" defined at https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/tools/ls.ts
+type ListFilesTool struct {
+	Path string `json:"path"`
+}
+
+func (t *ListFilesTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "ls",
+			Description: "List files in a directory.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Directory to list (default: current directory)",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *ListFilesTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	path := t.Path
+	if path == "" {
+		path = "."
+	}
+	log.Info("listing files in sandbox", "path", path)
+	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"ls", "-p", path},
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	result := llm.Message{
+		Content: &res.Stdout,
+	}
+
+	return result, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/read_file.go
+++ b/examples/sandboxed-tools/pkg/tools/read_file.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// ReadFileTool is a tool that reads file contents from the sandbox.
+type ReadFileTool struct {
+	Path string `json:"path"`
+}
+
+func (t *ReadFileTool) Schema() llm.Tool {
+	// Area of future investigation: do the models favor certain names (e.g. antigravity uses view_file)
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "read",
+			Description: "Read the contents of a file.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Path to the file to read (relative or absolute)",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *ReadFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	log.Info("reading file in sandbox", "path", t.Path)
+	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"cat", t.Path},
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	result := llm.Message{
+		Content: &res.Stdout,
+	}
+
+	return result, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/read_file.go
+++ b/examples/sandboxed-tools/pkg/tools/read_file.go
@@ -16,6 +16,7 @@ package tools
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
@@ -41,6 +42,7 @@ func (t *ReadFileTool) Schema() llm.Tool {
 						"description": "Path to the file to read (relative or absolute)",
 					},
 				},
+				"required": []string{"path"},
 			},
 		},
 	}
@@ -48,6 +50,10 @@ func (t *ReadFileTool) Schema() llm.Tool {
 
 func (t *ReadFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
 	log := klog.FromContext(ctx)
+
+	if t.Path == "" {
+		return llm.Message{}, fmt.Errorf("path is required")
+	}
 
 	log.Info("reading file in sandbox", "path", t.Path)
 	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{

--- a/examples/sandboxed-tools/pkg/tools/registry.go
+++ b/examples/sandboxed-tools/pkg/tools/registry.go
@@ -39,6 +39,9 @@ func NewRegistry() *Registry {
 
 // Add registers a new tool.
 func (r *Registry) Add(tool Tool) {
+	if tool == nil {
+		panic("cannot add nil tool to registry")
+	}
 	if reflect.TypeOf(tool).Kind() != reflect.Ptr {
 		panic(fmt.Sprintf("registered tool %T must be a pointer", tool))
 	}
@@ -69,7 +72,7 @@ func (r *Registry) All() []llm.Tool {
 func (r *Registry) Call(ctx context.Context, sandbox Sandbox, tc llm.ToolCall) (llm.Message, error) {
 	log := klog.FromContext(ctx)
 
-	log.Info("llm invoking tool", "tool.name", tc.Function.Name, "tool.arguments", tc.Function.Arguments)
+	log.Info("llm invoking tool", "tool.name", tc.Function.Name, "arguments.bytes", len(tc.Function.Arguments))
 
 	tool := r.tools[tc.Function.Name]
 	if tool == nil {

--- a/examples/sandboxed-tools/pkg/tools/registry.go
+++ b/examples/sandboxed-tools/pkg/tools/registry.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// Registry keeps track of available tools and handles their invocations.
+type Registry struct {
+	tools map[string]Tool
+}
+
+// NewRegistry initializes a new tool registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		tools: make(map[string]Tool),
+	}
+}
+
+// Add registers a new tool.
+func (r *Registry) Add(tool Tool) {
+	if reflect.TypeOf(tool).Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("registered tool %T must be a pointer", tool))
+	}
+	schema := tool.Schema()
+	name := schema.Function.Name
+	r.tools[name] = tool
+}
+
+// All returns schemas for all registered tools.
+func (r *Registry) All() []llm.Tool {
+	var list []llm.Tool
+	for _, tool := range r.tools {
+		list = append(list, tool.Schema())
+	}
+	slices.SortFunc(list, func(a, b llm.Tool) int {
+		if a.Function.Name < b.Function.Name {
+			return -1
+		}
+		if a.Function.Name > b.Function.Name {
+			return 1
+		}
+		return 0
+	})
+	return list
+}
+
+// Call executes a tool call inside the provided sandbox and returns the LLM tool response message.
+func (r *Registry) Call(ctx context.Context, sandbox Sandbox, tc llm.ToolCall) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	log.Info("llm invoking tool", "tool.name", tc.Function.Name, "tool.arguments", tc.Function.Arguments)
+
+	tool := r.tools[tc.Function.Name]
+	if tool == nil {
+		return llm.Message{}, fmt.Errorf("tool %q not found", tc.Function.Name)
+	}
+
+	toolType := reflect.TypeOf(tool).Elem()
+	toolInvocation := reflect.New(toolType).Interface().(Tool)
+
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), toolInvocation); err != nil {
+		return llm.Message{}, fmt.Errorf("failed to parse arguments: %w", err)
+	}
+
+	res, err := toolInvocation.Run(ctx, sandbox)
+	if err != nil {
+		return llm.Message{}, fmt.Errorf("failed to run tool: %w", err)
+	}
+
+	log.Info("tool result", "tool.name", tc.Function.Name, "result", res)
+
+	// Populate some default values so the tools don't all have to do it.
+	if res.Role == "" {
+		res.Role = "tool"
+	}
+	res.ToolCallID = tc.ID
+	return res, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/run_command.go
+++ b/examples/sandboxed-tools/pkg/tools/run_command.go
@@ -1,0 +1,69 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// RunCommand is a tool that runs shell commands in the sandbox.
+type RunCommand struct {
+	Command string `json:"command"`
+}
+
+func (t *RunCommand) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "run_command",
+			Description: "Executes a shell command inside a sandbox and returns the stdout and stderr.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"command": map[string]any{
+						"type":        "string",
+						"description": "The shell command to execute",
+					},
+				},
+				"required": []string{"command"},
+			},
+		},
+	}
+}
+
+func (t *RunCommand) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	log.Info("executing command in sandbox", "command", t.Command)
+	// TODO: Add a timeout to the tool execution?
+	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"sh", "-c", t.Command},
+	})
+
+	var toolResult string
+	if err != nil {
+		toolResult = fmt.Sprintf("Execution error: %v", err)
+	} else {
+		toolResult = fmt.Sprintf("stdout:\n%s\nstderr:\n%s\nexit_code: %d", res.Stdout, res.Stderr, res.ExitCode)
+	}
+
+	return llm.Message{
+		Content: &toolResult,
+	}, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/write_file.go
+++ b/examples/sandboxed-tools/pkg/tools/write_file.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
+)
+
+// WriteFileTool is a tool that writes content to a file in the sandbox.
+// OpenClaw uses "write" defined at https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/tools/write.ts
+type WriteFileTool struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+
+func (t *WriteFileTool) Schema() llm.Tool {
+	return llm.Tool{
+		Type: "function",
+		Function: llm.ToolFunction{
+			Name:        "write",
+			Description: "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path": map[string]any{
+						"type":        "string",
+						"description": "Path to the file to write (relative or absolute)",
+					},
+					"content": map[string]any{
+						"type":        "string",
+						"description": "Content to write to the file",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (t *WriteFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, error) {
+	log := klog.FromContext(ctx)
+
+	p := t.Path
+	if p == "" {
+		return llm.Message{}, fmt.Errorf("path is required")
+	}
+
+	dir := filepath.Dir(p)
+	log.Info("creating directory in sandbox", "dir", dir)
+	if _, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"mkdir", "-p", dir},
+	}); err != nil {
+		return llm.Message{}, fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	log.Info("writing file in sandbox", "path", p)
+	response, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"tee", p},
+		Stdin:   bytes.NewBufferString(t.Content),
+	})
+	if err != nil {
+		return llm.Message{}, err
+	}
+
+	content := strings.TrimSpace(response.Stdout)
+	if content == "" {
+		content = fmt.Sprintf("Wrote file %q", p)
+	}
+	result := llm.Message{
+		Content: &content,
+	}
+
+	return result, nil
+}

--- a/examples/sandboxed-tools/pkg/tools/write_file.go
+++ b/examples/sandboxed-tools/pkg/tools/write_file.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
@@ -50,6 +49,7 @@ func (t *WriteFileTool) Schema() llm.Tool {
 						"description": "Content to write to the file",
 					},
 				},
+				"required": []string{"path", "content"},
 			},
 		},
 	}
@@ -72,18 +72,15 @@ func (t *WriteFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, 
 	}
 
 	log.Info("writing file in sandbox", "path", p)
-	response, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
-		Command: []string{"tee", p},
+	_, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
+		Command: []string{"sh", "-c", `cat > "$1"`, "--", p},
 		Stdin:   bytes.NewBufferString(t.Content),
 	})
 	if err != nil {
 		return llm.Message{}, err
 	}
 
-	content := strings.TrimSpace(response.Stdout)
-	if content == "" {
-		content = fmt.Sprintf("Wrote file %q", p)
-	}
+	content := fmt.Sprintf("Successfully wrote %d bytes to %q", len(t.Content), p)
 	result := llm.Message{
 		Content: &content,
 	}


### PR DESCRIPTION
- **examples/sandboxed-tools: refactor tools into their own package**
  This lets us add more tools in a reasonable way, as most claw-style systems use a handful of tools.
  

- **examples/sandboxed-tools: persist sessions across invocations**
  This means we don't have to start again every time.
  
  Format is jsonl in the local filesystem;
  an interface means that a server could use a database instead.
  

- **examples/sandboxed-tools: we can keep the sandbox alive over multiple tool calls**
  We don't need to constantly restart a new sandbox, and this makes the system much faster.
  

- **examples/sandboxed-tools: support service-portals**
  

- **examples/sandboxed-tools: managed images**
  

- **llm: retry on failures**
  

- **fixup! examples/sandboxed-tools: managed images**
  