### PR TITLE
Add printer columns for sandbox resources

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -244,6 +244,12 @@ type SandboxStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=sandbox
 // +kubebuilder:storageversion
 // +kubebuilder:conversion:strategy=Webhook
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason",priority=1
+// +kubebuilder:printcolumn:name="Service",type="string",JSONPath=".status.service",priority=1
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeName",priority=1
+// +kubebuilder:printcolumn:name="Shutdown",type="date",JSONPath=".spec.shutdownTime",priority=1
 // Sandbox is the Schema for the sandboxes API.
 type Sandbox struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -161,10 +161,12 @@ type SandboxStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxclaim
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Sandbox",type="string",JSONPath=".status.sandbox.name"
-// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 // +kubebuilder:conversion:strategy=Webhook
+// +kubebuilder:printcolumn:name="WarmPool",type="string",JSONPath=".spec.warmPoolRef.name",priority=1
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].reason",priority=1
+// +kubebuilder:printcolumn:name="Shutdown",type="date",JSONPath=".spec.lifecycle.shutdownTime",priority=1
 // SandboxClaim is the Schema for the sandbox Claim API.
 type SandboxClaim struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1beta1/sandboxtemplate_types.go
+++ b/extensions/api/v1beta1/sandboxtemplate_types.go
@@ -164,6 +164,9 @@ type SandboxTemplateSpec struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxtemplate
 // +kubebuilder:storageversion
 // +kubebuilder:conversion:strategy=Webhook
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Network",type="string",JSONPath=".spec.networkPolicyManagement",priority=1
+// +kubebuilder:printcolumn:name="Containers",type="string",JSONPath=".spec.podTemplate.spec.containers[*].name",priority=1
 // SandboxTemplate is the Schema for the sandbox template API.
 type SandboxTemplate struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1beta1/sandboxwarmpool_types.go
