### PR TITLE
fix(python): bracket IPv6 addresses in HTTP URLs per RFC 3986

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -115,7 +115,8 @@ class AsyncSandboxConnector:
                 pod_ip = await self._get_pod_ip()
                 if pod_ip:
                     self._pod_ip = pod_ip
-                    self._cached_pod_ip_url = f"http://{pod_ip}:{self._server_port}"
+                    host = f"[{pod_ip}]" if ":" in pod_ip else pod_ip
+                    self._cached_pod_ip_url = f"http://{host}:{self._server_port}"
                     self._pod_ip_resolved = True
                     return self._cached_pod_ip_url
             return self._dns_url
@@ -131,7 +132,8 @@ class AsyncSandboxConnector:
                 self.connection_config.gateway_namespace,
                 self.connection_config.gateway_ready_timeout,
             )
-            self._base_url = f"http://{ip_address}"
+            host = f"[{ip_address}]" if ":" in ip_address else ip_address
+            self._base_url = f"http://{host}"
         else:
             raise ValueError(
                 f"AsyncSandboxConnector does not support {type(self.connection_config).__name__}."

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -114,7 +114,8 @@ class GatewayConnectionStrategy(ConnectionStrategy):
                 self.config.gateway_namespace,
                 self.config.gateway_ready_timeout
             )
-            self.base_url = f"http://{ip_address}"
+            host = f"[{ip_address}]" if ":" in ip_address else ip_address
+            self.base_url = f"http://{host}"
             return self.base_url
         except Exception:
             status = "failure"
@@ -259,7 +260,8 @@ class InClusterConnectionStrategy(ConnectionStrategy):
                 return self._cached_pod_ip_url or self._dns_url
             pod_ip = self._get_pod_ip()
             if pod_ip:
-                self._cached_pod_ip_url = f"http://{pod_ip}:{self._server_port}"
+                host = f"[{pod_ip}]" if ":" in pod_ip else pod_ip
+                self._cached_pod_ip_url = f"http://{host}:{self._server_port}"
                 self._resolved = True
                 return self._cached_pod_ip_url
         return self._dns_url

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -31,6 +31,7 @@ from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
 from k8s_agent_sandbox.exceptions import SandboxRequestError
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
+    SandboxGatewayConnectionConfig,
     SandboxInClusterConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
 )
@@ -387,6 +388,53 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         )
         url = await connector._resolve_base_url()
         self.assertEqual(url, "http://10.244.0.5:8888")
