### PR TITLE
Fix concurrency race condition in resourcectl local state management

### DIFF
--- a/dev/tools/go.mod
+++ b/dev/tools/go.mod
@@ -11,7 +11,10 @@ tool (
 	sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter
 )
 
-require k8s.io/klog/v2 v2.140.0
+require (
+	github.com/gofrs/flock v0.13.0
+	k8s.io/klog/v2 v2.140.0
+)
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
@@ -90,7 +93,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -206,6 +206,30 @@ func writeState(state *State) error {
 	return nil
 }
 
+// updateState performs a locked read-modify-write of the state file. The state
+// file lock is held only for the duration of fn, so fn must not perform slow or
+// blocking operations (such as network I/O) while it runs.
+func updateState(fn func(*State) error) error {
+	lockPath, err := stateLockFilePath()
+	if err != nil {
+		return err
+	}
+	fileLock := flock.New(lockPath)
+	if err := fileLock.Lock(); err != nil {
+		return fmt.Errorf("error acquiring lock: %v", err)
+	}
+	defer fileLock.Unlock()
+
+	state, err := readState()
+	if err != nil {
+		return err
+	}
+	if err := fn(state); err != nil {
+		return err
+	}
+	return writeState(state)
+}
+
 // getBoskosHost returns the boskos host from the environment variable BOSKOS_HOST.
 func getBoskosHost() (string, error) {
 	boskosHost := os.Getenv("BOSKOS_HOST")
@@ -271,39 +295,29 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 		return fmt.Errorf("error decoding response: %v", err)
 	}
 
