### PR TITLE
Upgrade Hugo from v0.150.0 to v0.163.3 for Agent Sandbox site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   command = "npm ci && hugo build -e production"
 
 [build.environment]
-  HUGO_VERSION = "0.150.0"
+  HUGO_VERSION = "0.163.3"
 
 [context.production.environment]
   HUGO_ENV = "production"

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -1,8 +1,16 @@
 baseURL: 'https://agent-sandbox.sigs.k8s.io/'
-languageCode: 'en-us'
+locale: 'en-us'
 title: 'Agent Sandbox'
 
 enableRobotsTXT: true
+
+security:
+  allowContent:
+    - '^text/html$'
+    - '^text/markdown$'
+  node:
+    permissions:
+      allowRead: ["*"]
 
 ## Docsy
 enableGitInfo: true
@@ -138,22 +146,22 @@ module:
   - disableWatch: true
     source: ../
     target: assets/additional
-    includeFiles: ["CONTRIBUTING.md", "README.md"]
+    files: ["CONTRIBUTING.md", "README.md"]
   - disableWatch: true
     source: ../examples
     target: assets/additional/examples
   - disableWatch: true
     source: ../clients/python/agentic-sandbox-client
     target: assets/additional/python-agentic-sandbox-client
-    includeFiles: ["README.md"]
+    files: ["README.md"]
   - disableWatch: true
     source: ../clients/go
     target: assets/additional/go-client
-    includeFiles: ["README.md"]
+    files: ["README.md"]
   - disableWatch: true
     source: ../docs
     target: assets/additional/docs
-    includeFiles: ["testing.md", "api.md", "api-migration-guide.md"]
+    files: ["testing.md", "api.md", "api-migration-guide.md"]
 
   imports:
     - path: github.com/google/docsy

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -1,5 +1,5 @@
 baseURL: 'https://agent-sandbox.sigs.k8s.io/'
-locale: 'en-us'
+locale: 'en-US'
 title: 'Agent Sandbox'
 
 enableRobotsTXT: true
@@ -10,7 +10,10 @@ security:
     - '^text/markdown$'
   node:
     permissions:
-      allowRead: ["*"]
+      allowRead:
+         - .
+         - assets
+         - node_modules
 
 ## Docsy
 enableGitInfo: true

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -117,7 +117,7 @@ module:
   proxy: direct
   hugoVersion:
     extended: true
-    min: 0.73.0
+    min: 0.163.3
   mounts:
   - disableWatch: false
     source: content

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -10,10 +10,7 @@ security:
     - '^text/markdown$'
   node:
     permissions:
-      allowRead:
-         - .
-         - assets
-         - node_modules
+      allowRead: ["*"]
 
 ## Docsy
 enableGitInfo: true


### PR DESCRIPTION

#### What this PR does / why we need it:

Addressed the following changes required for the hugo upgrade from v0.150.0 to v0.163.3 :
- Allowed 'text/html' and 'text/markdown' in security.allowContent (hugo v0.153.0 strict content policy)
- Granted NodeJS allowRead: ['*'] in security.node.permissions for PostCSS execution (hugo v0.163 Node Permission Model)
- Replaced deprecated languageCode with locale in config (hugo v0.158.0)
- Replaced deprecated includeFiles with files in module mounts (hugo v0.153.0)

#### Which issue(s) this PR is related to:

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the site build environment to use a newer Hugo version.
  * Refined site configuration for language/locale handling and added content access rules.
  * Adjusted mounted content inclusion settings to keep site builds consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->