### PR TITLE
fix(extensions): fix privilege escalation vulnerability in SandboxTemplate

### DIFF
--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -83,14 +83,20 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// 3. Handle "Unmanaged" Opt-Out
 	if management == extensionsv1beta1.NetworkPolicyManagementUnmanaged {
-		existingNP := &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{Name: npName, Namespace: npNamespace},
-		}
-		if err := r.Delete(ctx, existingNP); err != nil && !k8errors.IsNotFound(err) {
-			logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
-			return ctrl.Result{}, err
-		} else if err == nil {
+		existingNP := &networkingv1.NetworkPolicy{}
+		err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
+		if err == nil {
+			if !metav1.IsControlledBy(existingNP, template) {
+				return ctrl.Result{}, fmt.Errorf("NetworkPolicy %s is not controlled by SandboxTemplate %s", npName, template.Name)
+			}
+			if err := r.Delete(ctx, existingNP); err != nil && !k8errors.IsNotFound(err) {
+				logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
+				return ctrl.Result{}, err
+			}
 			logger.Info("Deleted unmanaged NetworkPolicy", "name", existingNP.Name)
+		} else if !k8errors.IsNotFound(err) {
+			logger.Error(err, "Failed to get unmanaged NetworkPolicy")
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
 	}
@@ -120,6 +126,10 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
 
 	if err == nil {
+		if !metav1.IsControlledBy(existingNP, template) {
+			return ctrl.Result{}, fmt.Errorf("NetworkPolicy %s is not controlled by SandboxTemplate %s", npName, template.Name)
+		}
+
 		// Policy exists: Semantic DeepEqual check for drift
 		if equality.Semantic.DeepEqual(existingNP.Spec, desiredSpec) {
 			return ctrl.Result{}, nil // Perfect match, O(1) efficiency.

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
@@ -87,16 +88,18 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
 		if err == nil {
 			if !metav1.IsControlledBy(existingNP, template) {
-				return ctrl.Result{}, fmt.Errorf("NetworkPolicy %s is not controlled by SandboxTemplate %s", npName, template.Name)
+				r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile",
+					"Refusing to delete NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
+				return ctrl.Result{}, fmt.Errorf("NetworkPolicy %s/%s is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
 			}
 			if err := r.Delete(ctx, existingNP); err != nil && !k8errors.IsNotFound(err) {
 				logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
-				return ctrl.Result{}, err
+				return ctrl.Result{}, fmt.Errorf("failed to delete unmanaged NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 			}
 			logger.Info("Deleted unmanaged NetworkPolicy", "name", existingNP.Name)
 		} else if !k8errors.IsNotFound(err) {
 			logger.Error(err, "Failed to get unmanaged NetworkPolicy")
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -127,7 +130,9 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if err == nil {
 		if !metav1.IsControlledBy(existingNP, template) {
-			return ctrl.Result{}, fmt.Errorf("NetworkPolicy %s is not controlled by SandboxTemplate %s", npName, template.Name)
+			r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile",
+				"Refusing to update NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
+			return ctrl.Result{}, fmt.Errorf("NetworkPolicy %s/%s is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
 		}
 
 		// Policy exists: Semantic DeepEqual check for drift
@@ -138,14 +143,14 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		existingNP.Spec = desiredSpec
 		if err := r.Update(ctx, existingNP); err != nil {
 			logger.Error(err, "Failed to update NetworkPolicy", "name", npName)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to update NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 		}
 		logger.Info("Successfully updated shared NetworkPolicy", "name", npName)
 		return ctrl.Result{}, nil
 	}
 
 	if !k8errors.IsNotFound(err) {
-		return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 	}
 
 	// 6. Create New Policy
@@ -160,7 +165,7 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if err := r.Create(ctx, np); err != nil {
 		logger.Error(err, "Failed to create NetworkPolicy", "name", npName)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to create NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 	}
 
 	logger.Info("Successfully created shared NetworkPolicy", "name", npName)

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -19,10 +19,12 @@ package controllers
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -265,6 +267,118 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 			}
 			if relabeledTemplate.ResourceVersion != resourceVersion {
 				t.Errorf("expected second reconcile to leave SandboxTemplate resourceVersion unchanged, got %q, want %q", relabeledTemplate.ResourceVersion, resourceVersion)
+			}
+		})
+	}
+}
+
+// TestSandboxTemplateReconcileNetworkPolicyOwnershipConflict is the regression test for the
+// privilege-escalation fix: a SandboxTemplate must never delete or modify a NetworkPolicy it
+// does not control. It covers both the unmanaged-delete path and the managed-update path with
+// an existing NetworkPolicy that has either no controller owner or a mismatched one. Without the
+// IsControlledBy guard, each case would let the template hijack/destroy a foreign NetworkPolicy;
+// these cases fail (no error, object mutated) against the unpatched controller.
+func TestSandboxTemplateReconcileNetworkPolicyOwnershipConflict(t *testing.T) {
+	otherIsController := true
+	foreignOwner := []metav1.OwnerReference{
+		{
+			APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+			Kind:       "SandboxTemplate",
+			Name:       "some-other-template",
+			Controller: &otherIsController,
+			UID:        "uid-some-other-template",
+		},
+	}
+
+	unmanagedTemplate := func() *extensionsv1beta1.SandboxTemplate {
+		return &extensionsv1beta1.SandboxTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout", Namespace: "default", UID: "uid-optout"},
+			Spec: extensionsv1beta1.SandboxTemplateSpec{
+				NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementUnmanaged,
+			},
+		}
+	}
+	managedTemplate := func() *extensionsv1beta1.SandboxTemplate {
+		return &extensionsv1beta1.SandboxTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom", Namespace: "default", UID: "uid-custom"},
+			Spec: extensionsv1beta1.SandboxTemplateSpec{
+				NetworkPolicy: &extensionsv1beta1.NetworkPolicySpec{
+					Egress: []networkingv1.NetworkPolicyEgressRule{
+						{To: []networkingv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "metrics"}}}}},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name      string
+		template  *extensionsv1beta1.SandboxTemplate
+		ownerRefs []metav1.OwnerReference
+	}{
+		{name: "Unmanaged refuses to delete NetworkPolicy with no controller owner", template: unmanagedTemplate(), ownerRefs: nil},
+		{name: "Unmanaged refuses to delete NetworkPolicy owned by a different template", template: unmanagedTemplate(), ownerRefs: foreignOwner},
+		{name: "Managed refuses to update NetworkPolicy with no controller owner", template: managedTemplate(), ownerRefs: nil},
+		{name: "Managed refuses to update NetworkPolicy owned by a different template", template: managedTemplate(), ownerRefs: foreignOwner},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newScheme(t)
+			// A foreign NetworkPolicy carrying a distinctive spec so any mutation is detectable.
+			foreignNP := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            tc.template.Name + "-network-policy",
+					Namespace:       "default",
+					OwnerReferences: tc.ownerRefs,
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"owned-by": "someone-else"}},
+				},
+			}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.template, foreignNP).Build()
+
+			recorder := events.NewFakeRecorder(10)
+			reconciler := &SandboxTemplateReconciler{
+				Client:   cl,
+				Scheme:   scheme,
+				Recorder: recorder,
+				Tracer:   asmetrics.NewNoOp(),
+			}
+
+			npKey := types.NamespacedName{Name: foreignNP.Name, Namespace: "default"}
+
+			// Capture the pre-reconcile state of the foreign NetworkPolicy.
+			var before networkingv1.NetworkPolicy
+			if err := cl.Get(context.Background(), npKey, &before); err != nil {
+				t.Fatalf("get foreign NetworkPolicy before reconcile: %v", err)
+			}
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.template.Name, Namespace: "default"}}
+			if _, err := reconciler.Reconcile(context.Background(), req); err == nil {
+				t.Fatalf("expected reconcile to return an error on ownership conflict, got nil")
+			}
+
+			// The foreign NetworkPolicy must still exist and be byte-for-byte unchanged.
+			var after networkingv1.NetworkPolicy
+			if err := cl.Get(context.Background(), npKey, &after); err != nil {
+				t.Fatalf("expected foreign NetworkPolicy to still exist after conflict, got err: %v", err)
+			}
+			if after.ResourceVersion != before.ResourceVersion {
+				t.Errorf("foreign NetworkPolicy was modified: resourceVersion %q -> %q", before.ResourceVersion, after.ResourceVersion)
+			}
+			if !equality.Semantic.DeepEqual(after.Spec, before.Spec) {
+				t.Errorf("foreign NetworkPolicy spec was mutated: %+v", after.Spec)
+			}
+
+			// A Warning event should have been recorded so the conflict is observable on the object.
+			select {
+			case ev := <-recorder.Events:
+				if !strings.Contains(ev, corev1.EventTypeWarning) || !strings.Contains(ev, "NetworkPolicyOwnershipConflict") {
+					t.Errorf("expected a Warning NetworkPolicyOwnershipConflict event, got %q", ev)
+				}
+			default:
+				t.Errorf("expected a Warning event to be recorded for the ownership conflict")
 			}
 		})
 	}

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -48,7 +48,7 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	}
 
 	templateWithNP := &extensionsv1beta1.SandboxTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom", Namespace: "default", UID: "uid-custom"},
 		Spec: extensionsv1beta1.SandboxTemplateSpec{
 			NetworkPolicy: &extensionsv1beta1.NetworkPolicySpec{
 				Ingress: []networkingv1.NetworkPolicyIngressRule{
@@ -70,7 +70,7 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	}
 
 	templateOptOut := &extensionsv1beta1.SandboxTemplate{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout", Namespace: "default", UID: "uid-optout"},
 		Spec: extensionsv1beta1.SandboxTemplateSpec{
 			NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementUnmanaged,
 			NetworkPolicy: &extensionsv1beta1.NetworkPolicySpec{
@@ -79,13 +79,38 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 		},
 	}
 
+	isController := true
 	existingNPToDelete := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-optout-network-policy", Namespace: "default"},
-		Spec:       networkingv1.NetworkPolicySpec{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-template-optout-network-policy",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+					Kind:       "SandboxTemplate",
+					Name:       "test-template-optout",
+					Controller: &isController,
+					UID:        "uid-optout",
+				},
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{},
 	}
 
 	outdatedNPToUpdate := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-template-custom-network-policy", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-template-custom-network-policy",
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+					Kind:       "SandboxTemplate",
+					Name:       "test-template-custom",
+					Controller: &isController,
+					UID:        "uid-custom",
+				},
+			},
+		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"old-label": "outdated"}}, // Will be overwritten
 		},


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes a privilege escalation vulnerability where an attacker with SandboxTemplate RBAC permissions could delete or overwrite arbitrary NetworkPolicy objects in the namespace by exploiting missing ownership validation on the SandboxTemplate's generated NetworkPolicy name.

This commit updates the Reconcile method to fetch the existing NetworkPolicy and assert ownership (`metav1.IsControlledBy`) before updating or deleting it.

#### Which issue(s) this PR is related to:
Fixes b/511321440

#### Release Note
```release-note
Fixes a privilege escalation vulnerability in the extensions controller where SandboxTemplates could erroneously update or delete unowned NetworkPolicies.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NetworkPolicy reconciliation to update/delete only when the policy is owned by the matching SandboxTemplate.
  * Added clearer error handling when cleanup encounters existing policies with ownership mismatches.
  * When a NetworkPolicy is missing during opt-out cleanup, reconciliation now safely skips without failing.
* **Tests**
  * Added coverage for NetworkPolicy ownership conflict scenarios, including validation that unmanaged resources aren’t modified and that a warning event is emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->