### PR TITLE
optimization: optimize NodeSpread selection to run in-memory, resolving concurrent latency regression

### DIFF
--- a/extensions/controllers/queue/simple_sandbox_queue.go
+++ b/extensions/controllers/queue/simple_sandbox_queue.go
@@ -16,12 +16,14 @@ package queue
 
 import (
 	"sync"
-
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // SandboxKey uniquely identifies a sandbox in the queue.
-type SandboxKey types.NamespacedName
+type SandboxKey struct {
+	Namespace string
+	Name      string
+	NodeName  string
+}
 
 // SandboxQueue defines the interface for managing a thread-safe,
 // highly concurrent queue of adoptable warm pool sandboxes.
@@ -81,14 +83,15 @@ func (q *synchronizedQueue) Remove(key SandboxKey) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
-	if _, exists := q.set[key]; !exists {
+	uniqueID := key.Namespace + "/" + key.Name
+	if _, exists := q.set[uniqueID]; !exists {
 		return
 	}
 
-	delete(q.set, key)
+	delete(q.set, uniqueID)
 
 	for i, k := range q.items {
-		if k == key {
+		if k.Namespace == key.Namespace && k.Name == key.Name {
 			// Shift left and clear the tail slot so removed keys don't linger.
 			// Same pattern as Pop()
 			last := len(q.items) - 1
@@ -106,13 +109,13 @@ func (q *synchronizedQueue) Remove(key SandboxKey) {
 type synchronizedQueue struct {
 	mu    sync.Mutex
 	items []SandboxKey
-	set   map[SandboxKey]struct{} // Used for O(1) deduplication
+	set   map[string]struct{} // Used for O(1) deduplication by namespace/name
 }
 
 func newSynchronizedQueue() *synchronizedQueue {
 	return &synchronizedQueue{
 		items: make([]SandboxKey, 0),
-		set:   make(map[SandboxKey]struct{}),
+		set:   make(map[string]struct{}),
 	}
 }
 
@@ -120,9 +123,18 @@ func newSynchronizedQueue() *synchronizedQueue {
 func (q *synchronizedQueue) Push(key SandboxKey) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if _, exists := q.set[key]; !exists {
-		q.set[key] = struct{}{}
+	uniqueID := key.Namespace + "/" + key.Name
+	if _, exists := q.set[uniqueID]; !exists {
+		q.set[uniqueID] = struct{}{}
 		q.items = append(q.items, key)
+	} else {
+		// Key already exists. Always update the NodeName to reflect latest placement state.
+		for i := range q.items {
+			if q.items[i].Namespace == key.Namespace && q.items[i].Name == key.Name {
+				q.items[i].NodeName = key.NodeName
+				break
+			}
+		}
 	}
 }
 
@@ -144,7 +156,7 @@ func (q *synchronizedQueue) Pop() (SandboxKey, bool) {
 
 	// Remove it from slice and set
 	q.items = q.items[1:]
-	delete(q.set, item)
+	delete(q.set, item.Namespace+"/"+item.Name)
 
 	return item, true
 }
@@ -170,8 +182,9 @@ func (q *synchronizedQueue) PopWithStrategy(pick func([]SandboxKey) (SandboxKey,
 		}
 
 		q.mu.Lock()
+		uniqueID := key.Namespace + "/" + key.Name
 		// Verify the key is still present in the queue
-		if _, exists := q.set[key]; !exists {
+		if _, exists := q.set[uniqueID]; !exists {
 			// The picked key was concurrently popped by another goroutine.
 			// Unlock and retry snapshot and pick.
 			q.mu.Unlock()
@@ -180,7 +193,7 @@ func (q *synchronizedQueue) PopWithStrategy(pick func([]SandboxKey) (SandboxKey,
 
 		// Find the picked key in q.items and remove it
 		for i, k := range q.items {
-			if k == key {
+			if k.Namespace == key.Namespace && k.Name == key.Name {
 				// Shift left and clear the tail slot
 				last := len(q.items) - 1
 				copy(q.items[i:], q.items[i+1:])
@@ -189,7 +202,7 @@ func (q *synchronizedQueue) PopWithStrategy(pick func([]SandboxKey) (SandboxKey,
 				break
 			}
 		}
-		delete(q.set, key)
+		delete(q.set, uniqueID)
 		q.mu.Unlock()
 
 		return key, true

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -604,40 +604,82 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	logger := log.FromContext(ctx)
 
 	var skipped []queue.SandboxKey
-	// Instantly returns unused keys the moment we find a valid candidate!
+	var fallbackSandbox *v1beta1.Sandbox
+	var fallbackKey queue.SandboxKey
+	var adoptingFallback bool
+
+	// Instantly returns unused keys the moment we find a valid/ready candidate!
 	defer func() {
 		for _, key := range skipped {
 			r.WarmSandboxQueue.Add(claim.Spec.WarmPoolRef.Name, key)
 		}
+		// If we parked a fallback sandbox but never ended up adopting it (due to error or adopting a ready one), requeue it.
+		if fallbackSandbox != nil && !adoptingFallback {
+			r.WarmSandboxQueue.Add(claim.Spec.WarmPoolRef.Name, fallbackKey)
+		}
 	}()
 
-	var sandboxList v1beta1.SandboxList
-	if err := r.List(ctx, &sandboxList, client.InNamespace(claim.Namespace)); err != nil {
-		logger.Error(err, "Failed to list sandboxes for smart selection node counting")
-		return nil, queue.SandboxKey{}, err
-	}
+	// Strategy helper to pick candidate using in-memory NodeSpread and FIFO tie-breaking
+	pickSmart := func(keys []queue.SandboxKey) (queue.SandboxKey, bool) {
+		namespaceKeys := keys
 
-	nodeCounts := make(map[string]int)
-	sbMap := make(map[string]*v1beta1.Sandbox)
-	for i := range sandboxList.Items {
-		sb := &sandboxList.Items[i]
-		sbMap[sb.Name] = sb
-		if _, isWarm := sb.Labels[warmPoolSandboxLabel]; !isWarm {
-			if sb.Status.NodeName != "" {
-				nodeCounts[sb.Status.NodeName]++
+		if len(namespaceKeys) == 0 {
+			return queue.SandboxKey{}, false
+		}
+		if len(namespaceKeys) == 1 {
+			return namespaceKeys[0], true
+		}
+
+		// Group candidates into scheduled vs unscheduled
+		var scheduledKeys []queue.SandboxKey
+		var unscheduledKeys []queue.SandboxKey
+		for _, key := range namespaceKeys {
+			if key.NodeName != "" {
+				scheduledKeys = append(scheduledKeys, key)
+			} else {
+				unscheduledKeys = append(unscheduledKeys, key)
 			}
 		}
-	}
 
-	selector := &smartSelector{
-		claim:      claim,
-		sbMap:      sbMap,
-		nodeCounts: nodeCounts,
+		// NodeSpread strategy: spread workloads by round-robinning nodes.
+		// We count the remaining warmpool sandboxes per node in the queue.
+		// The node with the most remaining sandboxes has been selected the least.
+		if len(scheduledKeys) > 0 {
+			nodeCounts := make(map[string]int)
+			for _, key := range scheduledKeys {
+				nodeCounts[key.NodeName]++
+			}
+
+			maxCount := 0
+			for _, count := range nodeCounts {
+				if count > maxCount {
+					maxCount = count
+				}
+			}
+
+			var bestCandidates []queue.SandboxKey
+			for _, key := range scheduledKeys {
+				if nodeCounts[key.NodeName] == maxCount {
+					bestCandidates = append(bestCandidates, key)
+				}
+			}
+
+			// Ties (equal counts) are resolved using oldest first (first in the slice)
+			return bestCandidates[0], true
+		}
+
+		// Fall back to oldest first (FIFO) for unscheduled keys
+		return unscheduledKeys[0], true
 	}
 
 	for {
-		adoptedKey, ok := r.WarmSandboxQueue.GetWithStrategy(claim.Spec.WarmPoolRef.Name, selector.pick)
+		adoptedKey, ok := r.WarmSandboxQueue.GetWithStrategy(claim.Spec.WarmPoolRef.Name, pickSmart)
 		if !ok {
+			// No more candidates in our namespace. If we found an unready fallback sandbox, return it.
+			if fallbackSandbox != nil {
+				adoptingFallback = true
+				return fallbackSandbox, fallbackKey, nil
+			}
 			return nil, queue.SandboxKey{}, nil
 		}
 
@@ -656,14 +698,29 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 
 		if err := verifySandboxCandidate(adopted, claim); err != nil {
 			logger.V(1).Info("sandbox candidate can't be adopted", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name, "reason", err.Error())
+			// If it is a good sandbox in the wrong namespace, put it back.
+			// (Though pickSmart makes this impossible, we keep it for safety).
 			if errors.Is(err, ErrCrossNamespaceAdoption) {
 				skipped = append(skipped, adoptedKey)
 			}
 			continue
 		}
 
-		// Valid candidate found
-		return adopted, adoptedKey, nil
+		// Candidate is valid! Now check if it is Ready
+		if isSandboxReady(adopted) {
+			// Found a Ready sandbox! Adopt it immediately.
+			return adopted, adoptedKey, nil
+		}
+
+		// Sandbox is valid but NOT Ready.
+		// Keep the first unready sandbox we found as fallback.
+		if fallbackSandbox == nil {
+			fallbackSandbox = adopted
+			fallbackKey = adoptedKey
+		} else {
+			// Push subsequent unready sandboxes to skipped so they go back to the queue
+			skipped = append(skipped, adoptedKey)
+		}
 	}
 }
 
@@ -1641,14 +1698,16 @@ func (h *sandboxEventHandler) Update(ctx context.Context, e event.UpdateEvent, _
 	newWarmPoolName := getWarmPoolName(newSandbox)
 
 	poolChanged := oldWarmPoolName != newWarmPoolName
+	nodeScheduled := oldSandbox.Status.NodeName != newSandbox.Status.NodeName
 
-	if (!oldAdoptable && newAdoptable) || (newAdoptable && poolChanged) {
-		// Add sandbox only on transition to adoptable.
+	if (!oldAdoptable && newAdoptable) || (newAdoptable && poolChanged) || (newAdoptable && nodeScheduled) {
+		// Add/update sandbox in the queue
 		key := queue.SandboxKey{
 			Namespace: newSandbox.Namespace,
 			Name:      newSandbox.Name,
+			NodeName:  newSandbox.Status.NodeName,
 		}
-		logger.V(1).Info("Adding sandbox to warm pool queue", "warmPool", newWarmPoolName, "sandbox", key)
+		logger.V(1).Info("Adding/updating sandbox in warm pool queue", "warmPool", newWarmPoolName, "sandbox", key)
 		if newWarmPoolName != "" {
 			h.sandboxQueue.Add(newWarmPoolName, key)
 		}
@@ -1751,85 +1810,4 @@ func getWarmPoolName(obj metav1.Object) string {
 		}
 	}
 	return ""
-}
-
-type smartSelector struct {
-	claim      *extensionsv1beta1.SandboxClaim
-	sbMap      map[string]*v1beta1.Sandbox
-	nodeCounts map[string]int
-}
-
-func (s *smartSelector) pick(keys []queue.SandboxKey) (queue.SandboxKey, bool) {
-	var bestKey queue.SandboxKey
-	var bestSandbox *v1beta1.Sandbox
-	found := false
-
-	for _, key := range keys {
-		// Upfront filter mismatching namespaces to avoid map lookup
-		if key.Namespace != s.claim.Namespace {
-			continue
-		}
-
-		sb, exists := s.sbMap[key.Name]
-		if !exists {
-			// The sandbox doesn't exist in cache/cluster or r.List failed.
-			// Pop it to either discard it (if deleted) or perform a direct Get fallback.
-			return key, true
-		}
-
-		if err := verifySandboxCandidate(sb, s.claim); err != nil {
-			// The sandbox is invalid. Pop it to discard it.
-			return key, true
-		}
-
-		if !found {
-			bestKey = key
-			bestSandbox = sb
-			found = true
-			continue
-		}
-
-		sbReady := isSandboxReady(sb)
-		bestReady := isSandboxReady(bestSandbox)
-
-		if sbReady != bestReady {
-			if sbReady {
-				bestKey = key
-				bestSandbox = sb
-			}
-			continue
-		}
-
-		sbNode := sb.Status.NodeName
-		bestNode := bestSandbox.Status.NodeName
-
-		if sbNode == "" && bestNode != "" {
-			continue
-		}
-		if sbNode != "" && bestNode == "" {
-			bestKey = key
-			bestSandbox = sb
-			continue
-		}
-
-		if sbNode != "" && bestNode != "" && sbNode != bestNode {
-			sbCount := s.nodeCounts[sbNode]
-			bestCount := s.nodeCounts[bestNode]
-			if sbCount < bestCount {
-				bestKey = key
-				bestSandbox = sb
-				continue
-			}
-			if sbCount > bestCount {
-				continue
-			}
-		}
-
-		if sb.CreationTimestamp.Before(&bestSandbox.CreationTimestamp) {
-			bestKey = key
-			bestSandbox = sb
-		}
-	}
-
-	return bestKey, found
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2008,7 +2008,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 				createWarmPoolSandbox("pool-sb-2", metav1.Now(), true),
 			},
 			expectSandboxAdoption:   true,
-			expectedAdoptedSandbox:  "pool-sb-1",
+			expectedAdoptedSandbox:  "pool-sb-2",
 			expectNewSandboxCreated: false,
 			simulateConflicts:       1, // Fail update on the first sandbox, succeed on the second
 		},
@@ -2097,7 +2097,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					// Only add valid, adoptable sandboxes to the queue
 					if isAdoptable(sb) == nil {
 						warmPoolName := getWarmPoolName(sb)
-						key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name}
+						key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name, NodeName: sb.Status.NodeName}
 						warmSandboxQueue.Add(warmPoolName, key)
 					}
 				}
@@ -2626,7 +2626,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		warmSandboxQueue := queue.NewSimpleSandboxQueue()
 		if isAdoptable(warmSandbox) == nil {
 			warmPoolName := getWarmPoolName(warmSandbox)
-			key := queue.SandboxKey{Namespace: warmSandbox.Namespace, Name: warmSandbox.Name}
+			key := queue.SandboxKey{Namespace: warmSandbox.Namespace, Name: warmSandbox.Name, NodeName: warmSandbox.Status.NodeName}
 			warmSandboxQueue.Add(warmPoolName, key)
 		}
 
@@ -3398,7 +3398,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	warmSandboxQueue := queue.NewSimpleSandboxQueue()
 	if isAdoptable(extraSandbox) == nil {
 		hash := extraSandbox.Labels[sandboxTemplateRefHash]
-		key := queue.SandboxKey{Namespace: extraSandbox.Namespace, Name: extraSandbox.Name}
+		key := queue.SandboxKey{Namespace: extraSandbox.Namespace, Name: extraSandbox.Name, NodeName: extraSandbox.Status.NodeName}
 		warmSandboxQueue.Add(hash, key)
 	}
 
@@ -3953,35 +3953,36 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 		existingSandboxes      []*sandboxv1beta1.Sandbox
 		otherObjects           []client.Object
 		expectedAdoptedSandbox string
+		expectedRemainingKeys  []string
 	}{
 		{
-			name: "picks oldest ready sandbox",
+			name: "picks oldest ready sandbox (FIFO queue order)",
 			existingSandboxes: []*sandboxv1beta1.Sandbox{
-				createWarmPoolSandboxWithNode("sb-young-ready", metav1.Now(), true, "node-1"),
 				createWarmPoolSandboxWithNode("sb-old-ready", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true, "node-2"),
+				createWarmPoolSandboxWithNode("sb-young-ready", metav1.Now(), true, "node-1"),
 				createWarmPoolSandboxWithNode("sb-old-not-ready", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}, false, "node-3"),
 			},
 			expectedAdoptedSandbox: "sb-old-ready",
+			expectedRemainingKeys:  []string{"sb-young-ready", "sb-old-not-ready"},
 		},
 		{
-			name: "picks sandbox on the node with fewest active sandboxes",
+			name: "skips unready sandbox to adopt younger ready sandbox",
 			existingSandboxes: []*sandboxv1beta1.Sandbox{
-				createWarmPoolSandboxWithNode("sb-node1-ready", metav1.Now(), true, "node-1"),
-				createWarmPoolSandboxWithNode("sb-node2-ready", metav1.Now(), true, "node-2"),
+				createWarmPoolSandboxWithNode("sb-old-unready", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}, false, "node-3"),
+				createWarmPoolSandboxWithNode("sb-young-ready", metav1.Now(), true, "node-1"),
 			},
-			otherObjects: []client.Object{
-				&sandboxv1beta1.Sandbox{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "active-sb-node1",
-						Namespace: "default",
-						Labels:    map[string]string{}, // No warmPoolSandboxLabel -> active
-					},
-					Status: sandboxv1beta1.SandboxStatus{
-						NodeName: "node-1",
-					},
-				},
+			expectedAdoptedSandbox: "sb-young-ready",
+			expectedRemainingKeys:  []string{"sb-old-unready"},
+		},
+		{
+			name: "picks sandbox on the node with most remaining warmpool sandboxes (NodeSpread balancing)",
+			existingSandboxes: []*sandboxv1beta1.Sandbox{
+				createWarmPoolSandboxWithNode("sb-node1-oldest", metav1.Time{Time: metav1.Now().Add(-2 * time.Hour)}, true, "node-1"),
+				createWarmPoolSandboxWithNode("sb-node2-younger-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true, "node-2"),
+				createWarmPoolSandboxWithNode("sb-node2-younger-2", metav1.Now(), true, "node-2"),
 			},
-			expectedAdoptedSandbox: "sb-node2-ready",
+			expectedAdoptedSandbox: "sb-node2-younger-1",
+			expectedRemainingKeys:  []string{"sb-node1-oldest", "sb-node2-younger-2"},
 		},
 	}
 
@@ -4024,7 +4025,7 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 
 			warmSandboxQueue := queue.NewSimpleSandboxQueue()
 			for _, sb := range tc.existingSandboxes {
-				key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name}
+				key := queue.SandboxKey{Namespace: sb.Namespace, Name: sb.Name, NodeName: sb.Status.NodeName}
 				warmSandboxQueue.Add("test-pool", key)
 			}
 
@@ -4047,108 +4048,17 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 			controllerRef := metav1.GetControllerOf(&adoptedSandbox)
 			require.NotNil(t, controllerRef)
 			require.Equal(t, claim.UID, controllerRef.UID)
+
+			// Verify that the expected remaining sandbox keys are still queued properly (regression test)
+			var actualRemaining []string
+			for {
+				key, ok := warmSandboxQueue.Get("test-pool")
+				if !ok {
+					break
+				}
+				actualRemaining = append(actualRemaining, key.Name)
+			}
+			require.Equal(t, tc.expectedRemainingKeys, actualRemaining)
 		})
 	}
-}
-
-func TestSmartSelector(t *testing.T) {
-	claim := &extensionsv1beta1.SandboxClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
-		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
-	}
-
-	createSandbox := func(name, ns, node string, ready bool) *sandboxv1beta1.Sandbox {
-		status := sandboxv1beta1.SandboxStatus{NodeName: node}
-		if ready {
-			status.Conditions = []metav1.Condition{{
-				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
-			}}
-		}
-		return &sandboxv1beta1.Sandbox{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: ns,
-				Labels: map[string]string{
-					warmPoolSandboxLabel:   sandboxcontrollers.NameHash("test-pool"),
-					sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
-				},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion: "extensions.agents.x-k8s.io/v1beta1",
-					Kind:       "SandboxWarmPool",
-					Name:       "test-pool",
-					UID:        "warmpool-uid",
-					Controller: new(true),
-				}},
-			},
-			Status: status,
-		}
-	}
-
-	t.Run("ignores keys from different namespaces", func(t *testing.T) {
-		selector := &smartSelector{
-			claim:      claim,
-			sbMap:      map[string]*sandboxv1beta1.Sandbox{},
-			nodeCounts: map[string]int{},
-		}
-		keys := []queue.SandboxKey{
-			{Namespace: "other-ns", Name: "sb-1"},
-		}
-		_, ok := selector.pick(keys)
-		require.False(t, ok)
-	})
-
-	t.Run("returns key, true when sandbox does not exist in sbMap to clean queue", func(t *testing.T) {
-		selector := &smartSelector{
-			claim:      claim,
-			sbMap:      map[string]*sandboxv1beta1.Sandbox{}, // Empty map
-			nodeCounts: map[string]int{},
-		}
-		keys := []queue.SandboxKey{
-			{Namespace: "default", Name: "sb-deleted"},
-		}
-		picked, ok := selector.pick(keys)
-		require.True(t, ok)
-		require.Equal(t, "sb-deleted", picked.Name)
-	})
-
-	t.Run("returns key, true when sandbox fails validation to clean queue", func(t *testing.T) {
-		sbInvalid := createSandbox("sb-invalid", "default", "", false)
-		// Make it invalid by removing the warm pool label
-		sbInvalid.Labels = map[string]string{}
-
-		selector := &smartSelector{
-			claim: claim,
-			sbMap: map[string]*sandboxv1beta1.Sandbox{
-				"sb-invalid": sbInvalid,
-			},
-			nodeCounts: map[string]int{},
-		}
-		keys := []queue.SandboxKey{
-			{Namespace: "default", Name: "sb-invalid"},
-		}
-		picked, ok := selector.pick(keys)
-		require.True(t, ok)
-		require.Equal(t, "sb-invalid", picked.Name)
-	})
-
-	t.Run("picks ready sandbox over unready", func(t *testing.T) {
-		sbUnready := createSandbox("sb-unready", "default", "node-1", false)
-		sbReady := createSandbox("sb-ready", "default", "node-2", true)
-
-		selector := &smartSelector{
-			claim: claim,
-			sbMap: map[string]*sandboxv1beta1.Sandbox{
-				"sb-unready": sbUnready,
-				"sb-ready":   sbReady,
-			},
-			nodeCounts: map[string]int{},
-		}
-		keys := []queue.SandboxKey{
-			{Namespace: "default", Name: "sb-unready"},
-			{Namespace: "default", Name: "sb-ready"},
-		}
-		picked, ok := selector.pick(keys)
-		require.True(t, ok)
-		require.Equal(t, "sb-ready", picked.Name)
-	})
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR optimizes the NodeSpread sandbox selection strategy to run purely in memory by tracking sandbox node placement directly in the queue keys.

The previous NodeSpread implementation #878  required calling [r.List](https://github.com/kubernetes-sigs/agent-sandbox/pull/878/changes#diff-b22786ea5b6b6e66e6683cd3c350a6f7ac73922396669b872bd4b41dea1bbd28R615) to retrieve all sandboxes in the namespace on every single claim reconciliation to calculate node workloads. Under high concurrent claim adoption (QPS=300, BURST_SIZE=300), this namespace list call triggered up to 270,000 object deep-copies, causing severe CPU/GC thrashing and cache read-lock contention.

This optimization resolves the latency regression by storing NodeName in `queue.SandboxKey` and calculating the node spread in memory from the queue snapshot. This drops the adoption complexity from `O(N)` to `O(1) `local cache reads.


## Performance Comparison

#### 1. Under Low Load (BURST_SIZE=100, QPS=50, WARMPOOL_SIZE=200)

| Metric / Percentile | main Branch (Unoptimized) | This Branch (Optimized) | Performance Delta (Speedup) |
| :------------------ | :------------------------ | :---------------------- | :-------------------------- |
| P50 Latency         | 123.2 ms                  | 98.5 ms                 | 1.2x faster                 |
| P90 Latency         | 1,551.5 ms (1.5s)         | 219.5 ms                | 7.0x faster                 |
| P99 Latency         | 9,730.6 ms (9.7s)         | 246.9 ms                | 39.4x faster (~4000% speedup) |

#### 2. Under High Stress (BURST_SIZE=300, QPS=300, WARMPOOL_SIZE=600, warm-pool-batch-size=1)

Testing with `batch-size=1` to eliminate node-level container startup backoff delays.

| Metric / Percentile | main Branch (Unoptimized) | This Branch (Optimized) | Performance Delta (Speedup) |
| :------------------ | :------------------------ | :---------------------- | :-------------------------- |
| P50 Latency         | 244.8 ms                  | 173.4 ms                | 1.4x faster                 |
| P90 Latency         | 481.1 ms                  | 237.7 ms                | 2.0x faster                 |
| P99 Latency         | 1,521.4 ms (1.52s)        | 393.4 ms (0.39s)        | 3.9x faster (~400% speedup)   |

```
        args:
        - "--leader-elect=true"
        - "--enable-tracing=true"
        - --zap-log-level=debug
        - --zap-encoder=json
        - --enable-pprof-debug
        - --kube-api-qps=1000
        - --kube-api-burst=2000
        - --sandbox-concurrent-workers=400
        - --sandbox-claim-concurrent-workers=400
        - --sandbox-warm-pool-concurrent-workers=1
        - --sandbox-warm-pool-max-batch-size=1
```

The tests are run based on this framework https://github.com/kubernetes-sigs/agent-sandbox/blob/main/dev/load-test/test-recipes/README-rapid-burst.md

When running high concurrent bursts ((creating 300+ claims concurrently), GKE nodes' default systemd cgroup driver can experience IPC D-Bus socket congestion, causing transient container startup failures (StartError). To prevent this node-level bottleneck, it is recommended to set the controller manager flag: `- "--sandbox-warm-pool-max-batch-size=1"`

This was the error that would trigger a `StartError` state in the pod of a warmpool: 

```
spec.containers{python-agent}: Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error setting cgroup config for procHooks process: unable to set unit properties: the maximum number of pending messages for service per connection has been reached
```

## Changes

*   **Redefined `queue.SandboxKey`**: Redefined the key in [simple_sandbox_queue.go](file:///usr/local/google/home/vicenteferrara/agent-sandbox/extensions/controllers/queue/simple_sandbox_queue.go) to track scheduling node placement (`NodeName`).
*   **Unique ID Queue Deduplication**: Updated `synchronizedQueue` to track unique items using `Namespace/Name` string keys. This allows updating the scheduled node placement of sandboxes dynamically without pushing duplicate queue items.
*   **Stale placement prevention**: Updated queue's `Push` logic to blindly copy the incoming key's `NodeName` on updates, guaranteeing the memory queue always reflects the latest node scheduling state.
*   **Dynamic Scheduling Events**: Updated the watcher's `sandboxEventHandler` in [sandboxclaim_controller.go](file:///usr/local/google/home/vicenteferrara/agent-sandbox/extensions/controllers/sandboxclaim_controller.go) to trigger queue updates when a sandbox pod's node scheduling changes (`oldSandbox.Status.NodeName != newSandbox.Status.NodeName`).
*   **In-Memory Node-Spreading**: Replaced the expensive `r.List` query in `getCandidate` with a pure in-memory `pickSmart` selector. It counts the remaining keys per node in the queue snapshot to round-robin adoptions across the least-selected nodes, falling back to FIFO (oldest first) on ties or unscheduled keys.
*   **Idempotency & Requeue Safety (Copilot / CodeRabbit Fix)**: Fixed a queue leak where a parked unready sandbox fallback key would be permanently dropped from the queue if the loop exited early due to error or returned a ready candidate. Introduced a boolean `adoptingFallback` flag in the deferred queue-retention logic to robustly requeue the fallback key on all early-return paths except when intentionally adopted.
*   **Unit Tests**: Added a dedicated `TestSandboxClaimAdoptionStrategy` verification in [sandboxclaim_controller_test.go](file:///usr/local/google/home/vicenteferrara/agent-sandbox/extensions/controllers/sandboxclaim_controller_test.go) covering oldest-ready FIFO sorting, unready candidates filtering, and in-memory NodeSpread balancing, including regression tests for skipped queue retention.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#491 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
- **extensions/controllers**: Optimized the NodeSpread warm pool sandbox selection strategy to run purely in memory, completely eliminating namespace list API/cache overhead and improving P99 concurrent claim latency by up to 4x.
- **extensions/queue**: Redefined SandboxKey to track scheduled node placement and updated thread-safe queue deduplication to handle dynamic scheduling updates.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced warm-pool sandbox selection with better node-balancing and FIFO tie-breaking for more even placement and predictable selection.
  * Improved queue deduplication to keep queued entries consistent when multiple placements exist.

* **Bug Fixes**
  * Fixed inconsistent removal and dequeue behavior when multiple placements for the same sandbox exist.

* **Tests**
  * Updated and expanded selection and adoption tests to cover ordering, node-spread, and retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->