### PR TITLE
fix(extensions): address #828 follow-ups for SandboxTemplate NetworkPolicy ownership

### DIFF
--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -94,11 +94,16 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				return ctrl.Result{}, nil
 			}
 			// Delete can race with an external deletion; treat NotFound as success to avoid noisy requeues.
-			if err := r.Delete(ctx, existingNP); err != nil && !k8errors.IsNotFound(err) {
-				logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
-				return ctrl.Result{}, fmt.Errorf("failed to delete unmanaged NetworkPolicy %s/%s: %w", npNamespace, npName, err)
+			if err := r.Delete(ctx, existingNP); err != nil {
+				if !k8errors.IsNotFound(err) {
+					logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
+					return ctrl.Result{}, fmt.Errorf("failed to delete unmanaged NetworkPolicy %s/%s: %w", npNamespace, npName, err)
+				}
+				// Removed out-of-band between Get and Delete; desired state already achieved.
+				logger.Info("Unmanaged NetworkPolicy already deleted", "name", existingNP.Name)
+			} else {
+				logger.Info("Deleted unmanaged NetworkPolicy", "name", existingNP.Name)
 			}
-			logger.Info("Deleted unmanaged NetworkPolicy", "name", existingNP.Name)
 		} else if !k8errors.IsNotFound(err) {
 			return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 		}

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
@@ -88,15 +89,18 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err == nil {
 			if !metav1.IsControlledBy(existingNP, template) {
 				logger.Info("Skipping deletion of NetworkPolicy not owned by template", "name", npName)
+				r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile",
+					"Skipping deletion of NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
 				return ctrl.Result{}, nil
 			}
-			if err := r.Delete(ctx, existingNP); err != nil {
+			// Delete can race with an external deletion; treat NotFound as success to avoid noisy requeues.
+			if err := r.Delete(ctx, existingNP); err != nil && !k8errors.IsNotFound(err) {
 				logger.Error(err, "Failed to clean up unmanaged NetworkPolicy")
-				return ctrl.Result{}, err
+				return ctrl.Result{}, fmt.Errorf("failed to delete unmanaged NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 			}
 			logger.Info("Deleted unmanaged NetworkPolicy", "name", existingNP.Name)
 		} else if !k8errors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy: %w", err)
+			return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 		}
 		return ctrl.Result{}, nil
 	}
@@ -127,7 +131,9 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if err == nil {
 		if !metav1.IsControlledBy(existingNP, template) {
-			return ctrl.Result{}, fmt.Errorf("refusing to update NetworkPolicy %q as it is not controlled by SandboxTemplate %q", npName, template.Name)
+			r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile",
+				"Refusing to update NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
+			return ctrl.Result{}, fmt.Errorf("refusing to update NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
 		}
 		// Policy exists: Semantic DeepEqual check for drift
 		if equality.Semantic.DeepEqual(existingNP.Spec, desiredSpec) {
@@ -137,14 +143,14 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		existingNP.Spec = desiredSpec
 		if err := r.Update(ctx, existingNP); err != nil {
 			logger.Error(err, "Failed to update NetworkPolicy", "name", npName)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to update NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 		}
 		logger.Info("Successfully updated shared NetworkPolicy", "name", npName)
 		return ctrl.Result{}, nil
 	}
 
 	if !k8errors.IsNotFound(err) {
-		return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to get NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 	}
 
 	// 6. Create New Policy
@@ -159,7 +165,7 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	if err := r.Create(ctx, np); err != nil {
 		logger.Error(err, "Failed to create NetworkPolicy", "name", npName)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to create NetworkPolicy %s/%s: %w", npNamespace, npName, err)
 	}
 
 	logger.Info("Successfully created shared NetworkPolicy", "name", npName)

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -87,10 +87,14 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		existingNP := &networkingv1.NetworkPolicy{}
 		err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
 		if err == nil {
+			// Unmanaged mode means the user has opted out of NP management for
+			// this template. If the NP is not ours we intentionally do nothing:
+			// silently skipping honors the opt-out (contrast with Managed below).
 			if !metav1.IsControlledBy(existingNP, template) {
-				logger.Info("Skipping deletion of NetworkPolicy not owned by template", "name", npName)
-				r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile",
-					"Skipping deletion of NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
+				msg := fmt.Sprintf("skipping deletion of NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s",
+					npNamespace, npName, template.Name)
+				logger.Info(msg)
+				r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile", "%s", msg)
 				return ctrl.Result{}, nil
 			}
 			// Delete can race with an external deletion; treat NotFound as success to avoid noisy requeues.
@@ -135,10 +139,14 @@ func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	err := r.Get(ctx, types.NamespacedName{Name: npName, Namespace: npNamespace}, existingNP)
 
 	if err == nil {
+		// Managed mode means we are the source of truth for this NP name. A
+		// collision with an unowned NP is a hard failure (contrast with the
+		// Unmanaged skip above), otherwise we would silently drift.
 		if !metav1.IsControlledBy(existingNP, template) {
-			r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile",
-				"Refusing to update NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
-			return ctrl.Result{}, fmt.Errorf("refusing to update NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s", npNamespace, npName, template.Name)
+			msg := fmt.Sprintf("refusing to update NetworkPolicy %s/%s: it is not controlled by SandboxTemplate %s",
+				npNamespace, npName, template.Name)
+			r.Recorder.Eventf(template, nil, corev1.EventTypeWarning, "NetworkPolicyOwnershipConflict", "Reconcile", "%s", msg)
+			return ctrl.Result{}, fmt.Errorf("%s", msg)
 		}
 		// Policy exists: Semantic DeepEqual check for drift
 		if equality.Semantic.DeepEqual(existingNP.Spec, desiredSpec) {

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -294,10 +295,11 @@ func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
 		}
 
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, unownedNP).Build()
+		recorder := events.NewFakeRecorder(10)
 		reconciler := &SandboxTemplateReconciler{
 			Client:   client,
 			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
+			Recorder: recorder,
 			Tracer:   asmetrics.NewNoOp(),
 		}
 
@@ -305,6 +307,7 @@ func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "victim", Namespace: "default"},
 		}
 
+		// Unmanaged mode skips (does not error) when the NetworkPolicy is unowned.
 		_, err := reconciler.Reconcile(context.Background(), req)
 		if err != nil {
 			t.Fatalf("reconcile: (%v)", err)
@@ -320,6 +323,9 @@ func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
 				t.Fatalf("failed to get network policy: %v", err)
 			}
 		}
+
+		// A Warning event should record the skipped deletion so the conflict is observable.
+		assertOwnershipConflictEvent(t, recorder)
 	})
 
 	t.Run("Does not update unowned NetworkPolicy", func(t *testing.T) {
@@ -342,10 +348,11 @@ func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
 		}
 
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, unownedNP).Build()
+		recorder := events.NewFakeRecorder(10)
 		reconciler := &SandboxTemplateReconciler{
 			Client:   client,
 			Scheme:   scheme,
-			Recorder: events.NewFakeRecorder(10),
+			Recorder: recorder,
 			Tracer:   asmetrics.NewNoOp(),
 		}
 
