### PR TITLE
feat(python-sdk): implement pod IP prioritization and normalization i…

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -197,7 +197,8 @@ class AsyncK8sHelper:
                             if cond.get("type") == "Ready" and cond.get("status") == "True":
                                 logger.info(f"Sandbox {name} is ready.")
                                 pod_ips = status.get("podIPs", [])
-                                return pod_ips[0] if pod_ips else None
+                                from .utils import select_pod_ip
+                                return select_pod_ip(pod_ips)
                     elif event["type"] == "DELETED":
                         logger.error(f"Sandbox {name} was deleted before becoming ready.")
                         raise SandboxNotFoundError(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -166,8 +166,8 @@ class AsyncK8sHelper:
     async def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int) -> str | None:
         """Waits for the Sandbox custom resource to have a 'Ready' status.
 
-        Returns the first pod IP from the sandbox status when ready, or None if
-        no IPs are present (e.g. on older controllers that don't populate podIPs).
+        Returns the selected pod IP from the sandbox status when ready, or None if
+        no valid IP can be selected.
         """
         await self._ensure_initialized()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -32,6 +32,7 @@ from .constants import (
     SANDBOX_PLURAL_NAME,
 )
 from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
+from .utils import select_pod_ip
 
 
 class AsyncK8sHelper:
@@ -197,7 +198,6 @@ class AsyncK8sHelper:
                             if cond.get("type") == "Ready" and cond.get("status") == "True":
                                 logger.info(f"Sandbox {name} is ready.")
                                 pod_ips = status.get("podIPs", [])
-                                from .utils import select_pod_ip
                                 return select_pod_ip(pod_ips)
                     elif event["type"] == "DELETED":
                         logger.error(f"Sandbox {name} was deleted before becoming ready.")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -99,7 +99,7 @@ class AsyncSandbox:
         """Selects a pod IP from the Sandbox status (prefers IPv4, normalizes canonical form).
 
         Always queries the K8s API for the latest IP — the pod IP can change
-        after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
+        after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed
         via setting spec.operatingMode to Running).
         Returns None if no valid IP can be selected.
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -21,6 +21,7 @@ from .constants import POD_NAME_ANNOTATION
 from .files.async_filesystem import AsyncFilesystem
 from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
 from .trace_manager import create_tracer_manager
+from .utils import select_pod_ip
 
 
 class AsyncSandbox:
@@ -95,7 +96,7 @@ class AsyncSandbox:
         return self._pod_name
 
     async def get_pod_ip(self) -> str | None:
-        """Fetches the first pod IP from the Sandbox status, prioritized and normalized.
+        """Selects a pod IP from the Sandbox status (prefers IPv4, normalizes canonical form).
 
         Always queries the K8s API for the latest IP — the pod IP can change
         after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
@@ -104,7 +105,6 @@ class AsyncSandbox:
         """
         sandbox_object = await self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get("status", {}).get("podIPs", [])
-        from .utils import select_pod_ip
         return select_pod_ip(pod_ips)
 
     @property

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -101,7 +101,7 @@ class AsyncSandbox:
         Always queries the K8s API for the latest IP — the pod IP can change
         after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
         via setting spec.operatingMode to Running).
-        Returns None if the controller does not populate podIPs.
+        Returns None if no valid IP can be selected.
         """
         sandbox_object = await self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get("status", {}).get("podIPs", [])

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -95,7 +95,7 @@ class AsyncSandbox:
         return self._pod_name
 
     async def get_pod_ip(self) -> str | None:
-        """Fetches the first pod IP from the Sandbox status.
+        """Fetches the first pod IP from the Sandbox status, prioritized and normalized.
 
         Always queries the K8s API for the latest IP — the pod IP can change
         after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
@@ -104,7 +104,8 @@ class AsyncSandbox:
         """
         sandbox_object = await self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get("status", {}).get("podIPs", [])
-        return pod_ips[0] if pod_ips else None
+        from .utils import select_pod_ip
+        return select_pod_ip(pod_ips)
 
     @property
     def commands(self) -> AsyncCommandExecutor | None:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -135,8 +135,8 @@ class K8sHelper:
     def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int) -> str | None:
         """Waits for the Sandbox custom resource to have a 'Ready' status.
 
-        Returns the first pod IP from the sandbox status when ready, or None if
-        no IPs are present (e.g. on older controllers that don't populate podIPs).
+        Returns the selected pod IP from the sandbox status when ready, or None if
+        no valid IP can be selected.
         """
         deadline = time.monotonic() + timeout
         logging.info(f"Watching for Sandbox {name} to become ready...")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -28,6 +28,7 @@ from .constants import (
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
 )
