### PR TITLE
fix(sdk): close connector on suspend to avoid stale IP routing

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -229,9 +229,17 @@ class SandboxWithSnapshotSupport(Sandbox):
                 error_reason=f"Failed to patch operatingMode: {e}",
                 error_code=ERROR_CODE
             )
-            
+          
         # Explicitly close the container connection since the pod is being terminated.
-        self.connector.close()
+        try:
+            self.connector.close()
+        except Exception as e:
+            logger.warning(
+                "Failed to close connector during suspend for Sandbox '%s': %s",
+                self.sandbox_id,
+                e,
+            )
+        self._pod_name = None
 
         if wait_for_pod_termination(self.k8s_helper, self.namespace, pod_name_to_wait, pod_uid_to_wait, wait_timeout):
             logger.info(f"Sandbox '{self.sandbox_id}' pod successfully terminated.")
@@ -253,7 +261,14 @@ class SandboxWithSnapshotSupport(Sandbox):
     def _restore_internal(self, target_snapshot_uid: str | None, wait_timeout: int) -> RestorationResponse:
         """Internal restore logic shared by resume() and restore()."""
         # Clear cached pod name and connection before resuming to ensure we pick up the new pod
-        self.connector.close()
+        try:
+            self.connector.close()
+        except Exception as e:
+            logger.warning(
+                "Failed to close connector during restore/resume for Sandbox '%s': %s",
+                self.sandbox_id,
+                e,
+            )
         self._pod_name = None
 
         try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -229,6 +229,9 @@ class SandboxWithSnapshotSupport(Sandbox):
                 error_reason=f"Failed to patch operatingMode: {e}",
                 error_code=ERROR_CODE
             )
+            
+        # Explicitly close the container connection since the pod is being terminated.
+        self.connector.close()
 
         if wait_for_pod_termination(self.k8s_helper, self.namespace, pod_name_to_wait, pod_uid_to_wait, wait_timeout):
             logger.info(f"Sandbox '{self.sandbox_id}' pod successfully terminated.")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -1125,6 +1125,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
     def test_suspend_success(self, mock_is_suspended, mock_wait):
         """Test suspend successfully takes a snapshot and scales down."""
         mock_wait.return_value = True
+        self.sandbox._pod_name = "test-pod"
         with patch.object(self.engine, 'create') as mock_create:
             mock_create.return_value = SnapshotResponse(
                 success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
@@ -1143,18 +1144,36 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 body={"spec": {"operatingMode": "Suspended"}}
             )
             self.sandbox.connector.close.assert_called_once()
+            self.assertIsNone(self.sandbox._pod_name)
 
     @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
     def test_suspend_without_snapshot(self, mock_is_suspended, mock_wait):
         """Test suspend successfully scales down without taking a snapshot."""
         mock_wait.return_value = True
+        self.sandbox._pod_name = "test-pod"
         result = self.sandbox.suspend(snapshot_before_suspend=False)
         
         self.assertTrue(result.success)
         self.assertIsNone(result.snapshot_response)
         self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once()
         self.sandbox.connector.close.assert_called_once()
+        self.assertIsNone(self.sandbox._pod_name)
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
+    def test_suspend_connector_close_exception(self, mock_is_suspended, mock_wait):
+        """Test suspend does not crash if connector close raises an exception."""
+        mock_wait.return_value = True
+        self.sandbox._pod_name = "test-pod"
+        self.sandbox.connector.close.side_effect = Exception("Mock Close Exception")
+        
+        result = self.sandbox.suspend(snapshot_before_suspend=False)
+        
+        self.assertTrue(result.success)
+        self.assertIsNone(result.snapshot_response)
+        self.sandbox.connector.close.assert_called_once()
+        self.assertIsNone(self.sandbox._pod_name)
 
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
     def test_suspend_pod_not_there(self, mock_is_suspended):
@@ -1196,6 +1215,22 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 name=self.sandbox.sandbox_id,
                 body={"spec": {"operatingMode": "Running"}}
             )
