### PR TITLE
docs: update the manual pdb example

### DIFF
--- a/examples/manual-pdb/README.md
+++ b/examples/manual-pdb/README.md
@@ -28,10 +28,16 @@ Because multiple Sandboxes share one PDB, we use `maxUnavailable: 0`.
 ### Step 1: Apply the Template
 The template includes the required labels and the `safe-to-evict` annotation.
 ```bash
-kubectl apply -f sandbox-template.yaml
+kubectl apply -f sandboxtemplate.yaml -n default
 ```
 
-### Step 2: Apply the Shared PDB (Once per Namespace)
+### Step 2: Apply the WarmPool
+The WarmPool references the template, with the desired number of sandboxes set to 2.
+```bash
+kubectl apply -f sandboxwarmpool.yaml -n default
+```
+
+### Step 3: Apply the Shared PDB (Once per Namespace)
 You must apply the PDB manifest to **every** namespace where you intend to run Sandboxes.
 
 ```bash
@@ -39,12 +45,12 @@ You must apply the PDB manifest to **every** namespace where you intend to run S
 kubectl apply -f shared-pdb.yaml -n default
 ```
 
-### Step 3: Create Sandbox Claims
+### Step 4: Create Sandbox Claims
 You can now create as many Claims as you want in that namespace.
 
 ```bash
 # Example for the 'default' namespace
-kubectl apply -f sandbox-claim.yaml -n default
+kubectl apply -f sandboxclaim.yaml -n default
 ```
 
 

--- a/examples/manual-pdb/sandboxwarmpool.yaml
+++ b/examples/manual-pdb/sandboxwarmpool.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: secure-warmpool
+spec:
+  replicas: 2
+  sandboxTemplateRef:
+    name: secure-template


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
While going through the `manual PDB` example, I found that the `sandboxClaim` manifest uses `warmPoolRef` to refer to a `sandboxwarmpool`, but this resource is missing from the example. I've updated the example accordingly.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated manual PodDisruptionBudget workflow guide with new example commands and file references for applying sandbox templates, warm pools, and sandbox claims.

* **Examples**
  * Added SandboxWarmPool example manifest demonstrating warm pool configuration with replica settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->