### PR TITLE
fix: correct markdown typos in analytics-tool README

### DIFF
--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -3,9 +3,9 @@
 ## Getting Started
 
 ### Prerequisites
-- Running **GKE** cluster (**Standard** or **Autopilot**))
+- Running **GKE** cluster (**Standard** or **Autopilot**)
 - `kubectl` access to a Kubernetes **GKE Standard** or **GKE Autopilot** cluster
-- Agent-sandbox installed on GKE. Here is the ([Installation Guide](../../getting_started/))
+- Agent-sandbox installed on GKE. Here is the [Installation Guide](../../getting_started/)
 
 ## Deploy analytics tools
 


### PR DESCRIPTION
Fix extra closing parenthesis and broken link syntax in prerequisites section.