### PR TITLE
[v1beta1 migration] Implement Two-Way CRD Conversion Webhook Logic

### DIFF
--- a/api/v1alpha1/sandbox_conversion.go
+++ b/api/v1alpha1/sandbox_conversion.go
@@ -1,0 +1,279 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	v1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+const v1alpha1SandboxStateAnnotation = "api.agents.x-k8s.io/v1alpha1-sandbox-state"
+
+// ConvertTo converts this Sandbox to the Hub version (v1beta1).
+func (s *Sandbox) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.Sandbox)
+
+	// Copy object metadata
+	s.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+
+	// Convert Spec
+	if err := ConvertSpecTo(&s.Spec, &dst.Spec); err != nil {
+		return err
+	}
+
+	// Convert Status
+	if err := ConvertStatusTo(&s.Status, &dst.Status); err != nil {
+		return err
+	}
+
+	// Preserve the original v1alpha1 object state for lossless round-tripping
+	if dst.Annotations == nil {
+		dst.Annotations = make(map[string]string)
+	}
+	sCopy := s.DeepCopy()
+	if sCopy.Annotations != nil {
+		delete(sCopy.Annotations, v1alpha1SandboxStateAnnotation)
+	}
+	stateJSON, err := json.Marshal(sCopy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal v1alpha1 Sandbox state: %w", err)
+	}
+	dst.Annotations[v1alpha1SandboxStateAnnotation] = string(stateJSON)
+
+	return nil
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this Sandbox.
+func (s *Sandbox) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.Sandbox)
+
+	// Copy object metadata
+	src.ObjectMeta.DeepCopyInto(&s.ObjectMeta)
+
+	// Convert Spec
+	if err := ConvertSpecFrom(&src.Spec, &s.Spec); err != nil {
+		return err
+	}
+
+	// Convert Status
+	if err := ConvertStatusFrom(&src.Status, &s.Status); err != nil {
+		return err
+	}
+
+	// Set best-effort default for Status.Replicas based on OperatingMode.
+	// This will be overridden by the restoration logic if the annotation exists.
+	if src.Spec.OperatingMode == v1beta1.SandboxOperatingModeSuspended {
+		s.Status.Replicas = 0
+	} else {
+		s.Status.Replicas = 1
+	}
+
+	// Restore original v1alpha1 state if present to ensure lossless conversion
+	if stateJSON, ok := s.Annotations[v1alpha1SandboxStateAnnotation]; ok {
+		// Strip the state annotation so it doesn't leak to clients and get sent back on updates
+		delete(s.Annotations, v1alpha1SandboxStateAnnotation)
+
+		var original Sandbox
+		if err := json.Unmarshal([]byte(stateJSON), &original); err != nil {
+			return fmt.Errorf("failed to unmarshal v1alpha1 Sandbox state: %w", err)
+		}
+
+		// Restore replicas field from original if OperatingMode matches original intent
+		switch src.Spec.OperatingMode {
+		case v1beta1.SandboxOperatingModeSuspended:
+			zero := int32(0)
+			s.Spec.Replicas = &zero
+		case v1beta1.SandboxOperatingModeRunning:
+			if original.Spec.Replicas == nil || *original.Spec.Replicas != 0 {
+				s.Spec.Replicas = original.Spec.Replicas
+			} else {
+				one := int32(1)
+				s.Spec.Replicas = &one
+			}
+		}
+
+		// Restore Status replicas
+		s.Status.Replicas = original.Status.Replicas
+	}
+
+	return nil
+}
+
+// Helper functions for Sandbox conversion
+
+func ConvertSpecTo(src *SandboxSpec, dst *v1beta1.SandboxSpec) error {
+	// PodTemplate
+	if err := ConvertPodTemplateTo(&src.PodTemplate, &dst.PodTemplate); err != nil {
+		return err
+	}
+
+	// VolumeClaimTemplates
+	if src.VolumeClaimTemplates != nil {
+		dst.VolumeClaimTemplates = make([]v1beta1.PersistentVolumeClaimTemplate, len(src.VolumeClaimTemplates))
+		for i := range src.VolumeClaimTemplates {
+			if err := ConvertPVCClaimTemplateTo(&src.VolumeClaimTemplates[i], &dst.VolumeClaimTemplates[i]); err != nil {
+				return err
+			}
+		}
+	} else {
+		dst.VolumeClaimTemplates = nil
+	}
+
+	// Lifecycle
+	if err := ConvertLifecycleTo(&src.Lifecycle, &dst.Lifecycle); err != nil {
+		return err
+	}
+
+	// Replicas -> OperatingMode
+	if src.Replicas != nil && *src.Replicas == 0 {
+		dst.OperatingMode = v1beta1.SandboxOperatingModeSuspended
+	} else {
+		dst.OperatingMode = v1beta1.SandboxOperatingModeRunning
+	}
+
+	// Service
+	dst.Service = src.Service
+
+	return nil
+}
+
+func ConvertSpecFrom(src *v1beta1.SandboxSpec, dst *SandboxSpec) error {
+	// PodTemplate
+	if err := ConvertPodTemplateFrom(&src.PodTemplate, &dst.PodTemplate); err != nil {
+		return err
+	}
+
+	// VolumeClaimTemplates
+	if src.VolumeClaimTemplates != nil {
+		dst.VolumeClaimTemplates = make([]PersistentVolumeClaimTemplate, len(src.VolumeClaimTemplates))
+		for i := range src.VolumeClaimTemplates {
+			if err := ConvertPVCClaimTemplateFrom(&src.VolumeClaimTemplates[i], &dst.VolumeClaimTemplates[i]); err != nil {
+				return err
+			}
+		}
+	} else {
+		dst.VolumeClaimTemplates = nil
+	}
+
+	// Lifecycle
+	if err := ConvertLifecycleFrom(&src.Lifecycle, &dst.Lifecycle); err != nil {
+		return err
+	}
+
+	// OperatingMode -> Replicas
+	one := int32(1)
+	zero := int32(0)
+	if src.OperatingMode == v1beta1.SandboxOperatingModeSuspended {
+		dst.Replicas = &zero
+	} else {
+		dst.Replicas = &one
+	}
+
+	// Service
+	dst.Service = src.Service
+
+	return nil
+}
+
+func ConvertStatusTo(src *SandboxStatus, dst *v1beta1.SandboxStatus) error {
+	dst.ServiceFQDN = src.ServiceFQDN
+	dst.Service = src.Service
+	dst.Conditions = src.Conditions
+	dst.LabelSelector = src.LabelSelector
+	dst.PodIPs = src.PodIPs
+	dst.NodeName = "" // NodeName is new in v1beta1 and does not exist in v1alpha1
+	return nil
+}
+
+func ConvertStatusFrom(src *v1beta1.SandboxStatus, dst *SandboxStatus) error {
+	dst.ServiceFQDN = src.ServiceFQDN
+	dst.Service = src.Service
+	dst.Conditions = src.Conditions
+	dst.LabelSelector = src.LabelSelector
+	dst.PodIPs = src.PodIPs
+	return nil
+}
+
+func ConvertPodTemplateTo(src *PodTemplate, dst *v1beta1.PodTemplate) error {
+	dst.Spec = src.Spec
+	ConvertPodMetadataTo(&src.ObjectMeta, &dst.ObjectMeta)
+	return nil
+}
+
+func ConvertPodTemplateFrom(src *v1beta1.PodTemplate, dst *PodTemplate) error {
+	dst.Spec = src.Spec
+	ConvertPodMetadataFrom(&src.ObjectMeta, &dst.ObjectMeta)
+	return nil
+}
+
+func ConvertPodMetadataTo(src *PodMetadata, dst *v1beta1.PodMetadata) {
+	dst.Labels = src.Labels
+	dst.Annotations = src.Annotations
+}
+
+func ConvertPodMetadataFrom(src *v1beta1.PodMetadata, dst *PodMetadata) {
+	dst.Labels = src.Labels
+	dst.Annotations = src.Annotations
+}
+
+func ConvertPVCClaimTemplateTo(src *PersistentVolumeClaimTemplate, dst *v1beta1.PersistentVolumeClaimTemplate) error {
+	dst.Spec = src.Spec
+	ConvertEmbeddedMetadataTo(&src.EmbeddedObjectMetadata, &dst.EmbeddedObjectMetadata)
+	return nil
+}
+
+func ConvertPVCClaimTemplateFrom(src *v1beta1.PersistentVolumeClaimTemplate, dst *PersistentVolumeClaimTemplate) error {
+	dst.Spec = src.Spec
+	ConvertEmbeddedMetadataFrom(&src.EmbeddedObjectMetadata, &dst.EmbeddedObjectMetadata)
+	return nil
+}
+
+func ConvertEmbeddedMetadataTo(src *EmbeddedObjectMetadata, dst *v1beta1.EmbeddedObjectMetadata) {
+	dst.Name = src.Name
+	dst.Labels = src.Labels
+	dst.Annotations = src.Annotations
+}
+
+func ConvertEmbeddedMetadataFrom(src *v1beta1.EmbeddedObjectMetadata, dst *EmbeddedObjectMetadata) {
+	dst.Name = src.Name
+	dst.Labels = src.Labels
+	dst.Annotations = src.Annotations
+}
+
+func ConvertLifecycleTo(src *Lifecycle, dst *v1beta1.Lifecycle) error {
+	dst.ShutdownTime = src.ShutdownTime
+	if src.ShutdownPolicy != nil {
+		policy := v1beta1.ShutdownPolicy(*src.ShutdownPolicy)
+		dst.ShutdownPolicy = &policy
+	} else {
+		dst.ShutdownPolicy = nil
+	}
+	return nil
+}
+
+func ConvertLifecycleFrom(src *v1beta1.Lifecycle, dst *Lifecycle) error {
+	dst.ShutdownTime = src.ShutdownTime
+	if src.ShutdownPolicy != nil {
+		policy := ShutdownPolicy(*src.ShutdownPolicy)
+		dst.ShutdownPolicy = &policy
+	} else {
+		dst.ShutdownPolicy = nil
+	}
+	return nil
+}

