### PR TITLE
feat(sdk): support env injection in sandbox claims

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -176,7 +176,9 @@ All options are documented on the `Options` struct in
 [options.go](sandbox/options.go). Key fields:
 
 - `WarmPoolName`: passed per-sandbox to `CreateSandbox`.
-- `Env`: environment variables to inject into the `SandboxClaim`.
+- `Env`: environment variables to inject into the `SandboxClaim`. Setting this
+  forces a cold start from the warm pool template instead of adopting a
+  pre-warmed pod, which may increase startup latency.
 - `GatewayName`: set to enable Gateway mode.
 - `APIURL`: set for Direct URL mode (takes precedence over `GatewayName`).
 - `TracerProvider`: OpenTelemetry integration.

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -176,6 +176,7 @@ All options are documented on the `Options` struct in
 [options.go](sandbox/options.go). Key fields:
 
 - `WarmPoolName`: passed per-sandbox to `CreateSandbox`.
+- `Env`: environment variables to inject into the `SandboxClaim`.
 - `GatewayName`: set to enable Gateway mode.
 - `APIURL`: set for Direct URL mode (takes precedence over `GatewayName`).
 - `TracerProvider`: OpenTelemetry integration.

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -188,7 +188,9 @@ All options are documented on the `Options` struct in
 [options.go](sandbox/options.go). Key fields:
 
 - `WarmPoolName`: passed per-sandbox to `CreateSandbox`.
-- `Env`: environment variables to inject into the `SandboxClaim`.
+- `Env`: environment variables to inject into the `SandboxClaim`. Setting this
+  forces a cold start from the warm pool template instead of adopting a
+  pre-warmed pod, which may increase startup latency.
 - `GatewayName`: set to enable Gateway mode.
 - `APIURL`: set for Direct URL mode (takes precedence over `GatewayName`).
 - `TracerProvider`: OpenTelemetry integration.

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -188,6 +188,7 @@ All options are documented on the `Options` struct in
 [options.go](sandbox/options.go). Key fields:
 
 - `WarmPoolName`: passed per-sandbox to `CreateSandbox`.
+- `Env`: environment variables to inject into the `SandboxClaim`.
 - `GatewayName`: set to enable Gateway mode.
 - `APIURL`: set for Direct URL mode (takes precedence over `GatewayName`).
 - `TracerProvider`: OpenTelemetry integration.

--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -122,7 +122,7 @@ func NewK8sHelper(restConfig *rest.Config, log logr.Logger) (*K8sHelper, error) 
 }
 
 // createClaim creates a SandboxClaim and returns its generated name.
-func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName string, tracer trace.Tracer, svcName string) (string, error) {
+func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName string, env []extv1beta1.EnvVar, tracer trace.Tracer, svcName string) (string, error) {
 	ctx, span := startSpan(ctx, tracer, svcName, "create_claim")
 	defer span.End()
 
@@ -143,6 +143,7 @@ func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName str
 			WarmPoolRef: extv1beta1.SandboxWarmPoolRef{
 				Name: warmPoolName,
 			},
+			Env: env,
 		},
 	}
 

--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -139,7 +139,7 @@ func stampClientRequestTime(annotations map[string]string, now time.Time) map[st
 }
 
 // createClaim creates a SandboxClaim and returns its generated name.