+
+    @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_ready')
+    @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
+    def test_resume_connector_close_exception(self, mock_is_suspended, mock_wait):
+        """Test resume does not crash if connector close raises an exception during restore."""
+        mock_wait.return_value = True
+        self.sandbox.connector.close.side_effect = Exception("Mock Close Exception")
+        with patch.object(self.engine, 'list') as mock_list:
+            mock_list.return_value = ListSnapshotResult(success=True, snapshots=[], error_reason="", error_code=0)
+            self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.return_value = {"status": "patched"}
+            
+            result = self.sandbox.resume()
+            
+            self.assertTrue(result.success)
+            self.assertFalse(result.restored_from_snapshot)
+            self.sandbox.connector.close.assert_called_once()
 
     @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended')
@@ -1251,6 +1286,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
     def test_suspend_api_exception(self, mock_is_suspended):
         """Test suspend raises exception when custom object patch API call fails."""
+        self.sandbox._pod_name = "test-pod"
         with patch.object(self.engine, 'create') as mock_create:
             mock_create.return_value = SnapshotResponse(
                 success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
@@ -1262,6 +1298,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             self.assertFalse(result.success)
             self.assertIn("Failed", result.error_reason)
             self.sandbox.connector.close.assert_not_called()
+            self.assertEqual(self.sandbox._pod_name, "test-pod")
 
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
     def test_resume_api_exception(self, mock_is_suspended):
@@ -1317,6 +1354,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
     def test_suspend_timeout(self, mock_is_suspended, mock_wait):
         """Test suspend times out when wait_for_pod_termination expires."""
         mock_wait.return_value = False
+        self.sandbox._pod_name = "test-pod"
         with patch.object(self.engine, 'create') as mock_create:
             mock_create.return_value = SnapshotResponse(
                 success=True, trigger_name="test-trigger", snapshot_uid="uid-123",
@@ -1328,6 +1366,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             self.assertFalse(result.success)
             self.assertIn("Timed out", result.error_reason)
             self.sandbox.connector.close.assert_called_once()
+            self.assertIsNone(self.sandbox._pod_name)
 
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
     def test_suspend_missing_name_hash(self, mock_is_suspended):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -1142,6 +1142,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 name=self.sandbox.sandbox_id,
                 body={"spec": {"operatingMode": "Suspended"}}
             )
+            self.sandbox.connector.close.assert_called_once()
 
     @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_termination')
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
@@ -1153,6 +1154,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertIsNone(result.snapshot_response)
         self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once()
+        self.sandbox.connector.close.assert_called_once()
 
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
     def test_suspend_pod_not_there(self, mock_is_suspended):
@@ -1216,6 +1218,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             self.assertEqual(
                 self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.call_count, 1
             )
+            self.sandbox.connector.close.assert_called_once()
 
     @patch('k8s_agent_sandbox.gke_extensions.snapshots.sandbox_with_snapshot_support.wait_for_pod_ready')
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended')
@@ -1258,6 +1261,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             result = self.sandbox.suspend()
             self.assertFalse(result.success)
             self.assertIn("Failed", result.error_reason)
+            self.sandbox.connector.close.assert_not_called()
 
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=True)
     def test_resume_api_exception(self, mock_is_suspended):
@@ -1323,6 +1327,7 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             
             self.assertFalse(result.success)
             self.assertIn("Timed out", result.error_reason)
+            self.sandbox.connector.close.assert_called_once()
 
     @patch.object(SandboxWithSnapshotSupport, 'is_suspended', return_value=False)
     def test_suspend_missing_name_hash(self, mock_is_suspended):


### PR DESCRIPTION
#### What this PR does / why we need it:
Explicitly close the client-side connector during the sandbox suspend operation.
When a sandbox is suspended, its pod is terminated. If the client-side connection is not explicitly closed, the local port-forwarding tunnel remains open pointing to a stale IP. Upon a subsequent resume, any command execution or file operation would experience up to 60 seconds of retries before a new tunnel is established.
Tearing down the connector during suspend ensures that the stale tunnel is immediately terminated. The next SDK operation post-resume will then automatically spin up a fresh tunnel to the correct, updated pod IP.

#### Which issue(s) this PR is related to:
Fixes #585 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container connection cleanup during sandbox suspension to ensure proper resource management and prevent connection leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->