### PR TITLE
🐛 flip AsyncSandboxClient cleanup default to True

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -53,10 +53,16 @@ class AsyncSandboxClient(Generic[T]):
     ``connection_config`` is required — the async client does not support
     ``SandboxLocalTunnelConnectionConfig``.
 
-    Pass ``cleanup=True`` to register an atexit hook that deletes all tracked
-    sandboxes on program termination::
+    By default (``cleanup=True``) an atexit hook is registered that deletes
+    all tracked sandboxes on program termination, so sandboxes are not leaked
+    if the program exits without explicit cleanup. Pass ``cleanup=False`` to
+    opt out of this behavior::
 
-        client = AsyncSandboxClient(connection_config=config, cleanup=True)
+        client = AsyncSandboxClient(connection_config=config, cleanup=False)
+
+    Note that this default differs from the synchronous ``SandboxClient``,
+    which defaults to ``cleanup=False``; the async client opts in to safer
+    out-of-the-box cleanup.
 
     Alternatively, use the ``async with`` context manager or explicitly call
     ``await client.delete_all()`` followed by ``await client.close()`` to
@@ -69,7 +75,7 @@ class AsyncSandboxClient(Generic[T]):
         self,
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
-        cleanup: bool = False,
+        cleanup: bool = True,
     ):
         """
         Args:
@@ -84,7 +90,10 @@ class AsyncSandboxClient(Generic[T]):
                 resources in a new event loop, so it is safe to call after
                 the main event loop has exited. Cleanup is best-effort —
                 per-claim and top-level failures emit warnings to
-                ``sys.stderr`` rather than raising. Defaults to False.
+                ``sys.stderr`` rather than raising. Defaults to True so that
+                sandboxes are not leaked when a caller forgets to clean up;
+                pass ``cleanup=False`` to opt out. Note this differs from the
+                synchronous ``SandboxClient``, which defaults to False.
         """
         if connection_config is None:
             raise ValueError(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -46,7 +46,8 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         self.config = SandboxDirectConnectionConfig(
             api_url="http://test-router:8080", server_port=8888
         )
-        self.client = AsyncSandboxClient(connection_config=self.config)
+        # cleanup=False keeps tests hermetic; the new default (True) registers a global atexit hook.
+        self.client = AsyncSandboxClient(connection_config=self.config, cleanup=False)
         self.mock_k8s_helper = self.client.k8s_helper
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
@@ -202,6 +203,12 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             AsyncSandboxClient(connection_config=None)
         self.assertIn("connection_config is required", str(ctx.exception))
 
+    def test_cleanup_default_registers_atexit(self):
+        """Constructing without cleanup= should default to True and register the hook."""
+        with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:
+            client = AsyncSandboxClient(connection_config=self.config)
+            mock_atexit.register.assert_called_once_with(client._atexit_cleanup)
+
     def test_cleanup_true_registers_atexit(self):
         """cleanup=True should register the _atexit_cleanup method as an atexit handler."""
         with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:
@@ -209,7 +216,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             mock_atexit.register.assert_called_once_with(client._atexit_cleanup)
 
     def test_cleanup_false_does_not_register_atexit(self):
-        """cleanup=False (default) should not register any atexit handler."""
+        """cleanup=False should opt out and not register any atexit handler."""
         with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:
             AsyncSandboxClient(connection_config=self.config, cleanup=False)
             mock_atexit.register.assert_not_called()
@@ -358,13 +365,13 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
 
     async def test_in_cluster_config_accepted(self):
         config = SandboxInClusterConnectionConfig()
-        client = AsyncSandboxClient(connection_config=config)
+        client = AsyncSandboxClient(connection_config=config, cleanup=False)
         self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
 
     async def test_use_pod_ip_not_passed_as_kwarg(self):
         """AsyncSandbox derives use_pod_ip from connection_config internally."""
         config = SandboxInClusterConnectionConfig(use_pod_ip=True)
-        client = AsyncSandboxClient(connection_config=config)
+        client = AsyncSandboxClient(connection_config=config, cleanup=False)
         mock_k8s_helper = client.k8s_helper
         mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
 
@@ -746,7 +753,8 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
         self.addCleanup(patcher.stop)
 
         self.config = SandboxInClusterConnectionConfig(server_port=8888, use_pod_ip=True)
-        self.client = AsyncSandboxClient(connection_config=self.config)
+        # cleanup=False keeps tests hermetic; the new default (True) registers a global atexit hook.
+        self.client = AsyncSandboxClient(connection_config=self.config, cleanup=False)
         self.mock_k8s_helper = self.client.k8s_helper
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
@@ -785,7 +793,7 @@ class TestAsyncSandboxClientInClusterUsePodIP(unittest.IsolatedAsyncioTestCase):
     async def test_get_sandbox_passes_connection_config_for_non_incluster(self):
         """Verify connection_config is passed through for non-InCluster configs."""
         config = SandboxDirectConnectionConfig(api_url="http://test", server_port=8888)
-        client = AsyncSandboxClient(connection_config=config)
+        client = AsyncSandboxClient(connection_config=config, cleanup=False)
         client.k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
         client.k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Flips the default value of `AsyncSandboxClient(..., cleanup=...)` from `False` to `True`, so the async client registers its `atexit` cleanup hook out of the box and tracked sandboxes are deleted on program termination unless the caller explicitly opts out with `cleanup=False`. The `cleanup=True` capability itself already landed in #859; this PR only changes the default.

Why this matters: in the #859 review, @barney-s asked whether `AsyncSandboxClient` should default to `cleanup=True` for a better out-of-the-box experience, and @aditya-shantanu agreed and invited a PR (#930). Without this, a caller who forgets to use the `async with` context manager or to call `delete_all()` / `close()` leaks sandbox claims when the program exits. Defaulting to `True` makes the safe behavior the default while keeping `cleanup=False` available for callers that manage lifecycles themselves.

Design note for reviewers: this intentionally makes the async client diverge from the synchronous `SandboxClient`, which stays `cleanup=False`. The issue title says "Consider", so the asymmetry is the reviewable decision; the docstrings now call it out explicitly. Happy to align the sync client instead if you'd prefer symmetry.

Tests updated/added in `test_async_sandboxclient.py`:
- new `test_cleanup_default_registers_atexit` — bare construction now registers the hook,
- `test_cleanup_true_registers_atexit` / `test_cleanup_false_does_not_register_atexit` retained as regression guards,
- setUp/helper constructions that don't exercise cleanup now pass `cleanup=False` to stay hermetic (the new default would otherwise register a real global `atexit` hook per test).

All 58 unit tests in the module pass locally.

#### Which issue(s) this PR is related to:

Fixes #930

#### Release Note

```release-note
The async `AsyncSandboxClient` now defaults to `cleanup=True`, registering an atexit hook that deletes tracked sandboxes on program termination. Pass `cleanup=False` to opt out. (This differs from the synchronous `SandboxClient`, which still defaults to `cleanup=False`.)
```

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The async sandbox client now automatically cleans up tracked sandbox claims when a program exits by default.
  * You can still disable this behavior by setting `cleanup=False`.

* **Bug Fixes**
  * Test setups were updated to avoid unintended exit-time cleanup side effects.
  * Added coverage for the new cleanup registration behavior, including default, enabled, and disabled cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->