### PR TITLE
feat(go-sdk): add DisablePodIPRouting option to bypass direct Pod IP …

### DIFF
--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -74,6 +74,9 @@ type connector struct {
 	log           logr.Logger
 	tracer        trace.Tracer
 	svcName       string
+
+	// disablePodIPRouting disables the direct Pod IP routing mechanism.
+	disablePodIPRouting bool
 }
 
 // connectorConfig holds the parameters needed to construct a connector.
@@ -87,6 +90,9 @@ type connectorConfig struct {
 	Log               logr.Logger
 	Tracer            trace.Tracer
 	TraceServiceName  string
+
+	// DisablePodIPRouting disables the direct Pod IP routing mechanism.
+	DisablePodIPRouting bool
 }
 
 // newConnector creates a connector with the given configuration.
@@ -113,9 +119,10 @@ func newConnector(cfg connectorConfig) *connector {
 		httpClient: &http.Client{
 			Transport: transport,
 		},
-		log:     cfg.Log,
-		tracer:  cfg.Tracer,
-		svcName: cfg.TraceServiceName,
+		log:                 cfg.Log,
+		tracer:              cfg.Tracer,
+		svcName:             cfg.TraceServiceName,
+		disablePodIPRouting: cfg.DisablePodIPRouting,
 	}
 }
 
@@ -254,6 +261,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		namespace := c.namespace
 		port := c.serverPort
 		podIP := c.podIP
+		disableRouting := c.disablePodIPRouting
 		c.mu.Unlock()
 
 		var bodyReader io.Reader
@@ -284,7 +292,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		req.Header.Set(headerSandboxNamespace, namespace)
 		req.Header.Set(headerSandboxPort, strconv.Itoa(port))
 		req.Header.Set(headerRequestID, reqID)
