### PR TITLE
fix(sandboxclaim): bounded requeue for createSandbox AlreadyExists cache lag

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -95,6 +95,15 @@ func (e *warmCandidatesPendingError) Error() string {
 	return fmt.Sprintf("%d warm pool candidate(s) are awaiting observed Pod IPs", e.pendingCandidates)
 }
 
+// errSandboxAlreadyExists signals a cold-start Create that returned AlreadyExists
+// because the informer cache had not yet indexed a sandbox from an earlier pass.
+var errSandboxAlreadyExists = errors.New("sandbox already exists (cache lag)")
+
+// cacheLagRequeueDelay bounds the wait before re-checking that a just-created
+// sandbox is visible in the informer cache (a fallback for the window before
+// the Owns(&Sandbox{}) watch, the primary trigger, delivers it).
+const cacheLagRequeueDelay = 50 * time.Millisecond
+
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
 
@@ -383,6 +392,17 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		if metricsErr != nil {
 			logger.V(1).Info("Sandboxclaim first-ready annotation patch failed; will retry on requeue", "error", metricsErr, "request", req.NamespacedName)
+		}
+		return ctrl.Result{RequeueAfter: requeueDelay}, nil
+	}
+
+	// Cache-lag AlreadyExists: bounded requeue with nil error to reset the
+	// failure counter instead of engaging the exponential backoff (#1042).
+	if errors.Is(reconcileErr, errSandboxAlreadyExists) {
+		logger.V(4).Info("Sandbox already exists; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
+		requeueDelay := cacheLagRequeueDelay
+		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
+			requeueDelay = result.RequeueAfter
 		}
 		return ctrl.Result{RequeueAfter: requeueDelay}, nil
 	}
@@ -706,6 +726,15 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 				ObservedGeneration: claim.Generation,
 			}
 		}
+		if errors.Is(err, errSandboxAlreadyExists) {
+			return metav1.Condition{
+				Type:               string(v1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             "SandboxCreatePending",
+				Message:            "Sandbox already created; waiting for cache to converge",
+				ObservedGeneration: claim.Generation,
+			}
+		}
 		if errors.Is(err, ErrInvalidMetadata) {
 			reason = "InvalidMetadata"
 			return metav1.Condition{
@@ -804,6 +833,11 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 }
 
 func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1beta1.SandboxClaim, sandbox *v1beta1.Sandbox, err error, isClaimExpired bool) {
+	// Cache-lag retry is a benign look-again: if status already records a
+	// sandbox Name, leave it and the conditions untouched instead of wiping them.
+	if sandbox == nil && errors.Is(err, errSandboxAlreadyExists) && claim.Status.SandboxStatus.Name != "" {
+		return
+	}
 	readyCondition := r.computeReadyCondition(claim, sandbox, err, isClaimExpired)
 	meta.SetStatusCondition(&claim.Status.Conditions, readyCondition)
 	r.syncFinishedCondition(claim, sandbox, isClaimExpired)
@@ -1709,6 +1743,9 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	}
 
 	if err := r.Create(ctx, sandbox); err != nil {
+		if k8errors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("%w: %w", errSandboxAlreadyExists, err)
+		}
 		err = fmt.Errorf("sandbox create error: %w", err)
 		logger.Error(err, "Error creating sandbox for claim", "claimName", claim.Name)
 		return nil, err

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -78,6 +78,18 @@ var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 // AdoptionConflict reason instead of ReconcilerError.
 var errAdoptionConflict = errors.New("adoption write conflict")
 
+// errSandboxAlreadyExists signals that a cold-start Create returned AlreadyExists
+// because the informer cache had not yet indexed a sandbox created by an earlier
+// reconcile pass. It is converted to a bounded requeue so the exponential failure
+// rate limiter is not engaged (#1042).
+var errSandboxAlreadyExists = errors.New("sandbox already exists (cache lag)")
+
+// cacheLagRequeueDelay is how long to wait before re-checking that a
+// just-created sandbox is visible in the informer cache. Long enough to
+// cover typical watch latency (so most claims converge in one extra pass),
+// but far below the multi-second exponential backoff it replaces.
+const cacheLagRequeueDelay = 50 * time.Millisecond
+
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
 
@@ -352,6 +364,19 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		if metricsErr != nil {
 			logger.V(1).Info("Sandboxclaim first-ready annotation patch failed; will retry on requeue", "error", metricsErr, "request", req.NamespacedName)
+		}
+		return ctrl.Result{RequeueAfter: requeueDelay}, nil
+	}
+
+	// Cold-start Create returned AlreadyExists because the informer cache had
+	// not yet indexed a sandbox created by an earlier pass. Bounded requeue
+	// with nil error to reset the failure counter instead of engaging the
+	// exponential backoff (#1042).
+	if errors.Is(reconcileErr, errSandboxAlreadyExists) {
+		logger.V(4).Info("Sandbox already exists; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
+		requeueDelay := cacheLagRequeueDelay
+		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
+			requeueDelay = result.RequeueAfter
 		}
 		return ctrl.Result{RequeueAfter: requeueDelay}, nil
 	}
