### PR TITLE
docs(examples): add Cilium identity-based egress e2e example

### DIFF
--- a/examples/demo-cilium-egress/README.md
+++ b/examples/demo-cilium-egress/README.md
@@ -1,0 +1,344 @@
+# Per-identity egress allowlisting for agent-sandbox (Cilium FQDN policy)
+
+This self-contained example demonstrates, end-to-end on GKE, that **a network
+policy bound to a workload identity controls which external domains a sandbox can
+reach**.
+
+Two agent-sandbox sandboxes get **distinct Kubernetes identities**. A Cilium
+policy lets **identity A** reach `github.com` while **identity B** is denied —
+proven by `git clone` succeeding in A and failing in B. Then a second policy
+**allowlists identity B**, and its clone starts working too.
+
+## Architecture
+
+```mermaid
+flowchart TB
+  EXT["external client (curl)<br/>optional ingress"]
+  GH["github.com:443<br/>(public internet)"]
+
+  subgraph CL["GKE Standard cluster — CNI: self-managed upstream Cilium"]
+    subgraph KS["kube-system"]
+      CIL["Cilium agent<br/>+ L7 DNS proxy"]
+      KD["kube-dns"]
+    end
+    subgraph ND["namespace: sandbox-demo"]
+      GWY["GKE Gateway + sandbox-router<br/>(optional ingress add-on)"]
+      SA["Sandbox A (pod)<br/>SA: sa-team-a<br/>label: demo.identity=team-a"]
+      SB["Sandbox B (pod)<br/>SA: sa-team-b<br/>label: demo.identity=team-b"]
+      NP["CiliumNetworkPolicies<br/>• allow-dns (both identities)<br/>• team-a-allow-github<br/>• team-b-allow-github (phase 2)"]
+    end
+  end
+
+  NP -->|program identity-based egress rules| CIL
+
+  EXT -.optional.-> GWY
+  GWY -.routes by X-Sandbox-ID.-> SA
+  GWY -.->  SB
+
+  SA -.->|DNS via proxy| CIL
+  SB -.->|DNS via proxy| CIL
+  CIL --> KD
+
+  SA ==>|443 ALLOWED| GH
+  SB -.->|443 DENIED until phase 2| GH
+
+  classDef allow stroke:#2e7d32,stroke-width:2px,fill:#e8f5e9;
+  classDef deny stroke:#c62828,stroke-width:2px,fill:#ffebee;
+  classDef opt stroke:#1565c0,stroke-width:1px,stroke-dasharray:4 3,fill:#e3f2fd;
+  class SA allow;
+  class SB deny;
+  class GWY,EXT opt;
+```
+
+Each sandbox pod carries an identity label + ServiceAccount. Every egress packet
+is evaluated by the Cilium dataplane against
+the `CiliumNetworkPolicies`: DNS is allowed for both identities (and snooped by
+the L7 DNS proxy so `toFQDNs` can resolve `github.com`), but only the identity
+named in a `*-allow-github` policy may open 443 to github. The blue dashed path
+is the **optional gateway routing** ingress add-on (see below); the egress
+decision is identical regardless of how the request arrives.
+
+### Phase flow (the demo story)
+
+```mermaid
+flowchart LR
+  subgraph P1["Phase 1 — one policy, mapped to team-a"]
+    A1["team-a:<br/>git clone github"] --> RA{"matches<br/>team-a-allow-github?"}
+    RA -->|yes| OKA["✅ clone succeeds"]
+    B1["team-b:<br/>git clone github"] --> RB{"matches any<br/>allow policy?"}
+    RB -->|no → default-deny| NOB["⛔ blocked (timeout)"]
+  end
+  subgraph P2["Phase 2 — allowlist team-b's identity"]
+    APPLY["kubectl apply<br/>team-b-allow-github"] --> B2["team-b:<br/>git clone github"]
+    B2 --> RB2{"matches<br/>team-b-allow-github?"}
+    RB2 -->|yes| OKB["✅ clone succeeds"]
+  end
+  P1 --> P2
+
+  classDef ok stroke:#2e7d32,stroke-width:2px,fill:#e8f5e9;
+  classDef no stroke:#c62828,stroke-width:2px,fill:#ffebee;
+  class OKA,OKB ok;
+  class NOB no;
+```
+
+## Why Cilium + GKE Standard (not Autopilot)
+
+Upstream Kubernetes `NetworkPolicy` can only match IP CIDRs — **not domains**.
+Allowing `github.com` by name requires a CNI extension. This demo uses real
+**`CiliumNetworkPolicy` with `toFQDNs`**, which needs control of the CNI. GKE
+Autopilot (and Dataplane V2) only exposes GKE's `FQDNNetworkPolicy` wrapper, not
+raw Cilium policy — so we run **GKE Standard with self-managed upstream Cilium**.
+
+Cilium derives a label-based **security identity** for every pod, which is the
+natural carrier of "the identity a policy maps to": each sandbox pod carries a
+`demo.identity=<team>` label (plus its own ServiceAccount), and each policy's
+`endpointSelector` matches that label.
+
+## How "policy maps to identity" works here
+
+- Each Sandbox runs as its own **ServiceAccount** (`sa-team-a` / `sa-team-b`) and
+  carries a propagated pod label **`demo.identity: team-a|team-b`**.
+- `10-cilium-allow-dns.yaml` selects **both** identities. In Cilium, once any
+  egress rule selects an endpoint it becomes **default-deny egress** — so this
+  both (a) locks egress down to DNS only and (b) enables the L7 DNS proxy that
+  `toFQDNs` needs to resolve domains.
+- `20-cilium-team-a-allow-github.yaml` opens `github.com:443` for **team-a only**.
+- team-b has no such rule → its github traffic is dropped.
+- `40-cilium-team-b-allow-github.yaml` (phase 2) adds the same allow for team-b.
+
+## Requirements
+
+- `gcloud` (authenticated; project access to create a GKE cluster)
+- `kubectl`
+- `cilium` CLI — https://github.com/cilium/cilium-cli/releases (or `brew install cilium-cli`)
+- `hubble` CLI — only for the optional flow-log inspection in Observability
+  (`hubble observe`). It's a **separate** binary from `cilium-cli`:
+  https://github.com/cilium/hubble/releases (or `brew install hubble`)
+- For the optional gateway-routing add-on: the Cloud Build API enabled (images are
+  built remotely — no local `docker` needed), plus a local `python3` (used by
+  `scripts/test-ingress.sh` to parse gateway responses)
+
+## Quick start
+
+```bash
+cd examples/demo-cilium-egress
+
+# Provision everything: cluster -> Cilium -> agent-sandbox -> demo resources.
+./scripts/setup-all.sh
+
+# Run the e2e assertions (phase 1 deny/allow, phase 2 allowlist).
+./scripts/test.sh
+```
+
+Override defaults via env vars (see `env.sh`), e.g. `ZONE=us-west1-a ./scripts/setup-all.sh`.
+
+## What each script does
+
+| Script | Purpose |
+|---|---|
+| `scripts/01-create-cluster.sh` | GKE Standard cluster, **no** Dataplane V2 (guards against `anetd`). |
+| `scripts/02-install-cilium.sh` | Installs upstream Cilium (`gke.enabled`, `ipam=kubernetes`) + DNS proxy. |
+| `scripts/03-install-agent-sandbox.sh` | Applies the latest agent-sandbox core + extensions release. |
+| `scripts/04-deploy-demo.sh` | Namespace, identities, baseline DNS policy, team-a allow, two sandboxes. |
+| `scripts/setup-all.sh` | Runs 01→04 (idempotent). |
+| `scripts/test.sh` | E2E verification; exits non-zero on any failed assertion. |
+| `scripts/teardown.sh` | Removes demo resources; `--all` also deletes the cluster. |
+| `scripts/optional-gateway-routing.sh` | **Optional**: builds the sandbox-router + exec-server images (Cloud Build) and deploys router + GKE Gateway (ingress). |
+| `scripts/05-observability.sh` | **Optional**: enables Managed Prometheus + Hubble metrics and ships egress-violation metrics to Cloud Monitoring. |
+
+## Manifests
+
+| File | Role |
+|---|---|
+| `manifests/00-namespace-and-identities.yaml` | Namespace + `sa-team-a` / `sa-team-b`. |
+| `manifests/10-cilium-allow-dns.yaml` | Baseline: default-deny egress + DNS (for both identities). |
+| `manifests/20-cilium-team-a-allow-github.yaml` | Allow `github.com` for team-a. |
+| `manifests/30-sandboxes.yaml` | Two Sandboxes with distinct identities. |
+| `manifests/40-cilium-team-b-allow-github.yaml` | Phase 2: allow `github.com` for team-b. |
+| `manifests/router/` | Optional sandbox-router + GKE Gateway (used by the ingress script). |
+| `manifests/observability/` | Optional GMP `ClusterPodMonitoring` (scrape Hubble) + `ClusterRules` (alert). |
+
+## Manual verification
+
+```bash
+# team-a: succeeds
+kubectl exec -n sandbox-demo sandbox-team-a -- \
+  sh -c 'git clone --depth 1 https://github.com/rtyley/small-test-repo /tmp/r && echo OK'
+
+# team-b: fails (DNS resolves, but 443 to github is dropped)
+kubectl exec -n sandbox-demo sandbox-team-b -- \
+  sh -c 'timeout 30 git clone --depth 1 https://github.com/rtyley/small-test-repo /tmp/r; echo exit=$?'
+
+# allowlist team-b, then it succeeds
+kubectl apply -f manifests/40-cilium-team-b-allow-github.yaml
+```
+
+See drops with Hubble:
+
+```bash
+cilium hubble enable
+hubble observe -n sandbox-demo --from-label demo.identity=team-b --verdict DROPPED
+```
+
+## Optional: gateway routing (full ingress + egress path)
+
+The core demo proves egress via `kubectl exec`. To also exercise agent-sandbox's
+**ingress "gateway routing"** — an external client → **GKE Gateway** → **sandbox-router**
+→ **sandbox** `/execute` → `git clone` — run the add-on. It builds two images with
+**Cloud Build** (no local docker needed), enables the GKE Gateway API, swaps the
+sandboxes to an HTTP exec-server image (same identities/policies), and deploys the
+router + Gateway.
+
+> ⚠️ **DEMO ONLY — do not run on a long-lived or shared cluster.** For
+> simplicity this add-on sets `ALLOW_UNAUTHENTICATED_ROUTER=true` and fronts the
+> sandbox-router with a **public** external L7 Gateway. That exposes the sandbox
+> `/execute` endpoint to the internet with **no authentication** — i.e.
+> unauthenticated remote code execution for anyone who finds the Gateway IP.
+> Use it only on a throwaway demo cluster, and tear it down when finished
+> (`./scripts/teardown.sh --all`). For any real use, enable the router's bearer
+> token (set `ALLOW_UNAUTHENTICATED_ROUTER=false` and provide `ROUTER_AUTH_TOKEN`
+> via a Secret — see `manifests/router/sandbox-router.yaml`) and/or restrict the
+> Gateway to an internal/allowlisted front end.
+
+```bash
+./scripts/optional-gateway-routing.sh   # build images, enable Gateway API, deploy router+Gateway
+./scripts/test-ingress.sh               # drive git clone THROUGH the gateway; asserts allow/deny/allowlist
+```
+
+```mermaid
+flowchart LR
+  C["curl<br/>POST /execute<br/>X-Sandbox-ID: team-a|b"] --> GWY["GKE Gateway<br/>(gke-l7 external LB)"]
+  GWY --> RT["sandbox-router<br/>(HTTP proxy)"]
+  RT -->|":8888 /execute"| SBX["sandbox pod<br/>(exec-server + git)"]
+  SBX --> EVAL{"Cilium egress<br/>policy for identity"}
+  EVAL ==>|team-a allowed| GH["github.com"]
+  EVAL -.->|team-b denied| GH
+  classDef ok stroke:#2e7d32,stroke-width:2px,fill:#e8f5e9;
+  class SBX ok;
+```
+
+The same per-identity Cilium policy still decides the outcome — now the request
+arrives through the gateway instead of `kubectl exec`. Ingress to the sandbox is
+unaffected because the policies are egress-only (Cilium default-deny is
+per-direction).
+
+## Optional: observability — catching egress violations
+
+As the cluster admin you want to know when a sandbox tries something it isn't
+allowed to. A denied egress is **not** silent inside Cilium — it's a Hubble
+policy-verdict / drop event. This add-on enables **Hubble metrics** and scrapes
+them into **Google Managed Prometheus** (Cloud Monitoring), so violations are
+queryable and alertable.
+
+```bash
+./scripts/05-observability.sh   # enable Managed Prometheus + Hubble metrics, install scrape + alert rule
+```
+
+```mermaid
+flowchart LR
+  SBX["sandbox pod<br/>(denied egress)"] --> CIL["Cilium / Hubble<br/>policy verdict: DROPPED"]
+  CIL -->|":9965 /metrics"| CPM["GMP ClusterPodMonitoring<br/>(scrape)"]
+  CPM --> GMP["Managed Prometheus<br/>(Cloud Monitoring)"]
+  GMP --> DASH["dashboards / PromQL"]
+  GMP --> ALERT["ClusterRules alert<br/>SandboxEgressPolicyDenied"]
+```
+
+**The signal.** Each Cilium agent exports flow metrics on port `9965`. The two
+that matter, with the labels this example configures (`sourceContext=pod`,
+`destinationContext=dns`):
+
+```text
+hubble_policy_verdicts_total{action="dropped", direction="egress",
+    source="sandbox-demo/sandbox-team-b", destination="github.com"}
+hubble_drop_total{reason="POLICY_DENIED",
+    source="sandbox-demo/sandbox-team-b", destination="github.com"}
+```
+
+So a violation tells you **who** (`source` = namespace/sandbox = identity) and
+**what** (`destination` = the FQDN), e.g. *sandbox-team-b → github.com, denied*.
+
+**Query it** (PromQL, for a dashboard or alert):
+
+```promql
+sum by (source, destination) (
+  rate(hubble_policy_verdicts_total{action="dropped", direction="egress"}[5m])
+)
+```
+
+**See it in the Google Cloud Console (Metrics Explorer):**
+
+1. Open **Monitoring → Metrics explorer**:
+   `https://console.cloud.google.com/monitoring/metrics-explorer?project=<PROJECT>`
+2. Click the **PromQL** tab (toggles the visual builder to a code editor).
+3. Paste a query and **Run**, with the time range set to **Last 1 hour**:
+   ```promql
+   hubble_policy_verdicts_total{action="dropped", direction="egress"}
+   ```
+   You'll see a series labeled `source="sandbox-demo/sandbox-team-b"`,
+   `destination="github.com"` — that's the denial (a counter that steps up on each
+   blocked attempt). For a rate line, query the recording rule
+   `sandbox:egress_policy_denied:rate5m` instead.
+4. Prefer the visual builder? Click **Select a metric** and search for
+   `hubble_policy_verdicts_total` (full type
+   `prometheus.googleapis.com/hubble_policy_verdicts_total/counter`), then filter
+   `action=dropped`, `direction=egress` and group by `source`, `destination`.
+5. **Save Chart → to a new Dashboard** to keep a standing "egress violations" panel.
+
+These metrics live under **Managed Service for Prometheus** (resource type
+*Prometheus Target*); the PromQL tab is the natural way to query them. If a graph
+looks empty, widen the time window and generate a fresh denial with the
+`kubectl exec ... git clone` from "Manual verification" above.
+
+Against Managed Prometheus directly (scripted) — this endpoint requires an
+**Application Default Credentials** token (`gcloud auth application-default login`
+first). A plain `gcloud auth print-access-token` is rejected here
+(`ACCESS_TOKEN_TYPE_UNSUPPORTED`), so ADC is intentional:
+
+```bash
+curl -s -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  "https://monitoring.googleapis.com/v1/projects/<PROJECT>/location/global/prometheus/api/v1/query" \
+  --data-urlencode 'query=hubble_policy_verdicts_total{action="dropped",direction="egress"}'
+```
+
+`manifests/observability/clusterrules.yaml` adds a recording rule
+(`sandbox:egress_policy_denied:rate5m`) and an alert (`SandboxEgressPolicyDenied`)
+evaluated by GMP's managed rule-evaluator. Delivering that alert to a channel
+additionally needs an Alertmanager target (managed Alertmanager via
+`OperatorConfig`, or your own) — see the GMP rule-evaluation docs.
+
+**Per-event forensics** (which identity, which domain, when): use Hubble flow
+logs rather than metrics —
+
+```bash
+cilium hubble enable        # already enabled by 05-observability.sh
+hubble observe -n sandbox-demo --verdict DROPPED   # add --follow for live
+```
+
+…and ship those to Cloud Logging (fluent-bit) or run Hubble UI for a visual map.
+
+> **Gotchas (handled by the script):**
+> - GMP collectors that started **before** Cilium can be stuck with "no route to
+>   host" to the API server — the script restarts the `gmp-system/collector`
+>   daemonset so they pick up Cilium networking.
+> - This uses **Cilium Hubble**, not GKE Dataplane-V2 network-policy logging
+>   (we run self-managed Cilium). GMP scrapes regardless of CNI; the metrics just
+>   come from Hubble.
+
+## Teardown
+
+```bash
+./scripts/teardown.sh        # remove demo resources, keep cluster
+./scripts/teardown.sh --all  # also delete the GKE cluster
+```
+
+## Notes / gotchas
+
+- `toFQDNs` depends on the DNS proxy: `10-cilium-allow-dns.yaml` must be applied
+  or even the allowed clone fails (DNS can't resolve through Cilium).
+- HTTPS `git clone` uses `github.com:443`; `codeload.github.com` is allowed
+  defensively. If a clone unexpectedly fails, widen to `*.github.com` and check
+  Hubble.
+- Image pulls happen on the node, not under the pod's egress policy, so
+  `alpine/git` pulls fine even under default-deny.
+- The cluster is **GKE Standard without Dataplane V2** on purpose; `01-create`
+  fails fast if `anetd` is detected.

--- a/examples/demo-cilium-egress/README.md
+++ b/examples/demo-cilium-egress/README.md
@@ -50,8 +50,10 @@ flowchart TB
   class GWY,EXT opt;
 ```
 
-Each sandbox pod carries an identity label + ServiceAccount. Every egress packet
-is evaluated by the Cilium dataplane against
+Each sandbox pod carries a `demo.identity` label (and its own ServiceAccount).
+Cilium derives the pod's **security identity from the label, not the SA** — the
+SA is kept only for hygiene (see "A note on the ServiceAccount" below). Every
+egress packet is evaluated by the Cilium dataplane against
 the `CiliumNetworkPolicies`: DNS is allowed for both identities (and snooped by
 the L7 DNS proxy so `toFQDNs` can resolve `github.com`), but only the identity
 named in a `*-allow-github` policy may open 443 to github. The blue dashed path
@@ -91,13 +93,15 @@ raw Cilium policy — so we run **GKE Standard with self-managed upstream Cilium
 
 Cilium derives a label-based **security identity** for every pod, which is the
 natural carrier of "the identity a policy maps to": each sandbox pod carries a
-`demo.identity=<team>` label (plus its own ServiceAccount), and each policy's
-`endpointSelector` matches that label.
+`demo.identity=<team>` label, and each policy's `endpointSelector` matches that
+label. (The pod also has its own Kubernetes ServiceAccount, but that is *not*
+what Cilium keys on — see "A note on the ServiceAccount" below.)
 
 ## How "policy maps to identity" works here
 
-- Each Sandbox runs as its own **ServiceAccount** (`sa-team-a` / `sa-team-b`) and
-  carries a propagated pod label **`demo.identity: team-a|team-b`**.
+- Each Sandbox carries a propagated pod label **`demo.identity: team-a|team-b`**
+  (this is what Cilium turns into a security identity) and runs as its own
+  **ServiceAccount** (`sa-team-a` / `sa-team-b`).
 - `10-cilium-allow-dns.yaml` selects **both** identities. In Cilium, once any
   egress rule selects an endpoint it becomes **default-deny egress** — so this
   both (a) locks egress down to DNS only and (b) enables the L7 DNS proxy that
@@ -105,6 +109,25 @@ natural carrier of "the identity a policy maps to": each sandbox pod carries a
 - `20-cilium-team-a-allow-github.yaml` opens `github.com:443` for **team-a only**.
 - team-b has no such rule → its github traffic is dropped.
 - `40-cilium-team-b-allow-github.yaml` (phase 2) adds the same allow for team-b.
+
+### A note on the ServiceAccount
+
+The two ServiceAccounts (`sa-team-a` / `sa-team-b`) are **not required** for the
+egress demo. Cilium builds each pod's security identity from its **labels**, so
+the `CiliumNetworkPolicy` `endpointSelector` matches `demo.identity`, never the
+SA. The sandboxes also set `automountServiceAccountToken: false`, so no token is
+even mounted. You could delete the SAs and the allow/deny behavior would be
+unchanged.
+
+They're kept on purpose, for realism rather than function:
+
+- **Hygiene** — without `serviceAccountName`, the pods would run as the namespace
+  `default` SA. A dedicated SA per workload is good practice.
+- **Workload Identity anchor** — if a sandbox ever needs to call a Google Cloud
+  API (e.g. read a GCS bucket), this KSA is exactly what you'd map to an IAM
+  principal via Workload Identity Federation. The SA is the GCP-facing identity;
+  the label is the network-facing identity. They are independent layers that
+  happen to move together here.
 
 ## Requirements
 

--- a/examples/demo-cilium-egress/README.md
+++ b/examples/demo-cilium-egress/README.md
@@ -212,16 +212,18 @@ The core demo proves egress via `kubectl exec`. To also exercise agent-sandbox's
 sandboxes to an HTTP exec-server image (same identities/policies), and deploys the
 router + Gateway.
 
-> ⚠️ **DEMO ONLY — do not run on a long-lived or shared cluster.** For
-> simplicity this add-on sets `ALLOW_UNAUTHENTICATED_ROUTER=true` and fronts the
-> sandbox-router with a **public** external L7 Gateway. That exposes the sandbox
-> `/execute` endpoint to the internet with **no authentication** — i.e.
-> unauthenticated remote code execution for anyone who finds the Gateway IP.
-> Use it only on a throwaway demo cluster, and tear it down when finished
-> (`./scripts/teardown.sh --all`). For any real use, enable the router's bearer
-> token (set `ALLOW_UNAUTHENTICATED_ROUTER=false` and provide `ROUTER_AUTH_TOKEN`
-> via a Secret — see `manifests/router/sandbox-router.yaml`) and/or restrict the
-> Gateway to an internal/allowlisted front end.
+> ⚠️ **DEMO ONLY — do not run on a long-lived or shared cluster.** This add-on
+> fronts the sandbox-router with a **public** external L7 Gateway, so the sandbox
+> `/execute` endpoint is reachable from the internet. By default the script mints
+> a random Bearer token into a `sandbox-router-auth` Secret and the router
+> **requires** it (`test-ingress.sh` reads the Secret and sends the token), so the
+> public endpoint is authenticated out of the box. You can still expose an
+> **unauthenticated** `/execute` — i.e. remote code execution for anyone who finds
+> the Gateway IP — only by deliberately opting in with
+> `ALLOW_UNAUTHENTICATED_ROUTER=true ./scripts/optional-gateway-routing.sh`. Even
+> with auth on, use a throwaway demo cluster and tear it down when finished
+> (`./scripts/teardown.sh --all`); for real use also restrict the Gateway to an
+> internal/allowlisted front end.
 
 ```bash
 ./scripts/optional-gateway-routing.sh   # build images, enable Gateway API, deploy router+Gateway

--- a/examples/demo-cilium-egress/env.sh
+++ b/examples/demo-cilium-egress/env.sh
@@ -16,7 +16,9 @@
 # Shared configuration for the Cilium per-identity egress demo.
 # Override any value by exporting it before sourcing, e.g. `ZONE=us-west1-a ./scripts/setup-all.sh`.
 
-export PROJECT="${PROJECT:-gke-ai-eco-dev}"
+# Defaults to your active gcloud project; export PROJECT to override. There is no
+# baked-in project so the scripts never operate on an unexpected one.
+export PROJECT="${PROJECT:-$(gcloud config get-value project 2>/dev/null)}"
 export ZONE="${ZONE:-us-central1-a}"
 export CLUSTER="${CLUSTER:-agent-sandbox-cilium-demo}"
 export MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-4}"

