### PR TITLE
PyPI publish update: Remove 'rc 'check for publishing in pypi

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -86,9 +86,9 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: read
 
-    # Run if it is a push event AND NOT a release candidate
+    # Run if it is a push event
     if: >-
-      (github.event_name == 'push' && !contains(github.ref, 'rc'))
+      (github.event_name == 'push')
 
     steps:
       - name: Download all the dists

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,10 @@ release-manifests:
 
 # Example usage:
 # make release-python-sdk TAG=v0.1.1.post1 (for patch release on PyPI)
+# make release-python-sdk TAG=v0.1.0rc1 (for release candidate on PyPI)
 .PHONY: release-python-sdk
 release-python-sdk:
-	@if [ -z "$(TAG)" ]; then echo "TAG is required (e.g., make release-python-sdk TAG=vX.Y.Z.postN)"; exit 1; fi
+	@if [ -z "$(TAG)" ]; then echo "TAG is required (e.g., make release-python-sdk TAG=vX.Y.Z, TAG=vX.Y.ZrcN, or TAG=vX.Y.Z.postN)"; exit 1; fi
 	./dev/tools/release-python --tag=${TAG} --remote=${REMOTE_UPSTREAM}
 
 .PHONY: toc-update

--- a/dev/tools/release-python
+++ b/dev/tools/release-python
@@ -21,7 +21,7 @@ from shared.git_ops import validate_tag, check_tag_exists, check_local_repo_stat
 def main():
     parser = argparse.ArgumentParser(description="Release Python Client.")
     parser.add_argument(
-        "--tag", required=True, help="The version to tag (e.g. v0.1.0)."
+        "--tag", required=True, help="The version to tag (e.g. v0.1.0, v0.1.0rc1)."
     )
     parser.add_argument(
         "--remote",


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Since, publishing to TestPyPI is removed, we can allow publishing rc versions to PyPI. 

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->


<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for release-candidate versions in the publishing workflow.
  * Updated release tool documentation to reflect supported version formats (e.g., v1.0.0rc1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->