### PR TITLE
metric: add warmpool_name label for sandboxclaim metrics

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1264,7 +1264,7 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxProvisioned", "Provisioning", "Created Sandbox %q", sandbox.Name)
 	}
 
-	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, "none", "not_ready")
+	asmetrics.RecordSandboxClaimCreation(claim.Namespace, template.Name, asmetrics.LaunchTypeCold, claim.Spec.WarmPoolRef.Name, "not_ready")
 
 	return sandbox, nil
 }
@@ -1721,7 +1721,7 @@ func getLaunchType(sandbox *v1beta1.Sandbox) string {
 }
 
 // recordClaimStartupLatency records the startup latency based on webhook annotation.
-func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string) {
+func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmpoolName string) {
 	logger := log.FromContext(ctx)
 	webhookSeenTimeStr := claim.Annotations[asmetrics.WebhookAnnotation]
 	if webhookSeenTimeStr == "" {
@@ -1738,11 +1738,11 @@ func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, 
 		logger.Error(errors.New("negative duration"), "Webhook seen time is in the future", "duration", duration, "webhookSeenTime", webhookSeenTime)
 		return
 	}
-	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, templateName)
+	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, templateName, warmpoolName)
 }
 
 // recordControllerStartupLatency records the controller startup latency based on observed time.
-func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string) {
+func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmpoolName string) {
 	logger := log.FromContext(ctx)
 	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
 		key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
@@ -1753,7 +1753,7 @@ func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Cont
 			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)
 			return
 		}
-		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, templateName)
+		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, templateName, warmpoolName)
 	}
 }
 
@@ -1806,11 +1806,12 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	}
 
 	templateName := r.resolveTemplateName(sandbox)
+	warmpoolName := claim.Spec.WarmPoolRef.Name
 
 	logger.V(1).Info("SandboxClaim is marked as Ready", "claim", claim.Name, "sandbox", sandboxName, "duration", time.Since(claim.CreationTimestamp.Time))
 
-	r.recordClaimStartupLatency(ctx, claim, launchType, templateName)
-	r.recordControllerStartupLatency(ctx, claim, launchType, templateName)
+	r.recordClaimStartupLatency(ctx, claim, launchType, templateName, warmpoolName)
+	r.recordControllerStartupLatency(ctx, claim, launchType, templateName, warmpoolName)
 	r.recordSandboxCreationLatency(sandbox, launchType, templateName)
 }
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1721,7 +1721,7 @@ func getLaunchType(sandbox *v1beta1.Sandbox) string {
 }
 
 // recordClaimStartupLatency records the startup latency based on webhook annotation.
-func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmpoolName string) {
+func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmPoolName string) {
 	logger := log.FromContext(ctx)
 	webhookSeenTimeStr := claim.Annotations[asmetrics.WebhookAnnotation]
 	if webhookSeenTimeStr == "" {
@@ -1738,11 +1738,11 @@ func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, 
 		logger.Error(errors.New("negative duration"), "Webhook seen time is in the future", "duration", duration, "webhookSeenTime", webhookSeenTime)
 		return
 	}
-	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, templateName, warmpoolName)
+	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, templateName, warmPoolName)
 }
 
 // recordControllerStartupLatency records the controller startup latency based on observed time.
-func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmpoolName string) {
+func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmPoolName string) {
 	logger := log.FromContext(ctx)
 	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
 		key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
@@ -1753,7 +1753,7 @@ func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Cont
 			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)
 			return
 		}
-		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, templateName, warmpoolName)
+		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, templateName, warmPoolName)
 	}
 }
 
@@ -1806,12 +1806,12 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	}
 
 	templateName := r.resolveTemplateName(sandbox)
-	warmpoolName := claim.Spec.WarmPoolRef.Name
+	warmPoolName := claim.Spec.WarmPoolRef.Name
 
 	logger.V(1).Info("SandboxClaim is marked as Ready", "claim", claim.Name, "sandbox", sandboxName, "duration", time.Since(claim.CreationTimestamp.Time))
 
-	r.recordClaimStartupLatency(ctx, claim, launchType, templateName, warmpoolName)
-	r.recordControllerStartupLatency(ctx, claim, launchType, templateName, warmpoolName)
+	r.recordClaimStartupLatency(ctx, claim, launchType, templateName, warmPoolName)
+	r.recordControllerStartupLatency(ctx, claim, launchType, templateName, warmPoolName)
 	r.recordSandboxCreationLatency(sandbox, launchType, templateName)
 }
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2714,7 +2714,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		}
 
 		// Verify metric