--- a/api/v1alpha1/sandbox_conversion_test.go
+++ b/api/v1alpha1/sandbox_conversion_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+func TestSandboxConversion(t *testing.T) {
+	one := int32(1)
+	zero := int32(0)
+
+	tests := []struct {
+		name                string
+		replicas            *int32
+		expectedMode        v1beta1.SandboxOperatingMode
+		statusReplicas      int32
+		expectedStatusRepls int32
+	}{
+		{
+			name:                "Replicas is nil (default running)",
+			replicas:            nil,
+			expectedMode:        v1beta1.SandboxOperatingModeRunning,
+			statusReplicas:      1,
+			expectedStatusRepls: 1,
+		},
+		{
+			name:                "Replicas is 1",
+			replicas:            &one,
+			expectedMode:        v1beta1.SandboxOperatingModeRunning,
+			statusReplicas:      1,
+			expectedStatusRepls: 1,
+		},
+		{
+			name:                "Replicas is 0 (suspended)",
+			replicas:            &zero,
+			expectedMode:        v1beta1.SandboxOperatingModeSuspended,
+			statusReplicas:      0,
+			expectedStatusRepls: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := metav1.Now()
+			policy := ShutdownPolicyDelete
+			bTrue := true
+
+			// Create src v1alpha1 Sandbox
+			src := &Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-sandbox",
+					Namespace: "default",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"baz":                          "qux",
+						v1alpha1SandboxStateAnnotation: "some-old-state",
+					},
+				},
+				Spec: SandboxSpec{
+					PodTemplate: PodTemplate{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "agent",
+									Image: "agent-image:latest",
+								},
+							},
+						},
+						ObjectMeta: PodMetadata{
+							Labels: map[string]string{
+								"pod-label": "value",
+							},
+						},
+					},
+					VolumeClaimTemplates: []PersistentVolumeClaimTemplate{
+						{
+							EmbeddedObjectMetadata: EmbeddedObjectMetadata{
+								Name: "workspace",
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{
+									corev1.ReadWriteOnce,
+								},
+							},
+						},
+					},
+					Lifecycle: Lifecycle{
+						ShutdownTime:   &now,
+						ShutdownPolicy: &policy,
+					},
+					Replicas: tc.replicas,
+					Service:  &bTrue,
+				},
+				Status: SandboxStatus{
+					ServiceFQDN:   "my-sandbox.default.svc.cluster.local",
+					LabelSelector: "sandbox=my-sandbox",
+					PodIPs: []string{
+						"10.244.0.5",
+					},
+					Replicas: tc.statusReplicas,
+				},
+			}
+
+			// Convert to Hub (v1beta1)
+			dst := &v1beta1.Sandbox{}
+			if err := src.ConvertTo(dst); err != nil {
+				t.Fatalf("failed to convert to v1beta1: %v", err)
+			}
+
+			// Verify src annotations and labels were not mutated during ConvertTo
+			if val, ok := src.Annotations[v1alpha1SandboxStateAnnotation]; !ok || val != "some-old-state" {
+				t.Errorf("src.Annotations was mutated during ConvertTo! expected 'some-old-state', got %q", val)
+			}
+			if len(src.Annotations) != 2 {
+				t.Errorf("expected 2 annotations in src, got %d", len(src.Annotations))
+			}
+			if len(src.Labels) != 1 {
+				t.Errorf("expected 1 label in src, got %d", len(src.Labels))
+			}
+
+			// Verify the marshaled state in dst does not contain the state annotation itself (no nesting)
+			marshaledState := dst.Annotations[v1alpha1SandboxStateAnnotation]
+			var stateObj Sandbox
+			if err := json.Unmarshal([]byte(marshaledState), &stateObj); err != nil {
+				t.Fatalf("failed to unmarshal state from dst: %v", err)
+			}
+			if _, ok := stateObj.Annotations[v1alpha1SandboxStateAnnotation]; ok {
+				t.Errorf("dst.Annotations state nestedly contains the state annotation! causing exponential growth")
+			}
+
+			// Verify fields in v1beta1
+			if dst.Spec.OperatingMode != tc.expectedMode {
+				t.Errorf("expected OperatingMode %q, got %q", tc.expectedMode, dst.Spec.OperatingMode)
+			}
+			if dst.Spec.PodTemplate.Spec.Containers[0].Image != "agent-image:latest" {
+				t.Errorf("expected image %q, got %q", "agent-image:latest", dst.Spec.PodTemplate.Spec.Containers[0].Image)
+			}
+			if dst.Spec.VolumeClaimTemplates[0].Name != "workspace" {
+				t.Errorf("expected VolumeClaimTemplate name %q, got %q", "workspace", dst.Spec.VolumeClaimTemplates[0].Name)
+			}
+			if dst.Spec.Lifecycle.ShutdownPolicy == nil || string(*dst.Spec.Lifecycle.ShutdownPolicy) != string(ShutdownPolicyDelete) {
+				t.Errorf("expected ShutdownPolicy %q, got %v", ShutdownPolicyDelete, dst.Spec.Lifecycle.ShutdownPolicy)
+			}
+
+			// Convert back to Spoke (v1alpha1)
+			roundTrip := &Sandbox{}
+			if err := roundTrip.ConvertFrom(dst); err != nil {
+				t.Fatalf("failed to convert back to v1alpha1: %v", err)
+			}
+
+			// Verify state annotation was stripped during ConvertFrom
+			if _, ok := roundTrip.Annotations[v1alpha1SandboxStateAnnotation]; ok {
+				t.Errorf("roundTrip.Annotations still contains the state annotation after ConvertFrom!")
+			}
+
+			// Verify round-trip preserves fields losslessly
+			if tc.replicas == nil {
+				if roundTrip.Spec.Replicas != nil {
+					t.Errorf("roundtrip Replicas mismatch: expected nil, got %v", *roundTrip.Spec.Replicas)
+				}
+			} else {
+				if roundTrip.Spec.Replicas == nil || *roundTrip.Spec.Replicas != *tc.replicas {
+					t.Errorf("roundtrip Replicas mismatch: expected %d, got %v", *tc.replicas, roundTrip.Spec.Replicas)
+				}
+			}
+
+			if roundTrip.Status.Replicas != tc.expectedStatusRepls {
+				t.Errorf("roundtrip Status.Replicas mismatch: expected %d, got %d", tc.expectedStatusRepls, roundTrip.Status.Replicas)
+			}
+
+			if roundTrip.Spec.PodTemplate.Spec.Containers[0].Image != src.Spec.PodTemplate.Spec.Containers[0].Image {
+				t.Errorf("roundtrip PodTemplate Image mismatch: expected %q, got %q", src.Spec.PodTemplate.Spec.Containers[0].Image, roundTrip.Spec.PodTemplate.Spec.Containers[0].Image)
+			}
+
+			if len(roundTrip.Spec.VolumeClaimTemplates) != len(src.Spec.VolumeClaimTemplates) || roundTrip.Spec.VolumeClaimTemplates[0].Name != src.Spec.VolumeClaimTemplates[0].Name {
+				t.Errorf("roundtrip VolumeClaimTemplates mismatch")
+			}
+
+			if roundTrip.Spec.Lifecycle.ShutdownPolicy == nil || *roundTrip.Spec.Lifecycle.ShutdownPolicy != *src.Spec.Lifecycle.ShutdownPolicy {
+				t.Errorf("roundtrip ShutdownPolicy mismatch")
+			}
+		})
+	}
+}
+
+func TestSandboxConversionFromHub(t *testing.T) {
+	// Test conversion of a v1beta1 Sandbox created without v1alpha1 state annotation (e.g. created directly via v1beta1 API)
+	tests := []struct {
+		name             string
+		mode             v1beta1.SandboxOperatingMode
+		expectedReplicas int32
+	}{
+		{
+			name:             "Hub Running mode",
+			mode:             v1beta1.SandboxOperatingModeRunning,
+			expectedReplicas: 1,
+		},
+		{
+			name:             "Hub Suspended mode",
+			mode:             v1beta1.SandboxOperatingModeSuspended,
+			expectedReplicas: 0,
+		},
+		{
+			name:             "Hub empty mode (defaults to Running/1)",
+			mode:             "",
+			expectedReplicas: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &v1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-sandbox",
+					Namespace: "default",
+				},
+				Spec: v1beta1.SandboxSpec{
+					OperatingMode: tc.mode,
+				},
+			}
+
+			dst := &Sandbox{}
+			if err := dst.ConvertFrom(src); err != nil {
+				t.Fatalf("failed to convert from v1beta1: %v", err)
+			}
+
+			if dst.Spec.Replicas == nil {
+				t.Fatalf("expected Replicas to be non-nil, got nil")
+			}
+			if *dst.Spec.Replicas != tc.expectedReplicas {
+				t.Errorf("expected Replicas to be %d, got %d", tc.expectedReplicas, *dst.Spec.Replicas)
+			}
+			if dst.Status.Replicas != tc.expectedReplicas {
+				t.Errorf("expected Status.Replicas to be %d, got %d", tc.expectedReplicas, dst.Status.Replicas)
+			}
+		})
+	}
+}