-	// Start heartbeat process
-	cmd := exec.Command(os.Args[0], "heartbeat", "--name", resource.Name, "--owner", owner)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
-	// TODO: Log stdout/stderr of the heartbeat process
-	if err := cmd.Start(); err != nil {
-		// We will fail the test here, but we don't want a resource to be reclaimed mid test
-		return fmt.Errorf("error starting heartbeat process: %w", err)
-	}
+	// Record the resource under the state lock. We start the heartbeat process
+	// only once we hold the lock so that a process blocked waiting for the lock
+	// never leaves an orphaned heartbeat running if it is interrupted before the
+	// resource is persisted.
+	if err := updateState(func(state *State) error {
+		// Start heartbeat process
+		cmd := exec.Command(os.Args[0], "heartbeat", "--name", resource.Name, "--owner", owner)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+		// TODO: Log stdout/stderr of the heartbeat process
+		if err := cmd.Start(); err != nil {
+			// We will fail the test here, but we don't want a resource to be reclaimed mid test
+			return fmt.Errorf("error starting heartbeat process: %w", err)
+		}
 
-	lockPath, err := stateLockFilePath()
-	if err != nil {
-		return err
-	}
-	fileLock := flock.New(lockPath)
-	if err := fileLock.Lock(); err != nil {
-		return fmt.Errorf("error acquiring lock: %v", err)
-	}
-	defer fileLock.Unlock()
-
-	state, err := readState()
-	if err != nil {
-		return err
-	}
-
-	state.BoskosResources = append(state.BoskosResources, BoskosResource{
-		Name:         resource.Name,
-		Type:         resourceType,
-		HeartbeatPID: cmd.Process.Pid,
-		Owner:        owner,
-		Key:          key,
-	})
-
-	if err := writeState(state); err != nil {
+		state.BoskosResources = append(state.BoskosResources, BoskosResource{
+			Name:         resource.Name,
+			Type:         resourceType,
+			HeartbeatPID: cmd.Process.Pid,
+			Owner:        owner,
+			Key:          key,
+		})
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -316,25 +330,27 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 // runCleanup releases all resources that this resourcectl instance has
 // acquired from Boskos.
 func runCleanup(ctx context.Context) error {
-	lockPath, err := stateLockFilePath()
-	if err != nil {
+	// Phase 1: under the lock, take ownership of the currently tracked resources
+	// and clear them from the state file. We release the lock immediately so the
+	// slow kill/release operations below do not block other resourcectl
+	// invocations from updating the state file.
+	var resources []BoskosResource
+	if err := updateState(func(state *State) error {
+		resources = state.BoskosResources
+		state.BoskosResources = nil
+		return nil
+	}); err != nil {
 		return err
 	}
-	fileLock := flock.New(lockPath)
-	if err := fileLock.Lock(); err != nil {
-		return fmt.Errorf("error acquiring lock: %v", err)
-	}
-	defer fileLock.Unlock()
 
-	state, err := readState()
-	if err != nil {
-		return err
-	}
+	// Phase 2: kill the heartbeat processes and release the resources from
+	// Boskos without holding the lock. Resources we fail to release are retained
+	// so a future cleanup can retry them.
 	var errs []error
 	var remainingResources []BoskosResource
 
-	for i := range state.BoskosResources {
-		r := &state.BoskosResources[i]
+	for i := range resources {
+		r := &resources[i]
 		if err := killHeartbeatProcess(ctx, r); err != nil {
 			errs = append(errs, err)
 		} else {
@@ -347,10 +363,16 @@ func runCleanup(ctx context.Context) error {
 		}
 	}
 
-	state.BoskosResources = remainingResources
-
-	if err := writeState(state); err != nil {
-		return err
+	// Phase 3: re-acquire the lock and put any resources we failed to release
+	// back into the state file. We re-read the state inside updateState so we do
+	// not clobber resources added concurrently while the lock was not held.
+	if len(remainingResources) > 0 {
+		if err := updateState(func(state *State) error {
+			state.BoskosResources = append(state.BoskosResources, remainingResources...)
+			return nil
+		}); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return errors.Join(errs...)

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -32,6 +32,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gofrs/flock"
 	"k8s.io/klog/v2"
 )
 
@@ -160,6 +161,15 @@ func stateFilePath() (string, error) {
 	return filepath.Join(dir, "state.json"), nil
 }
 
+// stateLockFilePath returns the path to the local state lock file.
+func stateLockFilePath() (string, error) {
+	p, err := stateFilePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(filepath.Dir(p), "state.lock"), nil
+}
+
 // readState reads the local state file.
 func readState() (*State, error) {
 	p, err := stateFilePath()
@@ -270,6 +280,16 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 		return fmt.Errorf("error starting heartbeat process: %w", err)
 	}
 
+	lockPath, err := stateLockFilePath()
+	if err != nil {
+		return err
+	}
+	fileLock := flock.New(lockPath)
+	if err := fileLock.Lock(); err != nil {
+		return fmt.Errorf("error acquiring lock: %v", err)
+	}
+	defer fileLock.Unlock()
+
 	state, err := readState()
 	if err != nil {
 		return err
@@ -296,6 +316,16 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 // runCleanup releases all resources that this resourcectl instance has
 // acquired from Boskos.
 func runCleanup(ctx context.Context) error {
+	lockPath, err := stateLockFilePath()
+	if err != nil {
+		return err
+	}
+	fileLock := flock.New(lockPath)
+	if err := fileLock.Lock(); err != nil {
+		return fmt.Errorf("error acquiring lock: %v", err)
+	}
+	defer fileLock.Unlock()
+
 	state, err := readState()
 	if err != nil {
 		return err

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -339,6 +339,16 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 			case <-done:
 			}
 		}
+
+		// Local state persistence failed, so this resource is not recorded and
+		// runCleanup will never release it. Network connectivity to Boskos is
+		// likely still functional, so best-effort release it now rather than
+		// tying it up for 10-15 minutes until the reaper reclaims it.
+		br := BoskosResource{Name: resource.Name, Owner: owner}
+		if relErr := br.ReleaseFromBoskos(ctx); relErr != nil {
+			log.Error(relErr, "failed to release resource from boskos after state update failure", "name", resource.Name)
+		}
+
 		return err
 	}
 

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -324,7 +324,7 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 			if killErr := syscall.Kill(pgid, syscall.SIGTERM); killErr != nil {
 				log.Error(killErr, "failed to send SIGTERM to heartbeat process group", "pgid", pgid)
 			}
-			
+
 			done := make(chan error, 1)
 			go func() {
 				done <- cmd.Wait()

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -299,9 +299,10 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 	// only once we hold the lock so that a process blocked waiting for the lock
 	// never leaves an orphaned heartbeat running if it is interrupted before the
 	// resource is persisted.
+	var cmd *exec.Cmd
 	if err := updateState(func(state *State) error {
 		// Start heartbeat process
-		cmd := exec.Command(os.Args[0], "heartbeat", "--name", resource.Name, "--owner", owner)
+		cmd = exec.Command(os.Args[0], "heartbeat", "--name", resource.Name, "--owner", owner)
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
 		// TODO: Log stdout/stderr of the heartbeat process
 		if err := cmd.Start(); err != nil {
@@ -318,6 +319,26 @@ func runGet(ctx context.Context, resourceType string, key string) error {
 		})
 		return nil
 	}); err != nil {
+		if cmd != nil && cmd.Process != nil {
+			pgid := -cmd.Process.Pid
+			if killErr := syscall.Kill(pgid, syscall.SIGTERM); killErr != nil {
+				log.Error(killErr, "failed to send SIGTERM to heartbeat process group", "pgid", pgid)
+			}
+			
+			done := make(chan error, 1)
+			go func() {
+				done <- cmd.Wait()
+			}()
+
+			select {
+			case <-time.After(time.Second):
+				if killErr := syscall.Kill(pgid, syscall.SIGKILL); killErr != nil {
+					log.Error(killErr, "failed to send SIGKILL to heartbeat process group", "pgid", pgid)
+				}
+				<-done
+			case <-done:
+			}
+		}
 		return err
 	}
 

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -435,7 +435,10 @@ func killHeartbeatProcess(ctx context.Context, r *BoskosResource) error {
 	}
 
 	if err := process.Kill(); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
+		// The heartbeat process is already gone (ESRCH on Unix, or ErrProcessDone
+		// from os.Process on Go's newer process-handle implementations); that's
+		// the desired end state, so treat it as success.
+		if errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone) {
 			return nil
 		}
 		return fmt.Errorf("error killing heartbeat process: %w", err)

--- a/dev/tools/resourcectl/main.go
+++ b/dev/tools/resourcectl/main.go
@@ -216,7 +216,7 @@ func updateState(fn func(*State) error) error {
 	}
 	fileLock := flock.New(lockPath)
 	if err := fileLock.Lock(); err != nil {
-		return fmt.Errorf("error acquiring lock: %v", err)
+		return fmt.Errorf("error acquiring lock: %w", err)
 	}
 	defer fileLock.Unlock()
 

--- a/dev/tools/resourcectl/main_test.go
+++ b/dev/tools/resourcectl/main_test.go
@@ -88,9 +88,7 @@ func TestConcurrentStateUpdates(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpHome)
 
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpHome)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpHome)
 
 	// Concurrently append a distinct resource from many goroutines. Without the
 	// state file lock these read-modify-write cycles would race and lose
@@ -152,9 +150,7 @@ func TestRunCleanup(t *testing.T) {
 	defer os.RemoveAll(tmpHome)
 
 	// Override HOME
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpHome)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpHome)
 
 	// Start a mock Boskos server
 	mockBoskos := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/dev/tools/resourcectl/main_test.go
+++ b/dev/tools/resourcectl/main_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -76,6 +77,57 @@ func TestIsHeartbeatProcess(t *testing.T) {
 
 	if isHeartbeatProcess(dummy.Process.Pid, "test-resource") {
 		t.Errorf("expected isHeartbeatProcess to return false for generic process, but got true")
+	}
+}
+
+func TestConcurrentStateUpdates(t *testing.T) {
+	// Create a temporary home directory to sandbox the state file.
+	tmpHome, err := os.MkdirTemp("", "resourcectl-test-home-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpHome)
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	// Concurrently append a distinct resource from many goroutines. Without the
+	// state file lock these read-modify-write cycles would race and lose
+	// entries; with it, every entry must survive.
+	const n = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errCh <- updateState(func(state *State) error {
+				// Widen the read-modify-write window so a missing lock would
+				// reliably drop entries.
+				time.Sleep(time.Millisecond)
+				state.BoskosResources = append(state.BoskosResources, BoskosResource{
+					Name: fmt.Sprintf("resource-%d", i),
+				})
+				return nil
+			})
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("updateState failed: %v", err)
+		}
+	}
+
+	state, err := readState()
+	if err != nil {
+		t.Fatalf("failed to read state file: %v", err)
+	}
+	if len(state.BoskosResources) != n {
+		t.Errorf("expected %d resources after concurrent updates, but got %d", n, len(state.BoskosResources))
 	}
 }
 

--- a/dev/tools/resourcectl/main_test.go
+++ b/dev/tools/resourcectl/main_test.go
@@ -129,6 +129,18 @@ func TestConcurrentStateUpdates(t *testing.T) {
 	if len(state.BoskosResources) != n {
 		t.Errorf("expected %d resources after concurrent updates, but got %d", n, len(state.BoskosResources))
 	}
+
+	seen := make(map[string]int, len(state.BoskosResources))
+	for _, resource := range state.BoskosResources {
+		seen[resource.Name]++
+	}
+
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("resource-%d", i)
+		if seen[name] != 1 {
+			t.Fatalf("expected exactly one %q entry, got %d", name, seen[name])
+		}
+	}
 }
 
 func TestRunCleanup(t *testing.T) {

--- a/dev/tools/resourcectl/main_test.go
+++ b/dev/tools/resourcectl/main_test.go
@@ -34,8 +34,10 @@ func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
-	// Just sleep forever (or until killed)
-	select {}
+	// Sleep until the parent kills us. We use a long sleep rather than an empty
+	// `select{}` because the latter trips Go's deadlock detector (exit code 2),
+	// which races the kill and makes the kill-signal assertion flaky.
+	time.Sleep(time.Hour)
 }
 
 func TestIsHeartbeatProcess(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes a concurrency race condition in the local state management of the `resourcectl` CLI utility (`dev/tools/resourcectl/main.go`). Previously, multiple instances of `resourcectl get` running concurrently would read the same `~/.local/resourcectl/state.json` file and overwrite each other's additions, leading to permanent loss of tracked Boskos resources and resource leaks as their heartbeat processes ran indefinitely. This change introduces file-based locking around the read-modify-write cycle of the state file using `github.com/gofrs/flock` to guarantee atomicity and prevent data loss.

#### Which issue(s) this PR is related to:
Fixes https://b.corp.google.com/issues/511322627

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Serialized CLI state access with file locking to prevent corruption during concurrent runs.
  - Background heartbeat is only started after state is persisted to avoid orphaned processes and ensure recorded PIDs are durable.
  - Cleanup now safely handles concurrent updates and re-appends resources that fail to release without overwriting new entries.

* **Tests**
  - Added a concurrency test validating safe simultaneous state updates and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->