-		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "none", "not_ready"))
+		val := testutil.ToFloat64(asmetrics.SandboxClaimCreationTotal.WithLabelValues("default", "test-template", asmetrics.LaunchTypeCold, "test-warmpool", "not_ready"))
 		if val != 1 {
 			t.Errorf("expected metric count 1, got %v", val)
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,7 +39,8 @@ var (
 	// ClaimStartupLatency measures the time from SandboxClaim creation to SandboxClaim Ready state.
 	// Labels:
 	// - launch_type: "warm", "cold", "unknown"
-	// - sandbox_template: the SandboxTemplateRef.
+	// - sandbox_template: the SandboxTemplateRef used by the SandboxWarmPool (from sandboxWarmPool.Spec).
+	// - warmpool_name: the name of the SandboxWarmPool (from SandboxWarmPoolRef.Name).
 	ClaimStartupLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "agent_sandbox_claim_startup_latency_ms",
@@ -47,13 +48,14 @@ var (
 			// Buckets for latency from 100ms to 4 minutes
 			Buckets: []float64{100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000},
 		},
-		[]string{"launch_type", "sandbox_template"},
+		[]string{"launch_type", "sandbox_template", "warmpool_name"},
 	)
 
 	// ClaimControllerStartupLatency measures the time from controller first observed timestamp to SandboxClaim Ready state.
 	// Labels:
 	// - launch_type: "warm", "cold", "unknown"
-	// - sandbox_template: the SandboxTemplateRef.
+	// - sandbox_template: the SandboxTemplateRef used by the SandboxWarmPool (from sandboxWarmPool.Spec).
+	// - warmpool_name: the name of the SandboxWarmPool (SandboxWarmPoolRef.Name).
 	ClaimControllerStartupLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "agent_sandbox_claim_controller_startup_latency_ms",
@@ -61,7 +63,7 @@ var (
 			// Buckets for latency from 100ms to 4 minutes
 			Buckets: []float64{100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000},
 		},
-		[]string{"launch_type", "sandbox_template"},
+		[]string{"launch_type", "sandbox_template", "warmpool_name"},
 	)
 
 	// SandboxCreationLatency measures the time from Sandbox creation to Pod Ready state.
