### PR TITLE
feat: add Desired printer column to SandboxWarmPool kubectl output

### DIFF
--- a/extensions/api/v1alpha1/sandboxwarmpool_types.go
+++ b/extensions/api/v1alpha1/sandboxwarmpool_types.go
@@ -90,6 +90,7 @@ type SandboxWarmPoolStatus struct {
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:scope=Namespaced,shortName=swp
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`
+// +kubebuilder:printcolumn:name="Desired",type=integer,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:deprecatedversion:warning="extensions.agents.x-k8s.io/v1alpha1 SandboxWarmPool is deprecated; use extensions.agents.x-k8s.io/v1beta1 SandboxWarmPool instead"
 // SandboxWarmPool is the Schema for the sandboxwarmpools API.

--- a/extensions/api/v1beta1/sandboxwarmpool_types.go
+++ b/extensions/api/v1beta1/sandboxwarmpool_types.go
@@ -98,6 +98,7 @@ type SandboxWarmPoolStatus struct {
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:scope=Namespaced,shortName=swp
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas"
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:storageversion
 // +kubebuilder:conversion:strategy=Webhook

--- a/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/helm/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .status.readyReplicas
       name: Ready
       type: integer
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -83,6 +86,9 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.readyReplicas
       name: Ready
+      type: integer
+    - jsonPath: .spec.replicas
+      name: Desired
       type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
+++ b/k8s/crds/extensions.agents.x-k8s.io_sandboxwarmpools.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .status.readyReplicas
       name: Ready
       type: integer
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -83,6 +86,9 @@ spec:
   - additionalPrinterColumns:
     - jsonPath: .status.readyReplicas
       name: Ready
+      type: integer
+    - jsonPath: .spec.replicas
+      name: Desired
       type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
Add a "Desired" printer column to SandboxWarmPool (both v1beta1 and v1alpha1) so that `kubectl get sandboxwarmpool` shows the desired replica count alongside the ready count.

Before:
  NAME                  READY   AGE
  my-sandbox-warmpool   2       5m

After:
  NAME                  READY   DESIRED   AGE
  my-sandbox-warmpool   2       4         5m

Ref #188

#### What this PR does / why we need it:
Adds a `Desired` printer column to `SandboxWarmPool` (both v1beta1 and v1alpha1) so that `kubectl get sandboxwarmpool` shows the desired replica count alongside the ready count. This follows the same pattern used by other Kubernetes SIG CRDs like Cluster API MachineSet and LeaderWorkerSet.

**Before:**
   ```
   NAME                  READY   AGE
   my-sandbox-warmpool   2       5m
   ```

   **After:**
   ```
   NAME                  READY   DESIRED   AGE
   my-sandbox-warmpool   2       4         5m
   ```

#### Which issue(s) this PR is related to:

Per [maintainer feedback](https://github.com/kubernetes-sigs/agent-sandbox/issues/188#issuecomment-3793088481) and [review on #610](https://github.com/kubernetes-sigs/agent-sandbox/pull/610#discussion_r2140299985), the remaining work for #188 is adding `READY` and `DESIRED` kubectl columns without introducing additional status fields like `AvailableReplicas` (which is functionally identical to `ReadyReplicas`). Conditions support can be addressed in a follow-up PR.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Desired** column to SandboxWarmPool listings, showing the configured replica count.
  * The new column appears across supported versions of the resource, alongside existing columns like **Ready** and **Age**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->