### PR TITLE
Propagate warmpool label from sandbox to pod

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -71,6 +71,8 @@ const (
 	SandboxPropagatedAnnotationsAnnotation = "agents.x-k8s.io/propagated-annotations"
 	// SandboxAdoptableLabel is the label used to authorize a Sandbox to adopt an existing unowned resource.
 	SandboxAdoptableLabel = "agents.x-k8s.io/adoptable"
+	// SandboxWarmPoolLabel is the label used to track the warm pool that owns the Sandbox.
+	SandboxWarmPoolLabel = "agents.x-k8s.io/warm-pool-sandbox"
 )
 
 type PodMetadata struct {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -42,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
 
@@ -846,9 +848,12 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	// Propagate the warm pool label directly from the Sandbox CR labels to the Pod,
 	// provided the Sandbox is actually owned by a Warm Pool.
 	// The warm pool label is required by the capacity buffer to identify the warm pool pods.
-	if ref := metav1.GetControllerOf(sandbox); ref != nil && ref.Kind == "SandboxWarmPool" {
-		if val, ok := sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
-			podLabels[sandboxv1beta1.SandboxWarmPoolLabel] = val
+	if ref := metav1.GetControllerOf(sandbox); ref != nil {
+		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+		if gvk.Group == extensionsv1beta1.GroupVersion.Group && gvk.Kind == "SandboxWarmPool" {
+			if val, ok := sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
+				podLabels[sandboxv1beta1.SandboxWarmPoolLabel] = val
+			}
 		}
 	}
 
@@ -982,8 +987,11 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	}
 	// Ensure the warm pool label is present if the sandbox is owned by a SandboxWarmPool.
 	var expectedWarmPoolHash string
-	if ref := metav1.GetControllerOf(sandbox); ref != nil && ref.Kind == "SandboxWarmPool" {
-		expectedWarmPoolHash = sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]
+	if ref := metav1.GetControllerOf(sandbox); ref != nil {
+		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+		if gvk.Group == extensionsv1beta1.GroupVersion.Group && gvk.Kind == "SandboxWarmPool" {
+			expectedWarmPoolHash = sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]
+		}
 	}
 	if expectedWarmPoolHash != "" {
 		if pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] != expectedWarmPoolHash {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -450,15 +450,6 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
-var (
-	// systemLabelExceptions is a list of system-reserved labels that are allowed
-	// to be set on the Pod.
-	systemLabelExceptions = map[string]struct{}{
-		// Required for the capacity buffer to identify warmpool pods.
-		"agents.x-k8s.io/warm-pool-sandbox": {},
-	}
-)
-
 // hasSystemReservedPrefix reports whether a key uses a label/annotation prefix
 // reserved for the sandbox system or its extensions.
 func hasSystemReservedPrefix(key string) bool {
@@ -471,9 +462,6 @@ func hasSystemReservedPrefix(key string) bool {
 // tenant could override security-critical labels (e.g. the headless Service selector
 // label) and hijack another Sandbox's network traffic.
 func isSystemLabel(key string) bool {
-	if _, ok := systemLabelExceptions[key]; ok {
-		return false
-	}
 	return hasSystemReservedPrefix(key)
 }
 
@@ -855,6 +843,15 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	// Assign system-owned labels after merging user input so they cannot be overridden.
 	podLabels[sandboxLabel] = nameHash
 
+	// Propagate the warm pool label directly from the Sandbox CR labels to the Pod,
+	// provided the Sandbox is actually owned by a Warm Pool.
+	// The warm pool label is required by the capacity buffer to identify the warm pool pods.
+	if ref := metav1.GetControllerOf(sandbox); ref != nil && ref.Kind == "SandboxWarmPool" {
+		if val, ok := sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
+			podLabels[sandboxv1beta1.SandboxWarmPoolLabel] = val
+		}
+	}
+
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
@@ -941,6 +938,23 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	if pod.Labels[sandboxLabel] != nameHash {
 		pod.Labels[sandboxLabel] = nameHash
 		updated = true
+	}
+	// Ensure the warm pool label is present if the sandbox is owned by a SandboxWarmPool.
+	var expectedWarmPoolHash string
+	if ref := metav1.GetControllerOf(sandbox); ref != nil && ref.Kind == "SandboxWarmPool" {
+		expectedWarmPoolHash = sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]
+	}
+	if expectedWarmPoolHash != "" {
+		if pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] != expectedWarmPoolHash {
+			pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] = expectedWarmPoolHash
+			updated = true
+		}
+	} else {
+		// If the Sandbox is no longer owned by a SandboxWarmPool, remove the warm pool label.
+		if _, exists := pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; exists {
+			delete(pod.Labels, sandboxv1beta1.SandboxWarmPoolLabel)
+			updated = true
+		}
 	}
 	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption),
 	// skipping system-reserved keys so a user-supplied template cannot override them.

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -450,6 +450,15 @@ func NameHash(objectName string) string {
 	return fmt.Sprintf("%08x", GetNumericHash(objectName))
 }
 
