### PR TITLE
fix: correct markdown typos in analytics-tool README

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -137,8 +137,10 @@ type SandboxSpec struct {
 
 	// volumeClaimTemplates is a list of claims that the sandbox pod is allowed to reference.
 	// Every claim in this list must have at least one matching access mode with a provisioner volume.
+	// This field is immutable after creation.
 	// +optional
 	// +listType=atomic
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeClaimTemplates is immutable"
 	VolumeClaimTemplates []PersistentVolumeClaimTemplate `json:"volumeClaimTemplates,omitempty"`
 
 	// Lifecycle defines when and how the sandbox should be shut down.

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,7 +143,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `podTemplate` _[PodTemplate](#podtemplate)_ | podTemplate describes the pod spec that will be used to create an agent sandbox. |  | Required: \{\} <br /> |
-| `volumeClaimTemplates` _[PersistentVolumeClaimTemplate](#persistentvolumeclaimtemplate) array_ | volumeClaimTemplates is a list of claims that the sandbox pod is allowed to reference.<br />Every claim in this list must have at least one matching access mode with a provisioner volume. |  | Optional: \{\} <br /> |
+| `volumeClaimTemplates` _[PersistentVolumeClaimTemplate](#persistentvolumeclaimtemplate) array_ | volumeClaimTemplates is a list of claims that the sandbox pod is allowed to reference.<br />Every claim in this list must have at least one matching access mode with a provisioner volume.<br />This field is immutable after creation. |  | Optional: \{\} <br /> |
 | `shutdownTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_ | shutdownTime is the absolute time when the sandbox expires. |  | Format: date-time <br />Optional: \{\} <br /> |
 | `shutdownPolicy` _[ShutdownPolicy](#shutdownpolicy)_ | shutdownPolicy determines if the Sandbox resource itself should be deleted when it expires.<br />Underlying resources(Pods, Services) are always deleted on expiry. | Retain | Enum: [Delete Retain] <br />Optional: \{\} <br /> |
 | `replicas` _integer_ | replicas is the number of desired replicas.<br />The only allowed values are 0 and 1.<br />Defaults to 1. | 1 | Maximum: 1 <br />Minimum: 0 <br />Optional: \{\} <br /> |

--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -3,9 +3,9 @@
 ## Getting Started
 
 ### Prerequisites
-- Running **GKE** cluster (**Standard** or **Autopilot**))
+- Running **GKE** cluster (**Standard** or **Autopilot**)
 - `kubectl` access to a Kubernetes **GKE Standard** or **GKE Autopilot** cluster
-- Agent-sandbox installed on GKE. Here is the ([Installation Guide](../../getting_started/))
+- Agent-sandbox installed on GKE. Here is the [Installation Guide](../../getting_started/)
 
 ## Deploy analytics tools
 

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3956,6 +3956,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: volumeClaimTemplates is immutable
+                  rule: self == oldSelf
             required:
             - podTemplate
             type: object

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -3956,6 +3956,9 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: volumeClaimTemplates is immutable
+                  rule: self == oldSelf
             required:
             - podTemplate
             type: object


### PR DESCRIPTION
Fix extra closing parenthesis and broken link syntax in prerequisites section.