--- a/api/v1beta1/sandbox_conversion.go
+++ b/api/v1beta1/sandbox_conversion.go
@@ -1,0 +1,18 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+// Hub marks Sandbox as a conversion Hub.
+func (*Sandbox) Hub() {}

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/felixge/fgprof"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	"sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1alpha1 "sigs.k8s.io/agent-sandbox/extensions/api/v1alpha1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -293,6 +294,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = ctrl.NewWebhookManagedBy(mgr, &sandboxv1beta1.Sandbox{}).
+		Complete(); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Sandbox")
+		os.Exit(1)
+	}
+
 	if extensions {
 		warmSandboxQueue := queue.NewSimpleSandboxQueue()
 
@@ -344,6 +351,24 @@ func main() {
 			EnableWarmPoolEviction: enableWarmPoolEviction,
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")
+			os.Exit(1)
+		}
+
+		if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxClaim{}).
+			Complete(); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "SandboxClaim")
+			os.Exit(1)
+		}
+
+		if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxTemplate{}).
+			Complete(); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "SandboxTemplate")
+			os.Exit(1)
+		}
+
+		if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxWarmPool{}).
+			Complete(); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "SandboxWarmPool")
 			os.Exit(1)
 		}
 	}

--- a/extensions/api/v1alpha1/sandboxclaim_conversion.go
+++ b/extensions/api/v1alpha1/sandboxclaim_conversion.go
@@ -1,0 +1,269 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	v1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+const v1alpha1SandboxClaimStateAnnotation = "api.agents.x-k8s.io/v1alpha1-sandboxclaim-state"
+
+// ConvertTo converts this SandboxClaim to the Hub version (v1beta1).
+func (s *SandboxClaim) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.SandboxClaim)
+
+	// Copy object metadata
+	s.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+
+	// Convert Spec
+	if err := convertClaimSpecTo(&s.Spec, &dst.Spec, s.Name, s.Status.SandboxStatus.Name); err != nil {
+		return err
+	}
+
+	// Convert Status
+	if err := convertClaimStatusTo(&s.Status, &dst.Status); err != nil {
+		return err
+	}
+
+	// Preserve the original v1alpha1 object state for lossless round-tripping
+	if dst.Annotations == nil {
+		dst.Annotations = make(map[string]string)
+	}
+	sCopy := s.DeepCopy()
+	if sCopy.Annotations != nil {
+		delete(sCopy.Annotations, v1alpha1SandboxClaimStateAnnotation)
+	}
+	stateJSON, err := json.Marshal(sCopy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal v1alpha1 SandboxClaim state: %w", err)
+	}
+	dst.Annotations[v1alpha1SandboxClaimStateAnnotation] = string(stateJSON)
+
+	return nil
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this SandboxClaim.
+func (s *SandboxClaim) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.SandboxClaim)
+
+	// Copy object metadata
+	src.ObjectMeta.DeepCopyInto(&s.ObjectMeta)
+
+	// Convert Spec
+	if err := convertClaimSpecFrom(&src.Spec, &s.Spec); err != nil {
+		return err
+	}
+
+	// Convert Status
+	if err := convertClaimStatusFrom(&src.Status, &s.Status); err != nil {
+		return err
+	}
+
+	// Restore original v1alpha1 state if present to ensure lossless conversion
+	if stateJSON, ok := s.Annotations[v1alpha1SandboxClaimStateAnnotation]; ok {
+		// Strip the state annotation so it doesn't leak to clients and get sent back on updates
+		delete(s.Annotations, v1alpha1SandboxClaimStateAnnotation)
+
+		var original SandboxClaim
+		if err := json.Unmarshal([]byte(stateJSON), &original); err != nil {
+			return fmt.Errorf("failed to unmarshal v1alpha1 SandboxClaim state: %w", err)
+		}
+
+		// If the warm pool ref in the hub hasn't changed (or matches the restored value),
+		// we restore the original templateRef and warmpool fields.
+		expectedWarmPoolRefName := ""
+		if original.Spec.WarmPool != nil && original.Spec.WarmPool.IsSpecificPool() {
+			expectedWarmPoolRefName = string(*original.Spec.WarmPool)
+		} else {
+			expectedWarmPoolRefName = original.Spec.TemplateRef.Name
+		}
+
+		if isWarmPoolRefMatching(src.Spec.WarmPoolRef.Name, expectedWarmPoolRefName, src.Status.SandboxStatus.Name) {
+			s.Spec.TemplateRef = original.Spec.TemplateRef
+			s.Spec.WarmPool = original.Spec.WarmPool
+		} else {
+			// The warm pool was updated in v1beta1, so we reflect it in v1alpha1
+			policy := WarmPoolPolicy(src.Spec.WarmPoolRef.Name)
+			s.Spec.WarmPool = &policy
+			// We can't know the new template ref easily, so we keep the original one as a fallback
+			s.Spec.TemplateRef = original.Spec.TemplateRef
+		}
+	}
+
+	return nil
+}
+
+func isWarmPoolRefMatching(actualName, expectedName, sandboxName string) bool {
+	if actualName == expectedName {
+		return true
+	}
+	if actualName == fmt.Sprintf("shadow-pool-%s", expectedName) {
+		return true
+	}
+	if sandboxName != "" && (actualName == sandboxName || actualName == stripRandomSuffix(sandboxName)) {
+		return true
+	}
+	return false
+}
+
+func stripRandomSuffix(name string) string {
+	if idx := strings.LastIndex(name, "-"); idx != -1 {
+		return name[:idx]
+	}
+	return name
+}
+
+// Helper functions for SandboxClaim conversion
+
+func convertClaimSpecTo(src *SandboxClaimSpec, dst *v1beta1.SandboxClaimSpec, claimName, sandboxName string) error {
+	// Lifecycle
+	if src.Lifecycle != nil {
+		dst.Lifecycle = &v1beta1.Lifecycle{
+			ShutdownTime:            src.Lifecycle.ShutdownTime,
+			TTLSecondsAfterFinished: src.Lifecycle.TTLSecondsAfterFinished,
+			ShutdownPolicy:          v1beta1.ShutdownPolicy(src.Lifecycle.ShutdownPolicy),
+		}
+	} else {
+		dst.Lifecycle = nil
+	}
+
+	// WarmPool / TemplateRef -> WarmPoolRef
+	if src.WarmPool != nil && src.WarmPool.IsSpecificPool() {
+		dst.WarmPoolRef = v1beta1.SandboxWarmPoolRef{
+			Name: string(*src.WarmPool),
+		}
+	} else {
+		// none or default warm pool policy
+		if sandboxName != "" && claimName != sandboxName {
+			// Warm start
+			dst.WarmPoolRef = v1beta1.SandboxWarmPoolRef{
+				Name: stripRandomSuffix(sandboxName),
+			}
+		} else {
+			// Cold start or no sandbox created yet
+			dst.WarmPoolRef = v1beta1.SandboxWarmPoolRef{
+				Name: fmt.Sprintf("shadow-pool-%s", src.TemplateRef.Name),
+			}
+		}
+	}
+
+	// AdditionalPodMetadata
+	if err := convertPodMetadataToClaim(&src.AdditionalPodMetadata, &dst.AdditionalPodMetadata); err != nil {
+		return err
+	}
+
+	// Env
+	if src.Env != nil {
+		dst.Env = make([]v1beta1.EnvVar, len(src.Env))
+		for i := range src.Env {
+			dst.Env[i] = v1beta1.EnvVar{
+				Name:          src.Env[i].Name,
+				Value:         src.Env[i].Value,
+				ContainerName: src.Env[i].ContainerName,
+			}
+		}
+	} else {
+		dst.Env = nil
+	}
+
+	return nil
+}
+
+func convertClaimSpecFrom(src *v1beta1.SandboxClaimSpec, dst *SandboxClaimSpec) error {
+	// Lifecycle
+	if src.Lifecycle != nil {
+		dst.Lifecycle = &Lifecycle{
+			ShutdownTime:            src.Lifecycle.ShutdownTime,
+			TTLSecondsAfterFinished: src.Lifecycle.TTLSecondsAfterFinished,
+			ShutdownPolicy:          ShutdownPolicy(src.Lifecycle.ShutdownPolicy),
+		}
+	} else {
+		dst.Lifecycle = nil
+	}
+
+	// WarmPoolRef -> WarmPool / TemplateRef
+	if templateName, ok := strings.CutPrefix(src.WarmPoolRef.Name, "shadow-pool-"); ok {
+		dst.TemplateRef = SandboxTemplateRef{
+			Name: templateName,
+		}
+		policy := WarmPoolPolicyDefault
+		dst.WarmPool = &policy
+	} else {
+		policy := WarmPoolPolicy(src.WarmPoolRef.Name)
+		dst.WarmPool = &policy
+		dst.TemplateRef = SandboxTemplateRef{
+			Name: src.WarmPoolRef.Name,
+		}
+	}
+
+	// AdditionalPodMetadata
+	if err := convertPodMetadataFromClaim(&src.AdditionalPodMetadata, &dst.AdditionalPodMetadata); err != nil {
+		return err
+	}
+
+	// Env
+	if src.Env != nil {
+		dst.Env = make([]EnvVar, len(src.Env))
+		for i := range src.Env {
+			dst.Env[i] = EnvVar{
+				Name:          src.Env[i].Name,
+				Value:         src.Env[i].Value,
+				ContainerName: src.Env[i].ContainerName,
+			}
+		}
+	} else {
+		dst.Env = nil
+	}
+
+	return nil
+}
+
+func convertClaimStatusTo(src *SandboxClaimStatus, dst *v1beta1.SandboxClaimStatus) error {
+	dst.Conditions = src.Conditions
+	dst.SandboxStatus = v1beta1.SandboxStatus{
+		Name:   src.SandboxStatus.Name,
+		PodIPs: src.SandboxStatus.PodIPs,
+	}
+	return nil
+}
+
+func convertClaimStatusFrom(src *v1beta1.SandboxClaimStatus, dst *SandboxClaimStatus) error {
+	dst.Conditions = src.Conditions
+	dst.SandboxStatus = SandboxStatus{
+		Name:   src.SandboxStatus.Name,
+		PodIPs: src.SandboxStatus.PodIPs,
+	}
+	return nil
+}
+
+func convertPodMetadataToClaim(src *sandboxv1alpha1.PodMetadata, dst *sandboxv1beta1.PodMetadata) error {
+	dst.Labels = src.Labels
+	dst.Annotations = src.Annotations
+	return nil
+}
+
+func convertPodMetadataFromClaim(src *sandboxv1beta1.PodMetadata, dst *sandboxv1alpha1.PodMetadata) error {
+	dst.Labels = src.Labels
+	dst.Annotations = src.Annotations
+	return nil
+}