+
+    async def test_in_cluster_resolves_ipv6_pod_ip(self):
+        """IPv6 pod IPs must be bracketed in the base URL (RFC 3986)."""
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        connector = AsyncSandboxConnector(
+            sandbox_id="my-sandbox",
+            namespace="dev",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+            get_pod_ip=AsyncMock(return_value="2001:db8::1"),
+        )
+        url = await connector._resolve_base_url()
+        self.assertEqual(url, "http://[2001:db8::1]:8888")
+
+    async def test_gateway_resolves_ipv6(self):
+        """Gateway IPv6 addresses must be bracketed in the base URL."""
+        config = SandboxGatewayConnectionConfig(
+            gateway_name="test-gw",
+            gateway_namespace="default",
+        )
+        mock_k8s = MagicMock()
+        mock_k8s.wait_for_gateway_ip = AsyncMock(return_value="2001:db8::1")
+        connector = AsyncSandboxConnector(
+            sandbox_id="test-sandbox",
+            namespace="default",
+            connection_config=config,
+            k8s_helper=mock_k8s,
+        )
+        url = await connector._resolve_base_url()
+        self.assertEqual(url, "http://[2001:db8::1]")
+
+    async def test_gateway_does_not_bracket_ipv4(self):
+        """Gateway IPv4 addresses must NOT be bracketed."""
+        config = SandboxGatewayConnectionConfig(
+            gateway_name="test-gw",
+            gateway_namespace="default",
+        )
+        mock_k8s = MagicMock()
+        mock_k8s.wait_for_gateway_ip = AsyncMock(return_value="34.56.78.90")
+        connector = AsyncSandboxConnector(
+            sandbox_id="test-sandbox",
+            namespace="default",
+            connection_config=config,
+            k8s_helper=mock_k8s,
+        )
+        url = await connector._resolve_base_url()
+        self.assertEqual(url, "http://34.56.78.90")
 
     async def test_in_cluster_does_not_inject_router_headers(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -94,6 +94,34 @@ class TestInClusterConnectionStrategy(unittest.TestCase):
         strategy.close()  # invalidates cache
         self.assertEqual(strategy.connect(), "http://10.0.0.2:8888")  # fresh resolve
 
+    def test_connect_brackets_ipv6_pod_ip(self):
+        """IPv6 pod IPs must be enclosed in brackets in URLs (RFC 3986)."""
+        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        strategy = InClusterConnectionStrategy(
+            "my-sandbox", "dev", config, get_pod_ip=lambda: "2001:db8::1"
+        )
+        self.assertEqual(strategy.connect(), "http://[2001:db8::1]:8888")
+
+
+class TestGatewayConnectionStrategy(unittest.TestCase):
+    """Unit tests for GatewayConnectionStrategy."""
+
+    def test_connect_brackets_ipv6(self):
+        """Gateway IPv6 addresses must be bracketed in the base URL."""
+        config = SandboxGatewayConnectionConfig(gateway_name="gw", gateway_namespace="default")
+        mock_helper = MagicMock()
+        mock_helper.wait_for_gateway_ip.return_value = "2001:db8::1"
+        strategy = GatewayConnectionStrategy(config, k8s_helper=mock_helper)
+        self.assertEqual(strategy.connect(), "http://[2001:db8::1]")
+
+    def test_connect_does_not_bracket_ipv4(self):
+        """Gateway IPv4 addresses must NOT be bracketed."""
+        config = SandboxGatewayConnectionConfig(gateway_name="gw", gateway_namespace="default")
+        mock_helper = MagicMock()
+        mock_helper.wait_for_gateway_ip.return_value = "34.56.78.90"
+        strategy = GatewayConnectionStrategy(config, k8s_helper=mock_helper)
+        self.assertEqual(strategy.connect(), "http://34.56.78.90")
+
 
 class TestExistingStrategiesDefaultHeaderInjection(unittest.TestCase):
     """Regression: existing strategies must still inject router headers by default."""

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -187,7 +187,7 @@ async def proxy_request(request: Request, full_path: str):
             ip = ipaddress.ip_address(pod_ip)
             if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
                 raise HTTPException(status_code=400, detail="Invalid target IP address.")
-            target_host = str(ip)
+            target_host = f"[{ip}]" if isinstance(ip, ipaddress.IPv6Address) else str(ip)
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid target IP address format.")
     else:

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -494,6 +494,52 @@ class TestProxyRouting:
                 request_obj.url
             )
 
+    def test_target_url_ipv6_pod_ip_construction(self, client):
+        """IPv6 pod IPs must be bracketed in the upstream URL (RFC 3986)."""
+        with patch.object(
+            sandbox_router.client,
+            "send",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("expected"),
+        ) as mock_send:
+            client.post(
+                "/some/path",
+                headers={
+                    "X-Sandbox-ID": "test-box",
+                    "X-Sandbox-Namespace": "prod",
+                    "X-Sandbox-Port": "9999",
+                    "X-Sandbox-Pod-IP": "2001:db8::1",
+                },
+            )
+            built_request = mock_send.call_args
+            request_obj = built_request[0][0]
+            assert "[2001:db8::1]:9999/some/path" in str(
+                request_obj.url
+            )
+
+    def test_target_url_ipv6_full_form_pod_ip_construction(self, client):
+        """Full-form IPv6 addresses are normalized and bracketed."""
+        with patch.object(
+            sandbox_router.client,
+            "send",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("expected"),
+        ) as mock_send:
+            client.post(
+                "/some/path",
+                headers={
+                    "X-Sandbox-ID": "test-box",
+                    "X-Sandbox-Namespace": "prod",
+                    "X-Sandbox-Port": "9999",
+                    "X-Sandbox-Pod-IP": "2001:0db8:0000:0000:0000:0000:0000:0001",
+                },
+            )
+            built_request = mock_send.call_args
+            request_obj = built_request[0][0]
+            assert "[2001:db8::1]:9999/some/path" in str(
+                request_obj.url
+            )
+
     def test_target_url_uses_custom_cluster_domain(self, client):
         """Module-level cluster_domain should be used when constructing the target URL."""
         with patch.object(sandbox_router, "cluster_domain", "custom.domain"):


