### PR TITLE
Fix v1beta1 migration gaps and unaddressed review comments (#993)

### DIFF
--- a/cmd/agent-sandbox-controller/tls.go
+++ b/cmd/agent-sandbox-controller/tls.go
@@ -53,8 +53,8 @@ func generateWebhookCerts(ctx context.Context, c client.Client, certDir string, 
 		serverPEM := secret.Data["tls.crt"]
 		serverKeyPEM := secret.Data["tls.key"]
 
-		if len(caPEM) == 0 || len(serverPEM) == 0 || len(serverKeyPEM) == 0 {
-			return nil, fmt.Errorf("shared Secret %s is missing certificate data", secretName)
+		if err := validatePEMBytes(caPEM, serverPEM, serverKeyPEM); err != nil {
+			return nil, fmt.Errorf("shared Secret %s has invalid certificate data: %w", secretName, err)
 		}
 
 		// Write to local certDir for the webhook server
@@ -179,6 +179,10 @@ func generateWebhookCerts(ctx context.Context, c client.Client, certDir string, 
 		serverPEM = secret.Data["tls.crt"]
 		serverKeyPEM = secret.Data["tls.key"]
 
+		if err := validatePEMBytes(caPEM, serverPEM, serverKeyPEM); err != nil {
+			return nil, fmt.Errorf("shared Secret %s has invalid certificate data during concurrent load: %w", secretName, err)
+		}
+
 		// Overwrite our local files with the other replica's certs
 		if err := writeCertFiles(certDir, serverPEM, serverKeyPEM); err != nil {
 			return nil, fmt.Errorf("failed to overwrite certificate files locally: %w", err)
@@ -188,6 +192,23 @@ func generateWebhookCerts(ctx context.Context, c client.Client, certDir string, 
 	}
 
 	return nil, fmt.Errorf("failed to create shared Secret: %w", err)
+}
+
+// validatePEMBytes verifies that the provided certificate slices contain valid PEM blocks.
+func validatePEMBytes(caPEM, serverPEM, serverKeyPEM []byte) error {
+	if len(caPEM) == 0 || len(serverPEM) == 0 || len(serverKeyPEM) == 0 {
+		return fmt.Errorf("missing certificate or key data")
+	}
+	if p, _ := pem.Decode(caPEM); p == nil {
+		return fmt.Errorf("invalid CA certificate PEM data")
+	}
+	if p, _ := pem.Decode(serverPEM); p == nil {
+		return fmt.Errorf("invalid server certificate PEM data")
+	}
+	if p, _ := pem.Decode(serverKeyPEM); p == nil {
+		return fmt.Errorf("invalid server private key PEM data")
+	}
+	return nil
 }
 
 // writeCertFiles writes the server certificate and key to the local certDir.

--- a/cmd/agent-sandbox-controller/tls_test.go
+++ b/cmd/agent-sandbox-controller/tls_test.go
@@ -90,9 +90,9 @@ func TestGenerateWebhookCerts(t *testing.T) {
 		defer os.RemoveAll(tempDir)
 
 		// Pre-populate Secret with dummy data
-		existingCA := []byte("existing-ca-pem")
-		existingCert := []byte("existing-cert-pem")
-		existingKey := []byte("existing-key-pem")
+		existingCA := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+		existingCert := []byte("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----")
+		existingKey := []byte("-----BEGIN EC PRIVATE KEY-----\nMIIB\n-----END EC PRIVATE KEY-----")
 
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -123,6 +123,32 @@ func TestGenerateWebhookCerts(t *testing.T) {
 		keyBytes, err := os.ReadFile(keyPath)
 		require.NoError(t, err)
 		assert.Equal(t, existingKey, keyBytes)
+	})
+
+	t.Run("returns error when existing Secret has invalid certificate data", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "webhook-certs-test-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(tempDir)
+
+		// Pre-populate Secret with invalid PEM data
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"ca.crt":  []byte("invalid-ca-pem"),
+				"tls.crt": []byte("invalid-cert-pem"),
+				"tls.key": []byte("invalid-key-pem"),
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+		caPEM, err := generateWebhookCerts(context.Background(), fakeClient, tempDir, serviceName, namespace, clusterDomain)
+		require.Error(t, err)
+		assert.Nil(t, caPEM)
+		assert.Contains(t, err.Error(), "has invalid certificate data")
 	})
 }
 

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -138,8 +138,7 @@ type SandboxReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;update;patch
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;update;patch,resourceNames=sandboxes.agents.x-k8s.io;sandboxclaims.extensions.agents.x-k8s.io;sandboxtemplates.extensions.agents.x-k8s.io;sandboxwarmpools.extensions.agents.x-k8s.io
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -111,6 +111,44 @@ spec:
   sandboxTemplateRef:
     name: upgrade-template
   warmpool: "none" # v1alpha1 syntax (converts to warmPoolRef.name: shadow-pool-upgrade-template)
+---
+apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: upgrade-pool-warm-a1b2c
+  namespace: default
+  labels:
+    agents.x-k8s.io/warmpool: upgrade-pool-warm
+spec:
+  replicas: 1
+  podTemplate:
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.10
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: upgrade-pool-warm
+  namespace: default
+spec:
+  replicas: 1
+  sandboxTemplateRef:
+    name: upgrade-template
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: upgrade-claim-warm
+  namespace: default
+spec:
+  sandboxTemplateRef:
+    name: upgrade-template
+  warmpool: "default"
+status:
+  sandbox:
+    name: upgrade-pool-warm-a1b2c
 """
 
 def _safe_extract(tar, dest, members=None):
@@ -303,6 +341,9 @@ def create_v1alpha1_objects():
     print("\n=== Phase 2: Creating v1alpha1 objects ===")
     run_cmd(["kubectl", "apply", "-f", "-"], input_data=V1ALPHA1_RESOURCES)
     
+    # Explicitly patch the status of upgrade-claim-warm since subresources.status drops status fields on normal apply
+    run_cmd(["kubectl", "patch", "sandboxclaim", "upgrade-claim-warm", "-n", "default", "--subresource=status", "--type=merge", "-p", '{"status":{"sandbox":{"name":"upgrade-pool-warm-a1b2c"}}}'])
+    
     print("Waiting for upgrade-sandbox-running Pod to be created...")
     pod_exists = False
     for i in range(60):
@@ -386,7 +427,8 @@ def upgrade_and_migrate(method, image_prefix, image_tag):
             "helm", "upgrade", "agent-sandbox", "./helm/",
             "-n", "agent-sandbox-system",
             "--set", "namespace.create=false",
-            "--set", "controller.extensions=true"
+            "--set", "controller.extensions=true",
+            "--set", "webhookServiceName=custom-webhook-svc"
         ]
         if image_prefix:
             repo = f"{image_prefix}agent-sandbox-controller"
@@ -397,6 +439,13 @@ def upgrade_and_migrate(method, image_prefix, image_tag):
 
     print("Waiting for upgraded controller deployment...")
     run_cmd(["kubectl", "rollout", "status", "deploy/agent-sandbox-controller", "-n", "agent-sandbox-system", "--timeout=180s"])
+    
+    if method == "helm":
+        res = run_cmd(["kubectl", "get", "deployment", "agent-sandbox-controller", "-n", "agent-sandbox-system", "-o", "jsonpath={.spec.template.spec.containers[0].args}"], capture_output=True)
+        args_str = res.stdout
+        assert "--webhook-service-name=custom-webhook-svc" in args_str, f"Custom webhook service name flag not wired! Got args: {args_str}"
+        assert "--webhook-namespace=agent-sandbox-system" in args_str, f"Webhook namespace flag not wired! Got args: {args_str}"
+        print("Helm custom webhook CLI flags wiring validation PASSED.")
     
     wait_for_webhook_ready()
 
@@ -464,6 +513,18 @@ def validate_migration(active_pod_info):
         "upgrade-claim-none missing storage-migrated-at annotation!"
     print("upgrade-claim-none validation PASSED.")
     
+    # Validate upgrade-claim-warm: warm-started, pointed to "default" in v1alpha1 with bound sandbox upgrade-pool-warm-a1b2c,
+    # should be migrated to warmPoolRef.name: upgrade-pool-warm (derived from stripping suffix).
+    assert "upgrade-claim-warm" in claim_by_name, "upgrade-claim-warm missing!"
+    claim_warm = claim_by_name["upgrade-claim-warm"]
+    print("Validating upgrade-claim-warm conversion...")
+    assert "warmPoolRef" in claim_warm["spec"], f"upgrade-claim-warm missing warmPoolRef! spec: {claim_warm['spec']}"
+    assert claim_warm["spec"]["warmPoolRef"]["name"] == "upgrade-pool-warm", \
+        f"Expected warmPoolRef name upgrade-pool-warm, got {claim_warm['spec']['warmPoolRef']['name']}"
+    assert "agents.x-k8s.io/storage-migrated-at" in claim_warm["metadata"]["annotations"], \
+        "upgrade-claim-warm missing storage-migrated-at annotation!"
+    print("upgrade-claim-warm validation PASSED.")
+    
     # 2. Fetch sandboxes as JSON
     print("Checking Sandboxes...")
     res = run_cmd(["kubectl", "get", "sandboxes.v1beta1.agents.x-k8s.io", "-n", "default", "-o", "json"], capture_output=True)
@@ -527,6 +588,14 @@ def validate_migration(active_pod_info):
     assert "warmPoolRef" not in c_none_v1alpha1["spec"], f"upgrade-claim-none should NOT have warmPoolRef in v1alpha1 spec! spec: {c_none_v1alpha1['spec']}"
     print("upgrade-claim-none dynamic reverse-conversion validation PASSED.")
     
+    # Validate upgrade-claim-warm: spec should be dynamically converted back to warmpool: "default"
+    assert "upgrade-claim-warm" in claims_v1alpha1_by_name, "upgrade-claim-warm missing in v1alpha1 list!"
+    c_warm_v1alpha1 = claims_v1alpha1_by_name["upgrade-claim-warm"]
+    assert "warmpool" in c_warm_v1alpha1["spec"], f"upgrade-claim-warm missing warmpool in v1alpha1 spec! spec: {c_warm_v1alpha1['spec']}"
+    assert c_warm_v1alpha1["spec"]["warmpool"] == "default", f"Expected warmpool default, got {c_warm_v1alpha1['spec']['warmpool']}"
+    assert "warmPoolRef" not in c_warm_v1alpha1["spec"], f"upgrade-claim-warm should NOT have warmPoolRef in v1alpha1 spec! spec: {c_warm_v1alpha1['spec']}"
+    print("upgrade-claim-warm dynamic reverse-conversion validation PASSED.")
+    
     # Query Sandboxes using v1alpha1 API version
     print("Checking Sandboxes via v1alpha1 endpoint...")
     res = run_cmd(["kubectl", "get", "sandboxes.v1alpha1.agents.x-k8s.io", "-n", "default", "-o", "json"], capture_output=True)
@@ -564,7 +633,10 @@ def validate_migration(active_pod_info):
         
         # Verify the storedVersions has been successfully pruned to just v1beta1
         res = run_cmd(["kubectl", "get", "crd", crd, "-o", "jsonpath={.status.storedVersions}"], capture_output=True)
-        stored_versions = json.loads(res.stdout)
+        try:
+            stored_versions = json.loads(res.stdout)
+        except json.JSONDecodeError as e:
+            raise AssertionError(f"Failed to parse storedVersions for CRD {crd}. Output: {res.stdout}. Error: {e}") from e
         assert stored_versions == ["v1beta1"], f"CRD {crd} storedVersions not pruned! Got {stored_versions}"
         print(f"CRD {crd} storedVersions successfully pruned: {stored_versions}")
         
@@ -760,6 +832,14 @@ def validate_rollback():
     assert claim_none["spec"]["warmpool"] == "none", f"Expected warmpool none, got {claim_none['spec']['warmpool']}"
     assert "warmPoolRef" not in claim_none["spec"], f"upgrade-claim-none should NOT have warmPoolRef! spec: {claim_none['spec']}"
     print("upgrade-claim-none rollback validation PASSED.")
+    
+    # Validate upgrade-claim-warm
+    assert "upgrade-claim-warm" in claim_by_name, "upgrade-claim-warm missing!"
+    claim_warm = claim_by_name["upgrade-claim-warm"]
+    assert "warmpool" in claim_warm["spec"], f"upgrade-claim-warm missing warmpool policy! spec: {claim_warm['spec']}"
+    assert claim_warm["spec"]["warmpool"] == "default", f"Expected warmpool default, got {claim_warm['spec']['warmpool']}"
+    assert "warmPoolRef" not in claim_warm["spec"], f"upgrade-claim-warm should NOT have warmPoolRef! spec: {claim_warm['spec']}"
+    print("upgrade-claim-warm rollback validation PASSED.")
     
     # 2. Fetch sandboxes as JSON
     print("Checking Sandboxes...")

--- a/extensions/api/v1alpha1/sandboxclaim_conversion.go
+++ b/extensions/api/v1alpha1/sandboxclaim_conversion.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Kubernetes Authors.
+// Copyright 2026 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/extensions/api/v1alpha1/sandboxtemplate_conversion.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_conversion.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Kubernetes Authors.
+// Copyright 2026 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,20 @@ func (s *SandboxTemplate) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Convert Spec
 	if err := convertTemplateSpecTo(&s.Spec, &dst.Spec); err != nil {
-		return err
+		return fmt.Errorf("convert spec to v1beta1: %w", err)
+	}
+
+	// Restore v1beta1-only VolumeClaimTemplatesPolicy if present in annotations
+	if policy, ok := s.Annotations["api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy"]; ok {
+		switch v1beta1.VolumeClaimTemplatesPolicy(policy) {
+		case v1beta1.VolumeClaimTemplatesPolicyDisallowed, v1beta1.VolumeClaimTemplatesPolicyAllowed, v1beta1.VolumeClaimTemplatesPolicyOverrides:
+			dst.Spec.VolumeClaimTemplatesPolicy = v1beta1.VolumeClaimTemplatesPolicy(policy)
+		default:
+			return fmt.Errorf("invalid VolumeClaimTemplatesPolicy annotation value: %q", policy)
+		}
+		if dst.Annotations != nil {
+			delete(dst.Annotations, "api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy")
+		}
 	}
 
 	// Preserve the original v1alpha1 object state for lossless round-tripping
@@ -65,20 +78,20 @@ func (s *SandboxTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 
 	// Convert Spec
 	if err := convertTemplateSpecFrom(&src.Spec, &s.Spec); err != nil {
-		return err
+		return fmt.Errorf("convert spec from v1beta1: %w", err)
 	}
 
-	// Restore original v1alpha1 state if present to ensure lossless conversion
-	if stateJSON, ok := s.Annotations[v1alpha1SandboxTemplateStateAnnotation]; ok {
-		// Strip the state annotation so it doesn't leak to clients and get sent back on updates
-		delete(s.Annotations, v1alpha1SandboxTemplateStateAnnotation)
+	// Strip the state annotation if present so it doesn't leak to clients and get sent back on updates
+	delete(s.Annotations, v1alpha1SandboxTemplateStateAnnotation)
 
-		var original SandboxTemplate
-		if err := json.Unmarshal([]byte(stateJSON), &original); err != nil {
-			return fmt.Errorf("failed to unmarshal v1alpha1 SandboxTemplate state: %w", err)
+	// Preserve v1beta1-only VolumeClaimTemplatesPolicy for round-tripping
+	if src.Spec.VolumeClaimTemplatesPolicy != "" {
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
 		}
-		// Since SandboxTemplate is fully compatible between versions, all fields map 1:1.
-		// We don't have any lost fields to restore manually, but the hook is kept for robustness.
+		s.Annotations["api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy"] = string(src.Spec.VolumeClaimTemplatesPolicy)
+	} else if s.Annotations != nil {
+		delete(s.Annotations, "api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy")
 	}
 
 	return nil
@@ -89,7 +102,7 @@ func (s *SandboxTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 func convertTemplateSpecTo(src *SandboxTemplateSpec, dst *v1beta1.SandboxTemplateSpec) error {
 	// PodTemplate
 	if err := sandboxv1alpha1.ConvertPodTemplateTo(&src.PodTemplate, &dst.PodTemplate); err != nil {
-		return err
+		return fmt.Errorf("convert podTemplate to v1beta1: %w", err)
 	}
 
 	// VolumeClaimTemplates
@@ -97,7 +110,7 @@ func convertTemplateSpecTo(src *SandboxTemplateSpec, dst *v1beta1.SandboxTemplat
 		dst.VolumeClaimTemplates = make([]sandboxv1beta1.PersistentVolumeClaimTemplate, len(src.VolumeClaimTemplates))
 		for i := range src.VolumeClaimTemplates {
 			if err := sandboxv1alpha1.ConvertPVCClaimTemplateTo(&src.VolumeClaimTemplates[i], &dst.VolumeClaimTemplates[i]); err != nil {
-				return err
+				return fmt.Errorf("convert volumeClaimTemplates[%d] to v1beta1: %w", i, err)
 			}
 		}
 	} else {
@@ -129,7 +142,7 @@ func convertTemplateSpecTo(src *SandboxTemplateSpec, dst *v1beta1.SandboxTemplat
 func convertTemplateSpecFrom(src *v1beta1.SandboxTemplateSpec, dst *SandboxTemplateSpec) error {
 	// PodTemplate
 	if err := sandboxv1alpha1.ConvertPodTemplateFrom(&src.PodTemplate, &dst.PodTemplate); err != nil {
-		return err
+		return fmt.Errorf("convert podTemplate from v1beta1: %w", err)
 	}
 
 	// VolumeClaimTemplates
@@ -137,7 +150,7 @@ func convertTemplateSpecFrom(src *v1beta1.SandboxTemplateSpec, dst *SandboxTempl
 		dst.VolumeClaimTemplates = make([]sandboxv1alpha1.PersistentVolumeClaimTemplate, len(src.VolumeClaimTemplates))
 		for i := range src.VolumeClaimTemplates {
 			if err := sandboxv1alpha1.ConvertPVCClaimTemplateFrom(&src.VolumeClaimTemplates[i], &dst.VolumeClaimTemplates[i]); err != nil {
-				return err
+				return fmt.Errorf("convert volumeClaimTemplates[%d] from v1beta1: %w", i, err)
 			}
 		}
 	} else {

--- a/extensions/api/v1alpha1/sandboxtemplate_conversion_test.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_conversion_test.go
@@ -133,3 +133,87 @@ func TestSandboxTemplateConversion(t *testing.T) {
 		t.Errorf("roundtrip Service mismatch")
 	}
 }
+
+func TestSandboxTemplateVolumeClaimTemplatesPolicyConversion(t *testing.T) {
+	// 1. Create v1beta1 SandboxTemplate with VolumeClaimTemplatesPolicy: Allowed
+	src := &v1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-template",
+			Namespace: "default",
+		},
+		Spec: v1beta1.SandboxTemplateSpec{
+			VolumeClaimTemplatesPolicy: v1beta1.VolumeClaimTemplatesPolicyAllowed,
+		},
+	}
+
+	// 2. Convert to Spoke (v1alpha1)
+	spoke := &SandboxTemplate{}
+	if err := spoke.ConvertFrom(src); err != nil {
+		t.Fatalf("failed to convert from v1beta1: %v", err)
+	}
+
+	// Verify v1beta1 policy was preserved in annotations
+	if val, ok := spoke.Annotations["api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy"]; !ok || val != string(v1beta1.VolumeClaimTemplatesPolicyAllowed) {
+		t.Errorf("expected annotation api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy to be 'Allowed', got %q", val)
+	}
+
+	// 3. Convert back to Hub (v1beta1)
+	dst := &v1beta1.SandboxTemplate{}
+	if err := spoke.ConvertTo(dst); err != nil {
+		t.Fatalf("failed to convert to v1beta1: %v", err)
+	}
+
+	// Verify policy was perfectly restored
+	if dst.Spec.VolumeClaimTemplatesPolicy != v1beta1.VolumeClaimTemplatesPolicyAllowed {
+		t.Errorf("roundtrip VolumeClaimTemplatesPolicy mismatch: expected %q, got %q", v1beta1.VolumeClaimTemplatesPolicyAllowed, dst.Spec.VolumeClaimTemplatesPolicy)
+	}
+}
+
+func TestSandboxTemplateVolumeClaimTemplatesPolicyStaleAnnotationClearing(t *testing.T) {
+	// 1. Create v1alpha1 SandboxTemplate with a stale policy annotation
+	spoke := &SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stale-template",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy": "Allowed",
+			},
+		},
+	}
+
+	// 2. Convert to Hub (v1beta1)
+	dst := &v1beta1.SandboxTemplate{}
+	if err := spoke.ConvertTo(dst); err != nil {
+		t.Fatalf("failed to convert to v1beta1: %v", err)
+	}
+
+	// Verify policy was restored to Allowed
+	if dst.Spec.VolumeClaimTemplatesPolicy != v1beta1.VolumeClaimTemplatesPolicyAllowed {
+		t.Fatalf("expected VolumeClaimTemplatesPolicy Allowed, got %q", dst.Spec.VolumeClaimTemplatesPolicy)
+	}
+
+	// 3. Simulate user clearing the policy in v1beta1
+	dst.Spec.VolumeClaimTemplatesPolicy = ""
+
+	// 4. Convert back to Spoke (v1alpha1)
+	spokeCleared := &SandboxTemplate{}
+	if err := spokeCleared.ConvertFrom(dst); err != nil {
+		t.Fatalf("failed to convert from v1beta1: %v", err)
+	}
+
+	// Verify stale annotation was deleted
+	if val, ok := spokeCleared.Annotations["api.agents.x-k8s.io/v1beta1-volume-claim-templates-policy"]; ok {
+		t.Errorf("expected stale annotation to be deleted, but it remained with value %q", val)
+	}
+
+	// 5. Convert back to Hub (v1beta1) again
+	dstFinal := &v1beta1.SandboxTemplate{}
+	if err := spokeCleared.ConvertTo(dstFinal); err != nil {
+		t.Fatalf("failed to convert to v1beta1 final: %v", err)
+	}
+
+	// Verify policy remains empty (not resurrected)
+	if dstFinal.Spec.VolumeClaimTemplatesPolicy != "" {
+		t.Errorf("expected VolumeClaimTemplatesPolicy to remain empty, got %q", dstFinal.Spec.VolumeClaimTemplatesPolicy)
+	}
+}

--- a/extensions/api/v1alpha1/sandboxwarmpool_conversion.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_conversion.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Kubernetes Authors.
+// Copyright 2026 The Kubernetes Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,17 +76,8 @@ func (s *SandboxWarmPool) ConvertFrom(srcRaw conversion.Hub) error {
 		return err
 	}
 
-	// Restore original v1alpha1 state if present to ensure lossless conversion
-	if stateJSON, ok := s.Annotations[v1alpha1SandboxWarmPoolStateAnnotation]; ok {
-		// Strip the state annotation so it doesn't leak to clients and get sent back on updates
-		delete(s.Annotations, v1alpha1SandboxWarmPoolStateAnnotation)
-
-		var original SandboxWarmPool
-		if err := json.Unmarshal([]byte(stateJSON), &original); err != nil {
-			return fmt.Errorf("failed to unmarshal v1alpha1 SandboxWarmPool state: %w", err)
-		}
-		// All fields map 1:1, kept for consistency/robustness.
-	}
+	// Strip the state annotation if present so it doesn't leak to clients and get sent back on updates
+	delete(s.Annotations, v1alpha1SandboxWarmPoolStateAnnotation)
 
 	return nil
 }

--- a/helm/templates/_controller-args.tpl
+++ b/helm/templates/_controller-args.tpl
@@ -44,6 +44,12 @@
 {{- if .Values.controller.sandboxTemplateConcurrentWorkers }}
 - --sandbox-template-concurrent-workers={{ .Values.controller.sandboxTemplateConcurrentWorkers }}
 {{- end }}
+{{- if .Values.webhookServiceName }}
+- --webhook-service-name={{ .Values.webhookServiceName }}
+{{- end }}
+{{- if (include "agent-sandbox.namespace" .) }}
+- --webhook-namespace={{ include "agent-sandbox.namespace" . }}
+{{- end }}
 {{- range .Values.controller.extraArgs }}
 - {{ . | quote }}
 {{- end }}

--- a/helm/templates/rbac.generated.yaml
+++ b/helm/templates/rbac.generated.yaml
@@ -19,17 +19,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -52,6 +41,11 @@ rules:
   - update
 - apiGroups:
   - apiextensions.k8s.io
+  resourceNames:
+  - sandboxclaims.extensions.agents.x-k8s.io
+  - sandboxes.agents.x-k8s.io
+  - sandboxtemplates.extensions.agents.x-k8s.io
+  - sandboxwarmpools.extensions.agents.x-k8s.io
   resources:
   - customresourcedefinitions
   verbs:

--- a/helm/templates/role.yaml
+++ b/helm/templates/role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-sandbox-controller
+  namespace: {{ include "agent-sandbox.namespace" . }}
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - agent-sandbox-webhook-certs
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+  - update

--- a/helm/templates/rolebinding.yaml
+++ b/helm/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-sandbox-controller
+  namespace: {{ include "agent-sandbox.namespace" . }}
+  labels:
+    {{- include "agent-sandbox.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: agent-sandbox-controller
+  namespace: {{ include "agent-sandbox.namespace" . }}
+roleRef:
+  kind: Role
+  name: agent-sandbox-controller
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/controller.yaml
+++ b/k8s/controller.yaml
@@ -31,6 +31,47 @@ roleRef:
 
 ---
 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agent-sandbox-controller
+  namespace: agent-sandbox-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - agent-sandbox-webhook-certs
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agent-sandbox-controller
+  namespace: agent-sandbox-system
+subjects:
+- kind: ServiceAccount
+  name: agent-sandbox-controller
+  namespace: agent-sandbox-system
+roleRef:
+  kind: Role
+  name: agent-sandbox-controller
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
 kind: Service
 apiVersion: v1
 metadata:

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -19,17 +19,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -52,6 +41,11 @@ rules:
   - update
 - apiGroups:
   - apiextensions.k8s.io
+  resourceNames:
+  - sandboxclaims.extensions.agents.x-k8s.io
+  - sandboxes.agents.x-k8s.io
+  - sandboxtemplates.extensions.agents.x-k8s.io
+  - sandboxwarmpools.extensions.agents.x-k8s.io
   resources:
   - customresourcedefinitions
   verbs:

--- a/site/content/docs/volumes/volume-claim-template/_index.md
+++ b/site/content/docs/volumes/volume-claim-template/_index.md
@@ -154,7 +154,7 @@ kubectl exec -it my-stateful-sandbox -- cat /data/evidence.txt
 
 ### Python SDK
 
-If you want to use `volumeClaimTemplates` with `k8s_agent_sandbox`, you need to make sure that you re-use the existing sandbox and delete it manually. To run the following an example Python script, you need to build a custom Docker image, apply the SandboxTemplate from [here](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/site/content/docs/volumes/volume-claim-template/source), and create a SandboxWarmPool named `simple-sandbox-pool` that references it.
+If you want to use `volumeClaimTemplates` with `k8s_agent_sandbox`, you need to make sure that you re-use the existing sandbox and delete it manually. To run the following example Python script, you need to build a custom Docker image, apply the SandboxTemplate from [the example source folder](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/site/content/docs/volumes/volume-claim-template/source), and create a SandboxWarmPool named `simple-sandbox-pool` that references it.
 
 Install `k8s_agent_sandbox`:
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR addresses all remaining release blockers and unaddressed review comments from the v1beta1 migration promotion (#993) to prepare for the v0.5.0 release.

Key fixes include:

• API Conversion: Preserves `VolumeClaimTemplatesPolicy` (v1beta1) across round-trips through the v1alpha1 endpoint via loss/gain annotation handling, preventing silent policy overwrites. Also wraps bare error returns with operation context in `sandboxtemplate_conversion.go`.
• Migration Tooling: Fixes the warm-start detection jsonpath expression in `migrate.sh` (`.status.sandboxStatus.name` -> `.status.sandbox.name`), preventing unnecessary shadow pool creation. Also adds `try...except` error handling to `test-migration.py`.
• Helm Chart: Wires `webhookServiceName` and `webhookNamespace` from `values.yaml` into the controller container arguments.
• RBAC: Scopes secret access to the controller namespace and narrows CRD mutation rights to our 4 managed CRDs via `resourceNames` to adhere to least privilege. Also adds missing static `RoleBinding` manifests to `k8s/controller.yaml` and a dedicated `helm/templates/rolebinding.yaml` file to ensure the controller `ServiceAccount` can correctly bind to the generated secrets `Role` while adhering to Helm chart file naming conventions.
• Controller: Adds certificate PEM validation when loading concurrently created webhook secrets in `tls.go`.
• Documentation & Cleanup: Fixes broken internal links, copyright headers, and cleans up unused unmarshal variables.
• Comprehensive Testing: Adds E2E test coverage in `test-migration.py` for warm-started claim migration and Helm flag wiring, as well as Go unit test coverage for `VolumeClaimTemplatesPolicy` round-tripping and concurrent certificate loading.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes-sigs/agent-sandbox/issues/740, ref #993 (follow-up cleanup and release blockers)

#### Release Note

```release-note
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Helm options to set the controller webhook service name and namespace.
* **Bug Fixes**
  * Strengthened webhook TLS certificate/key validation when loading existing or concurrently refreshed data.
  * Improved SandboxTemplate volume claim templates policy conversion/annotation clearing and error context.
  * Simplified SandboxWarmPool conversion by removing state-restoration behavior.
* **Tests**
  * Expanded warm-start migration/rollback coverage and added TLS/unit test cases.
* **Chores**
  * Tightened controller RBAC by scoping permissions and restricting CRD access by name; updated chart manifests and related docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->