-		if podIP != "" {
+		if podIP != "" && !disableRouting {
 			req.Header.Set(headerSandboxPodIP, podIP)
 		}
 		if contentType != "" {

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -261,7 +261,6 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		namespace := c.namespace
 		port := c.serverPort
 		podIP := c.podIP
-		disableRouting := c.disablePodIPRouting
 		c.mu.Unlock()
 
 		var bodyReader io.Reader
@@ -292,7 +291,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		req.Header.Set(headerSandboxNamespace, namespace)
 		req.Header.Set(headerSandboxPort, strconv.Itoa(port))
 		req.Header.Set(headerRequestID, reqID)
-		if podIP != "" && !disableRouting {
+		if podIP != "" && !c.disablePodIPRouting {
 			req.Header.Set(headerSandboxPodIP, podIP)
 		}
 		if contentType != "" {

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -36,7 +36,10 @@ import (
 // ---------------------------------------------------------------------------
 
 // newReadyTestSandboxWithOptions creates a Sandbox with the given options,
-// and simulates a successful connection.
+// filling in required defaults (such as WarmPoolName, Namespace, ServerPort,
+// and timeouts) if they are left empty. If opts.APIURL is empty, it is set
+// to serverURL, forcing the client into direct URL connection strategy.
+// It also simulates a successful connection.
 func newReadyTestSandboxWithOptions(serverURL string, opts Options) *Sandbox {
 	if opts.WarmPoolName == "" {
 		opts.WarmPoolName = "test-warmpool"

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -1548,3 +1548,40 @@ func TestWithMaxAttempts_CustomCount(t *testing.T) {
 		t.Errorf("expected exactly 3 attempts with WithMaxAttempts(3), got %d", got)
 	}
 }
+
+func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
+	var mu sync.Mutex
+	var headers http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		headers = r.Header.Clone()
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(map[string]bool{"exists": true})
+	}))
+	defer server.Close()
+
+	c := newReadyTestSandbox(server.URL)
+	c.connector.SetIdentity("my-claim")
+	c.connector.SetPodIP("10.244.0.42")
+	c.connector.mu.Lock()
+	c.connector.disablePodIPRouting = true
+	c.connector.namespace = "my-ns"
+	c.connector.serverPort = 9999
+	c.connector.mu.Unlock()
+
+	_, err := c.Exists(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("Exists() error: %v", err)
+	}
+
+	mu.Lock()
+	capturedHeaders := headers.Clone()
+	mu.Unlock()
+
+	if capturedHeaders.Get(headerSandboxID) != "my-claim" {
+		t.Errorf("wrong %s: %s", headerSandboxID, capturedHeaders.Get(headerSandboxID))
+	}
+	if _, ok := capturedHeaders[http.CanonicalHeaderKey(headerSandboxPodIP)]; ok {
+		t.Errorf("expected header %s to be absent when disablePodIPRouting is true, but it was present", headerSandboxPodIP)
+	}
+}

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -35,12 +35,12 @@ import (
 // Shared test helpers
 // ---------------------------------------------------------------------------
 
-// newReadyTestSandboxWithOptions creates a Sandbox with the given options,
-// filling in required defaults (such as WarmPoolName, Namespace, ServerPort,
-// and timeouts) if they are left empty. If opts.APIURL is empty, it is set
-// to serverURL, forcing the client into direct URL connection strategy.
+// newReadyTestSandboxWithDirectURL creates a Sandbox with the given options,
+// using DirectStrategy with the mock serverURL (assigned to opts.APIURL).
+// It fills in required defaults (such as WarmPoolName, Namespace, ServerPort,
+// and timeouts) if they are left empty.
 // It also simulates a successful connection.
-func newReadyTestSandboxWithOptions(serverURL string, opts Options) *Sandbox {
+func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 	if opts.WarmPoolName == "" {
 		opts.WarmPoolName = "test-warmpool"
 	}
@@ -68,7 +68,7 @@ func newReadyTestSandboxWithOptions(serverURL string, opts Options) *Sandbox {
 	opts.K8sHelper = k8s
 	sb, err := New(context.Background(), opts)
 	if err != nil {
-		panic("newReadyTestSandboxWithOptions: " + err.Error())
+		panic("newReadyTestSandboxWithDirectURL: " + err.Error())
 	}
 	// Simulate being connected
 	sb.connector.mu.Lock()
@@ -84,7 +84,7 @@ func newReadyTestSandboxWithOptions(serverURL string, opts Options) *Sandbox {
 
 // newReadyTestSandbox creates a Sandbox that's already "connected" to the given server URL.
 func newReadyTestSandbox(serverURL string) *Sandbox {
-	return newReadyTestSandboxWithOptions(serverURL, Options{})
+	return newReadyTestSandboxWithDirectURL(serverURL, Options{})
 }
 
 // newUnreadyTestSandbox returns a Sandbox that has not been opened.
@@ -463,7 +463,7 @@ func TestHTTPHeaders_AllSet(t *testing.T) {
 		Namespace:  "my-ns",
 		ServerPort: 9999,
 	}
-	c := newReadyTestSandboxWithOptions(server.URL, opts)
+	c := newReadyTestSandboxWithDirectURL(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
 	c.connector.SetPodIP("10.244.0.42")
 
@@ -509,7 +509,7 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 		Namespace:  "my-ns",
 		ServerPort: 9999,
 	}
-	c := newReadyTestSandboxWithOptions(server.URL, opts)
+	c := newReadyTestSandboxWithDirectURL(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
 	c.connector.SetPodIP("")
 
@@ -1594,7 +1594,7 @@ func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
 		Namespace:           "my-ns",
 		ServerPort:          9999,
 	}
-	c := newReadyTestSandboxWithOptions(server.URL, opts)
+	c := newReadyTestSandboxWithDirectURL(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
 	c.connector.SetPodIP("10.244.0.42")
 

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -38,17 +38,27 @@ import (
 // newReadyTestSandboxWithOptions creates a Sandbox with the given options,
 // and simulates a successful connection.
 func newReadyTestSandboxWithOptions(serverURL string, opts Options) *Sandbox {
-	opts.WarmPoolName = "test-warmpool"
+	if opts.WarmPoolName == "" {
+		opts.WarmPoolName = "test-warmpool"
+	}
 	if opts.Namespace == "" {
 		opts.Namespace = "default"
 	}
-	opts.APIURL = serverURL
+	if opts.APIURL == "" {
+		opts.APIURL = serverURL
+	}
 	if opts.ServerPort == 0 {
 		opts.ServerPort = 8888
 	}
-	opts.RequestTimeout = 5 * time.Second
-	opts.PerAttemptTimeout = 2 * time.Second
-	opts.Quiet = true
+	if opts.RequestTimeout == 0 {
+		opts.RequestTimeout = 5 * time.Second
+	}
+	if opts.PerAttemptTimeout == 0 {
+		opts.PerAttemptTimeout = 2 * time.Second
+	}
+	if opts.Logger.GetSink() == nil {
+		opts.Quiet = true
+	}
 	opts.setDefaults()
 
 	k8s := &K8sHelper{Log: opts.Logger}

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -473,6 +473,10 @@ func TestHTTPHeaders_AllSet(t *testing.T) {
 	}
 
 	mu.Lock()
+	if headers == nil {
+		mu.Unlock()
+		t.Fatal("HTTP handler was never invoked (headers is nil)")
+	}
 	capturedHeaders := headers.Clone()
 	mu.Unlock()
 
@@ -515,6 +519,10 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 	}
 
 	mu.Lock()
+	if headers == nil {
+		mu.Unlock()
+		t.Fatal("HTTP handler was never invoked (headers is nil)")
+	}
 	capturedHeaders := headers.Clone()
 	mu.Unlock()
 
@@ -1596,6 +1604,10 @@ func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
 	}
 
 	mu.Lock()
+	if headers == nil {
+		mu.Unlock()
+		t.Fatal("HTTP handler was never invoked (headers is nil)")
+	}
 	capturedHeaders := headers.Clone()
 	mu.Unlock()
 

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -35,24 +35,27 @@ import (
 // Shared test helpers
 // ---------------------------------------------------------------------------
 
-// newReadyTestSandbox creates a Sandbox that's already "connected" to the given server URL.
-func newReadyTestSandbox(serverURL string) *Sandbox {
-	opts := Options{
-		WarmPoolName:      "test-warmpool",
-		Namespace:         "default",
-		APIURL:            serverURL,
-		ServerPort:        8888,
-		RequestTimeout:    5 * time.Second,
-		PerAttemptTimeout: 2 * time.Second,
-		Quiet:             true,
+// newReadyTestSandboxWithOptions creates a Sandbox with the given options,
+// and simulates a successful connection.
+func newReadyTestSandboxWithOptions(serverURL string, opts Options) *Sandbox {
+	opts.WarmPoolName = "test-warmpool"
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
 	}
+	opts.APIURL = serverURL
+	if opts.ServerPort == 0 {
+		opts.ServerPort = 8888
+	}
+	opts.RequestTimeout = 5 * time.Second
+	opts.PerAttemptTimeout = 2 * time.Second
+	opts.Quiet = true
 	opts.setDefaults()
 
 	k8s := &K8sHelper{Log: opts.Logger}
 	opts.K8sHelper = k8s
 	sb, err := New(context.Background(), opts)
 	if err != nil {
-		panic("newReadyTestSandbox: " + err.Error())
+		panic("newReadyTestSandboxWithOptions: " + err.Error())
 	}
 	// Simulate being connected
 	sb.connector.mu.Lock()
@@ -64,6 +67,11 @@ func newReadyTestSandbox(serverURL string) *Sandbox {
 	sb.claimName = "test-claim-abc123"
 	sb.mu.Unlock()
 	return sb
+}
+
+// newReadyTestSandbox creates a Sandbox that's already "connected" to the given server URL.
+func newReadyTestSandbox(serverURL string) *Sandbox {
+	return newReadyTestSandboxWithOptions(serverURL, Options{})
 }
 
 // newUnreadyTestSandbox returns a Sandbox that has not been opened.
@@ -438,13 +446,13 @@ func TestHTTPHeaders_AllSet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newReadyTestSandbox(server.URL)
+	opts := Options{
+		Namespace:  "my-ns",
+		ServerPort: 9999,
+	}
+	c := newReadyTestSandboxWithOptions(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
 	c.connector.SetPodIP("10.244.0.42")
-	c.connector.mu.Lock()
-	c.connector.namespace = "my-ns"
-	c.connector.serverPort = 9999
-	c.connector.mu.Unlock()
 
 	_, err := c.Exists(context.Background(), "x")
 	if err != nil {
@@ -480,13 +488,13 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newReadyTestSandbox(server.URL)
+	opts := Options{
+		Namespace:  "my-ns",
+		ServerPort: 9999,
+	}
+	c := newReadyTestSandboxWithOptions(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
 	c.connector.SetPodIP("")
-	c.connector.mu.Lock()
-	c.connector.namespace = "my-ns"
-	c.connector.serverPort = 9999
-	c.connector.mu.Unlock()
 
 	_, err := c.Exists(context.Background(), "x")
 	if err != nil {
@@ -1560,14 +1568,14 @@ func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := newReadyTestSandbox(server.URL)
+	opts := Options{
+		DisablePodIPRouting: true,
+		Namespace:           "my-ns",
+		ServerPort:          9999,
+	}
+	c := newReadyTestSandboxWithOptions(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
 	c.connector.SetPodIP("10.244.0.42")
-	c.connector.mu.Lock()
-	c.connector.disablePodIPRouting = true
-	c.connector.namespace = "my-ns"
-	c.connector.serverPort = 9999
-	c.connector.mu.Unlock()
 
 	_, err := c.Exists(context.Background(), "x")
 	if err != nil {

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -56,7 +56,6 @@ func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 		opts.PerAttemptTimeout = 2 * time.Second
 	}
 
-
 	k8s := &K8sHelper{}
 	opts.K8sHelper = k8s
 	sb, err := New(context.Background(), opts)

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -55,9 +55,7 @@ func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 	if opts.PerAttemptTimeout == 0 {
 		opts.PerAttemptTimeout = 2 * time.Second
 	}
-	if opts.Logger.GetSink() == nil {
-		opts.Quiet = true
-	}
+
 
 	k8s := &K8sHelper{}
 	opts.K8sHelper = k8s
@@ -81,7 +79,7 @@ func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 
 // newReadyTestSandbox creates a Sandbox that's already "connected" to the given server URL.
 func newReadyTestSandbox(serverURL string) *Sandbox {
-	return newReadyTestSandboxWithDirectURL(serverURL, Options{})
+	return newReadyTestSandboxWithDirectURL(serverURL, Options{Quiet: true})
 }
 
 // newUnreadyTestSandbox returns a Sandbox that has not been opened.
@@ -459,6 +457,7 @@ func TestHTTPHeaders_AllSet(t *testing.T) {
 	opts := Options{
 		Namespace:  "my-ns",
 		ServerPort: 9999,
+		Quiet:      true,
 	}
 	c := newReadyTestSandboxWithDirectURL(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
@@ -505,6 +504,7 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 	opts := Options{
 		Namespace:  "my-ns",
 		ServerPort: 9999,
+		Quiet:      true,
 	}
 	c := newReadyTestSandboxWithDirectURL(server.URL, opts)
 	c.connector.SetIdentity("my-claim")
@@ -1590,6 +1590,7 @@ func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
 		DisablePodIPRouting: true,
 		Namespace:           "my-ns",
 		ServerPort:          9999,
+		Quiet:               true,
 	}
 	c := newReadyTestSandboxWithDirectURL(server.URL, opts)
 	c.connector.SetIdentity("my-claim")

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -46,6 +46,9 @@ func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 		opts.Namespace = "default"
 	}
 	opts.APIURL = serverURL
+	if opts.ServerPort == 0 {
+		opts.ServerPort = 8888
+	}
 	if opts.RequestTimeout == 0 {
 		opts.RequestTimeout = 5 * time.Second
 	}

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -37,8 +37,6 @@ import (
 
 // newReadyTestSandboxWithDirectURL creates a Sandbox with the given options,
 // using DirectStrategy with the mock serverURL (assigned to opts.APIURL).
-// It fills in required defaults (such as WarmPoolName, Namespace, ServerPort,
-// and timeouts) if they are left empty.
 // It also simulates a successful connection.
 func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 	if opts.WarmPoolName == "" {
@@ -47,12 +45,7 @@ func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 	if opts.Namespace == "" {
 		opts.Namespace = "default"
 	}
-	if opts.APIURL == "" {
-		opts.APIURL = serverURL
-	}
-	if opts.ServerPort == 0 {
-		opts.ServerPort = 8888
-	}
+	opts.APIURL = serverURL
 	if opts.RequestTimeout == 0 {
 		opts.RequestTimeout = 5 * time.Second
 	}
@@ -62,14 +55,15 @@ func newReadyTestSandboxWithDirectURL(serverURL string, opts Options) *Sandbox {
 	if opts.Logger.GetSink() == nil {
 		opts.Quiet = true
 	}
-	opts.setDefaults()
 
-	k8s := &K8sHelper{Log: opts.Logger}
+	k8s := &K8sHelper{}
 	opts.K8sHelper = k8s
 	sb, err := New(context.Background(), opts)
 	if err != nil {
 		panic("newReadyTestSandboxWithDirectURL: " + err.Error())
 	}
+	k8s.Log = sb.opts.Logger
+
 	// Simulate being connected
 	sb.connector.mu.Lock()
 	sb.connector.baseURL = serverURL

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -136,6 +136,9 @@ type Options struct {
 	// TracerProvider sets the OpenTelemetry TracerProvider for span creation.
 	// If nil, falls back to otel.GetTracerProvider (noop by default).
 	TracerProvider trace.TracerProvider
+
+	// DisablePodIPRouting disables routing requests directly to the sandbox Pod IP.
+	DisablePodIPRouting bool
 }
 
 func (o *Options) setDefaults() {

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -115,10 +115,11 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 		ServerPort:        opts.ServerPort,
 		RequestTimeout:    opts.RequestTimeout,
 		PerAttemptTimeout: opts.PerAttemptTimeout,
-		HTTPTransport:     opts.HTTPTransport,
-		Log:               opts.Logger,
-		Tracer:            tracer,
-		TraceServiceName:  svcName,
+		HTTPTransport:       opts.HTTPTransport,
+		Log:                 opts.Logger,
+		Tracer:              tracer,
+		TraceServiceName:    svcName,
+		DisablePodIPRouting: opts.DisablePodIPRouting,
 	})
 
 	// Wire tunnel's connector reference for death notifications.

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -110,11 +110,11 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	}
 
 	conn := newConnector(connectorConfig{
-		Strategy:          strategy,
-		Namespace:         opts.Namespace,
-		ServerPort:        opts.ServerPort,
-		RequestTimeout:    opts.RequestTimeout,
-		PerAttemptTimeout: opts.PerAttemptTimeout,
+		Strategy:            strategy,
+		Namespace:           opts.Namespace,
+		ServerPort:          opts.ServerPort,
+		RequestTimeout:      opts.RequestTimeout,
+		PerAttemptTimeout:   opts.PerAttemptTimeout,
 		HTTPTransport:       opts.HTTPTransport,
 		Log:                 opts.Logger,
 		Tracer:              tracer,

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -3067,4 +3067,3 @@ func TestNew_DisablePodIPRoutingPropagation(t *testing.T) {
 		t.Error("expected connector.disablePodIPRouting to be true, got false")
 	}
 }
-

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -3045,25 +3045,3 @@ func TestConnector_SetPodIP(t *testing.T) {
 		})
 	}
 }
-
-func TestNew_DisablePodIPRoutingPropagation(t *testing.T) {
-	opts := defaultTestOpts()
-	opts.DisablePodIPRouting = true
-
-	c, agentsCS, extensionsCS := newTestSandbox(opts)
-	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb"))
-
-	ctx := context.Background()
-	if err := c.Open(ctx); err != nil {
-		t.Fatalf("Open() returned error: %v", err)
-	}
-	defer c.Close(context.Background())
-
-	c.connector.mu.Lock()
-	gotDisable := c.connector.disablePodIPRouting
-	c.connector.mu.Unlock()
-
-	if !gotDisable {
-		t.Error("expected connector.disablePodIPRouting to be true, got false")
-	}
-}

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -3045,3 +3045,26 @@ func TestConnector_SetPodIP(t *testing.T) {
 		})
 	}
 }
+
+func TestNew_DisablePodIPRoutingPropagation(t *testing.T) {
+	opts := defaultTestOpts()
+	opts.DisablePodIPRouting = true
+
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb"))
+
+	ctx := context.Background()
+	if err := c.Open(ctx); err != nil {
+		t.Fatalf("Open() returned error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	c.connector.mu.Lock()
+	gotDisable := c.connector.disablePodIPRouting
+	c.connector.mu.Unlock()
+
+	if !gotDisable {
+		t.Error("expected connector.disablePodIPRouting to be true, got false")
+	}
+}
+


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Introduce DisablePodIPRouting to Option configuration, allowing clients to explicitly bypass Pod-to-Pod IP routing. When this option is enabled, the Go SDK connector omits the X-Sandbox-Pod-IP header from outgoing HTTP requests, causing the sandbox-router to fallback to standard DNS-based routing.
 
Includes:
- Propagation tests validating Options-to-connector value mapping.
- Header behavior tests validating omission of X-Sandbox-Pod-IP.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #916 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->