### PR TITLE
fix broken links

### DIFF
--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -99,7 +99,7 @@ print(f"<IMG>{img_str}</IMG>")
 
 In the end the code prints an encoded image. Inside the tool definition the regex expression is used to extract this string, decode, and plot it.
 
-![](https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/main/examples/analytics-tool/imgs/analytics-output.png)
+![Analytics output showing a bar chart of purchase amounts by location](https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/main/examples/analytics-tool/imgs/analytics-output.png)
 
 ## Cleanup
 

--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 - Running **GKE** cluster (**Standard** or **Autopilot**))
 - `kubectl` access to a Kubernetes **GKE Standard** or **GKE Autopilot** cluster
-- Agent-sandbox installed on GKE. Here is the ([Installation Guide](../../getting_started/))
+- Agent-sandbox installed on GKE. Here is the ([Installation Guide](https://agent-sandbox.sigs.k8s.io/docs/getting_started/install_prerequisites/))
 
 ## Deploy analytics tools
 
@@ -99,7 +99,7 @@ print(f"<IMG>{img_str}</IMG>")
 
 In the end the code prints an encoded image. Inside the tool definition the regex expression is used to extract this string, decode, and plot it.
 
-![](imgs/analytics-output.png)
+![](https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/main/examples/analytics-tool/imgs/analytics-output.png)
 
 ## Cleanup
 

--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 - Running **GKE** cluster (**Standard** or **Autopilot**))
 - `kubectl` access to a Kubernetes **GKE Standard** or **GKE Autopilot** cluster
-- Agent-sandbox installed on GKE. Here is the ([Installation Guide](https://agent-sandbox.sigs.k8s.io/docs/getting_started/install_prerequisites/))
+- Agent-sandbox installed on GKE. Here is the [Installation Guide](https://agent-sandbox.sigs.k8s.io/docs/getting_started/install_prerequisites/)
 
 ## Deploy analytics tools
 


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes 2 broken links in the [analytics tutorial](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/examples/analytics-tool). The output image wasn't rendered on the Hugo page.

#### Which issue(s) this PR is related to:
None

#### Release Note
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the prerequisites link to point to the canonical hosted installation guide.
  * Switched the analytics output image reference to a fully hosted image URL so it displays reliably outside the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->