+++ b/extensions/api/v1beta1/sandboxwarmpool_types.go
@@ -96,9 +96,13 @@ type SandboxWarmPoolStatus struct {
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:scope=Namespaced,shortName=swp
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 // +kubebuilder:conversion:strategy=Webhook
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",priority=1
+// +kubebuilder:printcolumn:name="Template",type="string",JSONPath=".spec.sandboxTemplateRef.name",priority=1
+// +kubebuilder:printcolumn:name="Selector",type="string",JSONPath=".status.selector",priority=1
 // SandboxWarmPool is the Schema for the sandboxwarmpools API.
 type SandboxWarmPool struct {
 	metav1.TypeMeta `json:",inline"`

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -15,7 +15,30 @@ spec:
     singular: sandbox
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      priority: 1
+      type: string
+    - jsonPath: .status.service
+      name: Service
+      priority: 1
+      type: string
+    - jsonPath: .status.nodeName
+      name: Node
+      priority: 1
+      type: string
+    - jsonPath: .spec.shutdownTime
+      name: Shutdown
+      priority: 1
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -22,11 +22,20 @@ spec:
     - jsonPath: .status.sandbox.name
       name: Sandbox
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
+      type: date
+    - jsonPath: .spec.warmPoolRef.name
+      name: WarmPool
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      priority: 1
+      type: string
+    - jsonPath: .spec.lifecycle.shutdownTime
+      name: Shutdown
+      priority: 1
       type: date
     name: v1beta1
     schema:

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -15,7 +15,19 @@ spec:
     singular: sandboxtemplate
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.networkPolicyManagement
+      name: Network
+      priority: 1
+      type: string
+    - jsonPath: .spec.podTemplate.spec.containers[*].name
+      name: Containers
+      priority: 1
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -4153,6 +4165,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
   - deprecated: true
     deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate is deprecated;
       use extensions.agents.x-k8s.io/v1beta1 SandboxTemplate instead

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -19,9 +19,24 @@ spec:
     - jsonPath: .status.readyReplicas
       name: Ready
       type: integer
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.replicas
+      name: Current
+      priority: 1
+      type: integer
+    - jsonPath: .spec.sandboxTemplateRef.name
+      name: Template
+      priority: 1
+      type: string
+    - jsonPath: .status.selector
+      name: Selector
+      priority: 1
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -15,7 +15,30 @@ spec:
     singular: sandbox
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      priority: 1
+      type: string
+    - jsonPath: .status.service
+      name: Service
+      priority: 1
+      type: string
+    - jsonPath: .status.nodeName
+      name: Node
+      priority: 1
+      type: string
+    - jsonPath: .spec.shutdownTime
+      name: Shutdown
+      priority: 1
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -22,11 +22,20 @@ spec:
     - jsonPath: .status.sandbox.name
       name: Sandbox
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Reason
-      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
+      type: date
+    - jsonPath: .spec.warmPoolRef.name
+      name: WarmPool
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Reason
+      priority: 1
+      type: string
+    - jsonPath: .spec.lifecycle.shutdownTime
+      name: Shutdown
+      priority: 1
       type: date
     name: v1beta1
     schema:

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -15,7 +15,19 @@ spec:
     singular: sandboxtemplate
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.networkPolicyManagement
+      name: Network
+      priority: 1
+      type: string
+    - jsonPath: .spec.podTemplate.spec.containers[*].name
+      name: Containers
+      priority: 1
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:
@@ -4153,6 +4165,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
   - deprecated: true
     deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate is deprecated;
       use extensions.agents.x-k8s.io/v1beta1 SandboxTemplate instead

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -19,9 +19,24 @@ spec:
     - jsonPath: .status.readyReplicas
       name: Ready
       type: integer
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.replicas
+      name: Current
+      priority: 1
+      type: integer
+    - jsonPath: .spec.sandboxTemplateRef.name
+      name: Template
+      priority: 1
+      type: string
+    - jsonPath: .status.selector
+      name: Selector
+      priority: 1
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
## Summary
- Add concise default printer columns for v1beta1 Sandbox, SandboxClaim, SandboxTemplate, and SandboxWarmPool.
- Put diagnostic fields such as reason, service/node, warm pool/template, selector, and shutdown time behind `-owide` via priority columns.
- Regenerate both `k8s/crds` and `helm/crds` from the updated markers.

## Example output

```console
$ kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -n default
NAME                                              READY   AGE
sandbox.agents.x-k8s.io/printer-demo-pool-7rxq4   True    2m13s
sandbox.agents.x-k8s.io/printer-demo-pool-jm5l8   True    92s
sandbox.agents.x-k8s.io/printer-demo-sandbox      True    2m13s

NAME                                                         READY   SANDBOX                   AGE
sandboxclaim.extensions.agents.x-k8s.io/printer-demo-claim   True    printer-demo-pool-7rxq4   93s

NAME                                                               AGE
sandboxtemplate.extensions.agents.x-k8s.io/printer-demo-template   2m13s

NAME                                                           READY   DESIRED   AGE
sandboxwarmpool.extensions.agents.x-k8s.io/printer-demo-pool   1       1         2m13s
```

```console
$ kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -n default -owide
NAME                                              READY   AGE     REASON              SERVICE                   NODE           SHUTDOWN
sandbox.agents.x-k8s.io/printer-demo-pool-7rxq4   True    2m13s   DependenciesReady   printer-demo-pool-7rxq4   minikube-m03   
sandbox.agents.x-k8s.io/printer-demo-pool-jm5l8   True    92s     DependenciesReady   printer-demo-pool-jm5l8   minikube-m02   
sandbox.agents.x-k8s.io/printer-demo-sandbox      True    2m13s   DependenciesReady   printer-demo-sandbox      minikube-m03   

NAME                                                         READY   SANDBOX                   AGE   WARMPOOL            REASON              SHUTDOWN
sandboxclaim.extensions.agents.x-k8s.io/printer-demo-claim   True    printer-demo-pool-7rxq4   93s   printer-demo-pool   DependenciesReady   

NAME                                                               AGE     NETWORK     CONTAINERS
sandboxtemplate.extensions.agents.x-k8s.io/printer-demo-template   2m13s   Unmanaged   main

NAME                                                           READY   DESIRED   AGE     CURRENT   TEMPLATE                SELECTOR
sandboxwarmpool.extensions.agents.x-k8s.io/printer-demo-pool   1       1         2m13s   1         printer-demo-template   agents.x-k8s.io/warm-pool-sandbox=f35db622
```

## Test Plan
- `go generate ./...`
- `git diff --check`
- `rg -n "additionalPrinterColumns|name: Ready|name: Desired|name: WarmPool|name: Network|priority: 1" k8s/crds helm/crds`
- `go test ./api/... ./extensions/api/... ./clients/k8s/... ./controllers ./extensions/controllers ./internal/metrics ./cmd/...`
- `kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -n default`
- `kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -n default -owide`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded `kubectl get` output columns for Sandbox resources (Ready, Age, Reason, Service, Node, Shutdown).
  * Added display columns for SandboxClaim (WarmPool, Shutdown).
  * Enhanced SandboxTemplate visibility with Age, Network, and Containers columns.
  * Improved SandboxWarmPool output with Desired, Current, Template, and Selector columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