--- a/extensions/api/v1alpha1/sandboxclaim_conversion_test.go
+++ b/extensions/api/v1alpha1/sandboxclaim_conversion_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+func TestSandboxClaimConversion(t *testing.T) {
+	tests := []struct {
+		name                string
+		claimName           string
+		warmPool            string
+		templateName        string
+		sandboxName         string
+		expectedWarmPoolRef string
+	}{
+		{
+			name:                "Cold start with specific warm pool policy",
+			claimName:           "my-claim",
+			warmPool:            "my-pool",
+			templateName:        "my-template",
+			sandboxName:         "my-claim",
+			expectedWarmPoolRef: "my-pool",
+		},
+		{
+			name:                "Cold start with none warm pool policy",
+			claimName:           "my-claim",
+			warmPool:            "none",
+			templateName:        "my-template",
+			sandboxName:         "my-claim",
+			expectedWarmPoolRef: "shadow-pool-my-template",
+		},
+		{
+			name:                "Cold start with default warm pool policy",
+			claimName:           "my-claim",
+			warmPool:            "default",
+			templateName:        "my-template",
+			sandboxName:         "my-claim",
+			expectedWarmPoolRef: "shadow-pool-my-template",
+		},
+		{
+			name:                "Warm start with specific warm pool policy",
+			claimName:           "my-claim",
+			warmPool:            "my-pool",
+			templateName:        "my-template",
+			sandboxName:         "my-pool-abcde",
+			expectedWarmPoolRef: "my-pool",
+		},
+		{
+			name:                "Warm start with default warm pool policy",
+			claimName:           "my-claim",
+			warmPool:            "default",
+			templateName:        "my-template",
+			sandboxName:         "my-pool-abcde",
+			expectedWarmPoolRef: "my-pool",
+		},
+		{
+			name:                "No sandbox created yet: fallback to warm pool name",
+			claimName:           "my-claim",
+			warmPool:            "my-pool",
+			templateName:        "my-template",
+			sandboxName:         "",
+			expectedWarmPoolRef: "my-pool",
+		},
+		{
+			name:                "No sandbox created yet and no specific warm pool: fallback to shadow-pool-my-template",
+			claimName:           "my-claim",
+			warmPool:            "",
+			templateName:        "my-template",
+			sandboxName:         "",
+			expectedWarmPoolRef: "shadow-pool-my-template",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create src v1alpha1 SandboxClaim
+			wpPolicy := WarmPoolPolicy(tc.warmPool)
+			src := &SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.claimName,
+					Namespace: "default",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"baz":                               "qux",
+						v1alpha1SandboxClaimStateAnnotation: "some-old-state",
+					},
+				},
+				Spec: SandboxClaimSpec{
+					TemplateRef: SandboxTemplateRef{
+						Name: tc.templateName,
+					},
+				},
+				Status: SandboxClaimStatus{
+					SandboxStatus: SandboxStatus{
+						Name: tc.sandboxName,
+					},
+				},
+			}
+			if tc.warmPool != "" {
+				src.Spec.WarmPool = &wpPolicy
+			}
+
+			// Convert to Hub (v1beta1)
+			dst := &v1beta1.SandboxClaim{}
+			if err := src.ConvertTo(dst); err != nil {
+				t.Fatalf("failed to convert to v1beta1: %v", err)
+			}
+
+			// Verify src annotations and labels were not mutated during ConvertTo
+			if val, ok := src.Annotations[v1alpha1SandboxClaimStateAnnotation]; !ok || val != "some-old-state" {
+				t.Errorf("src.Annotations was mutated during ConvertTo! expected 'some-old-state', got %q", val)
+			}
+			if len(src.Annotations) != 2 {
+				t.Errorf("expected 2 annotations in src, got %d", len(src.Annotations))
+			}
+			if len(src.Labels) != 1 {
+				t.Errorf("expected 1 label in src, got %d", len(src.Labels))
+			}
+
+			// Verify the marshaled state in dst does not contain the state annotation itself (no nesting)
+			marshaledState := dst.Annotations[v1alpha1SandboxClaimStateAnnotation]
+			var stateObj SandboxClaim
+			if err := json.Unmarshal([]byte(marshaledState), &stateObj); err != nil {
+				t.Fatalf("failed to unmarshal state from dst: %v", err)
+			}
+			if _, ok := stateObj.Annotations[v1alpha1SandboxClaimStateAnnotation]; ok {
+				t.Errorf("dst.Annotations state nestedly contains the state annotation! causing exponential growth")
+			}
+
+			// Verify WarmPoolRef name in v1beta1
+			if dst.Spec.WarmPoolRef.Name != tc.expectedWarmPoolRef {
+				t.Errorf("expected WarmPoolRef.Name %q, got %q", tc.expectedWarmPoolRef, dst.Spec.WarmPoolRef.Name)
+			}
+
+			// Convert back to Spoke (v1alpha1)
+			roundTrip := &SandboxClaim{}
+			if err := roundTrip.ConvertFrom(dst); err != nil {
+				t.Fatalf("failed to convert back to v1alpha1: %v", err)
+			}
+
+			// Verify state annotation was stripped during ConvertFrom
+			if _, ok := roundTrip.Annotations[v1alpha1SandboxClaimStateAnnotation]; ok {
+				t.Errorf("roundTrip.Annotations still contains the state annotation after ConvertFrom!")
+			}
+
+			// Verify round-trip preserves fields losslessly (due to state annotation preservation)
+			if roundTrip.Spec.TemplateRef.Name != src.Spec.TemplateRef.Name {
+				t.Errorf("roundtrip TemplateRef mismatch: expected %q, got %q", src.Spec.TemplateRef.Name, roundTrip.Spec.TemplateRef.Name)
+			}
+			if src.Spec.WarmPool != nil {
+				if roundTrip.Spec.WarmPool == nil || *roundTrip.Spec.WarmPool != *src.Spec.WarmPool {
+					t.Errorf("roundtrip WarmPool mismatch: expected %v, got %v", src.Spec.WarmPool, roundTrip.Spec.WarmPool)
+				}
+			} else {
+				if roundTrip.Spec.WarmPool != nil && *roundTrip.Spec.WarmPool != WarmPoolPolicyDefault && *roundTrip.Spec.WarmPool != "" {
+					t.Errorf("roundtrip WarmPool mismatch: expected nil or default, got %v", roundTrip.Spec.WarmPool)
+				}
+			}
+		})
+	}
+}
+
+func TestSandboxClaimConversionFromHub(t *testing.T) {
+	// Test conversion of a v1beta1 SandboxClaim created without v1alpha1 state annotation (e.g. created directly via v1beta1 API)
+	tests := []struct {
+		name                string
+		warmPoolRefName     string
+		expectedWarmPool    string
+		expectedTemplateRef string
+	}{
+		{
+			name:                "WarmPoolRef is a specific pool",
+			warmPoolRefName:     "my-pool",
+			expectedWarmPool:    "my-pool",
+			expectedTemplateRef: "my-pool",
+		},
+		{
+			name:                "WarmPoolRef is empty",
+			warmPoolRefName:     "",
+			expectedWarmPool:    "",
+			expectedTemplateRef: "",
+		},
+		{
+			name:                "WarmPoolRef is a synthetic shadow pool",
+			warmPoolRefName:     "shadow-pool-my-template",
+			expectedWarmPool:    "default",
+			expectedTemplateRef: "my-template",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &v1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-claim",
+					Namespace: "default",
+				},
+				Spec: v1beta1.SandboxClaimSpec{
+					WarmPoolRef: v1beta1.SandboxWarmPoolRef{
+						Name: tc.warmPoolRefName,
+					},
+				},
+			}
+
+			dst := &SandboxClaim{}
+			if err := dst.ConvertFrom(src); err != nil {
+				t.Fatalf("failed to convert from v1beta1: %v", err)
+			}
+
+			if dst.Spec.WarmPool == nil {
+				t.Fatalf("expected WarmPool to be non-nil, got nil")
+			}
+			if string(*dst.Spec.WarmPool) != tc.expectedWarmPool {
+				t.Errorf("expected WarmPool %q, got %q", tc.expectedWarmPool, string(*dst.Spec.WarmPool))
+			}
+			if dst.Spec.TemplateRef.Name != tc.expectedTemplateRef {
+				t.Errorf("expected TemplateRef.Name %q, got %q", tc.expectedTemplateRef, dst.Spec.TemplateRef.Name)
+			}
+		})
+	}
+}

