### PR TITLE
feat(go-client): add DisablePodIPRouting option

### DIFF
--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -57,12 +57,13 @@ type connector struct {
 	strategy   ConnectionStrategy
 	httpClient *http.Client
 
-	sandboxID  string // sandbox name, used as X-Sandbox-ID header
-	namespace  string
-	serverPort int
-	baseURL    string
-	podIP      string
-	lastError  error
+	sandboxID    string // sandbox name, used as X-Sandbox-ID header
+	namespace    string
+	serverPort   int
+	baseURL      string
+	podIP        string
+	disablePodIP bool
+	lastError    error
 
 	requestTimeout    time.Duration
 	perAttemptTimeout time.Duration
@@ -78,15 +79,16 @@ type connector struct {
 
 // connectorConfig holds the parameters needed to construct a connector.
 type connectorConfig struct {
-	Strategy          ConnectionStrategy
-	Namespace         string
-	ServerPort        int
-	RequestTimeout    time.Duration
-	PerAttemptTimeout time.Duration
-	HTTPTransport     http.RoundTripper
-	Log               logr.Logger
-	Tracer            trace.Tracer
-	TraceServiceName  string
+	Strategy            ConnectionStrategy
+	Namespace           string
+	ServerPort          int
+	RequestTimeout      time.Duration
+	PerAttemptTimeout   time.Duration
+	HTTPTransport       http.RoundTripper
+	DisablePodIPRouting bool
+	Log                 logr.Logger
+	Tracer              trace.Tracer
+	TraceServiceName    string
 }
 
 // newConnector creates a connector with the given configuration.
@@ -109,6 +111,7 @@ func newConnector(cfg connectorConfig) *connector {
 		serverPort:        cfg.ServerPort,
 		requestTimeout:    cfg.RequestTimeout,
 		perAttemptTimeout: cfg.PerAttemptTimeout,
+		disablePodIP:      cfg.DisablePodIPRouting,
 		ownsTransport:     cfg.HTTPTransport == nil,
 		httpClient: &http.Client{
 			Transport: transport,
@@ -284,7 +287,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		req.Header.Set(headerSandboxNamespace, namespace)
 		req.Header.Set(headerSandboxPort, strconv.Itoa(port))
 		req.Header.Set(headerRequestID, reqID)
-		if podIP != "" {
+		if podIP != "" && !c.disablePodIP {
 			req.Header.Set(headerSandboxPodIP, podIP)
 		}
 		if contentType != "" {

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -57,13 +57,13 @@ type connector struct {
 	strategy   ConnectionStrategy
 	httpClient *http.Client
 
-	sandboxID    string // sandbox name, used as X-Sandbox-ID header
-	namespace    string
-	serverPort   int
-	baseURL      string
-	podIP        string
-	disablePodIP bool
-	lastError    error
+	sandboxID           string // sandbox name, used as X-Sandbox-ID header
+	namespace           string
+	serverPort          int
+	baseURL             string
+	podIP               string
+	disablePodIPRouting bool
+	lastError           error
 
 	requestTimeout    time.Duration
 	perAttemptTimeout time.Duration
@@ -106,13 +106,13 @@ func newConnector(cfg connectorConfig) *connector {
 		}
 	}
 	return &connector{
-		strategy:          cfg.Strategy,
-		namespace:         cfg.Namespace,
-		serverPort:        cfg.ServerPort,
-		requestTimeout:    cfg.RequestTimeout,
-		perAttemptTimeout: cfg.PerAttemptTimeout,
-		disablePodIP:      cfg.DisablePodIPRouting,
-		ownsTransport:     cfg.HTTPTransport == nil,
+		strategy:            cfg.Strategy,
+		namespace:           cfg.Namespace,
+		serverPort:          cfg.ServerPort,
+		requestTimeout:      cfg.RequestTimeout,
+		perAttemptTimeout:   cfg.PerAttemptTimeout,
+		disablePodIPRouting: cfg.DisablePodIPRouting,
+		ownsTransport:       cfg.HTTPTransport == nil,
 		httpClient: &http.Client{
 			Transport: transport,
 		},
@@ -287,7 +287,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 		req.Header.Set(headerSandboxNamespace, namespace)
 		req.Header.Set(headerSandboxPort, strconv.Itoa(port))
 		req.Header.Set(headerRequestID, reqID)
-		if podIP != "" && !c.disablePodIP {
+		if podIP != "" && !c.disablePodIPRouting {
 			req.Header.Set(headerSandboxPodIP, podIP)
 		}
 		if contentType != "" {

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -59,12 +59,13 @@ type connector struct {
 	strategy   ConnectionStrategy
 	httpClient *http.Client
 
-	sandboxID  string // sandbox name, used as X-Sandbox-ID header
-	namespace  string
-	serverPort int
-	baseURL    string
-	podIP      string
-	lastError  error
+	sandboxID    string // sandbox name, used as X-Sandbox-ID header
+	namespace    string
+	serverPort   int
+	baseURL      string
+	podIP        string
+	disablePodIP bool
+	lastError    error
 
 	// routerHeaders controls whether X-Sandbox-* routing headers are sent.
 	// True for router-based transports (legacy runtime); false for the
@@ -89,16 +90,17 @@ type connector struct {
 
 // connectorConfig holds the parameters needed to construct a connector.
 type connectorConfig struct {
-	Strategy          ConnectionStrategy
-	Namespace         string
-	ServerPort        int
-	RouterHeaders     bool
-	RequestTimeout    time.Duration
-	PerAttemptTimeout time.Duration
-	HTTPTransport     http.RoundTripper
-	Log               logr.Logger
-	Tracer            trace.Tracer
-	TraceServiceName  string
+	Strategy            ConnectionStrategy
+	Namespace           string
+	ServerPort          int
+	RouterHeaders       bool
+	RequestTimeout      time.Duration
+	PerAttemptTimeout   time.Duration
+	HTTPTransport       http.RoundTripper
+	DisablePodIPRouting bool
+	Log                 logr.Logger
+	Tracer              trace.Tracer
+	TraceServiceName    string
 }
 
 // newConnector creates a connector with the given configuration.
@@ -122,6 +124,7 @@ func newConnector(cfg connectorConfig) *connector {
 		routerHeaders:     cfg.RouterHeaders,
 		requestTimeout:    cfg.RequestTimeout,
 		perAttemptTimeout: cfg.PerAttemptTimeout,
+		disablePodIP:      cfg.DisablePodIPRouting,
 		ownsTransport:     cfg.HTTPTransport == nil,
 		httpClient: &http.Client{
 			Transport: transport,
@@ -363,7 +366,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 					req.Header.Set(headerSandboxTimeout, strconv.FormatFloat(timeout.Seconds(), 'f', -1, 64))
 				}
 			}
-			if podIP != "" {
+			if podIP != "" && !c.disablePodIP {
 				req.Header.Set(headerSandboxPodIP, podIP)
 			}
 		}

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -59,13 +59,13 @@ type connector struct {
 	strategy   ConnectionStrategy
 	httpClient *http.Client
 
-	sandboxID    string // sandbox name, used as X-Sandbox-ID header
-	namespace    string
-	serverPort   int
-	baseURL      string
-	podIP        string
-	disablePodIP bool
-	lastError    error
+	sandboxID           string // sandbox name, used as X-Sandbox-ID header
+	namespace           string
+	serverPort          int
+	baseURL             string
+	podIP               string
+	disablePodIPRouting bool
+	lastError           error
 
 	// routerHeaders controls whether X-Sandbox-* routing headers are sent.
 	// True for router-based transports (legacy runtime); false for the
@@ -118,14 +118,14 @@ func newConnector(cfg connectorConfig) *connector {
 		}
 	}
 	return &connector{
-		strategy:          cfg.Strategy,
-		namespace:         cfg.Namespace,
-		serverPort:        cfg.ServerPort,
-		routerHeaders:     cfg.RouterHeaders,
-		requestTimeout:    cfg.RequestTimeout,
-		perAttemptTimeout: cfg.PerAttemptTimeout,
-		disablePodIP:      cfg.DisablePodIPRouting,
-		ownsTransport:     cfg.HTTPTransport == nil,
+		strategy:            cfg.Strategy,
+		namespace:           cfg.Namespace,
+		serverPort:          cfg.ServerPort,
+		routerHeaders:       cfg.RouterHeaders,
+		requestTimeout:      cfg.RequestTimeout,
+		perAttemptTimeout:   cfg.PerAttemptTimeout,
+		disablePodIPRouting: cfg.DisablePodIPRouting,
+		ownsTransport:       cfg.HTTPTransport == nil,
 		httpClient: &http.Client{
 			Transport: transport,
 			CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -366,7 +366,7 @@ func (c *connector) SendRequest(ctx context.Context, method, endpoint string, bo
 					req.Header.Set(headerSandboxTimeout, strconv.FormatFloat(timeout.Seconds(), 'f', -1, 64))
 				}
 			}
-			if podIP != "" && !c.disablePodIP {
+			if podIP != "" && !c.disablePodIPRouting {
 				req.Header.Set(headerSandboxPodIP, podIP)
 			}
 		}

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -505,6 +505,87 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 	}
 }
 
+func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
+	cases := []struct {
+		name         string
+		disable      bool
+		expectHeader bool
+	}{
+		{
+			name:         "default sends pod IP header",
+			disable:      false,
+			expectHeader: true,
+		},
+		{
+			name:         "disabled suppresses pod IP header",
+			disable:      true,
+			expectHeader: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var capturedHeaders http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				capturedHeaders = r.Header.Clone()
+				mu.Unlock()
+				_ = json.NewEncoder(w).Encode(map[string]bool{"exists": true})
+			}))
+			defer server.Close()
+
+			opts := Options{
+				WarmPoolName:        "test-warmpool",
+				Namespace:           "default",
+				APIURL:              server.URL,
+				ServerPort:          8888,
+				RequestTimeout:      5 * time.Second,
+				PerAttemptTimeout:   2 * time.Second,
+				Quiet:               true,
+				DisablePodIPRouting: tc.disable,
+			}
+			opts.setDefaults()
+			opts.K8sHelper = &K8sHelper{Log: opts.Logger}
+			sb, err := New(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("New() error: %v", err)
+			}
+			sb.connector.mu.Lock()
+			sb.connector.baseURL = server.URL
+			sb.connector.sandboxID = "test-claim"
+			sb.connector.backoffScale = 0.001
+			sb.connector.mu.Unlock()
+			sb.mu.Lock()
+			sb.claimName = "test-claim"
+			sb.mu.Unlock()
+
+			sb.connector.SetPodIP("10.244.0.42")
+
+			if _, err := sb.Exists(context.Background(), "x"); err != nil {
+				t.Fatalf("Exists() error: %v", err)
+			}
+
+			mu.Lock()
+			h := capturedHeaders
+			mu.Unlock()
+			if h == nil {
+				t.Fatal("handler was never invoked; no headers captured")
+			}
+
+			if tc.expectHeader {
+				if h.Get(headerSandboxPodIP) != "10.244.0.42" {
+					t.Errorf("expected %s=10.244.0.42, got %q", headerSandboxPodIP, h.Get(headerSandboxPodIP))
+				}
+			} else {
+				if _, ok := h[http.CanonicalHeaderKey(headerSandboxPodIP)]; ok {
+					t.Errorf("expected %s to be absent, but it was present", headerSandboxPodIP)
+				}
+			}
+		})
+	}
+}
+
 func TestOperations_NonOKStatus(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -545,8 +545,7 @@ func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
 				Quiet:               true,
 				DisablePodIPRouting: tc.disable,
 			}
-			opts.setDefaults()
-			opts.K8sHelper = &K8sHelper{Log: opts.Logger}
+			opts.K8sHelper = &K8sHelper{}
 			sb, err := New(context.Background(), opts)
 			if err != nil {
 				t.Fatalf("New() error: %v", err)

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -587,8 +587,7 @@ func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
 				Quiet:               true,
 				DisablePodIPRouting: tc.disable,
 			}
-			opts.setDefaults()
-			opts.K8sHelper = &K8sHelper{Log: opts.Logger}
+			opts.K8sHelper = &K8sHelper{}
 			sb, err := New(context.Background(), opts)
 			if err != nil {
 				t.Fatalf("New() error: %v", err)

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -547,6 +547,87 @@ func TestHTTPHeaders_PodIPNotSet(t *testing.T) {
 	}
 }
 
+func TestHTTPHeaders_DisablePodIPRouting(t *testing.T) {
+	cases := []struct {
+		name         string
+		disable      bool
+		expectHeader bool
+	}{
+		{
+			name:         "default sends pod IP header",
+			disable:      false,
+			expectHeader: true,
+		},
+		{
+			name:         "disabled suppresses pod IP header",
+			disable:      true,
+			expectHeader: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var capturedHeaders http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				capturedHeaders = r.Header.Clone()
+				mu.Unlock()
+				_ = json.NewEncoder(w).Encode(map[string]bool{"exists": true})
+			}))
+			defer server.Close()
+
+			opts := Options{
+				WarmPoolName:        "test-warmpool",
+				Namespace:           "default",
+				APIURL:              server.URL,
+				ServerPort:          8888,
+				RequestTimeout:      5 * time.Second,
+				PerAttemptTimeout:   2 * time.Second,
+				Quiet:               true,
+				DisablePodIPRouting: tc.disable,
+			}
+			opts.setDefaults()
+			opts.K8sHelper = &K8sHelper{Log: opts.Logger}
+			sb, err := New(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("New() error: %v", err)
+			}
+			sb.connector.mu.Lock()
+			sb.connector.baseURL = server.URL
+			sb.connector.sandboxID = "test-claim"
+			sb.connector.backoffScale = 0.001
+			sb.connector.mu.Unlock()
+			sb.mu.Lock()
+			sb.claimName = "test-claim"
+			sb.mu.Unlock()
+
+			sb.connector.SetPodIP("10.244.0.42")
+
+			if _, err := sb.Exists(context.Background(), "x"); err != nil {
+				t.Fatalf("Exists() error: %v", err)
+			}
+
+			mu.Lock()
+			h := capturedHeaders
+			mu.Unlock()
+			if h == nil {
+				t.Fatal("handler was never invoked; no headers captured")
+			}
+
+			if tc.expectHeader {
+				if h.Get(headerSandboxPodIP) != "10.244.0.42" {
+					t.Errorf("expected %s=10.244.0.42, got %q", headerSandboxPodIP, h.Get(headerSandboxPodIP))
+				}
+			} else {
+				if _, ok := h[http.CanonicalHeaderKey(headerSandboxPodIP)]; ok {
+					t.Errorf("expected %s to be absent, but it was present", headerSandboxPodIP)
+				}
+			}
+		})
+	}
+}
+
 func TestOperations_NonOKStatus(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -136,6 +136,13 @@ type Options struct {
 	// TracerProvider sets the OpenTelemetry TracerProvider for span creation.
 	// If nil, falls back to otel.GetTracerProvider (noop by default).
 	TracerProvider trace.TracerProvider
+
+	// DisablePodIPRouting suppresses the X-Sandbox-Pod-IP header even when a
+	// pod IP is available. Use in environments with strict network policies,
+	// service meshes, or secure overlays where direct pod-to-pod IP routing is
+	// restricted but service-based DNS routing works correctly.
+	// Default: false (pod IP routing enabled when a pod IP is present).
+	DisablePodIPRouting bool
 }
 
 func (o *Options) setDefaults() {

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -175,7 +175,8 @@ type Options struct {
 	// pod IP is available. Use in environments with strict network policies,
 	// service meshes, or secure overlays where direct pod-to-pod IP routing is
 	// restricted but service-based DNS routing works correctly.
-	// Default: false (pod IP routing enabled when a pod IP is present).
+	// Note: this only affects router-based transports that send X-Sandbox-* headers.
+	// Default: false (header is sent when router headers are enabled and a pod IP is present).
 	DisablePodIPRouting bool
 }
 

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -170,6 +170,13 @@ type Options struct {
 	// TracerProvider sets the OpenTelemetry TracerProvider for span creation.
 	// If nil, falls back to otel.GetTracerProvider (noop by default).
 	TracerProvider trace.TracerProvider
+
+	// DisablePodIPRouting suppresses the X-Sandbox-Pod-IP header even when a
+	// pod IP is available. Use in environments with strict network policies,
+	// service meshes, or secure overlays where direct pod-to-pod IP routing is
+	// restricted but service-based DNS routing works correctly.
+	// Default: false (pod IP routing enabled when a pod IP is present).
+	DisablePodIPRouting bool
 }
 
 func (o *Options) setDefaults() {

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -110,15 +110,16 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	}
 
 	conn := newConnector(connectorConfig{
-		Strategy:          strategy,
-		Namespace:         opts.Namespace,
-		ServerPort:        opts.ServerPort,
-		RequestTimeout:    opts.RequestTimeout,
-		PerAttemptTimeout: opts.PerAttemptTimeout,
-		HTTPTransport:     opts.HTTPTransport,
-		Log:               opts.Logger,
-		Tracer:            tracer,
-		TraceServiceName:  svcName,
+		Strategy:            strategy,
+		Namespace:           opts.Namespace,
+		ServerPort:          opts.ServerPort,
+		RequestTimeout:      opts.RequestTimeout,
+		PerAttemptTimeout:   opts.PerAttemptTimeout,
+		HTTPTransport:       opts.HTTPTransport,
+		DisablePodIPRouting: opts.DisablePodIPRouting,
+		Log:                 opts.Logger,
+		Tracer:              tracer,
+		TraceServiceName:    svcName,
 	})
 
 	// Wire tunnel's connector reference for death notifications.

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -125,16 +125,17 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	}
 
 	conn := newConnector(connectorConfig{
-		Strategy:          strategy,
-		Namespace:         opts.Namespace,
-		ServerPort:        opts.ServerPort,
-		RouterHeaders:     opts.Runtime != RuntimeSandboxd,
-		RequestTimeout:    opts.RequestTimeout,
-		PerAttemptTimeout: opts.PerAttemptTimeout,
-		HTTPTransport:     opts.HTTPTransport,
-		Log:               opts.Logger,
-		Tracer:            tracer,
-		TraceServiceName:  svcName,
+		Strategy:            strategy,
+		Namespace:           opts.Namespace,
+		ServerPort:          opts.ServerPort,
+		RouterHeaders:       opts.Runtime != RuntimeSandboxd,
+		RequestTimeout:      opts.RequestTimeout,
+		PerAttemptTimeout:   opts.PerAttemptTimeout,
+		HTTPTransport:       opts.HTTPTransport,
+		DisablePodIPRouting: opts.DisablePodIPRouting,
+		Log:                 opts.Logger,
+		Tracer:              tracer,
+		TraceServiceName:    svcName,
 	})
 
 	// Wire strategy connector references for death notifications (and, for

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -640,7 +640,8 @@ type Options struct {
     // pod IP is available. Use in environments with strict network policies,
     // service meshes, or secure overlays where direct pod-to-pod IP routing is
     // restricted but service-based DNS routing works correctly.
-    // Default: false (pod IP routing enabled when a pod IP is present).
+    // Note: this only affects router-based transports that send X-Sandbox-* headers.
+    // Default: false (header is sent when router headers are enabled and a pod IP is present).
     DisablePodIPRouting bool
 }
 ```

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -635,6 +635,13 @@ type Options struct {
     // TracerProvider sets the OpenTelemetry TracerProvider for span creation.
     // If nil, falls back to otel.GetTracerProvider (noop by default).
     TracerProvider trace.TracerProvider
+
+    // DisablePodIPRouting suppresses the X-Sandbox-Pod-IP header even when a
+    // pod IP is available. Use in environments with strict network policies,
+    // service meshes, or secure overlays where direct pod-to-pod IP routing is
+    // restricted but service-based DNS routing works correctly.
+    // Default: false (pod IP routing enabled when a pod IP is present).
+    DisablePodIPRouting bool
 }
 ```
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Adds a bool field to Options that stops the connector from sending the X-Sandbox-Pod-IP header, even when a pod IP is available. The default (false) keeps existing behavior unchanged.

Useful for clusters where direct pod-to-pod IP routing is blocked by network policy or a service mesh. Mirrors the use_pod_ip toggle in the Python SDK's SandboxInClusterConnectionConfig.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #916 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as Copilot cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once Copilot finishes the first pass, please resolve its comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to disable direct pod IP routing in the Go SDK.
  - When enabled, requests omit the pod IP routing header; routing remains enabled by default.

- **Documentation**
  - Updated the Go SDK reference to document the new routing option.

- **Tests**
  - Added coverage for both enabled and disabled pod IP routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->