--- a/examples/demo-cilium-egress/env.sh
+++ b/examples/demo-cilium-egress/env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared configuration for the Cilium per-identity egress demo.
+# Override any value by exporting it before sourcing, e.g. `ZONE=us-west1-a ./scripts/setup-all.sh`.
+
+export PROJECT="${PROJECT:-gke-ai-eco-dev}"
+export ZONE="${ZONE:-us-central1-a}"
+export CLUSTER="${CLUSTER:-agent-sandbox-cilium-demo}"
+export MACHINE_TYPE="${MACHINE_TYPE:-e2-standard-4}"
+export NUM_NODES="${NUM_NODES:-2}"
+export RELEASE_CHANNEL="${RELEASE_CHANNEL:-regular}"
+
+# The demo namespace is hard-coded in manifests/*.yaml; keep these in sync if you change it.
+export NAMESPACE="${NAMESPACE:-sandbox-demo}"
+
+# Public repo the sandboxes try to clone to prove egress.
+export TEST_REPO_URL="${TEST_REPO_URL:-https://github.com/rtyley/small-test-repo}"
+
+# agent-sandbox release tag, or "latest" to auto-discover the newest GitHub release.
+export AGENT_SANDBOX_VERSION="${AGENT_SANDBOX_VERSION:-latest}"
+
+# Optional: pin a Cilium chart version. Empty => cilium CLI default.
+export CILIUM_VERSION="${CILIUM_VERSION:-}"

