### PR TITLE
Track sandboxes created via SDK

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -60,8 +60,8 @@ const (
 	SandboxTemplateRefAnnotation = "agents.x-k8s.io/sandbox-template-ref"
 	// SandboxLaunchTypeLabel is the label used to track whether the Sandbox was cold-created or originated from a warm pool.
 	SandboxLaunchTypeLabel = "agents.x-k8s.io/launch-type"
-	// SandboxCreatedByLabel is the label used to track which component created the resource (e.g. client, controller, etc.).
-	SandboxCreatedByLabel = "agents.x-k8s.io/created-by"
+	// CreatedByLabel is the label used to track which component created the resource (e.g. client, controller, etc.).
+	CreatedByLabel = "agents.x-k8s.io/created-by"
 	// SandboxLaunchTypeCold indicates the Sandbox was cold-created.
 	SandboxLaunchTypeCold = "cold"
 	// SandboxLaunchTypeWarm indicates the Sandbox was pre-provisioned by or adopted from a SandboxWarmPool.

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -60,6 +60,8 @@ const (
 	SandboxTemplateRefAnnotation = "agents.x-k8s.io/sandbox-template-ref"
 	// SandboxLaunchTypeLabel is the label used to track whether the Sandbox was cold-created or originated from a warm pool.
 	SandboxLaunchTypeLabel = "agents.x-k8s.io/launch-type"
+	// SandboxCreatedByLabel is the label used to track which component created the resource (e.g. client, controller, etc.).
+	SandboxCreatedByLabel = "agents.x-k8s.io/created-by"
 	// SandboxLaunchTypeCold indicates the Sandbox was cold-created.
 	SandboxLaunchTypeCold = "cold"
 	// SandboxLaunchTypeWarm indicates the Sandbox was pre-provisioned by or adopted from a SandboxWarmPool.

--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -138,6 +138,9 @@ func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName str
 			GenerateName: "sandbox-claim-",
 			Namespace:    namespace,
 			Annotations:  annotations,
+			Labels: map[string]string{
+				sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+			},
 		},
 		Spec: extv1beta1.SandboxClaimSpec{
 			WarmPoolRef: extv1beta1.SandboxWarmPoolRef{

--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -139,7 +139,7 @@ func (h *K8sHelper) createClaim(ctx context.Context, namespace, warmPoolName str
 			Namespace:    namespace,
 			Annotations:  annotations,
 			Labels: map[string]string{
-				sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+				sandboxv1beta1.CreatedByLabel: "go-client",
 			},
 		},
 		Spec: extv1beta1.SandboxClaimSpec{

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -84,8 +84,8 @@ class AsyncK8sHelper:
             "name": name,
             "annotations": annotations or {},
             "labels": {
-                CREATED_BY_LABEL: "python-client",
                 **(labels or {}),
+                CREATED_BY_LABEL: "python-client",
             }
         }
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -30,6 +30,7 @@ from .constants import (
     SANDBOX_API_GROUP,
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
+    CREATED_BY_LABEL,
 )
 from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
 from .utils import select_pod_ip, is_valid_ip, is_valid_gateway_hostname
@@ -82,9 +83,11 @@ class AsyncK8sHelper:
         metadata = {
             "name": name,
             "annotations": annotations or {},
+            "labels": {
+                CREATED_BY_LABEL: "python-client",
+                **(labels or {}),
+            }
         }
-        if labels:
-            metadata["labels"] = labels
 
         spec = {
             "warmPoolRef": {

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -26,6 +26,7 @@ SANDBOX_API_VERSION = "v1beta1"
 SANDBOX_PLURAL_NAME = "sandboxes"
 
 POD_NAME_ANNOTATION = "agents.x-k8s.io/pod-name"
+CREATED_BY_LABEL = "agents.x-k8s.io/created-by"
 PODSNAPSHOT_POD_NAME_ANNOTATION = "podsnapshot.gke.io/origin-pod"
 PODSNAPSHOT_NAME_ANNOTATION = "podsnapshot.gke.io/ps-name"
 SANDBOX_NAME_HASH_LABEL = "agents.x-k8s.io/sandbox-name-hash"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -67,8 +67,8 @@ class K8sHelper:
             "name": name,
             "annotations": annotations or {},
             "labels": {
-                CREATED_BY_LABEL: "python-client",
                 **(labels or {}),
+                CREATED_BY_LABEL: "python-client",
             }
         }
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -28,6 +28,7 @@ from .constants import (
     SANDBOX_API_GROUP,
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
+    CREATED_BY_LABEL,
 )
 from .utils import select_pod_ip
 
@@ -65,9 +66,11 @@ class K8sHelper:
         metadata = {
             "name": name,
             "annotations": annotations or {},
+            "labels": {
+                CREATED_BY_LABEL: "python-client",
+                **(labels or {}),
+            }
         }
-        if labels:
-            metadata["labels"] = labels
 
         spec = {
             "warmPoolRef": {

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -54,6 +54,7 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
         body = call_kwargs["body"]
         self.assertNotIn("lifecycle", body["spec"])
+        self.assertEqual(body["metadata"]["labels"], {"agents.x-k8s.io/created-by": "python-client"})
 
     async def test_lifecycle_with_labels_and_annotations(self):
         lifecycle = {
@@ -70,7 +71,7 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
         body = call_kwargs["body"]
         self.assertEqual(body["spec"]["lifecycle"], lifecycle)
-        self.assertEqual(body["metadata"]["labels"], {"agent": "test"})
+        self.assertEqual(body["metadata"]["labels"], {"agent": "test", "agents.x-k8s.io/created-by": "python-client"})
         self.assertEqual(body["metadata"]["annotations"], {"key": "val"})
 
     async def test_pod_metadata_included_in_manifest(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -95,6 +95,16 @@ class TestAsyncK8sHelperCreateSandboxClaim(unittest.IsolatedAsyncioTestCase):
         body = call_kwargs["body"]
         self.assertNotIn("additionalPodMetadata", body["spec"])
 
+    async def test_created_by_label_override_rejected(self):
+        await self.helper.create_sandbox_claim(
+            "test-claim", "test-warmpool", "test-namespace",
+            labels={"agent": "test", "agents.x-k8s.io/created-by": "foo"},
+        )
+
+        call_kwargs = self.helper.custom_objects_api.create_namespaced_custom_object.call_args.kwargs
+        body = call_kwargs["body"]
+        self.assertEqual(body["metadata"]["labels"], {"agent": "test", "agents.x-k8s.io/created-by": "python-client"})
+
 
 class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -39,7 +39,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         mock_api.create_namespaced_custom_object.assert_called_once()
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["metadata"]["annotations"], {"opentelemetry.io/trace-context": "trace-data"})
-        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent", "team": "platform"})
+        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent", "team": "platform", "agents.x-k8s.io/created-by": "python-client"})
 
     def test_labels_only_no_annotations(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
@@ -53,7 +53,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["metadata"]["annotations"], {})
-        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent"})
+        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent", "agents.x-k8s.io/created-by": "python-client"})
 
     def test_no_labels_no_annotations(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
@@ -64,7 +64,7 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["metadata"]["annotations"], {})
-        self.assertNotIn("labels", body["metadata"])
+        self.assertEqual(body["metadata"]["labels"], {"agents.x-k8s.io/created-by": "python-client"})
 
     def test_lifecycle_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -66,6 +66,19 @@ class TestK8sHelperCreateSandboxClaim(unittest.TestCase):
         self.assertEqual(body["metadata"]["annotations"], {})
         self.assertEqual(body["metadata"]["labels"], {"agents.x-k8s.io/created-by": "python-client"})
 
+    def test_created_by_label_override_rejected(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.create_sandbox_claim(
+            "test-claim", "test-warmpool", "test-namespace",
+            labels={"agent": "code-agent", "agents.x-k8s.io/created-by": "foo"},
+        )
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["metadata"]["labels"], {"agent": "code-agent", "agents.x-k8s.io/created-by": "python-client"})
+
     def test_lifecycle_included_in_manifest(self, mock_config, mock_api_cls, mock_core_cls):
         mock_api = MagicMock()
         mock_api_cls.return_value = mock_api

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -168,6 +168,9 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		"sandbox.name":      sandbox.Name,
 		"sandbox.namespace": sandbox.Namespace,
 	}
+	if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
+		initialAttrs[sandboxv1beta1.SandboxCreatedByLabel] = val
+	}
 	ctx, end := r.Tracer.StartSpan(ctx, sandbox, "ReconcileSandbox", initialAttrs)
 	defer end()
 
@@ -879,6 +882,11 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		}
 	}
 
+	// Propagate the created-by label directly from the Sandbox CR labels to the Pod if present.
+	if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
+		podLabels[sandboxv1beta1.SandboxCreatedByLabel] = val
+	}
+
 	annotations := map[string]string{}
 	var managedAnnotationKeys []string
 	for k, v := range sandbox.Spec.PodTemplate.ObjectMeta.Annotations {
@@ -1024,6 +1032,20 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		// If the Sandbox is no longer owned by a SandboxWarmPool, remove the warm pool label.
 		if _, exists := pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; exists {
 			delete(pod.Labels, sandboxv1beta1.SandboxWarmPoolLabel)
+			updated = true
+		}
+	}
+
+	// Ensure the created-by label is present on the Pod if it is present on the Sandbox.
+	expectedCreatedBy := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]
+	if expectedCreatedBy != "" {
+		if pod.Labels[sandboxv1beta1.SandboxCreatedByLabel] != expectedCreatedBy {
+			pod.Labels[sandboxv1beta1.SandboxCreatedByLabel] = expectedCreatedBy
+			updated = true
+		}
+	} else {
+		if _, exists := pod.Labels[sandboxv1beta1.SandboxCreatedByLabel]; exists {
+			delete(pod.Labels, sandboxv1beta1.SandboxCreatedByLabel)
 			updated = true
 		}
 	}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -168,8 +168,8 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		"sandbox.name":      sandbox.Name,
 		"sandbox.namespace": sandbox.Namespace,
 	}
