### PR TITLE
fix: restore orphan adoption for sandbox child resources

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -565,15 +565,17 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			return nil, nil
 		}
 		// desired is true + unowned service — adopt
-		if service.Labels == nil || service.Labels[sandboxv1beta1.SandboxAdoptableLabel] != "true" {
-			logger.Info("Refusing to adopt unowned service: missing pool authorization label",
+		isAdoptablePool := service.Labels != nil && service.Labels[sandboxv1beta1.SandboxAdoptableLabel] == "true"
+		hasTrackingLabel := service.Labels != nil && service.Labels[sandboxLabel] == nameHash
+		if !isAdoptablePool && !hasTrackingLabel {
+			logger.V(4).Info("Refusing to adopt unowned service: missing pool authorization label or sandbox tracking label",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
-				"RequiredLabel", sandboxv1beta1.SandboxAdoptableLabel)
-			return nil, fmt.Errorf("cannot adopt unowned service %q: missing required %q label with value \"true\"",
-				service.Name, sandboxv1beta1.SandboxAdoptableLabel)
+				"RequiredLabel", sandboxv1beta1.SandboxAdoptableLabel, "TrackingLabel", sandboxLabel)
+			return nil, fmt.Errorf("cannot adopt unowned service %q: missing required pool authorization label (%q) or sandbox tracking label (%q)",
+				service.Name, sandboxv1beta1.SandboxAdoptableLabel, sandboxLabel)
 		}
 		if service.Spec.ClusterIP != corev1.ClusterIPNone && service.Spec.ClusterIP != "" {
-			logger.Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
+			logger.V(4).Info("Refusing to adopt service: ClusterIP mismatch (immutable, expected None)",
 				"Service.Name", service.Name, "Sandbox.Name", sandbox.Name,
 				"Service.ClusterIP", service.Spec.ClusterIP)
 			return nil, fmt.Errorf("cannot adopt service %q: ClusterIP is %q (expected %q, field is immutable)",
@@ -776,7 +778,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		ownership, controllerRef := checkOwnership(pod, sandbox)
 		switch ownership {
 		case resourceOwnedByOther:
-			logger.Info("Refusing to adopt pod: pod is owned by a different controller",
+			logger.V(4).Info("Refusing to adopt pod: pod is owned by a different controller",
 				"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
 				"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 
@@ -788,12 +790,14 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 				pod.Name, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
 
 		case resourceUnowned:
-			if pod.Labels == nil || pod.Labels[sandboxv1beta1.SandboxAdoptableLabel] != "true" {
-				logger.Info("Refusing to adopt unowned pod: missing pool authorization label",
+			isAdoptablePool := pod.Labels != nil && pod.Labels[sandboxv1beta1.SandboxAdoptableLabel] == "true"
+			hasTrackingLabel := pod.Labels != nil && pod.Labels[sandboxLabel] == nameHash
+			if !isAdoptablePool && !hasTrackingLabel {
+				logger.V(4).Info("Refusing to adopt unowned pod: missing pool authorization label or sandbox tracking label",
 					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
-					"RequiredLabel", sandboxv1beta1.SandboxAdoptableLabel)
-				return nil, fmt.Errorf("cannot adopt unowned pod %q: missing required %q label with value \"true\"",
-					pod.Name, sandboxv1beta1.SandboxAdoptableLabel)
+					"RequiredLabel", sandboxv1beta1.SandboxAdoptableLabel, "TrackingLabel", sandboxLabel)
+				return nil, fmt.Errorf("cannot adopt unowned pod %q: missing required pool authorization label (%q) or sandbox tracking label (%q)",
+					pod.Name, sandboxv1beta1.SandboxAdoptableLabel, sandboxLabel)
 			}
 
 			if err := ctrl.SetControllerReference(sandbox, pod, r.Scheme); err != nil {
@@ -1049,19 +1053,21 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 			ownership, controllerRef := checkOwnership(pvc, sandbox)
 			switch ownership {
 			case resourceOwnedByOther:
-				logger.Info("Refusing to use PVC: PVC is owned by a different controller",
+				logger.V(4).Info("Refusing to use PVC: PVC is owned by a different controller",
 					"PVC.Name", pvcName, "Sandbox.Name", sandbox.Name,
 					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
 				return fmt.Errorf("PVC %q is owned by %s/%s (UID: %s), not by sandbox %q",
 					pvcName, controllerRef.Kind, controllerRef.Name, controllerRef.UID, sandbox.Name)
 
 			case resourceUnowned:
-				if pvc.Labels == nil || pvc.Labels[sandboxv1beta1.SandboxAdoptableLabel] != "true" {
-					logger.Info("Refusing to adopt unowned PVC: missing pool authorization label",
+				isAdoptablePool := pvc.Labels != nil && pvc.Labels[sandboxv1beta1.SandboxAdoptableLabel] == "true"
+				hasTrackingLabel := pvc.Labels != nil && pvc.Labels[sandboxLabel] == nameHash
+				if !isAdoptablePool && !hasTrackingLabel {
+					logger.V(4).Info("Refusing to adopt unowned PVC: missing pool authorization label or sandbox tracking label",
 						"PVC.Name", pvcName, "Sandbox.Name", sandbox.Name,
-						"RequiredLabel", sandboxv1beta1.SandboxAdoptableLabel)
-					return fmt.Errorf("cannot adopt unowned PVC %q: missing required %q label with value \"true\"",
-						pvcName, sandboxv1beta1.SandboxAdoptableLabel)
+						"RequiredLabel", sandboxv1beta1.SandboxAdoptableLabel, "TrackingLabel", sandboxLabel)
+					return fmt.Errorf("cannot adopt unowned PVC %q: missing required pool authorization label (%q) or sandbox tracking label (%q)",
+						pvcName, sandboxv1beta1.SandboxAdoptableLabel, sandboxLabel)
 				}
 
 				logger.Info("Adopting unowned PVC", "PVC.Name", pvcName, "Sandbox.Name", sandbox.Name)

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -621,6 +621,72 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "sandbox with existing pod carrying legacy tracking label propagates PodIPs when adoptable label is absent",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      sandboxName,
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					Status: corev1.PodStatus{
+						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}, {IP: "fd00::5"}},
+						Phase:  corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			sandboxSpec: sandboxv1beta1.SandboxSpec{
+				Service: new(true),
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			wantStatus: sandboxv1beta1.SandboxStatus{
+				Service:       sandboxName,
+				ServiceFQDN:   "sandbox-name.sandbox-ns.svc.cluster.local",
+				LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+				PodIPs:        []string{"10.244.0.5", "fd00::5"},
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Ready",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonDependenciesReady,
+						Message:            "Pod is Ready; Service Exists",
+					},
+				},
+			},
+			wantObjs: []client.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+						ClusterIP: "None",
+					},
+				},
+			},
+		},
+		{
 			name: "sandbox with existing ready pod becomes Ready without Service by default",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{
@@ -1141,6 +1207,54 @@ func TestReconcilePod(t *testing.T) {
 						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
 						"custom-label":                       "label-val",
 						sandboxv1beta1.SandboxAdoptableLabel: "true",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name: "adopts unowned pod carrying legacy tracking label when adoptable label is absent",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+							"custom-label":                      "label-val",
+						},
+						Annotations: map[string]string{
+							"custom-annotation":                      "anno-val",
+							"agents.x-k8s.io/propagated-labels":      "custom-label",
+							"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
 					},
 					Annotations: map[string]string{
 						"custom-annotation":                      "anno-val",
@@ -2068,6 +2182,47 @@ func TestReconcileService(t *testing.T) {
 			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
 		},
 		{
+			name: "adopts unowned headless service carrying legacy tracking label when adoptable label is absent",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
 			name: "does not create service when service is nil",
 			sandbox: &sandboxv1beta1.Sandbox{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2399,6 +2554,7 @@ func TestReconcilePVCs(t *testing.T) {
 	otherUID := types.UID("other-uid-456")
 	pvcTemplateName := "data"
 	pvcName := pvcTemplateName + "-" + sandboxName // "data-test-sandbox"
+	nameHash := NameHash(sandboxName)
 
 	sandbox := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2494,6 +2650,21 @@ func TestReconcilePVCs(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "adopts unowned PVC carrying legacy tracking label when adoptable label is absent",
+			initialObjs: []runtime.Object{
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvcName,
+						Namespace: sandboxNs,
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
 			name: "refuses to adopt unowned PVC that lacks pool authorization label",
 			initialObjs: []runtime.Object{
 				&corev1.PersistentVolumeClaim{
@@ -2515,7 +2686,7 @@ func TestReconcilePVCs(t *testing.T) {
 				Tracer: asmetrics.NewNoOp(),
 			}
 
-			err := r.reconcilePVCs(t.Context(), sandbox, NameHash(sandboxName))
+			err := r.reconcilePVCs(t.Context(), sandbox, nameHash)
 			if tc.expectErr {
 				require.Error(t, err)
 				if tc.errContains != "" {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes a critical functional regression introduced in #784 that broke the standard Kubernetes orphan-adoption model for `Sandbox` child resources.

When a `Sandbox` custom resource is deleted with `Cascade=Orphan` (or during backup/restore/migration workflows where `OwnerReferences` are stripped), its child resources (`Service`, `Pod`, `PersistentVolumeClaim`) remain in the namespace as unowned objects. When the `Sandbox` is recreated, the controller should re-adopt them. However, #784 introduced a strict check requiring `agents.x-k8s.io/adoptable: "true"` on unowned resources. Because the Sandbox controller does not attach this label when creating child resources, re-adoption failed with an error.

This PR restores the orphan-adoption model by modifying `reconcileService`, `reconcilePod`, and `reconcilePVCs` to authorize adoption if EITHER:
1. The resource carries the explicit pool label (`agents.x-k8s.io/adoptable: "true"`), OR
2. The resource carries the controller's own internal tracking label (`agents.x-k8s.io/sandbox-name-hash: <nameHash>`).

This preserves protection against unintended adoption of foreign unowned resources (e.g., a `StatefulSet` PVC) while fully restoring declarative lifecycle management for Sandbox workloads.

#### Which issue(s) this PR is related to:
Fixes #943

#### Release Note
```release-note
Fix orphan-adoption regression by allowing Sandbox controller to adopt unowned child resources carrying the sandbox name hash tracking label.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox adoption now accepts unowned Services, Pods, and PersistentVolumeClaims if they carry either the pool authorization label or the legacy tracking label, restoring compatibility with previously labeled resources.
  * Reduced log noise when encountering Pods owned by other controllers by lowering the adoption-refusal log verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->