### PR TITLE
fix(extensions): record correct launch type and pod condition for SandboxClaim cold starts

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -243,7 +243,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, errs
 	}
 
-	r.recordCreationLatencyMetric(ctx, claim, originalClaimStatus, sandbox)
+	r.recordReadyTransitionMetrics(ctx, claim, originalClaimStatus, sandbox)
 
 	// Determine Result
 	var result ctrl.Result
@@ -780,13 +780,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			if r.Recorder != nil {
 				r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxAdopted", "Adoption", "Adopted warm pool Sandbox %q", adopted.Name)
 			}
-
-			podCondition := "not_ready"
-			if isSandboxReady(adopted) {
-				podCondition = "ready"
-			}
-			templateName := r.resolveTemplateName(adopted)
-			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition)
+			r.recordSandboxClaimCreation(claim, adopted)
 
 			return true, nil
 		}()
@@ -894,6 +888,9 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 
 // isSandboxReady checks if a sandbox has Ready=True condition.
 func isSandboxReady(sb *v1beta1.Sandbox) bool {
+	if sb == nil {
+		return false
+	}
 	for _, cond := range sb.Status.Conditions {
 		if cond.Type == string(v1beta1.SandboxConditionReady) && cond.Status == metav1.ConditionTrue {
 			return true
@@ -1193,7 +1190,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxProvisioned", "Provisioning", "Created Sandbox %q", sandbox.Name)
 	}
 
-	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, "none", "not_ready")
+	r.recordSandboxClaimCreation(claim, sandbox)
 
 	return sandbox, nil
 }
@@ -1560,7 +1557,10 @@ func getLaunchType(sandbox *v1beta1.Sandbox) string {
 	if sandbox == nil {
 		return asmetrics.LaunchTypeUnknown
 	}
-	if sandbox.Labels[v1beta1.SandboxLaunchTypeLabel] == v1beta1.SandboxLaunchTypeWarm {
+	if controllerRef := metav1.GetControllerOf(sandbox); controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
+		return asmetrics.LaunchTypeWarm
+	}
+	if sandbox.Labels != nil && sandbox.Labels[v1beta1.SandboxLaunchTypeLabel] == v1beta1.SandboxLaunchTypeWarm {
 		return asmetrics.LaunchTypeWarm
 	}
 	return asmetrics.LaunchTypeCold
@@ -1618,8 +1618,8 @@ func (r *SandboxClaimReconciler) recordSandboxCreationLatency(sandbox *v1beta1.S
 	}
 }
 
-// recordCreationLatencyMetric detects and records transitions to Ready state.
-func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
+// recordReadyTransitionMetrics detects and records the first transition to Ready state per claim.
+func (r *SandboxClaimReconciler) recordReadyTransitionMetrics(
 	ctx context.Context,
 	claim *extensionsv1beta1.SandboxClaim,
 	oldStatus *extensionsv1beta1.SandboxClaimStatus,
@@ -1644,6 +1644,23 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 		return
 	}
 
+	// Drain any entry recorded via CreateFunc/UpdateFunc + getOrRecordObservedTime
+	// for this claim's first transition to Ready. This covers the in-memory
+	// "controller first saw this claim" timestamp (used to backfill the
+	// ObservabilityAnnotation and for startup latency tracking). We must drain
+	// here so entries are not leaked for claims that never carried the annotation
+	// or that hit the warm-adoption guard below (which intentionally skips
+	// metric recording to avoid double-counting).
+	key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+	if entry, ok := r.observedTimes.Load(key); ok && entry.uid == claim.UID {
+		r.observedTimes.Delete(key)
+	}
+
+	// Avoid double-recording the "ready" metric when we just adopted an already-Ready
+	// sandbox from the warm pool (adoptSandboxFromCandidates already recorded it).
+	if oldStatus.SandboxStatus.Name == "" && isSandboxReady(sandbox) {
+		return
+	}
 	launchType := getLaunchType(sandbox)
 
 	sandboxName := "none"
@@ -1658,6 +1675,25 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	r.recordClaimStartupLatency(ctx, claim, launchType, templateName)
 	r.recordControllerStartupLatency(ctx, claim, launchType, templateName)
 	r.recordSandboxCreationLatency(sandbox, launchType, templateName)
