### PR TITLE
Feature(extensions): Adds printer columns to SandboxClaim CRD

### DIFF
--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -153,6 +153,9 @@ type SandboxStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxclaim
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Sandbox",type="string",JSONPath=".status.sandbox.name"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // SandboxClaim is the Schema for the sandbox Claim API.
 type SandboxClaim struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -155,6 +155,7 @@ type SandboxStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxclaim
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Sandbox",type="string",JSONPath=".status.sandbox.name"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // SandboxClaim is the Schema for the sandbox Claim API.
 type SandboxClaim struct {

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.sandbox.name
       name: Sandbox
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -16,7 +16,17 @@ spec:
     singular: sandboxclaim
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.sandbox.name
+      name: Sandbox
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -23,6 +23,9 @@ spec:
     - jsonPath: .status.sandbox.name
       name: Sandbox
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -16,7 +16,17 @@ spec:
     singular: sandboxclaim
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.sandbox.name
+      name: Sandbox
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
#### What this PR does / why we need it:
Feature(extensions): Adds printer columns to SandboxClaim CRD
Adds READY, SANDBOX, and AGE printer columns to the SandboxClaim CustomResourceDefinition. This surfaces condition status, and assigned Sandbox names directly in list views (kubectl get sandboxclaim), reducing the need to run
kubectl describe during routine health checks.

#### Which issue(s) this PR is related to:
Fixes #963


#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enhanced SandboxClaim resource display with three new columns—**Ready** (status condition), **Sandbox** (resource identifier), and **Age** (creation timestamp)—now visible when listing resources via kubectl for improved visibility and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->