-func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName string, tracer trace.Tracer, svcName string) (string, error) {
+func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName string, env []extv1beta1.EnvVar, tracer trace.Tracer, svcName string) (string, error) {
 	ctx, span := startSpan(ctx, tracer, svcName, "create_claim")
 	defer span.End()
 
@@ -164,6 +164,7 @@ func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName str
 			WarmPoolRef: extv1beta1.SandboxWarmPoolRef{
 				Name: warmPoolName,
 			},
+			Env: env,
 		},
 	}
 

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-logr/logr/funcr"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/rest"
+
+	extv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
 )
 
 const (
@@ -69,6 +71,10 @@ type Options struct {
 
 	// ServerPort is the port the sandbox runtime listens on. Default: 8888.
 	ServerPort int
+
+	// Env is the list of environment variables to inject into the SandboxClaim.
+	// Setting Env forces a cold start from the warm pool template.
+	Env []extv1beta1.EnvVar
 
 	// SandboxReadyTimeout is how long to wait for the sandbox to become ready. Default: 180s.
 	SandboxReadyTimeout time.Duration

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-logr/logr/funcr"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/client-go/rest"
+
+	extv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
 )
 
 const (
@@ -103,6 +105,10 @@ type Options struct {
 
 	// ServerPort is the port the sandbox runtime listens on. Default: 8888.
 	ServerPort int
+
+	// Env is the list of environment variables to inject into the SandboxClaim.
+	// Setting Env forces a cold start from the warm pool template.
+	Env []extv1beta1.EnvVar
 
 	// SandboxReadyTimeout is how long to wait for the sandbox to become ready. Default: 180s.
 	SandboxReadyTimeout time.Duration

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -238,7 +238,7 @@ func (s *Sandbox) Open(ctx context.Context) (retErr error) {
 	}
 
 	// Create claim.
-	claimName, err := s.k8s.createClaim(openCtx, s.opts.Namespace, s.opts.WarmPoolName, s.tracer, s.traceServiceName)
+	claimName, err := s.k8s.createClaim(openCtx, s.opts.Namespace, s.opts.WarmPoolName, s.opts.Env, s.tracer, s.traceServiceName)
 	if err != nil {
 		return err
 	}

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -271,7 +271,7 @@ func (s *Sandbox) Open(ctx context.Context) (retErr error) {
 	}
 
 	// Create claim.
-	claimName, err := s.k8s.createClaim(openCtx, s.opts.Namespace, s.opts.WarmPoolName, s.tracer, s.traceServiceName)
+	claimName, err := s.k8s.createClaim(openCtx, s.opts.Namespace, s.opts.WarmPoolName, s.opts.Env, s.tracer, s.traceServiceName)
 	if err != nil {
 		return err
 	}

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1378,6 +1379,42 @@ func TestOpen_CreateClaimSendsCorrectTemplate(t *testing.T) {
 
 	if capturedWarmPool != opts.WarmPoolName {
 		t.Errorf("expected warm pool name %q, got %q", opts.WarmPoolName, capturedWarmPool)
+	}
+}
+
+func TestOpen_CreateClaimSendsEnv(t *testing.T) {
+	opts := defaultTestOpts()
+	opts.Env = []extv1beta1.EnvVar{
+		{Name: "FOO", Value: "bar"},
+		{Name: "DEBUG", Value: "true"},
+	}
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+
+	var capturedEnv []extv1beta1.EnvVar
+	fakeWatcher := watch.NewFake()
+
+	extensionsCS.PrependReactor("create", "sandboxclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ca := action.(ktesting.CreateAction)
+		claim, ok := ca.GetObject().(*extv1beta1.SandboxClaim)
+		if ok {
+			if claim.Name == "" && claim.GenerateName != "" {
+				claim.Name = claim.GenerateName + "test12345"
+			}
+			capturedEnv = claim.Spec.Env
+			go fakeWatcher.Add(readySandbox(claim.Name))
+		}
+		return false, nil, nil
+	})
+
+	agentsCS.PrependWatchReactor("sandboxes", ktesting.DefaultWatchReactor(fakeWatcher, nil))
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if !reflect.DeepEqual(capturedEnv, opts.Env) {
+		t.Errorf("expected env %+v, got %+v", opts.Env, capturedEnv)
 	}
 }
 

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1393,6 +1394,42 @@ func TestOpen_CreateClaimSendsCorrectTemplate(t *testing.T) {
 
 	if capturedWarmPool != opts.WarmPoolName {
 		t.Errorf("expected warm pool name %q, got %q", opts.WarmPoolName, capturedWarmPool)
+	}
+}
+
+func TestOpen_CreateClaimSendsEnv(t *testing.T) {
+	opts := defaultTestOpts()
+	opts.Env = []extv1beta1.EnvVar{
+		{Name: "FOO", Value: "bar"},
+		{Name: "DEBUG", Value: "true"},
+	}
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+
+	var capturedEnv []extv1beta1.EnvVar
+	fakeWatcher := watch.NewFake()
+
+	extensionsCS.PrependReactor("create", "sandboxclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ca := action.(ktesting.CreateAction)
+		claim, ok := ca.GetObject().(*extv1beta1.SandboxClaim)
+		if ok {
+			if claim.Name == "" && claim.GenerateName != "" {
+				claim.Name = claim.GenerateName + "test12345"
+			}
+			capturedEnv = claim.Spec.Env
+			go fakeWatcher.Add(readySandbox(claim.Name))
+		}
+		return false, nil, nil
+	})
+
+	agentsCS.PrependWatchReactor("sandboxes", ktesting.DefaultWatchReactor(fakeWatcher, nil))
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if !reflect.DeepEqual(capturedEnv, opts.Env) {
+		t.Errorf("expected env %+v, got %+v", opts.Env, capturedEnv)
 	}
 }
 

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -162,6 +162,10 @@ sandbox = client.create_sandbox(
 )
 ```
 
+Setting `env` populates `SandboxClaim.spec.env`, which forces a cold start
+from the warm pool template instead of adopting a pre-warmed pod. This may
+increase startup latency.
+
 ### 3. In-Cluster Mode (Direct Pod Connection)
 
 Use this when the client runs **inside the cluster** (for example, another pod in the same cluster).

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -152,6 +152,16 @@ finally:
     sandbox.terminate()
 ```
 
+You can pass per-claim environment variables when creating a sandbox:
+
+```python
+sandbox = client.create_sandbox(
+    warmpool="python-sandbox-warmpool",
+    namespace="default",
+    env={"FOO": "bar"},
+)
+```
+
 ### 3. In-Cluster Mode (Direct Pod Connection)
 
 Use this when the client runs **inside the cluster** (for example, another pod in the same cluster).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -32,7 +32,12 @@ from .constants import (
     SANDBOX_PLURAL_NAME,
 )
 from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
-from .utils import select_pod_ip, is_valid_ip, is_valid_gateway_hostname
+from .utils import (
+    construct_sandbox_claim_env_spec,
+    is_valid_gateway_hostname,
+    is_valid_ip,
+    select_pod_ip,
+)
 
 
 class AsyncK8sHelper:
@@ -68,6 +73,7 @@ class AsyncK8sHelper:
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
         """Creates a SandboxClaim custom resource.
 
@@ -97,6 +103,9 @@ class AsyncK8sHelper:
             spec["volumeClaimTemplates"] = volume_claim_templates
         if pod_metadata:
             spec["additionalPodMetadata"] = pod_metadata
+        env_spec = construct_sandbox_claim_env_spec(env)
+        if env_spec:
+            spec["env"] = env_spec
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -105,7 +105,10 @@ class AsyncK8sHelper:
             spec["additionalPodMetadata"] = pod_metadata
         env_spec = construct_sandbox_claim_env_spec(env)
         if env_spec:
-            spec["env"] = env_spec
+            spec["env"] = [
+                env_var.model_dump(by_alias=True, exclude_none=True)
+                for env_var in env_spec
+            ]
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -36,7 +36,12 @@ from .constants import (
     TERMINAL_CLAIM_READY_REASONS,
 )
 from .exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
-from .utils import select_pod_ip, is_valid_ip, is_valid_gateway_hostname
+from .utils import (
+    construct_sandbox_claim_env_spec,
+    is_valid_gateway_hostname,
+    is_valid_ip,
+    select_pod_ip,
+)
 
 
 class AsyncK8sHelper:
@@ -72,6 +77,7 @@ class AsyncK8sHelper:
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
         """Creates a SandboxClaim custom resource.
 
@@ -107,6 +113,9 @@ class AsyncK8sHelper:
             spec["volumeClaimTemplates"] = volume_claim_templates
         if pod_metadata:
             spec["additionalPodMetadata"] = pod_metadata
+        env_spec = construct_sandbox_claim_env_spec(env)
+        if env_spec:
+            spec["env"] = env_spec
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -115,7 +115,10 @@ class AsyncK8sHelper:
             spec["additionalPodMetadata"] = pod_metadata
         env_spec = construct_sandbox_claim_env_spec(env)
         if env_spec:
-            spec["env"] = env_spec
+            spec["env"] = [
+                env_var.model_dump(by_alias=True, exclude_none=True)
+                for env_var in env_spec
+            ]
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -173,6 +173,9 @@ class AsyncSandboxClient(Generic[T]):
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
             env: Optional environment variables to inject into the SandboxClaim.
+                Setting this populates ``spec.env`` and forces a cold start
+                from the warm pool template instead of adopting a pre-warmed
+                pod, which may increase startup latency.
 
         Example::
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -149,6 +149,7 @@ class AsyncSandboxClient(Generic[T]):
         volume_claim_templates: list[dict] | None = None,
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
     ) -> T:
         """Provisions a new Sandbox claim and returns an async Sandbox handle.
 
@@ -171,6 +172,7 @@ class AsyncSandboxClient(Generic[T]):
                 the sandbox through the Downward API.
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
+            env: Optional environment variables to inject into the SandboxClaim.
 
         Example::
 
@@ -198,7 +200,8 @@ class AsyncSandboxClient(Generic[T]):
                 labels=labels,
                 lifecycle=lifecycle,
                 volume_claim_templates=volume_claim_templates,
-                pod_metadata=pod_metadata
+                pod_metadata=pod_metadata,
+                env=env,
             )
             start_time = time.monotonic()
             sandbox_id = await self.k8s_helper.resolve_sandbox_name(
@@ -416,6 +419,7 @@ class AsyncSandboxClient(Generic[T]):
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
         span = trace.get_current_span()
         if span.is_recording():
@@ -438,7 +442,8 @@ class AsyncSandboxClient(Generic[T]):
             labels=labels,
             lifecycle=lifecycle,
             volume_claim_templates=volume_claim_templates,
-            pod_metadata=pod_metadata
+            pod_metadata=pod_metadata,
+            env=env,
         )
 
     @async_trace_span("wait_for_sandbox_ready")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -172,6 +172,9 @@ class AsyncSandboxClient(Generic[T]):
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
             env: Optional environment variables to inject into the SandboxClaim.
+                Setting this populates ``spec.env`` and forces a cold start
+                from the warm pool template instead of adopting a pre-warmed
+                pod, which may increase startup latency.
 
         Example::
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -148,6 +148,7 @@ class AsyncSandboxClient(Generic[T]):
         volume_claim_templates: list[dict] | None = None,
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
     ) -> T:
         """Provisions a new Sandbox claim and returns an async Sandbox handle.
 
