### PR TITLE
Add warm pool create rate limiting

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -67,6 +67,8 @@ func main() {
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
 	var sandboxWarmPoolMaxBatchSize int
+	var sandboxWarmPoolMaxCreateRatePerWindow int
+	var sandboxWarmPoolCreateRateWindow time.Duration
 	var enableWarmPoolEviction bool
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
@@ -97,6 +99,8 @@ func main() {
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300.")
+	flag.IntVar(&sandboxWarmPoolMaxCreateRatePerWindow, "sandbox-warm-pool-max-create-rate-per-window", 0, "Max warm pool sandboxes to create per rate window. 0 disables create rate limiting.")
+	flag.DurationVar(&sandboxWarmPoolCreateRateWindow, "sandbox-warm-pool-create-rate-window", 0, "Warm pool sandbox create rate limit window. Must be set with --sandbox-warm-pool-max-create-rate-per-window.")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
 	opts := zap.Options{
 		Development: false,
@@ -117,6 +121,8 @@ func main() {
 		"sandboxWarmPool", sandboxWarmPoolConcurrentWorkers,
 		"sandboxTemplate", sandboxTemplateConcurrentWorkers,
 		"sandboxWarmPoolMaxBatchSize", sandboxWarmPoolMaxBatchSize,
+		"sandboxWarmPoolMaxCreateRatePerWindow", sandboxWarmPoolMaxCreateRatePerWindow,
+		"sandboxWarmPoolCreateRateWindow", sandboxWarmPoolCreateRateWindow,
 	)
 
 	// Validation checks for concurrency flags
@@ -127,6 +133,18 @@ func main() {
 	// Validation checks for sandboxWarmPoolMaxBatchSize (maximum batch size for sandbox creation and deletion in SandboxWarmPool controller)
 	if sandboxWarmPoolMaxBatchSize <= 0 {
 		setupLog.Error(nil, "sandbox-warm-pool-max-batch-size must be greater than 0")
+		os.Exit(1)
+	}
+	if sandboxWarmPoolMaxCreateRatePerWindow < 0 {
+		setupLog.Error(nil, "sandbox-warm-pool-max-create-rate-per-window must be greater than or equal to 0")
+		os.Exit(1)
+	}
+	if sandboxWarmPoolCreateRateWindow < 0 {
+		setupLog.Error(nil, "sandbox-warm-pool-create-rate-window must be greater than or equal to 0")
+		os.Exit(1)
+	}
+	if (sandboxWarmPoolMaxCreateRatePerWindow == 0) != (sandboxWarmPoolCreateRateWindow == 0) {
+		setupLog.Error(nil, "sandbox warm pool create rate limit requires both max-create-rate-per-window and create-rate-window to be set, or both disabled")
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -294,6 +312,8 @@ func main() {
 			Client:                 mgr.GetClient(),
 			Scheme:                 mgr.GetScheme(),
 			MaxBatchSize:           sandboxWarmPoolMaxBatchSize,
+			MaxCreateRatePerWindow: sandboxWarmPoolMaxCreateRatePerWindow,
+			CreateRateWindow:       sandboxWarmPoolCreateRateWindow,
 			EnableWarmPoolEviction: enableWarmPoolEviction,
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -57,7 +58,16 @@ type SandboxWarmPoolReconciler struct {
 	client.Client
 	Scheme                 *runtime.Scheme
 	MaxBatchSize           int
+	MaxCreateRatePerWindow int
+	CreateRateWindow       time.Duration
 	EnableWarmPoolEviction bool
+	createRateMu           sync.Mutex
+	createRateWindows      map[types.NamespacedName]createRateWindow
+}
+
+type createRateWindow struct {
+	startedAt time.Time
+	created   int
 }
 
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools,verbs=get;list;watch;create;update;patch;delete
@@ -90,8 +100,9 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	oldStatus := warmPool.Status.DeepCopy()
 
 	// Reconcile the pool (create or delete Sandboxes as needed)
-	if err := r.reconcilePool(ctx, warmPool); err != nil {
-		return ctrl.Result{}, err
+	result, err := r.reconcilePoolWithResult(ctx, warmPool)
+	if err != nil {
+		return result, err
 	}
 
 	// Update status if it has changed
@@ -100,11 +111,18 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 // reconcilePool ensures the correct number of pre-allocated sandboxes exist in the pool.
 func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool) error {
+	_, err := r.reconcilePoolWithResult(ctx, warmPool)
+	return err
+}
+
+// reconcilePoolWithResult ensures the correct number of pre-allocated sandboxes
+// exist in the pool and returns a requeue result when creation is rate-limited.
+func (r *SandboxWarmPoolReconciler) reconcilePoolWithResult(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Compute hash of the warm pool name for the pool label
@@ -121,7 +139,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		Namespace:     warmPool.Namespace,
 	}); err != nil {
 		logger.Error(err, "Failed to list sandboxes")
-		return err
+		return ctrl.Result{}, err
 	}
 
 	// Fetch template and compute hash once to avoid repeated expensive operations
@@ -174,8 +192,22 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 
 	// Create new sandboxes if we need more
 	if currentReplicas < desiredReplicas && tmplErr == nil {
-		sandboxesToCreate := min(desiredReplicas-currentReplicas, maxBatchSize)
-		logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
+		deficit := desiredReplicas - currentReplicas
+		sandboxesToCreate := int(min(deficit, maxBatchSize))
+		createCount, requeueAfter := r.reserveCreateRate(warmPool, sandboxesToCreate)
+
+		if createCount == 0 {
+			logger.Info("Delaying warm pool sandbox creation",
+				"remainingDelay", requeueAfter.Round(time.Millisecond),
+				"desired", desiredReplicas,
+				"current", currentReplicas,
+				"deficit", deficit,
+				"maxCreateRatePerWindow", r.MaxCreateRatePerWindow,
+				"createRateWindow", r.CreateRateWindow)
+			return ctrl.Result{RequeueAfter: requeueAfter}, allErrors
+		}
+
+		logger.Info("Creating new pool sandboxes", "count", createCount, "deficit", deficit)
 
 		sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash)
 		if err != nil {
@@ -183,13 +215,17 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 			allErrors = errors.Join(allErrors, err)
 		} else {
 			// Parallel sandbox creation with adaptive slow-start batching (starts with 1 and doubles on success)
-			_, createErr := slowStartBatch(ctx, int(sandboxesToCreate), 1, func(_ int) error {
+			_, createErr := slowStartBatch(ctx, createCount, 1, func(_ int) error {
 				return r.createPoolSandbox(ctx, warmPool, sandboxCR)
 			})
 			if createErr != nil {
 				logger.Error(createErr, "Failed to create pool sandboxes")
 				allErrors = errors.Join(allErrors, createErr)
 			}
+		}
+
+		if createCount < sandboxesToCreate {
+			return ctrl.Result{RequeueAfter: requeueAfter}, allErrors
 		}
 	}
 
@@ -227,7 +263,51 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		allErrors = errors.Join(allErrors, tmplErr)
 	}
 
-	return allErrors
+	return ctrl.Result{}, allErrors
+}
+
+func (r *SandboxWarmPoolReconciler) reserveCreateRate(warmPool *extensionsv1beta1.SandboxWarmPool, requested int) (int, time.Duration) {
+	if r.MaxCreateRatePerWindow <= 0 || r.CreateRateWindow <= 0 {
+		return requested, 0
+	}
+
+	now := time.Now()
+	key := types.NamespacedName{Name: warmPool.Name, Namespace: warmPool.Namespace}
+
+	r.createRateMu.Lock()
+	defer r.createRateMu.Unlock()
+
+	if r.createRateWindows == nil {
+		r.createRateWindows = make(map[types.NamespacedName]createRateWindow)
+	}
+
+	window, ok := r.createRateWindows[key]
+	if !ok || now.Sub(window.startedAt) >= r.CreateRateWindow {
+		window = createRateWindow{startedAt: now}
+	}
+
+	remainingBudget := r.MaxCreateRatePerWindow - window.created
+	if remainingBudget <= 0 {
+		r.createRateWindows[key] = window
+		return 0, remainingCreateRateWindowDelay(now, window.startedAt, r.CreateRateWindow)
+	}
+
+	createCount := min(requested, remainingBudget)
+	window.created += createCount
+	r.createRateWindows[key] = window
+
+	if createCount < requested {
+		return createCount, remainingCreateRateWindowDelay(now, window.startedAt, r.CreateRateWindow)
+	}
+	return createCount, 0
+}
+
+func remainingCreateRateWindowDelay(now, startedAt time.Time, window time.Duration) time.Duration {
+	remaining := window - now.Sub(startedAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
 }
 
 // adoptSandbox sets this warmpool as the owner of an orphaned sandbox.

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -230,6 +230,147 @@ func TestReconcilePool(t *testing.T) {
 	}
 }
 
+func TestReconcilePoolCreateRateLimit(t *testing.T) {
+	poolName := "test-pool"
+	poolNamespace := "default"
+	templateName := "test-template"
+	replicas := int32(5)
+
+	template := createTemplate(poolNamespace)
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+			UID:       "warmpool-uid-123",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas: replicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{
+				Name: templateName,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	scheme := newTestScheme()
+	r := SandboxWarmPoolReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(template).
+			Build(),
+		Scheme:                 scheme,
+		MaxBatchSize:           sandboxCreateDeleteMaxBatchSize,
+		MaxCreateRatePerWindow: 2,
+		CreateRateWindow:       10 * time.Second,
+	}
+
+	countSandboxes := func(t *testing.T) int32 {
+		t.Helper()
+		list := &sandboxv1beta1.SandboxList{}
+		err := r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace})
+		require.NoError(t, err)
+		return int32(len(list.Items))
+	}
+
+	result, err := r.reconcilePoolWithResult(ctx, warmPool)
+	require.NoError(t, err)
+	require.Greater(t, result.RequeueAfter, time.Duration(0))
+	require.LessOrEqual(t, result.RequeueAfter, 10*time.Second)
+	require.Equal(t, int32(2), countSandboxes(t))
+
+	result, err = r.reconcilePoolWithResult(ctx, warmPool)
+	require.NoError(t, err)
+	require.Greater(t, result.RequeueAfter, time.Duration(0))
+	require.LessOrEqual(t, result.RequeueAfter, 10*time.Second)
+	require.Equal(t, int32(2), countSandboxes(t), "rate limit should prevent immediate next create batch")
+
+	key := types.NamespacedName{Name: poolName, Namespace: poolNamespace}
+	r.createRateMu.Lock()
+	r.createRateWindows[key] = createRateWindow{startedAt: time.Now().Add(-11 * time.Second)}
+	r.createRateMu.Unlock()
+
+	result, err = r.reconcilePoolWithResult(ctx, warmPool)
+	require.NoError(t, err)
+	require.Greater(t, result.RequeueAfter, time.Duration(0))
+	require.LessOrEqual(t, result.RequeueAfter, 10*time.Second)
+	require.Equal(t, int32(4), countSandboxes(t))
+}
+
+func TestReconcilePoolCreateRateLimitAcrossSingleDeficitReconciles(t *testing.T) {
+	poolName := "test-pool"
+	poolNamespace := "default"
+	templateName := "test-template"
+	replicas := int32(5)
+
+	template := createTemplate(poolNamespace)
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+			UID:       "warmpool-uid-123",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas: replicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{
+				Name: templateName,
+			},
+		},
+	}
+
+	poolNameHash := sandboxcontrollers.NameHash(poolName)
+	initialSandboxes := []runtime.Object{template}
+	for _, suffix := range []string{"-a", "-b", "-c", "-d"} {
+		initialSandboxes = append(initialSandboxes, createPoolSandbox(poolName, poolNamespace, poolNameHash, template, suffix))
+	}
+
+	ctx := context.Background()
+	scheme := newTestScheme()
+	r := SandboxWarmPoolReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(initialSandboxes...).
+			Build(),
+		Scheme:                 scheme,
+		MaxBatchSize:           sandboxCreateDeleteMaxBatchSize,
+		MaxCreateRatePerWindow: 2,
+		CreateRateWindow:       10 * time.Second,
+	}
+
+	countSandboxes := func(t *testing.T) int32 {
+		t.Helper()
+		list := &sandboxv1beta1.SandboxList{}
+		err := r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace})
+		require.NoError(t, err)
+		return int32(len(list.Items))
+	}
+	deleteOneSandbox := func(t *testing.T) {
+		t.Helper()
+		list := &sandboxv1beta1.SandboxList{}
+		err := r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace})
+		require.NoError(t, err)
+		require.NotEmpty(t, list.Items)
+		err = r.Delete(ctx, &list.Items[0])
+		require.NoError(t, err)
+	}
+
+	result, err := r.reconcilePoolWithResult(ctx, warmPool)
+	require.NoError(t, err)
+	require.Zero(t, result.RequeueAfter)
+	require.Equal(t, int32(5), countSandboxes(t))
+
+	deleteOneSandbox(t)
+	result, err = r.reconcilePoolWithResult(ctx, warmPool)
+	require.NoError(t, err)
+	require.Zero(t, result.RequeueAfter)
+	require.Equal(t, int32(5), countSandboxes(t))
+
+	deleteOneSandbox(t)
+	result, err = r.reconcilePoolWithResult(ctx, warmPool)
+	require.NoError(t, err)
+	require.Greater(t, result.RequeueAfter, time.Duration(0))
+	require.Equal(t, int32(4), countSandboxes(t), "rate limit should prevent a third create within the same window")
+}
+
 func TestReconcilePoolControllerRef(t *testing.T) {
 	poolName := "test-pool"
 	poolNamespace := "default"


### PR DESCRIPTION
## What

Adds an optional create-rate limiter for the `SandboxWarmPool` controller:

- `--sandbox-warm-pool-max-create-rate-per-window`
- `--sandbox-warm-pool-create-rate-window`

Both flags default to disabled, so existing behavior is unchanged unless users
set both values.

This is separate from the existing `--sandbox-warm-pool-max-batch-size`. The
existing batch size limits the number of creates/deletes in one reconcile. It
does not limit bursts that arrive as many small reconciles, such as repeated
`deficit=1` reconciles when many warm sandboxes are claimed quickly.

## Why

When a warm pool is drained by a large claim burst, immediately replacing every
claimed warm sandbox can create startup contention with the newly claimed active
sandbox workloads. A per-pool create-rate window lets operators trade slower
warm-pool refill for lower active-session startup contention.

## Details

- Keeps the existing `MaxBatchSize` behavior.
- Adds a per-`SandboxWarmPool` in-memory create budget window.
- Returns `RequeueAfter` when the window budget is exhausted.
- Preserves the existing test helper `reconcilePool(...)` and adds
  `reconcilePoolWithResult(...)` for requeue-aware tests.
- Adds coverage for:
  - large deficits capped by the rate window
  - many `deficit=1` reconciles exhausting the same window budget

## Validation

```bash
GOMODCACHE=/Users/lj/Documents/projects/agent-workspace/.go/pkg/mod \
GOCACHE=/Users/lj/Documents/projects/agent-workspace/.go/cache \
go test ./extensions/controllers

GOMODCACHE=/Users/lj/Documents/projects/agent-workspace/.go/pkg/mod \
GOCACHE=/Users/lj/Documents/projects/agent-workspace/.go/cache \
go test ./cmd/agent-sandbox-controller
```

Both passed locally.

This PR adds the controller primitive behind disabled-by-default flags;
operator-specific values still need to be configured by each deployment.