@@ -84,7 +86,7 @@ var (
 	// - namespace: the namespace of the claim
 	// - sandbox_template: the SandboxTemplateRef
 	// - launch_type: "warm", "cold", "unknown"
-	// - warmpool_name: the name of the warm pool (if applicable)
+	// - warmpool_name: the name of the warm pool
 	// - pod_condition: "ready", "not_ready".
 	SandboxClaimCreationTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -139,15 +141,15 @@ func init() {
 }
 
 // RecordClaimStartupLatency records the duration since the provided start time.
-func RecordClaimStartupLatency(startTime time.Time, launchType, templateName string) {
+func RecordClaimStartupLatency(startTime time.Time, launchType, templateName, warmPoolName string) {
 	duration := float64(time.Since(startTime).Milliseconds())
-	ClaimStartupLatency.WithLabelValues(launchType, templateName).Observe(duration)
+	ClaimStartupLatency.WithLabelValues(launchType, templateName, warmPoolName).Observe(duration)
 }
 
 // RecordClaimControllerStartupLatency records the duration since the provided controller start time.
-func RecordClaimControllerStartupLatency(startTime time.Time, launchType, templateName string) {
+func RecordClaimControllerStartupLatency(startTime time.Time, launchType, templateName, warmPoolName string) {
 	duration := float64(time.Since(startTime).Milliseconds())
-	ClaimControllerStartupLatency.WithLabelValues(launchType, templateName).Observe(duration)
+	ClaimControllerStartupLatency.WithLabelValues(launchType, templateName, warmPoolName).Observe(duration)
 }
 
 // RecordSandboxCreationLatency records the measured latency duration for a sandbox creation.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,8 +39,8 @@ var (
 	// ClaimStartupLatency measures the time from SandboxClaim creation to SandboxClaim Ready state.
 	// Labels:
 	// - launch_type: "warm", "cold", "unknown"
-	// - sandbox_template: the SandboxTemplateRef used by the SandboxWarmPool (from sandboxWarmPool.Spec).
-	// - warmpool_name: the name of the SandboxWarmPool (from SandboxWarmPoolRef.Name).
+	// - sandbox_template: the resolved SandboxTemplateRef used to create the Sandbox.
+	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	ClaimStartupLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "agent_sandbox_claim_startup_latency_ms",
@@ -54,8 +54,8 @@ var (
 	// ClaimControllerStartupLatency measures the time from controller first observed timestamp to SandboxClaim Ready state.
 	// Labels:
 	// - launch_type: "warm", "cold", "unknown"
-	// - sandbox_template: the SandboxTemplateRef used by the SandboxWarmPool (from sandboxWarmPool.Spec).
-	// - warmpool_name: the name of the SandboxWarmPool (SandboxWarmPoolRef.Name).
+	// - sandbox_template: the resolved SandboxTemplateRef used to create the Sandbox.
+	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	ClaimControllerStartupLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "agent_sandbox_claim_controller_startup_latency_ms",
@@ -86,7 +86,7 @@ var (
 	// - namespace: the namespace of the claim
 	// - sandbox_template: the SandboxTemplateRef
 	// - launch_type: "warm", "cold", "unknown"
-	// - warmpool_name: the name of the warm pool
+	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	// - pod_condition: "ready", "not_ready".
 	SandboxClaimCreationTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -46,7 +46,14 @@ func TestClaimLatencyRecording(t *testing.T) {
 			ClaimStartupLatency.WithLabelValues(tc.launchType, "test-tmpl", "test-pool").Observe(1000)
 
 			if testutil.CollectAndCount(ClaimStartupLatency) != 1 {
-				t.Errorf("Expected 1 observation")
+				t.Errorf("Expected 1 observation for ClaimStartupLatency")
+			}
+
+			ClaimControllerStartupLatency.Reset()
+			ClaimControllerStartupLatency.WithLabelValues(tc.launchType, "test-tmpl", "test-pool").Observe(1000)
+
+			if testutil.CollectAndCount(ClaimControllerStartupLatency) != 1 {
+				t.Errorf("Expected 1 observation for ClaimControllerStartupLatency")
 			}
 		})
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -43,7 +43,7 @@ func TestClaimLatencyRecording(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ClaimStartupLatency.Reset()
-			ClaimStartupLatency.WithLabelValues(tc.launchType, "test-tmpl").Observe(1000)
+			ClaimStartupLatency.WithLabelValues(tc.launchType, "test-tmpl", "test-pool").Observe(1000)
 
 			if testutil.CollectAndCount(ClaimStartupLatency) != 1 {
 				t.Errorf("Expected 1 observation")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

**Why we need it:**
When a `SandboxClaim` references a `warmPoolRef` instead of a direct `sandboxTemplate`(#899), the metric labels are expected to be updated accordingly to reflect the targeted warm pool. 

This is currently a critical blocker for using KEDA (Kubernetes Event-driven Autoscaling) to scale warm pools down to zero:
1. When KEDA scales a `SandboxWarmPool` to 0 replicas, any incoming `SandboxClaim` will naturally trigger a cold-start since no ready sandboxes are available.
2. Previously, the controller recorded all cold-start events with a hardcoded `"none"` value for the `warmpool_name` label([code](https://github.com/kubernetes-sigs/agent-sandbox/blob/bce2dda61294744b764ed87ec0f085450d808568/extensions/controllers/sandboxclaim_controller.go#L1267)).
3. Because the metric counter was registered under `"none"`, any KEDA scaling queries filtering by a specific `warmpool_name` (such as `warmpool_name="python-sdk-warmpool"`) would return 0.
4. Consequently, KEDA would fail to detect the incoming claim activity, the activation threshold would never be crossed, and the warm pool would remain stuck at 0 replicas.

By replacing `"none"` with the actual referenced warm pool name (`claim.Spec.WarmPoolRef.Name`), we ensure that cold starts are correctly accounted for under the corresponding warm pool metric label. This enables KEDA to successfully monitor the claim rate from zero and wake the pool up on demand.


**What this PR does:**
1. **Controller Metrics Propagation** (`extensions/controllers/sandboxclaim_controller.go`):
   - Updates the cold-start metric recording call to pass the actual referenced warm pool name from `claim.Spec.WarmPoolRef.Name` instead of the hardcoded `"none"` value.
   - Updated helper functions (`recordClaimStartupLatency`, `recordControllerStartupLatency`, and `recordSandboxCreationLatency`) to accept and pass this new `warmpool_name` label parameter.
  
2. **Metrics definitions and record helpers** (`internal/metrics/metrics.go`):
   - Added `warmpool_name` to the label arrays of `ClaimStartupLatency` and `ClaimControllerStartupLatency` Prometheus vector metrics.

3. **Tests validation** (`internal/metrics/metrics_test.go` and `extensions/controllers/sandboxclaim_controller_test.go`):
   - Adjusted metric assertions to support the extra label value field in tests.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
To unblock issue #677 
Ref: #1048 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```
Added `warmpool_name` label to `ClaimStartupLatency` and `ClaimControllerStartupLatency`.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced sandbox claim startup and controller startup latency metrics to include the warm pool name as an additional label.

* **Bug Fixes**
  * Cold-start sandbox creation/ready tracking now reports the actual warm pool reference name instead of a generic placeholder.

* **Tests**
  * Updated metric expectations and assertions to account for the new warm pool label and validate label values and observation counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->