@@ -170,6 +171,7 @@ class AsyncSandboxClient(Generic[T]):
                 the sandbox through the Downward API.
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
+            env: Optional environment variables to inject into the SandboxClaim.
 
         Example::
 
@@ -197,7 +199,8 @@ class AsyncSandboxClient(Generic[T]):
                 labels=labels,
                 lifecycle=lifecycle,
                 volume_claim_templates=volume_claim_templates,
-                pod_metadata=pod_metadata
+                pod_metadata=pod_metadata,
+                env=env,
             )
             # Wait for the claim to be bound and Ready in a single watch.
             # The claim status carries the sandbox name (which differs from
@@ -419,6 +422,7 @@ class AsyncSandboxClient(Generic[T]):
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
         span = trace.get_current_span()
         if span.is_recording():
@@ -441,7 +445,8 @@ class AsyncSandboxClient(Generic[T]):
             labels=labels,
             lifecycle=lifecycle,
             volume_claim_templates=volume_claim_templates,
-            pod_metadata=pod_metadata
+            pod_metadata=pod_metadata,
+            env=env,
         )
 
     @async_trace_span("wait_for_claim_ready")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -86,7 +86,10 @@ class K8sHelper:
             spec["additionalPodMetadata"] = pod_metadata
         env_spec = construct_sandbox_claim_env_spec(env)
         if env_spec:
-            spec["env"] = env_spec
+            spec["env"] = [
+                env_var.model_dump(by_alias=True, exclude_none=True)
+                for env_var in env_spec
+            ]
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -17,7 +17,12 @@ import time
 from typing import List
 from kubernetes import client, config, watch
 from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