### PR DESCRIPTION
#### What this PR does / why we need it:

RFC 3986 requires IPv6 literal addresses in URLs to be enclosed in square brackets (e.g `http://[2001:db8::1]:8888/path`). Some code sites in the Python SDK and sandbox router construct URLs from raw pod/gateway IPs without bracketing, producing malformed URLs like `http://2600::16:8888/path` where the port is misinterpreted as part of the IPv6 address. This causes breakage on IPv6-only clusters: HTTP 500 on every proxied request through the router, and invalid base URLs from the SDK's InCluster and Gateway connection strategy.

The fix applies a conditional bracket at each URL-construction site:
- [sandbox_router.py](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py): use `isinstance(ip, ipaddress.IPv6Address)` since the parsed object is already available.
- [connector.py](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py): bracket in GatewayConnectionStrategy and InClusterConnectionStrategy.
- [async_connector.py](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py): same two strategies as async counterpart.

This matches the pattern the Go SDK already uses (`strings.Contains(addr, ":")`). IPv4 paths are unaffected, the `":"` in ip check is false for all IPv4 strings. New unit tests cover IPv6 bracketing and include IPv4 non-bracketing regression guards across all three components.

#### Which issue(s) this PR is related to:

Fixes #988 

#### How has it been tested end-to-end:

Deploy router to the IPv6 cluster and start port-forward. Send request with IPv6 pod IP:

```bash
curl -s -w "\n>>> HTTP Status: %{http_code}\n" \
  -X POST http://127.0.0.1:18080/execute \
  -H "Content-Type: application/json" \
  -H "X-Sandbox-ID: test-sandbox" \
  -H "X-Sandbox-Namespace: ipv6-test" \
  -H "X-Sandbox-Port: 8888" \
  -H "X-Sandbox-Pod-IP: 2001:db8::1" \
  -d '{"command": "echo hello"}'
```

Before the fix:
```
{"detail":"An internal error occurred in the proxy."}
>>> HTTP Status: 500
```

Checking router logs confirm the malformed URL:
```
An unexpected error occurred: Invalid port: 'db8::1:8888'
INFO:     ::1:45570 - "POST /execute HTTP/1.1" 500 Internal Server Error
```

With the fix:
```
{"detail":"Timed out waiting for the backend sandbox: test-sandbox"}
>>> HTTP Status: 504
```

Checking router logs confirm correctly formed URL

```
ERROR: Request to sandbox at http://[2001:db8::1]:8888/execute timed out. Error:
```

IPv6 address correctly enclosed in brackets per RFC 3986. The 504 is expected because no sandbox exists at that address; the URL construction bug is gone.

#### Release Note

```release-note
Fixed Python SDK and sandbox router producing malformed HTTP URLs for IPv6 pod and gateway addresses. IPv6 literals are now correctly enclosed in square brackets per RFC 3986, restoring connectivity on IPv6-only clusters.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 addresses in URLs are now properly formatted using RFC 3986 bracket notation standards. This ensures correct handling across different routing configurations.

* **Tests**
  * Added comprehensive unit tests validating IPv6 address handling and URL formatting across routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->