--- a/examples/demo-cilium-egress/exec-sandbox/Dockerfile
+++ b/examples/demo-cilium-egress/exec-sandbox/Dockerfile
@@ -1,0 +1,16 @@
+# Tiny HTTP "exec" sandbox image for the ingress demo: stdlib server + git.
+# The server exposes /healthz and POST /execute on port 8888 (the agent-sandbox
+# default sandbox port the router proxies to). git + ca-certificates let it clone
+# over HTTPS — subject to the pod's CiliumNetworkPolicy egress rules.
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY server.py .
+
+USER 1000:1000
+EXPOSE 8888
+CMD ["python", "server.py"]

--- a/examples/demo-cilium-egress/exec-sandbox/server.py
+++ b/examples/demo-cilium-egress/exec-sandbox/server.py
@@ -1,0 +1,84 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Minimal HTTP "exec" server for the ingress demo (Python stdlib only).
+#
+# ⚠️ DEMO ONLY: /execute runs caller-supplied commands (arbitrary code execution
+# by design — it's how the demo drives `git clone` to exercise the egress
+# policy). Do NOT expose this on a shared/long-lived cluster. The optional
+# ingress add-on fronts it with a public Gateway only for the throwaway demo;
+# for real use run the router authenticated (ROUTER_AUTH_TOKEN) / keep it private.
+# Endpoints:
+#   GET  /healthz  -> {"status":"ok"}   (used by the GKE Gateway health check path too)
+#   POST /execute  -> body {"command":"..."} runs the command and returns
+#                     {"stdout","stderr","exit_code"}
+# The sandbox-router proxies requests here (default sandbox port 8888). The command
+# runs inside the sandbox pod, so its egress is governed by the CiliumNetworkPolicy
+# bound to the pod's identity — that's what makes `git clone` succeed or fail.
+import json
+import shlex
+import subprocess
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = 8888
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path in ("/healthz", "/"):
+            self._send(200, {"status": "ok"})
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path != "/execute":
+            self._send(404, {"error": "not found"})
+            return
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(n) if n else b"{}"
+        try:
+            cmd = json.loads(raw or b"{}").get("command", "")
+        except Exception:
+            self._send(400, {"error": "invalid json"})
+            return
+        if not cmd:
+            self._send(400, {"error": "missing command"})
+            return
+        try:
+            argv = shlex.split(cmd)
+        except ValueError as err:
+            self._send(400, {"error": "invalid command syntax: %s" % err})
+            return
+        try:
+            p = subprocess.run(argv, capture_output=True, text=True, timeout=120)
+            self._send(200, {"stdout": p.stdout, "stderr": p.stderr, "exit_code": p.returncode})
+        except subprocess.TimeoutExpired:
+            self._send(200, {"stdout": "", "stderr": "command timed out", "exit_code": 124})
+        except (FileNotFoundError, OSError) as err:
+            self._send(200, {"stdout": "", "stderr": "exec failed: %s" % err, "exit_code": 127})
+
+    def log_message(self, *args):  # quiet
+        pass
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/examples/demo-cilium-egress/manifests/00-namespace-and-identities.yaml
+++ b/examples/demo-cilium-egress/manifests/00-namespace-and-identities.yaml
@@ -1,0 +1,19 @@
+# Demo namespace and two distinct Kubernetes identities (ServiceAccounts).
+# Each sandbox runs as one of these SAs and carries a matching `demo.identity` pod
+# label that the CiliumNetworkPolicies select on.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sandbox-demo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-team-a
+  namespace: sandbox-demo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-team-b
+  namespace: sandbox-demo

