### PR TITLE
[v1beta1 migration]: Implement Webhook Bootstrap, In-Memory Self-Signed TLS, and CRD Patcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ LD_FLAGS := -s -w -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
 
 .PHONY: build
 build:
-	go build -ldflags "$(LD_FLAGS)" -o bin/manager cmd/agent-sandbox-controller/main.go
+	go build -ldflags "$(LD_FLAGS)" -o bin/manager ./cmd/agent-sandbox-controller
 
 KIND_CLUSTER=agent-sandbox
 

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -243,6 +243,7 @@ type SandboxStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=sandbox
 // +kubebuilder:storageversion
+// +kubebuilder:conversion:strategy=Webhook
 // Sandbox is the Schema for the sandboxes API.
 type Sandbox struct {
 	metav1.TypeMeta `json:",inline"`

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -25,11 +25,14 @@ import (
 	"strings"
 	"time"
 
+	"crypto/tls"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/felixge/fgprof"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
@@ -39,9 +42,11 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 	"sigs.k8s.io/agent-sandbox/internal/version"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -70,7 +75,16 @@ func main() {
 	var sandboxWarmPoolMaxBatchSize int
 	var enableWarmPoolEviction bool
 	var printVersion bool
+	var webhookPort int
+	var webhookCertDir string
+	var webhookServiceName string
+	var webhookNamespace string
+
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook server binds to.")
+	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory that contains the certificates.")
+	flag.StringVar(&webhookServiceName, "webhook-service-name", "agent-sandbox-webhook-service", "The name of the webhook service.")
+	flag.StringVar(&webhookNamespace, "webhook-namespace", "agent-sandbox-system", "The namespace of the webhook service.")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -176,6 +190,7 @@ func main() {
 	http.DefaultServeMux = http.NewServeMux()
 
 	scheme := controllers.Scheme
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	if extensions {
 		utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
 		utilruntime.Must(extensionsv1beta1.AddToScheme(scheme))
@@ -222,6 +237,27 @@ func main() {
 	restConfig.QPS = float32(kubeAPIQPS)
 	restConfig.Burst = kubeAPIBurst
 
+	// Create a temporary client to patch the CRDs and access Secrets
+	tempClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create temporary client")
+		os.Exit(1)
+	}
+
+	// Generate or load self-signed TLS certificates for the webhook server
+	setupLog.Info("Preparing webhook certificates", "certDir", webhookCertDir)
+	caPEM, err := generateWebhookCerts(ctx, tempClient, webhookCertDir, webhookServiceName, webhookNamespace, clusterDomain)
+	if err != nil {
+		setupLog.Error(err, "unable to prepare webhook certificates")
+		os.Exit(1)
+	}
+
+	setupLog.Info("Patching CRDs with generated CA bundle")
+	if err := patchCRDs(ctx, tempClient, caPEM, webhookServiceName, webhookNamespace); err != nil {
+		setupLog.Error(err, "failed to patch CRDs with CA bundle")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsOpts,
@@ -229,6 +265,15 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionNamespace: leaderElectionNamespace,
 		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port:    webhookPort,
+			CertDir: webhookCertDir,
+			TLSOpts: []func(*tls.Config){
+				func(cfg *tls.Config) {
+					cfg.ClientAuth = tls.NoClientCert
+				},
+			},
+		}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/cmd/agent-sandbox-controller/tls.go
+++ b/cmd/agent-sandbox-controller/tls.go
@@ -1,0 +1,277 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// generateWebhookCerts generates a self-signed CA and a server certificate signed by that CA,
+// or loads them from a shared Kubernetes Secret if it already exists.
+// It writes the server certificate (tls.crt) and key (tls.key) to the certDir.
+// It returns the PEM-encoded CA certificate, which is the caBundle to patch into the CRDs.
+func generateWebhookCerts(ctx context.Context, c client.Client, certDir string, serviceName, namespace, clusterDomain string) ([]byte, error) {
+	secretName := "agent-sandbox-webhook-certs"
+
+	// 1. Try to get the existing shared secret
+	secret := &corev1.Secret{}
+	err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
+	if err == nil {
+		setupLog.Info("Found existing shared webhook certificates in Secret", "secret", secretName)
+		// Extract certs from secret
+		caPEM := secret.Data["ca.crt"]
+		serverPEM := secret.Data["tls.crt"]
+		serverKeyPEM := secret.Data["tls.key"]
+
+		if len(caPEM) == 0 || len(serverPEM) == 0 || len(serverKeyPEM) == 0 {
+			return nil, fmt.Errorf("shared Secret %s is missing certificate data", secretName)
+		}
+
+		// Write to local certDir for the webhook server
+		if err := writeCertFiles(certDir, serverPEM, serverKeyPEM); err != nil {
+			return nil, fmt.Errorf("failed to write certificate files locally: %w", err)
+		}
+
+		return caPEM, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to check for existing shared Secret: %w", err)
+	}
+
+	// 2. Secret does not exist; generate new certificates
+	setupLog.Info("No shared webhook certificates found; generating new ones")
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate CA private key: %w", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "agent-sandbox-conversion-webhook-ca",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour), // 1 year validity
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate server private key: %w", err)
+	}
+
+	dnsNames := []string{
+		serviceName,
+		fmt.Sprintf("%s.%s", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+		fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomain),
+	}
+
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              dnsNames,
+	}
+
+	serverBytes, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create server certificate: %w", err)
+	}
+
+	serverPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: serverBytes,
+	})
+
+	serverKeyBytes, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal server private key: %w", err)
+	}
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: serverKeyBytes,
+	})
+
+	// 3. Write to local certDir
+	if err := writeCertFiles(certDir, serverPEM, serverKeyPEM); err != nil {
+		return nil, fmt.Errorf("failed to write certificate files locally: %w", err)
+	}
+
+	// 4. Attempt to persist in a shared Secret
+	sharedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"ca.crt":  caPEM,
+			"tls.crt": serverPEM,
+			"tls.key": serverKeyPEM,
+		},
+	}
+
+	setupLog.Info("Creating shared webhook certificates Secret", "secret", secretName)
+	err = c.Create(ctx, sharedSecret)
+	if err == nil {
+		return caPEM, nil
+	}
+
+	// 5. Handle race condition: if another replica created it concurrently
+	if errors.IsAlreadyExists(err) {
+		setupLog.Info("Shared Secret was created concurrently by another replica; loading it", "secret", secretName)
+		secret = &corev1.Secret{}
+		if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+			return nil, fmt.Errorf("failed to get concurrently created Secret: %w", err)
+		}
+
+		caPEM = secret.Data["ca.crt"]
+		serverPEM = secret.Data["tls.crt"]
+		serverKeyPEM = secret.Data["tls.key"]
+
+		// Overwrite our local files with the other replica's certs
+		if err := writeCertFiles(certDir, serverPEM, serverKeyPEM); err != nil {
+			return nil, fmt.Errorf("failed to overwrite certificate files locally: %w", err)
+		}
+
+		return caPEM, nil
+	}
+
+	return nil, fmt.Errorf("failed to create shared Secret: %w", err)
+}
+
+// writeCertFiles writes the server certificate and key to the local certDir.
+func writeCertFiles(certDir string, serverPEM, serverKeyPEM []byte) error {
+	if err := os.MkdirAll(certDir, 0755); err != nil {
+		return err
+	}
+
+	certPath := filepath.Join(certDir, "tls.crt")
+	keyPath := filepath.Join(certDir, "tls.key")
+
+	if err := os.WriteFile(certPath, serverPEM, 0600); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(keyPath, serverKeyPEM, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// patchCRDs patches the CRDs in the cluster with the generated CA certificate and service details using a merge patch.
+func patchCRDs(ctx context.Context, c client.Client, caPEM []byte, serviceName, namespace string) error {
+	crdNames := []string{
+		"sandboxes.agents.x-k8s.io",
+		"sandboxclaims.extensions.agents.x-k8s.io",
+		"sandboxtemplates.extensions.agents.x-k8s.io",
+		"sandboxwarmpools.extensions.agents.x-k8s.io",
+	}
+
+	for _, name := range crdNames {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		err := c.Get(ctx, types.NamespacedName{Name: name}, crd)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				setupLog.Info("CRD not found, skipping patch", "crd", name)
+				continue
+			}
+			return fmt.Errorf("failed to get CRD %s: %w", name, err)
+		}
+
+		if crd.Spec.Conversion == nil || crd.Spec.Conversion.Strategy != apiextensionsv1.WebhookConverter {
+			setupLog.Info("CRD does not use Webhook conversion strategy, skipping patch", "crd", name)
+			continue
+		}
+
+		// Keep a copy of the original CRD for the merge patch
+		original := crd.DeepCopy()
+
+		webhook := crd.Spec.Conversion.Webhook
+		if webhook == nil {
+			webhook = &apiextensionsv1.WebhookConversion{}
+		}
+
+		// Ensure ConversionReviewVersions is set when missing
+		if len(webhook.ConversionReviewVersions) == 0 {
+			webhook.ConversionReviewVersions = []string{"v1", "v1beta1"}
+		}
+
+		if webhook.ClientConfig == nil {
+			webhook.ClientConfig = &apiextensionsv1.WebhookClientConfig{}
+		}
+
+		if webhook.ClientConfig.Service == nil {
+			webhook.ClientConfig.Service = &apiextensionsv1.ServiceReference{}
+		}
+
+		// Update service details and caBundle
+		webhook.ClientConfig.Service.Name = serviceName
+		webhook.ClientConfig.Service.Namespace = namespace
+		path := "/convert"
+		webhook.ClientConfig.Service.Path = &path
+		webhook.ClientConfig.CABundle = caPEM
+
+		crd.Spec.Conversion.Webhook = webhook
+
+		// Use Patch with MergeFrom to avoid write conflicts and managedFields issues
+		if err := c.Patch(ctx, crd, client.MergeFrom(original)); err != nil {
+			return fmt.Errorf("failed to patch CRD %s: %w", name, err)
+		}
+
+		setupLog.Info("Successfully patched CRD with webhook configuration", "crd", name)
+	}
+
+	return nil
+}