+from .utils import select_pod_ip
 
 class K8sHelper:
     """Helper class for Kubernetes API interactions."""
@@ -164,7 +165,6 @@ class K8sHelper:
                             logging.info(f"Sandbox {name} is ready.")
                             w.stop()
                             pod_ips = status.get('podIPs', [])
-                            from .utils import select_pod_ip
                             return select_pod_ip(pod_ips)
                 elif event["type"] == "DELETED":
                     logging.error(f"Sandbox {name} was deleted before becoming ready.")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -164,7 +164,8 @@ class K8sHelper:
                             logging.info(f"Sandbox {name} is ready.")
                             w.stop()
                             pod_ips = status.get('podIPs', [])
-                            return pod_ips[0] if pod_ips else None
+                            from .utils import select_pod_ip
+                            return select_pod_ip(pod_ips)
                 elif event["type"] == "DELETED":
                     logging.error(f"Sandbox {name} was deleted before becoming ready.")
                     w.stop()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -118,7 +118,7 @@ class Sandbox:
         Always queries the K8s API for the latest IP — the pod IP can change
         after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
         via setting spec.operatingMode to Running).
-        Returns None if the controller does not populate podIPs.
+        Returns None if no valid IP can be selected.
         """
         sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get('status', {}).get('podIPs', [])

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -28,6 +28,7 @@ from .exceptions import SandboxNotFoundError
 from .k8s_helper import K8sHelper
 from .connector import SandboxConnector
 from .constants import POD_NAME_ANNOTATION, SANDBOX_NAME_HASH_LABEL
+from .utils import select_pod_ip
 
 class Sandbox:
     """
@@ -112,7 +113,7 @@ class Sandbox:
         return None
 
     def get_pod_ip(self) -> str | None:
-        """Fetches the first pod IP from the Sandbox status, prioritized and normalized.
+        """Selects a pod IP from the Sandbox status (prefers IPv4, normalizes canonical form).
 
         Always queries the K8s API for the latest IP — the pod IP can change
         after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
@@ -121,7 +122,6 @@ class Sandbox:
         """
         sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get('status', {}).get('podIPs', [])
-        from .utils import select_pod_ip
         return select_pod_ip(pod_ips)
 
     def status(self) -> tuple[str, str]:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -112,7 +112,7 @@ class Sandbox:
         return None
 
     def get_pod_ip(self) -> str | None:
-        """Fetches the first pod IP from the Sandbox status.
+        """Fetches the first pod IP from the Sandbox status, prioritized and normalized.
 
         Always queries the K8s API for the latest IP — the pod IP can change
         after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
@@ -121,7 +121,8 @@ class Sandbox:
         """
         sandbox_object = self.k8s_helper.get_sandbox(self.sandbox_id, self.namespace) or {}
         pod_ips = sandbox_object.get('status', {}).get('podIPs', [])
