### PR TITLE
Add a nil UpdateStrategy round-trip case

### DIFF
--- a/extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go
@@ -120,3 +120,39 @@ func TestSandboxWarmPoolConversion(t *testing.T) {
 		t.Errorf("roundtrip Selector mismatch: expected %q, got %q", src.Status.Selector, roundTrip.Status.Selector)
 	}
 }
+
+// TestSandboxWarmPoolConversion_NilUpdateStrategy exercises the nil branch of
+// convertWarmPoolSpecTo/convertWarmPoolSpecFrom, ensuring a nil UpdateStrategy
+// is preserved across a full round-trip conversion.
+func TestSandboxWarmPoolConversion_NilUpdateStrategy(t *testing.T) {
+	src := &SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-warmpool",
+			Namespace: "default",
+		},
+		Spec: SandboxWarmPoolSpec{
+			Replicas:    1,
+			TemplateRef: SandboxTemplateRef{Name: "my-template"},
+			// UpdateStrategy intentionally nil to exercise the nil branch.
+			UpdateStrategy: nil,
+		},
+	}
+
+	// ConvertTo (v1alpha1 -> v1beta1) must preserve nil.
+	dst := &v1beta1.SandboxWarmPool{}
+	if err := src.ConvertTo(dst); err != nil {
+		t.Fatalf("failed to convert to v1beta1: %v", err)
+	}
+	if dst.Spec.UpdateStrategy != nil {
+		t.Errorf("expected nil UpdateStrategy after ConvertTo, got %v", dst.Spec.UpdateStrategy)
+	}
+
+	// ConvertFrom round-trip (v1beta1 -> v1alpha1) must preserve nil.
+	roundTrip := &SandboxWarmPool{}
+	if err := roundTrip.ConvertFrom(dst); err != nil {
+		t.Fatalf("failed to convert back to v1alpha1: %v", err)
+	}
+	if roundTrip.Spec.UpdateStrategy != nil {
+		t.Errorf("expected nil UpdateStrategy after round-trip, got %v", roundTrip.Spec.UpdateStrategy)
+	}
+}

--- a/extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go
@@ -23,136 +23,127 @@ import (
 )
 
 func TestSandboxWarmPoolConversion(t *testing.T) {
-	src := &SandboxWarmPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-warmpool",
-			Namespace: "default",
-			Labels: map[string]string{
-				"foo": "bar",
-			},
-			Annotations: map[string]string{
-				"baz":                                  "qux",
-				v1alpha1SandboxWarmPoolStateAnnotation: "some-old-state",
-			},
-		},
-		Spec: SandboxWarmPoolSpec{
-			Replicas: 3,
-			TemplateRef: SandboxTemplateRef{
-				Name: "my-template",
-			},
-			UpdateStrategy: &SandboxWarmPoolUpdateStrategy{
+	tests := []struct {
+		name           string
+		updateStrategy *SandboxWarmPoolUpdateStrategy
+	}{
+		{
+			name: "with update strategy",
+			updateStrategy: &SandboxWarmPoolUpdateStrategy{
 				Type: RecreateSandboxWarmPoolUpdateStrategyType,
 			},
 		},
-		Status: SandboxWarmPoolStatus{
-			Replicas:      3,
-			ReadyReplicas: 2,
-			Selector:      "app=my-warmpool",
+		{
+			// Exercises the nil branch of convertWarmPoolSpecTo/convertWarmPoolSpecFrom.
+			name:           "nil update strategy",
+			updateStrategy: nil,
 		},
 	}
 
-	// Convert to Hub (v1beta1)
-	dst := &v1beta1.SandboxWarmPool{}
-	if err := src.ConvertTo(dst); err != nil {
-		t.Fatalf("failed to convert to v1beta1: %v", err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &SandboxWarmPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-warmpool",
+					Namespace: "default",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"baz":                                  "qux",
+						v1alpha1SandboxWarmPoolStateAnnotation: "some-old-state",
+					},
+				},
+				Spec: SandboxWarmPoolSpec{
+					Replicas: 3,
+					TemplateRef: SandboxTemplateRef{
+						Name: "my-template",
+					},
+					UpdateStrategy: tc.updateStrategy,
+				},
+				Status: SandboxWarmPoolStatus{
+					Replicas:      3,
+					ReadyReplicas: 2,
+					Selector:      "app=my-warmpool",
+				},
+			}
 
-	// Verify src annotations and labels were not mutated during ConvertTo
-	if val, ok := src.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; !ok || val != "some-old-state" {
-		t.Errorf("src.Annotations was mutated during ConvertTo! expected 'some-old-state', got %q", val)
-	}
-	if len(src.Annotations) != 2 {
-		t.Errorf("expected 2 annotations in src, got %d", len(src.Annotations))
-	}
-	if len(src.Labels) != 1 {
-		t.Errorf("expected 1 label in src, got %d", len(src.Labels))
-	}
+			// Convert to Hub (v1beta1)
+			dst := &v1beta1.SandboxWarmPool{}
+			if err := src.ConvertTo(dst); err != nil {
+				t.Fatalf("failed to convert to v1beta1: %v", err)
+			}
 
-	// Verify the marshaled state in dst does not contain the state annotation itself (no nesting)
-	marshaledState := dst.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]
-	var stateObj SandboxWarmPool
-	if err := json.Unmarshal([]byte(marshaledState), &stateObj); err != nil {
-		t.Fatalf("failed to unmarshal state from dst: %v", err)
-	}
-	if _, ok := stateObj.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
-		t.Errorf("dst.Annotations state nestedly contains the state annotation! causing exponential growth")
-	}
+			// Verify src annotations and labels were not mutated during ConvertTo
+			if val, ok := src.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; !ok || val != "some-old-state" {
+				t.Errorf("src.Annotations was mutated during ConvertTo! expected 'some-old-state', got %q", val)
+			}
+			if len(src.Annotations) != 2 {
+				t.Errorf("expected 2 annotations in src, got %d", len(src.Annotations))
+			}
+			if len(src.Labels) != 1 {
+				t.Errorf("expected 1 label in src, got %d", len(src.Labels))
+			}
 