@@ -675,6 +700,15 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 				ObservedGeneration: claim.Generation,
 			}
 		}
+		if errors.Is(err, errSandboxAlreadyExists) {
+			return metav1.Condition{
+				Type:               string(v1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             "SandboxCreatePending",
+				Message:            "Sandbox already created; waiting for cache to converge",
+				ObservedGeneration: claim.Generation,
+			}
+		}
 		if errors.Is(err, ErrInvalidMetadata) {
 			reason = "InvalidMetadata"
 			return metav1.Condition{
@@ -773,6 +807,13 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 }
 
 func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1beta1.SandboxClaim, sandbox *v1beta1.Sandbox, err error, isClaimExpired bool) {
+	// A cache-lag retry is a benign look-again, not a state change. If the
+	// claim status was already finalized with a sandbox, leave the recorded
+	// Name/PodIPs and existing conditions untouched instead of transiently
+	// wiping them while the cache converges.
+	if sandbox == nil && errors.Is(err, errSandboxAlreadyExists) && claim.Status.SandboxStatus.Name != "" {
+		return
+	}
 	readyCondition := r.computeReadyCondition(claim, sandbox, err, isClaimExpired)
 	meta.SetStatusCondition(&claim.Status.Conditions, readyCondition)
 	r.syncFinishedCondition(claim, sandbox, isClaimExpired)
@@ -1659,6 +1700,9 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 	}
 
 	if err := r.Create(ctx, sandbox); err != nil {
+		if k8errors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("%w: %w", errSandboxAlreadyExists, err)
+		}
 		err = fmt.Errorf("sandbox create error: %w", err)
 		logger.Error(err, "Error creating sandbox for claim", "claimName", claim.Name)
 		return nil, err

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -102,7 +102,12 @@ var errSandboxAlreadyExists = errors.New("sandbox already exists (cache lag)")
 // cacheLagRequeueDelay bounds the wait before re-checking that a just-created
 // sandbox is visible in the informer cache (a fallback for the window before
 // the Owns(&Sandbox{}) watch, the primary trigger, delivers it).
-const cacheLagRequeueDelay = 50 * time.Millisecond
+//
+// TODO(#1313): a persistently lagging informer re-issues Create at this flat
+// rate, since the sentinel returns nil and resets the failure counter each
+// pass. The real fix is a per-claim attempt counter that grows the delay on
+// repeated misses (kept on the nil-error path).
+const cacheLagRequeueDelay = 200 * time.Millisecond
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -88,7 +88,18 @@ var errSandboxAlreadyExists = errors.New("sandbox already exists (cache lag)")
 // just-created sandbox is visible in the informer cache. Long enough to
 // cover typical watch latency (so most claims converge in one extra pass),
 // but far below the multi-second exponential backoff it replaces.
-const cacheLagRequeueDelay = 50 * time.Millisecond
+//
+// The Owns(&Sandbox{}) watch is the primary convergence trigger; this requeue
+// is only a fallback for the window before the created sandbox is indexed.
+//
+// TODO(#1313): a persistently lagging informer (one that never delivers a
+// sandbox that provably exists on the server) re-issues Create at this flat
+// rate indefinitely, because the sentinel returns a nil error and resets the
+// workqueue failure counter every pass. This modest delay only bounds the
+// flat-rate churn; the real fix is an in-memory per-claim attempt counter that
+// grows the delay on repeated consecutive misses, kept on the benign nil-error
+// path (AlreadyExists must never surface as a reconcile error).
+const cacheLagRequeueDelay = 200 * time.Millisecond
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -7676,3 +7676,110 @@ func TestSandboxClaimAdoptionResolveConflictThenCancellationPropagates(t *testin
 	}
 	require.Equal(t, 3, patches, "two conflicted patches then the interrupted one")
 }
