### PR TITLE
fix: sanitize git-derived version strings to prevent build-time command injection

### DIFF
--- a/dev/tools/shared/utils.py
+++ b/dev/tools/shared/utils.py
@@ -30,7 +30,8 @@ _SAFE_VERSION_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
 
 def _validate_version_string(value, source):
     """Ensures a git-derived version string is safe to interpolate into a shell
-    command, raising ValueError if it contains unexpected characters."""
+    command, raising ValueError if it contains unexpected characters.
+    """
     if not value or not _SAFE_VERSION_RE.match(value):
         raise ValueError(
             f"refusing to use unsafe {source} value {value!r}: only "
@@ -40,18 +41,18 @@ def _validate_version_string(value, source):
 
 def git_describe():
     """Gets the git describe output for HEAD."""
-    return _validate_version_string(
-        subprocess.check_output(
-            ["git", "describe", "--always", "--dirty"], text=True).strip(),
-        "git describe")
+    raw_version = subprocess.check_output(
+        ["git", "describe", "--always", "--dirty"], text=True
+    ).strip()
+    return _validate_version_string(raw_version, "git describe")
 
 
 def git_sha():
     """Gets the short git SHA for HEAD."""
-    return _validate_version_string(
-        subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"], text=True).strip(),
-        "git sha")
+    raw_sha = subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], text=True
+    ).strip()
+    return _validate_version_string(raw_sha, "git sha")
 
 
 def get_image_tag():

--- a/dev/tools/shared/utils.py
+++ b/dev/tools/shared/utils.py
@@ -15,19 +15,43 @@
 
 from datetime import datetime
 import os
+import re
 import subprocess
+
+
+# Version strings derived from git refs are interpolated unquoted into the
+# Dockerfile's `RUN go build -ldflags="...${GIT_VERSION}..."` instruction. A
+# git tag or branch containing shell metacharacters could therefore break out
+# of the quoted string and execute arbitrary commands during the build. Allow
+# only characters that legitimately appear in git describe/sha output and fail
+# closed on anything else.
+_SAFE_VERSION_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def _validate_version_string(value, source):
+    """Ensures a git-derived version string is safe to interpolate into a shell
+    command, raising ValueError if it contains unexpected characters."""
+    if not value or not _SAFE_VERSION_RE.match(value):
+        raise ValueError(
+            f"refusing to use unsafe {source} value {value!r}: only "
+            "alphanumerics and the characters '.', '_', '/', '-' are allowed")
+    return value
 
 
 def git_describe():
     """Gets the git describe output for HEAD."""
-    return subprocess.check_output(
-        ["git", "describe", "--always", "--dirty"], text=True).strip()
+    return _validate_version_string(
+        subprocess.check_output(
+            ["git", "describe", "--always", "--dirty"], text=True).strip(),
+        "git describe")
 
 
 def git_sha():
     """Gets the short git SHA for HEAD."""
-    return subprocess.check_output(
-        ["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+    return _validate_version_string(
+        subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], text=True).strip(),
+        "git sha")
 
 
 def get_image_tag():


### PR DESCRIPTION
#### What this PR does / why we need it:
Validates the output of `git_describe()` and `git_sha()` in `dev/tools/shared/utils.py` against a strict allowlist (`^[A-Za-z0-9._/-]+$`) and fails closed on anything else.

These values are passed by `dev/tools/push-images` as `--build-arg=GIT_VERSION` / `GIT_SHA`, which the `Dockerfile` interpolates unquoted inside the `-ldflags="...${GIT_VERSION}..."` string of a `RUN go build` instruction. A git tag or branch containing shell metacharacters (e.g. `v1.0"; touch /tmp/marker; echo "`) could break out of the quoted string and execute arbitrary commands during the image build. Sanitizing at the source neutralizes the tainted data for all consumers rather than patching each interpolation site.

#### Which issue(s) this PR is related to:
Fixes the AI Automated Triage Report finding: OS Command Injection via unsanitized Git version strings.

#### Release Note
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for git-derived version strings used in Docker image build arguments. Invalid, empty, or unsafe values are now rejected, preventing unsafe passthrough of git output and improving build reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->