### PR TITLE
fix: resolve race condition in test-migration by using separate template for cold-start claims

### DIFF
--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -47,6 +47,18 @@ spec:
         image: registry.k8s.io/pause:3.10
 ---
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: upgrade-template-cold
+  namespace: default
+spec:
+  podTemplate:
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.10
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxWarmPool
 metadata:
   name: upgrade-pool
@@ -89,8 +101,8 @@ metadata:
   namespace: default
 spec:
   sandboxTemplateRef:
-    name: upgrade-template
-  warmpool: "default" # v1alpha1 syntax (converts to warmPoolRef.name: shadow-pool-upgrade-template)
+    name: upgrade-template-cold
+  warmpool: "default" # v1alpha1 syntax (converts to warmPoolRef.name: shadow-pool-upgrade-template-cold)
 ---
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxClaim
@@ -109,8 +121,8 @@ metadata:
   namespace: default
 spec:
   sandboxTemplateRef:
-    name: upgrade-template
-  warmpool: "none" # v1alpha1 syntax (converts to warmPoolRef.name: shadow-pool-upgrade-template)
+    name: upgrade-template-cold
+  warmpool: "none" # v1alpha1 syntax (converts to warmPoolRef.name: shadow-pool-upgrade-template-cold)
 ---
 apiVersion: agents.x-k8s.io/v1alpha1
 kind: Sandbox
@@ -403,9 +415,9 @@ def upgrade_and_migrate(method, image_prefix, image_tag):
     
     # Verify shadow pool was created
     print("Verifying shadow pool creation...")
-    res = run_cmd(["kubectl", "get", "sandboxwarmpool", "shadow-pool-upgrade-template", "-n", "default", "-o", "json"], capture_output=True)
+    res = run_cmd(["kubectl", "get", "sandboxwarmpool", "shadow-pool-upgrade-template-cold", "-n", "default", "-o", "json"], capture_output=True)
     shadow_pool = json.loads(res.stdout)
-    assert shadow_pool["spec"]["sandboxTemplateRef"]["name"] == "upgrade-template", "Shadow pool template mismatch!"
+    assert shadow_pool["spec"]["sandboxTemplateRef"]["name"] == "upgrade-template-cold", "Shadow pool template mismatch!"
     print("Shadow pool successfully verified!")
 
     # 3. Upgrade Controller & CRDs
@@ -482,8 +494,8 @@ def validate_migration(active_pod_info):
     
     print("Validating upgrade-claim conversion...")
     assert "warmPoolRef" in claim1["spec"], f"upgrade-claim missing warmPoolRef! spec: {claim1['spec']}"
-    assert claim1["spec"]["warmPoolRef"]["name"] == "shadow-pool-upgrade-template", \
-        f"Expected warmPoolRef name shadow-pool-upgrade-template, got {claim1['spec']['warmPoolRef']['name']}"
+    assert claim1["spec"]["warmPoolRef"]["name"] == "shadow-pool-upgrade-template-cold", \
+        f"Expected warmPoolRef name shadow-pool-upgrade-template-cold, got {claim1['spec']['warmPoolRef']['name']}"
     assert "agents.x-k8s.io/storage-migrated-at" in claim1["metadata"]["annotations"], \
         "upgrade-claim missing storage-migrated-at annotation!"
     print("upgrade-claim validation PASSED.")
@@ -507,8 +519,8 @@ def validate_migration(active_pod_info):
     claim_none = claim_by_name["upgrade-claim-none"]
     print("Validating upgrade-claim-none conversion...")
     assert "warmPoolRef" in claim_none["spec"], f"upgrade-claim-none missing warmPoolRef! spec: {claim_none['spec']}"
-    assert claim_none["spec"]["warmPoolRef"]["name"] == "shadow-pool-upgrade-template", \
-        f"Expected warmPoolRef name shadow-pool-upgrade-template, got {claim_none['spec']['warmPoolRef']['name']}"
+    assert claim_none["spec"]["warmPoolRef"]["name"] == "shadow-pool-upgrade-template-cold", \
+        f"Expected warmPoolRef name shadow-pool-upgrade-template-cold, got {claim_none['spec']['warmPoolRef']['name']}"
     assert "agents.x-k8s.io/storage-migrated-at" in claim_none["metadata"]["annotations"], \
         "upgrade-claim-none missing storage-migrated-at annotation!"
     print("upgrade-claim-none validation PASSED.")


### PR DESCRIPTION
# PR Description
`test: resolve race condition in test-migration by using separate template for cold-start claims`


## Summary
This PR resolves a flaky/deterministic test failure in the migration E2E tests (`dev/tools/test-migration.py`).


### The Problem
During the `v1alpha1` phase of the migration test:
1. The test defines a warm pool (`upgrade-pool-warm` with `replicas: 1`) and a warm-started claim (`upgrade-claim-warm`) bound to its only replica (`upgrade-pool-warm-a1b2c`).
2. The test also defines a cold-start claim `upgrade-claim` with `warmpool: "default"`.
3. When the old `v0.4.6` controller manager reconciles these resources, it notices that `upgrade-pool-warm-a1b2c` is bound. To maintain the warmpool replica target of `1` idle sandbox, it scales up the warmpool by spinning up a new sandbox (e.g., `upgrade-pool-warm-zhnhp`).
4. Since `upgrade-claim` is unbound and configured to use the `"default"` warmpool policy (which matches any pool for the template `upgrade-template`), the running controller binds `upgrade-claim` to the newly created warm sandbox.
5. Once bound, `upgrade-claim` becomes warm-started. When converted during migration, the conversion webhook resolves its target warmpool to `upgrade-pool-warm` instead of `shadow-pool-upgrade-template`. This causes the test assertion to fail:

### The Solution
We introduce a separate template named `upgrade-template-cold` specifically for the cold-start claims (`upgrade-claim` and `upgrade-claim-none`).
- Because `upgrade-pool-warm` only matches `upgrade-template`, the controller cannot bind `upgrade-claim` or `upgrade-claim-none` to any warm sandbox.
- Both claims remain unbound (cold-started) throughout the test as intended, and are correctly migrated to `shadow-pool-upgrade-template-cold`.
- Update assertions and verification checks in `test-migration.py` to expect `shadow-pool-upgrade-template-cold` instead of `shadow-pool-upgrade-template` for these claims.


## Verification / Testing
Successfully verified the fix by running:

```bash
for i in {1..10}; do
  echo "=== Running Full Iteration $i ==="
  dev/ci/periodics/test-migration
  
  if [ $? -ne 0 ]; then
    echo "=== Failed at Iteration $i ==="
    break
  fi
done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated migration coverage to verify the newer warm-pool template naming during upgrade checks.
  * Adjusted expected warm-pool references in conversion validation to match the updated shadow pool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->