### PR TITLE
fix: normalize PVC error message to follow Go conventions

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1124,7 +1124,7 @@ func (r *SandboxReconciler) reconcilePVCs(ctx context.Context, sandbox *sandboxv
 
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "Failed to get PVC")
-			return fmt.Errorf("PVC Get Failed: %w", err)
+			return fmt.Errorf("failed to get PVC: %w", err)
 		}
 
 		pvcLabels := maps.Clone(pvcTemplate.Labels)


### PR DESCRIPTION
`fmt.Errorf("PVC Get Failed: %w")` used title-case and reversed verb/noun order, inconsistent with every other `fmt.Errorf` in the file which use `"failed to <verb> <noun>: %w"`.

Changed to `"failed to get PVC: %w"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity when PVC retrieval operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->