### PR TITLE
SandboxClaim: increase default number of workers

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -90,10 +90,10 @@ func main() {
 	flag.IntVar(&pprofMutexProfileFraction, "pprof-mutex-profile-fraction", 10,
 		"Mutex contention sampling rate for /debug/pprof/mutex when --enable-pprof-debug is set. "+
 			"<=0 disables; 1 samples all events; N>1 samples ~1/N events (e.g. 10 ~= 1/10, 100 ~= 1/100).")
-	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", -1.0, "QPS limit for kube API client (default is -1 no rate limit-unlimited)")
-	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 10, "Burst limit for kube API client")
+	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", -1.0, "Client-side QPS limit for the Kubernetes API client (default: -1, no client-side rate limiting)")
+	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 10, "The maximum burst for client-side throttling of the Kubernetes API client.")
 	flag.IntVar(&sandboxConcurrentWorkers, "sandbox-concurrent-workers", 1, "Max concurrent reconciles for the Sandbox controller")
-	flag.IntVar(&sandboxClaimConcurrentWorkers, "sandbox-claim-concurrent-workers", 1, "Max concurrent reconciles for the SandboxClaim controller")
+	flag.IntVar(&sandboxClaimConcurrentWorkers, "sandbox-claim-concurrent-workers", 50, "Max concurrent reconciles for the SandboxClaim controller")
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300.")

--- a/dev/load-test/test-recipes/README-rapid-burst.md
+++ b/dev/load-test/test-recipes/README-rapid-burst.md
@@ -48,8 +48,7 @@ Before running this test, ensure the following prerequisites are met:
           - --enable-tracing
           - --zap-log-level=debug
           - --zap-encoder=json
-          - --kube-api-qps=1000
-          - --kube-api-burst=1000
+          - --kube-api-qps=-1
           - --sandbox-concurrent-workers=1000
           - --sandbox-claim-concurrent-workers=1000
           - --sandbox-warm-pool-concurrent-workers=1000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,11 +5,11 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 ## Concurrency Settings
 
 * `--sandbox-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the Sandbox controller.
-* `--sandbox-claim-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxClaim controller.
+* `--sandbox-claim-concurrent-workers` (default: 50): The maximum number of concurrent reconciles for the SandboxClaim controller.
 * `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller.
 * `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch.
-* `--kube-api-qps` (default: -1 ; no rate limiting): The maximum Queries Per Second (QPS) sent to the Kubernetes API server from the controller.
-* `--kube-api-burst` (default: 10): The maximum burst for throttle requests to the Kubernetes API server.
+* `--kube-api-qps` (default: -1, no client-side rate limiting): Client-side QPS limit for the Kubernetes API client.
+* `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client.
 
 ## Cluster Settings
 
@@ -30,8 +30,6 @@ If using the core controller, update `manifest.yaml`:
         args:
         - --leader-elect=true
         - --sandbox-concurrent-workers=10
-        - --kube-api-qps=50
-        - --kube-api-burst=100
 ```
 
 If you are deploying the extensions controller (which includes the core controllers + extensions), update the args in `extensions.yaml` instead:
@@ -44,11 +42,9 @@ If you are deploying the extensions controller (which includes the core controll
         - --leader-elect=true
         - --extensions
         - --sandbox-concurrent-workers=10
-        - --sandbox-claim-concurrent-workers=10
+        - --sandbox-claim-concurrent-workers=100
         - --sandbox-warm-pool-concurrent-workers=10
         - --sandbox-warm-pool-max-batch-size=500
-        - --kube-api-qps=50
-        - --kube-api-burst=100
 ```
 **Using `kubectl patch` (Live Cluster):**
 If you have already deployed the controller (e.g., via `make deploy-kind`) and want to apply these concurrency flags dynamically to the running cluster, you can use a JSON patch:
@@ -59,11 +55,9 @@ kubectl patch deployment agent-sandbox-controller \
   --type='json' \
   -p='[
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-concurrent-workers=10"},
-    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-claim-concurrent-workers=10"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-claim-concurrent-workers=100"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-concurrent-workers=10"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-max-batch-size=500"},
-    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-qps=50"},
-    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--kube-api-burst=100"}
   ]'
 ```
 This method safely appends the new flags without overwriting existing necessary arguments like `--leader-elect=true` or `--extensions=true`.
@@ -85,11 +79,9 @@ spec:
       - name: agent-sandbox-controller
         args:
         - --sandbox-concurrent-workers=10
-        - --sandbox-claim-concurrent-workers=10
+        - --sandbox-claim-concurrent-workers=100
         - --sandbox-warm-pool-concurrent-workers=10
         - --sandbox-warm-pool-max-batch-size=500
-        - --kube-api-qps=50
-        - --kube-api-burst=100
 ```
 Then include the patch in your `kustomization.yaml`:
 ```yaml

--- a/helm/README.md
+++ b/helm/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters and their defaults.
 | `controller.leaderElect` | Enable leader election | `true` |
 | `controller.leaderElectionNamespace` | Namespace for the leader election resource (auto-detected if empty) | `""` |
 | `controller.clusterDomain` | Kubernetes cluster domain for service FQDN generation | `"cluster.local"` |
-| `controller.kubeApiQps` | QPS limit for the Kubernetes API client (`-1` = unlimited) | `-1.0` |
+| `controller.kubeApiQps` | Client-side QPS limit for the Kubernetes API client (`-1` = unlimited) | `-1.0` |
 | `controller.kubeApiBurst` | Burst limit for the Kubernetes API client | `10` |
 | `controller.sandboxConcurrentWorkers` | Max concurrent reconciles for the Sandbox controller | `1` |
 | `controller.sandboxClaimConcurrentWorkers` | Max concurrent reconciles for the SandboxClaim controller (extensions only) | `1` |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,7 +41,7 @@ controller:
   # kubeApiBurst: 10
   # sandboxConcurrentWorkers: 1
   ##### The following workers are only active when controller.extensions=true.
-  # sandboxClaimConcurrentWorkers: 1
+  # sandboxClaimConcurrentWorkers: 50
   # sandboxWarmPoolConcurrentWorkers: 1
   # sandboxTemplateConcurrentWorkers: 1
   ##### extraArgs passes additional flags not listed above (e.g. zap logging flags).

--- a/test/e2e/parallelism_test.go
+++ b/test/e2e/parallelism_test.go
@@ -33,7 +33,21 @@ import (
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
 )
 
-func patchControllerConcurrency(t *testing.T, tc *framework.TestContext, workers int) {
+type ControllerOptions struct {
+	// SandboxConcurrentWorkers configures the sandbox-concurrent-workers flag
+	SandboxConcurrentWorkers int
+	// SandboxClaimConcurrentWorkers configures the sandbox-claim-concurrent-workers flag
+	SandboxClaimConcurrentWorkers int
+	// SandboxWarmPoolConcurrentWorkers configures the sandbox-warm-pool-concurrent-workers flag
+	SandboxWarmPoolConcurrentWorkers int
+
+	// KubeAPIQPS configures the kube-api-qps flag
+	KubeAPIQPS float64
+	// KubeAPIBurst configures the kube-api-burst flag
+	KubeAPIBurst int
+}
+
+func patchControllerConcurrency(t *testing.T, tc *framework.TestContext, opt ControllerOptions) {
 	var originalDeployment appsv1.Deployment
 	err := tc.Get(t.Context(), types.NamespacedName{Name: "agent-sandbox-controller", Namespace: "agent-sandbox-system"}, &originalDeployment)
 	require.NoError(t, err, "failed to get controller deployment")
@@ -75,11 +89,21 @@ func patchControllerConcurrency(t *testing.T, tc *framework.TestContext, workers
 				}
 			}
 			newArgs = append(newArgs, "--extensions")
-			newArgs = append(newArgs, fmt.Sprintf("--sandbox-concurrent-workers=%d", workers))
-			newArgs = append(newArgs, fmt.Sprintf("--sandbox-claim-concurrent-workers=%d", workers))
-			newArgs = append(newArgs, fmt.Sprintf("--sandbox-warm-pool-concurrent-workers=%d", workers))
-			newArgs = append(newArgs, "--kube-api-qps=50")
-			newArgs = append(newArgs, "--kube-api-burst=100")
+			if opt.SandboxConcurrentWorkers != 0 {
+				newArgs = append(newArgs, fmt.Sprintf("--sandbox-concurrent-workers=%d", opt.SandboxConcurrentWorkers))
+			}
+			if opt.SandboxClaimConcurrentWorkers != 0 {
+				newArgs = append(newArgs, fmt.Sprintf("--sandbox-claim-concurrent-workers=%d", opt.SandboxClaimConcurrentWorkers))
+			}
+			if opt.SandboxWarmPoolConcurrentWorkers != 0 {
+				newArgs = append(newArgs, fmt.Sprintf("--sandbox-warm-pool-concurrent-workers=%d", opt.SandboxWarmPoolConcurrentWorkers))
+			}
+			if opt.KubeAPIQPS != 0 {
+				newArgs = append(newArgs, fmt.Sprintf("--kube-api-qps=%f", opt.KubeAPIQPS))
+			}
+			if opt.KubeAPIBurst != 0 {
+				newArgs = append(newArgs, fmt.Sprintf("--kube-api-burst=%d", opt.KubeAPIBurst))
+			}
 
 			deployment.Spec.Template.Spec.Containers[i].Args = newArgs
 			break
@@ -109,7 +133,13 @@ func patchControllerConcurrency(t *testing.T, tc *framework.TestContext, workers
 
 func TestParallelSandboxes(t *testing.T) {
 	tc := framework.NewTestContext(t)
-	patchControllerConcurrency(t, tc, 10)
+	patchControllerConcurrency(t, tc, ControllerOptions{
+		SandboxConcurrentWorkers:         10,
+		SandboxClaimConcurrentWorkers:    100,
+		SandboxWarmPoolConcurrentWorkers: 10,
+		KubeAPIQPS:                       -1, // No limit
+		KubeAPIBurst:                     10,
+	})
 
 	ns := &corev1.Namespace{}
 	ns.Name = fmt.Sprintf("parallel-sandboxes-%d", time.Now().UnixNano())
@@ -145,7 +175,13 @@ func TestParallelSandboxes(t *testing.T) {
 }
 
 func runParallelSandboxClaimsTest(t *testing.T, tc *framework.TestContext, poolSize int32, numClaims int) {
-	patchControllerConcurrency(t, tc, 10)
+	patchControllerConcurrency(t, tc, ControllerOptions{
+		SandboxConcurrentWorkers:         10,
+		SandboxClaimConcurrentWorkers:    100,
+		SandboxWarmPoolConcurrentWorkers: 10,
+		KubeAPIQPS:                       -1, // No limit
+		KubeAPIBurst:                     10,
+	})
 
 	ns := &corev1.Namespace{}
 	ns.Name = fmt.Sprintf("parallel-claims-pool-%d", time.Now().UnixNano())

--- a/test/e2e/warmpool_benchmark_test.go
+++ b/test/e2e/warmpool_benchmark_test.go
@@ -174,6 +174,8 @@ func runWarmPoolParallelClaim(t *framework.TestContext, warmPoolSize int) {
 		t.Fatalf("warmpool failed to become ready: %v", err)
 	}
 
+	// Start the clock!
+	t.Logf("BENCHMARK-START: starting benchmark run [claims=%d]", warmPoolSize)
 	t.StartTimer()
 	startTime := time.Now()
 
@@ -204,9 +206,9 @@ func runWarmPoolParallelClaim(t *framework.TestContext, warmPoolSize int) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
-	t.Logf("Successfully claimed %d sandboxes", warmPoolSize)
 
 	t.StopTimer()
+	t.Logf("BENCHMARK-END: Successfully claimed %d sandboxes", warmPoolSize)
 
 	// Active iteration cleanup to prevent resource leak over multiple benchmark iterations
 	if err := t.Delete(ctx, ns); err != nil {


### PR DESCRIPTION
This improves the BenchmarkWarmPoolParallelClaim benchmark.

Also be clearer about QPS=-1; this turns off client-side rate limiting,
relying instead on kube-apiserver Priority And Fairness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Increased default `--sandbox-claim-concurrent-workers` from 1 to 50.
  * Updated `--kube-api-qps`/`--kube-api-burst` flag/help text to clarify they control client-side throttling behavior.

* **Documentation**
  * Updated configuration and Helm documentation defaults and explanations.
  * Adjusted deployment and patch examples to omit kube API throttling flags where not needed.
  * Updated rapid burst test recipe to use `--kube-api-qps=-1` and remove the burst example.

* **Tests**
  * Improved parallelism test configurability and benchmark logging/timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->