--- a/extensions/api/v1alpha1/sandboxtemplate_conversion.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_conversion.go
@@ -1,0 +1,167 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	v1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+const v1alpha1SandboxTemplateStateAnnotation = "api.agents.x-k8s.io/v1alpha1-sandboxtemplate-state"
+
+// ConvertTo converts this SandboxTemplate to the Hub version (v1beta1).
+func (s *SandboxTemplate) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.SandboxTemplate)
+
+	// Copy object metadata
+	s.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+
+	// Convert Spec
+	if err := convertTemplateSpecTo(&s.Spec, &dst.Spec); err != nil {
+		return err
+	}
+
+	// Preserve the original v1alpha1 object state for lossless round-tripping
+	if dst.Annotations == nil {
+		dst.Annotations = make(map[string]string)
+	}
+	sCopy := s.DeepCopy()
+	if sCopy.Annotations != nil {
+		delete(sCopy.Annotations, v1alpha1SandboxTemplateStateAnnotation)
+	}
+	stateJSON, err := json.Marshal(sCopy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal v1alpha1 SandboxTemplate state: %w", err)
+	}
+	dst.Annotations[v1alpha1SandboxTemplateStateAnnotation] = string(stateJSON)
+
+	return nil
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this SandboxTemplate.
+func (s *SandboxTemplate) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.SandboxTemplate)
+
+	// Copy object metadata
+	src.ObjectMeta.DeepCopyInto(&s.ObjectMeta)
+
+	// Convert Spec
+	if err := convertTemplateSpecFrom(&src.Spec, &s.Spec); err != nil {
+		return err
+	}
+
+	// Restore original v1alpha1 state if present to ensure lossless conversion
+	if stateJSON, ok := s.Annotations[v1alpha1SandboxTemplateStateAnnotation]; ok {
+		// Strip the state annotation so it doesn't leak to clients and get sent back on updates
+		delete(s.Annotations, v1alpha1SandboxTemplateStateAnnotation)
+
+		var original SandboxTemplate
+		if err := json.Unmarshal([]byte(stateJSON), &original); err != nil {
+			return fmt.Errorf("failed to unmarshal v1alpha1 SandboxTemplate state: %w", err)
+		}
+		// Since SandboxTemplate is fully compatible between versions, all fields map 1:1.
+		// We don't have any lost fields to restore manually, but the hook is kept for robustness.
+	}
+
+	return nil
+}
+
+// Helper functions for SandboxTemplate conversion
+
+func convertTemplateSpecTo(src *SandboxTemplateSpec, dst *v1beta1.SandboxTemplateSpec) error {
+	// PodTemplate
+	if err := sandboxv1alpha1.ConvertPodTemplateTo(&src.PodTemplate, &dst.PodTemplate); err != nil {
+		return err
+	}
+
+	// VolumeClaimTemplates
+	if src.VolumeClaimTemplates != nil {
+		dst.VolumeClaimTemplates = make([]sandboxv1beta1.PersistentVolumeClaimTemplate, len(src.VolumeClaimTemplates))
+		for i := range src.VolumeClaimTemplates {
+			if err := sandboxv1alpha1.ConvertPVCClaimTemplateTo(&src.VolumeClaimTemplates[i], &dst.VolumeClaimTemplates[i]); err != nil {
+				return err
+			}
+		}
+	} else {
+		dst.VolumeClaimTemplates = nil
+	}
+
+	// NetworkPolicy
+	if src.NetworkPolicy != nil {
+		dst.NetworkPolicy = &v1beta1.NetworkPolicySpec{
+			Ingress: src.NetworkPolicy.Ingress,
+			Egress:  src.NetworkPolicy.Egress,
+		}
+	} else {
+		dst.NetworkPolicy = nil
+	}
+
+	// NetworkPolicyManagement
+	dst.NetworkPolicyManagement = v1beta1.NetworkPolicyManagement(src.NetworkPolicyManagement)
+
+	// EnvVarsInjectionPolicy
+	dst.EnvVarsInjectionPolicy = v1beta1.EnvVarsInjectionPolicy(src.EnvVarsInjectionPolicy)
+
+	// Service
+	dst.Service = src.Service
+
+	return nil
+}
+
+func convertTemplateSpecFrom(src *v1beta1.SandboxTemplateSpec, dst *SandboxTemplateSpec) error {
+	// PodTemplate
+	if err := sandboxv1alpha1.ConvertPodTemplateFrom(&src.PodTemplate, &dst.PodTemplate); err != nil {
+		return err
+	}
+
+	// VolumeClaimTemplates
+	if src.VolumeClaimTemplates != nil {
+		dst.VolumeClaimTemplates = make([]sandboxv1alpha1.PersistentVolumeClaimTemplate, len(src.VolumeClaimTemplates))
+		for i := range src.VolumeClaimTemplates {
+			if err := sandboxv1alpha1.ConvertPVCClaimTemplateFrom(&src.VolumeClaimTemplates[i], &dst.VolumeClaimTemplates[i]); err != nil {
+				return err
+			}
+		}
+	} else {
+		dst.VolumeClaimTemplates = nil
+	}
+
+	// NetworkPolicy
+	if src.NetworkPolicy != nil {
+		dst.NetworkPolicy = &NetworkPolicySpec{
+			Ingress: src.NetworkPolicy.Ingress,
+			Egress:  src.NetworkPolicy.Egress,
+		}
+	} else {
+		dst.NetworkPolicy = nil
+	}
+
+	// NetworkPolicyManagement
+	dst.NetworkPolicyManagement = NetworkPolicyManagement(src.NetworkPolicyManagement)
+
+	// EnvVarsInjectionPolicy
+	dst.EnvVarsInjectionPolicy = EnvVarsInjectionPolicy(src.EnvVarsInjectionPolicy)
+
+	// Service
+	dst.Service = src.Service
+
+	return nil
+}