--- a/examples/demo-cilium-egress/manifests/00-namespace-and-identities.yaml
+++ b/examples/demo-cilium-egress/manifests/00-namespace-and-identities.yaml
@@ -1,6 +1,11 @@
-# Demo namespace and two distinct Kubernetes identities (ServiceAccounts).
-# Each sandbox runs as one of these SAs and carries a matching `demo.identity` pod
-# label that the CiliumNetworkPolicies select on.
+# Demo namespace and two ServiceAccounts.
+#
+# These SAs are NOT what the CiliumNetworkPolicies select on — Cilium derives a
+# pod's security identity from its LABELS (the `demo.identity` pod label set in
+# 30-sandboxes.yaml). The SAs are kept for hygiene (so pods don't run as the
+# namespace `default` SA) and as the natural anchor for Workload Identity
+# Federation if a sandbox ever needs Google Cloud API access.
+# See the README's "A note on the ServiceAccount".
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/examples/demo-cilium-egress/manifests/10-cilium-allow-dns.yaml
+++ b/examples/demo-cilium-egress/manifests/10-cilium-allow-dns.yaml
@@ -1,0 +1,31 @@
+# Baseline policy for BOTH identities.
+#
+# Two effects:
+#  1. Selecting an endpoint with ANY egress rule flips it to "default-deny egress"
+#     in Cilium — so after this policy, team-a and team-b can ONLY do what is
+#     explicitly allowed (DNS here; github is added per-identity by 20-/40-).
+#  2. The L7 `rules.dns` clause routes DNS through Cilium's DNS proxy, which is
+#     what lets `toFQDNs` (in the github policies) learn the IPs behind a domain.
+#     Without this, toFQDNs cannot resolve and even the "allowed" clone fails.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: sandbox-demo
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: demo.identity
+        operator: Exists
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchPattern: "*"

--- a/examples/demo-cilium-egress/manifests/20-cilium-team-a-allow-github.yaml
+++ b/examples/demo-cilium-egress/manifests/20-cilium-team-a-allow-github.yaml
@@ -1,0 +1,21 @@
+# Grants ONLY identity `team-a` egress to github.com over HTTPS.
+# This is the "policy that maps to an identity and gives it access to the
+# github.com domain": the endpointSelector matches the team-a security identity,
+# and toFQDNs allowlists the domain (resolved via the DNS proxy from 10-allow-dns).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: team-a-allow-github
+  namespace: sandbox-demo
+spec:
+  endpointSelector:
+    matchLabels:
+      demo.identity: team-a
+  egress:
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: codeload.github.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/examples/demo-cilium-egress/manifests/30-sandboxes.yaml
+++ b/examples/demo-cilium-egress/manifests/30-sandboxes.yaml
@@ -1,0 +1,45 @@
+# Two agent-sandbox Sandboxes, each with a distinct identity.
+#
+# Identity = a dedicated ServiceAccount (spec.serviceAccountName) + a pod label
+# (metadata.labels.demo.identity) that the CiliumNetworkPolicies select on.
+# agent-sandbox propagates podTemplate labels onto the created Pod, so Cilium
+# derives the team-a / team-b security identity from them.
+#
+# Image: alpine/git has git pre-installed, so the only egress the demo needs is
+# DNS + github (no package install). Image pulls happen on the node and are not
+# subject to the pod's egress policy.
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: sandbox-team-a
+  namespace: sandbox-demo
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        demo.identity: team-a
+    spec:
+      serviceAccountName: sa-team-a
+      automountServiceAccountToken: false
+      containers:
+        - name: tools
+          image: alpine/git:latest
+          command: ["sleep", "infinity"]
+---
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: sandbox-team-b
+  namespace: sandbox-demo
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        demo.identity: team-b
+    spec:
+      serviceAccountName: sa-team-b
+      automountServiceAccountToken: false
+      containers:
+        - name: tools
+          image: alpine/git:latest
+          command: ["sleep", "infinity"]

--- a/examples/demo-cilium-egress/manifests/30-sandboxes.yaml
+++ b/examples/demo-cilium-egress/manifests/30-sandboxes.yaml
@@ -1,9 +1,15 @@
 # Two agent-sandbox Sandboxes, each with a distinct identity.
 #
-# Identity = a dedicated ServiceAccount (spec.serviceAccountName) + a pod label
-# (metadata.labels.demo.identity) that the CiliumNetworkPolicies select on.
-# agent-sandbox propagates podTemplate labels onto the created Pod, so Cilium
-# derives the team-a / team-b security identity from them.
+# The NETWORK identity is the pod label `demo.identity` (metadata.labels): Cilium
+# derives the team-a / team-b security identity from pod labels, and that is what
+# the CiliumNetworkPolicies select on. agent-sandbox propagates podTemplate labels
+# onto the created Pod, so the label reaches Cilium.
+#
+# The ServiceAccount (spec.serviceAccountName) is a SEPARATE identity layer and is
+# NOT what Cilium keys on — it's kept for hygiene and as the anchor for Workload
+# Identity Federation if a sandbox ever needs Google Cloud API access. The token is
+# not mounted (automountServiceAccountToken: false). See the README's
+# "A note on the ServiceAccount".
 #
 # Image: alpine/git has git pre-installed, so the only egress the demo needs is
 # DNS + github (no package install). Image pulls happen on the node and are not

--- a/examples/demo-cilium-egress/manifests/40-cilium-team-b-allow-github.yaml
+++ b/examples/demo-cilium-egress/manifests/40-cilium-team-b-allow-github.yaml
@@ -1,0 +1,20 @@
+# PHASE 2: allowlist identity `team-b` too.
+# Apply this after showing team-b is denied, and team-b's clone starts working
+# without touching team-a. Demonstrates additive, per-identity egress policy.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: team-b-allow-github
+  namespace: sandbox-demo
+spec:
+  endpointSelector:
+    matchLabels:
+      demo.identity: team-b
+  egress:
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: codeload.github.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/examples/demo-cilium-egress/manifests/ingress/30-sandboxes-http.yaml
+++ b/examples/demo-cilium-egress/manifests/ingress/30-sandboxes-http.yaml
@@ -1,0 +1,59 @@
+# Ingress variant of the two sandboxes: same identities (sa + demo.identity label)
+# as manifests/30-sandboxes.yaml, but running the exec-server image so the
+# sandbox-router can drive them over HTTP (port 8888). __SANDBOX_IMAGE__ is
+# substituted by scripts/optional-gateway-routing.sh.
+#
+# Egress is still governed by the same CiliumNetworkPolicies (they select on the
+# demo.identity label), so team-a can clone github and team-b cannot — now
+# exercised through the gateway -> router -> sandbox path instead of kubectl exec.
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: sandbox-team-a
+  namespace: sandbox-demo
+spec:
+  service: true # create a headless Service so the router can also reach it by DNS
+  podTemplate:
+    metadata:
+      labels:
+        demo.identity: team-a
+    spec:
+      serviceAccountName: sa-team-a
+      automountServiceAccountToken: false
+      containers:
+        - name: exec
+          image: __SANDBOX_IMAGE__
+          ports:
+            - containerPort: 8888
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 5
+---
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: sandbox-team-b
+  namespace: sandbox-demo
+spec:
+  service: true
+  podTemplate:
+    metadata:
+      labels:
+        demo.identity: team-b
+    spec:
+      serviceAccountName: sa-team-b
+      automountServiceAccountToken: false
+      containers:
+        - name: exec
+          image: __SANDBOX_IMAGE__
+          ports:
+            - containerPort: 8888
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 5

--- a/examples/demo-cilium-egress/manifests/observability/clusterpodmonitoring.yaml
+++ b/examples/demo-cilium-egress/manifests/observability/clusterpodmonitoring.yaml
@@ -1,0 +1,15 @@
+# Google Managed Prometheus scrape config for Cilium's Hubble metrics.
+# Scrapes every Cilium agent's hubble-metrics endpoint (port 9965) and ships the
+# flow/policy/drop metrics into Cloud Monitoring (Managed Prometheus).
+apiVersion: monitoring.googleapis.com/v1
+kind: ClusterPodMonitoring
+metadata:
+  name: hubble
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cilium
+  endpoints:
+    - port: hubble-metrics # named container port 9965 on the cilium agent pods
+      interval: 30s
+      path: /metrics

--- a/examples/demo-cilium-egress/manifests/observability/clusterrules.yaml
+++ b/examples/demo-cilium-egress/manifests/observability/clusterrules.yaml
@@ -1,0 +1,31 @@
+# Managed-Prometheus recording + alerting rules for egress-policy violations.
+# Evaluated by the GMP managed rule-evaluator over the ingested Hubble metrics.
+# (Delivering the alert to a channel additionally needs an Alertmanager target —
+# managed Alertmanager via OperatorConfig, or your own. See README.)
+apiVersion: monitoring.googleapis.com/v1
+kind: ClusterRules
+metadata:
+  name: sandbox-egress-violations
+spec:
+  groups:
+    - name: sandbox-egress
+      interval: 30s
+      rules:
+        # Per-(source,destination) rate of denied egress — handy for dashboards.
+        - record: sandbox:egress_policy_denied:rate5m
+          expr: |
+            sum by (source, destination) (
+              rate(hubble_policy_verdicts_total{action="dropped", direction="egress", source=~"sandbox-demo/.*"}[5m])
+            )
+        # Fire when any sandbox identity is denied egress to a destination.
+        - alert: SandboxEgressPolicyDenied
+          expr: |
+            sum by (source, destination) (
+              rate(hubble_policy_verdicts_total{action="dropped", direction="egress", source=~"sandbox-demo/.*"}[5m])
+            ) > 0
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Sandbox egress denied by network policy"
+            description: "{{ $labels.source }} was denied egress to {{ $labels.destination }} (Cilium policy verdict: dropped)."

