### PR TITLE
update go basic example client code to match v1beta1

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -42,13 +42,15 @@ discovers the Gateway address.
 
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
+    WarmPoolName:     "my-sandbox-warmpool",
+	Namespace:        "default",
     GatewayName:      "external-http-gateway",
     GatewayNamespace: "default",
 })
 if err != nil { log.Fatal(err) }
 defer client.DeleteAll(ctx)
 
-sb, err := client.CreateSandbox(ctx, "my-sandbox-pool", "default")
+sb, err := client.CreateSandbox(ctx, "my-sandbox-warmpool", "default")
 if err != nil { log.Fatal(err) }
 
 result, err := sb.Run(ctx, "echo 'Hello from Cloud!'")
@@ -62,11 +64,14 @@ Use this for local development or CI. If you omit `GatewayName` and `APIURL`, th
 automatically establishes an SPDY port-forward tunnel to the Router Service.
 
 ```go
-client, err := sandbox.NewClient(ctx, sandbox.Options{})
+client, err := sandbox.NewClient(ctx, sandbox.Options{
+    WarmPoolName: "my-sandbox-warmpool",
+	Namespace:    "default",
+})
 if err != nil { log.Fatal(err) }
 defer client.DeleteAll(ctx)
 
-sb, err := client.CreateSandbox(ctx, "my-sandbox-pool", "default")
+sb, err := client.CreateSandbox(ctx, "my-sandbox-warmpool", "default")
 if err != nil { log.Fatal(err) }
 
 result, err := sb.Run(ctx, "echo 'Hello from Local!'")
@@ -83,7 +88,9 @@ Use `APIURL` to bypass discovery entirely. Useful for:
 
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
-    APIURL: "http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080",
+    WarmPoolName: "my-sandbox-warmpool",
+	Namespace:    "default",
+    APIURL:       "http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080",
 })
 if err != nil { log.Fatal(err) }
 defer client.DeleteAll(ctx)

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -43,7 +43,7 @@ discovers the Gateway address.
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
     WarmPoolName:     "my-sandbox-warmpool",
-	Namespace:        "default",
+    Namespace:        "default",
     GatewayName:      "external-http-gateway",
     GatewayNamespace: "default",
 })
@@ -66,7 +66,7 @@ automatically establishes an SPDY port-forward tunnel to the Router Service.
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
     WarmPoolName: "my-sandbox-warmpool",
-	Namespace:    "default",
+    Namespace:    "default",
 })
 if err != nil { log.Fatal(err) }
 defer client.DeleteAll(ctx)
@@ -89,13 +89,13 @@ Use `APIURL` to bypass discovery entirely. Useful for:
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
     WarmPoolName: "my-sandbox-warmpool",
-	Namespace:    "default",
+    Namespace:    "default",
     APIURL:       "http://sandbox-router-svc.agent-sandbox-system.svc.cluster.local:8080",
 })
 if err != nil { log.Fatal(err) }
 defer client.DeleteAll(ctx)
 
-sb, err := client.CreateSandbox(ctx, "my-sandbox-pool", "default")
+sb, err := client.CreateSandbox(ctx, "my-sandbox-warmpool", "default")
 if err != nil { log.Fatal(err) }
 
 entries, err := sb.List(ctx, ".")

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -109,6 +109,8 @@ If your sandbox runtime listens on a port other than 8888, specify `ServerPort`.
 
 ```go
 client, err := sandbox.NewClient(ctx, sandbox.Options{
+    WarmPoolName: "my-sandbox-warmpool",
+    Namespace:    "default",
     ServerPort: 3000,
 })
 ```
@@ -136,6 +138,8 @@ If your Gateway uses HTTPS with a private CA, provide a custom transport:
 ```go
 tlsConfig := &tls.Config{RootCAs: myCAPool}
 client, err := sandbox.NewClient(ctx, sandbox.Options{
+    WarmPoolName:  "my-sandbox-warmpool",
+    Namespace:     "default",
     GatewayName:   "external-https-gateway",
     GatewayScheme: "https",
     HTTPTransport: &http.Transport{TLSClientConfig: tlsConfig},
@@ -145,13 +149,16 @@ client, err := sandbox.NewClient(ctx, sandbox.Options{
 ### Multi-Sandbox Management
 
 ```go
-client, err := sandbox.NewClient(ctx, sandbox.Options{})
+client, err := sandbox.NewClient(ctx, sandbox.Options{
+    WarmPoolName: "my-sandbox-warmpool",
+    Namespace:    "default",
+})
 stop := client.EnableAutoCleanup() // cleanup on SIGINT/SIGTERM
 defer stop()
 defer client.DeleteAll(ctx)
 
-sb1, _ := client.CreateSandbox(ctx, "python-pool", "default")
-sb2, _ := client.CreateSandbox(ctx, "node-pool", "default")
+sb1, _ := client.CreateSandbox(ctx, "my-sandbox-warmpool", "default")
+sb2, _ := client.CreateSandbox(ctx, "my-sandbox-warmpool", "default")
 
 // List tracked sandboxes
 for _, key := range client.ListActiveSandboxes() {

--- a/clients/go/examples/basic/main.go
+++ b/clients/go/examples/basic/main.go
@@ -28,7 +28,8 @@ func main() {
 
 	// Create client with shared configuration.
 	client, err := sandbox.NewClient(ctx, sandbox.Options{
-		Namespace: "default",
+		WarmPoolName: "my-sandbox-warmpool",
+		Namespace:    "default",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -38,7 +39,7 @@ func main() {
 	defer client.DeleteAll(ctx)
 
 	// Create a sandbox.
-	sb, err := client.CreateSandbox(ctx, "my-warmpool", "default")
+	sb, err := client.CreateSandbox(ctx, "my-sandbox-warmpool", "default")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func main() {
 	fmt.Printf("file content: %s\n", string(data))
 
 	// List files.
-	entries, err := sb.List(ctx, ".")
+	entries, err := sb.List(ctx, "./")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/clients/go/examples/basic/main.go
+++ b/clients/go/examples/basic/main.go
@@ -65,7 +65,7 @@ func main() {
 	fmt.Printf("file content: %s\n", string(data))
 
 	// List files.
-	entries, err := sb.List(ctx, "./")
+	entries, err := sb.List(ctx, ".")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:
Edit example basic go client to match v1beta1


#### Release Note
```release-note
NONE
```