### PR TITLE
helm:  add v1alpha1->v1beta1 migration script and upgrade hook Jobs

### DIFF
--- a/dev/tools/migrate.sh
+++ b/dev/tools/migrate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Thin wrapper around the canonical migration script bundled with the Helm
+# chart. The real implementation lives at helm/files/migrate.sh so the chart's
+# ConfigMap template can include it via .Files.Get without going outside the
+# chart directory. Operators are expected to invoke this wrapper from the
+# repo root:
+#
+#   bash dev/tools/migrate.sh --phase=bootstrap [--dry-run]
+#
+# See docs/api-migration.md for full usage.
+set -euo pipefail
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SELF_DIR}/../../helm/files/migrate.sh" "$@"

--- a/dev/tools/migrate.sh
+++ b/dev/tools/migrate.sh
@@ -21,7 +21,7 @@
 #
 #   bash dev/tools/migrate.sh --phase=bootstrap [--dry-run]
 #
-# See docs/api-migration.md for full usage.
+# See docs/api-migration-guide.md for full usage.
 set -euo pipefail
 
 SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -1,0 +1,92 @@
+# v1alpha1 → v1beta1 API migration guide
+
+This document covers the operational side of migrating `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` resources from the `v1alpha1` API to the `v1beta1` API.
+
+If you install the chart fresh with the v1beta1-storage version, there is nothing to migrate — read this only when **upgrading** an existing installation that holds v1alpha1-serialized resources in etcd.
+
+## What changes between versions
+
+Most CRDs are schema-compatible across the two versions; the migration matters mainly for **two reasons**:
+
+1. **`SandboxClaim` is not field-compatible.** v1alpha1 has `spec.sandboxTemplateRef` plus an optional `spec.warmpool` string policy (`"none"` / `"default"` / a specific pool name). v1beta1 requires `spec.warmPoolRef.name`. The conversion webhook handles the field rename automatically, but claims that used `warmpool: "none" / "default" / unset` have no obvious target pool — bootstrap creates per-claim shadow pools to fill the gap.
+2. **`Sandbox.spec.replicas` becomes `Sandbox.spec.operatingMode`.** `replicas: 0` → `Suspended`, `replicas: 1` (or unset) → `Running`. The webhook handles this automatically.
+
+The other two CRDs (`SandboxTemplate`, `SandboxWarmPool`) are structurally identical between versions but still need a storage rewrite so etcd holds them in v1beta1 form.
+
+## What runs automatically
+
+`helm upgrade agent-sandbox ./helm/ ...` triggers two Jobs via Helm hook annotations:
+
+| Phase | Job name | Hook | Does what |
+|---|---|---|---|
+| Pre-upgrade | `agent-sandbox-migration-bootstrap` | `pre-upgrade` | Scans every existing `SandboxClaim`. For each one whose `spec.warmpool` is `"none"`, `"default"`, unset, or names a pool that doesn't exist, creates a shadow `SandboxWarmPool` named `<claim>-shadow-pool` (replicas=0, references the claim's existing template). This gives the conversion webhook a valid `warmPoolRef` target. |
+| Post-upgrade | `agent-sandbox-migration-rewrite` | `post-upgrade` | Patches every existing `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` with a `agents.x-k8s.io/storage-migrated-at` annotation. The patch round-trips the resource through the conversion webhook, which causes the API server to rewrite the etcd record in v1beta1 format. |
+
+Both Jobs are **idempotent**. Helm will retry on failure (`backoffLimit: 2`); operators can also `kubectl delete job <name>` and `helm upgrade --no-hooks=false` to re-trigger.
+
+## What runs manually
+
+The same script the Jobs use is exposed at `dev/tools/migrate.sh` for operators who want finer control:
+
+```bash
+# Dry-run the bootstrap phase against the cluster your kubeconfig points at.
+bash dev/tools/migrate.sh --phase=bootstrap --dry-run
+
+# Actually create shadow pools.
+bash dev/tools/migrate.sh --phase=bootstrap
+
+# Trigger the storage rewrite for everything.
+bash dev/tools/migrate.sh --phase=migrate
+
+# Scope to one namespace.
+bash dev/tools/migrate.sh --phase=migrate --namespace=team-alpha
+```
+
+The script uses `kubectl` and respects the active kubeconfig. It exits non-zero if any resource fails to migrate (per-resource errors don't abort the run, but the final exit reflects total failures).
+
+## Opting out of the automated Jobs
+
+```bash
+helm upgrade agent-sandbox ./helm/ ... --set migration.enabled=false
+```
+
+Then run `dev/tools/migrate.sh` manually in whatever order and scope you want. Useful when:
+
+- The cluster is large enough that the default Job resource limits aren't appropriate (override `--set migration.resources....` or run manually).
+- You want to migrate one namespace at a time as part of a phased rollout.
+- The cluster has CRDs from a custom build of agent-sandbox and you need to validate behavior before letting the automated Job touch everything.
+
+## After migration completes
+
+The shadow `SandboxWarmPool`s created by the bootstrap phase remain in the cluster — the conversion webhook depends on them being valid `warmPoolRef` targets for the converted v1beta1 `SandboxClaim`s. They are marked with two annotations so you can find them later:
+
+```bash
+kubectl get sandboxwarmpools -A -o json \
+  | jq -r '.items[]
+      | select(.metadata.annotations["agents.x-k8s.io/migration-shadow"]=="true")
+      | "\(.metadata.namespace)/\(.metadata.name) (for claim: \(.metadata.annotations["agents.x-k8s.io/migration-source-claim"]))"'
+```
+
+Do **not** delete these pools while the corresponding `SandboxClaim`s still reference them via `warmPoolRef`. Once v1alpha1 is fully removed from the codebase (a future release) and you've manually re-pointed any remaining claims to real warm pools, the shadow pools can be cleaned up.
+
+## Verifying the migration worked
+
+After the post-upgrade Job completes:
+
+```bash
+# Every resource should now have the storage-migrated-at annotation.
+kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A \
+  -o jsonpath='{range .items[*]}{.kind}{" "}{.metadata.namespace}/{.metadata.name}{" -> "}{.metadata.annotations.agents\.x-k8s\.io/storage-migrated-at}{"\n"}{end}'
+
+# Check the actual etcd storage version (requires cluster-admin):
+kubectl get --raw '/apis/extensions.agents.x-k8s.io/v1beta1/sandboxclaims' \
+  | jq '.items[0].apiVersion'   # expect "extensions.agents.x-k8s.io/v1beta1"
+```
+
+## Troubleshooting
+
+**Pre-upgrade Job fails with "failed to list SandboxClaims"**: the script's ServiceAccount RBAC isn't applied yet. The bootstrap ClusterRole + ClusterRoleBinding should land in the same Helm hook batch. If you're testing manually, apply `helm/templates/migration-rbac.yaml` first.
+
+**Post-upgrade Job's init container `wait-for-webhook` times out**: the conversion webhook isn't reachable. Check that the `agent-sandbox-webhook-service` Service exists in the controller's namespace and that its endpoints are populated (`kubectl get endpoints agent-sandbox-webhook-service -n agent-sandbox-system`). If the Service is missing entirely, that's a chart issue separate from this migration — track it upstream.
+
+**Migrate phase reports failures on specific resources**: re-run the script (`bash dev/tools/migrate.sh --phase=migrate`). It's idempotent — already-migrated resources just get the annotation timestamp updated. If a specific resource keeps failing, fetch it (`kubectl get -o yaml`) and inspect what's wrong — usually it's a conversion-webhook error tied to a bad field combination that needs manual cleanup.

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -75,13 +75,36 @@ After the post-upgrade Job completes:
 
 ```bash
 # Every resource should now have the storage-migrated-at annotation.
-kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A \
-  -o jsonpath='{range .items[*]}{.kind}{" "}{.metadata.namespace}/{.metadata.name}{" -> "}{.metadata.annotations.agents\.x-k8s\.io/storage-migrated-at}{"\n"}{end}'
-
-# Check the actual etcd storage version (requires cluster-admin):
-kubectl get --raw '/apis/extensions.agents.x-k8s.io/v1beta1/sandboxclaims' \
-  | jq '.items[0].apiVersion'   # expect "extensions.agents.x-k8s.io/v1beta1"
+# jq handles annotation keys with "." and "/" correctly; kubectl jsonpath
+# dot-escaping cannot reliably read keys containing "/".
+kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A -o json \
+  | jq -r '.items[]
+      | "\(.kind) \(.metadata.namespace)/\(.metadata.name) -> \(.metadata.annotations["agents.x-k8s.io/storage-migrated-at"] // "<missing>")"'
 ```
+
+To verify the actual etcd storage version, check each CRD's `status.storedVersions`. The kube-apiserver records every version that has ever been used to write any record there; after the rewrite Job touches every resource, you can manually prune `v1alpha1` from the list to confirm nothing v1alpha1 is left:
+
+```bash
+for crd in \
+    sandboxes.agents.x-k8s.io \
+    sandboxclaims.extensions.agents.x-k8s.io \
+    sandboxtemplates.extensions.agents.x-k8s.io \
+    sandboxwarmpools.extensions.agents.x-k8s.io; do
+  printf '%s: ' "${crd}"
+  kubectl get crd "${crd}" -o jsonpath='{.status.storedVersions}'
+  printf '\n'
+done
+```
+
+If a CRD still lists `["v1alpha1","v1beta1"]` after the rewrite Job succeeded, every existing record has been rewritten in v1beta1 form, but the `storedVersions` array is not auto-pruned. To finalize:
+
+```bash
+# Confirm no v1alpha1-only records remain, then prune storedVersions.
+kubectl patch crd <crd-name> --subresource=status --type=merge \
+  -p '{"status":{"storedVersions":["v1beta1"]}}'
+```
+
+Only do this after you've confirmed every existing record carries `agents.x-k8s.io/storage-migrated-at` from the rewrite Job's run.
 
 ## Troubleshooting
 

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -46,27 +46,9 @@ See [Recovery from backup](#recovery-from-backup) in the Troubleshooting section
 
 Pick one of three flows depending on how you manage installs.
 
-### Flow A — Helm-managed, automatic (default)
+### Flow A — Manual via kubectl (default)
 
-The chart ships two Helm hook Jobs that run the bootstrap and rewrite phases automatically as part of `helm upgrade`:
-
-```bash
-helm upgrade agent-sandbox ./helm/ \
-  --namespace agent-sandbox-system \
-  --reuse-values \
-  --set image.tag=<new-version>
-```
-
-| Phase | Job name | Hook | What it does |
-|---|---|---|---|
-| Pre-upgrade | `agent-sandbox-migration-bootstrap` | `pre-upgrade` | Runs `migrate.sh --phase=bootstrap` against the existing v1alpha1 state. |
-| Post-upgrade | `agent-sandbox-migration-rewrite` | `post-upgrade` | Runs `migrate.sh --phase=migrate` after the new controller + webhook are running. The Job has a `wait-for-webhook` initContainer that polls the webhook Service endpoints for up to 120s. |
-
-Both Jobs run `helm/files/migrate.sh` from a ConfigMap (defaultMode 0755) mounted in the pod. Helm retries on failure (`backoffLimit: 2`); operators can also `kubectl delete job <name>` and re-run `helm upgrade` to re-trigger.
-
-### Flow B — Manual via kubectl (Helm-free install)
-
-For clusters that install the controller via `kubectl apply -f` (not Helm), run the script directly. The script is at `dev/tools/migrate.sh` (a thin wrapper around `helm/files/migrate.sh`).
+The official agent-sandbox installation path is `kubectl apply -f` against the release manifests (see the project README and release notes), so this is the default migration flow. Run the script directly from `dev/tools/migrate.sh` (a thin wrapper around `helm/files/migrate.sh`):
 
 ```bash
 # 1. Pre-create the shadow pools BEFORE applying the new CRDs.
@@ -93,6 +75,24 @@ If the cluster is large, scope the rewrite to one namespace at a time:
 ```bash
 bash dev/tools/migrate.sh --phase=migrate --namespace=team-alpha
 ```
+
+### Flow B — Helm-managed, automatic
+
+For installs managed by the Helm chart, the chart ships two Helm hook Jobs that run the bootstrap and rewrite phases automatically as part of `helm upgrade`:
+
+```bash
+helm upgrade agent-sandbox ./helm/ \
+  --namespace agent-sandbox-system \
+  --reuse-values \
+  --set image.tag=<new-version>
+```
+
+| Phase | Job name | Hook | What it does |
+|---|---|---|---|
+| Pre-upgrade | `agent-sandbox-migration-bootstrap` | `pre-upgrade` | Runs `migrate.sh --phase=bootstrap` against the existing v1alpha1 state. |
+| Post-upgrade | `agent-sandbox-migration-rewrite` | `post-upgrade` | Runs `migrate.sh --phase=migrate` after the new controller + webhook are running. The Job has a `wait-for-webhook` initContainer that polls the webhook Service endpoints for up to 120s. |
+
+Both Jobs run `helm/files/migrate.sh` from a ConfigMap (defaultMode 0755) mounted in the pod. Helm retries on failure (`backoffLimit: 2`); operators can also `kubectl delete job <name>` and re-run `helm upgrade` to re-trigger.
 
 ### Flow C — Helm-managed, manual script (hooks disabled)
 
@@ -143,7 +143,7 @@ kubectl get sandboxwarmpools -A -o json \
       | "\(.metadata.namespace)/\(.metadata.name) (for template: \(.metadata.annotations["agents.x-k8s.io/migration-source-template"]))"'
 ```
 
-Do **not** delete these pools while any v1beta1 `SandboxClaim` still references them via `warmPoolRef`. Once v1alpha1 is fully removed from the codebase (a future release) and you've manually re-pointed any remaining claims to real warm pools, the shadow pools can be cleaned up.
+Do **not** delete these pools while any v1beta1 `SandboxClaim` still references them via `warmPoolRef`. v1alpha1 is removed from the codebase in the release this guide accompanies, so there is no v1alpha1 fallback for claims still pointing at a shadow pool. Once you've manually re-pointed any remaining claims to real warm pools, the shadow pools can be cleaned up.
 
 ### Re-pointing warm-started claims
 

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -25,6 +25,23 @@ The migration script has two phases, run in this order:
 
 Both phases are idempotent — safe to re-run.
 
+## Before you start: back up your data
+
+Before running either phase, dump every CR the migration will touch so you have a known-good snapshot to fall back to if anything goes wrong:
+
+```bash
+kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools \
+  -A -o yaml > agent-sandbox-backup-$(date -u +%Y%m%dT%H%M%SZ).yaml
+```
+
+Keep the file somewhere durable (not on a worker pod that may get rescheduled). Useful for:
+
+- Inspecting the original v1alpha1 shape if a converted v1beta1 record looks wrong.
+- Comparing pre- vs post-migration to confirm only the expected fields changed.
+- Re-creating individual mangled resources by hand without restoring the whole namespace.
+
+See [Recovery from backup](#recovery-from-backup) in the Troubleshooting section if you need to roll back.
+
 ## Migration flows
 
 Pick one of three flows depending on how you manage installs.
@@ -196,3 +213,36 @@ kubectl get endpoints agent-sandbox-webhook-service -n agent-sandbox-system
 **Migrate phase reports failures on specific resources**: re-run the script (`bash dev/tools/migrate.sh --phase=migrate`). It's idempotent — already-migrated resources just get the annotation timestamp updated. If a specific resource keeps failing, fetch it (`kubectl get -o yaml`) and inspect what's wrong — usually it's a conversion-webhook error tied to a bad field combination that needs manual cleanup.
 
 **Bootstrap printed `OPERATOR ACTION REQUIRED` for some claims**: those claims reference specific pool names that don't currently exist. The conversion webhook will still rewrite them to point at those names — you must create the pools manually post-migration, or re-point the claims (see "Re-pointing warm-started claims" above).
+
+### Recovery from backup
+
+If migration produces broken or unexpected v1beta1 resources, use the backup file from [Before you start: back up your data](#before-you-start-back-up-your-data) to restore.
+
+**Per-resource restore** (preferred — only touches what's actually broken):
+
+```bash
+# Inspect a specific resource against the backup to confirm it's wrong.
+kubectl get <kind> <name> -n <namespace> -o yaml \
+  | diff - <(yq '.items[] | select(.kind=="<kind>" and .metadata.name=="<name>")' backup.yaml)
+
+# Delete the broken record and re-apply the v1alpha1 spec from the backup.
+# The conversion webhook re-converts it on apply.
+kubectl delete <kind> <name> -n <namespace>
+yq '.items[] | select(.kind=="<kind>" and .metadata.name=="<name>")' backup.yaml \
+  | kubectl apply -f -
+```
+
+**Bulk restore** (last resort — only when many resources are broken AND the conversion webhook is functioning):
+
+```bash
+# CAUTION: deletes every Sandbox/SandboxClaim/SandboxTemplate/SandboxWarmPool
+# across all namespaces, then re-creates them from the backup.
+kubectl delete sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A --all
+kubectl apply -f backup.yaml
+```
+
+Caveats:
+
+- Restoration depends on a functioning conversion webhook. If the webhook itself is broken, fix that first (typically: roll the controller image back to the pre-migration version, then re-apply the backup), or restore in two phases by first re-installing the old chart and then re-applying the backup against the old CRDs.
+- The backup captures `status` subresources too. Strip them before re-apply so the controllers re-derive status from spec rather than racing your stale snapshot: `yq 'del(.items[].status)' backup.yaml | kubectl apply -f -`.
+- Backups don't capture cluster-scoped state like `SandboxWarmPool` controller progress; freshly-applied pools will repopulate themselves from the template.

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -10,7 +10,7 @@ Most CRDs are schema-compatible across the two versions; the migration matters m
 
 1. **`SandboxClaim` is not field-compatible.** v1alpha1 has `spec.sandboxTemplateRef` plus an optional `spec.warmpool` string policy (`"none"` / `"default"` / a specific pool name). v1beta1 requires `spec.warmPoolRef.name`. The conversion webhook (in `extensions/api/v1alpha1/sandboxclaim_conversion.go`) handles the rewrite via three branches:
    - **Specific pool name** (`warmpool: my-pool`) → webhook uses that name verbatim. If the pool doesn't exist, the converted claim points at a missing pool — operator must create it.
-   - **`""` / `"none"` / `"default"`, warm-started** (claim has a bound `Sandbox` whose name differs from the claim's name) → webhook derives the pool name from the existing `Sandbox` via `stripRandomSuffix(sandboxName)`. The source pool already exists; nothing to do at migration time.
+   - **`""` / `"default"`, warm-started** (claim has a bound `Sandbox` whose name differs from the claim's name) → webhook derives the pool name from the existing `Sandbox` via `stripRandomSuffix(sandboxName)`. The source pool already exists; nothing to do at migration time. (`"none"` never falls into this branch — `"none"` always cold-starts.)
    - **`""` / `"none"` / `"default"`, cold-start** (no bound `Sandbox`, or `Sandbox.name == claim.name`) → webhook redirects to `shadow-pool-<template-name>`. The bootstrap phase ensures one such shadow pool exists per `(namespace, template)` combination.
 2. **`Sandbox.spec.replicas` becomes `Sandbox.spec.operatingMode`.** `replicas: 0` → `Suspended`, `replicas: 1` (or unset) → `Running`. The webhook handles this automatically.
 
@@ -57,9 +57,13 @@ For clusters that install the controller via `kubectl apply -f` (not Helm), run 
 bash dev/tools/migrate.sh --phase=bootstrap
 
 # 2. Install the new controller + CRDs (which include the conversion webhook).
+#    The release ships two manifests: manifest.yaml (core controller + base
+#    CRDs + webhook Service) and extensions.yaml (the extensions API group
+#    CRDs: SandboxClaim, SandboxTemplate, SandboxWarmPool). Apply both.
 #    Wait until the controller pod is Ready and the webhook Service has
 #    endpoints before proceeding.
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.0/manifest.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.0/extensions.yaml
 kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system
 kubectl wait --for=condition=Ready pods -l app=agent-sandbox-controller -n agent-sandbox-system
 

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -8,66 +8,139 @@ If you install the chart fresh with the v1beta1-storage version, there is nothin
 
 Most CRDs are schema-compatible across the two versions; the migration matters mainly for **two reasons**:
 
-1. **`SandboxClaim` is not field-compatible.** v1alpha1 has `spec.sandboxTemplateRef` plus an optional `spec.warmpool` string policy (`"none"` / `"default"` / a specific pool name). v1beta1 requires `spec.warmPoolRef.name`. The conversion webhook handles the field rename automatically, but claims that used `warmpool: "none" / "default" / unset` have no obvious target pool — bootstrap creates per-claim shadow pools to fill the gap.
+1. **`SandboxClaim` is not field-compatible.** v1alpha1 has `spec.sandboxTemplateRef` plus an optional `spec.warmpool` string policy (`"none"` / `"default"` / a specific pool name). v1beta1 requires `spec.warmPoolRef.name`. The conversion webhook (in `extensions/api/v1alpha1/sandboxclaim_conversion.go`) handles the rewrite via three branches:
+   - **Specific pool name** (`warmpool: my-pool`) → webhook uses that name verbatim. If the pool doesn't exist, the converted claim points at a missing pool — operator must create it.
+   - **`""` / `"none"` / `"default"`, warm-started** (claim has a bound `Sandbox` whose name differs from the claim's name) → webhook derives the pool name from the existing `Sandbox` via `stripRandomSuffix(sandboxName)`. The source pool already exists; nothing to do at migration time.
+   - **`""` / `"none"` / `"default"`, cold-start** (no bound `Sandbox`, or `Sandbox.name == claim.name`) → webhook redirects to `shadow-pool-<template-name>`. The bootstrap phase ensures one such shadow pool exists per `(namespace, template)` combination.
 2. **`Sandbox.spec.replicas` becomes `Sandbox.spec.operatingMode`.** `replicas: 0` → `Suspended`, `replicas: 1` (or unset) → `Running`. The webhook handles this automatically.
 
 The other two CRDs (`SandboxTemplate`, `SandboxWarmPool`) are structurally identical between versions but still need a storage rewrite so etcd holds them in v1beta1 form.
 
-## What runs automatically
+## Two phases
 
-`helm upgrade agent-sandbox ./helm/ ...` triggers two Jobs via Helm hook annotations:
+The migration script has two phases, run in this order:
 
-| Phase | Job name | Hook | Does what |
-|---|---|---|---|
-| Pre-upgrade | `agent-sandbox-migration-bootstrap` | `pre-upgrade` | Scans every existing `SandboxClaim`. For each one whose `spec.warmpool` is `"none"`, `"default"`, unset, or names a pool that doesn't exist, creates a shadow `SandboxWarmPool` named `<claim>-shadow-pool` (replicas=0, references the claim's existing template). This gives the conversion webhook a valid `warmPoolRef` target. |
-| Post-upgrade | `agent-sandbox-migration-rewrite` | `post-upgrade` | Patches every existing `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` with a `agents.x-k8s.io/storage-migrated-at` annotation. The patch round-trips the resource through the conversion webhook, which causes the API server to rewrite the etcd record in v1beta1 format. |
+- **`--phase=bootstrap`** — must run **before** the v1beta1 CRDs/controller are applied. Pre-creates any `shadow-pool-<template>` pools needed by the conversion webhook so cold-start claims have a valid `warmPoolRef` target. Operates on the v1alpha1 API.
+- **`--phase=migrate`** — must run **after** the v1beta1 CRDs and conversion webhook are live. Patches every existing resource with a benign annotation, forcing the API server to read it through the conversion webhook and rewrite it to etcd in v1beta1 storage format.
 
-Both Jobs are **idempotent**. Helm will retry on failure (`backoffLimit: 2`); operators can also `kubectl delete job <name>` and `helm upgrade --no-hooks=false` to re-trigger.
+Both phases are idempotent — safe to re-run.
 
-## What runs manually
+## Migration flows
 
-The same script the Jobs use is exposed at `dev/tools/migrate.sh` for operators who want finer control:
+Pick one of three flows depending on how you manage installs.
+
+### Flow A — Helm-managed, automatic (default)
+
+The chart ships two Helm hook Jobs that run the bootstrap and rewrite phases automatically as part of `helm upgrade`:
 
 ```bash
-# Dry-run the bootstrap phase against the cluster your kubeconfig points at.
-bash dev/tools/migrate.sh --phase=bootstrap --dry-run
+helm upgrade agent-sandbox ./helm/ \
+  --namespace agent-sandbox-system \
+  --reuse-values \
+  --set image.tag=<new-version>
+```
 
-# Actually create shadow pools.
+| Phase | Job name | Hook | What it does |
+|---|---|---|---|
+| Pre-upgrade | `agent-sandbox-migration-bootstrap` | `pre-upgrade` | Runs `migrate.sh --phase=bootstrap` against the existing v1alpha1 state. |
+| Post-upgrade | `agent-sandbox-migration-rewrite` | `post-upgrade` | Runs `migrate.sh --phase=migrate` after the new controller + webhook are running. The Job has a `wait-for-webhook` initContainer that polls the webhook Service endpoints for up to 120s. |
+
+Both Jobs run `helm/files/migrate.sh` from a ConfigMap (defaultMode 0755) mounted in the pod. Helm retries on failure (`backoffLimit: 2`); operators can also `kubectl delete job <name>` and re-run `helm upgrade` to re-trigger.
+
+### Flow B — Manual via kubectl (Helm-free install)
+
+For clusters that install the controller via `kubectl apply -f` (not Helm), run the script directly. The script is at `dev/tools/migrate.sh` (a thin wrapper around `helm/files/migrate.sh`).
+
+```bash
+# 1. Pre-create the shadow pools BEFORE applying the new CRDs.
+#    Operates on v1alpha1 - this is the last step that does.
 bash dev/tools/migrate.sh --phase=bootstrap
 
-# Trigger the storage rewrite for everything.
-bash dev/tools/migrate.sh --phase=migrate
+# 2. Install the new controller + CRDs (which include the conversion webhook).
+#    Wait until the controller pod is Ready and the webhook Service has
+#    endpoints before proceeding.
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.0/manifest.yaml
+kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system
+kubectl wait --for=condition=Ready pods -l app=agent-sandbox-controller -n agent-sandbox-system
 
-# Scope to one namespace.
+# 3. Force-rewrite every resource in v1beta1 storage format.
+bash dev/tools/migrate.sh --phase=migrate
+```
+
+If the cluster is large, scope the rewrite to one namespace at a time:
+
+```bash
 bash dev/tools/migrate.sh --phase=migrate --namespace=team-alpha
 ```
 
-The script uses `kubectl` and respects the active kubeconfig. It exits non-zero if any resource fails to migrate (per-resource errors don't abort the run, but the final exit reflects total failures).
+### Flow C — Helm-managed, manual script (hooks disabled)
 
-## Opting out of the automated Jobs
+If you want Helm to manage the chart but want to run the migration script yourself (e.g., to scope to specific namespaces, dry-run first, or run between specific cluster events), disable the hooks:
 
 ```bash
-helm upgrade agent-sandbox ./helm/ ... --set migration.enabled=false
+# 1. Pre-create shadow pools while v1alpha1 is still the storage version.
+bash dev/tools/migrate.sh --phase=bootstrap --dry-run   # inspect first
+bash dev/tools/migrate.sh --phase=bootstrap
+
+# 2. Upgrade the chart WITHOUT the migration Jobs.
+helm upgrade agent-sandbox ./helm/ \
+  --namespace agent-sandbox-system \
+  --reuse-values \
+  --set image.tag=<new-version> \
+  --set migration.enabled=false
+
+# 3. Wait for the new controller + webhook to be Ready, then rewrite storage.
+bash dev/tools/migrate.sh --phase=migrate
 ```
 
-Then run `dev/tools/migrate.sh` manually in whatever order and scope you want. Useful when:
+## Dry-runs
 
-- The cluster is large enough that the default Job resource limits aren't appropriate (override `--set migration.resources....` or run manually).
-- You want to migrate one namespace at a time as part of a phased rollout.
-- The cluster has CRDs from a custom build of agent-sandbox and you need to validate behavior before letting the automated Job touch everything.
+Both phases support `--dry-run`. The script prints what it would do without writing anything:
+
+```bash
+bash dev/tools/migrate.sh --phase=bootstrap --dry-run
+bash dev/tools/migrate.sh --phase=migrate --dry-run
+```
+
+The `bootstrap` dry-run also prints the "operator action required" summary (claims referencing missing specific pools), which is useful to inspect even when you intend to apply.
 
 ## After migration completes
 
-The shadow `SandboxWarmPool`s created by the bootstrap phase remain in the cluster — the conversion webhook depends on them being valid `warmPoolRef` targets for the converted v1beta1 `SandboxClaim`s. They are marked with two annotations so you can find them later:
+### Shadow pools
+
+The bootstrap phase creates one `shadow-pool-<template>` per `(namespace, template)` combination referenced by cold-start v1alpha1 claims. They're marked with two annotations:
+
+- `agents.x-k8s.io/migration-shadow: "true"`
+- `agents.x-k8s.io/migration-source-template: <template-name>`
+
+List them:
 
 ```bash
 kubectl get sandboxwarmpools -A -o json \
   | jq -r '.items[]
       | select(.metadata.annotations["agents.x-k8s.io/migration-shadow"]=="true")
-      | "\(.metadata.namespace)/\(.metadata.name) (for claim: \(.metadata.annotations["agents.x-k8s.io/migration-source-claim"]))"'
+      | "\(.metadata.namespace)/\(.metadata.name) (for template: \(.metadata.annotations["agents.x-k8s.io/migration-source-template"]))"'
 ```
 
-Do **not** delete these pools while the corresponding `SandboxClaim`s still reference them via `warmPoolRef`. Once v1alpha1 is fully removed from the codebase (a future release) and you've manually re-pointed any remaining claims to real warm pools, the shadow pools can be cleaned up.
+Do **not** delete these pools while any v1beta1 `SandboxClaim` still references them via `warmPoolRef`. Once v1alpha1 is fully removed from the codebase (a future release) and you've manually re-pointed any remaining claims to real warm pools, the shadow pools can be cleaned up.
+
+### Re-pointing warm-started claims
+
+The bootstrap phase intentionally **skips** warm-started v1alpha1 claims (those with `warmpool: ""`/`"none"`/`"default"` AND a bound `Sandbox` whose name differs from the claim's). The webhook redirects those claims' `warmPoolRef` to the pool that produced their current `Sandbox` (via `stripRandomSuffix(sandboxName)`), so they end up pointing at a real, existing pool — no shadow needed.
+
+That said, after migration completes you may want to re-point such claims at a different pool (e.g., consolidate, or move to a shadow). The `warmPoolRef.name` is editable on the v1beta1 claim:
+
+```bash
+kubectl patch sandboxclaim <name> -n <ns> --type=merge \
+  -p '{"spec":{"warmPoolRef":{"name":"my-preferred-pool"}}}'
+```
+
+### Operator-action items from the bootstrap summary
+
+If `bootstrap` printed an `OPERATOR ACTION REQUIRED` section listing claims that reference specific pools which don't currently exist, the conversion webhook will still rewrite those claims to point at those exact (missing) pool names. To make those claims work, either:
+
+1. Create the missing pools manually, OR
+2. Re-point the claims to existing pools via the `kubectl patch` above.
 
 ## Verifying the migration worked
 
@@ -110,6 +183,12 @@ Only do this after you've confirmed every existing record carries `agents.x-k8s.
 
 **Pre-upgrade Job fails with "failed to list SandboxClaims"**: the script's ServiceAccount RBAC isn't applied yet. The bootstrap ClusterRole + ClusterRoleBinding should land in the same Helm hook batch. If you're testing manually, apply `helm/templates/migration-rbac.yaml` first.
 
-**Post-upgrade Job's init container `wait-for-webhook` times out**: the conversion webhook isn't reachable. Check that the `agent-sandbox-webhook-service` Service exists in the controller's namespace and that its endpoints are populated (`kubectl get endpoints agent-sandbox-webhook-service -n agent-sandbox-system`). If the Service is missing entirely, that's a chart issue separate from this migration — track it upstream.
+**Post-upgrade Job's init container `wait-for-webhook` times out**: the conversion webhook isn't reachable. Check that the Service named by `migration.webhookServiceName` (default `agent-sandbox-webhook-service`) exists in the controller's namespace and that its endpoints are populated:
+
+```bash
+kubectl get endpoints agent-sandbox-webhook-service -n agent-sandbox-system
+```
 
 **Migrate phase reports failures on specific resources**: re-run the script (`bash dev/tools/migrate.sh --phase=migrate`). It's idempotent — already-migrated resources just get the annotation timestamp updated. If a specific resource keeps failing, fetch it (`kubectl get -o yaml`) and inspect what's wrong — usually it's a conversion-webhook error tied to a bad field combination that needs manual cleanup.
+
+**Bootstrap printed `OPERATOR ACTION REQUIRED` for some claims**: those claims reference specific pool names that don't currently exist. The conversion webhook will still rewrite them to point at those names — you must create the pools manually post-migration, or re-point the claims (see "Re-pointing warm-started claims" above).

--- a/helm/README.md
+++ b/helm/README.md
@@ -58,7 +58,7 @@ Upgrades to chart versions that move CRDs from `v1alpha1` to `v1beta1` ship two 
 - **Pre-upgrade** Job (`agent-sandbox-migration-bootstrap`) scans every existing `SandboxClaim` and creates a per-claim shadow `SandboxWarmPool` (replicas=0) when needed, so the conversion webhook has a valid `warmPoolRef` target for the v1beta1 schema.
 - **Post-upgrade** Job (`agent-sandbox-migration-rewrite`) patches every existing `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` to force the API server to rewrite each resource in v1beta1 storage format, eliminating stale v1alpha1 records from etcd.
 
-Both Jobs run the same idempotent script bundled in the chart's ConfigMap. The same script is exposed at `dev/tools/migrate.sh` (a wrapper) for manual operator use. See [`docs/api-migration.md`](../docs/api-migration.md) for full operational details, including how to opt out of the automated Jobs (`--set migration.enabled=false`) and run the script manually.
+Both Jobs run the same idempotent script bundled in the chart's ConfigMap. The same script is exposed at `dev/tools/migrate.sh` (a wrapper) for manual operator use. See [`docs/api-migration-guide.md`](../docs/api-migration-guide.md) for full operational details, including how to opt out of the automated Jobs (`--set migration.enabled=false`) and run the script manually.
 
 Fresh `helm install` runs never trigger migration — there is no v1alpha1 data to convert.
 
@@ -115,3 +115,4 @@ The following table lists the configurable parameters and their defaults.
 | `migration.enabled` | Run v1alpha1 → v1beta1 pre/post-upgrade Jobs. See [v1alpha1 → v1beta1 storage migration](#v1alpha1--v1beta1-storage-migration). Set false to opt out and run `dev/tools/migrate.sh` manually | `true` |
 | `migration.image` | Image used by the migration Jobs. Must have `bash` + `kubectl` available | `bitnami/kubectl:1.30` |
 | `migration.resources` | CPU/memory requests and limits for the migration Job pods | `{requests: {cpu: 100m, memory: 64Mi}, limits: {cpu: 500m, memory: 256Mi}}` |
+| `migration.webhookServiceName` | Name of the conversion webhook Service the post-upgrade Job waits for before starting the storage rewrite | `agent-sandbox-webhook-service` |

--- a/helm/README.md
+++ b/helm/README.md
@@ -55,7 +55,7 @@ helm upgrade agent-sandbox ./helm/ \
 
 Upgrades to chart versions that move CRDs from `v1alpha1` to `v1beta1` ship two automated Helm hook Jobs that handle the migration end-to-end:
 
-- **Pre-upgrade** Job (`agent-sandbox-migration-bootstrap`) scans every existing `SandboxClaim` and creates a per-claim shadow `SandboxWarmPool` (replicas=0) when needed, so the conversion webhook has a valid `warmPoolRef` target for the v1beta1 schema.
+- **Pre-upgrade** Job (`agent-sandbox-migration-bootstrap`) scans every existing `SandboxClaim` and, for each unique template referenced by a cold-start claim, creates a `shadow-pool-<template>` `SandboxWarmPool` (replicas=0) in that claim's namespace. Warm-started claims are left alone (the conversion webhook derives their `warmPoolRef` from the bound `Sandbox`).
 - **Post-upgrade** Job (`agent-sandbox-migration-rewrite`) patches every existing `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` to force the API server to rewrite each resource in v1beta1 storage format, eliminating stale v1alpha1 records from etcd.
 
 Both Jobs run the same idempotent script bundled in the chart's ConfigMap. The same script is exposed at `dev/tools/migrate.sh` (a wrapper) for manual operator use. See [`docs/api-migration-guide.md`](../docs/api-migration-guide.md) for full operational details, including how to opt out of the automated Jobs (`--set migration.enabled=false`) and run the script manually.

--- a/helm/README.md
+++ b/helm/README.md
@@ -51,6 +51,17 @@ helm upgrade agent-sandbox ./helm/ \
 > kubectl apply -f helm/crds/
 > ```
 
+### v1alpha1 → v1beta1 storage migration
+
+Upgrades to chart versions that move CRDs from `v1alpha1` to `v1beta1` ship two automated Helm hook Jobs that handle the migration end-to-end:
+
+- **Pre-upgrade** Job (`agent-sandbox-migration-bootstrap`) scans every existing `SandboxClaim` and creates a per-claim shadow `SandboxWarmPool` (replicas=0) when needed, so the conversion webhook has a valid `warmPoolRef` target for the v1beta1 schema.
+- **Post-upgrade** Job (`agent-sandbox-migration-rewrite`) patches every existing `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` to force the API server to rewrite each resource in v1beta1 storage format, eliminating stale v1alpha1 records from etcd.
+
+Both Jobs run the same idempotent script bundled in the chart's ConfigMap. The same script is exposed at `dev/tools/migrate.sh` (a wrapper) for manual operator use. See [`docs/api-migration.md`](../docs/api-migration.md) for full operational details, including how to opt out of the automated Jobs (`--set migration.enabled=false`) and run the script manually.
+
+Fresh `helm install` runs never trigger migration — there is no v1alpha1 data to convert.
+
 ## Uninstallation
 
 ```bash
@@ -101,3 +112,6 @@ The following table lists the configurable parameters and their defaults.
 | `containerSecurityContext` | Container `securityContext` for the controller; only rendered when set | `null` |
 | `podAnnotations` | Annotations added to the controller pod template (e.g. service-mesh sidecar toggles, Prometheus scrape autodiscovery) | `{}` |
 | `podLabels` | Extra labels added to the controller pod template alongside the chart's selector labels (selector labels take precedence on conflict) | `{}` |
+| `migration.enabled` | Run v1alpha1 → v1beta1 pre/post-upgrade Jobs. See [v1alpha1 → v1beta1 storage migration](#v1alpha1--v1beta1-storage-migration). Set false to opt out and run `dev/tools/migrate.sh` manually | `true` |
+| `migration.image` | Image used by the migration Jobs. Must have `bash` + `kubectl` available | `bitnami/kubectl:1.30` |
+| `migration.resources` | CPU/memory requests and limits for the migration Job pods | `{requests: {cpu: 100m, memory: 64Mi}, limits: {cpu: 500m, memory: 256Mi}}` |

--- a/helm/files/migrate.sh
+++ b/helm/files/migrate.sh
@@ -161,10 +161,12 @@ resource_exists() {
 #       still rewrite the claim to point at the missing pool, and the
 #       operator must create it manually).
 #
-#   (B) spec.warmpool in {"", "none", "default"} AND the claim was warm-
-#       started (status.sandboxStatus.name is non-empty and != claim name)
-#       -> webhook uses stripRandomSuffix(sandboxName). The source pool
+#   (B) spec.warmpool in {"", "default"} AND the claim was warm-started
+#       (status.sandboxStatus.name is non-empty and != claim name) ->
+#       webhook uses stripRandomSuffix(sandboxName). The source pool
 #       already exists (the sandbox came from it); no shadow needed.
+#       ("none" never reaches this branch: claims with warmpool="none"
+#       always cold-start, so they fall through to (C).)
 #
 #   (C) spec.warmpool in {"", "none", "default"} AND the claim is cold-
 #       start (no sandbox, or sandbox.name == claim.name) -> webhook uses

--- a/helm/files/migrate.sh
+++ b/helm/files/migrate.sh
@@ -193,9 +193,17 @@ bootstrap_phase() {
   # Pull namespace, name, templateRef, warmpool policy, and the bound
   # sandbox name (if any) for every SandboxClaim in one shot. jsonpath
   # keeps us jq-free so the container image can be any minimal kubectl
-  # image. Trailing blank fields are preserved as empty strings between
-  # tabs. status.sandboxStatus.name distinguishes warm-started (sandbox
+  # image. status.sandboxStatus.name distinguishes warm-started (sandbox
   # exists and != claim name) from cold-start.
+  #
+  # We deliberately use '|' (a non-whitespace character) as the field
+  # delimiter rather than tab. When IFS contains whitespace characters
+  # like tab, bash's `read` collapses *consecutive* whitespace IFS chars
+  # into a single delimiter (POSIX word-splitting rule), so an empty
+  # spec.warmpool field (which is the common case under default
+  # networkPolicyManagement) would shift sandbox_name into the warmpool
+  # slot and corrupt the warm-start detection. '|' is non-whitespace, so
+  # consecutive '|' characters are preserved as empty fields.
   #
   # Listing failures must abort the phase. Suppressing them silently would
   # make a missing-RBAC or transient API error look like "no claims found"
@@ -203,7 +211,7 @@ bootstrap_phase() {
   local items
   # shellcheck disable=SC2046
   if ! items="$(kctl get sandboxclaims.extensions.agents.x-k8s.io $(ns_args) \
-      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.sandboxTemplateRef.name}{"\t"}{.spec.warmpool}{"\t"}{.status.sandboxStatus.name}{"\n"}{end}' \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"|"}{.metadata.name}{"|"}{.spec.sandboxTemplateRef.name}{"|"}{.spec.warmpool}{"|"}{.status.sandboxStatus.name}{"\n"}{end}' \
       2>&1)"; then
     errlog "failed to list SandboxClaims: $items"
     errlog "check RBAC: ServiceAccount needs get/list on sandboxclaims.extensions.agents.x-k8s.io"
@@ -215,7 +223,7 @@ bootstrap_phase() {
     return 0
   fi
 
-  while IFS=$'\t' read -r claim_ns claim_name template_name warmpool sandbox_name; do
+  while IFS='|' read -r claim_ns claim_name template_name warmpool sandbox_name; do
     [[ -z "$claim_ns" ]] && continue
     scanned=$((scanned + 1))
 

--- a/helm/files/migrate.sh
+++ b/helm/files/migrate.sh
@@ -18,11 +18,13 @@
 # Two phases, both idempotent:
 #
 #   --phase=bootstrap   Pre-upgrade. Scans every v1alpha1 SandboxClaim
-#                       cluster-wide and creates a per-claim "shadow"
-#                       SandboxWarmPool (replicas=0) for claims that don't
-#                       reference a specific existing pool. This gives the
-#                       conversion webhook a valid warmPoolRef target when it
-#                       converts those claims to v1beta1 later.
+#                       cluster-wide and, for each unique template referenced
+#                       by a cold-start claim with no specific pool, creates
+#                       a "shadow-pool-<template>" SandboxWarmPool (replicas=0)
+#                       in that claim's namespace. The conversion webhook in
+#                       v1beta1 redirects cold-start claims to that exact
+#                       pool name; warm-started claims are left alone (the
+#                       webhook derives their pool from the existing Sandbox).
 #
 #   --phase=migrate     Post-upgrade. Patches every Sandbox / SandboxClaim /
 #                       SandboxTemplate / SandboxWarmPool cluster-wide with
@@ -50,9 +52,9 @@ set -euo pipefail
 
 # --- Config / constants -----------------------------------------------------
 
-readonly SHADOW_POOL_SUFFIX="-shadow-pool"
+readonly SHADOW_POOL_PREFIX="shadow-pool-"
 readonly SHADOW_ANNOTATION_KEY="agents.x-k8s.io/migration-shadow"
-readonly SHADOW_SOURCE_ANNOTATION_KEY="agents.x-k8s.io/migration-source-claim"
+readonly SHADOW_SOURCE_TEMPLATE_ANNOTATION_KEY="agents.x-k8s.io/migration-source-template"
 readonly MIGRATED_AT_ANNOTATION_KEY="agents.x-k8s.io/storage-migrated-at"
 
 # CRDs are patched in this order to maximize the chance that, mid-migration,
@@ -149,26 +151,57 @@ resource_exists() {
 
 # --- Phase: bootstrap -------------------------------------------------------
 
-# bootstrap_phase iterates all v1alpha1 SandboxClaims and ensures each has a
-# corresponding SandboxWarmPool the conversion webhook can use as the
-# v1beta1 warmPoolRef target. Idempotent: existing shadow pools are skipped;
-# user-created pools with conflicting names are left alone (with a warning).
+# bootstrap_phase iterates all v1alpha1 SandboxClaims and ensures the
+# conversion webhook has a valid warmPoolRef target for each. The webhook
+# (extensions/api/v1alpha1/sandboxclaim_conversion.go) has three branches:
+#
+#   (A) spec.warmpool is a specific pool name -> webhook uses that name
+#       verbatim. We verify the pool exists; if not, list it in the
+#       operator-action summary at the end (don't fail; the webhook will
+#       still rewrite the claim to point at the missing pool, and the
+#       operator must create it manually).
+#
+#   (B) spec.warmpool in {"", "none", "default"} AND the claim was warm-
+#       started (status.sandboxStatus.name is non-empty and != claim name)
+#       -> webhook uses stripRandomSuffix(sandboxName). The source pool
+#       already exists (the sandbox came from it); no shadow needed.
+#
+#   (C) spec.warmpool in {"", "none", "default"} AND the claim is cold-
+#       start (no sandbox, or sandbox.name == claim.name) -> webhook uses
+#       shadow-pool-<template>. We collect a deduped set of (namespace,
+#       template) pairs and create one shadow per pair, so claims sharing
+#       a template share a single shadow pool.
+#
+# Idempotent: existing shadows are skipped; user-created pools that
+# happen to share a shadow name are left alone (with a warning).
 bootstrap_phase() {
   log "Bootstrap: scanning v1alpha1 SandboxClaims to identify pools needed..."
 
-  local total=0 created=0 skipped_existing_shadow=0 skipped_user_pool=0 errors=0
+  local scanned=0 warmstart_skipped=0 specific_existing=0 created=0
+  local skipped_existing_shadow=0 errors=0
+  # Dedupe key "ns:template" -> any value indicates we need a shadow pool
+  # for that (namespace, template) pair.
+  declare -A needed_shadows=()
+  # "ns/claim -> pool-name" entries for the operator-action summary printed
+  # at the end. These are claims that named a specific pool that does not
+  # currently exist; the webhook will rewrite the claim to point at that
+  # name regardless, so the operator must create the pool manually.
+  declare -a missing_specific_pools=()
 
-  # Pull namespace, name, templateRef, and warmpool policy for every
-  # SandboxClaim in one shot. jsonpath keeps us jq-free so the container
-  # image can be any minimal kubectl image. Trailing blank fields are
-  # preserved as empty strings between tabs.
+  # Pull namespace, name, templateRef, warmpool policy, and the bound
+  # sandbox name (if any) for every SandboxClaim in one shot. jsonpath
+  # keeps us jq-free so the container image can be any minimal kubectl
+  # image. Trailing blank fields are preserved as empty strings between
+  # tabs. status.sandboxStatus.name distinguishes warm-started (sandbox
+  # exists and != claim name) from cold-start.
+  #
   # Listing failures must abort the phase. Suppressing them silently would
   # make a missing-RBAC or transient API error look like "no claims found"
   # and exit 0, skipping the bootstrap entirely.
   local items
   # shellcheck disable=SC2046
   if ! items="$(kctl get sandboxclaims.extensions.agents.x-k8s.io $(ns_args) \
-      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.sandboxTemplateRef.name}{"\t"}{.spec.warmpool}{"\n"}{end}' \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.sandboxTemplateRef.name}{"\t"}{.spec.warmpool}{"\t"}{.status.sandboxStatus.name}{"\n"}{end}' \
       2>&1)"; then
     errlog "failed to list SandboxClaims: $items"
     errlog "check RBAC: ServiceAccount needs get/list on sandboxclaims.extensions.agents.x-k8s.io"
@@ -180,67 +213,92 @@ bootstrap_phase() {
     return 0
   fi
 
-  while IFS=$'\t' read -r claim_ns claim_name template_name warmpool; do
+  while IFS=$'\t' read -r claim_ns claim_name template_name warmpool sandbox_name; do
     [[ -z "$claim_ns" ]] && continue
-    total=$((total + 1))
-
-    # Decide what pool the v1beta1 warmPoolRef should target.
-    local target_pool=""
-    case "$warmpool" in
-      ""|"none"|"default")
-        target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
-        ;;
-      *)
-        # User specified a specific pool name. resource_exists returns:
-        #   0 = pool exists -> nothing to do
-        #   1 = NotFound    -> mint a shadow (typo, deleted, etc.)
-        #   2 = transient   -> log and skip (will retry on next run; do
-        #                      NOT mint a shadow, because the pool may
-        #                      actually exist and we just couldn't tell)
-        local rc=0
-        resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$warmpool" || rc=$?
-        case "$rc" in
-          0)
-            log "claim $claim_ns/$claim_name: existing pool '$warmpool' found, no shadow needed"
-            skipped_user_pool=$((skipped_user_pool + 1))
-            continue
-            ;;
-          1)
-            warn "claim $claim_ns/$claim_name references non-existent pool '$warmpool'; minting shadow pool"
-            target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
-            ;;
-          *)
-            errlog "claim $claim_ns/$claim_name: transient error checking pool '$warmpool'; skipping (re-run to retry)"
-            errors=$((errors + 1))
-            continue
-            ;;
-        esac
-        ;;
-    esac
+    scanned=$((scanned + 1))
 
     if [[ -z "$template_name" ]]; then
-      warn "claim $claim_ns/$claim_name has no sandboxTemplateRef.name; cannot mint shadow pool, skipping"
+      warn "claim $claim_ns/$claim_name has no sandboxTemplateRef.name; cannot determine target pool, skipping"
       errors=$((errors + 1))
       continue
     fi
 
-    # Check if shadow pool already exists.
-    case "$(resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$target_pool"; echo $?)" in
+    case "$warmpool" in
+      ""|"none"|"default")
+        # Branch B vs C: warm-started or cold-start?
+        if [[ -n "$sandbox_name" && "$sandbox_name" != "$claim_name" ]]; then
+          # Warm-started. Webhook derives pool from sandbox name; that
+          # pool already exists by virtue of having produced the sandbox.
+          log "claim $claim_ns/$claim_name: warm-started (sandbox=$sandbox_name); no shadow needed"
+          warmstart_skipped=$((warmstart_skipped + 1))
+        else
+          # Cold-start. Webhook will use shadow-pool-<template>. Dedupe
+          # by (namespace, template) so multiple cold-start claims sharing
+          # a template share a single shadow pool.
+          needed_shadows["${claim_ns}:${template_name}"]=1
+        fi
+        ;;
+      *)
+        # Branch A: specific pool name. Webhook uses it verbatim. If the
+        # pool doesn't exist, the webhook will still rewrite the claim to
+        # point at it, but it won't be backed by anything - operator must
+        # create the pool manually. We list these at the end of the phase
+        # so the operator knows what work remains.
+        local rc=0
+        resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$warmpool" || rc=$?
+        case "$rc" in
+          0)
+            log "claim $claim_ns/$claim_name: specific pool '$warmpool' exists, no action needed"
+            specific_existing=$((specific_existing + 1))
+            ;;
+          1)
+            warn "claim $claim_ns/$claim_name references non-existent pool '$warmpool'; needs manual creation post-migration"
+            missing_specific_pools+=("$claim_ns/$claim_name -> $warmpool")
+            ;;
+          *)
+            errlog "claim $claim_ns/$claim_name: transient error checking pool '$warmpool'; re-run to retry"
+            errors=$((errors + 1))
+            ;;
+        esac
+        ;;
+    esac
+  done <<< "$items"
+
+  # Create the deduped shadow pools.
+  local key ns template pool_name
+  for key in "${!needed_shadows[@]}"; do
+    ns="${key%%:*}"
+    template="${key#*:}"
+    pool_name="${SHADOW_POOL_PREFIX}${template}"
+
+    # K8s names max 63 chars (DNS-1123 label). "shadow-pool-" is 12 chars,
+    # so the template name can be up to 51 chars. Anything longer would
+    # produce an invalid name; operator must rename the template or
+    # pre-create a pool the webhook can reach.
+    if (( ${#pool_name} > 63 )); then
+      errlog "shadow pool name '$pool_name' exceeds K8s 63-char limit (template '$template' too long); operator must rename template or pre-create a pool"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    local rc=0
+    resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$ns" "$pool_name" || rc=$?
+    case "$rc" in
       0)
-        # Exists. Verify it's actually our shadow and not a user pool with the
-        # same name (which could happen if the user named one *-shadow-pool).
+        # Pool with that name already exists. Verify it's actually our
+        # shadow and not a user pool that happens to share the name.
         # kubectl jsonpath does not reliably traverse annotation keys
         # containing "/" via dot-notation escaping, so we use go-template
-        # with `index` which handles arbitrary keys correctly. Missing
-        # annotation prints "<no value>", which is != "true" - safe default.
+        # with `index`. Missing annotation prints "<no value>" which is
+        # != "true" - safe default.
         local existing_shadow
-        existing_shadow="$(kctl get sandboxwarmpool -n "$claim_ns" "$target_pool" \
+        existing_shadow="$(kctl get sandboxwarmpool -n "$ns" "$pool_name" \
           -o go-template="{{ index .metadata.annotations \"${SHADOW_ANNOTATION_KEY}\" }}" \
           2>/dev/null || true)"
         if [[ "$existing_shadow" == "true" ]]; then
           skipped_existing_shadow=$((skipped_existing_shadow + 1))
         else
-          warn "pool $claim_ns/$target_pool exists but is not marked as a migration shadow; not touching it"
+          warn "pool $ns/$pool_name exists but is not marked as a migration shadow; not touching it"
           errors=$((errors + 1))
         fi
         continue
@@ -251,7 +309,7 @@ bootstrap_phase() {
         ;;
     esac
 
-    log "creating shadow pool $claim_ns/$target_pool for claim $claim_name (template: $template_name)"
+    log "creating shadow pool $ns/$pool_name (for template $template)"
     if [[ "$DRY_RUN" == "true" ]]; then
       created=$((created + 1))
       continue
@@ -262,26 +320,40 @@ bootstrap_phase() {
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxWarmPool
 metadata:
-  name: ${target_pool}
-  namespace: ${claim_ns}
+  name: ${pool_name}
+  namespace: ${ns}
   annotations:
     ${SHADOW_ANNOTATION_KEY}: "true"
-    ${SHADOW_SOURCE_ANNOTATION_KEY}: "${claim_name}"
+    ${SHADOW_SOURCE_TEMPLATE_ANNOTATION_KEY}: "${template}"
 spec:
   replicas: 0
   sandboxTemplateRef:
-    name: ${template_name}
+    name: ${template}
 EOF
 )"
     if printf '%s\n' "$manifest" | kctl apply -f - >/dev/null 2>&1; then
       created=$((created + 1))
     else
-      errlog "failed to create shadow pool $claim_ns/$target_pool"
+      errlog "failed to create shadow pool $ns/$pool_name"
       errors=$((errors + 1))
     fi
-  done <<< "$items"
+  done
 
-  log "Bootstrap summary: scanned=$total created=$created skipped_existing_shadow=$skipped_existing_shadow skipped_user_pool=$skipped_user_pool errors=$errors"
+  log "Bootstrap summary: scanned=$scanned warmstart_skipped=$warmstart_skipped specific_existing=$specific_existing created=$created skipped_existing_shadow=$skipped_existing_shadow errors=$errors"
+
+  if (( ${#missing_specific_pools[@]} > 0 )); then
+    warn ""
+    warn "OPERATOR ACTION REQUIRED: the following SandboxClaims reference"
+    warn "specific pools that do not currently exist. After migration, the"
+    warn "conversion webhook will set warmPoolRef.name to those exact names,"
+    warn "and you must create the pools manually for those claims to be"
+    warn "satisfiable (or edit the claim's warmPoolRef to point elsewhere):"
+    local line
+    for line in "${missing_specific_pools[@]}"; do
+      warn "  - $line"
+    done
+  fi
+
   if (( errors > 0 )); then
     warn "completed with $errors error(s); review log above"
     return 1

--- a/helm/files/migrate.sh
+++ b/helm/files/migrate.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# migrate.sh — agent-sandbox v1alpha1 -> v1beta1 migration helper.
+#
+# Two phases, both idempotent:
+#
+#   --phase=bootstrap   Pre-upgrade. Scans every v1alpha1 SandboxClaim
+#                       cluster-wide and creates a per-claim "shadow"
+#                       SandboxWarmPool (replicas=0) for claims that don't
+#                       reference a specific existing pool. This gives the
+#                       conversion webhook a valid warmPoolRef target when it
+#                       converts those claims to v1beta1 later.
+#
+#   --phase=migrate     Post-upgrade. Patches every Sandbox / SandboxClaim /
+#                       SandboxTemplate / SandboxWarmPool cluster-wide with
+#                       a storage-migrated-at annotation, which forces the
+#                       API server to read each resource and rewrite it to
+#                       etcd in the v1beta1 storage format. Prevents stale
+#                       v1alpha1 records from lingering and becoming
+#                       unreadable when v1alpha1 is removed in a future
+#                       release.
+#
+# Both phases tolerate per-resource failures (log + continue) and print a
+# summary at the end. Both phases can be re-run safely.
+#
+# Usage:
+#   migrate.sh --phase=bootstrap|migrate [--dry-run] [--namespace=<ns>]
+#              [--kubectl=<path>]
+#
+# Environment variables (override CLI):
+#   KUBECTL                 Path to kubectl binary. Default: kubectl.
+#   MIGRATE_DRY_RUN         If "true", same effect as --dry-run.
+#
+# Documented entry point for operators: docs/api-migration.md.
+
+set -euo pipefail
+
+# --- Config / constants -----------------------------------------------------
+
+readonly SHADOW_POOL_SUFFIX="-shadow-pool"
+readonly SHADOW_ANNOTATION_KEY="agents.x-k8s.io/migration-shadow"
+readonly SHADOW_SOURCE_ANNOTATION_KEY="agents.x-k8s.io/migration-source-claim"
+readonly MIGRATED_AT_ANNOTATION_KEY="agents.x-k8s.io/storage-migrated-at"
+
+# CRDs are patched in this order to maximize the chance that, mid-migration,
+# the cluster is internally consistent: pools and templates first (so any
+# claim's warmPoolRef target is converted before the claim itself is touched),
+# then sandboxes, then claims last.
+readonly -a CRDS_TO_MIGRATE=(
+  "sandboxwarmpools.extensions.agents.x-k8s.io"
+  "sandboxtemplates.extensions.agents.x-k8s.io"
+  "sandboxes.agents.x-k8s.io"
+  "sandboxclaims.extensions.agents.x-k8s.io"
+)
+
+# --- CLI parsing ------------------------------------------------------------
+
+PHASE=""
+NAMESPACE=""              # empty = all namespaces
+DRY_RUN="${MIGRATE_DRY_RUN:-false}"
+KUBECTL="${KUBECTL:-kubectl}"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 --phase=bootstrap|migrate [--dry-run] [--namespace=<ns>] [--kubectl=<path>]
+
+  --phase=PHASE     Required. One of: bootstrap, migrate.
+  --dry-run         Print planned actions, do not modify any resources.
+  --namespace=NS    Restrict to a single namespace. Default: all namespaces.
+  --kubectl=PATH    Override kubectl binary path. Default: kubectl (or \$KUBECTL).
+  -h, --help        Show this help.
+
+See docs/api-migration.md for full operator documentation.
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --phase=*)     PHASE="${arg#*=}" ;;
+    --namespace=*) NAMESPACE="${arg#*=}" ;;
+    --kubectl=*)   KUBECTL="${arg#*=}" ;;
+    --dry-run)     DRY_RUN="true" ;;
+    -h|--help)     usage; exit 0 ;;
+    *)             echo "ERROR: unknown argument: $arg" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$PHASE" ]]; then
+  echo "ERROR: --phase is required" >&2
+  usage
+  exit 2
+fi
+
+if [[ "$PHASE" != "bootstrap" && "$PHASE" != "migrate" ]]; then
+  echo "ERROR: --phase must be one of: bootstrap, migrate (got: $PHASE)" >&2
+  exit 2
+fi
+
+# --- Logging helpers --------------------------------------------------------
+
+log()    { echo "[migrate:$PHASE] $*"; }
+warn()   { echo "[migrate:$PHASE] WARN: $*" >&2; }
+errlog() { echo "[migrate:$PHASE] ERROR: $*" >&2; }
+
+# --- kubectl wrappers -------------------------------------------------------
+
+# kubectl wrapper that respects --namespace if set; otherwise --all-namespaces
+# for list operations.
+kctl() { "$KUBECTL" "$@"; }
+
+# ns_args echoes the namespace flag(s) for list operations.
+ns_args() {
+  if [[ -n "$NAMESPACE" ]]; then
+    echo "-n $NAMESPACE"
+  else
+    echo "--all-namespaces"
+  fi
+}
+
+# resource_exists checks if a specific named resource exists in a namespace.
+# Returns 0 if exists, 1 if not, 2 on transient error.
+resource_exists() {
+  local kind="$1" ns="$2" name="$3"
+  if kctl get "$kind" -n "$ns" "$name" >/dev/null 2>&1; then
+    return 0
+  fi
+  # Distinguish NotFound from other errors so the caller can decide.
+  local out
+  out="$(kctl get "$kind" -n "$ns" "$name" 2>&1 || true)"
+  if [[ "$out" == *"NotFound"* || "$out" == *"not found"* ]]; then
+    return 1
+  fi
+  errlog "transient error checking $kind $ns/$name: $out"
+  return 2
+}
+
+# --- Phase: bootstrap -------------------------------------------------------
+
+# bootstrap_phase iterates all v1alpha1 SandboxClaims and ensures each has a
+# corresponding SandboxWarmPool the conversion webhook can use as the
+# v1beta1 warmPoolRef target. Idempotent: existing shadow pools are skipped;
+# user-created pools with conflicting names are left alone (with a warning).
+bootstrap_phase() {
+  log "Bootstrap: scanning v1alpha1 SandboxClaims to identify pools needed..."
+
+  local total=0 created=0 skipped_existing_shadow=0 skipped_user_pool=0 errors=0
+
+  # Pull namespace, name, templateRef, and warmpool policy for every
+  # SandboxClaim in one shot. jsonpath keeps us jq-free so the container
+  # image can be any minimal kubectl image. Trailing blank fields are
+  # preserved as empty strings between tabs.
+  local items
+  # shellcheck disable=SC2046
+  items="$(kctl get sandboxclaims.extensions.agents.x-k8s.io $(ns_args) \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.sandboxTemplateRef.name}{"\t"}{.spec.warmpool}{"\n"}{end}' \
+    2>/dev/null || true)"
+
+  if [[ -z "$items" ]]; then
+    log "Bootstrap: no SandboxClaims found. Nothing to do."
+    return 0
+  fi
+
+  while IFS=$'\t' read -r claim_ns claim_name template_name warmpool; do
+    [[ -z "$claim_ns" ]] && continue
+    total=$((total + 1))
+
+    # Decide what pool the v1beta1 warmPoolRef should target.
+    local target_pool=""
+    case "$warmpool" in
+      ""|"none"|"default")
+        target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
+        ;;
+      *)
+        # User specified a specific pool name. If it actually exists in the
+        # claim's namespace, no shadow needed. If it doesn't exist (typo,
+        # deleted, etc.), fall back to a shadow pool so the claim still has
+        # a valid target post-conversion.
+        if resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$warmpool"; then
+          log "claim $claim_ns/$claim_name: existing pool '$warmpool' found, no shadow needed"
+          skipped_user_pool=$((skipped_user_pool + 1))
+          continue
+        else
+          warn "claim $claim_ns/$claim_name references non-existent pool '$warmpool'; minting shadow pool"
+          target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
+        fi
+        ;;
+    esac
+
+    if [[ -z "$template_name" ]]; then
+      warn "claim $claim_ns/$claim_name has no sandboxTemplateRef.name; cannot mint shadow pool, skipping"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    # Check if shadow pool already exists.
+    case "$(resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$target_pool"; echo $?)" in
+      0)
+        # Exists. Verify it's actually our shadow and not a user pool with the
+        # same name (which could happen if the user named one *-shadow-pool).
+        local existing_shadow
+        existing_shadow="$(kctl get sandboxwarmpool -n "$claim_ns" "$target_pool" \
+          -o jsonpath="{.metadata.annotations.${SHADOW_ANNOTATION_KEY//./\\.}}" 2>/dev/null || true)"
+        if [[ "$existing_shadow" == "true" ]]; then
+          skipped_existing_shadow=$((skipped_existing_shadow + 1))
+        else
+          warn "pool $claim_ns/$target_pool exists but is not marked as a migration shadow; not touching it"
+          errors=$((errors + 1))
+        fi
+        continue
+        ;;
+      2)
+        errors=$((errors + 1))
+        continue
+        ;;
+    esac
+
+    log "creating shadow pool $claim_ns/$target_pool for claim $claim_name (template: $template_name)"
+    if [[ "$DRY_RUN" == "true" ]]; then
+      created=$((created + 1))
+      continue
+    fi
+
+    local manifest
+    manifest="$(cat <<EOF
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: ${target_pool}
+  namespace: ${claim_ns}
+  annotations:
+    ${SHADOW_ANNOTATION_KEY}: "true"
+    ${SHADOW_SOURCE_ANNOTATION_KEY}: "${claim_name}"
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    name: ${template_name}
+EOF
+)"
+    if printf '%s\n' "$manifest" | kctl apply -f - >/dev/null 2>&1; then
+      created=$((created + 1))
+    else
+      errlog "failed to create shadow pool $claim_ns/$target_pool"
+      errors=$((errors + 1))
+    fi
+  done <<< "$items"
+
+  log "Bootstrap summary: scanned=$total created=$created skipped_existing_shadow=$skipped_existing_shadow skipped_user_pool=$skipped_user_pool errors=$errors"
+  if (( errors > 0 )); then
+    warn "completed with $errors error(s); review log above"
+    return 1
+  fi
+  return 0
+}
+
+# --- Phase: migrate ---------------------------------------------------------
+
+# migrate_phase patches every resource of every migrated CRD with a benign
+# annotation, which forces the API server to rewrite the resource through
+# the conversion webhook in v1beta1 storage format. Idempotent.
+migrate_phase() {
+  log "Migrate: rewriting storage for all migrated CRDs..."
+  local now
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  local total_success=0 total_failure=0
+  for kind in "${CRDS_TO_MIGRATE[@]}"; do
+    local k_success=0 k_failure=0
+    log "processing $kind ..."
+
+    local items
+    # shellcheck disable=SC2046
+    items="$(kctl get "$kind" $(ns_args) \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' \
+      2>/dev/null || true)"
+
+    if [[ -z "$items" ]]; then
+      log "  no resources found"
+      continue
+    fi
+
+    while IFS=$'\t' read -r ns name; do
+      [[ -z "$ns" ]] && continue
+
+      if [[ "$DRY_RUN" == "true" ]]; then
+        log "  DRY-RUN: would patch $kind $ns/$name"
+        k_success=$((k_success + 1))
+        continue
+      fi
+
+      local patch
+      patch="{\"metadata\":{\"annotations\":{\"${MIGRATED_AT_ANNOTATION_KEY}\":\"${now}\"}}}"
+      if kctl patch "$kind" -n "$ns" "$name" --type=merge -p "$patch" >/dev/null 2>&1; then
+        k_success=$((k_success + 1))
+      else
+        errlog "  failed to patch $kind $ns/$name"
+        k_failure=$((k_failure + 1))
+      fi
+    done <<< "$items"
+
+    log "  $kind: success=$k_success failure=$k_failure"
+    total_success=$((total_success + k_success))
+    total_failure=$((total_failure + k_failure))
+  done
+
+  log "Migrate summary: total_success=$total_success total_failure=$total_failure"
+  if (( total_failure > 0 )); then
+    warn "completed with $total_failure failure(s); review log above and re-run if appropriate"
+    return 1
+  fi
+  return 0
+}
+
+# --- Main dispatcher --------------------------------------------------------
+
+log "agent-sandbox migration tool starting (kubectl=$KUBECTL, dry_run=$DRY_RUN, namespace=${NAMESPACE:-<all>})"
+
+case "$PHASE" in
+  bootstrap) bootstrap_phase ;;
+  migrate)   migrate_phase ;;
+esac
+
+exit_code=$?
+log "phase=$PHASE finished with exit_code=$exit_code"
+exit "$exit_code"

--- a/helm/files/migrate.sh
+++ b/helm/files/migrate.sh
@@ -44,7 +44,7 @@
 #   KUBECTL                 Path to kubectl binary. Default: kubectl.
 #   MIGRATE_DRY_RUN         If "true", same effect as --dry-run.
 #
-# Documented entry point for operators: docs/api-migration.md.
+# Documented entry point for operators: docs/api-migration-guide.md.
 
 set -euo pipefail
 
@@ -83,7 +83,7 @@ Usage: $0 --phase=bootstrap|migrate [--dry-run] [--namespace=<ns>] [--kubectl=<p
   --kubectl=PATH    Override kubectl binary path. Default: kubectl (or \$KUBECTL).
   -h, --help        Show this help.
 
-See docs/api-migration.md for full operator documentation.
+See docs/api-migration-guide.md for full operator documentation.
 EOF
 }
 
@@ -162,11 +162,18 @@ bootstrap_phase() {
   # SandboxClaim in one shot. jsonpath keeps us jq-free so the container
   # image can be any minimal kubectl image. Trailing blank fields are
   # preserved as empty strings between tabs.
+  # Listing failures must abort the phase. Suppressing them silently would
+  # make a missing-RBAC or transient API error look like "no claims found"
+  # and exit 0, skipping the bootstrap entirely.
   local items
   # shellcheck disable=SC2046
-  items="$(kctl get sandboxclaims.extensions.agents.x-k8s.io $(ns_args) \
-    -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.sandboxTemplateRef.name}{"\t"}{.spec.warmpool}{"\n"}{end}' \
-    2>/dev/null || true)"
+  if ! items="$(kctl get sandboxclaims.extensions.agents.x-k8s.io $(ns_args) \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.sandboxTemplateRef.name}{"\t"}{.spec.warmpool}{"\n"}{end}' \
+      2>&1)"; then
+    errlog "failed to list SandboxClaims: $items"
+    errlog "check RBAC: ServiceAccount needs get/list on sandboxclaims.extensions.agents.x-k8s.io"
+    return 1
+  fi
 
   if [[ -z "$items" ]]; then
     log "Bootstrap: no SandboxClaims found. Nothing to do."
@@ -184,18 +191,30 @@ bootstrap_phase() {
         target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
         ;;
       *)
-        # User specified a specific pool name. If it actually exists in the
-        # claim's namespace, no shadow needed. If it doesn't exist (typo,
-        # deleted, etc.), fall back to a shadow pool so the claim still has
-        # a valid target post-conversion.
-        if resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$warmpool"; then
-          log "claim $claim_ns/$claim_name: existing pool '$warmpool' found, no shadow needed"
-          skipped_user_pool=$((skipped_user_pool + 1))
-          continue
-        else
-          warn "claim $claim_ns/$claim_name references non-existent pool '$warmpool'; minting shadow pool"
-          target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
-        fi
+        # User specified a specific pool name. resource_exists returns:
+        #   0 = pool exists -> nothing to do
+        #   1 = NotFound    -> mint a shadow (typo, deleted, etc.)
+        #   2 = transient   -> log and skip (will retry on next run; do
+        #                      NOT mint a shadow, because the pool may
+        #                      actually exist and we just couldn't tell)
+        local rc=0
+        resource_exists sandboxwarmpools.extensions.agents.x-k8s.io "$claim_ns" "$warmpool" || rc=$?
+        case "$rc" in
+          0)
+            log "claim $claim_ns/$claim_name: existing pool '$warmpool' found, no shadow needed"
+            skipped_user_pool=$((skipped_user_pool + 1))
+            continue
+            ;;
+          1)
+            warn "claim $claim_ns/$claim_name references non-existent pool '$warmpool'; minting shadow pool"
+            target_pool="${claim_name}${SHADOW_POOL_SUFFIX}"
+            ;;
+          *)
+            errlog "claim $claim_ns/$claim_name: transient error checking pool '$warmpool'; skipping (re-run to retry)"
+            errors=$((errors + 1))
+            continue
+            ;;
+        esac
         ;;
     esac
 