--- a/examples/demo-cilium-egress/manifests/router/gateway.yaml
+++ b/examples/demo-cilium-egress/manifests/router/gateway.yaml
@@ -1,0 +1,50 @@
+# GKE Gateway API ingress in front of the sandbox-router (the agent-sandbox
+# "gateway routing" path). Adapted from the repo's sandbox-router/gateway.yaml,
+# pinned to the demo namespace.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-http-gateway
+  namespace: sandbox-demo
+spec:
+  gatewayClassName: gke-l7-global-external-managed # GKE-specific managed L7 LB
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sandbox-router-route
+  namespace: sandbox-demo
+spec:
+  parentRefs:
+    - name: external-http-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: sandbox-router-svc
+          port: 8080
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: router-health-check-policy
+  namespace: sandbox-demo
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: sandbox-router-svc
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz

--- a/examples/demo-cilium-egress/manifests/router/sandbox-router.yaml
+++ b/examples/demo-cilium-egress/manifests/router/sandbox-router.yaml
@@ -1,0 +1,83 @@
+# agent-sandbox sandbox-router (HTTP ingress proxy to sandbox pods).
+# Adapted from clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
+# and pinned to the demo namespace. __ROUTER_IMAGE__ is substituted by
+# scripts/optional-gateway-routing.sh after building + pushing the image.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-router-svc
+  namespace: sandbox-demo
+spec:
+  type: ClusterIP
+  selector:
+    app: sandbox-router
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-router-deployment
+  namespace: sandbox-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sandbox-router
+  template:
+    metadata:
+      labels:
+        app: sandbox-router
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: sandbox-router
+      containers:
+        - name: router
+          image: __ROUTER_IMAGE__
+          env:
+            - name: PROXY_TIMEOUT_SECONDS
+              value: "180"
+            # ⚠️ DANGER (demo only): with the public L7 Gateway in gateway.yaml,
+            # this exposes the sandbox /execute endpoint to the internet with NO
+            # auth = unauthenticated remote code execution. Only use on a
+            # throwaway cluster. For real use set this to "false" and supply
+            # ROUTER_AUTH_TOKEN from a Secret (see the commented block below).
+            - name: ALLOW_UNAUTHENTICATED_ROUTER
+              value: "true"
+            # - name: ROUTER_AUTH_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: sandbox-router-auth
+            #       key: auth-token
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/examples/demo-cilium-egress/manifests/router/sandbox-router.yaml
+++ b/examples/demo-cilium-egress/manifests/router/sandbox-router.yaml
@@ -1,7 +1,8 @@
 # agent-sandbox sandbox-router (HTTP ingress proxy to sandbox pods).
 # Adapted from clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
 # and pinned to the demo namespace. __ROUTER_IMAGE__ is substituted by
-# scripts/optional-gateway-routing.sh after building + pushing the image.
+# scripts/optional-gateway-routing.sh after building + pushing the image
+# (along with __ALLOW_UNAUTHENTICATED_ROUTER__).
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,18 +46,23 @@ spec:
           env:
             - name: PROXY_TIMEOUT_SECONDS
               value: "180"
-            # ⚠️ DANGER (demo only): with the public L7 Gateway in gateway.yaml,
-            # this exposes the sandbox /execute endpoint to the internet with NO
-            # auth = unauthenticated remote code execution. Only use on a
-            # throwaway cluster. For real use set this to "false" and supply
-            # ROUTER_AUTH_TOKEN from a Secret (see the commented block below).
+            # Secure by default: the router requires a Bearer token read from the
+            # sandbox-router-auth Secret that scripts/optional-gateway-routing.sh
+            # mints. optional:true so the explicit unauthenticated path below can
+            # also run (when no Secret is created).
+            - name: ROUTER_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sandbox-router-auth
+                  key: auth-token
+                  optional: true
+            # ⚠️ DANGER (demo only): set to "true" ONLY when you deliberately opt
+            # into the unauthenticated path (ALLOW_UNAUTHENTICATED_ROUTER=true when
+            # running optional-gateway-routing.sh). Combined with the public L7
+            # Gateway in gateway.yaml this exposes /execute to the internet with NO
+            # auth = unauthenticated remote code execution. Throwaway clusters only.
             - name: ALLOW_UNAUTHENTICATED_ROUTER
-              value: "true"
-            # - name: ROUTER_AUTH_TOKEN
-            #   valueFrom:
-            #     secretKeyRef:
-            #       name: sandbox-router-auth
-            #       key: auth-token
+              value: "__ALLOW_UNAUTHENTICATED_ROUTER__"
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/examples/demo-cilium-egress/scripts/01-create-cluster.sh
+++ b/examples/demo-cilium-egress/scripts/01-create-cluster.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a GKE Standard cluster WITHOUT Dataplane V2 so we can install upstream Cilium.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+
+if gcloud container clusters describe "$CLUSTER" --zone "$ZONE" --project "$PROJECT" >/dev/null 2>&1; then
+  echo "Cluster $CLUSTER already exists in $ZONE; skipping create."
+else
+  echo "Creating GKE Standard cluster $CLUSTER in $ZONE (no Dataplane V2, no network-policy add-on)..."
+  gcloud container clusters create "$CLUSTER" \
+    --zone "$ZONE" \
+    --project "$PROJECT" \
+    --release-channel "$RELEASE_CHANNEL" \
+    --enable-ip-alias \
+    --num-nodes "$NUM_NODES" \
+    --machine-type "$MACHINE_TYPE" \
+    --image-type COS_CONTAINERD \
+    --no-enable-autoupgrade
+fi
+
+gcloud container clusters get-credentials "$CLUSTER" --zone "$ZONE" --project "$PROJECT"
+
+# Guard: raw CiliumNetworkPolicy requires that GKE is NOT managing the dataplane.
+if kubectl get ds -n kube-system anetd >/dev/null 2>&1; then
+  echo "ERROR: Dataplane V2 (anetd) is present. GKE manages Cilium here and raw" >&2
+  echo "       CiliumNetworkPolicy is unavailable. Recreate the cluster WITHOUT" >&2
+  echo "       --enable-dataplane-v2 (and without --enable-network-policy)." >&2
+  exit 1
+fi
+# Also reject the legacy GKE network-policy add-on (Calico) — it manages policy too.
+if [ "$(gcloud container clusters describe "$CLUSTER" --zone "$ZONE" --project "$PROJECT" \
+        --format='value(networkPolicy.enabled)' 2>/dev/null)" = "True" ]; then
+  echo "ERROR: the GKE network-policy add-on is enabled. Recreate the cluster" >&2
+  echo "       without --enable-network-policy so upstream Cilium can own policy." >&2
+  exit 1
+fi
+echo "OK: cluster ready with a replaceable dataplane; safe to install upstream Cilium."

--- a/examples/demo-cilium-egress/scripts/02-install-cilium.sh
+++ b/examples/demo-cilium-egress/scripts/02-install-cilium.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install upstream Cilium on the GKE cluster, with the L7 DNS proxy that toFQDNs needs.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+
+if ! command -v cilium >/dev/null 2>&1; then
+  echo "ERROR: 'cilium' CLI not found on PATH." >&2
+  echo "Install it: https://github.com/cilium/cilium-cli/releases (or 'brew install cilium-cli')." >&2
+  exit 1
+fi
+
+if cilium status >/dev/null 2>&1; then
+  echo "Cilium already installed; skipping install."
+else
+  echo "Installing Cilium (gke.enabled, ipam=kubernetes)..."
+  # gke.enabled configures the GKE-specific CNI bin path, node-init and routing.
+  # cluster.name must be <=32 chars; GKE's auto-derived name is often too long.
+  cluster_name="${CILIUM_CLUSTER_NAME:-agent-sandbox-demo}"
+  if [ "${#cluster_name}" -gt 32 ]; then
+    echo "ERROR: CILIUM_CLUSTER_NAME '$cluster_name' is ${#cluster_name} chars; Cilium's cluster.name limit is 32." >&2
+    exit 1
+  fi
+  if [ -n "${CILIUM_VERSION:-}" ]; then
+    cilium install --version "$CILIUM_VERSION" --set cluster.name="$cluster_name" \
+      --set gke.enabled=true --set ipam.mode=kubernetes
+  else
+    cilium install --set cluster.name="$cluster_name" \
+      --set gke.enabled=true --set ipam.mode=kubernetes
+  fi
+fi
+
+cilium status --wait
+
+# Make sure core DNS is managed by Cilium (so its egress flows through the DNS proxy).
+# Fail fast if it doesn't restart — toFQDNs depends on this, and swallowing the
+# error would turn the later allow/deny checks into a confusing flake.
+kubectl -n kube-system rollout restart deployment kube-dns >/dev/null
+kubectl -n kube-system rollout status deployment kube-dns --timeout=180s >/dev/null
+
+echo "OK: Cilium installed and ready."

--- a/examples/demo-cilium-egress/scripts/03-install-agent-sandbox.sh
+++ b/examples/demo-cilium-egress/scripts/03-install-agent-sandbox.sh
@@ -19,9 +19,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
 
 version="$AGENT_SANDBOX_VERSION"
 if [ "$version" = "latest" ]; then
+  version=""
+  # Prefer gh, but it fails if installed-yet-unauthenticated; tolerate that and
+  # fall back to the redirect-based discovery rather than aborting under set -e.
   if command -v gh >/dev/null 2>&1; then