-from .utils import is_valid_ip, is_valid_gateway_hostname
+from .utils import (
+    construct_sandbox_claim_env_spec,
+    is_valid_gateway_hostname,
+    is_valid_ip,
+    select_pod_ip,
+)
 from .constants import (
     CLAIM_API_GROUP,
     CLAIM_API_VERSION,
@@ -29,7 +34,6 @@ from .constants import (
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
 )
-from .utils import select_pod_ip
 
 class K8sHelper:
     """Helper class for Kubernetes API interactions."""
@@ -51,11 +55,11 @@ class K8sHelper:
         labels: dict | None = None,
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
-        pod_metadata: dict | None = None
+        pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
-        """
-        Creates a SandboxClaim custom resource.
-        
+        """Creates a SandboxClaim custom resource.
+
         Args:
             pod_metadata: Optional ``{"labels": {...}, "annotations": {...}}``
                 dict emitted as ``spec.additionalPodMetadata`` so the labels and
@@ -80,6 +84,9 @@ class K8sHelper:
             spec["volumeClaimTemplates"] = volume_claim_templates
         if pod_metadata:
             spec["additionalPodMetadata"] = pod_metadata
+        env_spec = construct_sandbox_claim_env_spec(env)
+        if env_spec:
+            spec["env"] = env_spec
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -17,8 +17,14 @@ import time
 from datetime import datetime, UTC
 from typing import List
 from kubernetes import client, config, watch
+<<<<<<< HEAD
 from .exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
-from .utils import is_valid_ip, is_valid_gateway_hostname
+from .utils import (
+    construct_sandbox_claim_env_spec,
+    is_valid_gateway_hostname,
+    is_valid_ip,
+    select_pod_ip,
+)
 from .constants import (
     CLAIM_API_GROUP,
     CLAIM_API_VERSION,
@@ -33,7 +39,6 @@ from .constants import (
     SANDBOX_PLURAL_NAME,
     CREATED_BY_LABEL,
 )
-from .utils import select_pod_ip
 
 class K8sHelper:
     """Helper class for Kubernetes API interactions."""
@@ -55,11 +60,11 @@ class K8sHelper:
         labels: dict | None = None,
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
-        pod_metadata: dict | None = None
+        pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
-        """
-        Creates a SandboxClaim custom resource.
-        
+        """Creates a SandboxClaim custom resource.
+
         Args:
             pod_metadata: Optional ``{"labels": {...}, "annotations": {...}}``
                 dict emitted as ``spec.additionalPodMetadata`` so the labels and
@@ -90,6 +95,9 @@ class K8sHelper:
             spec["volumeClaimTemplates"] = volume_claim_templates
         if pod_metadata:
             spec["additionalPodMetadata"] = pod_metadata
+        env_spec = construct_sandbox_claim_env_spec(env)
+        if env_spec:
+            spec["env"] = env_spec
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -17,7 +17,6 @@ import time
 from datetime import datetime, UTC
 from typing import List
 from kubernetes import client, config, watch
-<<<<<<< HEAD
 from .exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
 from .utils import (
     construct_sandbox_claim_env_spec,
@@ -97,7 +96,10 @@ class K8sHelper:
             spec["additionalPodMetadata"] = pod_metadata
         env_spec = construct_sandbox_claim_env_spec(env)
         if env_spec:
-            spec["env"] = env_spec
+            spec["env"] = [
+                env_var.model_dump(by_alias=True, exclude_none=True)
+                for env_var in env_spec
+            ]
 
         manifest = {
             "apiVersion": f"{CLAIM_API_GROUP}/{CLAIM_API_VERSION}",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -16,6 +16,8 @@ import re
 from typing import Literal, Union
 from pydantic import BaseModel, Field, field_validator
 
+_ENV_VAR_NAME_RE = re.compile(r"^[-._a-zA-Z][-._a-zA-Z0-9]*$")
+
 class ExecutionResult(BaseModel):
     """A structured object for holding the result of a command execution."""
     stdout: str = ""  # Standard output from the command.
@@ -34,6 +36,20 @@ class SandboxClaimEnvVar(BaseModel):
     name: str  # Name of the environment variable.
     value: str  # Value of the environment variable.
     container_name: str | None = Field(default=None, serialization_alias="containerName")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not _ENV_VAR_NAME_RE.match(v):
+            raise ValueError(
+                "Invalid environment variable name: must consist of alphabetic "
+                "characters, digits, '_', '-', or '.', and must not start with a digit"
+            )
+        if v == "." or v == ".." or v.startswith(".."):
+            raise ValueError(
+                "Invalid environment variable name: must not be '.', '..', or start with '..'"
+            )
+        return v
 
 class SandboxDirectConnectionConfig(BaseModel):
     """Configuration for connecting directly to a Sandbox URL."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -14,7 +14,7 @@
 
 import re
 from typing import Literal, Union
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 class ExecutionResult(BaseModel):
     """A structured object for holding the result of a command execution."""
@@ -28,6 +28,12 @@ class FileEntry(BaseModel):
     size: int  # Size of the file in bytes.
     type: Literal["file", "directory"]  # Type of the entry (file or directory).
     mod_time: float # Last modification time of the file. (POSIX timestamp)
+
+class SandboxClaimEnvVar(BaseModel):
+    """Represents an environment variable entry in a SandboxClaim spec."""
+    name: str  # Name of the environment variable.
+    value: str  # Value of the environment variable.
+    container_name: str | None = Field(default=None, serialization_alias="containerName")
 
 class SandboxDirectConnectionConfig(BaseModel):
     """Configuration for connecting directly to a Sandbox URL."""
@@ -77,4 +83,3 @@ class SandboxTracerConfig(BaseModel):
     """Configuration for tracer level information"""
     enable_tracing: bool = False  # Whether to enable OpenTelemetry tracing.
     trace_service_name: str = "sandbox-client"  # Service name used for traces.
-    

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -15,7 +15,7 @@
 import re
 from datetime import datetime, timezone
 from typing import Literal, Optional, Union
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 class ExecutionResult(BaseModel):
     """A structured object for holding the result of a command execution."""
@@ -57,6 +57,12 @@ class FileEntry(BaseModel):
             modified=datetime.fromisoformat(entry["modified_at"].replace("Z", "+00:00")),
             mode=entry.get("mode"),
         )
+
+class SandboxClaimEnvVar(BaseModel):
+    """Represents an environment variable entry in a SandboxClaim spec."""
+    name: str  # Name of the environment variable.
+    value: str  # Value of the environment variable.
+    container_name: str | None = Field(default=None, serialization_alias="containerName")
 
 class SandboxDirectConnectionConfig(BaseModel):
     """Configuration for connecting directly to a Sandbox URL."""
@@ -122,4 +128,3 @@ class SandboxTracerConfig(BaseModel):
     """Configuration for tracer level information"""
     enable_tracing: bool = False  # Whether to enable OpenTelemetry tracing.
     trace_service_name: str = "sandbox-client"  # Service name used for traces.
-    

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from typing import Literal, Optional, Union
 from pydantic import BaseModel, Field, field_validator
 
+_ENV_VAR_NAME_RE = re.compile(r"^[-._a-zA-Z][-._a-zA-Z0-9]*$")
+
 class ExecutionResult(BaseModel):
     """A structured object for holding the result of a command execution."""
     stdout: str = ""  # Standard output from the command.
@@ -63,6 +65,20 @@ class SandboxClaimEnvVar(BaseModel):
     name: str  # Name of the environment variable.
     value: str  # Value of the environment variable.
     container_name: str | None = Field(default=None, serialization_alias="containerName")
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not _ENV_VAR_NAME_RE.match(v):
+            raise ValueError(
+                "Invalid environment variable name: must consist of alphabetic "
+                "characters, digits, '_', '-', or '.', and must not start with a digit"
+            )
+        if v == "." or v == ".." or v.startswith(".."):
+            raise ValueError(
+                "Invalid environment variable name: must not be '.', '..', or start with '..'"
+            )
+        return v
 
 class SandboxDirectConnectionConfig(BaseModel):
     """Configuration for connecting directly to a Sandbox URL."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -100,10 +100,11 @@ class SandboxClient(Generic[T]):
         *,
         shutdown_after_seconds: int | None = None,
         volume_claim_templates: list[dict] | None = None,
-        pod_labels: dict[str, str] | None = None, 
-        pod_annotations: dict[str, str] | None = None
+        pod_labels: dict[str, str] | None = None,
+        pod_annotations: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
     ) -> T:
-        """Provisions new Sandbox claim and returns a Sandbox handle which tracks 
+        """Provisions new Sandbox claim and returns a Sandbox handle which tracks
            the underlying infrastructure.
 
         Args:
@@ -125,6 +126,7 @@ class SandboxClient(Generic[T]):
                 the sandbox through the Downward API.
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
+            env: Optional environment variables to inject into the SandboxClaim.
 
         Example:
 
@@ -153,6 +155,7 @@ class SandboxClient(Generic[T]):
                 lifecycle=lifecycle,
                 volume_claim_templates=volume_claim_templates,
                 pod_metadata=pod_metadata,
+                env=env,
             )
             # Resolve the sandbox id from the sandbox claim object.
             # In case of warmpool, sandbox id is not the same as claim name.
@@ -325,6 +328,7 @@ class SandboxClient(Generic[T]):
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
         """Creates the SandboxClaim custom resource in the Kubernetes cluster."""
         span = trace.get_current_span()
@@ -349,6 +353,7 @@ class SandboxClient(Generic[T]):
             lifecycle=lifecycle,
             volume_claim_templates=volume_claim_templates,
             pod_metadata=pod_metadata,
+            env=env,
         )
 
     @trace_span("wait_for_sandbox_ready")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -127,6 +127,9 @@ class SandboxClient(Generic[T]):
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
             env: Optional environment variables to inject into the SandboxClaim.
+                Setting this populates ``spec.env`` and forces a cold start
+                from the warm pool template instead of adopting a pre-warmed
+                pod, which may increase startup latency.
 
         Example:
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -126,6 +126,9 @@ class SandboxClient(Generic[T]):
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
             env: Optional environment variables to inject into the SandboxClaim.
+                Setting this populates ``spec.env`` and forces a cold start
+                from the warm pool template instead of adopting a pre-warmed
+                pod, which may increase startup latency.
 
         Example:
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -99,10 +99,11 @@ class SandboxClient(Generic[T]):
         *,
         shutdown_after_seconds: int | None = None,
         volume_claim_templates: list[dict] | None = None,
-        pod_labels: dict[str, str] | None = None, 
-        pod_annotations: dict[str, str] | None = None
+        pod_labels: dict[str, str] | None = None,
+        pod_annotations: dict[str, str] | None = None,
+        env: dict[str, str] | None = None,
     ) -> T:
-        """Provisions new Sandbox claim and returns a Sandbox handle which tracks 
+        """Provisions new Sandbox claim and returns a Sandbox handle which tracks
            the underlying infrastructure.
 
         Args:
