### PR TITLE
fix(examples): cross-compile chrome-sandbox entrypoint to avoid QEMU Go crash

### DIFF
--- a/examples/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/Dockerfile
@@ -1,12 +1,20 @@
 # Compile our golang binaries in a separate stage to keep the final image small.
-FROM golang:1.26.4 AS builder
+# Pin the builder to the build platform and cross-compile to the target arch so the
+# Go toolchain always runs natively instead of under QEMU emulation. Running `go build`
+# under emulation can crash the Go runtime/GC ("found pointer to free object").
+# See https://github.com/golang/go/issues/69255#issuecomment-2523276831
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+
+# Declare TARGETARCH/TARGETOS to make them available in this build stage.
+ARG TARGETARCH
+ARG TARGETOS=linux
 
 WORKDIR /src
 
 COPY go.mod go.sum ./
 COPY cmd ./cmd
 
-RUN CGO_ENABLED=0 go build -o /chrome-sandbox-entrypoint ./cmd/chrome-sandbox-entrypoint
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /chrome-sandbox-entrypoint ./cmd/chrome-sandbox-entrypoint
 
 #----------------------
 # Use a base image with a minimal set of packages.


### PR DESCRIPTION
#### What this PR does / why we need it:

The `examples/chrome-sandbox` builder stage ran `go build` *inside* the
target-architecture stage. Under a multi-arch `docker buildx` build
(`linux/amd64,linux/arm64`), this compiled the arm64 binary by running the Go
toolchain **under QEMU emulation**. Go 1.26.4's garbage collector can abort with
`fatal error: found pointer to free object` when running emulated, which breaks
the `linux/arm64` image build — and any CI job that builds it (observed in
`presubmit-agent-sandbox-benchmarks-kops-gcp`).

This pins the builder to `--platform=$BUILDPLATFORM` and cross-compiles with
`GOOS=${TARGETOS} GOARCH=${TARGETARCH}`, exactly matching the controller
`Dockerfile` (which already references golang/go#69255 for the same reason). The
Go toolchain now always runs natively on the build platform; only the produced
binary targets arm64.

This is a pre-existing build-infra bug, independent of any example/feature
change. The emulated parts that are not Go (e.g. arm64 `apt-get install
chromium`) are unaffected.

**Verification:** reproduced the multi-arch build on Cloud Build (amd64 host,
QEMU for arm64). Before: the arm64 `go build` step aborts with `found pointer to
free object`. After this change: the `linux/amd64,linux/arm64` build completes
successfully (the arm64 builder step runs as a native `amd64->arm64`
cross-compile in ~11s).

See https://github.com/golang/go/issues/69255#issuecomment-2523276831

#### Which issue(s) this PR is related to:

NONE

#### Release Note
```release-note
Fixed the chrome-sandbox example image build failing for linux/arm64 under emulation by cross-compiling the Go entrypoint instead of building it under QEMU.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build support for multiple architectures, making sandbox images easier to build for different target platforms.
  * Build settings were updated to use platform-specific Go compilation during image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->