@@ -210,9 +229,14 @@ bootstrap_phase() {
       0)
         # Exists. Verify it's actually our shadow and not a user pool with the
         # same name (which could happen if the user named one *-shadow-pool).
+        # kubectl jsonpath does not reliably traverse annotation keys
+        # containing "/" via dot-notation escaping, so we use go-template
+        # with `index` which handles arbitrary keys correctly. Missing
+        # annotation prints "<no value>", which is != "true" - safe default.
         local existing_shadow
         existing_shadow="$(kctl get sandboxwarmpool -n "$claim_ns" "$target_pool" \
-          -o jsonpath="{.metadata.annotations.${SHADOW_ANNOTATION_KEY//./\\.}}" 2>/dev/null || true)"
+          -o go-template="{{ index .metadata.annotations \"${SHADOW_ANNOTATION_KEY}\" }}" \
+          2>/dev/null || true)"
         if [[ "$existing_shadow" == "true" ]]; then
           skipped_existing_shadow=$((skipped_existing_shadow + 1))
         else
@@ -282,9 +306,14 @@ migrate_phase() {
 
     local items
     # shellcheck disable=SC2046
-    items="$(kctl get "$kind" $(ns_args) \
-      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' \
-      2>/dev/null || true)"
+    if ! items="$(kctl get "$kind" $(ns_args) \
+        -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' \
+        2>&1)"; then
+      errlog "  failed to list $kind: $items"
+      errlog "  treating as failure for this CRD; continuing with other CRDs"
+      total_failure=$((total_failure + 1))
+      continue
+    fi
 
     if [[ -z "$items" ]]; then
       log "  no resources found"

--- a/helm/templates/migration-configmap.yaml
+++ b/helm/templates/migration-configmap.yaml
@@ -1,0 +1,30 @@
+{{/*
+  ConfigMap embedding the v1alpha1 -> v1beta1 migration script that the
+  pre- and post-upgrade Helm hook Jobs mount and execute. The same script
+  is exposed at dev/tools/migrate.sh (as a wrapper) so operators can run
+  it manually with the same arguments.
+
+  Marked as both pre-upgrade AND post-upgrade so the ConfigMap exists when
+  EITHER hook Job runs. before-hook-creation as the sole delete policy
+  means it persists between the two phases (and across upgrades) without
+  ever lingering as a stale duplicate.
+
+  No hook annotation on install — fresh installs have no v1alpha1
+  resources to migrate, so skipping the Jobs entirely is correct.
+*/}}
+{{- if .Values.migration.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-sandbox-migration
+  namespace: {{ include "agent-sandbox.namespace" . }}
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  migrate.sh: |-
+{{ .Files.Get "files/migrate.sh" | indent 4 }}
+{{- end }}

--- a/helm/templates/migration-job-bootstrap.yaml
+++ b/helm/templates/migration-job-bootstrap.yaml
@@ -29,9 +29,23 @@ spec:
     spec:
       serviceAccountName: agent-sandbox-migration
       restartPolicy: OnFailure
+      # Restricted Pod Security Admission requires runAsNonRoot and a
+      # non-Unconfined seccompProfile at pod-level (or via every container);
+      # set both here so Jobs are accepted under "restricted" out of the box.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: migrate
           image: {{ .Values.migration.image | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - /bin/bash
             - /scripts/migrate.sh

--- a/helm/templates/migration-job-bootstrap.yaml
+++ b/helm/templates/migration-job-bootstrap.yaml
@@ -1,0 +1,50 @@
+{{/*
+  Pre-upgrade Job that scans v1alpha1 SandboxClaims and creates per-claim
+  shadow SandboxWarmPools (replicas=0) so the conversion webhook has a
+  valid warmPoolRef target when it converts each claim to v1beta1.
+
+  Runs BEFORE the new CRDs and controller are applied, so it operates on
+  the previous-version v1alpha1 API. Script is idempotent — safe to retry
+  on failure (Helm will, up to backoffLimit).
+*/}}
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: agent-sandbox-migration-bootstrap
+  namespace: {{ include "agent-sandbox.namespace" . }}
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "agent-sandbox.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: agent-sandbox-migration
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: {{ .Values.migration.image | quote }}
+          command:
+            - /bin/bash
+            - /scripts/migrate.sh
+            - --phase=bootstrap
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            name: agent-sandbox-migration
+            defaultMode: 0755
+{{- end }}

--- a/helm/templates/migration-job-migrate.yaml
+++ b/helm/templates/migration-job-migrate.yaml
@@ -1,0 +1,84 @@
+{{/*
+  Post-upgrade Job that forces a storage rewrite of every Sandbox /
+  SandboxClaim / SandboxTemplate / SandboxWarmPool resource through the
+  conversion webhook, so etcd ends up holding only v1beta1-serialized
+  records. Without this, resources created under v1alpha1 would remain
+  serialized as v1alpha1 in etcd and become unreadable when v1alpha1 is
+  eventually removed from the codebase.
+
+  Runs AFTER the new controller and webhook are live. The script is
+  idempotent: it just patches each resource with a timestamp annotation,
+  which round-trips through the conversion webhook.
+
+  initContainer waits up to ~120s for the conversion webhook endpoint to
+  be Ready before letting the patch script run. If the webhook isn't
+  reachable, every patch would fail; better to fail fast at init with a
+  clear error than spam the API server with failing patches.
+*/}}
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: agent-sandbox-migration-rewrite
+  namespace: {{ include "agent-sandbox.namespace" . }}
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "agent-sandbox.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: agent-sandbox-migration
+      restartPolicy: OnFailure
+      initContainers:
+        # Block until the conversion webhook is reachable. Without a
+        # working webhook, patch operations fail with conversion errors,
+        # so it's cheaper to wait up front than to retry per-resource.
+        - name: wait-for-webhook
+          image: {{ .Values.migration.image | quote }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              SVC=agent-sandbox-webhook-service
+              NS={{ include "agent-sandbox.namespace" . }}
+              echo "Waiting for ${SVC} endpoints in ${NS}..."
+              for i in $(seq 1 24); do
+                if kubectl get endpoints "${SVC}" -n "${NS}" \
+                    -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null \
+                    | grep -qE '^[0-9]+\.'; then
+                  echo "Webhook endpoint ready."
+                  exit 0
+                fi
+                echo "  not ready yet (attempt ${i}/24); sleeping 5s..."
+                sleep 5
+              done
+              echo "ERROR: webhook endpoint did not become ready in 120s" >&2
+              exit 1
+      containers:
+        - name: migrate
+          image: {{ .Values.migration.image | quote }}
+          command:
+            - /bin/bash
+            - /scripts/migrate.sh
+            - --phase=migrate
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: scripts
+          configMap:
+            name: agent-sandbox-migration
+            defaultMode: 0755
+{{- end }}

--- a/helm/templates/migration-job-migrate.yaml
+++ b/helm/templates/migration-job-migrate.yaml
@@ -37,12 +37,28 @@ spec:
     spec:
       serviceAccountName: agent-sandbox-migration
       restartPolicy: OnFailure
+      # Restricted Pod Security Admission requires runAsNonRoot and a
+      # non-Unconfined seccompProfile at pod-level (or via every container);
+      # set both here so Jobs are accepted under "restricted" out of the box.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # Block until the conversion webhook is reachable. Without a
         # working webhook, patch operations fail with conversion errors,
         # so it's cheaper to wait up front than to retry per-resource.
         - name: wait-for-webhook
           image: {{ .Values.migration.image | quote }}
+          # Restricted-PSA-compatible defaults. This init just runs
+          # kubectl get; no privileges needed.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - /bin/bash
             - -c
@@ -52,13 +68,22 @@ spec:
               NS={{ include "agent-sandbox.namespace" . }}
               echo "Waiting for ${SVC} endpoints in ${NS}..."
               for i in $(seq 1 24); do
-                if kubectl get endpoints "${SVC}" -n "${NS}" \
-                    -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null \
-                    | grep -qE '^[0-9]+\.'; then
-                  echo "Webhook endpoint ready."
-                  exit 0
+                # Capture combined output so RBAC / API errors surface in
+                # the Job log instead of silently retrying. Any non-empty
+                # address (IPv4 or IPv6) means there's a ready endpoint -
+                # the previous IPv4-shaped regex check broke on IPv6
+                # clusters.
+                if out="$(kubectl get endpoints "${SVC}" -n "${NS}" \
+                    -o jsonpath='{.subsets[*].addresses[*].ip}' 2>&1)"; then
+                  if [[ -n "$out" ]]; then
+                    echo "Webhook endpoint(s) ready: $out"
+                    exit 0
+                  fi
+                  echo "  (attempt ${i}/24) endpoints object exists but has no ready addresses; sleeping 5s..."
+                else
+                  echo "  (attempt ${i}/24) kubectl get endpoints failed: $out" >&2
+                  echo "  sleeping 5s before retry..."
                 fi
-                echo "  not ready yet (attempt ${i}/24); sleeping 5s..."
                 sleep 5
               done
               echo "ERROR: webhook endpoint did not become ready in 120s" >&2
@@ -66,6 +91,13 @@ spec:
       containers:
         - name: migrate
           image: {{ .Values.migration.image | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - /bin/bash
             - /scripts/migrate.sh

--- a/helm/templates/migration-job-migrate.yaml
+++ b/helm/templates/migration-job-migrate.yaml
@@ -48,7 +48,7 @@ spec:
             - -c
             - |
               set -euo pipefail
-              SVC=agent-sandbox-webhook-service
+              SVC={{ .Values.migration.webhookServiceName | quote }}
               NS={{ include "agent-sandbox.namespace" . }}
               echo "Waiting for ${SVC} endpoints in ${NS}..."
               for i in $(seq 1 24); do

--- a/helm/templates/migration-rbac.yaml
+++ b/helm/templates/migration-rbac.yaml
@@ -1,0 +1,104 @@
+{{/*
+  RBAC for the v1alpha1 -> v1beta1 migration Jobs.
+
+  One ServiceAccount used by both Jobs (bootstrap + rewrite), two
+  cluster-scoped Roles with the minimum permissions each phase needs:
+
+    bootstrap: read SandboxClaims (to discover what shadow pools are
+               needed) and create SandboxWarmPools (to mint them). Does
+               not need delete/patch.
+
+    rewrite:   read + patch all four migrated CRDs. Patch is the operation
+               that forces the API server to rewrite each resource in the
+               v1beta1 storage format.
+
+  Same hook annotations as the ConfigMap so the SA/Roles/Bindings exist
+  whenever either phase Job runs.
+*/}}
+{{- if .Values.migration.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agent-sandbox-migration
+  namespace: {{ include "agent-sandbox.namespace" . }}
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-sandbox-migration-bootstrap
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims"]
+    verbs: ["get", "list"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxwarmpools"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: agent-sandbox-migration-rewrite
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxclaims", "sandboxtemplates", "sandboxwarmpools"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-sandbox-migration-bootstrap
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+subjects:
+  - kind: ServiceAccount
+    name: agent-sandbox-migration
+    namespace: {{ include "agent-sandbox.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-sandbox-migration-bootstrap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: agent-sandbox-migration-rewrite
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade,post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+subjects:
+  - kind: ServiceAccount
+    name: agent-sandbox-migration
+    namespace: {{ include "agent-sandbox.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: agent-sandbox-migration-rewrite
+{{- end }}

--- a/helm/templates/migration-rbac.yaml
+++ b/helm/templates/migration-rbac.yaml
@@ -63,6 +63,20 @@ rules:
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims", "sandboxtemplates", "sandboxwarmpools"]
     verbs: ["get", "list", "patch"]
+  # The post-upgrade rewrite Job's wait-for-webhook initContainer reads
+  # the conversion webhook's Endpoints object to know when the webhook
+  # is reachable. Without this, kubectl get endpoints is RBAC-forbidden,
+  # the readiness loop never succeeds, and the rewrite Job times out
+  # on every Helm upgrade.
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get"]
+  # endpoints is being deprecated in favor of endpointslices; granting
+  # both lets us switch the readiness check to endpointslices later
+  # without another RBAC change.
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,9 +93,14 @@ migration:
   enabled: true
 
   # Container image used by both the bootstrap and rewrite Jobs. Needs
-  # bash + kubectl. bitnami/kubectl bundles both. If your registry policy
-  # forbids docker.io / Bitnami images, override to a mirror or a locally
-  # built image with the same packages.
+  # bash + kubectl. bitnami/kubectl bundles both, but note Bitnami
+  # restricted their public Docker Hub catalog in 2025 - if your registry
+  # policy or rate-limiting blocks docker.io, mirror this image into a
+  # registry you control, or substitute a minimal kubectl+bash image of
+  # your own (registry.k8s.io/kubectl is distroless and lacks bash, so
+  # cannot be used as a drop-in). For reproducibility under upgrades,
+  # pin by digest:
+  #   image: bitnami/kubectl@sha256:<digest>
   image: bitnami/kubectl:1.30
 
   # Resource requests/limits for the migration Job pods. Defaults are

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -80,3 +80,31 @@ podSecurityContext: null
 #   seccompProfile:
 #     type: RuntimeDefault
 containerSecurityContext: null
+
+# migration controls the v1alpha1 -> v1beta1 upgrade hooks (bootstrap +
+# storage rewrite). Set enabled: false on fresh installs and clusters that
+# have already been migrated, to skip the Jobs entirely.
+#
+# The Jobs run only at `helm upgrade` time (NOT on initial install), so a
+# `helm install` of this chart never triggers migration regardless of this
+# setting. The setting exists so operators can also opt out of migration
+# during an upgrade (e.g., to run dev/tools/migrate.sh manually instead).
+migration:
+  enabled: true
+
+  # Container image used by both the bootstrap and rewrite Jobs. Needs
+  # bash + kubectl. bitnami/kubectl bundles both. If your registry policy
+  # forbids docker.io / Bitnami images, override to a mirror or a locally
+  # built image with the same packages.
+  image: bitnami/kubectl:1.30
+
+  # Resource requests/limits for the migration Job pods. Defaults are
+  # conservative; bump if you have very large clusters (thousands of
+  # SandboxClaims) and the script needs more memory.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -108,3 +108,9 @@ migration:
     limits:
       cpu: 500m
       memory: 256Mi
+
+  # Name of the conversion webhook Service the post-upgrade Job waits for
+  # before starting the storage rewrite. Override if your install uses a
+  # non-default webhook Service name (e.g. a multi-tenant install with a
+  # renamed webhook).
+  webhookServiceName: agent-sandbox-webhook-service


### PR DESCRIPTION
  #### What this PR does / why we need it:

  Implements tasks **# 4 (Bootstrap & Storage Migration Script)** and **# 5 (Automated Helm Hook Integration)** of #959, combined into a single PR per @janetkuo's suggestion that we ship one script driven by two Helm hook Jobs (rather than
  separate bootstrap and rewrite scripts).

  - **One script** at `helm/files/migrate.sh` with two phases (`--phase=bootstrap`, `--phase=migrate`), both idempotent and re-runnable.
  - **Wrapper** at `dev/tools/migrate.sh` so operators can invoke the same script manually outside of `helm upgrade`.
  - **Two Helm hook Jobs**:
    - `agent-sandbox-migration-bootstrap` (`pre-upgrade`) — scans v1alpha1 `SandboxClaim`s and, for each unique `(namespace, template)` pair referenced by a cold-start claim, creates a `shadow-pool-<template>` `SandboxWarmPool` (replicas=0)
  in that claim's namespace. Matches the naming convention used by the conversion webhook in #966 (`extensions/api/v1alpha1/sandboxclaim_conversion.go`). Warm-started claims (where `status.sandboxStatus.name` differs from the claim name) are
  skipped — the webhook derives their pool from the bound `Sandbox`, no shadow needed. Claims that reference a specific pool that doesn't exist are surfaced in a final `OPERATOR ACTION REQUIRED` summary.
    - `agent-sandbox-migration-rewrite` (`post-upgrade`) — patches every existing `Sandbox` / `SandboxClaim` / `SandboxTemplate` / `SandboxWarmPool` with a `agents.x-k8s.io/storage-migrated-at` annotation, forcing the API server to rewrite
  each record in v1beta1 storage format.
  - **Shared infra** (`agent-sandbox-migration` ServiceAccount, 2 ClusterRoles, 2 ClusterRoleBindings, ConfigMap embedding the script) annotated `pre-upgrade,post-upgrade` with weight `-10` and `before-hook-creation` delete policy so they
  persist across both phases of the upgrade.
  - The post-upgrade Job has a `wait-for-webhook` initContainer that polls the conversion webhook Service's endpoints for up to 120s (24 × 5s), accepts IPv4/IPv6/dual-stack, surfaces RBAC/API errors in the Job log, and fails fast with a
  clear error if the webhook never becomes Ready. The rewrite Job pod is also hardened to be admitted under restricted Pod Security Admission (pod-level `runAsNonRoot` + `RuntimeDefault` seccomp; container-level drop-ALL caps +
  `allowPrivilegeEscalation: false`).
  - The webhook Service name is configurable via `migration.webhookServiceName` (defaults to `agent-sandbox-webhook-service`, matching the Service added in #966).
  - Opt-out via `--set migration.enabled=false` for operators who want to run `dev/tools/migrate.sh` manually (e.g. phased rollout, custom resource limits, large clusters, or a non-Helm install path).
  - `docs/api-migration-guide.md` documents three explicit operator flows (Helm-automatic, manual kubectl, Helm-with-hooks-disabled), shadow-pool lifecycle, re-pointing warm-started claims post-migration, verification commands, and
  troubleshooting.

  Notes:
  1. **Depends on #966** for the conversion webhook logic and the `agent-sandbox-webhook-service` Service. Without #966 merged, the migrate phase's patch round-trip is a no-op (no conversion happens) and the `wait-for-webhook` init has no
  Service to wait for. Once #966 lands and this PR is rebased, end-to-end migration on a Helm-installed cluster works without further changes.
  2. **E2E upgrade test suite** is task #6 of #959 — separate scope. This PR's script will be invoked from there.
  3. **Migration guide / site banner** is task #7 of #959.

  ## Test plan
  
  - [x] `bash -n` syntax check on both shell scripts
  - [x] `shellcheck helm/files/migrate.sh` and `dev/tools/migrate.sh` (no findings)
  - [x] `helm lint ./helm/` passes
  - [x] `helm template` with `migration.enabled=true` renders SA + ConfigMap + 2 ClusterRoles + 2 ClusterRoleBindings + 2 Jobs (bootstrap pre-upgrade, rewrite post-upgrade with `wait-for-webhook` initContainer and restricted-PSA
  securityContext)
  - [x] `helm template --set migration.enabled=false` renders zero migration resources (all properly gated)
  - [x] `helm template --set migration.webhookServiceName=...` propagates to the `wait-for-webhook` init's `SVC=` variable
  - [x] Rewrite Job's ClusterRole includes RBAC for core `endpoints` (so `wait-for-webhook` is not silently RBAC-forbidden) and `discovery.k8s.io/endpointslices` (forward-compat)
  - [ ] **Deferred to task #6 of #959** (E2E test suite): full kind-cluster E2E — install old chart with v1alpha1-only state → create mixed-warmpool `SandboxClaim`s (cold-start + warm-started + specific-pool + missing-specific-pool) → `helm
  upgrade` to this chart → verify (a) all claims still resolve, (b) one `shadow-pool-<template>` per unique cold-start `(namespace, template)` with expected annotations, (c) warm-started claims have `warmPoolRef.name` derived from their
  bound `Sandbox`, (d) `OPERATOR ACTION REQUIRED` summary lists exactly the claims with missing specific pools, (e) every resource has `agents.x-k8s.io/storage-migrated-at`, (f) etcd storage version is v1beta1.
  - [ ] **Deferred**: idempotency E2E. Script is designed for it — re-running each phase should be a no-op except for the annotation timestamp on the rewrite path. Will be exercised by #6.

  #### Which issue(s) this PR is related to:

  Towards #959
  
  #### Release Note
  ```release-note
  ```


<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added v1alpha1 API versions for Sandbox, SandboxClaim, SandboxTemplate, and SandboxWarmPool resources
  * Enabled webhook-based API conversion between v1alpha1 and v1beta1 versions
  * Added automated migration path with pre/post-upgrade Helm hooks for v1alpha1 → v1beta1 conversion
  * Added manual migration script accessible via `dev/tools/migrate.sh`

* **Documentation**
  * Added comprehensive API migration guide with troubleshooting steps
  * Expanded API reference documentation with v1alpha1 schema definitions

* **Tests**
  * Added integration tests for webhook certificate handling and CRD patching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->