@@ -124,6 +125,7 @@ class SandboxClient(Generic[T]):
                 the sandbox through the Downward API.
             pod_annotations: Optional annotations stamped onto the running
                 Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
+            env: Optional environment variables to inject into the SandboxClaim.
 
         Example:
 
@@ -152,6 +154,7 @@ class SandboxClient(Generic[T]):
                 lifecycle=lifecycle,
                 volume_claim_templates=volume_claim_templates,
                 pod_metadata=pod_metadata,
+                env=env,
             )
             # Wait for the claim to be bound and Ready in a single watch.
             # The claim status carries the sandbox name (which differs from
@@ -326,6 +329,7 @@ class SandboxClient(Generic[T]):
         lifecycle: dict | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_metadata: dict | None = None,
+        env: dict[str, str] | None = None,
     ):
         """Creates the SandboxClaim custom resource in the Kubernetes cluster."""
         span = trace.get_current_span()
@@ -350,6 +354,7 @@ class SandboxClient(Generic[T]):
             lifecycle=lifecycle,
             volume_claim_templates=volume_claim_templates,
             pod_metadata=pod_metadata,
+            env=env,
         )
 
     @trace_span("wait_for_claim_ready")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -32,6 +32,24 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.helper.custom_objects_api.create_namespaced_custom_object = AsyncMock()
         self.helper.core_v1_api = MagicMock()
 
+    async def test_env_included_in_manifest(self):
+        await self.helper.create_sandbox_claim(
+            "test-claim",
+            "test-warmpool",
+            "test-namespace",
+            env={"FOO": "bar", "DEBUG": "true"},
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertEqual(
+            body["spec"]["env"],
+            [
+                {"name": "FOO", "value": "bar"},
+                {"name": "DEBUG", "value": "true"},
+            ],
+        )
+
     async def test_lifecycle_included_in_manifest(self):
         lifecycle = {
             "shutdownTime": "2026-12-31T23:59:59Z",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -35,6 +35,24 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         self.helper.custom_objects_api.create_namespaced_custom_object = AsyncMock()
         self.helper.core_v1_api = MagicMock()
 
+    async def test_env_included_in_manifest(self):
+        await self.helper.create_sandbox_claim(
+            "test-claim",
+            "test-warmpool",
+            "test-namespace",
+            env={"FOO": "bar", "DEBUG": "true"},
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertEqual(
+            body["spec"]["env"],
+            [
+                {"name": "FOO", "value": "bar"},
+                {"name": "DEBUG", "value": "true"},
+            ],
+        )
+
     async def test_lifecycle_included_in_manifest(self):
         lifecycle = {
             "shutdownTime": "2026-12-31T23:59:59Z",

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -73,13 +73,41 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 labels=None,
                 lifecycle=None,
                 volume_claim_templates=None,
-                pod_metadata=None
+                pod_metadata=None,
+                env=None,
             )
 
             self.assertEqual(sandbox, mock_sandbox_instance)
 
             active = await self.client.list_active_sandboxes()
             self.assertEqual(len(active), 1)
+
+    @patch("uuid.uuid4")
+    async def test_create_sandbox_with_env(self, mock_uuid):
+        mock_uuid.return_value.hex = "1234abcd"
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+
+        mock_sandbox_instance = MagicMock()
+        mock_sandbox_instance.terminate = AsyncMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        env = {"FOO": "bar", "DEBUG": "true"}
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+             patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+
+            await self.client.create_sandbox("test-warmpool", "test-namespace", env=env)
+
+            mock_create.assert_called_once_with(
+                "sandbox-claim-1234abcd",
+                "test-warmpool",
+                "test-namespace",
+                labels=None,
+                lifecycle=None,
+                volume_claim_templates=None,
+                pod_metadata=None,
+                env=env,
+            )
 
     async def test_create_sandbox_failure_cleanup(self):
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(
@@ -349,6 +377,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 lifecycle=None,
                 volume_claim_templates=vcts,
                 pod_metadata=None,
+                env=None,
             )
 
     async def test_create_claim_with_volume_claim_templates(self):
@@ -374,6 +403,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             lifecycle=None,
             volume_claim_templates=vcts,
             pod_metadata=None,
+            env=None,
         )
 
     async def test_create_sandbox_without_shutdown_after_seconds(self):
@@ -390,6 +420,26 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             call_kwargs = mock_create.call_args
             lifecycle = call_kwargs[1].get("lifecycle")
             self.assertIsNone(lifecycle)
+
+    async def test_create_claim_with_env(self):
+        self.client.tracing_manager = MagicMock()
+        self.client.tracing_manager.get_trace_context_json.return_value = None
+        self.mock_k8s_helper.create_sandbox_claim = AsyncMock()
+
+        env = {"FOO": "bar"}
+        await self.client._create_claim("test-claim", "test-warmpool", "test-namespace", env=env)
+
+        self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
+            "test-claim",
+            "test-warmpool",
+            "test-namespace",
+            annotations={},
+            labels=None,
+            lifecycle=None,
+            volume_claim_templates=None,
+            pod_metadata=None,
+            env=env,
+        )
 
     async def test_shutdown_after_seconds_validation_zero(self):
         with self.assertRaises(ValueError):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -85,7 +85,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
     @patch("uuid.uuid4")
     async def test_create_sandbox_with_env(self, mock_uuid):
         mock_uuid.return_value.hex = "1234abcd"
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="resolved-id")
 
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
@@ -93,8 +93,8 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
 
         env = {"FOO": "bar", "DEBUG": "true"}
 
-        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
-             patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = {"metadata": {"resourceVersion": "12345"}}
 
             await self.client.create_sandbox("test-warmpool", "test-namespace", env=env)
 
@@ -107,6 +107,9 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 volume_claim_templates=None,
                 pod_metadata=None,
                 env=env,
+            )
+            self.mock_k8s_helper.wait_for_claim_ready.assert_awaited_once_with(
+                "sandbox-claim-1234abcd", "test-namespace", 180, resource_version="12345"
             )
 
     async def test_create_sandbox_failure_cleanup(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -73,13 +73,41 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 labels=None,
                 lifecycle=None,
                 volume_claim_templates=None,
-                pod_metadata=None
+                pod_metadata=None,
+                env=None,
             )
 
             self.assertEqual(sandbox, mock_sandbox_instance)
 
             active = await self.client.list_active_sandboxes()
             self.assertEqual(len(active), 1)
+
+    @patch("uuid.uuid4")
+    async def test_create_sandbox_with_env(self, mock_uuid):
+        mock_uuid.return_value.hex = "1234abcd"
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+
+        mock_sandbox_instance = MagicMock()
+        mock_sandbox_instance.terminate = AsyncMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        env = {"FOO": "bar", "DEBUG": "true"}
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+             patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+
+            await self.client.create_sandbox("test-warmpool", "test-namespace", env=env)
+
+            mock_create.assert_called_once_with(
+                "sandbox-claim-1234abcd",
+                "test-warmpool",
+                "test-namespace",
+                labels=None,
+                lifecycle=None,
+                volume_claim_templates=None,
+                pod_metadata=None,
+                env=env,
+            )
 
     async def test_create_sandbox_failure_cleanup(self):
         self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(
@@ -349,6 +377,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 lifecycle=None,
                 volume_claim_templates=vcts,
                 pod_metadata=None,
+                env=None,
             )
 
     async def test_create_claim_with_volume_claim_templates(self):
