### PR TITLE
Remove use_pod_ip from Python sandbox clients

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -157,27 +157,15 @@ finally:
 Use this when the client runs **inside the cluster** (for example, another pod in the same cluster).
 The client connects **directly to the sandbox runtime pod**, bypassing the sandbox router.
 
-The **default** is **cluster DNS** (`use_pod_ip=False`). Omit the argument or pass `use_pod_ip=False`
-to use it; set `use_pod_ip=True` only when you want the pod IP path.
-
-**Option A: Direct Pod IP** — `SandboxInClusterConnectionConfig(use_pod_ip=True)`
-
-- Uses the pod IP from the Sandbox status for **low-latency**, direct connections without relying on
-  cluster DNS resolution.
-
-**Option B: Cluster DNS** — `SandboxInClusterConnectionConfig(use_pod_ip=False)`
-
-- Uses a stable DNS-style endpoint (typically `http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}`).
-  Prefer this when you want **stable DNS-based routing** across pod lifecycle events.
+The client first uses the pod IP reported in the Sandbox status. If the pod IP is not available
+(for example, before status is populated or when running against an older controller), it falls
+back to the stable cluster DNS endpoint:
+`http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}`.
 
 ```python
 from k8s_agent_sandbox import SandboxClient
 from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
 
-# Choose one connection_config (default = cluster DNS):
-#   SandboxInClusterConnectionConfig()  # same as use_pod_ip=False
-# Option A — direct pod IP (low latency):
-#   SandboxInClusterConnectionConfig(use_pod_ip=True)
 connection_config = SandboxInClusterConnectionConfig()
 
 client = SandboxClient(connection_config=connection_config)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -19,7 +19,7 @@ from .async_k8s_helper import AsyncK8sHelper
 from .commands.async_command_executor import AsyncCommandExecutor
 from .constants import POD_NAME_ANNOTATION
 from .files.async_filesystem import AsyncFilesystem
-from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxTracerConfig
 from .trace_manager import create_tracer_manager
 from .utils import select_pod_ip
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/models.py
@@ -57,14 +57,11 @@ class SandboxLocalTunnelConnectionConfig(BaseModel):
 class SandboxInClusterConnectionConfig(BaseModel):
     """Configuration for direct in-cluster connection to the sandbox pod, bypassing the router.
 
-    By default, connects via stable K8s DNS:
+    The client first uses the pod IP reported in the Sandbox status. If the pod IP
+    is unavailable, it falls back to the stable Kubernetes DNS endpoint:
         http://{sandbox_id}.{namespace}.svc.cluster.local:{server_port}
-
-    When use_pod_ip=True, connects directly to the pod IP from the Sandbox status,
-    avoiding DNS resolution at the cost of needing a K8s API call to retrieve the IP.
     """
     server_port: int = 8888  # Port the sandbox container listens on.
-    use_pod_ip: bool = False  # If True, connect via pod IP instead of cluster DNS.
 
 SandboxConnectionConfig = Union[
     SandboxDirectConnectionConfig,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -20,7 +20,6 @@ from .commands.command_executor import CommandExecutor
 from .files.filesystem import Filesystem
 from .models import (
     SandboxConnectionConfig,
-    SandboxInClusterConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
     SandboxTracerConfig,
 )

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -447,6 +447,25 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(await sandbox.get_pod_ip(), "10.244.0.42")
 
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncFilesystem")
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncCommandExecutor")
+    @patch("k8s_agent_sandbox.async_sandbox.create_tracer_manager")
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncSandboxConnector")
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncK8sHelper")
+    async def test_in_cluster_passes_pod_ip_callback(self, mock_k8s_helper, mock_connector, mock_create_tracer_manager, mock_command_executor, mock_filesystem):
+        config = SandboxInClusterConnectionConfig()
+        mock_create_tracer_manager.return_value = (MagicMock(), MagicMock())
+
+        sandbox = AsyncSandbox(
+            claim_name="test-claim",
+            sandbox_id="test-id",
+            connection_config=config,
+        )
+
+        callback = mock_connector.call_args.kwargs["get_pod_ip"]
+        self.assertIs(callback.__self__, sandbox)
+        self.assertIs(callback.__func__, AsyncSandbox.get_pod_ip)
+
 
 class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
 
@@ -460,9 +479,8 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         client = AsyncSandboxClient(connection_config=config, cleanup=False)
         self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
 
-    async def test_use_pod_ip_not_passed_as_kwarg(self):
-        """AsyncSandbox derives use_pod_ip from connection_config internally."""
-        config = SandboxInClusterConnectionConfig(use_pod_ip=True)
+    async def test_in_cluster_connection_config_passed_to_sandbox(self):
+        config = SandboxInClusterConnectionConfig()
         client = AsyncSandboxClient(connection_config=config, cleanup=False)
         mock_k8s_helper = client.k8s_helper
         mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
@@ -476,8 +494,7 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
             await client.create_sandbox("my-warmpool")
 
         call_kwargs = mock_sandbox_class.call_args.kwargs
-        self.assertNotIn("use_pod_ip", call_kwargs,
-                        "use_pod_ip should not be passed; AsyncSandbox derives it from connection_config")
+        self.assertEqual(call_kwargs["connection_config"], config)
 
 
 class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
@@ -504,7 +521,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(url, "http://my-sandbox.dev.svc.cluster.local:8888")
 
     async def test_in_cluster_resolves_pod_ip_via_callable(self):
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
         connector = AsyncSandboxConnector(
             sandbox_id="my-sandbox",
             namespace="dev",
@@ -517,7 +534,7 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
 
     async def test_in_cluster_resolves_ipv6_pod_ip(self):
         """IPv6 pod IPs must be bracketed in the base URL (RFC 3986)."""
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
         connector = AsyncSandboxConnector(
             sandbox_id="my-sandbox",
             namespace="dev",
@@ -883,23 +900,21 @@ class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
             await connector.close()
 
 
-class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
-    """Tests that use_pod_ip is NOT passed as a kwarg — AsyncSandbox derives it internally."""
+class TestAsyncSandboxClientInClusterConnectionConfig(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         patcher = patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper")
         self.MockAsyncK8sHelper = patcher.start()
         self.addCleanup(patcher.stop)
 
-        self.config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        self.config = SandboxInClusterConnectionConfig(server_port=8888)
         # cleanup=False keeps tests hermetic; the new default (True) registers a global atexit hook.
         self.client = AsyncSandboxClient(connection_config=self.config, cleanup=False)
         self.mock_k8s_helper = self.client.k8s_helper
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
 
-    async def test_create_sandbox_does_not_pass_use_pod_ip(self):
-        """AsyncSandbox derives use_pod_ip from connection_config internally."""
+    async def test_create_sandbox_passes_connection_config(self):
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
         self.mock_k8s_helper.wait_for_sandbox_ready = AsyncMock(return_value="10.244.0.5")
 
@@ -910,12 +925,9 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
             await self.client.create_sandbox("test-template", "default")
 
         call_kwargs = self.mock_sandbox_class.call_args.kwargs
-        self.assertNotIn("use_pod_ip", call_kwargs,
-                        "use_pod_ip should not be passed; AsyncSandbox derives it from connection_config")
         self.assertEqual(call_kwargs["connection_config"], self.config)
 
-    async def test_get_sandbox_does_not_pass_use_pod_ip(self):
-        """get_sandbox should not pass use_pod_ip — AsyncSandbox derives it."""
+    async def test_get_sandbox_passes_connection_config(self):
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
         self.mock_k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
 
@@ -925,8 +937,6 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
         await self.client.get_sandbox("test-claim", "default")
 
         call_kwargs = self.mock_sandbox_class.call_args.kwargs
-        self.assertNotIn("use_pod_ip", call_kwargs,
-                        "use_pod_ip should not be passed; AsyncSandbox derives it from connection_config")
         self.assertEqual(call_kwargs["connection_config"], self.config)
 
     async def test_get_sandbox_passes_connection_config_for_non_incluster(self):
@@ -942,7 +952,6 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
         await client.get_sandbox("test-claim", "default")
 
         call_kwargs = client.sandbox_class.call_args.kwargs
-        self.assertNotIn("use_pod_ip", call_kwargs)
         self.assertEqual(call_kwargs["connection_config"], config)
 
 
@@ -951,7 +960,7 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
 
     async def test_http_status_error_clears_pod_ip_cache(self):
         """Verify HTTPStatusError (4xx/5xx) clears pod IP cache (Bug Fix #2)."""
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
 
         # Mock get_pod_ip to track how many times it's called
         call_count = [0]
@@ -1005,7 +1014,7 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
 
     async def test_http_error_clears_pod_ip_cache(self):
         """Verify HTTPError (connection failures) also clears pod IP cache."""
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
 
         async def mock_get_pod_ip():
             return "10.244.0.5"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -65,17 +65,17 @@ class TestInClusterConnectionStrategy(unittest.TestCase):
         self.strategy.close()
 
     def test_connect_uses_pod_ip_when_callable_provided(self):
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
         strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, get_pod_ip=lambda: "10.244.0.5")
         self.assertEqual(strategy.connect(), "http://10.244.0.5:8888")
 
     def test_connect_falls_back_to_dns_when_callable_returns_none(self):
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
         strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, get_pod_ip=lambda: None)
         self.assertEqual(strategy.connect(), "http://my-sandbox.dev.svc.cluster.local:8888")
 
     def test_connect_uses_dns_when_no_callable(self):
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
         strategy = InClusterConnectionStrategy("my-sandbox", "dev", config, get_pod_ip=None)
         self.assertEqual(strategy.connect(), "http://my-sandbox.dev.svc.cluster.local:8888")
 
@@ -96,7 +96,7 @@ class TestInClusterConnectionStrategy(unittest.TestCase):
 
     def test_connect_brackets_ipv6_pod_ip(self):
         """IPv6 pod IPs must be enclosed in brackets in URLs (RFC 3986)."""
-        config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
+        config = SandboxInClusterConnectionConfig(server_port=8888)
         strategy = InClusterConnectionStrategy(
             "my-sandbox", "dev", config, get_pod_ip=lambda: "2001:db8::1"
         )

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -18,7 +18,11 @@ from unittest.mock import MagicMock, patch
 
 
 from k8s_agent_sandbox.sandbox import Sandbox
-from k8s_agent_sandbox.models import SandboxLocalTunnelConnectionConfig, SandboxTracerConfig
+from k8s_agent_sandbox.models import (
+    SandboxInClusterConnectionConfig,
+    SandboxLocalTunnelConnectionConfig,
+    SandboxTracerConfig,
+)
 from k8s_agent_sandbox.utils import select_pod_ip
 
 
@@ -112,6 +116,33 @@ class TestSandbox(unittest.TestCase):
         mock_create_tracer_manager.assert_called_once_with(mock_tracer_config)
         mock_command_executor.assert_called_once_with(mock_connector.return_value, mock_tracer, "custom-tracer")
         mock_filesystem.assert_called_once_with(mock_connector.return_value, mock_tracer, "custom-tracer")
+
+    @patch('k8s_agent_sandbox.sandbox.Filesystem')
+    @patch('k8s_agent_sandbox.sandbox.CommandExecutor')
+    @patch('k8s_agent_sandbox.sandbox.create_tracer_manager')
+    @patch('k8s_agent_sandbox.sandbox.SandboxConnector')
+    @patch('k8s_agent_sandbox.sandbox.K8sHelper')
+    def test_in_cluster_passes_pod_ip_callback(
+        self,
+        mock_k8s_helper,
+        mock_connector,
+        mock_create_tracer_manager,
+        mock_command_executor,
+        mock_filesystem,
+    ):
+        config = SandboxInClusterConnectionConfig()
+        mock_create_tracer_manager.return_value = (MagicMock(), MagicMock())
+
+        sandbox = Sandbox(
+            claim_name=self.claim_name,
+            sandbox_id=self.sandbox_id,
+            namespace=self.namespace,
+            connection_config=config,
+        )
+
+        callback = mock_connector.call_args.kwargs["get_pod_ip"]
+        self.assertIs(callback.__self__, sandbox)
+        self.assertIs(callback.__func__, Sandbox.get_pod_ip)
 
     def test_get_pod_name_with_annotation(self):
         self.mock_k8s_helper.get_sandbox.return_value = {

--- a/examples/ray-integration/direct-proxy/rl_production_loop.py
+++ b/examples/ray-integration/direct-proxy/rl_production_loop.py
@@ -39,13 +39,11 @@ class SecureEnvironmentActor:
         
         print(f"[{self.env_id}] - Initializing GKE Sandbox Client natively In-Cluster...")
         
-        # By using SandboxInClusterConnectionConfig with `use_pod_ip=True`, we bypass 
-        # the external Gateway and internal Routers. The SDK resolves the internal K8s 
-        # pod IP of the sandbox and routes traffic directly via pod-to-pod 
-        # communication.
+        # By using SandboxInClusterConnectionConfig, we bypass the external Gateway
+        # and internal Routers. The SDK tries the internal K8s pod IP first and
+        # falls back to stable in-cluster DNS if the pod IP is not available.
         connection_config = SandboxInClusterConnectionConfig(
-            use_pod_ip=True,
-            server_port=8888 
+            server_port=8888
         )
         
         self.client = SandboxClient(connection_config=connection_config, cleanup=True)

--- a/site/content/docs/use-cases/anthropic-managed-agents/_index.md
+++ b/site/content/docs/use-cases/anthropic-managed-agents/_index.md
@@ -128,7 +128,7 @@ to the bound pod:
 ```python
 ant = anthropic.Anthropic(auth_token=os.environ["ANTHROPIC_ENVIRONMENT_KEY"])
 sbx = SandboxClient(
-    connection_config=SandboxInClusterConnectionConfig(use_pod_ip=True, server_port=8080)
+    connection_config=SandboxInClusterConnectionConfig(server_port=8080)
 )
 
 while True:


### PR DESCRIPTION
#### What this PR does / why we need it:

Removes the `use_pod_ip` option from the Python in-cluster connection config.

The current in-cluster client behavior is to use the Sandbox status pod IP when it is available and fall back to the stable Kubernetes DNS endpoint otherwise. Keeping a separate `use_pod_ip` toggle made the public API and docs disagree with that behavior.

This updates the sync and async clients, README, and unit tests around the pod-IP-first, DNS-fallback path.

#### Which issue(s) this PR is related to:

Fixes #1029

#### Release Note

```release-note
fix(python-sdk): remove use_pod_ip from in-cluster sandbox connections
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In-cluster connections now automatically prefer the sandbox pod IP when available, and fall back to the in-cluster DNS endpoint when it isn’t (improves behavior across newer/older cluster states, including IPv6 formatting).

* **Documentation**
  * Updated Python client README and example snippets to match the new in-cluster connection behavior (including removing the need to explicitly enable pod-IP mode).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->