--- a/extensions/api/v1alpha1/sandboxtemplate_conversion_test.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_conversion_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+	v1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+func TestSandboxTemplateConversion(t *testing.T) {
+	bTrue := true
+	src := &SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-template",
+			Namespace: "default",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"baz":                                  "qux",
+				v1alpha1SandboxTemplateStateAnnotation: "some-old-state",
+			},
+		},
+		Spec: SandboxTemplateSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "my-agent",
+							Image: "my-image:latest",
+						},
+					},
+				},
+			},
+			VolumeClaimTemplates: []sandboxv1alpha1.PersistentVolumeClaimTemplate{
+				{
+					EmbeddedObjectMetadata: sandboxv1alpha1.EmbeddedObjectMetadata{
+						Name: "data",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+					},
+				},
+			},
+			NetworkPolicy: &NetworkPolicySpec{
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{}, // empty ingress rule to verify it gets converted
+				},
+			},
+			NetworkPolicyManagement: NetworkPolicyManagementManaged,
+			EnvVarsInjectionPolicy:  EnvVarsInjectionPolicyAllowed,
+			Service:                 &bTrue,
+		},
+	}
+
+	// Convert to Hub (v1beta1)
+	dst := &v1beta1.SandboxTemplate{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("failed to convert to v1beta1: %v", err)
+	}
+
+	// Verify src annotations and labels were not mutated during ConvertTo
+	if val, ok := src.Annotations[v1alpha1SandboxTemplateStateAnnotation]; !ok || val != "some-old-state" {
+		t.Errorf("src.Annotations was mutated during ConvertTo! expected 'some-old-state', got %q", val)
+	}
+	if len(src.Annotations) != 2 {
+		t.Errorf("expected 2 annotations in src, got %d", len(src.Annotations))
+	}
+	if len(src.Labels) != 1 {
+		t.Errorf("expected 1 label in src, got %d", len(src.Labels))
+	}
+
+	// Verify the marshaled state in dst does not contain the state annotation itself (no nesting)
+	marshaledState := dst.Annotations[v1alpha1SandboxTemplateStateAnnotation]
+	var stateObj SandboxTemplate
+	if err := json.Unmarshal([]byte(marshaledState), &stateObj); err != nil {
+		t.Fatalf("failed to unmarshal state from dst: %v", err)
+	}
+	if _, ok := stateObj.Annotations[v1alpha1SandboxTemplateStateAnnotation]; ok {
+		t.Errorf("dst.Annotations state nestedly contains the state annotation! causing exponential growth")
+	}
+
+	// Verify v1beta1 fields
+	if dst.Spec.PodTemplate.Spec.Containers[0].Image != "my-image:latest" {
+		t.Errorf("unexpected image: %s", dst.Spec.PodTemplate.Spec.Containers[0].Image)
+	}
+	if string(dst.Spec.EnvVarsInjectionPolicy) != string(EnvVarsInjectionPolicyAllowed) {
+		t.Errorf("unexpected EnvVarsInjectionPolicy: %s", dst.Spec.EnvVarsInjectionPolicy)
+	}
+
+	// Convert back to Spoke (v1alpha1)
+	roundTrip := &SandboxTemplate{}
+	if err := roundTrip.ConvertFrom(dst); err != nil {
+		t.Fatalf("failed to convert back to v1alpha1: %v", err)
+	}
+
+	// Verify state annotation was stripped during ConvertFrom
+	if _, ok := roundTrip.Annotations[v1alpha1SandboxTemplateStateAnnotation]; ok {
+		t.Errorf("roundTrip.Annotations still contains the state annotation after ConvertFrom!")
+	}
+
+	// Verify round-trip preserves all fields
+	if roundTrip.Spec.PodTemplate.Spec.Containers[0].Image != src.Spec.PodTemplate.Spec.Containers[0].Image {
+		t.Errorf("roundtrip PodTemplate Image mismatch: expected %q, got %q", src.Spec.PodTemplate.Spec.Containers[0].Image, roundTrip.Spec.PodTemplate.Spec.Containers[0].Image)
+	}
+	if roundTrip.Spec.EnvVarsInjectionPolicy != src.Spec.EnvVarsInjectionPolicy {
+		t.Errorf("roundtrip EnvVarsInjectionPolicy mismatch: expected %q, got %q", src.Spec.EnvVarsInjectionPolicy, roundTrip.Spec.EnvVarsInjectionPolicy)
+	}
+	if roundTrip.Spec.NetworkPolicyManagement != src.Spec.NetworkPolicyManagement {
+		t.Errorf("roundtrip NetworkPolicyManagement mismatch: expected %q, got %q", src.Spec.NetworkPolicyManagement, roundTrip.Spec.NetworkPolicyManagement)
+	}
+	if roundTrip.Spec.Service == nil || *roundTrip.Spec.Service != *src.Spec.Service {
+		t.Errorf("roundtrip Service mismatch")
+	}
+}