--- a/cmd/agent-sandbox-controller/tls_test.go
+++ b/cmd/agent-sandbox-controller/tls_test.go
@@ -1,0 +1,225 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGenerateWebhookCerts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	serviceName := "test-service"
+	namespace := "test-namespace"
+	clusterDomain := "cluster.local"
+	secretName := "agent-sandbox-webhook-certs"
+
+	t.Run("successfully generates new certs when Secret does not exist", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "webhook-certs-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		caPEM, err := generateWebhookCerts(context.Background(), fakeClient, tempDir, serviceName, namespace, clusterDomain)
+		require.NoError(t, err)
+		require.NotEmpty(t, caPEM)
+
+		// 1. Verify files are written locally
+		certPath := filepath.Join(tempDir, "tls.crt")
+		keyPath := filepath.Join(tempDir, "tls.key")
+		assert.FileExists(t, certPath)
+		assert.FileExists(t, keyPath)
+
+		// 2. Verify server certificate has correct DNS SANs
+		certBytes, err := os.ReadFile(certPath)
+		require.NoError(t, err)
+		certBlock, _ := pem.Decode(certBytes)
+		require.NotNil(t, certBlock)
+		cert, err := x509.ParseCertificate(certBlock.Bytes)
+		require.NoError(t, err)
+
+		expectedDNSNames := []string{
+			"test-service",
+			"test-service.test-namespace",
+			"test-service.test-namespace.svc",
+			"test-service.test-namespace.svc.cluster.local",
+		}
+		assert.ElementsMatch(t, expectedDNSNames, cert.DNSNames)
+
+		// 3. Verify the Secret was created in the cluster
+		secret := &corev1.Secret{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
+		require.NoError(t, err)
+		assert.Equal(t, caPEM, secret.Data["ca.crt"])
+		assert.NotEmpty(t, secret.Data["tls.crt"])
+		assert.NotEmpty(t, secret.Data["tls.key"])
+	})
+
+	t.Run("successfully loads existing certs from Secret when it exists", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "webhook-certs-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		// Pre-populate Secret with dummy data
+		existingCA := []byte("existing-ca-pem")
+		existingCert := []byte("existing-cert-pem")
+		existingKey := []byte("existing-key-pem")
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"ca.crt":  existingCA,
+				"tls.crt": existingCert,
+				"tls.key": existingKey,
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+		caPEM, err := generateWebhookCerts(context.Background(), fakeClient, tempDir, serviceName, namespace, clusterDomain)
+		require.NoError(t, err)
+		assert.Equal(t, existingCA, caPEM)
+
+		// Verify files are written locally with the pre-populated values
+		certPath := filepath.Join(tempDir, "tls.crt")
+		keyPath := filepath.Join(tempDir, "tls.key")
+
+		certBytes, err := os.ReadFile(certPath)
+		require.NoError(t, err)
+		assert.Equal(t, existingCert, certBytes)
+
+		keyBytes, err := os.ReadFile(keyPath)
+		require.NoError(t, err)
+		assert.Equal(t, existingKey, keyBytes)
+	})
+}
+
+func TestPatchCRDs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := apiextensionsv1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	// Create a helper function to build a fake CRD
+	makeCRD := func(name string, hasWebhook bool) *apiextensionsv1.CustomResourceDefinition {
+		crd := &apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "agents.x-k8s.io",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Kind: "Sandbox",
+				},
+				Scope: apiextensionsv1.NamespaceScoped,
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name:    "v1beta1",
+						Served:  true,
+						Storage: true,
+					},
+					{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: false,
+					},
+				},
+			},
+		}
+		if hasWebhook {
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
+				Strategy: apiextensionsv1.WebhookConverter,
+				Webhook: &apiextensionsv1.WebhookConversion{
+					ConversionReviewVersions: []string{"v1", "v1beta1"},
+					ClientConfig: &apiextensionsv1.WebhookClientConfig{
+						Service: &apiextensionsv1.ServiceReference{
+							Name:      "old-service",
+							Namespace: "old-namespace",
+						},
+						CABundle: []byte("old-ca"),
+					},
+				},
+			}
+		} else {
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{
+				Strategy: apiextensionsv1.NoneConverter,
+			}
+		}
+		return crd
+	}
+
+	t.Run("successfully patches CRDs with Webhook strategy", func(t *testing.T) {
+		crd1 := makeCRD("sandboxes.agents.x-k8s.io", true)
+		crd2 := makeCRD("sandboxclaims.extensions.agents.x-k8s.io", true)
+		// crd3 is not installed (simulating extensions disabled)
+		crd4 := makeCRD("sandboxwarmpools.extensions.agents.x-k8s.io", false) // has None strategy
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(crd1, crd2, crd4).
+			Build()
+
+		caPEM := []byte("new-ca-pem")
+		serviceName := "new-service"
+		namespace := "new-namespace"
+
+		err := patchCRDs(context.Background(), fakeClient, caPEM, serviceName, namespace)
+		require.NoError(t, err)
+
+		// Verify crd1 was patched
+		patchedCRD1 := &apiextensionsv1.CustomResourceDefinition{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "sandboxes.agents.x-k8s.io"}, patchedCRD1)
+		require.NoError(t, err)
+		require.NotNil(t, patchedCRD1.Spec.Conversion)
+		require.NotNil(t, patchedCRD1.Spec.Conversion.Webhook)
+		assert.Equal(t, serviceName, patchedCRD1.Spec.Conversion.Webhook.ClientConfig.Service.Name)
+		assert.Equal(t, namespace, patchedCRD1.Spec.Conversion.Webhook.ClientConfig.Service.Namespace)
+		assert.Equal(t, "/convert", *patchedCRD1.Spec.Conversion.Webhook.ClientConfig.Service.Path)
+		assert.Equal(t, caPEM, patchedCRD1.Spec.Conversion.Webhook.ClientConfig.CABundle)
+
+		// Verify crd2 was patched
+		patchedCRD2 := &apiextensionsv1.CustomResourceDefinition{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "sandboxclaims.extensions.agents.x-k8s.io"}, patchedCRD2)
+		require.NoError(t, err)
+		assert.Equal(t, serviceName, patchedCRD2.Spec.Conversion.Webhook.ClientConfig.Service.Name)
+		assert.Equal(t, caPEM, patchedCRD2.Spec.Conversion.Webhook.ClientConfig.CABundle)
+
+		// Verify crd4 was NOT patched (strategy remains None)
+		patchedCRD4 := &apiextensionsv1.CustomResourceDefinition{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "sandboxwarmpools.extensions.agents.x-k8s.io"}, patchedCRD4)
+		require.NoError(t, err)
+		assert.Equal(t, apiextensionsv1.NoneConverter, patchedCRD4.Spec.Conversion.Strategy)
+		assert.Nil(t, patchedCRD4.Spec.Conversion.Webhook)
+	})
+}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -138,6 +138,8 @@ type SandboxReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;update;patch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/dev/tools/sort-crd-versions
+++ b/dev/tools/sort-crd-versions
@@ -16,7 +16,13 @@
 import os
 import re
 import sys