-	if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
-		initialAttrs[sandboxv1beta1.SandboxCreatedByLabel] = val
+	if val, ok := sandbox.Labels[sandboxv1beta1.CreatedByLabel]; ok {
+		initialAttrs[sandboxv1beta1.CreatedByLabel] = val
 	}
 	ctx, end := r.Tracer.StartSpan(ctx, sandbox, "ReconcileSandbox", initialAttrs)
 	defer end()
@@ -882,9 +882,10 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		}
 	}
 
-	// Propagate the created-by label directly from the Sandbox CR labels to the Pod if present.
-	if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
-		podLabels[sandboxv1beta1.SandboxCreatedByLabel] = val
+	// Propagate the created-by label from the Sandbox CR labels to the Pod if present,
+	// normalizing it to a known allow-list to prevent invalid values or high cardinality.
+	if val, ok := sandbox.Labels[sandboxv1beta1.CreatedByLabel]; ok && val != "" {
+		podLabels[sandboxv1beta1.CreatedByLabel] = asmetrics.NormalizeCreatedBy(val)
 	}
 
 	annotations := map[string]string{}
@@ -1037,15 +1038,19 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 	}
 
 	// Ensure the created-by label is present on the Pod if it is present on the Sandbox.
-	expectedCreatedBy := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]
+	// We normalize it to a known allow-list to prevent invalid values or high cardinality on the Pod.
+	var expectedCreatedBy string
+	if val, ok := sandbox.Labels[sandboxv1beta1.CreatedByLabel]; ok && val != "" {
+		expectedCreatedBy = asmetrics.NormalizeCreatedBy(val)
+	}
 	if expectedCreatedBy != "" {
-		if pod.Labels[sandboxv1beta1.SandboxCreatedByLabel] != expectedCreatedBy {
-			pod.Labels[sandboxv1beta1.SandboxCreatedByLabel] = expectedCreatedBy
+		if pod.Labels[sandboxv1beta1.CreatedByLabel] != expectedCreatedBy {
+			pod.Labels[sandboxv1beta1.CreatedByLabel] = expectedCreatedBy
 			updated = true
 		}
 	} else {
-		if _, exists := pod.Labels[sandboxv1beta1.SandboxCreatedByLabel]; exists {
-			delete(pod.Labels, sandboxv1beta1.SandboxCreatedByLabel)
+		if _, exists := pod.Labels[sandboxv1beta1.CreatedByLabel]; exists {
+			delete(pod.Labels, sandboxv1beta1.CreatedByLabel)
 			updated = true
 		}
 	}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -169,7 +169,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		"sandbox.namespace": sandbox.Namespace,
 	}
 	if val, ok := sandbox.Labels[sandboxv1beta1.CreatedByLabel]; ok {
-		initialAttrs[sandboxv1beta1.CreatedByLabel] = val
+		initialAttrs[sandboxv1beta1.CreatedByLabel] = asmetrics.NormalizeCreatedBy(val)
 	}
 	ctx, end := r.Tracer.StartSpan(ctx, sandbox, "ReconcileSandbox", initialAttrs)
 	defer end()

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2060,6 +2060,76 @@ func TestReconcilePod(t *testing.T) {
 			expectErr:              true,
 			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: "adopted-pod-name"},
 		},
