### PR TITLE
api: Add kubebuilder deprecation markers to v1alpha1 CRDs.

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -226,6 +226,7 @@ type SandboxStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:scope=Namespaced,shortName=sandbox
+// +kubebuilder:deprecatedversion:warning="agents.x-k8s.io/v1alpha1 Sandbox is deprecated; use agents.x-k8s.io/v1beta1 Sandbox instead"
 // Sandbox is the Schema for the sandboxes API.
 type Sandbox struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1alpha1/sandboxclaim_types.go
+++ b/extensions/api/v1alpha1/sandboxclaim_types.go
@@ -180,6 +180,7 @@ type SandboxStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxclaim
+// +kubebuilder:deprecatedversion:warning="extensions.agents.x-k8s.io/v1alpha1 SandboxClaim is deprecated; use extensions.agents.x-k8s.io/v1beta1 SandboxClaim instead"
 // SandboxClaim is the Schema for the sandbox Claim API.
 type SandboxClaim struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1alpha1/sandboxtemplate_types.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_types.go
@@ -141,6 +141,7 @@ type SandboxTemplateSpec struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=sandboxtemplate
+// +kubebuilder:deprecatedversion:warning="extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate is deprecated; use extensions.agents.x-k8s.io/v1beta1 SandboxTemplate instead"
 // SandboxTemplate is the Schema for the sandbox template API.
 type SandboxTemplate struct {
 	metav1.TypeMeta `json:",inline"`

--- a/extensions/api/v1alpha1/sandboxwarmpool_types.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_types.go
@@ -90,6 +90,7 @@ type SandboxWarmPoolStatus struct {
 // +kubebuilder:resource:scope=Namespaced,shortName=swp
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:deprecatedversion:warning="extensions.agents.x-k8s.io/v1alpha1 SandboxWarmPool is deprecated; use extensions.agents.x-k8s.io/v1beta1 SandboxWarmPool instead"
 // SandboxWarmPool is the Schema for the sandboxwarmpools API.
 type SandboxWarmPool struct {
 	metav1.TypeMeta `json:",inline"`

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -4016,7 +4016,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: agents.x-k8s.io/v1alpha1 Sandbox is deprecated; use agents.x-k8s.io/v1beta1
+      Sandbox instead
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -257,7 +257,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxClaim is deprecated;
+      use extensions.agents.x-k8s.io/v1beta1 SandboxClaim instead
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -4153,7 +4153,10 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate is deprecated;
+      use extensions.agents.x-k8s.io/v1beta1 SandboxTemplate instead
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -87,6 +87,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxWarmPool is deprecated;
+      use extensions.agents.x-k8s.io/v1beta1 SandboxWarmPool instead
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -4016,7 +4016,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: agents.x-k8s.io/v1alpha1 Sandbox is deprecated; use agents.x-k8s.io/v1beta1
+      Sandbox instead
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxclaims.yaml
@@ -257,7 +257,10 @@ spec:
     storage: true
     subresources:
       status: {}
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxClaim is deprecated;
+      use extensions.agents.x-k8s.io/v1beta1 SandboxClaim instead
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxtemplates.yaml
@@ -4153,7 +4153,10 @@ spec:
         type: object
     served: true
     storage: true
-  - name: v1alpha1
+  - deprecated: true
+    deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxTemplate is deprecated;
+      use extensions.agents.x-k8s.io/v1beta1 SandboxTemplate instead
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -87,6 +87,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: extensions.agents.x-k8s.io/v1alpha1 SandboxWarmPool is deprecated;
+      use extensions.agents.x-k8s.io/v1beta1 SandboxWarmPool instead
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds explicit `// +kubebuilder:deprecatedversion:warning="..."` markers to the root structs of all `v1alpha1` API types (`Sandbox`, `SandboxClaim`, `SandboxTemplate`, `SandboxWarmPool`). This ensures that `deprecated: true` and `deprecationWarning` are populated in the generated CRD manifests, allowing the Kubernetes API server to emit deprecation warnings to users applying legacy `v1alpha1` manifests.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/pull/993, #740

#### Release Note
```release-note
Added explicit deprecation warnings to v1alpha1 CRDs (`Sandbox`, `SandboxClaim`, `SandboxTemplate`, `SandboxWarmPool`). Users applying v1alpha1 manifests will now receive deprecation warnings from the Kubernetes API server.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked v1alpha1 versions of `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` APIs as deprecated. Users are directed to migrate to the corresponding v1beta1 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->