### PR TITLE
chore: Migrate from deprecated `k8s.io/apimachinery/pkg/util/httpstream` to `k8s.io/streaming` 

### DIFF
--- a/clients/go/sandbox/tunnel.go
+++ b/clients/go/sandbox/tunnel.go
@@ -26,12 +26,12 @@ import (
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/httpstream" //nolint:staticcheck
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	discoveryv1client "k8s.io/client-go/kubernetes/typed/discovery/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
+	"k8s.io/streaming/pkg/httpstream"
 )
 
 const maxStderrSize = 64 << 10 // 64 KB
@@ -69,7 +69,7 @@ func (b *syncBuffer) String() string {
 	return b.buf.String()
 }
 
-// trackingDialer wraps an httpstream.Dialer to track the SPDY connection so it
+// trackingDialer wraps an httpstream.Dialer to track the streaming connection so it
 // can be forcefully closed when the stop channel alone does not unblock ForwardPorts.
 type trackingDialer struct {
 	inner  httpstream.Dialer
@@ -166,7 +166,7 @@ func (t *tunnelStrategy) Connect(ctx context.Context) (string, error) {
 			return http.ErrUseLastResponse
 		},
 	}
-	td := &trackingDialer{inner: spdy.NewDialer(upgrader, spdyClient, http.MethodPost, reqURL)}
+	td := &trackingDialer{inner: spdy.NewDialerForStreaming(upgrader, spdyClient, http.MethodPost, reqURL)}
 
 	t.mu.Lock()
 	if t.spdyUpgradeClient != nil {
@@ -179,7 +179,7 @@ func (t *tunnelStrategy) Connect(ctx context.Context) (string, error) {
 	stopChan := make(chan struct{})
 	readyChan := make(chan struct{})
 	var stderrBuf syncBuffer
-	fw, err := portforward.New(td, []string{"0:8080"}, stopChan, readyChan, io.Discard, &stderrBuf)
+	fw, err := portforward.NewForStreaming(td, []string{"0:8080"}, stopChan, readyChan, io.Discard, &stderrBuf)
 	if err != nil {
 		recordError(span, err)
 		return "", fmt.Errorf("sandbox: failed to create port forwarder: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/streaming v0.36.0
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/yaml v1.6.0
@@ -91,7 +92,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/streaming v0.36.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/tools.mod
+++ b/tools.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/streaming v0.36.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/yaml v1.6.0
@@ -102,7 +103,6 @@ require (
 	k8s.io/code-generator v0.36.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/kube-openapi v0.0.0-20260427204847-8949caaa1199 // indirect
-	k8s.io/streaming v0.36.0 // indirect
 	sigs.k8s.io/controller-tools v0.21.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

Replace the deprecated `k8s.io/apimachinery/pkg/util/httpstream` package with the new `k8s.io/streaming/pkg/httpstream` module, as `k8s.io/apimachinery` v0.36.0 has deprecated the old httpstream package. 

ref: https://github.com/kubernetes-sigs/agent-sandbox/pull/779#discussion_r3464102210

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
None
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel and port-forward connection handling for more reliable forwarding.
  * Updated module dependencies to support the newer streaming-based connection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->