### PR TITLE
fix(client/go): prevent registry clobber leaking orphaned sandbox handles

### DIFF
--- a/clients/go/sandbox/client.go
+++ b/clients/go/sandbox/client.go
@@ -127,21 +127,17 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 
 	c.mu.Lock()
 	existing := c.registry[key]
-	c.mu.Unlock()
-
 	if existing != nil && existing.IsReady() {
+		c.mu.Unlock()
 		return existing, nil
 	}
-
-	// Evict stale handle (compare-and-delete: never evict a newer handle that a
-	// concurrent caller may have installed while we checked readiness).
+	// Evict stale handle atomically: we already know existing is nil or
+	// not-ready, and no concurrent caller can have changed it since we
+	// still hold the lock.
 	if existing != nil {
-		c.mu.Lock()
-		if c.registry[key] == existing {
-			delete(c.registry, key)
-		}
-		c.mu.Unlock()
+		delete(c.registry, key)
 	}
+	c.mu.Unlock()
 
 	sandboxOpts := c.opts
 	sandboxOpts.Namespace = namespace

--- a/clients/go/sandbox/client.go
+++ b/clients/go/sandbox/client.go
@@ -100,28 +100,10 @@ func (c *Client) CreateSandbox(ctx context.Context, warmPoolName, namespace stri
 	}
 
 	key := Key{Namespace: namespace, ClaimName: sb.ClaimName()}
-	c.mu.Lock()
-	if tracked := c.registry[key]; tracked != nil && tracked.IsReady() {
-		c.mu.Unlock()
-		// A ready handle is already tracked for this key. The registry key is
-		// built from the server-assigned (GenerateName) claim name, which is
-		// unique to this sb, so a hit means tracked and sb reference the SAME
-		// claim — a concurrent GetSandbox attached to the claim we just created
-		// (e.g. after spotting it via ListAllSandboxes) and registered first.
-		// Tear down only our redundant transport (Disconnect); Close() would
-		// deleteClaim on the shared claim and destroy the sandbox out from under
-		// the tracked handle we return. Use a detached context: the caller's ctx
-		// may already be cancelled/near-deadline, which would make Disconnect bail
-		// before tearing down the transport — leaking the very handle we discard.
-		if derr := sb.Disconnect(context.Background()); derr != nil {
-			c.log.Error(derr, "disconnecting redundant handle after registry race", "claim", key.ClaimName, "namespace", namespace)
-		}
-		return tracked, nil
-	}
-	c.registry[key] = sb
-	c.mu.Unlock()
-
-	return sb, nil
+	// The registry key is built from the server-assigned (GenerateName) claim
+	// name, which is unique to this sb, so a hit means a concurrent GetSandbox
+	// attached to the very claim we just created and registered first.
+	return c.trackOrAdoptRace(key, sb), nil
 }
 
 // GetSandbox retrieves an existing sandbox by claim name. Returns the
@@ -174,24 +156,36 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 		return nil, fmt.Errorf("sandbox: failed to re-attach to claim %q in %q: %w", claimName, namespace, err)
 	}
 