+		{
+			name:        "propagates and normalizes created-by label value go-client",
+			initialObjs: []runtime.Object{},
+			sandbox: func() *sandboxv1beta1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Labels = map[string]string{
+					sandboxv1beta1.CreatedByLabel: "go-client",
+				}
+				return sb
+			}(),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+						sandboxv1beta1.CreatedByLabel:       "go-client",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name:        "normalizes invalid created-by label to unknown",
+			initialObjs: []runtime.Object{},
+			sandbox: func() *sandboxv1beta1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Labels = map[string]string{
+					sandboxv1beta1.CreatedByLabel: "invalid-user-value-which-is-too-long-or-custom",
+				}
+				return sb
+			}(),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+						sandboxv1beta1.CreatedByLabel:       "unknown",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -3425,22 +3425,22 @@ type mockTracer struct {
 	capturedAttrs map[string]string
 }
 
-func (m *mockTracer) StartSpan(ctx context.Context, obj metav1.Object, spanName string, attrs map[string]string) (context.Context, func()) {
+func (m *mockTracer) StartSpan(ctx context.Context, _ metav1.Object, _ string, attrs map[string]string) (context.Context, func()) {
 	if len(attrs) > 0 {
 		m.capturedAttrs = attrs
 	}
 	return ctx, func() {}
 }
 
-func (m *mockTracer) GetTraceContext(ctx context.Context) string {
+func (m *mockTracer) GetTraceContext(_ context.Context) string {
 	return ""
 }
 
-func (m *mockTracer) IsRecording(ctx context.Context) bool {
+func (m *mockTracer) IsRecording(_ context.Context) bool {
 	return true
 }
 
-func (m *mockTracer) AddEvent(ctx context.Context, name string, attrs map[string]string) {}
+func (m *mockTracer) AddEvent(_ context.Context, _ string, _ map[string]string) {}
 
 func TestReconcile_TracingNormalization(t *testing.T) {
 	sbName := "tracing-test-sandbox"
@@ -3484,4 +3484,3 @@ func TestReconcile_TracingNormalization(t *testing.T) {
 	require.NotNil(t, mt.capturedAttrs)
 	require.Equal(t, "unknown", mt.capturedAttrs[sandboxv1beta1.CreatedByLabel], "created-by label must be normalized in span attributes")
 }
-

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2130,6 +2130,115 @@ func TestReconcilePod(t *testing.T) {
 				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
 			},
 		},
+		{
+			name: "updates and normalizes created-by label on existing Pod",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+							"custom-label":                       "label-val",
+							sandboxv1beta1.SandboxAdoptableLabel: "true",
+							sandboxv1beta1.CreatedByLabel:        "controller",
+						},
+						Annotations: map[string]string{
+							"custom-annotation":                      "anno-val",
+							"agents.x-k8s.io/propagated-labels":      "custom-label",
+							"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: func() *sandboxv1beta1.Sandbox {
+				sb := sandboxObj.DeepCopy()
+				sb.Labels = map[string]string{
+					sandboxv1beta1.CreatedByLabel: "python-client",
+				}
+				return sb
+			}(),
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+						"custom-label":                       "label-val",
+						sandboxv1beta1.SandboxAdoptableLabel: "true",
+						sandboxv1beta1.CreatedByLabel:        "python-client",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name: "removes created-by label from existing Pod when Sandbox lacks it",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+							"custom-label":                       "label-val",
+							sandboxv1beta1.SandboxAdoptableLabel: "true",
+							sandboxv1beta1.CreatedByLabel:        "go-client",
+						},
+						Annotations: map[string]string{
+							"custom-annotation":                      "anno-val",
+							"agents.x-k8s.io/propagated-labels":      "custom-label",
+							"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: sandboxObj,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+						"custom-label":                       "label-val",
+						sandboxv1beta1.SandboxAdoptableLabel: "true",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -3419,3 +3419,69 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 	require.Len(t, got.Status.Conditions, 1,
 		"conditions slice must not grow across %d reconcile iterations — controller must upsert not append", iters)
 }
+
+type mockTracer struct {
+	asmetrics.Instrumenter
+	capturedAttrs map[string]string
+}
+
+func (m *mockTracer) StartSpan(ctx context.Context, obj metav1.Object, spanName string, attrs map[string]string) (context.Context, func()) {
+	if len(attrs) > 0 {
+		m.capturedAttrs = attrs
+	}
+	return ctx, func() {}
+}
+
+func (m *mockTracer) GetTraceContext(ctx context.Context) string {
+	return ""
+}
+
+func (m *mockTracer) IsRecording(ctx context.Context) bool {
+	return true
+}
+
+func (m *mockTracer) AddEvent(ctx context.Context, name string, attrs map[string]string) {}
+
+func TestReconcile_TracingNormalization(t *testing.T) {
+	sbName := "tracing-test-sandbox"
+	sbNs := "default"
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sbName,
+			Namespace: sbNs,
+			UID:       "uid-1",
+			Labels: map[string]string{
+				sandboxv1beta1.CreatedByLabel: "invalid-value",
+			},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container", Image: "nginx"}},
+				},
+			},
+		},
+	}
+
+	fc := newFakeClient(sandbox)
+	mt := &mockTracer{}
+	r := &SandboxReconciler{
+		Client:        fc,
+		Scheme:        Scheme,
+		Tracer:        mt,
+		ClusterDomain: "cluster.local",
+	}
+
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sbName, Namespace: sbNs}}
+
+	var sb sandboxv1beta1.Sandbox
+	require.NoError(t, fc.Get(ctx, req.NamespacedName, &sb))
+
+	_, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	require.NotNil(t, mt.capturedAttrs)
+	require.Equal(t, "unknown", mt.capturedAttrs[sandboxv1beta1.CreatedByLabel], "created-by label must be normalized in span attributes")
+}
+

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -3455,9 +3455,11 @@ func TestReconcile_TracingNormalization(t *testing.T) {
 			},
 		},
 		Spec: sandboxv1beta1.SandboxSpec{
-			PodTemplate: sandboxv1beta1.PodTemplate{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "test-container", Image: "nginx"}},
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container", Image: "nginx"}},
+					},
 				},
 			},
 		},

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -224,7 +224,15 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Start Tracing Span
-	ctx, end := r.Tracer.StartSpan(ctx, claim, "ReconcileSandboxClaim", nil)
+	var initialAttrs map[string]string
+	if claim.Labels != nil {
+		if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+			initialAttrs = map[string]string{
+				v1beta1.SandboxCreatedByLabel: val,
+			}
+		}
+	}
+	ctx, end := r.Tracer.StartSpan(ctx, claim, "ReconcileSandboxClaim", initialAttrs)
 	defer end()
 
 	if !claim.DeletionTimestamp.IsZero() {
@@ -449,6 +457,9 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 			templateHash := SandboxTemplateRefHash(template.Name)
 			mergedMeta.Labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
 			mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
+			if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+				mergedMeta.Labels[v1beta1.SandboxCreatedByLabel] = val
+			}
 
 			if err := r.mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
 				return nil, err
@@ -460,6 +471,13 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 					sandbox.Labels = make(map[string]string)
 				}
 				sandbox.Labels[sandboxTemplateRefHash] = templateHash