+	r.recordSandboxClaimCreation(claim, sandbox)
+}
+
+// recordSandboxClaimCreation records the claim creation counter using the sandbox's current readiness.
+// Call sites typically emit an initial "not_ready" at creation/adoption and then a "ready" increment
+// on the claim's first transition to Ready (via recordReadyTransitionMetrics).
+func (r *SandboxClaimReconciler) recordSandboxClaimCreation(claim *extensionsv1beta1.SandboxClaim, sandbox *v1beta1.Sandbox) {
+	if sandbox == nil {
+		asmetrics.RecordSandboxClaimCreation(claim.Namespace, "__unknown__", asmetrics.LaunchTypeUnknown, claim.Spec.WarmPoolRef.Name, "not_ready")
+		return
+	}
+
+	podCondition := "not_ready"
+	if isSandboxReady(sandbox) {
+		podCondition = "ready"
+	}
+	launchType := getLaunchType(sandbox)
+	templateName := r.resolveTemplateName(sandbox)
+	asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, launchType, claim.Spec.WarmPoolRef.Name, podCondition)
 }
 
 func hasSandboxExpiredCondition(conditions []metav1.Condition) bool {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2521,7 +2521,7 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 				tc.setupReconciler(r)
 			}
 
-			r.recordCreationLatencyMetric(ctx, tc.claim, tc.oldStatus, tc.sandbox)
+			r.recordReadyTransitionMetrics(ctx, tc.claim, tc.oldStatus, tc.sandbox)
 
 			// Verify the metric was observed in the Prometheus registry
 			count := testutil.CollectAndCount(asmetrics.ClaimStartupLatency)
@@ -2578,7 +2578,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		}
 
 		// Verify metric
-		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "none", "not_ready"))
+		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready"))
 		if val != 1 {
 			t.Errorf("expected metric count 1, got %v", val)
 		}
@@ -4060,5 +4060,335 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 			}
 			require.Equal(t, tc.expectedRemainingKeys, actualRemaining)
 		})