-import yaml
+
+try:
+    import yaml
+except ImportError:
+    print("Error: The 'PyYAML' package is required to sort and patch CRDs, but it is not installed.", file=sys.stderr)
+    print("Please install it by running: pip install PyYAML", file=sys.stderr)
+    sys.exit(1)
 
 def parse_k8s_version(version_str):
     # Matches v<major>[{alpha,beta}<minor>]
@@ -65,11 +71,26 @@ def sort_crd_versions(file_path):
             spec = doc.get('spec', {})
             versions = spec.get('versions', [])
             if len(versions) > 1:
+                # Force conversion strategy to Webhook and populate webhook configuration
+                spec['conversion'] = {
+                    'strategy': 'Webhook',
+                    'webhook': {
+                        'conversionReviewVersions': ['v1', 'v1beta1'],
+                        'clientConfig': {
+                            'service': {
+                                'name': 'agent-sandbox-webhook-service',
+                                'namespace': 'agent-sandbox-system',
+                                'path': '/convert'
+                            },
+                            'caBundle': 'Cg=='
+                        }
+                    }
+                }
                 # Sort versions descending by Kubernetes version priority
                 sorted_versions = sorted(versions, key=lambda v: parse_k8s_version(v.get('name', '')), reverse=True)
                 if sorted_versions != versions:
                     spec['versions'] = sorted_versions
