### PR TITLE
fix(python): reraise ApiException on non-404 delete failure

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -221,7 +221,7 @@ class AsyncK8sHelper:
         except client.ApiException as e:
             if e.status != 404:
                 logger.error(f"Error terminating sandbox {name}: {e}")
-                raise SandboxNotFoundError(f"The sandbox claim {name} does not exist.")
+                raise
 
     async def get_sandbox(self, name: str, namespace: str):
         """Gets a Sandbox custom resource."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -220,7 +220,7 @@ class AsyncK8sHelper:
             logger.info(f"Terminated SandboxClaim: {name}")
         except client.ApiException as e:
             if e.status != 404:
-                logger.error(f"Error terminating sandbox {name}: {e}")
+                logger.error(f"Error terminating SandboxClaim {name}: {e}")
                 raise
 
     async def get_sandbox(self, name: str, namespace: str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -393,7 +393,4 @@ class AsyncSandboxClient(Generic[T]):
 
     @async_trace_span("delete_claim")
     async def _delete_claim(self, claim_name: str, namespace: str):
-        try:
-            await self.k8s_helper.delete_sandbox_claim(claim_name, namespace)
-        except Exception as e:
-            logger.error(f"Failed to cleanup SandboxClaim '{claim_name}': {e}")
+        await self.k8s_helper.delete_sandbox_claim(claim_name, namespace)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -181,7 +181,7 @@ class K8sHelper:
         except client.ApiException as e:
             if e.status != 404:
                 logging.error(f"Error terminating sandbox {name}: {e}")
-                raise SandboxNotFoundError(f"The sandbox claim {name} does not exist.")
+                raise
 
     def get_sandbox(self, name: str, namespace: str):
         """Gets a Sandbox custom resource."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -180,7 +180,7 @@ class K8sHelper:
             logging.info(f"Terminated SandboxClaim: {name}")
         except client.ApiException as e:
             if e.status != 404:
-                logging.error(f"Error terminating sandbox {name}: {e}")
+                logging.error(f"Error terminating SandboxClaim {name}: {e}")
                 raise
 
     def get_sandbox(self, name: str, namespace: str):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -24,7 +24,6 @@ from .models import (
     SandboxLocalTunnelConnectionConfig,
     SandboxTracerConfig,
 )
-from .exceptions import SandboxNotFoundError
 from .k8s_helper import K8sHelper
 from .connector import SandboxConnector
 from .constants import POD_NAME_ANNOTATION, SANDBOX_NAME_HASH_LABEL
@@ -203,12 +202,7 @@ class Sandbox:
             # Already deleted (or never successfully created a claim).
             return
 
-        try:
-            self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
-        except SandboxNotFoundError:
-            return
-        except Exception as e:
-            raise e
+        self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
 
         # Clear after successful delete so a retry does not 404.
         self.claim_name = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -359,10 +359,7 @@ class SandboxClient(Generic[T]):
     @trace_span("delete_claim")
     def _delete_claim(self, claim_name: str, namespace: str):
         """Deletes the SandboxClaim custom resource from the Kubernetes cluster."""
-        try:
-            self.k8s_helper.delete_sandbox_claim(claim_name, namespace)
-        except Exception as e:
-            logging.error(f"Failed to cleanup SandboxClaim '{claim_name}': {e}")
+        self.k8s_helper.delete_sandbox_claim(claim_name, namespace)
 
     def get_sandbox_claim_template_name(self, claim_name: str, namespace: str) -> str:
         """Get template name of a sandbox claim."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -212,5 +212,30 @@ class TestAsyncK8sHelperWaitForSandboxReady(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(result)
 
+class TestAsyncK8sHelperDeleteSandboxClaim(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.helper = AsyncK8sHelper()
+        self.helper._initialized = True
+        self.helper.custom_objects_api = MagicMock()
+        self.helper.core_v1_api = MagicMock()
+
+    async def test_delete_404_is_ignored(self):
+        from kubernetes_asyncio import client as async_client
+        exc = async_client.ApiException(status=404)
+        self.helper.custom_objects_api.delete_namespaced_custom_object = AsyncMock(side_effect=exc)
+
+        await self.helper.delete_sandbox_claim("missing-claim", "default")
+
+    async def test_delete_non_404_reraises(self):
+        from kubernetes_asyncio import client as async_client
+        exc = async_client.ApiException(status=403)
+        self.helper.custom_objects_api.delete_namespaced_custom_object = AsyncMock(side_effect=exc)
+
+        with self.assertRaises(async_client.ApiException) as ctx:
+            await self.helper.delete_sandbox_claim("claim", "default")
+        self.assertEqual(ctx.exception.status, 403)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -15,6 +15,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+from kubernetes import client
 from k8s_agent_sandbox.k8s_helper import K8sHelper
 from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
 
@@ -180,6 +181,32 @@ class TestK8sHelperResolveSandboxName(unittest.TestCase):
             helper.resolve_sandbox_name("test-claim", "default", timeout=5)
             
         self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
+
+
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperDeleteSandboxClaim(unittest.TestCase):
+
+    def test_delete_404_is_ignored(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+        exc = client.ApiException(status=404)
+        mock_api.delete_namespaced_custom_object.side_effect = exc
+
+        helper = K8sHelper()
+        helper.delete_sandbox_claim("missing-claim", "default")
+
+    def test_delete_non_404_reraises(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+        exc = client.ApiException(status=403)
+        mock_api.delete_namespaced_custom_object.side_effect = exc
+
+        helper = K8sHelper()
+        with self.assertRaises(client.ApiException) as ctx:
+            helper.delete_sandbox_claim("claim", "default")
+        self.assertEqual(ctx.exception.status, 403)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`delete_sandbox_claim` in both `k8s_helper.py` and `async_k8s_helper.py`
caught any `ApiException` with status != 404 and raised
`SandboxNotFoundError("does not exist")`. This is wrong: a 403 or 500
means the claim exists but could not be deleted, not that it is missing.

The fix reraises the original `ApiException` so callers see the real error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox deletion now ignores missing resources (HTTP 404) but re-raises other API errors.
  * Cleanup operations no longer swallow deletion failures — errors from claim deletion now propagate to callers.

* **Tests**
  * Added sync and async unit tests covering 404 vs non-404 sandbox deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->