### PR TITLE
feat(helm): publish chart to a GitHub Pages Helm repository

### DIFF
--- a/.github/cr.yaml
+++ b/.github/cr.yaml
@@ -1,0 +1,1 @@
+release-name-template: "helm-chart-{{ .Name }}-{{ .Version }}"

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -6,11 +6,16 @@ on:
       - main
     paths:
       - 'helm/**'
+      - '.github/cr.yaml'
+      - '.github/workflows/helm-chart-release.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
-
 jobs:
   release:
     name: Release Chart

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -1,0 +1,40 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'helm/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release Chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Push packaged charts and index.yaml to the gh-pages branch and create chart releases
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # ratchet:azure/setup-helm@v4.3.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # ratchet:helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: .
+          config: .github/cr.yaml
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/helm/README.md
+++ b/helm/README.md
@@ -5,7 +5,26 @@ CRDs are bundled in the `crds/` directory and are installed automatically by Hel
 
 ## Installation
 
-### Basic install
+### Install from the Helm repository
+
+Released chart versions are published to a Helm repository hosted on GitHub Pages.
+
+```bash
+helm repo add agent-sandbox https://kubernetes-sigs.github.io/agent-sandbox
+helm repo update
+helm install agent-sandbox agent-sandbox/agent-sandbox \
+  --namespace agent-sandbox-system \
+  --create-namespace \
+  --set image.tag=<version>
+```
+
+To list the available chart versions:
+
+```bash
+helm search repo agent-sandbox --versions
+```
+
+### Install from a local checkout
 
 ```bash
 helm install agent-sandbox ./helm/ \
@@ -101,3 +120,19 @@ The following table lists the configurable parameters and their defaults.
 | `containerSecurityContext` | Container `securityContext` for the controller; only rendered when set | `null` |
 | `podAnnotations` | Annotations added to the controller pod template (e.g. service-mesh sidecar toggles, Prometheus scrape autodiscovery) | `{}` |
 | `podLabels` | Extra labels added to the controller pod template alongside the chart's selector labels (selector labels take precedence on conflict) | `{}` |
+
+## Publishing new chart versions
+
+The [`helm-chart-release`](../.github/workflows/helm-chart-release.yml) workflow uses
+[`chart-releaser-action`](https://github.com/helm/chart-releaser-action) to package the
+chart and publish it to the Helm repository on the `gh-pages` branch.
+
+To cut a new chart release, bump `version` in [`Chart.yaml`](./Chart.yaml) and merge to
+`main`. The workflow only publishes a version that does not already have a corresponding
+`helm-chart-agent-sandbox-<version>` release (the release name is set in
+[`.github/cr.yaml`](../.github/cr.yaml)), so each release requires a version bump.
+
+> **One-time setup**: GitHub Pages must be enabled for the repository with the source set
+> to the `gh-pages` branch (Settings → Pages). The repository docs site is served
+> separately via Netlify, so this branch is dedicated to the Helm repository index.
+


### PR DESCRIPTION
## What this does

Adds a Helm chart registry hosted on GitHub Pages so users can install released chart versions with `helm repo add` instead of cloning the repo. This mirrors the approach used by [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler).

### Changes
- **`.github/workflows/helm-chart-release.yml`** — On push to `main` touching `helm/**` (plus manual `workflow_dispatch`), runs [`chart-releaser-action`](https://github.com/helm/chart-releaser-action) to package the chart and publish it to the `gh-pages` branch. `charts_dir: .` is used because the chart lives at `helm/` rather than the action's default `charts/<name>/` layout. Actions are SHA-pinned to match the repo's ratchet convention.
- **`.github/cr.yaml`** — Sets `release-name-template: helm-chart-{{ .Name }}-{{ .Version }}` so chart releases (`helm-chart-agent-sandbox-<version>`) stay distinct from the project's existing `v*` releases produced by `release.yml`.
- **`helm/README.md`** — Documents installing from the repository and a maintainer "Publishing new chart versions" section.

### Usage once published
```bash
helm repo add agent-sandbox https://kubernetes-sigs.github.io/agent-sandbox
helm repo update
helm install agent-sandbox agent-sandbox/agent-sandbox \
  --namespace agent-sandbox-system --create-namespace \
  --set image.tag=<version>
```

## Notes for maintainers
- **One-time setup required:** GitHub Pages must be enabled with the source set to the `gh-pages` branch (Settings → Pages). The docs site is served separately via Netlify, so this branch is free for the Helm repository index.
- **Each release needs a `version` bump** in `helm/Chart.yaml` — the action skips versions that already have a corresponding release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated Helm chart release workflow that publishes updates to the repository.

* **Documentation**
  * Updated installation instructions with explicit steps for adding and installing from the Helm repository.
  * Added guidance on the chart release workflow and GitHub Pages setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->