--- a/extensions/api/v1alpha1/sandboxwarmpool_conversion.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_conversion.go
@@ -1,0 +1,142 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	v1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+const v1alpha1SandboxWarmPoolStateAnnotation = "api.agents.x-k8s.io/v1alpha1-sandboxwarmpool-state"
+
+// ConvertTo converts this SandboxWarmPool to the Hub version (v1beta1).
+func (s *SandboxWarmPool) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.SandboxWarmPool)
+
+	// Copy object metadata
+	s.ObjectMeta.DeepCopyInto(&dst.ObjectMeta)
+
+	// Convert Spec
+	if err := convertWarmPoolSpecTo(&s.Spec, &dst.Spec); err != nil {
+		return err
+	}
+
+	// Convert Status
+	if err := convertWarmPoolStatusTo(&s.Status, &dst.Status); err != nil {
+		return err
+	}
+
+	// Preserve the original v1alpha1 object state for lossless round-tripping
+	if dst.Annotations == nil {
+		dst.Annotations = make(map[string]string)
+	}
+	sCopy := s.DeepCopy()
+	if sCopy.Annotations != nil {
+		delete(sCopy.Annotations, v1alpha1SandboxWarmPoolStateAnnotation)
+	}
+	stateJSON, err := json.Marshal(sCopy)
+	if err != nil {
+		return fmt.Errorf("failed to marshal v1alpha1 SandboxWarmPool state: %w", err)
+	}
+	dst.Annotations[v1alpha1SandboxWarmPoolStateAnnotation] = string(stateJSON)
+
+	return nil
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this SandboxWarmPool.
+func (s *SandboxWarmPool) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.SandboxWarmPool)
+
+	// Copy object metadata
+	src.ObjectMeta.DeepCopyInto(&s.ObjectMeta)
+
+	// Convert Spec
+	if err := convertWarmPoolSpecFrom(&src.Spec, &s.Spec); err != nil {
+		return err
+	}
+
+	// Convert Status
+	if err := convertWarmPoolStatusFrom(&src.Status, &s.Status); err != nil {
+		return err
+	}
+
+	// Restore original v1alpha1 state if present to ensure lossless conversion
+	if stateJSON, ok := s.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
+		// Strip the state annotation so it doesn't leak to clients and get sent back on updates
+		delete(s.Annotations, v1alpha1SandboxWarmPoolStateAnnotation)
+
+		var original SandboxWarmPool
+		if err := json.Unmarshal([]byte(stateJSON), &original); err != nil {
+			return fmt.Errorf("failed to unmarshal v1alpha1 SandboxWarmPool state: %w", err)
+		}
+		// All fields map 1:1, kept for consistency/robustness.
+	}
+
+	return nil
+}
+
+// Helper functions for SandboxWarmPool conversion
+
+func convertWarmPoolSpecTo(src *SandboxWarmPoolSpec, dst *v1beta1.SandboxWarmPoolSpec) error {
+	dst.Replicas = src.Replicas
+	dst.TemplateRef = v1beta1.SandboxTemplateRef{
+		Name: src.TemplateRef.Name,
+	}
+
+	if src.UpdateStrategy != nil {
+		dst.UpdateStrategy = &v1beta1.SandboxWarmPoolUpdateStrategy{
+			Type: v1beta1.SandboxWarmPoolUpdateStrategyType(src.UpdateStrategy.Type),
+		}
+	} else {
+		dst.UpdateStrategy = nil
+	}
+
+	return nil
+}
+
+func convertWarmPoolSpecFrom(src *v1beta1.SandboxWarmPoolSpec, dst *SandboxWarmPoolSpec) error {
+	dst.Replicas = src.Replicas
+	dst.TemplateRef = SandboxTemplateRef{
+		Name: src.TemplateRef.Name,
+	}
+
+	if src.UpdateStrategy != nil {
+		dst.UpdateStrategy = &SandboxWarmPoolUpdateStrategy{
+			Type: SandboxWarmPoolUpdateStrategyType(src.UpdateStrategy.Type),
+		}
+	} else {
+		dst.UpdateStrategy = nil
+	}
+
+	return nil
+}
+
+func convertWarmPoolStatusTo(src *SandboxWarmPoolStatus, dst *v1beta1.SandboxWarmPoolStatus) error {
+	dst.Replicas = src.Replicas
+	dst.ReadyReplicas = src.ReadyReplicas
+	dst.Selector = src.Selector
+	return nil
+}
+
+func convertWarmPoolStatusFrom(src *v1beta1.SandboxWarmPoolStatus, dst *SandboxWarmPoolStatus) error {
+	dst.Replicas = src.Replicas
+	dst.ReadyReplicas = src.ReadyReplicas
+	dst.Selector = src.Selector
+	return nil
+}

