### PR TITLE
fix:resolve race condition in test-migration script via owner reference patch.

### DIFF
--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -334,7 +334,8 @@ def install_v1alpha1(method, version):
                 "helm", "install", "agent-sandbox", extracted_helm_path,
                 "-n", "agent-sandbox-system", "--create-namespace",
                 "--set", "namespace.create=false",
-                "--set", f"image.tag={version}"
+                "--set", f"image.tag={version}",
+                "--set", "controller.extensions=true"
             ])
         finally:
             # Clean up the downloaded and extracted files
@@ -353,8 +354,28 @@ def create_v1alpha1_objects():
     print("\n=== Phase 2: Creating v1alpha1 objects ===")
     run_cmd(["kubectl", "apply", "-f", "-"], input_data=V1ALPHA1_RESOURCES)
     
+    # Explicitly patch the Sandbox with the owner reference pointing to upgrade-claim-warm
+    res = run_cmd(["kubectl", "get", "sandboxclaim", "upgrade-claim-warm", "-n", "default", "-o", "jsonpath={.metadata.uid}"], capture_output=True)
+    claim_uid = res.stdout.strip()
+    owner_patch = {
+        "metadata": {
+            "ownerReferences": [
+                {
+                    "apiVersion": "extensions.agents.x-k8s.io/v1alpha1",
+                    "kind": "SandboxClaim",
+                    "name": "upgrade-claim-warm",
+                    "uid": claim_uid,
+                    "controller": True,
+                    "blockOwnerDeletion": True
+                }
+            ]
+        }
+    }
+    run_cmd(["kubectl", "patch", "sandbox", "upgrade-pool-warm-a1b2c", "-n", "default", "--type=merge", "-p", json.dumps(owner_patch)])
+
     # Explicitly patch the status of upgrade-claim-warm since subresources.status drops status fields on normal apply
     run_cmd(["kubectl", "patch", "sandboxclaim", "upgrade-claim-warm", "-n", "default", "--subresource=status", "--type=merge", "-p", '{"status":{"sandbox":{"name":"upgrade-pool-warm-a1b2c"}}}'])
+
     
     print("Waiting for upgrade-sandbox-running Pod to be created...")
     pod_exists = False
@@ -388,9 +409,6 @@ def create_v1alpha1_objects():
     pod_creation = pod_data["metadata"]["creationTimestamp"]
     print(f"Captured active pod info - Name: upgrade-sandbox-running, UID: {pod_uid}, CreatedAt: {pod_creation}")
     
-    print("Waiting for v1alpha1 claims to be bound...")
-    # Give a short sleep for claims to reconcile
-    time.sleep(10)
     # Check claim exists and status has reconciled
     run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "-n", "default"])
     


### PR DESCRIPTION
# PR Description

## Title
`test: resolve race conditions and enable active extensions in test-migration E2E upgrade tests`

## Summary
This PR resolves race conditions in the migration E2E tests (`dev/tools/test-migration.py`) and aligns the Helm test path to match the Kubectl test path.

### 1. Robust Warm-started Claim Binding via Dynamic ownerReference
* **Problem:** If we let the controller naturally bind the claim, it often falls back to a cold-start because the warmpool sandbox is not yet Ready when the claim is reconciled. However, if we manually patch the status using a mock sandbox, the old controller manager clears it because of a missing owner reference (since claim UIDs are dynamic).
* **Fix:** We use a static mock sandbox `upgrade-pool-warm-a1b2c`. We dynamically fetch the claim's UID at startup and patch the Sandbox's `ownerReferences` before setting the claim status. This ensures the controller manager accepts the binding and never clears it or falls back to a cold-start.

### 2. Enabled Extensions under Helm
* **Problem:** Under the Helm test path, `v0.4.6` was installed via `helm install` without the extensions controller enabled (`controller.extensions=true`).
* **Fix:** We updated the `install_v1alpha1` function for the Helm path to pass `"--set", "controller.extensions=true"`, ensuring extensions are active and claims are reconciled during Helm migration runs.

## Verification / Testing
Successfully verified by running:
```bash
dev/ci/periodics/test-migration


### Verification

```bash
for i in {1..10}; do
  echo "=== Iteration $i ==="
  dev/ci/periodics/test-migration
  if [ $? -ne 0 ]; then
    echo "Failed on iteration $i"
    break
  fi
done

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration setup so the controller is configured consistently during upgrade validation.
  * Ensured the warm sandbox is correctly linked to its claim before status is updated, helping migration checks proceed more reliably.
  * Removed an unnecessary wait during claim creation, reducing avoidable delay in the migration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->