+
+func TestCreateSandboxToleratesAlreadyExists(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "already-exists-claim"
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			SandboxStatus: extensionsv1beta1.SandboxStatus{Name: claimName},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// Pre-create the sandbox owned by this claim to simulate a previous successful create.
+	existingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxClaim",
+				Name:       claimName,
+				UID:        "claim-uid",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// Cache lag: first reconcile's sandbox Gets return NotFound (so Create
+	// hits AlreadyExists); flip the flag afterwards to let the cache catch up.
+	cacheStale := true
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, warmPool, template, existingSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == claimName && cacheStale {
+					return k8errors.NewNotFound(
+						schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+						key.Name,
+					)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+
+	// First reconcile: cache miss triggers AlreadyExists, converted to bounded requeue.
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err, "sentinel should be converted to nil error")
+	require.Equal(t, cacheLagRequeueDelay, result.RequeueAfter, "expected bounded requeue delay")
+
+	// The guard short-circuits on the pre-existing SandboxStatus.Name, so the
+	// status is preserved intact.
+	pendingClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, pendingClaim))
+	require.Equal(t, claimName, pendingClaim.Status.SandboxStatus.Name, "SandboxStatus.Name should not be wiped during cache lag")
+
+	// Cache has caught up — sandbox will be visible on the next reconcile.
+	cacheStale = false
+
+	// Second reconcile: cache has caught up, sandbox is found and returned.
+	_, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// Verify the claim status points to the existing sandbox.
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, claimName, updatedClaim.Status.SandboxStatus.Name)
+
+	// Verify the Ready condition is set now that the sandbox is visible.
+	readyCond := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCond, "expected Ready condition after cache converged")
+	require.NotEqual(t, "SandboxCreatePending", readyCond.Reason, "expected pending reason to clear once cache converged")
+}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -7164,3 +7164,114 @@ func TestSandboxClaimAdoptionResolveConflictThenCancellationPropagates(t *testin
 	}
 	require.Equal(t, 3, patches, "two conflicted patches then the interrupted one")
 }
+
+func TestCreateSandboxToleratesAlreadyExists(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "already-exists-claim"
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			SandboxStatus: extensionsv1beta1.SandboxStatus{Name: claimName},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// Pre-create the sandbox owned by this claim to simulate a previous successful create.
+	existingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxClaim",
+				Name:       claimName,
+				UID:        "claim-uid",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// Simulate cache lag: during the first reconcile ALL sandbox Gets return
+	// NotFound (the informer cache hasn't seen the sandbox yet), which causes
+	// createSandbox to call Create and get AlreadyExists from the API server.
+	// After the first reconcile returns we flip the flag so the second
+	// reconcile's Gets succeed, simulating the cache catching up.
+	cacheStale := true
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, warmPool, template, existingSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == claimName && cacheStale {
+					return k8errors.NewNotFound(
+						schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+						key.Name,
+					)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+
+	// First reconcile: cache miss triggers AlreadyExists, converted to bounded requeue.
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err, "sentinel should be converted to nil error")
+	require.Equal(t, cacheLagRequeueDelay, result.RequeueAfter, "expected bounded requeue delay")
+
+	// The computeAndSetStatus guard detects errSandboxAlreadyExists with a
+	// pre-existing SandboxStatus.Name and short-circuits — no conditions are
+	// set or wiped. Verify the guard preserved the status intact.
+	pendingClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, pendingClaim))
+	require.Equal(t, claimName, pendingClaim.Status.SandboxStatus.Name, "SandboxStatus.Name should not be wiped during cache lag")
+
+	// Cache has caught up — sandbox will be visible on the next reconcile.
+	cacheStale = false
+
+	// Second reconcile: cache has caught up, sandbox is found and returned.
+	_, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+
+	// Verify the claim status points to the existing sandbox.
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, claimName, updatedClaim.Status.SandboxStatus.Name)
+
+	// Verify the Ready condition is set now that the sandbox is visible.
+	readyCond := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCond, "expected Ready condition after cache converged")
+	require.NotEqual(t, "SandboxCreatePending", readyCond.Reason, "expected pending reason to clear once cache converged")
+}


### PR DESCRIPTION
## What this PR does / why we need it:
When the informer cache lags behind the API server, the SandboxClaim controller's getOrCreateSandbox cached Get can miss a Sandbox that was already created by a previous reconcile. This causes createSandbox to retry Create, which fails with AlreadyExists and is treated as a fatal error - riding the exponential failure rate limiter and transiently wiping SandboxStatus.Name from the claim.
  
This PR follows the sentinel + bounded requeue pattern established in #1108 (errAdoptionTriggeredRetry) for the same class of cache-lag problem:
- Adds errSandboxAlreadyExists sentinel error returned from createSandbox
- Converts it in Reconcile to RequeueAfter(50ms) with nil error, resetting the workqueue failure counter instead of compounding backoff
- Handles it in computeReadyCondition with SandboxCreatePending reason instead of the generic ReconcilerError
- Extends the computeAndSetStatus cache-lag guard to prevent transient SandboxStatus.Name wipe during convergence


<!-- Provide a clear and concise description of the changes in this PR. -->

## Which issue(s) this PR is related to:
Fixes #1042 
Previously attempted in #679

## Release Note
None

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox creation reconciliation to gracefully handle Kubernetes “already exists” responses during cache convergence, avoiding queue backoff failures.
  * Updated claim Ready condition while waiting for convergence to “SandboxCreatePending”.
  * Prevented temporary wiping of previously recorded sandbox status details during retries.

* **Tests**
  * Added `TestCreateSandboxToleratesAlreadyExists` to verify bounded requeue behavior and that the claim eventually links to the pre-existing sandbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->