-    version="$(gh release view --repo kubernetes-sigs/agent-sandbox --json tagName -q .tagName)"
-  else
+    version="$(gh release view --repo kubernetes-sigs/agent-sandbox --json tagName -q .tagName 2>/dev/null || true)"
+  fi
+  if [ -z "$version" ]; then
     # Resolve the /releases/latest redirect to its tag.
     version="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
       https://github.com/kubernetes-sigs/agent-sandbox/releases/latest | sed 's#.*/tag/##')"

--- a/examples/demo-cilium-egress/scripts/03-install-agent-sandbox.sh
+++ b/examples/demo-cilium-egress/scripts/03-install-agent-sandbox.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install the agent-sandbox controller (core + extensions) from a published release.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+
+version="$AGENT_SANDBOX_VERSION"
+if [ "$version" = "latest" ]; then
+  if command -v gh >/dev/null 2>&1; then
+    version="$(gh release view --repo kubernetes-sigs/agent-sandbox --json tagName -q .tagName)"
+  else
+    # Resolve the /releases/latest redirect to its tag.
+    version="$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+      https://github.com/kubernetes-sigs/agent-sandbox/releases/latest | sed 's#.*/tag/##')"
+  fi
+fi
+echo "Installing agent-sandbox $version ..."
+
+base="https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${version}"
+kubectl apply --server-side -f "${base}/manifest.yaml"
+kubectl apply --server-side -f "${base}/extensions.yaml"
+
+echo "Waiting for the controller to become Available..."
+kubectl wait --for=condition=Available deploy --all -n agent-sandbox-system --timeout=180s
+echo "OK: agent-sandbox $version installed."

--- a/examples/demo-cilium-egress/scripts/04-deploy-demo.sh
+++ b/examples/demo-cilium-egress/scripts/04-deploy-demo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploy the demo: namespace + identities, baseline DNS policy, team-a github allow,
+# and the two sandboxes. (Phase 2 / team-b allow is applied by test.sh.)
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+M="$(dirname "${BASH_SOURCE[0]}")/../manifests"
+
+kubectl apply -f "$M/00-namespace-and-identities.yaml"
+kubectl apply -f "$M/10-cilium-allow-dns.yaml"
+kubectl apply -f "$M/20-cilium-team-a-allow-github.yaml"
+# Ensure phase-1 state on re-runs: remove any team-b allow left over from phase 2.
+kubectl delete -f "$M/40-cilium-team-b-allow-github.yaml" --ignore-not-found
+kubectl apply -f "$M/30-sandboxes.yaml"
+
+echo "Waiting for sandboxes to be Ready..."
+kubectl wait --for=condition=Ready sandbox/sandbox-team-a sandbox/sandbox-team-b \
+  -n "$NAMESPACE" --timeout=180s
+
+kubectl get sandbox -n "$NAMESPACE"
+kubectl get pods -n "$NAMESPACE" -L demo.identity
+echo "OK: demo deployed (phase 1 — team-a allowed, team-b denied)."

--- a/examples/demo-cilium-egress/scripts/05-observability.sh
+++ b/examples/demo-cilium-egress/scripts/05-observability.sh
@@ -59,7 +59,7 @@ echo '  sum by (source,destination) (rate(hubble_policy_verdicts_total{action="d
 echo
 echo "Query Managed Prometheus directly:"
 cat <<EOF
-  curl -s -H "Authorization: Bearer \$(gcloud auth print-access-token)" \\
+  curl -s -H "Authorization: Bearer \$(gcloud auth application-default print-access-token)" \\
     "https://monitoring.googleapis.com/v1/projects/${PROJECT}/location/global/prometheus/api/v1/query" \\
     --data-urlencode 'query=hubble_policy_verdicts_total{action="dropped",direction="egress"}'
 EOF

--- a/examples/demo-cilium-egress/scripts/05-observability.sh
+++ b/examples/demo-cilium-egress/scripts/05-observability.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OPTIONAL: visibility into egress-policy violations.
+# Enables Google Managed Prometheus + Cilium Hubble metrics, scrapes the Hubble
+# policy/drop metrics into Cloud Monitoring, and installs a recording+alert rule.
+# Works on a fresh cluster (idempotent). Requires: gcloud, kubectl, cilium CLI.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+M="$(dirname "${BASH_SOURCE[0]}")/../manifests/observability"
+
+# 1. Enable Managed Prometheus on the cluster (no-op if already on).
+if [ "$(gcloud container clusters describe "$CLUSTER" --zone "$ZONE" --project "$PROJECT" \
+        --format='value(monitoringConfig.managedPrometheusConfig.enabled)' 2>/dev/null)" != "True" ]; then
+  echo "Enabling Managed Prometheus..."
+  gcloud container clusters update "$CLUSTER" --zone "$ZONE" --project "$PROJECT" --enable-managed-prometheus
+else
+  echo "Managed Prometheus already enabled."
+fi
+
+# 2. Enable Hubble + Hubble flow metrics on Cilium (policy/drop with source+FQDN labels).
+echo "Enabling Hubble metrics on Cilium..."
+cilium upgrade --reuse-values \
+  --set hubble.enabled=true \
+  --set hubble.relay.enabled=true \
+  --set hubble.metrics.enableOpenMetrics=true \
+  --set hubble.metrics.enabled="{dns,drop:sourceContext=pod;destinationContext=dns,flow,policy:sourceContext=pod;destinationContext=dns}"
+kubectl -n kube-system rollout restart ds/cilium
+kubectl -n kube-system rollout status ds/cilium --timeout=180s
+
+# 3. Managed Prometheus collectors that started BEFORE Cilium can be stuck with
+#    "no route to host" to the API server; restart them so they pick up Cilium
+#    networking. (Harmless if they're already healthy.)
+if kubectl -n gmp-system get daemonset/collector >/dev/null 2>&1; then
+  kubectl -n gmp-system rollout restart daemonset/collector
+  kubectl -n gmp-system rollout status daemonset/collector --timeout=120s
+fi
+
+# 4. Scrape Hubble metrics into Managed Prometheus + install the alert rule.
+kubectl apply -f "$M/clusterpodmonitoring.yaml"
+kubectl apply -f "$M/clusterrules.yaml"
+
+echo
+echo "Done. Hubble policy/drop metrics now flow into Managed Prometheus."
+echo "Try (PromQL via Cloud Monitoring / Managed Prometheus):"
+echo '  sum by (source,destination) (rate(hubble_policy_verdicts_total{action="dropped",direction="egress"}[5m]))'
+echo
+echo "Query Managed Prometheus directly:"
+cat <<EOF
+  curl -s -H "Authorization: Bearer \$(gcloud auth print-access-token)" \\
+    "https://monitoring.googleapis.com/v1/projects/${PROJECT}/location/global/prometheus/api/v1/query" \\
+    --data-urlencode 'query=hubble_policy_verdicts_total{action="dropped",direction="egress"}'
+EOF

--- a/examples/demo-cilium-egress/scripts/optional-gateway-routing.sh
+++ b/examples/demo-cilium-egress/scripts/optional-gateway-routing.sh
@@ -36,6 +36,12 @@ AR="${AR_LOC}-docker.pkg.dev/${PROJECT}/${AR_REPO}"
 ROUTER_IMAGE="${ROUTER_IMAGE:-$AR/sandbox-router:latest}"
 SANDBOX_IMAGE="${SANDBOX_IMAGE:-$AR/exec-sandbox:latest}"
 
+# Router auth is on by default: we mint a random Bearer token into the
+# sandbox-router-auth Secret and the router requires it on /execute. To
+# deliberately expose an UNAUTHENTICATED /execute (public RCE) on a throwaway
+# cluster, run with ALLOW_UNAUTHENTICATED_ROUTER=true.
+ALLOW_UNAUTHENTICATED_ROUTER="${ALLOW_UNAUTHENTICATED_ROUTER:-false}"
+
 # 0. Ensure the GKE Gateway API controller is enabled on the cluster.
 if ! kubectl get gatewayclass gke-l7-global-external-managed >/dev/null 2>&1; then
   echo "Enabling GKE Gateway API on the cluster (one-time, a few minutes)..."
@@ -61,14 +67,29 @@ sed "s#__SANDBOX_IMAGE__#${SANDBOX_IMAGE}#g" "$DEMO/manifests/ingress/30-sandbox
 kubectl apply -f "$tmp"; rm -f "$tmp"
 kubectl wait --for=condition=Ready sandbox/sandbox-team-a sandbox/sandbox-team-b -n "$NAMESPACE" --timeout=180s
 
-# 3. Deploy router + GKE Gateway.
+# 3. Router auth. Secure by default: mint a token Secret the router enforces.
+if [ "$ALLOW_UNAUTHENTICATED_ROUTER" = "true" ]; then
+  echo "WARNING: deploying sandbox-router with NO auth. With the public Gateway this"
+  echo "         exposes /execute to the internet (unauthenticated RCE). Throwaway clusters only."
+  kubectl delete secret sandbox-router-auth -n "$NAMESPACE" --ignore-not-found
+else
+  ROUTER_AUTH_TOKEN="${ROUTER_AUTH_TOKEN:-$(openssl rand -hex 24)}"
+  kubectl create secret generic sandbox-router-auth -n "$NAMESPACE" \
+    --from-literal=auth-token="$ROUTER_AUTH_TOKEN" \
+    --dry-run=client -o yaml | kubectl apply -f -
+  echo "Router auth enabled; /execute requires a Bearer token (stored in Secret sandbox-router-auth)."
+fi
+
+# 4. Deploy router + GKE Gateway.
 tmp="$(mktemp)"
-sed "s#__ROUTER_IMAGE__#${ROUTER_IMAGE}#g" "$DEMO/manifests/router/sandbox-router.yaml" > "$tmp"
+sed -e "s#__ROUTER_IMAGE__#${ROUTER_IMAGE}#g" \
+    -e "s#__ALLOW_UNAUTHENTICATED_ROUTER__#${ALLOW_UNAUTHENTICATED_ROUTER}#g" \
+    "$DEMO/manifests/router/sandbox-router.yaml" > "$tmp"
 kubectl apply -f "$tmp"; rm -f "$tmp"
 kubectl apply -f "$DEMO/manifests/router/gateway.yaml"
 kubectl -n "$NAMESPACE" rollout status deploy/sandbox-router-deployment --timeout=180s
 
