### PR TITLE
fix broken ref in troubleshooting article

### DIFF
--- a/site/content/docs/getting_started/troubleshooting/_index.md
+++ b/site/content/docs/getting_started/troubleshooting/_index.md
@@ -16,7 +16,7 @@ While standard errors are often surfaced directly in your script, the `k8s_agent
 
 ## Prerequisites
 
-- A running Kubernetes cluster with the [Agent Sandbox Controller]({{< ref "/docs/overview" >}}) installed.
+- A running Kubernetes cluster with the [Agent Sandbox Controller]({{< ref "/docs/getting_started/overview" >}}) installed.
 - The [Sandbox Router](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/README.md) deployed in your cluster.
 - A `SandboxTemplate` named `python-sandbox-template` applied to your cluster. See the [Python Runtime Sandbox]({{< ref "/docs/runtime-templates/python" >}}) guide for setup instructions.
 - The [Python SDK]({{< ref "/docs/python-client" >}}) installed with the tracing extra: `pip install "k8s-agent-sandbox[tracing]"`.


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently netlify deploy is broken due to wrong ref in the troubleshooting doc. This seems to fix it 