+	}
+}
+
+// Test_RecordSandboxClaimCreation_WarmPath exercises the warm adoption path through
+// reconcileActive->getOrCreateSandbox -> adoptSandboxFromCandidates
+// It verifies the "not_ready" recording first,
+// then after the adopted sandbox is marked Ready, a subsequent full Reconcile triggers
+// for the "ready" recording.
+func Test_RecordSandboxClaimCreation_WarmPath(t *testing.T) {
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}},
+				},
+			},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-warmpool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"}},
+	}
+
+	// Create a warm-pool-owned candidate sandbox (not yet adopted by any claim).
+	// It must pass isAdoptable and be added to the WarmSandboxQueue so that
+	// getOrCreateSandbox -> adoptSandboxFromCandidates is taken, leading to the
+	// record call at 731 (with sandbox==nil, forcing not_ready + LaunchTypeUnknown).
+	poolNameHash := sandboxcontrollers.NameHash("test-warmpool")
+	warmCandidate := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-sb",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			Annotations: map[string]string{
+				sandboxv1beta1.SandboxTemplateRefAnnotation: "test-template",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-warmpool",
+				UID:        "pool-uid",
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			},
+		},
+		// Intentionally not Ready yet; the first recording (via 731) will be not_ready.
+	}
+
+	scheme := newScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, warmPool, claim, warmCandidate).WithStatusSubresource(claim).Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	if isAdoptable(warmCandidate) == nil {
+		warmPoolName := getWarmPoolName(warmCandidate)
+		key := queue.SandboxKey{Namespace: warmCandidate.Namespace, Name: warmCandidate.Name}
+		warmSandboxQueue.Add(warmPoolName, key)
+	}
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           client,
+		Scheme:           scheme,
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}}
+
+	// First Reconcile exercises adoption (731) and records not_ready.
+	asmetrics.SandboxClaimCreationTotal.Reset()
+
+	for range 5 {
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile (warm adopt, not_ready) failed: %v", err)
+		}
+	}
+
+	// Adoption path (nil sandbox) always records with WarmPoolRef.Name in the template slot,
+	// LaunchTypeUnknown, "none" for warm pool name slot, "not_ready".
+	val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues(claim.Namespace, template.Name, asmetrics.LaunchTypeWarm, claim.Spec.WarmPoolRef.Name, "not_ready"))
+	if val != 1 {
+		t.Errorf("expected warm/not_ready count 1 via recordSandboxClaimCreation, got %v", val)
+	}
+	//sandbox is not ready yet so the metric should be false.
+	val = testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues(claim.Namespace, template.Name, asmetrics.LaunchTypeWarm, claim.Spec.WarmPoolRef.Name, "ready"))
+	if val != 0 {
+		t.Errorf("expected warm/ready count 0 (sandbox not ready yet), got %v", val)
+	}
+
+	// Simulate the (adopted) sandbox becoming Ready. The sandbox retains its original name.
+	currentSB := &sandboxv1beta1.Sandbox{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "warm-sb", Namespace: "default"}, currentSB); err != nil {
+		t.Fatalf("get sandbox after first: %v", err)
+	}
+	currentSB.Status.Conditions = []metav1.Condition{{
+		Type:   string(sandboxv1beta1.SandboxConditionReady),
+		Status: metav1.ConditionTrue,
+		Reason: "Ready",
+	}}
+	if err := client.Update(ctx, currentSB); err != nil {
+		t.Fatalf("update sandbox to ready: %v", err)
+	}
+
+	// Second Reconcile: sandbox is ready, claim status becomes Ready.
+	for range 5 {
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile (warm adopt follow-up, ready) failed: %v", err)
+		}
+	}
+
+	// On ready path we resolve real template + launch type (warm because of adoptedFrom annotation set during adoption).
+	val = testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues(claim.Namespace, "test-template", asmetrics.LaunchTypeWarm, claim.Spec.WarmPoolRef.Name, "ready"))
+	if val != 1 {
+		t.Errorf("expected warm/ready count 1 via recordSandboxClaimCreation, got %v", val)
+	}
+}
+
+// TestRecordSandboxClaimCreation_ColdPath exercises the cold create path through
+// createSandbox (hitting recordSandboxClaimCreation for the initial
+// "not_ready" recording).
+func Test_RecordSandboxClaimCreation_ColdPath(t *testing.T) {
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}},
+				},
+			},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-warmpool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"}},
+	}
+
+	scheme := newScheme(t)
+	// No pre-existing sandbox and an empty warm queue: getOrCreateSandbox returns nil,
+	// cold path is taken, getTemplate succeeds (because warmPool exists), createSandbox
+	// runs and calls recordSandboxClaimCreation (line 1147).
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, warmPool, claim).WithStatusSubresource(claim).Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           client,
+		Scheme:           scheme,
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}}
+
+	// First Reconcile: cold create -> records not_ready (sandbox just created is not ready).
+	asmetrics.SandboxClaimCreationTotal.Reset()
+	for range 5 {
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile (cold, not_ready) failed: %v", err)
+		}
+	}
+
+	// Cold create path resolves template name from the sandbox annotation and uses the
+	// claim's WarmPoolRef.Name for the warm pool dimension.
+	val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "test-warmpool", "not_ready"))
+	if val != 1 {
+		t.Errorf("expected cold/not_ready count 1 via recordSandboxClaimCreation, got %v", val)
+	}
+
+	// Simulate the sandbox (created with name == claim.Name for cold starts) becoming ready.
+	currentSB := &sandboxv1beta1.Sandbox{}
+	if err := client.Get(ctx, types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}, currentSB); err != nil {
+		t.Fatalf("get sandbox after first: %v", err)
+	}
+	currentSB.Status.Conditions = []metav1.Condition{{
+		Type:   string(sandboxv1beta1.SandboxConditionReady),
+		Status: metav1.ConditionTrue,
+		Reason: "Ready",
+	}}
+	if err := client.Update(ctx, currentSB); err != nil {
+		t.Fatalf("update sandbox to ready: %v", err)
+	}
+
+	// Second Reconcile: sandbox now ready
+	for range 5 {
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile (cold follow-up, ready) failed: %v", err)
+		}
+	}
+
+	val = testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "test-warmpool", "ready"))
+	if val != 1 {
+		t.Errorf("expected cold/ready count 1 via recordSandboxClaimCreation, got %v", val)
+	}
+}
+
+// Test_RecordSandboxClaimCreation_WarmPath_AlreadyReadySandbox exercises the warm
+// adoption path when the SandboxWarmPool candidate is *already* Ready=True.
+//
+// In this scenario:
+//   - adoptSandboxFromCandidates calls recordSandboxClaimCreation(...) with a ready sandbox
+//     (records "ready" once).
+//   - Later in the *same* Reconcile, computeAndSetStatus + recordReadyTransitionMetrics
+//     also detects the claim status transition to Ready and calls recordSandboxClaimCreation
+//     again (tries to record "ready" a second time).
+func Test_RecordSandboxClaimCreation_WarmPath_AlreadyReadySandbox(t *testing.T) {
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}},
+				},
+			},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-warmpool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"}},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash("test-warmpool")
+	warmCandidate := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-sb",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			Annotations: map[string]string{
+				sandboxv1beta1.SandboxTemplateRefAnnotation: "test-template",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-warmpool",
+				UID:        "pool-uid",
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container", Image: "test-image"}}},
+			},
+		},
+		// Already Ready → triggers duplicate recording
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+
+	scheme := newScheme(t)
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, warmCandidate).
+		WithStatusSubresource(claim).
+		Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	if isAdoptable(warmCandidate) == nil {
+		warmPoolName := getWarmPoolName(warmCandidate)
+		key := queue.SandboxKey{Namespace: warmCandidate.Namespace, Name: warmCandidate.Name}
+		warmSandboxQueue.Add(warmPoolName, key)
+	}
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           client,
+		Scheme:           scheme,
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	ctx := context.Background()
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}}
+
+	asmetrics.SandboxClaimCreationTotal.Reset()
+
+	// One reconcile is enough to adopt + transition claim to Ready (we still do a few for stability)
+	for range 5 {
+		if _, err := reconciler.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile (warm adopt already-ready) failed: %v", err)
+		}
+	}
+
+	// Because the adopted sandbox was already Ready, we get:
+	// record from adoptSandboxFromCandidates (inside completeAdoption success path)
+	// record from recordReadyTransitionMetrics (claim status transition in same reconcile)
+	// tests duplication for the exact same label set.
+	val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues(
+		claim.Namespace, "test-template", asmetrics.LaunchTypeWarm, claim.Spec.WarmPoolRef.Name, "ready"))
+	if val != 1 {
+		t.Errorf("expected warm/ready count == 1 , got %v", val)
+	}
+
+	// Should be zero for not_ready in this path
+	val = testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues(
+		claim.Namespace, "test-template", asmetrics.LaunchTypeWarm, claim.Spec.WarmPoolRef.Name, "not_ready"))
+	if val != 0 {
+		t.Errorf("expected warm/not_ready count == 0, got %v", val)
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the cold-start metric problem for `SandboxClaim` (#872).
- Restores `reconcileConditions` called after both the fast-path (`if` at ~340) and cold-path (`else` at ~380) in `reconcileActive`.
- Now uses `getLaunchType(sandbox)` instead of hardcoding `LaunchTypeWarm`, so cold starts correctly emit under `cold` + both `not_ready` and `ready`.
- Preserves original warm pool name via annotation for adopted sandboxes.

#### Which issue(s) this PR is related to:

Fixes #872


#### Release Note

```release-note
agent_sandbox_claim_creation_total` for `SandboxClaim` now correctly uses `launch_type=cold` (and observes `pod_condition=ready` transitions) for cold starts.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and improved metrics for sandbox provisioning: readiness transitions now use a dedicated readiness-transition recorder, creation metrics emitted via a single helper, launch-type detection and nil-sandbox handling clarified, and a guard added to prevent double-counting during warm-pool adoption.

* **Tests**
  * Added tests for warm-pool adoption, cold-start provisioning, and an already-ready warm candidate to validate "not-ready" vs "ready" metric recordings and correct labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->