-# 4. Wait for the Gateway to get an external address (can take several minutes).
+# 5. Wait for the Gateway to get an external address (can take several minutes).
 echo "Waiting for the Gateway external address..."
 ip=""
 for _ in $(seq 1 40); do

--- a/examples/demo-cilium-egress/scripts/optional-gateway-routing.sh
+++ b/examples/demo-cilium-egress/scripts/optional-gateway-routing.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OPTIONAL ingress add-on: stand up the agent-sandbox "gateway routing" path
+# (GKE Gateway API -> sandbox-router -> sandbox pod) and switch the two demo
+# sandboxes to an HTTP exec-server image so they can be driven over HTTP.
+#
+# After this, you can drive `git clone` THROUGH the gateway and watch the same
+# per-identity Cilium egress policy allow team-a and deny team-b.
+#
+# Images are built with Cloud Build (no local docker/buildx needed, amd64-native).
+# Requires: gcloud (Cloud Build API enabled) and kubectl. Enables the GKE Gateway
+# API controller on the cluster if it isn't already.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+DEMO="$REPO_ROOT/examples/demo-cilium-egress"
+ROUTER_SRC="$REPO_ROOT/clients/python/agentic-sandbox-client/sandbox-router"
+
+AR_LOC="${AR_LOC:-us-central1}"
+AR_REPO="${AR_REPO:-agent-sandbox-demo}"
+AR="${AR_LOC}-docker.pkg.dev/${PROJECT}/${AR_REPO}"
+ROUTER_IMAGE="${ROUTER_IMAGE:-$AR/sandbox-router:latest}"
+SANDBOX_IMAGE="${SANDBOX_IMAGE:-$AR/exec-sandbox:latest}"
+
+# 0. Ensure the GKE Gateway API controller is enabled on the cluster.
+if ! kubectl get gatewayclass gke-l7-global-external-managed >/dev/null 2>&1; then
+  echo "Enabling GKE Gateway API on the cluster (one-time, a few minutes)..."
+  gcloud container clusters update "$CLUSTER" --zone "$ZONE" --project "$PROJECT" --gateway-api=standard
+fi
+
+# 1. Artifact Registry repo + build both images with Cloud Build.
+if ! gcloud artifacts repositories describe "$AR_REPO" --location "$AR_LOC" --project "$PROJECT" >/dev/null 2>&1; then
+  gcloud artifacts repositories create "$AR_REPO" --repository-format=docker --location "$AR_LOC" --project "$PROJECT"
+fi
+echo "Building images with Cloud Build..."
+gcloud builds submit --project "$PROJECT" --tag "$ROUTER_IMAGE" "$ROUTER_SRC"
+gcloud builds submit --project "$PROJECT" --tag "$SANDBOX_IMAGE" "$DEMO/exec-sandbox"
+
+# 2. Switch the sandboxes to the HTTP exec image (same identities/policies).
+#    Delete first: agent-sandbox does not recreate the pod on an in-place image
+#    change (see kubernetes-sigs/agent-sandbox#581), so we replace the Sandboxes.
+kubectl delete sandbox sandbox-team-a sandbox-team-b -n "$NAMESPACE" --ignore-not-found
+# Wait for deletion to finish so the re-apply doesn't race a terminating object.
+kubectl wait --for=delete sandbox/sandbox-team-a sandbox/sandbox-team-b -n "$NAMESPACE" --timeout=180s 2>/dev/null || true
+tmp="$(mktemp)"
+sed "s#__SANDBOX_IMAGE__#${SANDBOX_IMAGE}#g" "$DEMO/manifests/ingress/30-sandboxes-http.yaml" > "$tmp"
+kubectl apply -f "$tmp"; rm -f "$tmp"
+kubectl wait --for=condition=Ready sandbox/sandbox-team-a sandbox/sandbox-team-b -n "$NAMESPACE" --timeout=180s
+
+# 3. Deploy router + GKE Gateway.
+tmp="$(mktemp)"
+sed "s#__ROUTER_IMAGE__#${ROUTER_IMAGE}#g" "$DEMO/manifests/router/sandbox-router.yaml" > "$tmp"
+kubectl apply -f "$tmp"; rm -f "$tmp"
+kubectl apply -f "$DEMO/manifests/router/gateway.yaml"
+kubectl -n "$NAMESPACE" rollout status deploy/sandbox-router-deployment --timeout=180s
+
+# 4. Wait for the Gateway to get an external address (can take several minutes).
+echo "Waiting for the Gateway external address..."
+ip=""
+for _ in $(seq 1 40); do
+  ip="$(kubectl -n "$NAMESPACE" get gateway external-http-gateway -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)"
+  [ -n "$ip" ] && break
+  sleep 20
+done
+echo "Gateway address: ${ip:-<pending>}"
+[ -n "$ip" ] || { echo "ERROR: Gateway did not receive an external address within the timeout." >&2; exit 1; }
+echo
+echo "Ingress is up. Verify end-to-end with:  ./scripts/test-ingress.sh"

--- a/examples/demo-cilium-egress/scripts/setup-all.sh
+++ b/examples/demo-cilium-egress/scripts/setup-all.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One-shot: provision everything (cluster -> Cilium -> agent-sandbox -> demo).
+# Idempotent: safe to re-run; existing pieces are skipped.
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$here/01-create-cluster.sh"
+bash "$here/02-install-cilium.sh"
+bash "$here/03-install-agent-sandbox.sh"
+bash "$here/04-deploy-demo.sh"
+echo
+echo "Setup complete. Run $here/test.sh to execute the e2e verification."

--- a/examples/demo-cilium-egress/scripts/teardown.sh
+++ b/examples/demo-cilium-egress/scripts/teardown.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Teardown. By default removes only the demo resources (keeps the cluster).
+# Pass --all to also delete the GKE cluster.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+M="$(dirname "${BASH_SOURCE[0]}")/../manifests"
+
+echo "Removing demo resources from namespace $NAMESPACE ..."
+# Optional add-ons (observability + ingress): only attempt the CRD-backed deletes
+# when their CRDs are installed, so a missing optional kind is skipped while real
+# auth/API/manifest errors still fail the script (-e). --ignore-not-found covers
+# absent resources; the router Deployment/Service are core kinds (no guard needed).
+if kubectl get crd rules.monitoring.googleapis.com >/dev/null 2>&1; then
+  kubectl delete -f "$M/observability/clusterrules.yaml" --ignore-not-found
+  kubectl delete -f "$M/observability/clusterpodmonitoring.yaml" --ignore-not-found
+fi
+if kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; then
+  kubectl delete -f "$M/router/gateway.yaml" --ignore-not-found
+fi
+kubectl -n "$NAMESPACE" delete deploy/sandbox-router-deployment svc/sandbox-router-svc --ignore-not-found
+kubectl delete -f "$M/40-cilium-team-b-allow-github.yaml" --ignore-not-found
+kubectl delete -f "$M/30-sandboxes.yaml" --ignore-not-found
+kubectl delete -f "$M/20-cilium-team-a-allow-github.yaml" --ignore-not-found
+kubectl delete -f "$M/10-cilium-allow-dns.yaml" --ignore-not-found
+kubectl delete -f "$M/00-namespace-and-identities.yaml" --ignore-not-found
+
+if [ "${1:-}" = "--all" ]; then
+  echo "Deleting GKE cluster $CLUSTER in $ZONE ..."
+  gcloud container clusters delete "$CLUSTER" --zone "$ZONE" --project "$PROJECT" --quiet
+  echo "Cluster deleted."
+else
+  echo "Demo resources removed. Cluster left running. Use '--all' to delete the cluster too."
+fi

--- a/examples/demo-cilium-egress/scripts/teardown.sh
+++ b/examples/demo-cilium-egress/scripts/teardown.sh
@@ -32,6 +32,7 @@ if kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; then
   kubectl delete -f "$M/router/gateway.yaml" --ignore-not-found
 fi
 kubectl -n "$NAMESPACE" delete deploy/sandbox-router-deployment svc/sandbox-router-svc --ignore-not-found
+kubectl -n "$NAMESPACE" delete secret sandbox-router-auth --ignore-not-found
 kubectl delete -f "$M/40-cilium-team-b-allow-github.yaml" --ignore-not-found
 kubectl delete -f "$M/30-sandboxes.yaml" --ignore-not-found
 kubectl delete -f "$M/20-cilium-team-a-allow-github.yaml" --ignore-not-found

