### PR TITLE
Update setup.sh to utilize dataplane-v2

### DIFF
--- a/examples/kata-gke-sandbox/setup.sh
+++ b/examples/kata-gke-sandbox/setup.sh
@@ -77,6 +77,8 @@ else
         --num-nodes "${NUM_NODES}" \
         --machine-type "${MACHINE_TYPE}" \
         --image-type "${IMAGE_TYPE}" \
+        --enable-dataplane-v2 \
+        --enable-ip-alias \
         --enable-nested-virtualization; then
         echo "### GKE Cluster creation failed. ###"
         exit 1


### PR DESCRIPTION
Dataplane-v2 is recommended for high performance, larger scale, and network policies.

#### What this PR does / why we need it:
Enable DPv2 during cluster creation.

#### Which issue(s) this PR is related to:
N/A

#### Release Note
NONE