--- a/extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+func TestSandboxWarmPoolConversion(t *testing.T) {
+	src := &SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-warmpool",
+			Namespace: "default",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"baz":                                  "qux",
+				v1alpha1SandboxWarmPoolStateAnnotation: "some-old-state",
+			},
+		},
+		Spec: SandboxWarmPoolSpec{
+			Replicas: 3,
+			TemplateRef: SandboxTemplateRef{
+				Name: "my-template",
+			},
+			UpdateStrategy: &SandboxWarmPoolUpdateStrategy{
+				Type: RecreateSandboxWarmPoolUpdateStrategyType,
+			},
+		},
+		Status: SandboxWarmPoolStatus{
+			Replicas:      3,
+			ReadyReplicas: 2,
+			Selector:      "app=my-warmpool",
+		},
+	}
+
+	// Convert to Hub (v1beta1)
+	dst := &v1beta1.SandboxWarmPool{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("failed to convert to v1beta1: %v", err)
+	}
+
+	// Verify src annotations and labels were not mutated during ConvertTo
+	if val, ok := src.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; !ok || val != "some-old-state" {
+		t.Errorf("src.Annotations was mutated during ConvertTo! expected 'some-old-state', got %q", val)
+	}
+	if len(src.Annotations) != 2 {
+		t.Errorf("expected 2 annotations in src, got %d", len(src.Annotations))
+	}
+	if len(src.Labels) != 1 {
+		t.Errorf("expected 1 label in src, got %d", len(src.Labels))
+	}
+
+	// Verify the marshaled state in dst does not contain the state annotation itself (no nesting)
+	marshaledState := dst.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]
+	var stateObj SandboxWarmPool
+	if err := json.Unmarshal([]byte(marshaledState), &stateObj); err != nil {
+		t.Fatalf("failed to unmarshal state from dst: %v", err)
+	}
+	if _, ok := stateObj.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
+		t.Errorf("dst.Annotations state nestedly contains the state annotation! causing exponential growth")
+	}
+
+	// Verify v1beta1 fields
+	if dst.Spec.Replicas != 3 {
+		t.Errorf("unexpected replicas: %d", dst.Spec.Replicas)
+	}
+	if dst.Spec.TemplateRef.Name != "my-template" {
+		t.Errorf("unexpected template ref: %s", dst.Spec.TemplateRef.Name)
+	}
+	if dst.Spec.UpdateStrategy == nil || string(dst.Spec.UpdateStrategy.Type) != string(RecreateSandboxWarmPoolUpdateStrategyType) {
+		t.Errorf("unexpected update strategy: %v", dst.Spec.UpdateStrategy)
+	}
+	if dst.Status.ReadyReplicas != 2 {
+		t.Errorf("unexpected ready replicas: %d", dst.Status.ReadyReplicas)
+	}
+
+	// Convert back to Spoke (v1alpha1)
+	roundTrip := &SandboxWarmPool{}
+	if err := roundTrip.ConvertFrom(dst); err != nil {
+		t.Fatalf("failed to convert back to v1alpha1: %v", err)
+	}
+
+	// Verify state annotation was stripped during ConvertFrom
+	if _, ok := roundTrip.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
+		t.Errorf("roundTrip.Annotations still contains the state annotation after ConvertFrom!")
+	}
+
+	// Verify round-trip preserves all fields
+	if roundTrip.Spec.Replicas != src.Spec.Replicas {
+		t.Errorf("roundtrip Replicas mismatch: expected %d, got %d", src.Spec.Replicas, roundTrip.Spec.Replicas)
+	}
+	if roundTrip.Spec.TemplateRef.Name != src.Spec.TemplateRef.Name {
+		t.Errorf("roundtrip TemplateRef mismatch: expected %q, got %q", src.Spec.TemplateRef.Name, roundTrip.Spec.TemplateRef.Name)
+	}
+	if roundTrip.Spec.UpdateStrategy == nil || roundTrip.Spec.UpdateStrategy.Type != src.Spec.UpdateStrategy.Type {
+		t.Errorf("roundtrip UpdateStrategy mismatch")
+	}
+	if roundTrip.Status.ReadyReplicas != src.Status.ReadyReplicas {
+		t.Errorf("roundtrip ReadyReplicas mismatch: expected %d, got %d", src.Status.ReadyReplicas, roundTrip.Status.ReadyReplicas)
+	}
+	if roundTrip.Status.Selector != src.Status.Selector {
+		t.Errorf("roundtrip Selector mismatch: expected %q, got %q", src.Status.Selector, roundTrip.Status.Selector)
+	}
+}

--- a/extensions/api/v1beta1/sandboxclaim_conversion.go
+++ b/extensions/api/v1beta1/sandboxclaim_conversion.go
@@ -1,0 +1,18 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+// Hub marks SandboxClaim as a conversion Hub.
+func (*SandboxClaim) Hub() {}

--- a/extensions/api/v1beta1/sandboxtemplate_conversion.go
+++ b/extensions/api/v1beta1/sandboxtemplate_conversion.go
@@ -1,0 +1,18 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+// Hub marks SandboxTemplate as a conversion Hub.
+func (*SandboxTemplate) Hub() {}

--- a/extensions/api/v1beta1/sandboxwarmpool_conversion.go
+++ b/extensions/api/v1beta1/sandboxwarmpool_conversion.go
@@ -1,0 +1,18 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+// Hub marks SandboxWarmPool as a conversion Hub.
+func (*SandboxWarmPool) Hub() {}

--- a/k8s/controller.yaml
+++ b/k8s/controller.yaml
@@ -79,3 +79,23 @@ spec:
         - name: healthz
           containerPort: 8081
           protocol: TCP
+        - name: webhook
+          containerPort: 9443
+          protocol: TCP
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: agent-sandbox-webhook-service
+  namespace: agent-sandbox-system
+spec:
+  selector:
+    app: agent-sandbox-controller
+  ports:
+  - name: webhook
+    port: 443
+    targetPort: 9443
+    protocol: TCP
+


### PR DESCRIPTION
Working on https://github.com/kubernetes-sigs/agent-sandbox/issues/959

# PR Description: Implement Two-Way CRD Conversion Webhook Logic 

## Summary

This PR implements **Step 3: Implement Conversion Webhook Logic** of the *Agent Sandbox OSS API Versioning & Migration Initiative*. It establishes the core Hub-and-Spoke conversion logic to seamlessly translate between `v1alpha1` and `v1beta1` versions of the `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` APIs. 

This enables older `v1alpha1` clients and controllers to interact seamlessly with a cluster that stores resources under the new `v1beta1` storage version, guaranteeing complete backward compatibility and facilitating a zero-downtime migration.

## Detailed Changes

### 1. Hub and Spoke Interface Registrations
* **Hub (`v1beta1`):** Marked `v1beta1.Sandbox`, `v1beta1.SandboxClaim`, `v1beta1.SandboxTemplate`, and `v1beta1.SandboxWarmPool` as the **Hub** versions by implementing the `sigs.k8s.io/controller-runtime/pkg/conversion.Hub` interface (adding the marker `Hub()` method).
* **Spoke (`v1alpha1`):** Made `v1alpha1.Sandbox`, `v1alpha1.SandboxClaim`, `v1alpha1.SandboxTemplate`, and `v1alpha1.SandboxWarmPool` implement the `sigs.k8s.io/controller-runtime/pkg/conversion.Spoke` interface by writing `ConvertTo(Hub)` and `ConvertFrom(Hub)` methods.

### 2. Lossless State Restoration Pattern

* When converting `v1alpha1 -> v1beta1`, the original `v1alpha1` resource is serialized to JSON and stored in a special transient annotation (e.g., `api.agents.x-k8s.io/v1alpha1-sandbox-state`).
* When converting `v1beta1 -> v1alpha1`, if the state annotation is present, it is deserialized and used to restore any version-specific fields (like `Replicas` or `Status.Replicas`), while still overlaying any modifications made by the `v1beta1` client.

### 3. Structural API Translations
* **`Sandbox` Spec Conversion:**
  * Maps `v1alpha1.Spec.Replicas` (`*int32`) to `v1beta1.Spec.OperatingMode` (`Running`/`Suspended`), and vice versa.
  * Translates package-specific sub-structures (`PodTemplate`, `PersistentVolumeClaimTemplate`, `Lifecycle`) field-by-field.
* **`SandboxClaim` Spec Conversion:**
  * Elegantly maps `v1alpha1`'s combination of `TemplateRef` and `WarmPool` policy to `v1beta1`'s required `WarmPoolRef`.
  * Implements smart resolution:
    * If `WarmPool` is a specific pool name, it uses it.
    * If `WarmPool` is `"none"` or `"default"`, it resolves a cold-start to a shadow pool name (`shadow-pool-<template-name>`) and a warm-start by parsing the adopted sandbox name from `Status.SandboxStatus.Name`.
* **`SandboxTemplate` & `SandboxWarmPool` Conversion:**
  * Translates all spec and status fields 1:1 using package-specific conversion helpers.

---

## Verification & Testing
 * Comprehensive unit-test
 * Manual round trip test via `EXTENSIONS=true CONTROLLER_ONLY=true make deploy-kind`.