-	// Re-check under the final lock: a concurrent GetSandbox/CreateSandbox for
-	// the same key may have installed a ready handle while we were attaching.
-	// If so, return the already-tracked handle and tear down our redundant
-	// transport WITHOUT deleting the shared claim (Disconnect, not Close). Use a
-	// detached context so a cancelled/near-deadline caller ctx can't make
-	// Disconnect bail before the transport is torn down, leaking it.
+	// A concurrent GetSandbox/CreateSandbox for the same key may have installed
+	// a ready handle while we were attaching; adopt it if so.
+	return c.trackOrAdoptRace(key, sb), nil
+}
+
+// trackOrAdoptRace resolves the registry race that both CreateSandbox and
+// GetSandbox can hit: another goroutine may have installed a ready handle for
+// key while sb was being opened/attached. Under the lock it re-checks for a
+// tracked ready handle; if one exists it adopts that handle and tears down only
+// sb's redundant transport (Disconnect), returning the tracked handle.
+// Otherwise it registers sb and returns it.
+//
+// Disconnect (not Close) is deliberate: sb and the tracked handle reference the
+// SAME shared claim, so Close would deleteClaim and destroy the sandbox out from
+// under the handle we return. Disconnect runs on a detached context because the
+// caller's ctx may already be cancelled/near-deadline, which would make
+// Disconnect bail before tearing down the transport — leaking the very handle we
+// discard.
+func (c *Client) trackOrAdoptRace(key Key, sb *Sandbox) *Sandbox {
 	c.mu.Lock()
 	if tracked := c.registry[key]; tracked != nil && tracked.IsReady() {
 		c.mu.Unlock()
 		if derr := sb.Disconnect(context.Background()); derr != nil {
-			c.log.Error(derr, "disconnecting redundant handle after registry race", "claim", claimName, "namespace", namespace)
+			c.log.Error(derr, "disconnecting redundant handle after registry race", "claim", key.ClaimName, "namespace", key.Namespace)
 		}
-		return tracked, nil
+		return tracked
 	}
 	c.registry[key] = sb
 	c.mu.Unlock()
-
-	return sb, nil
+	return sb
 }
 
 // ListActiveSandboxes returns tracked sandboxes, pruning inactive handles.