+				needsUpdate = true
+			}
+			if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok && sandbox.Labels[v1beta1.SandboxCreatedByLabel] != val {
+				if sandbox.Labels == nil {
+					sandbox.Labels = make(map[string]string)
+				}
+				sandbox.Labels[v1beta1.SandboxCreatedByLabel] = val
 				needsUpdate = true
 			}
 
@@ -735,6 +753,9 @@ func ensureClaimIdentityLabels(labels map[string]string, claim *extensionsv1beta
 		labels = make(map[string]string)
 	}
 	labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
+	if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+		labels[v1beta1.SandboxCreatedByLabel] = val
+	}
 	return labels
 }
 
@@ -935,7 +956,11 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 				podCondition = "ready"
 			}
 			templateName := r.resolveTemplateName(adopted)
-			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition)
+			createdBy := "unknown"
+			if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+				createdBy = val
+			}
+			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition, createdBy)
 
 			return true, nil
 		}()
@@ -1022,6 +1047,9 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		mergedMeta.Labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
 		if templateHash != "" {
 			mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
+		}
+		if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+			mergedMeta.Labels[v1beta1.SandboxCreatedByLabel] = val
 		}
 
 		if err := r.mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
@@ -1368,7 +1396,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxProvisioned", "Provisioning", "Created Sandbox %q", sandbox.Name)
 	}
 
-	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready")
+	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready", createdBy)
 
 	return sandbox, nil
 }

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -226,7 +226,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Start Tracing Span
 	var initialAttrs map[string]string
 	if claim.Labels != nil {
-		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 			initialAttrs = map[string]string{
 				v1beta1.CreatedByLabel: val,
 			}
@@ -459,7 +459,7 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 			mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
 			// Sync the created-by label to the Pod template. If the claim does not have it,
 			// we remove it to ensure consistency with cold starts and prevent stale label values.
-			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 				mergedMeta.Labels[v1beta1.CreatedByLabel] = val
 			} else {
 				delete(mergedMeta.Labels, v1beta1.CreatedByLabel)
@@ -477,7 +477,7 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 				sandbox.Labels[sandboxTemplateRefHash] = templateHash
 				needsUpdate = true
 			}
-			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 				if sandbox.Labels[v1beta1.CreatedByLabel] != val {
 					if sandbox.Labels == nil {
 						sandbox.Labels = make(map[string]string)
@@ -766,7 +766,7 @@ func ensureClaimIdentityLabels(labels map[string]string, claim *extensionsv1beta
 	labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
 	// Propagate created-by label from the claim if present. If absent, explicitly
 	// delete it to synchronize removal or prevent stale propagation from warm sandboxes.
-	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 		labels[v1beta1.CreatedByLabel] = val
 	} else {
 		delete(labels, v1beta1.CreatedByLabel)
@@ -972,7 +972,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			}
 			templateName := r.resolveTemplateName(adopted)
 			createdBy := "unknown"
-			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 				createdBy = val
 			}
 			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition, createdBy)
@@ -1065,7 +1065,7 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		}
 		// Propagate created-by label to the Pod template during adoption. If absent,
 		// explicitly delete it to ensure it is not kept from the pre-warmed sandbox.
-		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 			mergedMeta.Labels[v1beta1.CreatedByLabel] = val
 		} else {
 			delete(mergedMeta.Labels, v1beta1.CreatedByLabel)
@@ -1416,7 +1416,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	}
 
 	createdBy := "unknown"
-	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 		createdBy = val
 	}
 	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready", createdBy)

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -226,9 +226,9 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Start Tracing Span
 	var initialAttrs map[string]string
 	if claim.Labels != nil {
-		if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
 			initialAttrs = map[string]string{
-				v1beta1.SandboxCreatedByLabel: val,
+				v1beta1.CreatedByLabel: val,
 			}
 		}
 	}
@@ -457,8 +457,12 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 			templateHash := SandboxTemplateRefHash(template.Name)
 			mergedMeta.Labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
 			mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
-			if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
-				mergedMeta.Labels[v1beta1.SandboxCreatedByLabel] = val
+			// Sync the created-by label to the Pod template. If the claim does not have it,
+			// we remove it to ensure consistency with cold starts and prevent stale label values.
+			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+				mergedMeta.Labels[v1beta1.CreatedByLabel] = val
+			} else {
+				delete(mergedMeta.Labels, v1beta1.CreatedByLabel)
 			}
 
 			if err := r.mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
@@ -473,12 +477,19 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 				sandbox.Labels[sandboxTemplateRefHash] = templateHash
 				needsUpdate = true
 			}
-			if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok && sandbox.Labels[v1beta1.SandboxCreatedByLabel] != val {
-				if sandbox.Labels == nil {
-					sandbox.Labels = make(map[string]string)
+			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+				if sandbox.Labels[v1beta1.CreatedByLabel] != val {
+					if sandbox.Labels == nil {
+						sandbox.Labels = make(map[string]string)
+					}
+					sandbox.Labels[v1beta1.CreatedByLabel] = val
+					needsUpdate = true
 				}
-				sandbox.Labels[v1beta1.SandboxCreatedByLabel] = val
-				needsUpdate = true
+			} else {
+				if _, exists := sandbox.Labels[v1beta1.CreatedByLabel]; exists {
+					delete(sandbox.Labels, v1beta1.CreatedByLabel)
+					needsUpdate = true
+				}
 			}
 
 			if needsUpdate {
@@ -753,8 +764,12 @@ func ensureClaimIdentityLabels(labels map[string]string, claim *extensionsv1beta
 		labels = make(map[string]string)
 	}
 	labels[extensionsv1beta1.SandboxIDLabel] = string(claim.UID)
-	if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
-		labels[v1beta1.SandboxCreatedByLabel] = val
+	// Propagate created-by label from the claim if present. If absent, explicitly
+	// delete it to synchronize removal or prevent stale propagation from warm sandboxes.
+	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+		labels[v1beta1.CreatedByLabel] = val
+	} else {
+		delete(labels, v1beta1.CreatedByLabel)
 	}
 	return labels
 }
@@ -957,7 +972,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			}
 			templateName := r.resolveTemplateName(adopted)
 			createdBy := "unknown"
-			if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
+			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
 				createdBy = val
 			}
 			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition, createdBy)
@@ -1048,8 +1063,12 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		if templateHash != "" {
 			mergedMeta.Labels[sandboxTemplateRefHash] = templateHash
 		}