@@ -374,6 +403,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             lifecycle=None,
             volume_claim_templates=vcts,
             pod_metadata=None,
+            env=None,
         )
 
     async def test_create_sandbox_without_shutdown_after_seconds(self):
@@ -390,6 +420,26 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             call_kwargs = mock_create.call_args
             lifecycle = call_kwargs[1].get("lifecycle")
             self.assertIsNone(lifecycle)
+
+    async def test_create_claim_with_env(self):
+        self.client.tracing_manager = MagicMock()
+        self.client.tracing_manager.get_trace_context_json.return_value = None
+        self.mock_k8s_helper.create_sandbox_claim = AsyncMock()
+
+        env = {"FOO": "bar"}
+        await self.client._create_claim("test-claim", "test-warmpool", "test-namespace", env=env)
+
+        self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
+            "test-claim",
+            "test-warmpool",
+            "test-namespace",
+            annotations={},
+            labels=None,
+            lifecycle=None,
+            volume_claim_templates=None,
+            pod_metadata=None,
+            env=env,
+        )
 
     async def test_shutdown_after_seconds_validation_zero(self):
         with self.assertRaises(ValueError):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -25,6 +25,27 @@ from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNo
 @patch("k8s_agent_sandbox.k8s_helper.config")
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
+    def test_env_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim",
+            "test-warmpool",
+            "test-namespace",
+            env={"FOO": "bar", "DEBUG": "true"},
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(
+            body["spec"]["env"],
+            [
+                {"name": "FOO", "value": "bar"},
+                {"name": "DEBUG", "value": "true"},
+            ],
+        )
+
     def test_labels_and_annotations_coexist_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -41,6 +41,19 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         with self.assertRaises(ValidationError):
             SandboxClaimEnvVar(name="FOO", value=1)
 
+    def test_env_var_model_accepts_kubernetes_env_var_names(self, mock_config, mock_api_cls, mock_core_cls):
+        valid_names = ["FOO", "_FOO", "my.env-name", "MY_ENV.NAME", "MyEnvName1"]
+
+        for name in valid_names:
+            self.assertEqual(SandboxClaimEnvVar(name=name, value="bar").name, name)
+
+    def test_env_var_model_rejects_invalid_names(self, mock_config, mock_api_cls, mock_core_cls):
+        invalid_names = ["", "1FOO", "BAD NAME", "BAD=NAME", ".", "..", "..FOO"]
+
+        for name in invalid_names:
+            with self.assertRaises(ValidationError):
+                SandboxClaimEnvVar(name=name, value="bar")
+
     def test_env_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -16,14 +16,30 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from kubernetes import client
+from pydantic import ValidationError
 from k8s_agent_sandbox.k8s_helper import K8sHelper
 from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
+from k8s_agent_sandbox.models import SandboxClaimEnvVar
 
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
 @patch("k8s_agent_sandbox.k8s_helper.config")
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
+
+    def test_env_var_model_serializes_container_name_alias(self, mock_config, mock_api_cls, mock_core_cls):
+        env_var = SandboxClaimEnvVar(
+            name="FOO", value="bar", container_name="runtime"
+        )
+
+        self.assertEqual(
+            env_var.model_dump(by_alias=True, exclude_none=True),
+            {"name": "FOO", "value": "bar", "containerName": "runtime"},
+        )
+
+    def test_env_var_model_rejects_non_string_values(self, mock_config, mock_api_cls, mock_core_cls):
+        with self.assertRaises(ValidationError):
+            SandboxClaimEnvVar(name="FOO", value=1)
 
     def test_env_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -26,6 +26,27 @@ from k8s_agent_sandbox.constants import CLIENT_REQUEST_TIME_ANNOTATION
 @patch("k8s_agent_sandbox.k8s_helper.config")
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
+    def test_env_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim",
+            "test-warmpool",
+            "test-namespace",
+            env={"FOO": "bar", "DEBUG": "true"},
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(
+            body["spec"]["env"],
+            [
+                {"name": "FOO", "value": "bar"},
+                {"name": "DEBUG", "value": "true"},
+            ],
+        )
+
     def test_labels_and_annotations_coexist_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -16,15 +16,31 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from kubernetes import client
+from pydantic import ValidationError
 from k8s_agent_sandbox.k8s_helper import K8sHelper
 from k8s_agent_sandbox.exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxTemplateNotFoundError
 from k8s_agent_sandbox.constants import CLIENT_REQUEST_TIME_ANNOTATION
+from k8s_agent_sandbox.models import SandboxClaimEnvVar
 
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
 @patch("k8s_agent_sandbox.k8s_helper.config")
 class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
+
+    def test_env_var_model_serializes_container_name_alias(self, mock_config, mock_api_cls, mock_core_cls):
+        env_var = SandboxClaimEnvVar(
+            name="FOO", value="bar", container_name="runtime"
+        )
+
+        self.assertEqual(
+            env_var.model_dump(by_alias=True, exclude_none=True),
+            {"name": "FOO", "value": "bar", "containerName": "runtime"},
+        )
+
+    def test_env_var_model_rejects_non_string_values(self, mock_config, mock_api_cls, mock_core_cls):
+        with self.assertRaises(ValidationError):
+            SandboxClaimEnvVar(name="FOO", value=1)
 
     def test_env_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -42,6 +42,19 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         with self.assertRaises(ValidationError):
             SandboxClaimEnvVar(name="FOO", value=1)
 
+    def test_env_var_model_accepts_kubernetes_env_var_names(self, mock_config, mock_api_cls, mock_core_cls):
+        valid_names = ["FOO", "_FOO", "my.env-name", "MY_ENV.NAME", "MyEnvName1"]
+
+        for name in valid_names:
+            self.assertEqual(SandboxClaimEnvVar(name=name, value="bar").name, name)
+
+    def test_env_var_model_rejects_invalid_names(self, mock_config, mock_api_cls, mock_core_cls):
+        invalid_names = ["", "1FOO", "BAD NAME", "BAD=NAME", ".", "..", "..FOO"]
+
+        for name in invalid_names:
+            with self.assertRaises(ValidationError):
+                SandboxClaimEnvVar(name=name, value="bar")
+
     def test_env_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -74,8 +74,8 @@ class TestSandboxClient(unittest.TestCase):
                 lifecycle=None,
                 volume_claim_templates=None,
                 pod_metadata=None,
+                env=None,
             )
-
             self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
             mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
             self.assertEqual(sandbox, mock_sandbox_instance)
