### PR TITLE
feat(python): expose additionalPodMetadata in sandbox client

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -312,6 +312,15 @@ sandbox = client.create_sandbox(
 `pod_labels` are validated with the same Kubernetes label rules as `labels`. The
 same parameters are available on `AsyncSandboxClient.create_sandbox`.
 
+Behavioral notes:
+
+- A `pod_label` / `pod_annotation` whose key already exists on the warmpool
+  template with a different value is rejected by the controller's "No
+  Overrides" rule, and the reconcile errors.
+- Client-side validation only checks RFC-1123 label syntax. The controller's
+  domain allow-list and system-label restrictions are enforced server-side and
+  are not replicated client-side.
+
 ## Testing
 
 A test script is included to verify the full lifecycle (Creation -> Execution -> File I/O -> Cleanup).

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -286,6 +286,32 @@ async def main():
 asyncio.run(main())
 ```
 
+### 7. Labels and Pod Metadata
+
+`create_sandbox` lets you attach metadata at two different levels:
+
+- `labels`: Kubernetes labels on the **SandboxClaim object** itself
+  (`SandboxClaim.metadata.labels`). Useful for selecting/listing claims.
+- `pod_labels` / `pod_annotations`: labels and annotations stamped onto the
+  running Sandbox **Pod** via `spec.additionalPodMetadata`. Because they live on
+  the Pod, the workload can read them from inside the sandbox through the
+  [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/)
+  (for example, to stamp a tenant or client identifier and reject requests that
+  don't belong to it).
+
+```python
+sandbox = client.create_sandbox(
+    warmpool="python-sandbox-warmpool",
+    namespace="default",
+    labels={"team": "platform"},            # on the SandboxClaim object
+    pod_labels={"client-id": "tenant-a"},   # on the running Pod
+    pod_annotations={"owner": "tenant-a"},  # on the running Pod
+)
+```
+
+`pod_labels` are validated with the same Kubernetes label rules as `labels`. The
+same parameters are available on `AsyncSandboxClient.create_sandbox`.
+
 ## Testing
 
 A test script is included to verify the full lifecycle (Creation -> Execution -> File I/O -> Cleanup).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -65,8 +65,16 @@ class AsyncK8sHelper:
         annotations: dict | None = None,
         labels: dict | None = None,
         lifecycle: dict | None = None,
+        pod_metadata: dict | None = None,
     ):
-        """Creates a SandboxClaim custom resource."""
+        """Creates a SandboxClaim custom resource.
+
+        Args:
+            pod_metadata: Optional ``{"labels": {...}, "annotations": {...}}``
+                dict emitted as ``spec.additionalPodMetadata`` so the labels and
+                annotations propagate onto the running Sandbox Pod (as opposed to
+                ``labels``, which only land on the SandboxClaim object).
+        """
         await self._ensure_initialized()
 
         metadata = {
@@ -83,6 +91,8 @@ class AsyncK8sHelper:
         }
         if lifecycle:
             spec["lifecycle"] = lifecycle
+        if pod_metadata:
+            spec["additionalPodMetadata"] = pod_metadata
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -22,7 +22,6 @@ Requires the ``async`` optional dependencies::
 import atexit
 import asyncio
 import logging
-import re
 import sys
 import time
 import uuid
@@ -31,6 +30,7 @@ from typing import Generic, TypeVar
 from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
+from .pod_metadata import build_pod_metadata, validate_labels
 from .utils import construct_sandbox_claim_lifecycle_spec
 from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
 from .trace_manager import async_trace_span, create_tracer_manager, initialize_tracer, trace
@@ -170,9 +170,9 @@ class AsyncSandboxClient(Generic[T]):
             raise ValueError("Warmpool name cannot be empty.")
 
         if labels:
-            self._validate_labels(labels)
+            validate_labels(labels)
 
-        pod_metadata = self._build_pod_metadata(pod_labels, pod_annotations)
+        pod_metadata = build_pod_metadata(pod_labels, pod_annotations)
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
@@ -385,77 +385,6 @@ class AsyncSandboxClient(Generic[T]):
                     f"[agent-sandbox] Warning: atexit cleanup failed: {e}",
                     file=sys.stderr,
                 )
-
-    # --- Label validation (shared with sync client) ---
-
-    _LABEL_NAME_RE = re.compile(r"^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$|^[A-Za-z0-9]$")
-    _LABEL_PREFIX_RE = re.compile(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$")
-    _LABEL_NAME_MAX_LENGTH = 63
-    _LABEL_PREFIX_MAX_LENGTH = 253
-
-    @staticmethod
-    def _validate_label_name(name: str, context: str):
-        if len(name) > AsyncSandboxClient._LABEL_NAME_MAX_LENGTH:
-            raise ValueError(
-                f"Label {context} '{name}' exceeds max length of "
-                f"{AsyncSandboxClient._LABEL_NAME_MAX_LENGTH} characters."
-            )
-        if not AsyncSandboxClient._LABEL_NAME_RE.match(name):
-            raise ValueError(
-                f"Label {context} '{name}' contains invalid characters. "
-                f"Must start and end with alphanumeric, and contain only [-A-Za-z0-9_.]."
-            )
-
-    @staticmethod
-    def _validate_labels(labels: dict[str, str]):
-        for key, value in labels.items():
-            if not key:
-                raise ValueError("Label key cannot be empty.")
-
-            if "/" in key:
-                prefix, name = key.split("/", 1)
-                if not prefix or len(prefix) > AsyncSandboxClient._LABEL_PREFIX_MAX_LENGTH:
-                    raise ValueError(
-                        f"Label key prefix '{prefix}' is invalid or exceeds "
-                        f"{AsyncSandboxClient._LABEL_PREFIX_MAX_LENGTH} characters."
-                    )
-                if not AsyncSandboxClient._LABEL_PREFIX_RE.match(prefix):
-                    raise ValueError(
-                        f"Label key prefix '{prefix}' must be a valid DNS subdomain."
-                    )
-                if not name:
-                    raise ValueError(f"Label key '{key}' has an empty name after prefix.")
-                AsyncSandboxClient._validate_label_name(name, f"key name in '{key}'")
-            else:
-                AsyncSandboxClient._validate_label_name(key, f"key '{key}'")
-
-            if value:
-                AsyncSandboxClient._validate_label_name(
-                    value, f"value '{value}' for key '{key}'"
-                )
-
-    @classmethod
-    def _build_pod_metadata(
-        cls,
-        pod_labels: dict[str, str] | None,
-        pod_annotations: dict[str, str] | None,
-    ) -> dict | None:
-        """Assembles the ``spec.additionalPodMetadata`` payload.
-
-        ``pod_labels`` are validated with the same RFC-1123 rules as claim
-        labels so callers fail fast client-side. Empty sections are omitted, and
-        ``None`` is returned when neither labels nor annotations are supplied so
-        no empty ``additionalPodMetadata`` is written to the manifest.
-        """
-        if pod_labels:
-            cls._validate_labels(pod_labels)
-
-        pod_metadata: dict = {}
-        if pod_labels:
-            pod_metadata["labels"] = pod_labels
-        if pod_annotations:
-            pod_metadata["annotations"] = pod_annotations
-        return pod_metadata or None
 
     @async_trace_span("create_claim")
     async def _create_claim(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -137,6 +137,8 @@ class AsyncSandboxClient(Generic[T]):
         labels: dict[str, str] | None = None,
         *,
         shutdown_after_seconds: int | None = None,
+        pod_labels: dict[str, str] | None = None,
+        pod_annotations: dict[str, str] | None = None,
     ) -> T:
         """Provisions a new Sandbox claim and returns an async Sandbox handle.
 
@@ -144,12 +146,19 @@ class AsyncSandboxClient(Generic[T]):
             warmpool: Name of the SandboxWarmPool to use.
             namespace: Kubernetes namespace for the claim.
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
-            labels: Optional Kubernetes labels to attach to the claim.
+            labels: Optional Kubernetes labels to attach to the claim object
+                (``SandboxClaim.metadata.labels``).
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
                 of ``"Delete"``, so the controller auto-deletes the claim on
                 expiry. Must be a positive integer.
+            pod_labels: Optional labels stamped onto the running Sandbox **Pod**
+                via ``spec.additionalPodMetadata.labels``. Unlike ``labels``
+                (which land on the claim object), these are readable from inside
+                the sandbox through the Downward API.
+            pod_annotations: Optional annotations stamped onto the running
+                Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
 
         Example::
 
@@ -163,12 +172,14 @@ class AsyncSandboxClient(Generic[T]):
         if labels:
             self._validate_labels(labels)
 
+        pod_metadata = self._build_pod_metadata(pod_labels, pod_annotations)
+
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
 
         try:
-            await self._create_claim(claim_name, warmpool, namespace, labels=labels, lifecycle=lifecycle)
+            await self._create_claim(claim_name, warmpool, namespace, labels=labels, lifecycle=lifecycle, pod_metadata=pod_metadata)
             start_time = time.monotonic()
             sandbox_id = await self.k8s_helper.resolve_sandbox_name(
                 claim_name, namespace, sandbox_ready_timeout
@@ -423,6 +434,29 @@ class AsyncSandboxClient(Generic[T]):
                     value, f"value '{value}' for key '{key}'"
                 )
 
+    @classmethod
+    def _build_pod_metadata(
+        cls,
+        pod_labels: dict[str, str] | None,
+        pod_annotations: dict[str, str] | None,
+    ) -> dict | None:
+        """Assembles the ``spec.additionalPodMetadata`` payload.
+
+        ``pod_labels`` are validated with the same RFC-1123 rules as claim
+        labels so callers fail fast client-side. Empty sections are omitted, and
+        ``None`` is returned when neither labels nor annotations are supplied so
+        no empty ``additionalPodMetadata`` is written to the manifest.
+        """
+        if pod_labels:
+            cls._validate_labels(pod_labels)
+
+        pod_metadata: dict = {}
+        if pod_labels:
+            pod_metadata["labels"] = pod_labels
+        if pod_annotations:
+            pod_metadata["annotations"] = pod_annotations
+        return pod_metadata or None
+
     @async_trace_span("create_claim")
     async def _create_claim(
         self,
@@ -431,6 +465,7 @@ class AsyncSandboxClient(Generic[T]):
         namespace: str,
         labels: dict[str, str] | None = None,
         lifecycle: dict | None = None,
+        pod_metadata: dict | None = None,
     ):
         span = trace.get_current_span()
         if span.is_recording():
@@ -446,7 +481,7 @@ class AsyncSandboxClient(Generic[T]):
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
         await self.k8s_helper.create_sandbox_claim(
-            claim_name, warmpool_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle
+            claim_name, warmpool_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle, pod_metadata=pod_metadata
         )
 
     @async_trace_span("wait_for_sandbox_ready")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -40,8 +40,15 @@ class K8sHelper:
         self.custom_objects_api = client.CustomObjectsApi()
         self.core_v1_api = client.CoreV1Api()
 
-    def create_sandbox_claim(self, name: str, warmpool: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None):
-        """Creates a SandboxClaim custom resource."""
+    def create_sandbox_claim(self, name: str, warmpool: str, namespace: str, annotations: dict | None = None, labels: dict | None = None, lifecycle: dict | None = None, pod_metadata: dict | None = None):
+        """Creates a SandboxClaim custom resource.
+
+        Args:
+            pod_metadata: Optional ``{"labels": {...}, "annotations": {...}}``
+                dict emitted as ``spec.additionalPodMetadata`` so the labels and
+                annotations propagate onto the running Sandbox Pod (as opposed to
+                ``labels``, which only land on the SandboxClaim object).
+        """
         metadata = {
             "name": name,
             "annotations": annotations or {},
@@ -56,6 +63,8 @@ class K8sHelper:
         }
         if lifecycle:
             spec["lifecycle"] = lifecycle
+        if pod_metadata:
+            spec["additionalPodMetadata"] = pod_metadata
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/pod_metadata.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/pod_metadata.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for validating labels and assembling pod metadata."""
+
+import re
+
+
+# Kubernetes label validation: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+_LABEL_NAME_RE = re.compile(r"^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$|^[A-Za-z0-9]$")
+_LABEL_PREFIX_RE = re.compile(r"^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$")
+LABEL_NAME_MAX_LENGTH = 63
+LABEL_PREFIX_MAX_LENGTH = 253
+
+
+def validate_label_name(name: str, context: str):
+    """Validates a label name segment (key or value) against k8s constraints."""
+    if len(name) > LABEL_NAME_MAX_LENGTH:
+        raise ValueError(
+            f"Label {context} '{name}' exceeds max length of {LABEL_NAME_MAX_LENGTH} characters."
+        )
+    if not _LABEL_NAME_RE.match(name):
+        raise ValueError(
+            f"Label {context} '{name}' contains invalid characters. "
+            f"Must start and end with alphanumeric, and contain only [-A-Za-z0-9_.]."
+        )
+
+
+def validate_labels(labels: dict[str, str]):
+    """Validates label keys and values against Kubernetes constraints."""
+    for key, value in labels.items():
+        if not key:
+            raise ValueError("Label key cannot be empty.")
+
+        # Keys can have an optional prefix: "prefix/name"
+        if "/" in key:
+            prefix, name = key.split("/", 1)
+            if not prefix or len(prefix) > LABEL_PREFIX_MAX_LENGTH:
+                raise ValueError(
+                    f"Label key prefix '{prefix}' is invalid or exceeds {LABEL_PREFIX_MAX_LENGTH} characters."
+                )
+            if not _LABEL_PREFIX_RE.match(prefix):
+                raise ValueError(
+                    f"Label key prefix '{prefix}' must be a valid DNS subdomain."
+                )
+            if not name:
+                raise ValueError(f"Label key '{key}' has an empty name after prefix.")
+            validate_label_name(name, f"key name in '{key}'")
+        else:
+            validate_label_name(key, f"key '{key}'")
+
+        # Values can be empty, but if non-empty must match the same name constraints
+        if value:
+            validate_label_name(value, f"value '{value}' for key '{key}'")
+
+
+def build_pod_metadata(
+    pod_labels: dict[str, str] | None,
+    pod_annotations: dict[str, str] | None,
+) -> dict | None:
+    """Assembles the ``spec.additionalPodMetadata`` payload.
+
+    ``pod_labels`` are validated with the same RFC-1123 rules as claim
+    labels so callers fail fast client-side. Client-side validation only
+    checks label syntax (RFC-1123) and does not replicate the controller's domain
+    allow-list or system-label restrictions, so some keys accepted here may
+    still be rejected server-side. Empty sections are omitted, and ``None`` is
+    returned when neither labels nor annotations are supplied so no empty
+    ``additionalPodMetadata`` is written to the manifest.
+    """
+    if pod_labels:
+        validate_labels(pod_labels)
+
+    pod_metadata: dict = {}
+    if pod_labels:
+        pod_metadata["labels"] = pod_labels
+    if pod_annotations:
+        pod_metadata["annotations"] = pod_annotations
+    return pod_metadata or None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -17,7 +17,6 @@ It handles lifecycle management (claiming, waiting) and interaction (execution,
 file I/O) via the Sandbox resource handle.
 """
 
-import re
 import uuid
 import atexit
 import sys
@@ -36,6 +35,7 @@ from .models import (
     SandboxTracerConfig,
 )
 from .k8s_helper import K8sHelper
+from .pod_metadata import build_pod_metadata, validate_labels
 from .utils import construct_sandbox_claim_lifecycle_spec
 from .exceptions import SandboxNotFoundError
 
@@ -123,9 +123,9 @@ class SandboxClient(Generic[T]):
             raise ValueError("Warmpool name cannot be empty.")
 
         if labels:
-            self._validate_labels(labels)
+            validate_labels(labels)
 
-        pod_metadata = self._build_pod_metadata(pod_labels, pod_annotations)
+        pod_metadata = build_pod_metadata(pod_labels, pod_annotations)
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
@@ -293,72 +293,6 @@ class SandboxClient(Generic[T]):
                 logging.error(
                     f"Cleanup failed for {claim_name} in namespace {ns}: {e}"
                 )
-
-    # Kubernetes label validation: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
-    _LABEL_NAME_RE = re.compile(r'^[A-Za-z0-9][-A-Za-z0-9_.]*[A-Za-z0-9]$|^[A-Za-z0-9]$')
-    _LABEL_PREFIX_RE = re.compile(r'^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$')
-    _LABEL_NAME_MAX_LENGTH = 63
-    _LABEL_PREFIX_MAX_LENGTH = 253
-
-    @staticmethod
-    def _validate_label_name(name: str, context: str):
-        """Validates a label name segment (key or value) against k8s constraints."""
-        if len(name) > SandboxClient._LABEL_NAME_MAX_LENGTH:
-            raise ValueError(
-                f"Label {context} '{name}' exceeds max length of {SandboxClient._LABEL_NAME_MAX_LENGTH} characters."
-            )
-        if not SandboxClient._LABEL_NAME_RE.match(name):
-            raise ValueError(
-                f"Label {context} '{name}' contains invalid characters. "
-                f"Must start and end with alphanumeric, and contain only [-A-Za-z0-9_.]."
-            )
-
-    @staticmethod
-    def _validate_labels(labels: dict[str, str]):
-        """Validates label keys and values against Kubernetes constraints."""
-        for key, value in labels.items():
-            if not key:
-                raise ValueError("Label key cannot be empty.")
-
-            # Keys can have an optional prefix: "prefix/name"
-            if '/' in key:
-                prefix, name = key.split('/', 1)
-                if not prefix or len(prefix) > SandboxClient._LABEL_PREFIX_MAX_LENGTH:
-                    raise ValueError(
-                        f"Label key prefix '{prefix}' is invalid or exceeds {SandboxClient._LABEL_PREFIX_MAX_LENGTH} characters."
-                    )
-                if not SandboxClient._LABEL_PREFIX_RE.match(prefix):
-                    raise ValueError(
-                        f"Label key prefix '{prefix}' must be a valid DNS subdomain."
-                    )
-                if not name:
-                    raise ValueError(f"Label key '{key}' has an empty name after prefix.")
-                SandboxClient._validate_label_name(name, f"key name in '{key}'")
-            else:
-                SandboxClient._validate_label_name(key, f"key '{key}'")
-
-            # Values can be empty, but if non-empty must match the same name constraints
-            if value:
-                SandboxClient._validate_label_name(value, f"value '{value}' for key '{key}'")
-
-    @classmethod
-    def _build_pod_metadata(cls, pod_labels: dict[str, str] | None, pod_annotations: dict[str, str] | None) -> dict | None:
-        """Assembles the ``spec.additionalPodMetadata`` payload.
-
-        ``pod_labels`` are validated with the same RFC-1123 rules as claim
-        labels so callers fail fast client-side. Empty sections are omitted, and
-        ``None`` is returned when neither labels nor annotations are supplied so
-        no empty ``additionalPodMetadata`` is written to the manifest.
-        """
-        if pod_labels:
-            cls._validate_labels(pod_labels)
-
-        pod_metadata: dict = {}
-        if pod_labels:
-            pod_metadata["labels"] = pod_labels
-        if pod_annotations:
-            pod_metadata["annotations"] = pod_annotations
-        return pod_metadata or None
 
     @trace_span("create_claim")
     def _create_claim(self, claim_name: str, warmpool_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None, pod_metadata: dict | None = None):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -91,23 +91,30 @@ class SandboxClient(Generic[T]):
         if cleanup:
             atexit.register(self.delete_all)
 
-    def create_sandbox(self, warmpool: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None, *, shutdown_after_seconds: int | None = None) -> T:
-        """Provisions new Sandbox claim and returns a Sandbox handle which tracks 
+    def create_sandbox(self, warmpool: str, namespace: str = "default", sandbox_ready_timeout: int = 180, labels: dict[str, str] | None = None, *, shutdown_after_seconds: int | None = None, pod_labels: dict[str, str] | None = None, pod_annotations: dict[str, str] | None = None) -> T:
+        """Provisions new Sandbox claim and returns a Sandbox handle which tracks
            the underlying infrastructure.
 
         Args:
             warmpool: Name of the SandboxWarmPool to use.
             namespace: Kubernetes namespace for the claim.
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
-            labels: Optional Kubernetes labels to attach to the claim.
+            labels: Optional Kubernetes labels to attach to the claim object
+                (``SandboxClaim.metadata.labels``).
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
                 of ``"Delete"``, so the controller auto-deletes the claim on
                 expiry. Must be a positive integer.
+            pod_labels: Optional labels stamped onto the running Sandbox **Pod**
+                via ``spec.additionalPodMetadata.labels``. Unlike ``labels``
+                (which land on the claim object), these are readable from inside
+                the sandbox through the Downward API.
+            pod_annotations: Optional annotations stamped onto the running
+                Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
 
         Example:
-        
+
             >>> client = SandboxClient()
             >>> sandbox = client.create_sandbox(warmpool="python-sandbox-pool")
             >>> sandbox.commands.run("echo 'Hello World'")
@@ -118,12 +125,14 @@ class SandboxClient(Generic[T]):
         if labels:
             self._validate_labels(labels)
 
+        pod_metadata = self._build_pod_metadata(pod_labels, pod_annotations)
+
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
-        
+
         try:
-            self._create_claim(claim_name, warmpool, namespace, labels=labels, lifecycle=lifecycle)
+            self._create_claim(claim_name, warmpool, namespace, labels=labels, lifecycle=lifecycle, pod_metadata=pod_metadata)
             # Resolve the sandbox id from the sandbox claim object.
             # In case of warmpool, sandbox id is not the same as claim name.
             start_time = time.monotonic()
@@ -332,8 +341,27 @@ class SandboxClient(Generic[T]):
             if value:
                 SandboxClient._validate_label_name(value, f"value '{value}' for key '{key}'")
 
+    @classmethod
+    def _build_pod_metadata(cls, pod_labels: dict[str, str] | None, pod_annotations: dict[str, str] | None) -> dict | None:
+        """Assembles the ``spec.additionalPodMetadata`` payload.
+
+        ``pod_labels`` are validated with the same RFC-1123 rules as claim
+        labels so callers fail fast client-side. Empty sections are omitted, and
+        ``None`` is returned when neither labels nor annotations are supplied so
+        no empty ``additionalPodMetadata`` is written to the manifest.
+        """
+        if pod_labels:
+            cls._validate_labels(pod_labels)
+
+        pod_metadata: dict = {}
+        if pod_labels:
+            pod_metadata["labels"] = pod_labels
+        if pod_annotations:
+            pod_metadata["annotations"] = pod_annotations
+        return pod_metadata or None
+
     @trace_span("create_claim")
-    def _create_claim(self, claim_name: str, warmpool_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None):
+    def _create_claim(self, claim_name: str, warmpool_name: str, namespace: str, labels: dict[str, str] | None = None, lifecycle: dict | None = None, pod_metadata: dict | None = None):
         """Creates the SandboxClaim custom resource in the Kubernetes cluster."""
         span = trace.get_current_span()
         if span.is_recording():
@@ -348,7 +376,7 @@ class SandboxClient(Generic[T]):
             if trace_context_str:
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
-        self.k8s_helper.create_sandbox_claim(claim_name, warmpool_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle)
+        self.k8s_helper.create_sandbox_claim(claim_name, warmpool_name, namespace, annotations=annotations, labels=labels, lifecycle=lifecycle, pod_metadata=pod_metadata)
 
     @trace_span("wait_for_sandbox_ready")
     def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -73,6 +73,27 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(body["metadata"]["labels"], {"agent": "test"})
         self.assertEqual(body["metadata"]["annotations"], {"key": "val"})
 
+    async def test_pod_metadata_included_in_manifest(self):
+        pod_metadata = {"labels": {"client-id": "tenant-a"}}
+        await self.helper.create_sandbox_claim(
+            "test-claim", "test-warmpool", "test-namespace", pod_metadata=pod_metadata
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertEqual(
+            body["spec"]["additionalPodMetadata"]["labels"]["client-id"], "tenant-a"
+        )
+
+    async def test_no_pod_metadata_omits_key(self):
+        await self.helper.create_sandbox_claim(
+            "test-claim", "test-warmpool", "test-namespace"
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertNotIn("additionalPodMetadata", body["spec"])
+
 
 class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -65,7 +65,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             sandbox = await self.client.create_sandbox("test-warmpool", "test-namespace")
 
             mock_create.assert_called_once_with(
-                ANY, "test-warmpool", "test-namespace", labels=None, lifecycle=None
+                ANY, "test-warmpool", "test-namespace", labels=None, lifecycle=None, pod_metadata=None
             )
             self.assertEqual(sandbox, mock_sandbox_instance)
 
@@ -260,6 +260,34 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
     async def test_validate_labels_rejects_empty_key(self):
         with self.assertRaises(ValueError):
             await self.client.create_sandbox("t", labels={"": "v"})
+
+    async def test_create_sandbox_with_pod_metadata(self):
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        mock_sandbox_instance = MagicMock()
+        mock_sandbox_instance.terminate = AsyncMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+             patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+
+            await self.client.create_sandbox(
+                "test-warmpool", "test-namespace",
+                pod_labels={"client-id": "tenant-a"},
+                pod_annotations={"note": "owned-by-tenant-a"},
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            self.assertEqual(
+                call_kwargs["pod_metadata"],
+                {
+                    "labels": {"client-id": "tenant-a"},
+                    "annotations": {"note": "owned-by-tenant-a"},
+                },
+            )
+
+    async def test_create_sandbox_rejects_invalid_pod_label(self):
+        with self.assertRaises(ValueError):
+            await self.client.create_sandbox("t", pod_labels={"bad key!": "v"})
 
     async def test_create_sandbox_with_shutdown_after_seconds(self):
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -92,6 +92,31 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertNotIn("lifecycle", body["spec"])
 
+    def test_pod_metadata_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        pod_metadata = {"labels": {"client-id": "tenant-a"}}
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim", "test-warmpool", "test-namespace", pod_metadata=pod_metadata
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(
+            body["spec"]["additionalPodMetadata"]["labels"]["client-id"], "tenant-a"
+        )
+
+    def test_no_pod_metadata_omits_key(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim("test-claim", "test-warmpool", "test-namespace")
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertNotIn("additionalPodMetadata", body["spec"])
+
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -65,7 +65,7 @@ class TestSandboxClient(unittest.TestCase):
             
             sandbox = self.client.create_sandbox("test-warmpool", "test-namespace")
             
-            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-warmpool", "test-namespace", labels=None, lifecycle=None)
+            mock_create_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-warmpool", "test-namespace", labels=None, lifecycle=None, pod_metadata=None)
             self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
             mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
             self.assertEqual(sandbox, mock_sandbox_instance)
@@ -207,7 +207,40 @@ class TestSandboxClient(unittest.TestCase):
                 "sandbox-claim-1234abcd", "test-warmpool", "test-namespace",
                 labels={"agent": "code-agent", "team": "platform"},
                 lifecycle=None,
+                pod_metadata=None,
             )
+
+    @patch('uuid.uuid4')
+    def test_create_sandbox_with_pod_metadata(self, mock_uuid):
+        mock_uuid.return_value.hex = '1234abcd'
+        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+
+        mock_sandbox_instance = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+             patch.object(self.client, '_wait_for_sandbox_ready'):
+
+            self.client.create_sandbox(
+                "test-warmpool", "test-namespace",
+                pod_labels={"client-id": "tenant-a"},
+                pod_annotations={"note": "owned-by-tenant-a"},
+            )
+
+            mock_create_claim.assert_called_once_with(
+                "sandbox-claim-1234abcd", "test-warmpool", "test-namespace",
+                labels=None,
+                lifecycle=None,
+                pod_metadata={
+                    "labels": {"client-id": "tenant-a"},
+                    "annotations": {"note": "owned-by-tenant-a"},
+                },
+            )
+
+    def test_create_sandbox_rejects_invalid_pod_label(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-warmpool", pod_labels={"bad key!": "value"})
+        self.assertIn("invalid characters", str(ctx.exception))
 
     def test_create_claim_with_labels(self):
         self.client.tracing_manager = MagicMock()
@@ -221,19 +254,38 @@ class TestSandboxClient(unittest.TestCase):
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels={"agent": "code-agent"},
             lifecycle=None,
+            pod_metadata=None,
         )
 
-    def test_create_claim(self):
+    def test_create_claim_with_pod_metadata(self):
         self.client.tracing_manager = MagicMock()
         self.client.tracing_manager.get_trace_context_json.return_value = "trace-data"
-        
-        self.client._create_claim("test-claim", "test-warmpool", "test-namespace")
-        
+
+        pod_metadata = {"labels": {"client-id": "tenant-a"}}
+        self.client._create_claim(
+            "test-claim", "test-warmpool", "test-namespace", pod_metadata=pod_metadata
+        )
+
         self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
             "test-claim", "test-warmpool", "test-namespace",
             annotations={"opentelemetry.io/trace-context": "trace-data"},
             labels=None,
             lifecycle=None,
+            pod_metadata={"labels": {"client-id": "tenant-a"}},
+        )
+
+    def test_create_claim(self):
+        self.client.tracing_manager = MagicMock()
+        self.client.tracing_manager.get_trace_context_json.return_value = "trace-data"
+
+        self.client._create_claim("test-claim", "test-warmpool", "test-namespace")
+
+        self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
+            "test-claim", "test-warmpool", "test-namespace",
+            annotations={"opentelemetry.io/trace-context": "trace-data"},
+            labels=None,
+            lifecycle=None,
+            pod_metadata=None,
         )
 
     def test_validate_labels_rejects_invalid_value(self):
@@ -345,6 +397,7 @@ class TestSandboxClient(unittest.TestCase):
             annotations={},
             labels=None,
             lifecycle=lifecycle,
+            pod_metadata=None,
         )
 
     def test_create_claim_without_lifecycle(self):
@@ -358,6 +411,7 @@ class TestSandboxClient(unittest.TestCase):
             annotations={},
             labels=None,
             lifecycle=None,
+            pod_metadata=None,
         )
 
     def test_shutdown_after_seconds_validation_zero(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -26,6 +26,7 @@ from urllib3.util.retry import Retry
 from kubernetes import config as k8s_config
 from k8s_agent_sandbox.sandbox_client import SandboxClient
 from k8s_agent_sandbox.connector import SandboxConnector
+from k8s_agent_sandbox.pod_metadata import validate_labels
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
     SandboxInClusterConnectionConfig,
@@ -314,7 +315,7 @@ class TestSandboxClient(unittest.TestCase):
         self.assertIn("exceeds max length", str(ctx.exception))
 
     def test_validate_labels_accepts_prefixed_key(self):
-        SandboxClient._validate_labels({"app.kubernetes.io/name": "my-app"})
+        validate_labels({"app.kubernetes.io/name": "my-app"})
 
     def test_validate_labels_rejects_invalid_prefix(self):
         with self.assertRaises(ValueError) as ctx:
@@ -322,13 +323,13 @@ class TestSandboxClient(unittest.TestCase):
         self.assertIn("valid DNS subdomain", str(ctx.exception))
 
     def test_validate_labels_accepts_single_char_prefix(self):
-        SandboxClient._validate_labels({"a/name": "value"})
+        validate_labels({"a/name": "value"})
 
     def test_validate_labels_accepts_empty_value(self):
-        SandboxClient._validate_labels({"key": ""})
+        validate_labels({"key": ""})
 
     def test_validate_labels_accepts_valid(self):
-        SandboxClient._validate_labels({"agent": "code-agent", "team": "platform-123"})
+        validate_labels({"agent": "code-agent", "team": "platform-123"})
 
     def test_wait_for_sandbox_ready(self):
         self.client._wait_for_sandbox_ready("sandbox-id", "test-namespace", 45)


### PR DESCRIPTION
#### What this PR does / why we need it:

The `SandboxClaim` CRD already supports `spec.additionalPodMetadata`, and the
claim controller propagates its `labels` and `annotations` onto the running
Sandbox **Pod**. Until now the Python client had no way to set it: the existing
`labels` argument on `create_sandbox` only wires the *claim object's own*
`metadata.labels`, which lands on the `SandboxClaim` resource and never reaches
the Pod.

This PR adds two new optional, keyword-only parameters to both the sync
(`SandboxClient`) and async (`AsyncSandboxClient`) `create_sandbox`:

- `pod_labels` -> `spec.additionalPodMetadata.labels`
- `pod_annotations` -> `spec.additionalPodMetadata.annotations`

They flow from the public client through `_create_claim` into the
`create_sandbox_claim` manifest builders (`k8s_helper` / `async_k8s_helper`),
mirroring the existing `labels` / `lifecycle` plumbing rather than introducing a
new pattern. With this, a caller can stamp a tenant / client identifier onto the
Pod and the running sandbox can read its own identity via the Downward API.

Details:

- Additive and keyword-only, so existing callers are unaffected.
- `pod_labels` reuse the existing `_validate_labels` RFC-1123 validation so bad
  keys/values fail fast client-side (the controller validates server-side too).
- Empty sections are omitted; no empty `additionalPodMetadata` is written when
  neither `pod_labels` nor `pod_annotations` is provided.
- README documents the distinction between claim-level `labels` and Pod-level
  `pod_labels` / `pod_annotations`.

#### Which issue(s) this PR is related to:

Fixes #914
Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/914

#### Testing

- Added unit tests for the sync and async k8s helpers (manifest emits
  `spec.additionalPodMetadata`; key omitted when unset).
- Added unit tests for the sync and async clients (parameters thread through to
  `_create_claim` / `create_sandbox_claim` as the expected `pod_metadata` dict;
  invalid pod-label keys raise the same validation error as claim labels).
- Updated existing client tests that assert the exact `_create_claim` /
  `create_sandbox_claim` call signature.
- `python -m pytest k8s_agent_sandbox/test/unit` passes (223 passed).

AI was used for assistance.

#### Release Note
```release-note
The Python `SandboxClient` and `AsyncSandboxClient` now accept `pod_labels` and `pod_annotations` on `create_sandbox`, which are propagated to the Sandbox Pod via `spec.additionalPodMetadata`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pod_labels` and `pod_annotations` parameters to the Python sandbox clients to apply metadata directly to the running Sandbox Pod.
  * Supported in both synchronous and asynchronous clients, with client-side validation for pod label formatting.

* **Documentation**
  * Expanded the client README with a “Labels and Pod Metadata” section and new usage snippets, including Kubernetes validation expectations.
  * Fixed the “Run in Production Mode” code example formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->