+var (
+	// systemLabelExceptions is a list of system-reserved labels that are allowed
+	// to be set on the Pod.
+	systemLabelExceptions = map[string]struct{}{
+		// Required for the capacity buffer to identify warmpool pods.
+		"agents.x-k8s.io/warm-pool-sandbox": {},
+	}
+)
+
 // hasSystemReservedPrefix reports whether a key uses a label/annotation prefix
 // reserved for the sandbox system or its extensions.
 func hasSystemReservedPrefix(key string) bool {
@@ -462,6 +471,9 @@ func hasSystemReservedPrefix(key string) bool {
 // tenant could override security-critical labels (e.g. the headless Service selector
 // label) and hijack another Sandbox's network traffic.
 func isSystemLabel(key string) bool {
+	if _, ok := systemLabelExceptions[key]; ok {
+		return false
+	}
 	return hasSystemReservedPrefix(key)
 }
 

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -939,23 +939,6 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		pod.Labels[sandboxLabel] = nameHash
 		updated = true
 	}
-	// Ensure the warm pool label is present if the sandbox is owned by a SandboxWarmPool.
-	var expectedWarmPoolHash string
-	if ref := metav1.GetControllerOf(sandbox); ref != nil && ref.Kind == "SandboxWarmPool" {
-		expectedWarmPoolHash = sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]
-	}
-	if expectedWarmPoolHash != "" {
-		if pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] != expectedWarmPoolHash {
-			pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] = expectedWarmPoolHash
-			updated = true
-		}
-	} else {
-		// If the Sandbox is no longer owned by a SandboxWarmPool, remove the warm pool label.
-		if _, exists := pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; exists {
-			delete(pod.Labels, sandboxv1beta1.SandboxWarmPoolLabel)
-			updated = true
-		}
-	}
 	// Propagate pod template labels to the existing pod (e.g., after warm pool adoption),
 	// skipping system-reserved keys so a user-supplied template cannot override them.
 	var managedLabelKeys []string
@@ -995,6 +978,23 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 				delete(pod.Labels, k)
 				updated = true
 			}