-	// Verify v1beta1 fields
-	if dst.Spec.Replicas != 3 {
-		t.Errorf("unexpected replicas: %d", dst.Spec.Replicas)
-	}
-	if dst.Spec.TemplateRef.Name != "my-template" {
-		t.Errorf("unexpected template ref: %s", dst.Spec.TemplateRef.Name)
-	}
-	if dst.Spec.UpdateStrategy == nil || string(dst.Spec.UpdateStrategy.Type) != string(RecreateSandboxWarmPoolUpdateStrategyType) {
-		t.Errorf("unexpected update strategy: %v", dst.Spec.UpdateStrategy)
-	}
-	if dst.Status.ReadyReplicas != 2 {
-		t.Errorf("unexpected ready replicas: %d", dst.Status.ReadyReplicas)
-	}
+			// Verify the marshaled state in dst does not contain the state annotation itself (no nesting)
+			marshaledState := dst.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]
+			var stateObj SandboxWarmPool
+			if err := json.Unmarshal([]byte(marshaledState), &stateObj); err != nil {
+				t.Fatalf("failed to unmarshal state from dst: %v", err)
+			}
+			if _, ok := stateObj.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
+				t.Errorf("dst.Annotations state nestedly contains the state annotation! causing exponential growth")
+			}
 
-	// Convert back to Spoke (v1alpha1)
-	roundTrip := &SandboxWarmPool{}
-	if err := roundTrip.ConvertFrom(dst); err != nil {
-		t.Fatalf("failed to convert back to v1alpha1: %v", err)
-	}
+			// Verify v1beta1 fields
+			if dst.Spec.Replicas != 3 {
+				t.Errorf("unexpected replicas: %d", dst.Spec.Replicas)
+			}
+			if dst.Spec.TemplateRef.Name != "my-template" {
+				t.Errorf("unexpected template ref: %s", dst.Spec.TemplateRef.Name)
+			}
+			if tc.updateStrategy == nil {
+				if dst.Spec.UpdateStrategy != nil {
+					t.Errorf("expected nil UpdateStrategy after ConvertTo, got %v", dst.Spec.UpdateStrategy)
+				}
+			} else if dst.Spec.UpdateStrategy == nil || string(dst.Spec.UpdateStrategy.Type) != string(tc.updateStrategy.Type) {
+				t.Errorf("unexpected update strategy: %v", dst.Spec.UpdateStrategy)
+			}
+			if dst.Status.ReadyReplicas != 2 {
+				t.Errorf("unexpected ready replicas: %d", dst.Status.ReadyReplicas)
+			}
 
-	// Verify state annotation was stripped during ConvertFrom
-	if _, ok := roundTrip.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
-		t.Errorf("roundTrip.Annotations still contains the state annotation after ConvertFrom!")
-	}
+			// Convert back to Spoke (v1alpha1)
+			roundTrip := &SandboxWarmPool{}
+			if err := roundTrip.ConvertFrom(dst); err != nil {
+				t.Fatalf("failed to convert back to v1alpha1: %v", err)
+			}
 