@@ -353,10 +360,13 @@ func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
 			NamespacedName: types.NamespacedName{Name: "victim", Namespace: "default"},
 		}
 
+		// Managed mode must refuse (return an error) rather than overwrite an unowned NetworkPolicy.
 		_, err := reconciler.Reconcile(context.Background(), req)
-		// We expect an error here once fixed, but currently it might succeed and overwrite
-		if err != nil {
-			t.Logf("Reconcile returned error (expected after fix): %v", err)
+		if err == nil {
+			t.Fatalf("expected reconcile to return an error for an unowned NetworkPolicy in Managed mode, got nil")
+		}
+		if !strings.Contains(err.Error(), "not controlled by SandboxTemplate") {
+			t.Errorf("unexpected error message: %v", err)
 		}
 
 		// Check if unownedNP was updated
@@ -369,5 +379,22 @@ func TestSandboxTemplateReconcile_Vulnerability(t *testing.T) {
 		if _, ok := np.Spec.PodSelector.MatchLabels["keep"]; !ok {
 			t.Errorf("VULNERABILITY: Unowned NetworkPolicy was updated/overwritten!")
 		}
+
+		// A Warning event should record the refusal so the conflict is observable.
+		assertOwnershipConflictEvent(t, recorder)
 	})
+}
+
+// assertOwnershipConflictEvent fails the test unless a Warning NetworkPolicyOwnershipConflict
+// event was recorded by the reconciler.
+func assertOwnershipConflictEvent(t *testing.T, recorder *events.FakeRecorder) {
+	t.Helper()
+	select {
+	case ev := <-recorder.Events:
+		if !strings.Contains(ev, corev1.EventTypeWarning) || !strings.Contains(ev, "NetworkPolicyOwnershipConflict") {
+			t.Errorf("expected a Warning NetworkPolicyOwnershipConflict event, got %q", ev)
+		}
+	default:
+		t.Errorf("expected a Warning event to be recorded for the ownership conflict")
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow-up to #828, which added the `metav1.IsControlledBy` ownership check to the SandboxTemplate controller's NetworkPolicy management. This PR addresses the leftover review feedback on #828 and adds a few related robustness/observability improvements:

- **Avoid noisy requeues on delete races (#828 review):** in the unmanaged-cleanup path, treat `IsNotFound` on the `Delete` as success. A NetworkPolicy deleted out-of-band between the `Get` and the `Delete` no longer fails the reconcile.
- **Record a Warning event on ownership conflicts:** both the unmanaged-skip and managed-refuse paths now emit a `NetworkPolicyOwnershipConflict` Warning event via the recorder, so the refusal is visible on the object instead of only in controller logs.
- **Wrap client errors with resource identity:** the NetworkPolicy `Get`/`Delete`/`Update`/`Create` errors now include the `namespace/name` for actionable logs and callers.
- **Tighten the security regression test (#828 review):** `TestSandboxTemplateReconcile_Vulnerability` now asserts that Reconcile returns an error (and verifies the message) for an unowned NetworkPolicy in Managed mode, instead of only logging it; both subtests also assert the Warning event is recorded.

Behavioral note: this keeps #828's deliberate asymmetry — Unmanaged mode *skips* (no error) when the existing NetworkPolicy is unowned, while Managed mode *refuses with an error*. The new Warning event is recorded in both cases.

#### Which issue(s) this PR is related to:

NONE (follow-up to #828)

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation handling for `NetworkPolicy` ownership conflicts by emitting `NetworkPolicyOwnershipConflict` warning events.
  * Updated error messages to consistently include the affected `NetworkPolicy` namespace and name.
  * In unmanaged mode, missing `NetworkPolicy` resources are now treated as successful to reduce race-condition requeues.
* **Tests**
  * Enhanced reconciler tests to assert warning event emission, verify ownership-related error text, and confirm unmanaged deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->