--- a/examples/demo-cilium-egress/scripts/test-ingress.sh
+++ b/examples/demo-cilium-egress/scripts/test-ingress.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2E verification of the FULL path: external client -> GKE Gateway -> sandbox-router
+# -> sandbox /execute -> git clone (governed by the per-identity Cilium egress policy).
+#   Phase 1: team-a clone SUCCEEDS, team-b clone FAILS (denied).
+#   Phase 2: apply team-b allowlist, team-b clone SUCCEEDS.
+# Run after scripts/optional-gateway-routing.sh. Exits non-zero on any failed assertion.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+M="$(dirname "${BASH_SOURCE[0]}")/../manifests"
+NS="$NAMESPACE"
+
+GW="$(kubectl -n "$NS" get gateway external-http-gateway -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || true)"
+[ -n "$GW" ] || { echo "ERROR: gateway has no external address yet."; exit 1; }
+echo "Gateway address: $GW"
+
+echo "Waiting for the gateway backend to pass health checks..."
+code=""
+for _ in $(seq 1 30); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://$GW/healthz" || true)"
+  [ "$code" = "200" ] && break
+  sleep 10
+done
+echo "GET http://$GW/healthz -> $code"
+[ "$code" = "200" ] || { echo "ERROR: gateway not healthy."; exit 1; }
+
+podip() { kubectl -n "$NS" get pod "$1" -o jsonpath='{.status.podIP}'; }
+
+# Drive a clone through the gateway+router into the sandbox; print only exit_code.
+gw_clone() {
+  local sb="$1" ip; ip="$(podip "$sb")"
+  curl -s --max-time 90 -X POST "http://$GW/execute" \
+    -H "X-Sandbox-ID: $sb" -H "X-Sandbox-Namespace: $NS" -H "X-Sandbox-Pod-IP: $ip" \
+    -H 'Content-Type: application/json' \
+    -d "{\"command\":\"timeout 25 git clone --depth 1 $TEST_REPO_URL /tmp/r-$$-$RANDOM\"}" \
+    | python3 -c 'import sys,json
+try:
+    print(json.load(sys.stdin).get("exit_code","ERR"))
+except Exception:
+    print("ERR")'
+}
+
+# Poll gw_clone until it reaches the expected state (policy changes are async),
+# or give up after ~90s. Returns the last observed exit code.
+poll_clone() { # sandbox op(eq0|ne0)
+  local sb="$1" op="$2" a=""
+  for _ in $(seq 1 18); do
+    a="$(gw_clone "$sb")"
+    if { [ "$op" = eq0 ] && [ "$a" = 0 ]; } || \
+       { [ "$op" = ne0 ] && [ "$a" != 0 ] && [ "$a" != ERR ]; }; then
+      break
+    fi
+    sleep 5
+  done
+  echo "$a"
+}
+
+pass=0; fail=0
+check() { # desc actual op(eq0|ne0)
+  local d="$1" a="$2" op="$3"
+  # Empty/non-numeric means the gateway call itself failed — never a real "deny".
+  case "$a" in
+    ''|*[!0-9]*) echo "FAIL: $d (no numeric exit code: '$a')"; fail=$((fail+1)); return;;
+  esac
+  if { [ "$op" = eq0 ] && [ "$a" = 0 ]; } || { [ "$op" = ne0 ] && [ "$a" != 0 ]; }; then
+    echo "PASS: $d (exit=$a)"; pass=$((pass+1))
+  else echo "FAIL: $d (exit=$a)"; fail=$((fail+1)); fi
+}
+
+# Reset to phase 1 so this is re-runnable.
+kubectl delete -f "$M/40-cilium-team-b-allow-github.yaml" --ignore-not-found >/dev/null 2>&1 || true
+
+echo "== Phase 1 (through the gateway) =="
+check "team-a ALLOWED to clone github via gateway"  "$(poll_clone sandbox-team-a eq0)" eq0
+check "team-b DENIED from cloning github via gateway" "$(poll_clone sandbox-team-b ne0)" ne0
+
+echo
+echo "== Phase 2: allowlist team-b =="
+kubectl apply -f "$M/40-cilium-team-b-allow-github.yaml"
+check "team-b ALLOWED after allowlist via gateway" "$(poll_clone sandbox-team-b eq0)" eq0
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1
+echo "Full ingress + egress flow verified. 🎉"

--- a/examples/demo-cilium-egress/scripts/test-ingress.sh
+++ b/examples/demo-cilium-egress/scripts/test-ingress.sh
@@ -27,6 +27,11 @@ GW="$(kubectl -n "$NS" get gateway external-http-gateway -o jsonpath='{.status.a
 [ -n "$GW" ] || { echo "ERROR: gateway has no external address yet."; exit 1; }
 echo "Gateway address: $GW"
 
+# Auth: optional-gateway-routing.sh mints a Bearer token Secret by default. Read
+# it (empty in the opt-in unauthenticated mode) and send it on /execute calls.
+TOKEN="$(kubectl -n "$NS" get secret sandbox-router-auth -o jsonpath='{.data.auth-token}' 2>/dev/null | base64 -d 2>/dev/null || true)"
+AUTH=(); [ -n "$TOKEN" ] && AUTH=(-H "Authorization: Bearer $TOKEN")
+
 echo "Waiting for the gateway backend to pass health checks..."
 code=""
 for _ in $(seq 1 30); do
@@ -43,6 +48,7 @@ podip() { kubectl -n "$NS" get pod "$1" -o jsonpath='{.status.podIP}'; }
 gw_clone() {
   local sb="$1" ip; ip="$(podip "$sb")"
   curl -s --max-time 90 -X POST "http://$GW/execute" \
+    ${AUTH[@]+"${AUTH[@]}"} \
     -H "X-Sandbox-ID: $sb" -H "X-Sandbox-Namespace: $NS" -H "X-Sandbox-Pod-IP: $ip" \
     -H 'Content-Type: application/json' \
     -d "{\"command\":\"timeout 25 git clone --depth 1 $TEST_REPO_URL /tmp/r-$$-$RANDOM\"}" \

--- a/examples/demo-cilium-egress/scripts/test.sh
+++ b/examples/demo-cilium-egress/scripts/test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# E2E verification of per-identity egress.
+#   Phase 1: team-a clone SUCCEEDS, team-b clone FAILS (denied).
+#   Phase 2: apply team-b allowlist, team-b clone SUCCEEDS.
+# Exits non-zero if any assertion fails.
+set -uo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+M="$(dirname "${BASH_SOURCE[0]}")/../manifests"
+NS="$NAMESPACE"
+
+pass=0; fail=0
+
+# Run a clone inside a sandbox; print only the exit code (0 = success).
+clone() {
+  kubectl exec -n "$NS" "$1" -- sh -c \
+    "rm -rf /tmp/r; timeout 40 git clone --depth 1 $TEST_REPO_URL /tmp/r >/dev/null 2>&1; echo \$?" \
+    2>/dev/null | tail -n1
+}
+
+check() { # desc, actual, expected_op (eq0|ne0)
+  local desc="$1" actual="$2" op="$3"
+  # An empty/non-numeric result means the exec itself failed (pod not ready,
+  # API error) — never let that masquerade as a passing "denied" assertion.
+  case "$actual" in
+    ''|*[!0-9]*) echo "FAIL: $desc (no numeric exit code: '$actual')"; fail=$((fail+1)); return;;
+  esac
+  if { [ "$op" = "eq0" ] && [ "$actual" = "0" ]; } || { [ "$op" = "ne0" ] && [ "$actual" != "0" ]; }; then
+    echo "PASS: $desc (exit=$actual)"; pass=$((pass+1))
+  else
+    echo "FAIL: $desc (exit=$actual)"; fail=$((fail+1))
+  fi
+}
+
+# Reset to phase-1 state so this script is re-runnable (remove any prior team-b allow).
+kubectl delete -f "$M/40-cilium-team-b-allow-github.yaml" --ignore-not-found >/dev/null 2>&1 || true
+sleep 4
+
+echo "== Phase 1 =="
+check "team-a is ALLOWED to clone github"  "$(clone sandbox-team-a)" eq0
+check "team-b is DENIED from cloning github" "$(clone sandbox-team-b)" ne0
+
+echo
+echo "== Phase 2: allowlist team-b's identity =="
+kubectl apply -f "$M/40-cilium-team-b-allow-github.yaml"
+echo "Waiting for the new policy to take effect..."
+sleep 8
+check "team-b is now ALLOWED after allowlist" "$(clone sandbox-team-b)" eq0
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || { echo "Tip: 'cilium hubble enable' then 'hubble observe -n $NS --verdict DROPPED' to see drops."; exit 1; }
+echo "All assertions passed. 🎉"


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `examples/demo-cilium-egress/`, a self-contained, end-to-end example that demonstrates **per-identity network egress control** for Agent Sandbox using Cilium.

Two sandboxes are given distinct Kubernetes identities (a dedicated ServiceAccount plus a `demo.identity` pod label). A `CiliumNetworkPolicy` with `toFQDNs` grants one identity egress to `github.com` while the other is denied — proven by `git clone` succeeding in the first sandbox and failing (timeout) in the second. A second policy then allowlists the second identity and its clone starts working too, showing additive, per-identity domain egress.

The example is fully programmatic and includes:
- Provisioning scripts: GKE Standard cluster (no Dataplane V2), self-managed upstream Cilium (with the L7 DNS proxy `toFQDNs` requires), and the agent-sandbox controller.
- Manifests: namespace + identities, baseline default-deny + DNS `CiliumNetworkPolicy`, per-identity `toFQDNs` github allow policies, and the two Sandboxes.
- An asserting test script (`test.sh`) that verifies allow/deny/allowlist.
- An optional "gateway routing" ingress add-on: GKE Gateway API + the sandbox-router + a small exec-server sandbox image (built via Cloud Build), plus `test-ingress.sh` that drives `git clone` through the gateway and asserts the same per-identity outcome.
- Architecture and phase-flow Mermaid diagrams, and a teardown script.

Why: upstream Kubernetes `NetworkPolicy` cannot match domains, so domain-level, identity-scoped egress needs a CNI extension. No existing example shows this — the repo only mentions `CiliumNetworkPolicy` as an option for `Unmanaged` NetworkPolicy mode. This provides a concrete, tested realization and ties into the roadmap's "Network Policy Attach at Claim Time" and "Sandbox / Pod Identity Association" themes.

#### Which issue(s) this PR is related to:
NONE

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an identity-based egress allowlisting demo with automated end-to-end setup, teardown, and verification.
  * Added an optional gateway routing mode plus an HTTP “exec” sandbox for `/execute` testing.
  * Added Managed Prometheus + Cilium Hubble observability, including recording/alerting for denied egress and example queries.
* **Documentation**
  * Added a full walkthrough README with manual verification, safety notes, and troubleshooting gotchas.
* **Bug Fixes**
  * Added installation/deployment safeguards to prevent unsupported cluster and dataplane configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->