@@ -219,6 +219,7 @@ class TestSandboxClient(unittest.TestCase):
                 lifecycle=None,
                 volume_claim_templates=None,
                 pod_metadata=None,
+                env=None,
             )
 
     @patch('uuid.uuid4')
@@ -247,6 +248,7 @@ class TestSandboxClient(unittest.TestCase):
                     "labels": {"client-id": "tenant-a"},
                     "annotations": {"note": "owned-by-tenant-a"},
                 },
+                env=None,
             )
 
     def test_create_sandbox_rejects_invalid_pod_label(self):
@@ -279,6 +281,7 @@ class TestSandboxClient(unittest.TestCase):
                 lifecycle=None,
                 volume_claim_templates=vcts,
                 pod_metadata=None,
+                env=None,
             )
 
     def test_create_claim_with_volume_claim_templates(self):
@@ -300,6 +303,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=vcts,
             pod_metadata=None,
+            env=None,
         )
 
     def test_create_claim_with_labels(self):
@@ -316,6 +320,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
         )
 
     def test_create_claim_with_pod_metadata(self):
@@ -334,6 +339,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata={"labels": {"client-id": "tenant-a"}},
+            env=None,
         )
 
     def test_create_claim(self):
@@ -349,6 +355,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
         )
 
     def test_validate_labels_rejects_invalid_value(self):
@@ -422,6 +429,32 @@ class TestSandboxClient(unittest.TestCase):
             self.assertIn("shutdownTime", lifecycle)
 
     @patch('uuid.uuid4')
+    def test_create_sandbox_with_env(self, mock_uuid):
+        mock_uuid.return_value.hex = '1234abcd'
+        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+
+        mock_sandbox_instance = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        env = {"FOO": "bar", "DEBUG": "true"}
+
+        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+             patch.object(self.client, '_wait_for_sandbox_ready'):
+
+            self.client.create_sandbox("test-warmpool", "test-namespace", env=env)
+
+            mock_create_claim.assert_called_once_with(
+                "sandbox-claim-1234abcd",
+                "test-warmpool",
+                "test-namespace",
+                labels=None,
+                lifecycle=None,
+                volume_claim_templates=None,
+                pod_metadata=None,
+                env=env,
+            )
+
+    @patch('uuid.uuid4')
     def test_create_sandbox_without_shutdown_after_seconds(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
@@ -462,6 +495,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=lifecycle,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
         )
 
     def test_create_claim_without_lifecycle(self):
@@ -477,6 +511,24 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
+        )
+
+    def test_create_claim_with_env(self):
+        self.client.tracing_manager = MagicMock()
+        self.client.tracing_manager.get_trace_context_json.return_value = None
+
+        env = {"FOO": "bar"}
+        self.client._create_claim("test-claim", "test-warmpool", "test-namespace", env=env)
+
+        self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
+            "test-claim", "test-warmpool", "test-namespace",
+            annotations={},
+            labels=None,
+            lifecycle=None,
+            volume_claim_templates=None,
+            pod_metadata=None,
+            env=env,
         )
 
     def test_shutdown_after_seconds_validation_zero(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -76,8 +76,8 @@ class TestSandboxClient(unittest.TestCase):
                 lifecycle=None,
                 volume_claim_templates=None,
                 pod_metadata=None,
+                env=None,
             )
-
             # A single claim watch resolves the sandbox name AND readiness;
             # no separate wait on the Sandbox resource. The watch starts at
             # the created claim's resourceVersion.
@@ -225,6 +225,7 @@ class TestSandboxClient(unittest.TestCase):
                 lifecycle=None,
                 volume_claim_templates=None,
                 pod_metadata=None,
+                env=None,
             )
 
     @patch('uuid.uuid4')
@@ -253,6 +254,7 @@ class TestSandboxClient(unittest.TestCase):
                     "labels": {"client-id": "tenant-a"},
                     "annotations": {"note": "owned-by-tenant-a"},
                 },
+                env=None,
             )
 
     def test_create_sandbox_rejects_invalid_pod_label(self):
@@ -285,6 +287,7 @@ class TestSandboxClient(unittest.TestCase):
                 lifecycle=None,
                 volume_claim_templates=vcts,
                 pod_metadata=None,
+                env=None,
             )
 
     def test_create_claim_with_volume_claim_templates(self):
@@ -306,6 +309,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=vcts,
             pod_metadata=None,
+            env=None,
         )
 
     def test_create_claim_with_labels(self):
@@ -322,6 +326,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
         )
 
     def test_create_claim_with_pod_metadata(self):
@@ -340,6 +345,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata={"labels": {"client-id": "tenant-a"}},
+            env=None,
         )
 
     def test_create_claim(self):
@@ -355,6 +361,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
         )
 
     def test_validate_labels_rejects_invalid_value(self):
@@ -428,6 +435,32 @@ class TestSandboxClient(unittest.TestCase):
             self.assertIn("shutdownTime", lifecycle)
 
     @patch('uuid.uuid4')
+    def test_create_sandbox_with_env(self, mock_uuid):
+        mock_uuid.return_value.hex = '1234abcd'
+        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+
+        mock_sandbox_instance = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        env = {"FOO": "bar", "DEBUG": "true"}
+
+        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+             patch.object(self.client, '_wait_for_sandbox_ready'):
+
+            self.client.create_sandbox("test-warmpool", "test-namespace", env=env)
+
+            mock_create_claim.assert_called_once_with(
+                "sandbox-claim-1234abcd",
+                "test-warmpool",
+                "test-namespace",
+                labels=None,
+                lifecycle=None,
+                volume_claim_templates=None,
+                pod_metadata=None,
+                env=env,
+            )
+
+    @patch('uuid.uuid4')
     def test_create_sandbox_without_shutdown_after_seconds(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
@@ -468,6 +501,7 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=lifecycle,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
         )
 
     def test_create_claim_without_lifecycle(self):
@@ -483,6 +517,24 @@ class TestSandboxClient(unittest.TestCase):
             lifecycle=None,
             volume_claim_templates=None,
             pod_metadata=None,