-	// Verify round-trip preserves all fields
-	if roundTrip.Spec.Replicas != src.Spec.Replicas {
-		t.Errorf("roundtrip Replicas mismatch: expected %d, got %d", src.Spec.Replicas, roundTrip.Spec.Replicas)
-	}
-	if roundTrip.Spec.TemplateRef.Name != src.Spec.TemplateRef.Name {
-		t.Errorf("roundtrip TemplateRef mismatch: expected %q, got %q", src.Spec.TemplateRef.Name, roundTrip.Spec.TemplateRef.Name)
-	}
-	if roundTrip.Spec.UpdateStrategy == nil || roundTrip.Spec.UpdateStrategy.Type != src.Spec.UpdateStrategy.Type {
-		t.Errorf("roundtrip UpdateStrategy mismatch")
-	}
-	if roundTrip.Status.ReadyReplicas != src.Status.ReadyReplicas {
-		t.Errorf("roundtrip ReadyReplicas mismatch: expected %d, got %d", src.Status.ReadyReplicas, roundTrip.Status.ReadyReplicas)
-	}
-	if roundTrip.Status.Selector != src.Status.Selector {
-		t.Errorf("roundtrip Selector mismatch: expected %q, got %q", src.Status.Selector, roundTrip.Status.Selector)
-	}
-}
+			// Verify state annotation was stripped during ConvertFrom
+			if _, ok := roundTrip.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
+				t.Errorf("roundTrip.Annotations still contains the state annotation after ConvertFrom!")
+			}
 
-// TestSandboxWarmPoolConversion_NilUpdateStrategy exercises the nil branch of
-// convertWarmPoolSpecTo/convertWarmPoolSpecFrom, ensuring a nil UpdateStrategy
-// is preserved across a full round-trip conversion.
-func TestSandboxWarmPoolConversion_NilUpdateStrategy(t *testing.T) {
-	src := &SandboxWarmPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-warmpool",
-			Namespace: "default",
-		},
-		Spec: SandboxWarmPoolSpec{
-			Replicas:    1,
-			TemplateRef: SandboxTemplateRef{Name: "my-template"},
-			// UpdateStrategy intentionally nil to exercise the nil branch.
-			UpdateStrategy: nil,
-		},
-	}
-
-	// ConvertTo (v1alpha1 -> v1beta1) must preserve nil.
-	dst := &v1beta1.SandboxWarmPool{}
-	if err := src.ConvertTo(dst); err != nil {
-		t.Fatalf("failed to convert to v1beta1: %v", err)
-	}
-	if dst.Spec.UpdateStrategy != nil {
-		t.Errorf("expected nil UpdateStrategy after ConvertTo, got %v", dst.Spec.UpdateStrategy)
-	}
-
-	// ConvertFrom round-trip (v1beta1 -> v1alpha1) must preserve nil.
-	roundTrip := &SandboxWarmPool{}
-	if err := roundTrip.ConvertFrom(dst); err != nil {
-		t.Fatalf("failed to convert back to v1alpha1: %v", err)
-	}
-	if roundTrip.Spec.UpdateStrategy != nil {
-		t.Errorf("expected nil UpdateStrategy after round-trip, got %v", roundTrip.Spec.UpdateStrategy)
+			// Verify round-trip preserves all fields
+			if roundTrip.Spec.Replicas != src.Spec.Replicas {
+				t.Errorf("roundtrip Replicas mismatch: expected %d, got %d", src.Spec.Replicas, roundTrip.Spec.Replicas)
+			}
+			if roundTrip.Spec.TemplateRef.Name != src.Spec.TemplateRef.Name {
+				t.Errorf("roundtrip TemplateRef mismatch: expected %q, got %q", src.Spec.TemplateRef.Name, roundTrip.Spec.TemplateRef.Name)
+			}
+			if tc.updateStrategy == nil {
+				if roundTrip.Spec.UpdateStrategy != nil {
+					t.Errorf("expected nil UpdateStrategy after round-trip, got %v", roundTrip.Spec.UpdateStrategy)
+				}
+			} else if roundTrip.Spec.UpdateStrategy == nil || roundTrip.Spec.UpdateStrategy.Type != tc.updateStrategy.Type {
+				t.Errorf("roundtrip UpdateStrategy mismatch")
+			}
+			if roundTrip.Status.ReadyReplicas != src.Status.ReadyReplicas {
+				t.Errorf("roundtrip ReadyReplicas mismatch: expected %d, got %d", src.Status.ReadyReplicas, roundTrip.Status.ReadyReplicas)
+			}
+			if roundTrip.Status.Selector != src.Status.Selector {
+				t.Errorf("roundtrip Selector mismatch: expected %q, got %q", src.Status.Selector, roundTrip.Status.Selector)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR adds a conversion test case to verify that `SandboxWarmPool` conversions round-trip correctly when the `UpdateStrategy` is `nil`. 

By adding this test case to `extensions/api/v1alpha1/sandboxwarmpool_conversion_test.go`, we ensure that API version conversions handle `nil` or empty update strategies gracefully, preventing potential regressions or nil-pointer dereferences during conversion round-trips.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Based on this comment - https://github.com/kubernetes-sigs/agent-sandbox/pull/993#pullrequestreview-4546773559 

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for sandbox warm pool conversion edge cases, adding table-driven subtests to verify correct round-trip behavior for optional update strategy configuration (including `nil` handling) and ensuring warm-pool state annotations are stripped as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->