### PR TITLE
ci: optimize staging image builds and increase promotion timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
           GCP_LOCATION: "us-central1"
           GEMINI_MODEL: gemini-2.5-flash
         run: |
-          pip install google-genai==1.30.0 pyopenssl==25.1.0
+          pip install google-genai==1.30.0 pyopenssl==25.1.0 pyyaml==6.0.2
 
           # This finally publishes the draft for your review
           make release-publish TAG="${{ needs.promote-images.outputs.new_tag }}"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
 options:
   enableStructuredLogging: true
   # Using a more powerful machine type can speed up docker builds.
-  machineType: "E2_HIGHCPU_8"
+  machineType: "E2_HIGHCPU_32"
   substitution_option: "ALLOW_LOOSE"
 substitutions:
   _GIT_TAG: "12345"

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -61,6 +61,11 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
         f"--output=type={args.docker_build_output_type}",
     ]
     if args.docker_build_output_type == "registry":
+        cache_ref = utils.get_full_image_name(args, service_name, tag="buildcache")
+        build_cmd.extend([
+            f"--cache-from=type=registry,ref={cache_ref}",
+            f"--cache-to=type=registry,ref={cache_ref},mode=max",
+        ])
         build_cmd.append("--platform=" + platforms)
     image_name = utils.get_full_image_name(args, service_name, tag=image_tag)
     build_cmd.extend(["-t", image_name])

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -110,8 +110,8 @@ def get_latest_digest(image_name, tag):
     
     print(f"   Searching {image_path} for tag pattern: {filter_arg}")
     
-    # Wait up to 45 minutes (45 * 60s)
-    for i in range(45): 
+    # Wait up to 90 minutes (90 * 60s)
+    for i in range(90): 
         try:
             out = run_command(
                 [

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -188,7 +188,7 @@ def main():
     # --- Step 2: Wait for Staging Images ---
     # CI job: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-agent-sandbox-push-images
     print(f"--- Step 2: Waiting for Staging Images ---")
-    print("⏳ Polling registry (timeout: 45 mins)...")
+    print("⏳ Polling registry (timeout: 90 mins)...")
     
     collected_digests = {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Optimizes staging image builds and increases the release promotion polling timeout to prevent CI pipeline failures during scheduled releases. Specifically:
1. **Increase polling timeout:** Bumps the per-image staging registry polling timeout in `dev/tools/tag-promote-images` from 45 to 90 minutes to accommodate slower Prow postsubmit builds.
2. **Increase compute resources:** Bumps the Google Cloud Build machine type in `cloudbuild.yaml` from `E2_HIGHCPU_8` to `E2_HIGHCPU_32` (32 vCPUs, 32 GB RAM) to accelerate C/Python dependency compilation.
3. **Enable registry caching:** Configures `docker buildx` in `dev/tools/push-images` to push and pull layer cache manifests (`type=registry`) to/from the K8s staging Artifact Registry (`:buildcache`), allowing subsequent Prow builds to instantly reuse pre-compiled Python wheels and base layers.
4. **Fix workflows issue:** add pyyaml dependency for crd sorting during release publish

#### Which issue(s) this PR is related to:
NONE

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased Cloud Build machine capacity to improve compilation performance.
  * Enabled Docker Buildx registry caching to speed up image builds.
  * Extended image promotion registry polling timeout to 90 minutes to improve reliability.
* **Documentation**
  * Added an extra Python dependency during draft release generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->