+            env=None,
+        )
+
+    def test_create_claim_with_env(self):
+        self.client.tracing_manager = MagicMock()
+        self.client.tracing_manager.get_trace_context_json.return_value = None
+
+        env = {"FOO": "bar"}
+        self.client._create_claim("test-claim", "test-warmpool", "test-namespace", env=env)
+
+        self.mock_k8s_helper.create_sandbox_claim.assert_called_once_with(
+            "test-claim", "test-warmpool", "test-namespace",
+            annotations={},
+            labels=None,
+            lifecycle=None,
+            volume_claim_templates=None,
+            pod_metadata=None,
+            env=env,
         )
 
     def test_shutdown_after_seconds_validation_zero(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -18,6 +18,8 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 import ipaddress
 
+from .models import SandboxClaimEnvVar
+
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
     """Construct a SandboxClaim lifecycle spec dict from a TTL in seconds.
@@ -148,12 +150,12 @@ def is_valid_gateway_hostname(s: str) -> bool:
     return last != '-' and last != '.'
 
 
-def construct_sandbox_claim_env_spec(env: Mapping[str, str] | None) -> list[dict[str, str]]:
-    """Construct a SandboxClaim env spec list from a mapping of names to values."""
+def construct_sandbox_claim_env_spec(env: Mapping[str, str] | None) -> list[SandboxClaimEnvVar]:
+    """Construct SandboxClaim env spec entries from a mapping of names to values."""
     if not env:
         return []
 
     return [
-        {"name": name, "value": value}
+        SandboxClaimEnvVar(name=name, value=value)
         for name, value in env.items()
     ]

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -146,3 +146,14 @@ def is_valid_gateway_hostname(s: str) -> bool:
             return False
     last = s[-1]
     return last != '-' and last != '.'
+
+
+def construct_sandbox_claim_env_spec(env: Mapping[str, str] | None) -> list[dict[str, str]]:
+    """Construct a SandboxClaim env spec list from a mapping of names to values."""
+    if not env:
+        return []
+
+    return [
+        {"name": name, "value": value}
+        for name, value in env.items()
+    ]

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -191,3 +191,14 @@ def extract_sandbox_name_hash(sandbox_object: dict[str, Any]) -> str | None:
             return value.strip() or None
 
     return None
+
+
+def construct_sandbox_claim_env_spec(env: Mapping[str, str] | None) -> list[dict[str, str]]:
+    """Construct a SandboxClaim env spec list from a mapping of names to values."""
+    if not env:
+        return []
+
+    return [
+        {"name": name, "value": value}
+        for name, value in env.items()
+    ]

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -22,6 +22,7 @@ import time
 from typing import Any
 
 from .constants import SANDBOX_NAME_HASH_LABEL
+from .models import SandboxClaimEnvVar
 
 
 def record_latency(metric):
@@ -51,7 +52,6 @@ def record_latency(metric):
                     metric.labels(status=status).observe(duration)
         return wrapper
     return decorator
-
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:
     """Construct a SandboxClaim lifecycle spec dict from a TTL in seconds.
@@ -193,12 +193,12 @@ def extract_sandbox_name_hash(sandbox_object: dict[str, Any]) -> str | None:
     return None
 
 
-def construct_sandbox_claim_env_spec(env: Mapping[str, str] | None) -> list[dict[str, str]]:
-    """Construct a SandboxClaim env spec list from a mapping of names to values."""
+def construct_sandbox_claim_env_spec(env: Mapping[str, str] | None) -> list[SandboxClaimEnvVar]:
+    """Construct SandboxClaim env spec entries from a mapping of names to values."""
     if not env:
         return []
 
     return [
-        {"name": name, "value": value}
+        SandboxClaimEnvVar(name=name, value=value)
         for name, value in env.items()
     ]

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -582,6 +582,10 @@ type Options struct {
     // ServerPort is the port the sandbox runtime listens on. Default: 8888.
     ServerPort int
 
+    // Env is the list of environment variables to inject into the SandboxClaim.
+    // Setting Env forces a cold start from the warm pool template.
+    Env []extv1beta1.EnvVar
+
     // SandboxReadyTimeout is how long to wait for the sandbox to become ready. Default: 180s.
     SandboxReadyTimeout time.Duration
 

--- a/docs/python_sdk_reference.md
+++ b/docs/python_sdk_reference.md
@@ -59,7 +59,8 @@ def create_sandbox(warmpool: str,
                    shutdown_after_seconds: int | None = None,
                    volume_claim_templates: list[dict] | None = None,
                    pod_labels: dict[str, str] | None = None,
-                   pod_annotations: dict[str, str] | None = None) -> T
+                   pod_annotations: dict[str, str] | None = None,
+                   env: dict[str, str] | None = None) -> T
 ```
 
 Provisions new Sandbox claim and returns a Sandbox handle which tracks
@@ -85,6 +86,10 @@ the underlying infrastructure.
   the sandbox through the Downward API.
 - `pod_annotations` - Optional annotations stamped onto the running
   Sandbox **Pod** via ``spec.additionalPodMetadata.annotations``.
+- `env` - Optional environment variables to inject into the SandboxClaim.
+  Setting this populates ``spec.env`` and forces a cold start
+  from the warm pool template instead of adopting a pre-warmed
+  pod, which may increase startup latency.
   
 
 **Example**:
@@ -312,6 +317,28 @@ def from_sandboxd(cls, entry: dict) -> "FileEntry"
 
 Build from a sandboxd DirectoryListing entry.
 
+<a id="k8s_agent_sandbox.models.SandboxClaimEnvVar"></a>
+
+### SandboxClaimEnvVar Objects
+
+```python
+class SandboxClaimEnvVar(BaseModel)
+```
+
+Represents an environment variable entry in a SandboxClaim spec.
+
+<a id="k8s_agent_sandbox.models.SandboxClaimEnvVar.name"></a>
+
+##### name
+
+Name of the environment variable.
+
+<a id="k8s_agent_sandbox.models.SandboxClaimEnvVar.value"></a>
+
+##### value
+
+Value of the environment variable.
+
 <a id="k8s_agent_sandbox.models.SandboxDirectConnectionConfig"></a>
 
 ### SandboxDirectConnectionConfig Objects
@@ -469,4 +496,3 @@ Whether to enable OpenTelemetry tracing.
 ##### trace\_service\_name
 
 Service name used for traces.
-

--- a/docs/python_sdk_reference.md
+++ b/docs/python_sdk_reference.md
@@ -496,3 +496,4 @@ Whether to enable OpenTelemetry tracing.
 ##### trace\_service\_name
 
 Service name used for traces.
+


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds SDK support for injecting environment variables into SandboxClaims when creating sandboxes.

- Python sync and async clients accept an optional `env` mapping on `create_sandbox(...)` and populate `spec.env`.
- Go SDK exposes `Options.Env []extv1beta1.EnvVar` and passes it into SandboxClaim creation.
- Adds unit test coverage and updates Python/Go client documentation.

This builds on the existing SandboxClaim `spec.env` support added by #555.

#### Which issue(s) this PR is related to:
Fixes #724

#### Release Note
```release-note
Client SDKs can now inject environment variables into SandboxClaims during sandbox creation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for injecting per-sandbox environment variables at claim creation time (Go `Env` / Python `env`), propagated into the sandbox claim spec.
  * When `env` is set, sandboxes start from a cold-start template instead of using a pre-warmed pod.

* **Documentation**
  * Updated Go configuration docs and the Python “Developer Mode (Local Tunnel)” example to show how to pass `env` and describe the cold-start behavior.

* **Tests**
  * Added/expanded unit tests to verify `env` propagation and correct manifest serialization, including validation of env-var naming and value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->