-        return pod_ips[0] if pod_ips else None
+        from .utils import select_pod_ip
+        return select_pod_ip(pod_ips)
 
     def status(self) -> tuple[str, str]:
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -116,7 +116,7 @@ class Sandbox:
         """Selects a pod IP from the Sandbox status (prefers IPv4, normalizes canonical form).
 
         Always queries the K8s API for the latest IP — the pod IP can change
-        after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed 
+        after a pod restart (e.g. when spec.operatingMode is set to Suspended and resumed
         via setting spec.operatingMode to Running).
         Returns None if no valid IP can be selected.
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -151,7 +151,7 @@ class TestAsyncK8sHelperWaitForSandboxReady(unittest.IsolatedAsyncioTestCase):
                 "object": {
                     "status": {
                         "conditions": [{"type": "Ready", "status": "True"}],
-                        "podIPs": ["10.244.0.5", "fd00::5"],
+                        "podIPs": ["::ffff:10.244.0.5", "fd00::5"],
                     }
                 },
             }

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -269,6 +269,38 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
             )
         self.assertIn("connection_config is required", str(ctx.exception))
 
+    async def test_get_pod_ip(self):
+        """Tests that get_pod_ip returns the pod IP when present."""
+        mock_k8s_helper = AsyncMock()
+        mock_k8s_helper.get_sandbox = AsyncMock(return_value={
+            "status": {
+                "podIPs": ["10.244.0.42"]
+            }
+        })
+        sandbox = AsyncSandbox(
+            claim_name="test",
+            sandbox_id="test-id",
+            connection_config=MagicMock(),
+            k8s_helper=mock_k8s_helper,
+        )
+        self.assertEqual(await sandbox.get_pod_ip(), "10.244.0.42")
+
+    async def test_get_pod_ip_prioritization_and_normalization(self):
+        """Tests that get_pod_ip uses select_pod_ip to prioritize and normalize IPs."""
+        mock_k8s_helper = AsyncMock()
+        mock_k8s_helper.get_sandbox = AsyncMock(return_value={
+            "status": {
+                "podIPs": ["::ffff:10.244.0.42", "2001:db8::1"]
+            }
+        })
+        sandbox = AsyncSandbox(
+            claim_name="test",
+            sandbox_id="test-id",
+            connection_config=MagicMock(),
+            k8s_helper=mock_k8s_helper,
+        )
+        self.assertEqual(await sandbox.get_pod_ip(), "10.244.0.42")
+
 
 class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -364,9 +364,6 @@ class TestSelectPodIP(unittest.TestCase):
     def test_select_pod_ip_ipv4_mapped_ipv6_normalization(self):
         self.assertEqual(select_pod_ip(["::ffff:10.0.0.1"]), "10.0.0.1")
 
-    def test_select_pod_ip_non_string(self):
-        self.assertEqual(select_pod_ip([None, 123, "10.244.0.42"]), "10.244.0.42")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -252,6 +252,24 @@ class TestSandbox(unittest.TestCase):
         self.assertEqual(self.sandbox.get_sandbox_name_hash(), "mycachedhash")
         self.mock_k8s_helper.get_sandbox.assert_not_called()
 
+    def test_get_pod_ip(self):
+        """Tests that get_pod_ip returns the pod IP when present."""
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {
+                "podIPs": ["10.244.0.42"]
+            }
+        }
+        self.assertEqual(self.sandbox.get_pod_ip(), "10.244.0.42")
+
+    def test_get_pod_ip_prioritization_and_normalization(self):
+        """Tests that get_pod_ip uses select_pod_ip to prioritize and normalize IPs."""
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "status": {
+                "podIPs": ["::ffff:10.244.0.42", "2001:db8::1"]
+            }
+        }
+        self.assertEqual(self.sandbox.get_pod_ip(), "10.244.0.42")
+
 
 class TestSandboxTerminateIdempotent(unittest.TestCase):
     """`Sandbox.terminate()` must be idempotent — a second call must not
@@ -307,6 +325,48 @@ class TestSandboxTerminateIdempotent(unittest.TestCase):
         sandbox.terminate()
         self.assertEqual(helper.delete_sandbox_claim.call_count, 2)
         self.assertIsNone(sandbox.claim_name)
+
+
+
+from k8s_agent_sandbox.utils import select_pod_ip
+
+class TestSelectPodIP(unittest.TestCase):
+    def test_select_pod_ip_empty(self):
+        self.assertIsNone(select_pod_ip(None))
+        self.assertIsNone(select_pod_ip([]))
+        self.assertIsNone(select_pod_ip(["", "   "]))
+
+    def test_select_pod_ip_single_ipv4(self):
+        self.assertEqual(select_pod_ip(["10.244.0.42"]), "10.244.0.42")
+
+    def test_select_pod_ip_single_ipv6(self):
+        self.assertEqual(select_pod_ip(["2001:db8::1"]), "2001:db8::1")
+
+    def test_select_pod_ip_dual_stack_ipv4_first(self):
+        self.assertEqual(select_pod_ip(["10.244.0.42", "2001:db8::1"]), "10.244.0.42")
+
+    def test_select_pod_ip_dual_stack_ipv6_first(self):
+        self.assertEqual(select_pod_ip(["2001:db8::1", "10.244.0.42"]), "10.244.0.42")
+
+    def test_select_pod_ip_multiple_ipv6_selects_first(self):
+        self.assertEqual(select_pod_ip(["2001:db8::1", "2001:db8::2"]), "2001:db8::1")
+
+    def test_select_pod_ip_skips_invalid(self):
+        self.assertEqual(select_pod_ip(["not-a-valid-ip", "10.244.0.42"]), "10.244.0.42")
+        self.assertEqual(select_pod_ip(["not-a-valid-ip", "2001:db8::1"]), "2001:db8::1")
+        self.assertIsNone(select_pod_ip(["not-a-valid-ip", "bad-address"]))
+
+    def test_select_pod_ip_whitespace_normalization(self):
+        self.assertEqual(select_pod_ip(["  192.168.1.1  "]), "192.168.1.1")
+
+    def test_select_pod_ip_ipv6_compression_normalization(self):
+        self.assertEqual(select_pod_ip(["2001:db8:0:0:0:0:2:1"]), "2001:db8::2:1")
+
+    def test_select_pod_ip_ipv4_mapped_ipv6_normalization(self):
+        self.assertEqual(select_pod_ip(["::ffff:10.0.0.1"]), "10.0.0.1")
+
+    def test_select_pod_ip_non_string(self):
+        self.assertEqual(select_pod_ip([None, 123, "10.244.0.42"]), "10.244.0.42")
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -361,6 +361,9 @@ class TestSelectPodIP(unittest.TestCase):
     def test_select_pod_ip_ipv4_mapped_ipv6_normalization(self):
         self.assertEqual(select_pod_ip(["::ffff:10.0.0.1"]), "10.0.0.1")
 