-		if val, ok := claim.Labels[v1beta1.SandboxCreatedByLabel]; ok {
-			mergedMeta.Labels[v1beta1.SandboxCreatedByLabel] = val
+		// Propagate created-by label to the Pod template during adoption. If absent,
+		// explicitly delete it to ensure it is not kept from the pre-warmed sandbox.
+		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+			mergedMeta.Labels[v1beta1.CreatedByLabel] = val
+		} else {
+			delete(mergedMeta.Labels, v1beta1.CreatedByLabel)
 		}
 
 		if err := r.mergePodMetadata(&mergedMeta, &claim.Spec.AdditionalPodMetadata); err != nil {
@@ -1396,6 +1415,10 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxProvisioned", "Provisioning", "Created Sandbox %q", sandbox.Name)
 	}
 
+	createdBy := "unknown"
+	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok {
+		createdBy = val
+	}
 	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready", createdBy)
 
 	return sandbox, nil

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -228,7 +228,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if claim.Labels != nil {
 		if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
 			initialAttrs = map[string]string{
-				v1beta1.CreatedByLabel: val,
+				v1beta1.CreatedByLabel: asmetrics.NormalizeCreatedBy(val),
 			}
 		}
 	}
@@ -971,11 +971,7 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 				podCondition = "ready"
 			}
 			templateName := r.resolveTemplateName(adopted)
-			createdBy := "unknown"
-			if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
-				createdBy = val
-			}
-			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition, createdBy)
+			asmetrics.RecordSandboxClaimCreation(claim.Namespace, templateName, asmetrics.LaunchTypeWarm, poolName, podCondition, claim.Labels[v1beta1.CreatedByLabel])
 
 			return true, nil
 		}()
@@ -1415,11 +1411,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxProvisioned", "Provisioning", "Created Sandbox %q", sandbox.Name)
 	}
 
-	createdBy := "unknown"
-	if val, ok := claim.Labels[v1beta1.CreatedByLabel]; ok && val != "" {
-		createdBy = val
-	}
-	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready", createdBy)
+	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready", claim.Labels[v1beta1.CreatedByLabel])
 
 	return sandbox, nil
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -5035,22 +5035,22 @@ type mockTracer struct {
 	capturedAttrs map[string]string
 }
 
-func (m *mockTracer) StartSpan(ctx context.Context, obj metav1.Object, spanName string, attrs map[string]string) (context.Context, func()) {
+func (m *mockTracer) StartSpan(ctx context.Context, _ metav1.Object, _ string, attrs map[string]string) (context.Context, func()) {
 	if len(attrs) > 0 {
 		m.capturedAttrs = attrs
 	}
 	return ctx, func() {}
 }
 
-func (m *mockTracer) GetTraceContext(ctx context.Context) string {
+func (m *mockTracer) GetTraceContext(_ context.Context) string {
 	return ""
 }
 
-func (m *mockTracer) IsRecording(ctx context.Context) bool {
+func (m *mockTracer) IsRecording(_ context.Context) bool {
 	return true
 }
 
-func (m *mockTracer) AddEvent(ctx context.Context, name string, attrs map[string]string) {}
+func (m *mockTracer) AddEvent(_ context.Context, _ string, _ map[string]string) {}
 
 func TestReconcile_TracingNormalization(t *testing.T) {
 	claimName := "tracing-test-claim"
@@ -5091,4 +5091,3 @@ func TestReconcile_TracingNormalization(t *testing.T) {
 	require.NotNil(t, mt.capturedAttrs)
 	require.Equal(t, "unknown", mt.capturedAttrs[sandboxv1beta1.CreatedByLabel], "created-by label must be normalized in span attributes")
 }
-

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2201,7 +2201,7 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					if cCopy.Labels == nil {
 						cCopy.Labels = make(map[string]string)
 					}
-					cCopy.Labels[sandboxv1beta1.SandboxCreatedByLabel] = "go-client"
+					cCopy.Labels[sandboxv1beta1.CreatedByLabel] = "go-client"
 					return cCopy
 				}(),
 				func() client.Object {
@@ -2209,17 +2209,41 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					if sb.Labels == nil {
 						sb.Labels = make(map[string]string)
 					}
-					sb.Labels[sandboxv1beta1.SandboxCreatedByLabel] = "controller"
+					sb.Labels[sandboxv1beta1.CreatedByLabel] = "controller"
 					return sb
 				}(),
 			},
 			expectSandboxAdoption:  true,
 			expectedAdoptedSandbox: "pool-sb-1",
 			expectedLabels: map[string]string{
-				sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+				sandboxv1beta1.CreatedByLabel: "go-client",
 			},
 			expectedPodLabels: map[string]string{
-				sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+				sandboxv1beta1.CreatedByLabel: "go-client",
+			},
+			expectNewSandboxCreated: false,
+		},
+		{
+			name: "removes created-by label during adoption when claim lacks it",
+			existingObjects: []client.Object{
+				template,
+				claim.DeepCopy(),
+				func() client.Object {
+					sb := createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true)
+					if sb.Labels == nil {
+						sb.Labels = make(map[string]string)
+					}
+					sb.Labels[sandboxv1beta1.CreatedByLabel] = "controller"
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:  true,
+			expectedAdoptedSandbox: "pool-sb-1",
+			expectedLabels: map[string]string{
+				sandboxv1beta1.CreatedByLabel: "",
+			},
+			expectedPodLabels: map[string]string{
+				sandboxv1beta1.CreatedByLabel: "",
 			},
 			expectNewSandboxCreated: false,
 		},
@@ -2739,6 +2763,18 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		if val != 1 {
 			t.Errorf("expected metric count 1, got %v", val)
 		}
+
+		// Verify created Sandbox labels are absent
+		sb := &sandboxv1beta1.Sandbox{}
+		if err := client.Get(context.Background(), types.NamespacedName{Name: claim.Name, Namespace: "default"}, sb); err != nil {
+			t.Fatalf("failed to get created sandbox: %v", err)
+		}
+		if val, exists := sb.Labels[sandboxv1beta1.CreatedByLabel]; exists && val != "" {
+			t.Errorf("expected sandbox created-by label to be absent, got %q", val)
+		}
+		if val, exists := sb.Spec.PodTemplate.ObjectMeta.Labels[sandboxv1beta1.CreatedByLabel]; exists && val != "" {
+			t.Errorf("expected sandbox pod template created-by label to be absent, got %q", val)
+		}
 	})
 
 	t.Run("Warm Start", func(t *testing.T) {
@@ -2751,8 +2787,9 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 				Name:      "warm-sb",
 				Namespace: "default",
 				Labels: map[string]string{
-					warmPoolSandboxLabel:   poolNameHash,
-					sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+					warmPoolSandboxLabel:          poolNameHash,
+					sandboxTemplateRefHash:        sandboxcontrollers.NameHash("test-template"),
+					sandboxv1beta1.CreatedByLabel: "controller",
 				},
 				Annotations: map[string]string{
 					sandboxv1beta1.SandboxTemplateRefAnnotation: "test-template",
@@ -2802,6 +2839,18 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeWarm, "test-warmpool", "ready", "unknown"))
 		if val != 1 {
 			t.Errorf("expected metric count 1, got %v", val)
+		}
+
+		// Verify adopted Sandbox labels are removed (since claim lacks it)
+		sb := &sandboxv1beta1.Sandbox{}
+		if err := client.Get(context.Background(), types.NamespacedName{Name: "warm-sb", Namespace: "default"}, sb); err != nil {
+			t.Fatalf("failed to get adopted sandbox: %v", err)
+		}
+		if val, exists := sb.Labels[sandboxv1beta1.CreatedByLabel]; exists && val != "" {
+			t.Errorf("expected sandbox created-by label to be absent, got %q", val)
+		}
+		if val, exists := sb.Spec.PodTemplate.ObjectMeta.Labels[sandboxv1beta1.CreatedByLabel]; exists && val != "" {
+			t.Errorf("expected sandbox pod template created-by label to be absent, got %q", val)
 		}
 	})
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1996,6 +1996,8 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		expectedAdoptedSandbox  string
 		expectedAnnotations     map[string]string
 		expectedPodAnnotations  map[string]string
