### PR TITLE
versionbump: go 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build go binaries
 # See https://github.com/golang/go/issues/69255#issuecomment-2523276831
-FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Declare TARGETARCH to make it available in this build stage
 ARG TARGETARCH

--- a/dev/tools/go.mod
+++ b/dev/tools/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/agent-sandbox/dev/tools
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/examples/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our golang binaries in a separate stage to keep the final image small.
-FROM golang:1.26.3 AS builder
+FROM golang:1.26.4 AS builder
 
 WORKDIR /src
 

--- a/examples/chrome-sandbox/go.mod
+++ b/examples/chrome-sandbox/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/agent-sandbox/examples/chrome-sandbox
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require k8s.io/klog/v2 v2.140.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/agent-sandbox
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/felixge/fgprof v0.9.5

--- a/tools.mod
+++ b/tools.mod
@@ -2,7 +2,7 @@ module sigs.k8s.io/agent-sandbox
 
 go 1.26
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
Using the bump-go-version skill.
