### PR TITLE
[v1beta1-migration]: fix: Add single quote to support Python 3.11 in prow job.

### DIFF
--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -507,7 +507,7 @@ def validate_migration(active_pod_info):
     assert "upgrade-claim" in claims_v1alpha1_by_name, "upgrade-claim missing in v1alpha1 list!"
     c1_v1alpha1 = claims_v1alpha1_by_name["upgrade-claim"]
     assert "warmpool" in c1_v1alpha1["spec"], f"upgrade-claim missing warmpool in v1alpha1 spec! spec: {c1_v1alpha1['spec']}"
-    assert c1_v1alpha1["spec"]["warmpool"] == "default", f"Expected warmpool default, got {c1_v1alpha1["spec"]["warmpool"]}"
+    assert c1_v1alpha1["spec"]["warmpool"] == "default", f"Expected warmpool default, got {c1_v1alpha1['spec']['warmpool']}"
     assert "warmPoolRef" not in c1_v1alpha1["spec"], f"upgrade-claim should NOT have warmPoolRef in v1alpha1 spec! spec: {c1_v1alpha1['spec']}"
     print("upgrade-claim dynamic reverse-conversion validation PASSED.")
     


### PR DESCRIPTION
# PR Description
`fix: resolve Python 3.11 compatibility in migration test runner`

## Description
This PR resolves a syntax compatibility issue with Python 3.11 in the migration test runner. 

The migration test runner script introduced nested double quotes within an f-string at `dev/tools/test-migration.py:510`:
```python
f"Expected warmpool default, got {c1_v1alpha1["spec"]["warmpool"]}"
```

While this is valid in `Python 3.12+` (due to PEP 701), the Kubernetes Prow CI environment uses Debian Bookworm, which runs `Python 3.11` by default. Since `Python 3.11` is the standard runtime environment for all Kubernetes CI jobs, the standard and most robust solution is to change the nested double quotes to single quotes in the `agent-sandbox` script.