+		expectedLabels          map[string]string
+		expectedPodLabels       map[string]string
 		expectNewSandboxCreated bool
 		simulateConflicts       int
 	}{
@@ -2189,8 +2191,37 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					return sb
 				}(),
 			},
-			expectSandboxAdoption:   false,
-			expectNewSandboxCreated: true,
+		},
+		{
+			name: "propagates and overwrites created-by label during adoption",
+			existingObjects: []client.Object{
+				template,
+				func() client.Object {
+					cCopy := claim.DeepCopy()
+					if cCopy.Labels == nil {
+						cCopy.Labels = make(map[string]string)
+					}
+					cCopy.Labels[sandboxv1beta1.SandboxCreatedByLabel] = "go-client"
+					return cCopy
+				}(),
+				func() client.Object {
+					sb := createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true)
+					if sb.Labels == nil {
+						sb.Labels = make(map[string]string)
+					}
+					sb.Labels[sandboxv1beta1.SandboxCreatedByLabel] = "controller"
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:  true,
+			expectedAdoptedSandbox: "pool-sb-1",
+			expectedLabels: map[string]string{
+				sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+			},
+			expectedPodLabels: map[string]string{
+				sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+			},
+			expectNewSandboxCreated: false,
 		},
 	}
 
@@ -2305,6 +2336,14 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 
 				for key, expected := range tc.expectedAnnotations {
 					require.Equal(t, expected, adoptedSandbox.Annotations[key])
+				}
+
+				for key, expected := range tc.expectedLabels {
+					require.Equal(t, expected, adoptedSandbox.Labels[key])
+				}
+
+				for key, expected := range tc.expectedPodLabels {
+					require.Equal(t, expected, adoptedSandbox.Spec.PodTemplate.ObjectMeta.Labels[key])
 				}
 
 				// 5. Verify the claim records the assigned sandbox annotation
@@ -2696,7 +2735,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		}
 
 		// Verify metric
-		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "test-warmpool", "not_ready"))
+		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "test-warmpool", "not_ready", "unknown"))
 		if val != 1 {
 			t.Errorf("expected metric count 1, got %v", val)
 		}
@@ -2760,7 +2799,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		}
 
 		// Verify metric
-		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeWarm, "test-warmpool", "ready"))
+		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeWarm, "test-warmpool", "ready", "unknown"))
 		if val != 1 {
 			t.Errorf("expected metric count 1, got %v", val)
 		}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -5029,3 +5029,66 @@ func TestCreateSandboxClaimVolumeClaimTemplatesErrors(t *testing.T) {
 		})
 	}
 }
+
+type mockTracer struct {
+	asmetrics.Instrumenter
+	capturedAttrs map[string]string
+}
+
+func (m *mockTracer) StartSpan(ctx context.Context, obj metav1.Object, spanName string, attrs map[string]string) (context.Context, func()) {
+	if len(attrs) > 0 {
+		m.capturedAttrs = attrs
+	}
+	return ctx, func() {}
+}
+
+func (m *mockTracer) GetTraceContext(ctx context.Context) string {
+	return ""
+}
+
+func (m *mockTracer) IsRecording(ctx context.Context) bool {
+	return true
+}
+
+func (m *mockTracer) AddEvent(ctx context.Context, name string, attrs map[string]string) {}
+
+func TestReconcile_TracingNormalization(t *testing.T) {
+	claimName := "tracing-test-claim"
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: "default",
+			UID:       "uid-claim-1",
+			Labels: map[string]string{
+				sandboxv1beta1.CreatedByLabel: "invalid-value",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-warmpool"},
+		},
+	}
+
+	scheme := newScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(claim).
+		WithStatusSubresource(claim).
+		Build()
+
+	mt := &mockTracer{}
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           mt,
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	_ = err
+
+	require.NotNil(t, mt.capturedAttrs)
+	require.Equal(t, "unknown", mt.capturedAttrs[sandboxv1beta1.CreatedByLabel], "created-by label must be normalized in span attributes")
+}
+

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2191,6 +2191,8 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 					return sb
 				}(),
 			},