+    def test_select_pod_ip_non_string(self):
+        self.assertEqual(select_pod_ip([None, 123, {"ip": "1.2.3.4"}, "10.244.0.42"]), "10.244.0.42") # type: ignore
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -372,7 +372,7 @@ class TestSelectPodIP(unittest.TestCase):
             {"ip": "2001:db8::1"},
             ObjWithIP("10.244.0.42"),
         ]
-        self.assertEqual(select_pod_ip(mixed_ips), "10.244.0.42")
+        self.assertEqual(select_pod_ip(mixed_ips), "10.244.0.42")  # type: ignore[arg-type]
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -282,9 +282,6 @@ class TestSandboxTerminateIdempotent(unittest.TestCase):
     @patch('k8s_agent_sandbox.sandbox.SandboxConnector')
     def _build_sandbox(self, mock_connector, mock_tracer, mock_cmd, mock_files):
         mock_tracer.return_value = (MagicMock(), MagicMock())
-        from k8s_agent_sandbox.models import (
-            SandboxLocalTunnelConnectionConfig, SandboxTracerConfig,
-        )
         k8s_helper = MagicMock()
         return Sandbox(
             claim_name="my-claim",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 from k8s_agent_sandbox.sandbox import Sandbox
 from k8s_agent_sandbox.models import SandboxLocalTunnelConnectionConfig, SandboxTracerConfig
+from k8s_agent_sandbox.utils import select_pod_ip
 
 
 class TestSandbox(unittest.TestCase):
@@ -327,8 +328,6 @@ class TestSandboxTerminateIdempotent(unittest.TestCase):
         self.assertIsNone(sandbox.claim_name)
 
 
-
-from k8s_agent_sandbox.utils import select_pod_ip
 
 class TestSelectPodIP(unittest.TestCase):
     def test_select_pod_ip_empty(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -362,7 +362,17 @@ class TestSelectPodIP(unittest.TestCase):
         self.assertEqual(select_pod_ip(["::ffff:10.0.0.1"]), "10.0.0.1")
 
     def test_select_pod_ip_non_string(self):
-        self.assertEqual(select_pod_ip([None, 123, {"ip": "1.2.3.4"}, "10.244.0.42"]), "10.244.0.42") # type: ignore
+        class ObjWithIP:
+            def __init__(self, ip: str):
+                self.ip = ip
+
+        mixed_ips = [
+            None,
+            123,
+            {"ip": "2001:db8::1"},
+            ObjWithIP("10.244.0.42"),
+        ]
+        self.assertEqual(select_pod_ip(mixed_ips), "10.244.0.42")  # type: ignore[arg-type]
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -372,7 +372,7 @@ class TestSelectPodIP(unittest.TestCase):
             {"ip": "2001:db8::1"},
             ObjWithIP("10.244.0.42"),
         ]
-        self.assertEqual(select_pod_ip(mixed_ips), "10.244.0.42")  # type: ignore[arg-type]
+        self.assertEqual(select_pod_ip(mixed_ips), "10.244.0.42")
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -556,7 +556,7 @@ class TestK8sHelperWatchNoneEvents(unittest.TestCase):
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
     def test_wait_for_sandbox_ready_returns_pod_ip(self, mock_watch_cls):
-        """wait_for_sandbox_ready returns the first pod IP when present."""
+        """wait_for_sandbox_ready returns the prioritized and normalized pod IP when present."""
         mock_watch = MagicMock()
         mock_watch_cls.return_value = mock_watch
         mock_watch.stream.return_value = [{
@@ -564,7 +564,7 @@ class TestK8sHelperWatchNoneEvents(unittest.TestCase):
             "object": {
                 "status": {
                     "conditions": [{"type": "Ready", "status": "True"}],
-                    "podIPs": ["10.244.0.5", "fd00::5"],
+                    "podIPs": ["::ffff:10.244.0.5", "fd00::5"],
                 },
             },
         }]

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -17,7 +17,6 @@
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 import ipaddress
-from typing import Any, Protocol
 
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
@@ -50,14 +49,7 @@ def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[
     }
 
 
-class HasIP(Protocol):
-    ip: str
-
-
-IPEntry = str | Mapping[str, Any] | HasIP
-
-
-def select_pod_ip(ips: Sequence[IPEntry] | None) -> str | None:
+def select_pod_ip(ips: Sequence[object] | None) -> str | None:
     """Selects a prioritized and normalized Pod IP address from a list of IPs.
 
     Scans the list of IP entries, validates them, and returns the

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -16,6 +16,7 @@
 
 import ipaddress
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
@@ -48,11 +49,16 @@ def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[
     }
 
 
-def select_pod_ip(ips: list[str] | None) -> str | None:
+def select_pod_ip(ips: list[Any] | None) -> str | None:
     """Selects a prioritized and normalized Pod IP address from a list of IPs.
 
-    Scans the list of IP addresses, validates them, and returns the
+    Scans the list of IP entries, validates them, and returns the
     normalized/canonical IP address string (preferring IPv4 over IPv6).
+
+    The elements in the input list can be:
+    - String representation of IP addresses (e.g. "10.0.0.1").
+    - Dictionaries containing an "ip" key (e.g. {"ip": "10.0.0.1"}).
+    - Objects containing an "ip" attribute.
 
     In dual-stack environments, we explicitly prefer IPv4 over IPv6.
     If no IPv4 is found, it falls back to the first syntactically valid IP.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -14,9 +14,9 @@
 
 """Utility functions for the Kubernetes Agent Sandbox Python client."""
 
-import ipaddress
-from datetime import datetime, timedelta, timezone
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+import ipaddress
 from typing import Any, Protocol
 
 
@@ -76,7 +76,7 @@ def select_pod_ip(ips: Sequence[IPEntry] | None) -> str | None:
     if not ips:
         return None
 
-    first_valid = None
+    first_valid: str | None = None
     for ip_entry in ips:
         ip_str = None
         if isinstance(ip_entry, str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -16,7 +16,8 @@
 
 import ipaddress
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
 
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
@@ -49,7 +50,14 @@ def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[
     }
 
 
-def select_pod_ip(ips: list[Any] | None) -> str | None:
+class HasIP(Protocol):
+    ip: str
+
+
+IPEntry = str | Mapping[str, Any] | HasIP
+
+
+def select_pod_ip(ips: Sequence[IPEntry] | None) -> str | None:
     """Selects a prioritized and normalized Pod IP address from a list of IPs.
 
     Scans the list of IP entries, validates them, and returns the
@@ -57,11 +65,13 @@ def select_pod_ip(ips: list[Any] | None) -> str | None:
 
     The elements in the input list can be:
     - String representation of IP addresses (e.g. "10.0.0.1").
-    - Dictionaries containing an "ip" key (e.g. {"ip": "10.0.0.1"}).
+    - Mappings containing an "ip" key (e.g. {"ip": "10.0.0.1"}).
     - Objects containing an "ip" attribute.
 
     In dual-stack environments, we explicitly prefer IPv4 over IPv6.
     If no IPv4 is found, it falls back to the first syntactically valid IP.
+    IPv4-mapped IPv6 addresses (e.g., "::ffff:10.0.0.1") are normalized and
+    returned as standard IPv4 addresses (e.g., "10.0.0.1").
     """
     if not ips:
         return None
@@ -71,7 +81,7 @@ def select_pod_ip(ips: list[Any] | None) -> str | None:
         ip_str = None
         if isinstance(ip_entry, str):
             ip_str = ip_entry
-        elif isinstance(ip_entry, dict):
+        elif isinstance(ip_entry, Mapping):
             ip_str = ip_entry.get("ip")
         elif ip_entry is not None:
             ip_str = getattr(ip_entry, "ip", None)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -71,7 +71,7 @@ def select_pod_ip(ips: list[str] | None) -> str | None:
                 return str(parsed)
             if parsed.version == 6 and parsed.ipv4_mapped:
                 return str(parsed.ipv4_mapped)
-            
+
             if first_valid is None:
                 first_valid = str(parsed)
         except ValueError:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -65,6 +65,8 @@ def select_pod_ip(ips: list[str] | None) -> str | None:
         if not ip_str:
             continue
         cleaned = ip_str.strip()
+        if not cleaned:
+            continue
         try:
             parsed = ipaddress.ip_address(cleaned)
             if parsed.version == 4:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -61,7 +61,15 @@ def select_pod_ip(ips: list[str] | None) -> str | None:
         return None
 
     first_valid = None
-    for ip_str in ips:
+    for ip_entry in ips:
+        ip_str = None
+        if isinstance(ip_entry, str):
+            ip_str = ip_entry
+        elif isinstance(ip_entry, dict):
+            ip_str = ip_entry.get("ip")
+        elif ip_entry is not None:
+            ip_str = getattr(ip_entry, "ip", None)
+
         if not isinstance(ip_str, str) or not ip_str:
             continue
         cleaned = ip_str.strip()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Utility functions for the Kubernetes Agent Sandbox python client."""
+"""Utility functions for the Kubernetes Agent Sandbox Python client."""
 
 import ipaddress
 from datetime import datetime, timedelta, timezone
@@ -60,11 +60,9 @@ def select_pod_ip(ips: list[str] | None) -> str | None:
 
     first_valid = None
     for ip_str in ips:
-        if not isinstance(ip_str, str):
+        if not ip_str:
             continue
         cleaned = ip_str.strip()
-        if not cleaned:
-            continue
         try:
             parsed = ipaddress.ip_address(cleaned)
             if parsed.version == 4:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Utility functions for the Kubernetes Agent Sandbox python client."""
+
+import ipaddress
 from datetime import datetime, timedelta, timezone
 
 
@@ -43,3 +46,35 @@ def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[
         "shutdownTime": shutdown_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "shutdownPolicy": "Delete",
     }
+
+
+def select_pod_ip(ips: list[str] | None) -> str | None:
+    """Scans the list of IP addresses, validates them, and returns the
+    normalized/canonical IP address string (preferring IPv4 over IPv6).
+
+    In dual-stack environments, we explicitly prefer IPv4 over IPv6.
+    If no IPv4 is found, it falls back to the first syntactically valid IP.
+    """
+    if not ips:
+        return None
+
+    first_valid = None
+    for ip_str in ips:
+        if not isinstance(ip_str, str):
+            continue
+        cleaned = ip_str.strip()
+        if not cleaned:
+            continue
+        try:
+            parsed = ipaddress.ip_address(cleaned)
+            if parsed.version == 4:
+                return str(parsed)
+            if parsed.version == 6 and parsed.ipv4_mapped:
+                return str(parsed.ipv4_mapped)
+            
+            if first_valid is None:
+                first_valid = str(parsed)
+        except ValueError:
+            continue
+
+    return first_valid

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -49,7 +49,9 @@ def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[
 
 
 def select_pod_ip(ips: list[str] | None) -> str | None:
-    """Scans the list of IP addresses, validates them, and returns the
+    """Selects a prioritized and normalized Pod IP address from a list of IPs.
+
+    Scans the list of IP addresses, validates them, and returns the
     normalized/canonical IP address string (preferring IPv4 over IPv6).
 
     In dual-stack environments, we explicitly prefer IPv4 over IPv6.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -62,7 +62,7 @@ def select_pod_ip(ips: list[str] | None) -> str | None:
 
     first_valid = None
     for ip_str in ips:
-        if not ip_str:
+        if not isinstance(ip_str, str) or not ip_str:
             continue
         cleaned = ip_str.strip()
         if not cleaned:


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
In dual-stack environments, the Python SDK now parses and prioritizes IPv4 addresses and normalizes mapped IPv6 loopback/IP addresses (e.g. ::ffff:10.0.0.1 to 10.0.0.1), matching the Go SDK implementation.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes: #915

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->