### PR TITLE
docs: fix typos in site content

### DIFF
--- a/site/content/docs/getting_started/go-sdk-quickstart/_index.md
+++ b/site/content/docs/getting_started/go-sdk-quickstart/_index.md
@@ -17,7 +17,7 @@ Agent Sandbox is a quick and easy way to start secure containers that will let a
 
 ## Connection Modes
 
-In this example the client is in the *Port-Forward mode* which is suitable for local development and testing. Learn more about the other modes in the [Go Client's main pageee]({{< ref "/docs/go-client/_index.md" >}}).
+In this example the client is in the *Port-Forward mode* which is suitable for local development and testing. Learn more about the other modes in the [Go Client's main page]({{< ref "/docs/go-client/_index.md" >}}).
 
 
 ## Usage

--- a/site/content/docs/getting_started/install_prerequisites/_index.md
+++ b/site/content/docs/getting_started/install_prerequisites/_index.md
@@ -42,7 +42,7 @@ description: >
    kubectl -n agent-sandbox-system get pods
    ```
 
-3. Before using the client, you must deploy the `sandbox-router`. Follow these there steps:
+3. Before using the client, you must deploy the `sandbox-router`. Follow these three steps:
    ```sh
    curl -sSL https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/refs/tags/${VERSION}/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml | sed 's|${ROUTER_IMAGE}|us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router:latest-main|g' > sandbox_router.yaml
    kubectl apply -f sandbox_router.yaml

--- a/site/content/docs/getting_started/sdk_reference/_index.md
+++ b/site/content/docs/getting_started/sdk_reference/_index.md
@@ -332,7 +332,7 @@ Port the sandbox container listens on.
 class SandboxTracerConfig(BaseModel)
 ```
 
-Configuration for tracer level information
+Configuration for tracer-level information
 
 <a id="k8s_agent_sandbox.models.SandboxTracerConfig.enable_tracing"></a>
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -11,7 +11,7 @@ disableKinds:
 
 menu:
   main:
-    - name: "Github"
+    - name: "GitHub"
       weight: 99
       pre: "<i class='fab fa-github pe-2'></i>"
       url: "https://github.com/kubernetes-sigs/agent-sandbox"


### PR DESCRIPTION
Fix four typos across site docs:

- `Github` -> `GitHub` in hugo.yaml
- `there` -> `three` in install_prerequisites
- `pageee` -> `page` in go-sdk-quickstart
- `tracer level` -> `tracer-level` in sdk_reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typo in Go SDK Quickstart documentation
  * Corrected wording and clarified instructions in Agent Sandbox Installation guide
  * Updated terminology in SDK Reference for consistency

* **Style**
  * Corrected capitalization of "GitHub" in site navigation menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->