### PR TITLE
feat(sandbox-router): add MAX_KEEPALIVE_CONNECTIONS configuration

### DIFF
--- a/clients/python/agentic-sandbox-client/sandbox-router/README.md
+++ b/clients/python/agentic-sandbox-client/sandbox-router/README.md
@@ -48,6 +48,7 @@ The router can be configured using the following environment variables:
 
 | Variable | Description | Default |
 |---|---|---|
+| `MAX_KEEPALIVE_CONNECTIONS` | Maximum keep-alive connections in the httpx connection pool. Set to `0` to disable pooling — useful when sandbox pods restart frequently, as it forces DNS re-resolution on every request. | `20` |
 | `PROXY_TIMEOUT_SECONDS` | Timeout in seconds for proxied requests to sandbox pods. Increase this for long-running operations (e.g., code execution, model inference). | `180` (3 minutes) |
 
 ## Deployment

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -34,6 +34,7 @@ DEFAULT_SANDBOX_PORT = 8888
 DEFAULT_NAMESPACE = "default"
 DEFAULT_PROXY_TIMEOUT = 180.0
 DEFAULT_CLUSTER_DOMAIN = "cluster.local"
+DEFAULT_MAX_KEEPALIVE_CONNECTIONS = 20
 
 
 def _get_proxy_timeout() -> float:
@@ -62,6 +63,23 @@ def _get_cluster_domain() -> str:
               f"falling back to {DEFAULT_CLUSTER_DOMAIN}")
         return DEFAULT_CLUSTER_DOMAIN
     return cluster_domain
+
+
+def _get_max_keepalive_connections() -> int:
+    raw = os.environ.get("MAX_KEEPALIVE_CONNECTIONS")
+    if raw is None:
+        return DEFAULT_MAX_KEEPALIVE_CONNECTIONS
+    try:
+        value = int(raw)
+    except (ValueError, TypeError):
+        print(f"WARNING: Invalid MAX_KEEPALIVE_CONNECTIONS='{raw}', "
+              f"falling back to {DEFAULT_MAX_KEEPALIVE_CONNECTIONS}")
+        return DEFAULT_MAX_KEEPALIVE_CONNECTIONS
+    if value < 0:
+        print(f"WARNING: MAX_KEEPALIVE_CONNECTIONS must be >= 0, got {value}, "
+              f"falling back to {DEFAULT_MAX_KEEPALIVE_CONNECTIONS}")
+        return DEFAULT_MAX_KEEPALIVE_CONNECTIONS
+    return value
 
 
 def _get_request_timeout(request: Request) -> float:
@@ -108,12 +126,17 @@ def _env_var_is_truthy(name: str) -> bool:
         return False
     return raw.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
 proxy_timeout = _get_proxy_timeout()
-client = httpx.AsyncClient(timeout=proxy_timeout)
+max_keepalive_connections = _get_max_keepalive_connections()
+client = httpx.AsyncClient(
+    timeout=proxy_timeout,
+    limits=httpx.Limits(max_keepalive_connections=max_keepalive_connections),
+)
 
 ROUTER_AUTH_TOKEN = os.environ.get("ROUTER_AUTH_TOKEN", "").strip() or None
 ALLOW_UNAUTHENTICATED_ROUTER = _env_var_is_truthy("ALLOW_UNAUTHENTICATED_ROUTER")
 
 print(f"Sandbox router configured with proxy timeout: {proxy_timeout}s")
+print(f"Sandbox router configured with max_keepalive_connections: {max_keepalive_connections}")
 print(f"Sandbox router configured with cluster_domain: {cluster_domain}")
 if ROUTER_AUTH_TOKEN:
     print("Authentication enabled: requests must include valid Bearer token.")

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -657,8 +657,7 @@ class TestMaxKeepaliveConnections:
             assert sandbox_router.max_keepalive_connections == 50
 
     def test_default_when_env_var_unset(self):
-        env = {k: v for k, v in os.environ.items() if k != "MAX_KEEPALIVE_CONNECTIONS"}
-        with patch.dict(os.environ, env, clear=True):
+        with patch.dict(os.environ, {"ALLOW_UNAUTHENTICATED_ROUTER": "true"}, clear=True):
             importlib.reload(sandbox_router)
             assert sandbox_router.max_keepalive_connections == 20
 

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -645,3 +645,40 @@ class TestProxyRouting:
         assert hasattr(
             sent_request.stream, "__aiter__"
         ), "Content should be an async iterable"
+
+
+class TestMaxKeepaliveConnections:
+    def test_default_max_keepalive_connections(self):
+        assert sandbox_router.DEFAULT_MAX_KEEPALIVE_CONNECTIONS == 20
+
+    def test_env_var_overrides(self):
+        with patch.dict(os.environ, {"MAX_KEEPALIVE_CONNECTIONS": "50"}):
+            importlib.reload(sandbox_router)
+            assert sandbox_router.max_keepalive_connections == 50
+
+    def test_default_when_env_var_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "MAX_KEEPALIVE_CONNECTIONS"}
+        with patch.dict(os.environ, env, clear=True):
+            importlib.reload(sandbox_router)
+            assert sandbox_router.max_keepalive_connections == 20
+
+    def test_invalid_env_var_falls_back_to_default(self, capsys):
+        with patch.dict(os.environ, {"MAX_KEEPALIVE_CONNECTIONS": "not-a-number"}):
+            result = sandbox_router._get_max_keepalive_connections()
+        assert result == 20
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "MAX_KEEPALIVE_CONNECTIONS" in captured.out
+
+    def test_negative_env_var_falls_back_to_default(self, capsys):
+        with patch.dict(os.environ, {"MAX_KEEPALIVE_CONNECTIONS": "-1"}):
+            result = sandbox_router._get_max_keepalive_connections()
+        assert result == 20
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "MAX_KEEPALIVE_CONNECTIONS" in captured.out
+
+    def test_zero_disables_pooling(self):
+        with patch.dict(os.environ, {"MAX_KEEPALIVE_CONNECTIONS": "0"}):
+            result = sandbox_router._get_max_keepalive_connections()
+        assert result == 0


### PR DESCRIPTION
## What

Adds `MAX_KEEPALIVE_CONNECTIONS` environment variable to control the [httpx connection pool](https://www.python-httpx.org/advanced/resource-limits/) size in the sandbox router.

## Why

In environments with strict network policies, pooled connections can trigger unexpected drops when the target pod is deleted in meantime without the router being aware. Setting `MAX_KEEPALIVE_CONNECTIONS=0` disables pooling entirely, forcing a fresh connection (and DNS re-resolution) on every request.

## Changes

- `sandbox_router.py`: adds `DEFAULT_MAX_KEEPALIVE_CONNECTIONS = 20` constant, `_get_max_keepalive_connections()` helper (mirrors `_get_proxy_timeout` pattern), and wires the value into `httpx.Limits` on the shared `AsyncClient`.
- `test_sandbox_router.py`: adds `TestMaxKeepaliveConnections` class (6 test cases) mirroring `TestProxyTimeout`.
- `README.md`: adds `MAX_KEEPALIVE_CONNECTIONS` row to the configuration table.

## Configuration

| Variable | Default | Notes |
|---|---|---|
| `MAX_KEEPALIVE_CONNECTIONS` | `20` | Set to `0` to disable pooling |

Non-negative integers are accepted; negative values and non-integers fall back to the default with a `WARNING` log line.