### PR TITLE
feat: add topologySpreadConstraints support to helm chart

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters and their defaults.
 | `nodeSelector` | Node selector for the controller pod | `{}` |
 | `tolerations` | Tolerations for the controller pod | `[]` |
 | `affinity` | Affinity rules for the controller pod | `{}` |
+| `topologySpreadConstraints` | Topology spread constraints for the controller pod | `[]` |
 | `podSecurityContext` | Pod `securityContext`; only rendered when set (e.g. Kyverno / Pod Security) | `null` |
 | `containerSecurityContext` | Container `securityContext` for the controller; only rendered when set | `null` |
 | `podAnnotations` | Annotations added to the controller pod template (e.g. service-mesh sidecar toggles, Prometheus scrape autodiscovery) | `{}` |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -61,6 +61,18 @@ tolerations: []
 
 affinity: {}
 
+# topologySpreadConstraints spread the controller pods across topology domains
+# (e.g. nodes, zones). Default [] — only rendered when set. Useful with
+# replicaCount > 1 to keep replicas off the same node/zone for availability.
+topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/hostname
+  #   whenUnsatisfiable: ScheduleAnyway
+  #   labelSelector:
+  #     matchLabels:
+  #       app.kubernetes.io/name: agent-sandbox
+  #       app.kubernetes.io/instance: agent-sandbox
+
 # Pod-level securityContext (spec.template.spec.securityContext). Default null — omitted unless set.
 # Example for Kyverno / restricted Pod Security:
 # podSecurityContext:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -61,17 +61,20 @@ tolerations: []
 
 affinity: {}
 
-# topologySpreadConstraints spread the controller pods across topology domains
-# (e.g. nodes, zones). Default [] — only rendered when set. Useful with
-# replicaCount > 1 to keep replicas off the same node/zone for availability.
+# topologySpreadConstraints control how the controller pods are spread across
+# topology domains (e.g. nodes, zones). Default [] — only rendered when non-empty.
+# Useful with replicaCount > 1 to keep replicas off the same node/zone.
 topologySpreadConstraints: []
   # - maxSkew: 1
   #   topologyKey: kubernetes.io/hostname
   #   whenUnsatisfiable: ScheduleAnyway
   #   labelSelector:
   #     matchLabels:
-  #       app.kubernetes.io/name: agent-sandbox
-  #       app.kubernetes.io/instance: agent-sandbox
+  #       # app.kubernetes.io/name defaults to the chart name, but if you set
+  #       # nameOverride it will use that value instead. To scope the spread to a
+  #       # single release, also add:
+  #       #   app.kubernetes.io/instance: <your-release-name>
+  #       app.kubernetes.io/name: agent-sandbox # or your nameOverride value
 
 # Pod-level securityContext (spec.template.spec.securityContext). Default null — omitted unless set.
 # Example for Kyverno / restricted Pod Security:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds an optional `topologySpreadConstraints` value to the controller Deployment, rendered only when set. Lets operators spread controller replicas across nodes/zones for availability when running with replicaCount > 1. 
Mirrors the existing affinity/nodeSelector/tolerations pattern; no behavior change when unset.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->

```release-note
Add `topologySpreadConstraints` value to the Helm chart for spreading the controller pods across topology domains.
```


<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Kubernetes topology spread constraints for controller pod placement.
  * Introduced a new Helm values option (`topologySpreadConstraints`, default `[]`) to control how pods are distributed across topology domains.
* **Documentation**
  * Updated the Helm chart README configuration reference to include the new `topologySpreadConstraints` parameter and an example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->