--- a/clients/go/sandbox/client.go
+++ b/clients/go/sandbox/client.go
@@ -103,11 +103,18 @@ func (c *Client) CreateSandbox(ctx context.Context, warmPoolName, namespace stri
 	c.mu.Lock()
 	if tracked := c.registry[key]; tracked != nil && tracked.IsReady() {
 		c.mu.Unlock()
-		// A concurrent caller already tracks a ready handle for this key. Our
-		// handle owns a distinct freshly-created claim, so Close() it (tears
-		// down transport + deletes the redundant claim) and return the tracked one.
-		if cerr := sb.Close(ctx); cerr != nil {
-			c.log.Error(cerr, "closing redundant handle after registry race", "claim", key.ClaimName, "namespace", namespace)
+		// A ready handle is already tracked for this key. The registry key is
+		// built from the server-assigned (GenerateName) claim name, which is
+		// unique to this sb, so a hit means tracked and sb reference the SAME
+		// claim — a concurrent GetSandbox attached to the claim we just created
+		// (e.g. after spotting it via ListAllSandboxes) and registered first.
+		// Tear down only our redundant transport (Disconnect); Close() would
+		// deleteClaim on the shared claim and destroy the sandbox out from under
+		// the tracked handle we return. Use a detached context: the caller's ctx
+		// may already be cancelled/near-deadline, which would make Disconnect bail
+		// before tearing down the transport — leaking the very handle we discard.
+		if derr := sb.Disconnect(context.Background()); derr != nil {
+			c.log.Error(derr, "disconnecting redundant handle after registry race", "claim", key.ClaimName, "namespace", namespace)
 		}
 		return tracked, nil
 	}
@@ -170,11 +177,13 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 	// Re-check under the final lock: a concurrent GetSandbox/CreateSandbox for
 	// the same key may have installed a ready handle while we were attaching.
 	// If so, return the already-tracked handle and tear down our redundant
-	// transport WITHOUT deleting the shared claim (Disconnect, not Close).
+	// transport WITHOUT deleting the shared claim (Disconnect, not Close). Use a
+	// detached context so a cancelled/near-deadline caller ctx can't make
+	// Disconnect bail before the transport is torn down, leaking it.
 	c.mu.Lock()
 	if tracked := c.registry[key]; tracked != nil && tracked.IsReady() {
 		c.mu.Unlock()
-		if derr := sb.Disconnect(ctx); derr != nil {
+		if derr := sb.Disconnect(context.Background()); derr != nil {
 			c.log.Error(derr, "disconnecting redundant handle after registry race", "claim", claimName, "namespace", namespace)
 		}
 		return tracked, nil

--- a/clients/go/sandbox/client.go
+++ b/clients/go/sandbox/client.go
@@ -101,6 +101,16 @@ func (c *Client) CreateSandbox(ctx context.Context, warmPoolName, namespace stri
 
 	key := Key{Namespace: namespace, ClaimName: sb.ClaimName()}
 	c.mu.Lock()
+	if tracked := c.registry[key]; tracked != nil && tracked.IsReady() {
+		c.mu.Unlock()
+		// A concurrent caller already tracks a ready handle for this key. Our
+		// handle owns a distinct freshly-created claim, so Close() it (tears
+		// down transport + deletes the redundant claim) and return the tracked one.
+		if cerr := sb.Close(ctx); cerr != nil {
+			c.log.Error(cerr, "closing redundant handle after registry race", "claim", key.ClaimName, "namespace", namespace)
+		}
+		return tracked, nil
+	}
 	c.registry[key] = sb
 	c.mu.Unlock()
 
@@ -123,10 +133,13 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 		return existing, nil
 	}
 
-	// Evict stale handle.
+	// Evict stale handle (compare-and-delete: never evict a newer handle that a
+	// concurrent caller may have installed while we checked readiness).
 	if existing != nil {
 		c.mu.Lock()
-		delete(c.registry, key)
+		if c.registry[key] == existing {
+			delete(c.registry, key)
+		}
 		c.mu.Unlock()
 	}
 
@@ -158,7 +171,18 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 		return nil, fmt.Errorf("sandbox: failed to re-attach to claim %q in %q: %w", claimName, namespace, err)
 	}
 
+	// Re-check under the final lock: a concurrent GetSandbox/CreateSandbox for
+	// the same key may have installed a ready handle while we were attaching.
+	// If so, return the already-tracked handle and tear down our redundant
+	// transport WITHOUT deleting the shared claim (Disconnect, not Close).
 	c.mu.Lock()
+	if tracked := c.registry[key]; tracked != nil && tracked.IsReady() {
+		c.mu.Unlock()
+		if derr := sb.Disconnect(ctx); derr != nil {
+			c.log.Error(derr, "disconnecting redundant handle after registry race", "claim", claimName, "namespace", namespace)
+		}
+		return tracked, nil
+	}
 	c.registry[key] = sb
 	c.mu.Unlock()
 

--- a/clients/go/sandbox/client_test.go
+++ b/clients/go/sandbox/client_test.go
@@ -255,6 +255,95 @@ func TestClient_DeleteSandbox_Tracked(t *testing.T) {
 	}
 }
 
+// TestClient_CreateSandbox_RedundantHandleKeepsSharedClaim guards the registry
+// re-check branch in CreateSandbox. The registry key is the server-assigned
+// (GenerateName) claim name, so a hit under our key means a concurrent
+// GetSandbox already attached to the very claim we just created and registered a
+// ready handle first. In that case CreateSandbox must tear down only its
+// redundant transport (Disconnect) and NOT delete the shared claim — otherwise
+// it deletes the sandbox out from under the tracked handle it returns.
+func TestClient_CreateSandbox_RedundantHandleKeepsSharedClaim(t *testing.T) {
+	agentsCS := fakeagents.NewSimpleClientset()         //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
+	extensionsCS := fakeextensions.NewSimpleClientset() //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
+
+	opts := Options{
+		WarmPoolName:        "test-warmpool",
+		Namespace:           "default",
+		APIURL:              "http://localhost:9999",
+		SandboxReadyTimeout: 2 * time.Second,
+		Quiet:               true,
+	}
+	opts.setDefaults()
+	opts.K8sHelper = &K8sHelper{
+		AgentsClient:     agentsCS.AgentsV1beta1(),
+		ExtensionsClient: extensionsCS.ExtensionsV1beta1(),
+		Log:              logr.Discard(),
+	}
+
+	// Resolve the sandbox name from the claim status (claim name == sandbox name).
+	extensionsCS.PrependReactor("get", "sandboxclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ga := action.(ktesting.GetAction)
+		return true, &extv1beta1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: ga.GetName(), Namespace: ga.GetNamespace()},
+			Status: extv1beta1.SandboxClaimStatus{
+				SandboxStatus: extv1beta1.SandboxStatus{Name: ga.GetName()},
+			},
+		}, nil
+	})
+
+	// Wire create (GenerateName -> deterministic name) and a ready sandbox on
+	// list/watch so CreateSandbox's Open() succeeds.
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("placeholder"))
+
+	// Fail loudly if the shared claim is ever deleted: the old Close()-based
+	// path in this branch would issue a delete here.
+	var deleteCalled bool
+	extensionsCS.PrependReactor("delete", "sandboxclaims", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		deleteCalled = true
+		return true, nil, nil
+	})
+
+	c, err := NewClient(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// setupWatchWithReactor assigns "<GenerateName>test12345" to created claims,
+	// so the key CreateSandbox computes is known ahead of time. Pre-seed a ready
+	// handle under it to force the re-check branch to fire deterministically.
+	const claimName = "sandbox-claim-test12345"
+	tracked := &Sandbox{log: logr.Discard()}
+	tracked.connector = &connector{}
+	tracked.connector.baseURL = "http://fake" // makes IsReady() true
+	key := Key{Namespace: "default", ClaimName: claimName}
+	c.mu.Lock()
+	c.registry[key] = tracked
+	c.mu.Unlock()
+
+	got, err := c.CreateSandbox(context.Background(), "test-warmpool", "default")
+	if err != nil {
+		t.Fatalf("CreateSandbox: %v", err)
+	}
+
+	if got != tracked {
+		t.Error("expected the already-tracked handle to be returned, not the redundant one")
+	}
+	if deleteCalled {
+		t.Error("shared claim was deleted; redundant handle must be Disconnect()ed, not Close()d")
+	}
+	if !tracked.IsReady() {
+		t.Error("tracked handle should remain ready after the redundant handle is torn down")
+	}
+
+	// The registry must still hold the tracked handle under the shared key.
+	c.mu.Lock()
+	stillTracked := c.registry[key]
+	c.mu.Unlock()
+	if stillTracked != tracked {
+		t.Error("expected tracked handle to remain registered under the shared key")
+	}
+}
+
 func TestClient_EnableAutoCleanup_Idempotent(t *testing.T) {
 	c, _ := newTestClient(t)
 

--- a/clients/go/sandbox/client_test.go
+++ b/clients/go/sandbox/client_test.go
@@ -344,6 +344,110 @@ func TestClient_CreateSandbox_RedundantHandleKeepsSharedClaim(t *testing.T) {
 	}
 }
 