+			expectSandboxAdoption:   false,
+			expectNewSandboxCreated: true,
 		},
 		{
 			name: "propagates and overwrites created-by label during adoption",

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -377,6 +377,7 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(
 		sandboxv1beta1.SandboxLaunchTypeLabel:                sandboxv1beta1.SandboxLaunchTypeWarm,
 		sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel: currentPodTemplateHash,
 		sandboxv1beta1.SandboxTemplateHashLabel:              currentSandboxBlueprintHash,
+		sandboxv1beta1.SandboxCreatedByLabel:       "controller",
 	}
 
 	// Build annotations for the Sandbox CR

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -377,7 +377,7 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(
 		sandboxv1beta1.SandboxLaunchTypeLabel:                sandboxv1beta1.SandboxLaunchTypeWarm,
 		sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel: currentPodTemplateHash,
 		sandboxv1beta1.SandboxTemplateHashLabel:              currentSandboxBlueprintHash,
-		sandboxv1beta1.SandboxCreatedByLabel:       "controller",
+		sandboxv1beta1.CreatedByLabel:              "controller",
 	}
 
 	// Build annotations for the Sandbox CR

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -377,7 +377,7 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(
 		sandboxv1beta1.SandboxLaunchTypeLabel:                sandboxv1beta1.SandboxLaunchTypeWarm,
 		sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel: currentPodTemplateHash,
 		sandboxv1beta1.SandboxTemplateHashLabel:              currentSandboxBlueprintHash,
-		sandboxv1beta1.CreatedByLabel:              "controller",
+		sandboxv1beta1.CreatedByLabel:                        "controller",
 	}
 
 	// Build annotations for the Sandbox CR

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -171,6 +171,7 @@ func NormalizeCreatedBy(createdBy string) string {
 }
 
 // RecordSandboxClaimCreation increments the total count of created sandbox claims.
+// The createdBy value is automatically normalized.
 func RecordSandboxClaimCreation(namespace, templateName, launchType, warmPoolName, podCondition, createdBy string) {
 	SandboxClaimCreationTotal.WithLabelValues(namespace, templateName, launchType, warmPoolName, podCondition, NormalizeCreatedBy(createdBy)).Inc()
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -88,7 +88,7 @@ var (
 	// - launch_type: "warm", "cold", "unknown"
 	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	// - pod_condition: "ready", "not_ready".
-	// - created_by: the component that created the claim (e.g. "go-client", "python-client", "unknown").
+	// - created_by: the component that created the claim (e.g. "go-client", "python-client", "controller", "unknown").
 	SandboxClaimCreationTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "agent_sandbox_claim_creation_total",
@@ -105,7 +105,7 @@ var (
 	// - launch_type: "warm" | "cold"
 	// - sandbox_template: sandboxTemplateRef.
 	// - owned_by: "SandboxClaim" | "SandboxWarmPool" | "None".
-	// - created_by: the component that created the sandbox (e.g. "client", "unknown").
+	// - created_by: the component that created the sandbox (e.g. "go-client", "python-client", "controller", "unknown").
 	AgentSandboxesDesc = prometheus.NewDesc(
 		"agent_sandboxes",
 		"Monitor the point-in-time number of sandboxes in the cluster.",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -88,12 +88,13 @@ var (
 	// - launch_type: "warm", "cold", "unknown"
 	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	// - pod_condition: "ready", "not_ready".
+	// - created_by: the component that created the claim (e.g. "go-client", "python-client", "unknown").
 	SandboxClaimCreationTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "agent_sandbox_claim_creation_total",
-			Help: "Total number of SandboxClaims created, labeled by namespace, sandbox template, launch type, warmpool name, and pod condition.",
+			Help: "Total number of SandboxClaims created, labeled by namespace, sandbox template, launch type, warmpool name, pod condition, and created_by.",
 		},
-		[]string{"namespace", "sandbox_template", "launch_type", "warmpool_name", "pod_condition"},
+		[]string{"namespace", "sandbox_template", "launch_type", "warmpool_name", "pod_condition", "created_by"},
 	)
 
 	// AgentSandboxesDesc describes the agent_sandboxes metric point-in-time counts.
@@ -104,10 +105,11 @@ var (
 	// - launch_type: "warm" | "cold"
 	// - sandbox_template: sandboxTemplateRef.
 	// - owned_by: "SandboxClaim" | "SandboxWarmPool" | "None".
+	// - created_by: the component that created the sandbox (e.g. "client", "unknown").
 	AgentSandboxesDesc = prometheus.NewDesc(
 		"agent_sandboxes",
 		"Monitor the point-in-time number of sandboxes in the cluster.",
-		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template", "owned_by"},
+		[]string{"namespace", "ready_condition", "expired", "launch_type", "sandbox_template", "owned_by", "created_by"},
 		nil,
 	)
 
@@ -158,6 +160,6 @@ func RecordSandboxCreationLatency(duration time.Duration, namespace, launchType,
 }
 
 // RecordSandboxClaimCreation increments the total count of created sandbox claims.
-func RecordSandboxClaimCreation(namespace, templateName, launchType, warmPoolName, podCondition string) {
-	SandboxClaimCreationTotal.WithLabelValues(namespace, templateName, launchType, warmPoolName, podCondition).Inc()
+func RecordSandboxClaimCreation(namespace, templateName, launchType, warmPoolName, podCondition, createdBy string) {
+	SandboxClaimCreationTotal.WithLabelValues(namespace, templateName, launchType, warmPoolName, podCondition, createdBy).Inc()
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -159,7 +159,18 @@ func RecordSandboxCreationLatency(duration time.Duration, namespace, launchType,
 	SandboxCreationLatency.WithLabelValues(namespace, launchType, templateName).Observe(float64(duration.Milliseconds()))
 }
 
+// NormalizeCreatedBy returns the createdBy label normalized to a known allow-list
+// (go-client, python-client, controller) or "unknown" for anything else.
+func NormalizeCreatedBy(createdBy string) string {
+	switch createdBy {
+	case "go-client", "python-client", "controller":
+		return createdBy
+	default:
+		return "unknown"
+	}
+}
+
 // RecordSandboxClaimCreation increments the total count of created sandbox claims.
 func RecordSandboxClaimCreation(namespace, templateName, launchType, warmPoolName, podCondition, createdBy string) {
-	SandboxClaimCreationTotal.WithLabelValues(namespace, templateName, launchType, warmPoolName, podCondition, createdBy).Inc()
+	SandboxClaimCreationTotal.WithLabelValues(namespace, templateName, launchType, warmPoolName, podCondition, NormalizeCreatedBy(createdBy)).Inc()
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -96,7 +96,7 @@ func TestSandboxClaimCreationRecording(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			SandboxClaimCreationTotal.Reset()
-			SandboxClaimCreationTotal.WithLabelValues("default", "test-tmpl", tc.launchType, "test-pool", tc.podCondition).Inc()
+			SandboxClaimCreationTotal.WithLabelValues("default", "test-tmpl", tc.launchType, "test-pool", tc.podCondition, "unknown").Inc()
 
 			if testutil.CollectAndCount(SandboxClaimCreationTotal) != 1 {
 				t.Errorf("Expected 1 observation")

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -148,7 +148,7 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		createdByStr := "unknown"
-		if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
+		if val, ok := sandbox.Labels[sandboxv1beta1.CreatedByLabel]; ok {
 			createdByStr = NormalizeCreatedBy(val)
 		}
 

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -41,6 +41,7 @@ type AgentSandboxesMetricKey struct {
 	LaunchType     string
 	Template       string
 	OwnedBy        string
+	CreatedBy      string
 }
 
 // NewAgentSandboxesConstMetric creates a new Prometheus ConstMetric for the agent_sandboxes gauge.
@@ -55,6 +56,7 @@ func NewAgentSandboxesConstMetric(count int, key AgentSandboxesMetricKey) promet
 		key.LaunchType,
 		key.Template,
 		key.OwnedBy,
+		key.CreatedBy,
 	)
 }
 
@@ -145,6 +147,11 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 
+		createdByStr := "unknown"
+		if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
+			createdByStr = val
+		}
+
 		key := AgentSandboxesMetricKey{
 			Namespace:      sandbox.Namespace,
 			ReadyCondition: readyConditionStr,
@@ -152,6 +159,7 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			LaunchType:     launchTypeStr,
 			Template:       sandboxTemplateStr,
 			OwnedBy:        ownedByStr,
+			CreatedBy:      createdByStr,
 		}
 		counts[key]++
 	}

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -149,7 +149,7 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 
 		createdByStr := "unknown"
 		if val, ok := sandbox.Labels[sandboxv1beta1.SandboxCreatedByLabel]; ok {
-			createdByStr = val
+			createdByStr = NormalizeCreatedBy(val)
 		}
 
 		key := AgentSandboxesMetricKey{

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -315,6 +315,32 @@ func TestSandboxCollector(t *testing.T) {
 				"created_by:python-client expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
+		{
+			name: "untrusted created_by label normalized to unknown",
+			sandboxes: []runtime.Object{
+				&sandboxv1beta1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-untrusted",
+						Namespace: "default",
+						Labels: map[string]string{
+							sandboxv1beta1.SandboxCreatedByLabel: "hacker-client",
+						},
+					},
+					Status: sandboxv1beta1.SandboxStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1beta1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -64,7 +64,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -82,7 +82,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:warm namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
+				"created_by:unknown expired:false launch_type:warm namespace:default owned_by:None ready_condition:false sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -194,9 +194,9 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 3, // We expect 3 distinct metric series for the 4 sandboxes
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown":     1,
-				"expired:true launch_type:warm namespace:test-ns owned_by:None ready_condition:false sandbox_template:my-template": 1,
-				"expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown":    2,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown":     1,
+				"created_by:unknown expired:true launch_type:warm namespace:test-ns owned_by:None ready_condition:false sandbox_template:my-template": 1,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:None ready_condition:false sandbox_template:unknown":    2,
 			},
 		},
 		{
@@ -228,7 +228,7 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:SandboxClaim ready_condition:true sandbox_template:unknown": 1,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:SandboxClaim ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 		{
@@ -260,7 +260,59 @@ func TestSandboxCollector(t *testing.T) {
 			},
 			expectedCount: 1,
 			expectedLabels: map[string]int{
-				"expired:false launch_type:cold namespace:default owned_by:SandboxWarmPool ready_condition:true sandbox_template:unknown": 1,
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:SandboxWarmPool ready_condition:true sandbox_template:unknown": 1,
+			},
+		},
+		{
+			name: "client-created sandbox",
+			sandboxes: []runtime.Object{
+				&sandboxv1beta1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-client",
+						Namespace: "default",
+						Labels: map[string]string{
+							sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+						},
+					},
+					Status: sandboxv1beta1.SandboxStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1beta1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"created_by:go-client expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
+			},
+		},
+		{
+			name: "python client created sandbox",
+			sandboxes: []runtime.Object{
+				&sandboxv1beta1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-python-client",
+						Namespace: "default",
+						Labels: map[string]string{
+							sandboxv1beta1.SandboxCreatedByLabel: "python-client",
+						},
+					},
+					Status: sandboxv1beta1.SandboxStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1beta1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"created_by:python-client expired:false launch_type:cold namespace:default owned_by:None ready_condition:true sandbox_template:unknown": 1,
 			},
 		},
 	}

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -271,7 +271,7 @@ func TestSandboxCollector(t *testing.T) {
 						Name:      "sandbox-client",
 						Namespace: "default",
 						Labels: map[string]string{
-							sandboxv1beta1.SandboxCreatedByLabel: "go-client",
+							sandboxv1beta1.CreatedByLabel: "go-client",
 						},
 					},
 					Status: sandboxv1beta1.SandboxStatus{
@@ -297,7 +297,7 @@ func TestSandboxCollector(t *testing.T) {
 						Name:      "sandbox-python-client",
 						Namespace: "default",
 						Labels: map[string]string{
-							sandboxv1beta1.SandboxCreatedByLabel: "python-client",
+							sandboxv1beta1.CreatedByLabel: "python-client",
 						},
 					},
 					Status: sandboxv1beta1.SandboxStatus{
@@ -323,7 +323,7 @@ func TestSandboxCollector(t *testing.T) {
 						Name:      "sandbox-untrusted",
 						Namespace: "default",
 						Labels: map[string]string{
-							sandboxv1beta1.SandboxCreatedByLabel: "hacker-client",
+							sandboxv1beta1.CreatedByLabel: "hacker-client",
 						},
 					},
 					Status: sandboxv1beta1.SandboxStatus{


### PR DESCRIPTION
## PR Description

Distinguish sandboxes created programmatically via client SDKs (Go/Python) from those created manually using raw Kubernetes resource manifests (YAML/Helm).

We classify these patterns based on the presence of the `agents.x-k8s.io/created-by` label key:
1. **SDK-based Creations**: Stamped with `created-by` (`go-client` or `python-client`).
2. **Direct YAML Creations**: missing label

## Key Changes
### 1. SDKs Stamping
* **Go SDK**: Configured `K8sHelper` to automatically label created `SandboxClaims` with `agents.x-k8s.io/created-by: go-client`.
* **Python SDK**: Configured sync and async `K8sHelper` to automatically label created `SandboxClaims` with `agents.x-k8s.io/created-by: python-client` (renamed `PYTHON_CLIENT_LABEL` to `CREATED_BY_LABEL` to align with the core API specification).
### 2. Label Propagation (Controllers)
* **SandboxClaim Controller**: 
  * Propagates the `created-by` label value from `SandboxClaim` resources to `Sandbox` resources and backing Pod templates during creation, update, and warm pool adoption.
  * When adopting a warm-pool Sandbox (which defaults to `created-by: controller`), the label on the adopted `Sandbox` is dynamically overwritten to match the SDK client that claimed it.
* **Sandbox Controller**: Unconditionally propagates the `created-by` label from the `Sandbox` resource to the backing Pod labels in both the Pod creation and update paths. This ensures the labels are processed by the GKE Concord pipeline for BigQuery analytics.
* **SandboxWarmPool Controller**: Proactively creates pre-warmed sandboxes with `created-by: controller` to distinguish un-allocated warm buffer objects from actively claimed ones.
### 3. Prometheus Telemetry
* Added the `created_by` label dimension to:
  * `agent_sandboxes` point-in-time gauge metric.
  * `agent_sandbox_claim_creation_total` creation counter metric.
* Updated helper recording functions and all corresponding Go unit tests in `internal/metrics` and `extensions/controllers`.
---
## Verification & Testing

* Ran unit tests:
  ```bash
  go test -v ./extensions/controllers -run TestSandboxClaimSandboxAdoption  # PASS
  go test -v ./internal/metrics                                             # PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enforced a `created-by` label across sandboxes, sandbox claims, and related pod templates (warm-pool defaults to `controller`).
  * Added `created_by` as a new dimension to sandbox/claim metrics, normalized to known values or `unknown`.

* **Bug Fixes**
  * Client-created claims always set `created-by` and reject attempts to override it with a different value.
  * Controllers now propagate, synchronize, and remove `created-by` consistently between sandboxes and Pods during reconciliation and adoption.

* **Tests**
  * Expanded unit coverage for label propagation, override prevention, normalization, and updated metric expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->