### PR TITLE
Use UUID names for warm-pool sandboxes

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -331,6 +334,47 @@ func computePodTemplateHash(template *extensionsv1beta1.SandboxTemplate) (string
 	return sandboxcontrollers.NameHash(string(specJSON)), nil
 }
 
+func newWarmPoolSandboxName(warmPoolName string) (string, error) {
+	suffix, err := uuid.NewV7()
+	if err != nil {
+		return "", fmt.Errorf("generate sandbox name UUID: %w", err)
+	}
+	return warmPoolSandboxName(warmPoolName, suffix.String()), nil
+}
+
+func warmPoolSandboxName(warmPoolName, suffix string) string {
+	maxPoolNameLength := validation.DNS1123LabelMaxLength - len(suffix) - 1
+	trimmedPoolName := dns1123LabelPrefix(warmPoolName)
+	if len(trimmedPoolName) > maxPoolNameLength {
+		trimmedPoolName = trimmedPoolName[:maxPoolNameLength]
+	}
+	trimmedPoolName = strings.TrimRight(trimmedPoolName, "-")
+	if trimmedPoolName == "" {
+		trimmedPoolName = "warmpool"
+	}
+	return trimmedPoolName + "-" + suffix
+}
+
+func dns1123LabelPrefix(name string) string {
+	lowerName := strings.ToLower(name)
+	var builder strings.Builder
+	lastHyphen := false
+	for i := 0; i < len(lowerName); i++ {
+		ch := lowerName[i]
+		valid := (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')
+		if valid {
+			builder.WriteByte(ch)
+			lastHyphen = false
+			continue
+		}
+		if builder.Len() > 0 && !lastHyphen {
+			builder.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.Trim(builder.String(), "-")
+}
+
 // fetchTemplateAndHash fetches the sandbox template and computes its hash.
 func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool) (*extensionsv1beta1.SandboxTemplate, string, error) {
 	logger := log.FromContext(ctx)
@@ -381,10 +425,9 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(warmPool *extensionsv1beta1.S
 
 	sandbox := &sandboxv1beta1.Sandbox{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", warmPool.Name),
-			Namespace:    warmPool.Namespace,
-			Labels:       sandboxLabels,
-			Annotations:  sandboxAnnotations,
+			Namespace:   warmPool.Namespace,
+			Labels:      sandboxLabels,
+			Annotations: sandboxAnnotations,
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
 			Service: template.Spec.Service,
@@ -421,6 +464,12 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(warmPool *extensionsv1beta1.S
 func (r *SandboxWarmPoolReconciler) createPoolSandbox(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, sandboxCR *sandboxv1beta1.Sandbox) error {
 	logger := log.FromContext(ctx)
 	sandbox := sandboxCR.DeepCopy()
+	name, err := newWarmPoolSandboxName(warmPool.Name)
+	if err != nil {
+		logger.Error(err, "Failed to generate pool sandbox name")
+		return err
+	}
+	sandbox.Name = name
 	if err := r.Create(ctx, sandbox); err != nil {
 		logger.Error(err, "Failed to create pool sandbox")
 		return err

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
@@ -228,6 +231,91 @@ func TestReconcilePool(t *testing.T) {
 			require.Equal(t, expectedSelector, warmPool.Status.Selector, "Status.Selector mismatch")
 		})
 	}
+}
+
+func TestReconcilePoolCreatesExplicitUUIDNames(t *testing.T) {
+	poolName := "test-pool"
+	poolNamespace := "default"
+	templateName := "test-template"
+	replicas := int32(4)
+
+	template := createTemplate(poolNamespace)
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+			UID:       "warmpool-uid-123",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas: replicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{
+				Name: templateName,
+			},
+		},
+	}
+
+	scheme := newTestScheme()
+	r := SandboxWarmPoolReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(template).
+			Build(),
+		Scheme:       scheme,
+		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
+	}
+
+	ctx := context.Background()
+	err := r.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+
+	list := &sandboxv1beta1.SandboxList{}
+	err = r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace})
+	require.NoError(t, err)
+	require.Len(t, list.Items, int(replicas))
+
+	seenNames := make(map[string]struct{}, replicas)
+	for _, sb := range list.Items {
+		require.Empty(t, sb.GenerateName, "warm-pool sandboxes must not rely on Kubernetes GenerateName")
+		require.NotEmpty(t, sb.Name)
+		require.LessOrEqual(t, len(sb.Name), validation.DNS1123LabelMaxLength)
+		require.Empty(t, validation.IsDNS1123Label(sb.Name))
+		require.True(t, strings.HasPrefix(sb.Name, poolName+"-"))
+
+		suffix := strings.TrimPrefix(sb.Name, poolName+"-")
+		require.Len(t, suffix, 36, "suffix should be a full UUID string")
+		parsedSuffix, err := uuid.Parse(suffix)
+		require.NoError(t, err)
+		require.Equal(t, 7, int(parsedSuffix.Version()), "suffix should be UUIDv7-derived")
+
+		_, exists := seenNames[sb.Name]
+		require.False(t, exists, "sandbox name should be unique")
+		seenNames[sb.Name] = struct{}{}
+	}
+}
+
+func TestWarmPoolSandboxNameTrimsLongPoolNames(t *testing.T) {
+	suffix := "018f0f2d-1d3c-7abc-9def-0123456789ab"
+
+	poolName := strings.Repeat("a", 26) + "-" + strings.Repeat("b", 36)
+	name := warmPoolSandboxName(poolName, suffix)
+	require.Equal(t, strings.Repeat("a", 26)+"-"+suffix, name)
+	require.Len(t, name, validation.DNS1123LabelMaxLength)
+	require.Empty(t, validation.IsDNS1123Label(name))
+
+	poolNameWithTrimmedHyphen := strings.Repeat("a", 25) + "-" + strings.Repeat("b", 37)
+	name = warmPoolSandboxName(poolNameWithTrimmedHyphen, suffix)
+	require.Equal(t, strings.Repeat("a", 25)+"-"+suffix, name)
+	require.NotContains(t, name, "--")
+	require.Empty(t, validation.IsDNS1123Label(name))
+}
+
+func TestWarmPoolSandboxNameSanitizesPoolName(t *testing.T) {
+	suffix := "018f0f2d-1d3c-7abc-9def-0123456789ab"
+
+	name := warmPoolSandboxName("TN.Claw_WarmPool", suffix)
+
+	require.Equal(t, "tn-claw-warmpool-"+suffix, name)
+	require.Empty(t, validation.IsDNS1123Label(name))
 }
 
 func TestReconcilePoolControllerRef(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/felixge/fgprof v0.9.5
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
@@ -54,7 +55,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
## Summary

- assign explicit UUIDv7-based names for warm-pool Sandbox objects
- stop relying on Kubernetes `generateName` short suffixes for warm-pool allocations
- sanitize the warm-pool name prefix to DNS-1123 label characters and trim to the 63-character label limit
- add controller tests for explicit names, uniqueness, no `GenerateName`, long-name compliance, and invalid-prefix sanitization

## Why

Short provider-generated suffixes make warm-pool sandbox name reuse possible over time. UUIDv7 names make provider identity collisions effectively disappear at the GAS layer, while tn-api separately owns durable lifecycle identity.

## Validation

- `go test ./extensions/controllers`
- `gofmt -l extensions/controllers/sandboxwarmpool_controller.go extensions/controllers/sandboxwarmpool_controller_test.go`
- `git diff --check`

## Review Notes

- This complements the tn-api runtime lifecycle identity PR. GAS naming reduces collision probability; tn-api lifecycle ids remove our dependency on provider-name permanence.