+		}
+	}
+	// Ensure the warm pool label is present if the sandbox is owned by a SandboxWarmPool.
+	var expectedWarmPoolHash string
+	if ref := metav1.GetControllerOf(sandbox); ref != nil && ref.Kind == "SandboxWarmPool" {
+		expectedWarmPoolHash = sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]
+	}
+	if expectedWarmPoolHash != "" {
+		if pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] != expectedWarmPoolHash {
+			pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] = expectedWarmPoolHash
+			updated = true
+		}
+	} else {
+		// If the Sandbox is no longer owned by a SandboxWarmPool, remove the warm pool label.
+		if _, exists := pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; exists {
+			delete(pod.Labels, sandboxv1beta1.SandboxWarmPoolLabel)
+			updated = true
 		}
 	}
 	// Propagate pod template annotations to the existing pod

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1346,7 +1346,7 @@ func TestReconcilePod(t *testing.T) {
 				Spec: sandboxv1beta1.SandboxSpec{
 					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
 					PodTemplate: sandboxv1beta1.PodTemplate{
-						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 						ObjectMeta: sandboxv1beta1.PodMetadata{
 							Labels: map[string]string{
 								"custom-label":                      "label-val",

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1306,7 +1306,7 @@ func TestReconcilePod(t *testing.T) {
 					Namespace: sandboxNs,
 					UID:       sandboxUID,
 					Labels: map[string]string{
-						"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+						sandboxv1beta1.SandboxWarmPoolLabel: "pool-hash",
 					},
 				},
 				Spec: sandboxv1beta1.SandboxSpec{
@@ -1336,7 +1336,7 @@ func TestReconcilePod(t *testing.T) {
 			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
 		},
 		{
-			name: "propagates allowed system labels (exceptions) from Sandbox PodTemplate to Pod",
+			name: "does not propagate system labels from Sandbox PodTemplate to Pod",
 			sandbox: &sandboxv1beta1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sandboxName,
@@ -1350,7 +1350,7 @@ func TestReconcilePod(t *testing.T) {
 						ObjectMeta: sandboxv1beta1.PodMetadata{
 							Labels: map[string]string{
 								"custom-label":                      "label-val",
-								"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+								sandboxv1beta1.SandboxWarmPoolLabel: "pool-hash",
 							},
 						},
 					},
@@ -1364,10 +1364,9 @@ func TestReconcilePod(t *testing.T) {
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 						"custom-label":                      "label-val",
-						"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
 					},
 					Annotations: map[string]string{
-						"agents.x-k8s.io/propagated-labels": "agents.x-k8s.io/warm-pool-sandbox,custom-label",
+						"agents.x-k8s.io/propagated-labels": "custom-label",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
@@ -1376,7 +1375,54 @@ func TestReconcilePod(t *testing.T) {
 			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
 		},
 		{
-			name: "updates allowed system label exceptions on an existing Pod",
+			name: "propagates warm pool label from Sandbox owner reference to Pod",
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Labels: map[string]string{
+						sandboxv1beta1.SandboxWarmPoolLabel: NameHash("my-warm-pool"),
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+							Kind:       "SandboxWarmPool",
+							Name:       "my-warm-pool",
+							UID:        "pool-uid",
+							Controller: new(true),
+						},
+					},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						sandboxv1beta1.SandboxWarmPoolLabel: NameHash("my-warm-pool"),
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/propagated-labels": "custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+		},
+		{
+			name: "removes warm pool label from Pod when Sandbox is no longer owned by SandboxWarmPool",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1385,11 +1431,11 @@ func TestReconcilePod(t *testing.T) {
 						ResourceVersion: "1",
 						Labels: map[string]string{
 							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+							sandboxv1beta1.SandboxWarmPoolLabel:  "pool-hash",
 							"custom-label":                       "label-val",
 							sandboxv1beta1.SandboxAdoptableLabel: "true",
 						},
 						Annotations: map[string]string{
-							"custom-annotation":                 "anno-val",
 							"agents.x-k8s.io/propagated-labels": "custom-label",
 						},
 					},
@@ -1407,16 +1453,8 @@ func TestReconcilePod(t *testing.T) {
 				Spec: sandboxv1beta1.SandboxSpec{
 					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
 					PodTemplate: sandboxv1beta1.PodTemplate{
-						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
-						ObjectMeta: sandboxv1beta1.PodMetadata{
-							Labels: map[string]string{
-								"custom-label":                      "label-val",
-								"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
-							},
-							Annotations: map[string]string{
-								"custom-annotation": "anno-val",
-							},
-						},
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
 					},
 				},
 			},
@@ -1428,13 +1466,82 @@ func TestReconcilePod(t *testing.T) {
 					Labels: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
 						"custom-label":                       "label-val",
-						"agents.x-k8s.io/warm-pool-sandbox":  "pool-hash",
 						sandboxv1beta1.SandboxAdoptableLabel: "true",
 					},
 					Annotations: map[string]string{
-						"custom-annotation":                      "anno-val",
-						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
-						"agents.x-k8s.io/propagated-labels":      "agents.x-k8s.io/warm-pool-sandbox,custom-label",
+						"agents.x-k8s.io/propagated-labels": "custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name: "adds warm pool label to existing Pod when Sandbox is owned by SandboxWarmPool",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+							"custom-label":                       "label-val",
+							sandboxv1beta1.SandboxAdoptableLabel: "true",
+						},
+						Annotations: map[string]string{
+							"agents.x-k8s.io/propagated-labels": "custom-label",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Labels: map[string]string{
+						sandboxv1beta1.SandboxWarmPoolLabel: NameHash("my-warm-pool"),
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+							Kind:       "SandboxWarmPool",
+							Name:       "my-warm-pool",
+							UID:        "pool-uid",
+							Controller: new(true),
+						},
+					},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+						sandboxv1beta1.SandboxWarmPoolLabel:  NameHash("my-warm-pool"),
+						"custom-label":                       "label-val",
+						sandboxv1beta1.SandboxAdoptableLabel: "true",
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/propagated-labels": "custom-label",
 					},
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1336,6 +1336,46 @@ func TestReconcilePod(t *testing.T) {
 			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
 		},
 		{
+			name: "propagates allowed system labels (exceptions) from Sandbox PodTemplate to Pod",
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{
+							Labels: map[string]string{
+								"custom-label":                      "label-val",
+								"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+							},
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+						"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/propagated-labels": "agents.x-k8s.io/warm-pool-sandbox,custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+		},
+		{
 			name: "delete pod if mode is Suspended",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1376,6 +1376,77 @@ func TestReconcilePod(t *testing.T) {
 			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
 		},
 		{
+			name: "updates allowed system label exceptions on an existing Pod",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+							"custom-label":                       "label-val",
+							sandboxv1beta1.SandboxAdoptableLabel: "true",
+						},
+						Annotations: map[string]string{
+							"custom-annotation":                 "anno-val",
+							"agents.x-k8s.io/propagated-labels": "custom-label",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+						ObjectMeta: sandboxv1beta1.PodMetadata{
+							Labels: map[string]string{
+								"custom-label":                      "label-val",
+								"agents.x-k8s.io/warm-pool-sandbox": "pool-hash",
+							},
+							Annotations: map[string]string{
+								"custom-annotation": "anno-val",
+							},
+						},
+					},
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+						"custom-label":                       "label-val",
+						"agents.x-k8s.io/warm-pool-sandbox":  "pool-hash",
+						sandboxv1beta1.SandboxAdoptableLabel: "true",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+						"agents.x-k8s.io/propagated-labels":      "agents.x-k8s.io/warm-pool-sandbox,custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
 			name: "delete pod if mode is Suspended",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	sandboxTemplateRefHash          = "agents.x-k8s.io/sandbox-template-ref-hash"
-	warmPoolSandboxLabel            = "agents.x-k8s.io/warm-pool-sandbox"
+	warmPoolSandboxLabel            = sandboxv1beta1.SandboxWarmPoolLabel
 	sandboxCreateDeleteMaxBatchSize = 300
 	warmPoolEvictionAnnotation      = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 )


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
The system labels are not propagated from the sandbox to pod currently - https://github.com/kubernetes-sigs/agent-sandbox/blob/main/controllers/sandbox_controller.go#L836. 
However, the label `agents.x-k8s.io/warm-pool-sandbox` is required by the capacity buffer to identify the pods belonging to a warmpool using this label selector. 
Explicitly added the warmpool labels to the pod based on the Sandbox ownership and its labels.

Added unit tests for different cases. 

Test:
```
$ kubectl get swp -n sandbox-test -o yaml | grep selector
    selector: agents.x-k8s.io/warm-pool-sandbox=11ea0998

$ kubectl get pod -n sandbox-test -l agents.x-k8s.io/warm-pool-sandbox=11ea0998
NAME                            READY   STATUS    RESTARTS   AGE
sandboxwarmpool-example-mgzdd   1/1     Running   0          88s
sandboxwarmpool-example-wdqkx   1/1     Running   0          88s
```

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized warm-pool sandbox labeling across controllers for consistent identification.
  * Pod label management now automatically syncs warm-pool ownership metadata and removes labels when ownership changes.
* **Tests**
  * Expanded test coverage to verify warm-pool label propagation, addition, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->