+// TestClient_GetSandbox_AdoptsRacingHandleKeepsSharedClaim guards the registry
+// re-check branch in GetSandbox — the symmetric counterpart to the CreateSandbox
+// branch. While GetSandbox is resolving+attaching, a concurrent
+// GetSandbox/CreateSandbox for the same key can install a ready handle first. In
+// that case GetSandbox must return the already-tracked handle and tear down only
+// its own redundant transport (Disconnect), never deleting the shared claim.
+//
+// The race is forced deterministically: a "get sandboxclaims" reactor installs a
+// ready tracked handle during resolveSandboxName (before this GetSandbox finishes
+// attaching), so by the time it reaches trackOrAdoptRace the adopt branch is
+// guaranteed to fire.
+func TestClient_GetSandbox_AdoptsRacingHandleKeepsSharedClaim(t *testing.T) {
+	agentsCS := fakeagents.NewSimpleClientset()         //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
+	extensionsCS := fakeextensions.NewSimpleClientset() //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
+
+	opts := Options{
+		WarmPoolName:        "test-warmpool",
+		Namespace:           "default",
+		APIURL:              "http://localhost:9999",
+		SandboxReadyTimeout: 2 * time.Second,
+		Quiet:               true,
+	}
+	opts.setDefaults()
+	opts.K8sHelper = &K8sHelper{
+		AgentsClient:     agentsCS.AgentsV1beta1(),
+		ExtensionsClient: extensionsCS.ExtensionsV1beta1(),
+		Log:              logr.Discard(),
+	}
+
+	c, err := NewClient(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const claimName = "shared-claim"
+	key := Key{Namespace: "default", ClaimName: claimName}
+
+	// The handle a concurrent caller registers first. GetSandbox must return
+	// exactly this handle and leave it registered.
+	tracked := &Sandbox{log: logr.Discard()}
+	tracked.connector = &connector{}
+	tracked.connector.baseURL = "http://fake" // makes IsReady() true
+
+	// Reactor for every "get sandboxclaims" (verifyClaimExists +
+	// resolveSandboxName). On the resolveSandboxName call — the second get — it
+	// installs the ready tracked handle under key, simulating a concurrent caller
+	// that wins the race while this GetSandbox is still attaching.
+	var getCalls int
+	extensionsCS.PrependReactor("get", "sandboxclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
+		getCalls++
+		if getCalls == 2 {
+			c.mu.Lock()
+			c.registry[key] = tracked
+			c.mu.Unlock()
+		}
+		ga := action.(ktesting.GetAction)
+		return true, &extv1beta1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: ga.GetName(), Namespace: ga.GetNamespace()},
+			Status: extv1beta1.SandboxClaimStatus{
+				SandboxStatus: extv1beta1.SandboxStatus{Name: ga.GetName()},
+			},
+		}, nil
+	})
+
+	// Reconnect path: verifySandboxAlive gets a ready sandbox so the redundant
+	// handle this GetSandbox builds actually opens — proving adoption happens
+	// because a ready handle already exists, not because our own attach failed.
+	agentsCS.PrependReactor("get", "sandboxes", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ga := action.(ktesting.GetAction)
+		return true, readySandbox(ga.GetName()), nil
+	})
+
+	// Fail loudly if the shared claim is ever deleted: the buggy Close()-based
+	// path in this branch would issue a delete here.
+	var deleteCalled bool
+	extensionsCS.PrependReactor("delete", "sandboxclaims", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		deleteCalled = true
+		return true, nil, nil
+	})
+
+	got, err := c.GetSandbox(context.Background(), claimName, "default")
+	if err != nil {
+		t.Fatalf("GetSandbox: %v", err)
+	}
+
+	if got != tracked {
+		t.Error("expected the already-tracked handle to be returned, not the redundant one")
+	}
+	if deleteCalled {
+		t.Error("shared claim was deleted; redundant handle must be Disconnect()ed, not Close()d")
+	}
+	if !tracked.IsReady() {
+		t.Error("tracked handle should remain ready after the redundant handle is torn down")
+	}
+
+	// The registry must still hold the tracked handle under the shared key.
+	c.mu.Lock()
+	stillTracked := c.registry[key]
+	c.mu.Unlock()
+	if stillTracked != tracked {
+		t.Error("expected tracked handle to remain registered under the shared key")
+	}
+}
+
 func TestClient_EnableAutoCleanup_Idempotent(t *testing.T) {
 	c, _ := newTestClient(t)
 

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -183,7 +183,7 @@ func (c *Client) CreateSandbox(ctx context.Context, warmPoolName, namespace stri
 CreateSandbox provisions a new sandbox and returns a managed handle. On failure, the orphaned claim is cleaned up.
 
 <a name="Client.DeleteAll"></a>
-#### func \(\*Client\) [DeleteAll](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L219>)
+#### func \(\*Client\) [DeleteAll](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L242>)
 
 ```go
 func (c *Client) DeleteAll(ctx context.Context)
@@ -192,7 +192,7 @@ func (c *Client) DeleteAll(ctx context.Context)
 DeleteAll closes and deletes all tracked sandboxes. Best\-effort.
 
 <a name="Client.DeleteSandbox"></a>
-#### func \(\*Client\) [DeleteSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L201>)
+#### func \(\*Client\) [DeleteSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L224>)
 
 ```go
 func (c *Client) DeleteSandbox(ctx context.Context, claimName, namespace string) error
@@ -201,7 +201,7 @@ func (c *Client) DeleteSandbox(ctx context.Context, claimName, namespace string)
 DeleteSandbox closes the handle \(if tracked\) and deletes the claim.
 
 <a name="Client.EnableAutoCleanup"></a>
-#### func \(\*Client\) [EnableAutoCleanup](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L235>)
+#### func \(\*Client\) [EnableAutoCleanup](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L258>)
 
 ```go
 func (c *Client) EnableAutoCleanup() (stop func())
@@ -210,7 +210,7 @@ func (c *Client) EnableAutoCleanup() (stop func())
 EnableAutoCleanup calls DeleteAll on SIGINT/SIGTERM. Call the returned function to stop the signal handler.
 
 <a name="Client.GetSandbox"></a>
-#### func \(\*Client\) [GetSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L112>)
+#### func \(\*Client\) [GetSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L111>)
 
 ```go
 func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*Sandbox, error)
@@ -219,7 +219,7 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 GetSandbox retrieves an existing sandbox by claim name. Returns the cached handle if connected, otherwise re\-attaches.
 
 <a name="Client.ListActiveSandboxes"></a>
-#### func \(\*Client\) [ListActiveSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L169>)
+#### func \(\*Client\) [ListActiveSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L192>)
 
 ```go
 func (c *Client) ListActiveSandboxes() []Key
@@ -228,7 +228,7 @@ func (c *Client) ListActiveSandboxes() []Key
 ListActiveSandboxes returns tracked sandboxes, pruning inactive handles.
 
 <a name="Client.ListAllSandboxes"></a>
-#### func \(\*Client\) [ListAllSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L185>)
+#### func \(\*Client\) [ListAllSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L208>)
 
 ```go
 func (c *Client) ListAllSandboxes(ctx context.Context, namespace string) ([]string, error)


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes a TOCTOU race in the Go client's handle registry. `GetSandbox`/`CreateSandbox` read `c.registry` under `c.mu`, release the lock, do network I/O (`verifyClaimExists`, `resolveSandboxName`, `Open`), then write `c.registry[key] = sb` **unconditionally**. Two concurrent calls for the same key each build a `*Sandbox`, and the second write clobbers the first without `Close()`-ing it. The displaced handle stays connected but becomes unreachable through the `Client`, so `DeleteAll`/`DeleteSandbox`/`ListActiveSandboxes` can never reach it — leaking its port-forward goroutines (`ForwardPorts` + `monitorPortForward`), SPDY connection, and owned `http.Transport` for the lifetime of the process. (A reproduction on kind with 12 concurrent callers leaked 11 handles and ~205 goroutines; with the fix, 0 orphans.)

The fix re-checks the registry under the final lock (compare-and-set): if a ready handle is already tracked for the key, it returns that one and tears down the redundant handle it just built — `Disconnect` in `GetSandbox` (the claim is shared) / `Close` in `CreateSandbox` (the claim is freshly created). The stale-handle eviction becomes a compare-and-delete so it can't remove a handle a concurrent caller just installed.

Two tests attached (to be run inside `clients/go/sandbox`).

[repro_kind_test.txt](https://github.com/user-attachments/files/29152545/repro_kind_test.txt)
[client_race_test.txt](https://github.com/user-attachments/files/29152544/client_race_test.txt)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox create/retrieve handling to be race-safe when multiple callers act on the same shared claim, preventing accidental claim deletion.
  * Added “adopt ready handle” behavior so callers reuse an already-ready sandbox handle when available, while disconnecting only redundant transports.
  * Streamlined cache readiness/eviction so ready sandboxes return immediately and stale entries are removed promptly.

* **Tests**
  * Added deterministic unit tests validating adopt/re-check behavior for both create and get paths without shared-claim deletion.

* **Documentation**
  * Updated Go SDK reference links to match revised source line numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->