-                    modified = True
+                modified = True
         new_docs.append(doc)
 
     if modified:

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -154,6 +154,7 @@ type SandboxStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxclaim
 // +kubebuilder:storageversion
+// +kubebuilder:conversion:strategy=Webhook
 // SandboxClaim is the Schema for the sandbox Claim API.
 type SandboxClaim struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1beta1/sandboxtemplate_types.go
+++ b/extensions/api/v1beta1/sandboxtemplate_types.go
@@ -142,6 +142,7 @@ type SandboxTemplateSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxtemplate
 // +kubebuilder:storageversion
+// +kubebuilder:conversion:strategy=Webhook
 // SandboxTemplate is the Schema for the sandbox template API.
 type SandboxTemplate struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1beta1/sandboxwarmpool_types.go
+++ b/extensions/api/v1beta1/sandboxwarmpool_types.go
@@ -98,6 +98,7 @@ type SandboxWarmPoolStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
+// +kubebuilder:conversion:strategy=Webhook
 // SandboxWarmPool is the Schema for the sandboxwarmpools API.
 type SandboxWarmPool struct {
 	metav1.TypeMeta `json:",inline"`

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -8023,3 +8023,15 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -258,3 +258,15 @@ spec:
     storage: false
     subresources:
       status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -8277,3 +8277,15 @@ spec:
         type: object
     served: true
     storage: false
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -145,3 +145,15 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/helm/templates/rbac.generated.yaml
+++ b/helm/templates/rbac.generated.yaml
@@ -19,6 +19,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -35,6 +46,14 @@ rules:
   resources:
   - sandboxes/finalizers
   - sandboxes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
   verbs:
   - get
   - patch

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -8023,3 +8023,15 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -258,3 +258,15 @@ spec:
     storage: false
     subresources:
       status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -8277,3 +8277,15 @@ spec:
         type: object
     served: true
     storage: false
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -145,3 +145,15 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: agent-sandbox-webhook-service
+          namespace: agent-sandbox-system
+          path: /convert
+        caBundle: Cg==

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -19,6 +19,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -35,6 +46,14 @@ rules:
   resources:
   - sandboxes/finalizers
   - sandboxes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
   verbs:
   - get
   - patch


### PR DESCRIPTION
Working on https://github.com/kubernetes-sigs/agent-sandbox/issues/959

# PR: Implement Webhook Bootstrap, In-Memory Self-Signed TLS (with Multi-Replica Safety), and CRD Patcher

## Summary

This PR introduces a **lightweight, in-controller TLS bootstrap and CRD patching mechanism** to support webhook-based resource conversion between `v1alpha1` and `v1beta1` for `Sandbox` and extensions CRDs. 

To ensure **multi-replica safety (scaled Deployment support)**, the controller manager implements a shared Kubernetes Secret mechanism. The first starting replica (or the leader) automatically generates a self-signed CA and server certificate, stores them in a shared Kubernetes Secret (`agent-sandbox-webhook-certs`), and patches the CRDs' `caBundle` in-cluster. All other starting replicas dynamically load the exact same certificates from this Secret, preventing TLS breakages and mismatch issues across load-balanced pods.

---

## Key Changes

### 1. In-Memory TLS, Shared Secret & Patcher 
* **`generateWebhookCerts`**: Implements the dual-mode TLS bootstrap:
  * Attempts to get the existing `agent-sandbox-webhook-certs` Secret in the namespace. If found, it loads the certificates directly from the Secret (handling scale-up and restart scenarios).
  * If not found, it generates a new self-signed CA and server certificate (ECDSA P-256) with correct DNS SANs, writes them locally, and creates the shared Secret.
  * Gracefully handles concurrent creation race conditions (split-brain) by falling back to reading the Secret if another replica created it first.
* **`patchCRDs`**: Runs synchronously at startup before the manager begins. It fetches the four CRDs (`sandboxes`, `sandboxclaims`, `sandboxtemplates`, `sandboxwarmpools`), filters for those using the `Webhook` conversion strategy, and dynamically patches their `caBundle` and service endpoints in-cluster.

### 2. Controller Manager Integration 
* Added command-line flags for webhook customization: `--webhook-port`, `--webhook-cert-dir`, `--webhook-service-name`, and `--webhook-namespace`.
* Registered the `apiextensions.k8s.io/v1` API group to the manager's scheme.
* Reordered the startup sequence to initialize the temporary client first, enabling the TLS generator to communicate with the Kubernetes API to check/create the shared Secret before launching the manager's `WebhookServer` (`ClientAuth = tls.NoClientCert`).

### 3. Automated CRD Post-Processing 
* Enhanced the post-processing script to automatically inject the complete `spec.conversion` webhook configuration block (pointing to the controller's service on `/convert` and setting `conversionReviewVersions: ["v1", "v1beta1"]` and a dummy `caBundle`) for all CustomResourceDefinitions with multiple versions.

### 4. RBAC Permissions 
* Added kubebuilder RBAC markers to grant the controller manager ServiceAccount the necessary cluster-scoped permissions (`get`, `update`, `patch`) on `customresourcedefinitions`, as well as namespace-scoped permissions (`get`, `list`, `watch`, `create`, `update`, `patch`) on `secrets`.

### 5. Build & Test Suite 
* Updated the `Makefile` to build the entire `./cmd/agent-sandbox-controller` package.
* Added comprehensive unit test coverage in `tls_test.go`:
  * `successfully_generates_new_certs_when_Secret_does_not_exist`: Verifies key generation, SAN DNS name configurations, and Secret creation in the cluster.
  * `successfully_loads_existing_certs_from_Secret_when_it_exists`: Verifies that certificates are correctly loaded and written to disk from pre-existing Secrets (preventing mismatch on scale).
  * `successfully_patches_CRDs_with_Webhook_strategy`: Verifies that CRDs are correctly fetched and patched.

## Testing

* Manual Testing via `deploy-kind` and verified that the CRD now have the CA bundle. 