### PR TITLE
metric: remove warmpool_name label from claim latency histograms

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1887,7 +1887,7 @@ func getLaunchType(sandbox *v1beta1.Sandbox) string {
 }
 
 // recordClaimStartupLatency records the startup latency based on webhook annotation.
-func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmPoolName string) {
+func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string) {
 	logger := log.FromContext(ctx)
 	webhookSeenTimeStr := claim.Annotations[asmetrics.WebhookAnnotation]
 	if webhookSeenTimeStr == "" {
@@ -1904,11 +1904,11 @@ func (r *SandboxClaimReconciler) recordClaimStartupLatency(ctx context.Context, 
 		logger.Error(errors.New("negative duration"), "Webhook seen time is in the future", "duration", duration, "webhookSeenTime", webhookSeenTime)
 		return
 	}
-	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, templateName, warmPoolName)
+	asmetrics.RecordClaimStartupLatency(webhookSeenTime, launchType, templateName)
 }
 
 // recordControllerStartupLatency records the controller startup latency based on observed time.
-func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string, warmPoolName string) {
+func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, launchType string, templateName string) {
 	logger := log.FromContext(ctx)
 	if observedTimeString := claim.Annotations[asmetrics.ObservabilityAnnotation]; observedTimeString != "" {
 		key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
@@ -1919,7 +1919,7 @@ func (r *SandboxClaimReconciler) recordControllerStartupLatency(ctx context.Cont
 			logger.Error(err, "Failed to parse controller observation time", "value", observedTimeString)
 			return
 		}
-		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, templateName, warmPoolName)
+		asmetrics.RecordClaimControllerStartupLatency(observedTime, launchType, templateName)
 	}
 }
 
@@ -1972,12 +1972,11 @@ func (r *SandboxClaimReconciler) recordCreationLatencyMetric(
 	}
 
 	templateName := r.resolveTemplateName(sandbox)
-	warmPoolName := claim.Spec.WarmPoolRef.Name
 
 	logger.V(1).Info("SandboxClaim is marked as Ready", "claim", claim.Name, "sandbox", sandboxName, "duration", time.Since(claim.CreationTimestamp.Time))
 
-	r.recordClaimStartupLatency(ctx, claim, launchType, templateName, warmPoolName)
-	r.recordControllerStartupLatency(ctx, claim, launchType, templateName, warmPoolName)
+	r.recordClaimStartupLatency(ctx, claim, launchType, templateName)
+	r.recordControllerStartupLatency(ctx, claim, launchType, templateName)
 	r.recordSandboxCreationLatency(sandbox, launchType, templateName)
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -40,7 +40,6 @@ var (
 	// Labels:
 	// - launch_type: "warm", "cold", "unknown"
 	// - sandbox_template: the resolved SandboxTemplateRef used to create the Sandbox.
-	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	ClaimStartupLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "agent_sandbox_claim_startup_latency_ms",
@@ -48,14 +47,13 @@ var (
 			// Buckets for latency from 100ms to 4 minutes
 			Buckets: []float64{100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000},
 		},
-		[]string{"launch_type", "sandbox_template", "warmpool_name"},
+		[]string{"launch_type", "sandbox_template"},
 	)
 
 	// ClaimControllerStartupLatency measures the time from controller first observed timestamp to SandboxClaim Ready state.
 	// Labels:
 	// - launch_type: "warm", "cold", "unknown"
 	// - sandbox_template: the resolved SandboxTemplateRef used to create the Sandbox.
-	// - warmpool_name: the requested warm pool reference name (from SandboxClaim spec.warmPoolRef.name).
 	ClaimControllerStartupLatency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "agent_sandbox_claim_controller_startup_latency_ms",
@@ -63,7 +61,7 @@ var (
 			// Buckets for latency from 100ms to 4 minutes
 			Buckets: []float64{100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000},
 		},
-		[]string{"launch_type", "sandbox_template", "warmpool_name"},
+		[]string{"launch_type", "sandbox_template"},
 	)
 
 	// SandboxCreationLatency measures the time from Sandbox creation to Pod Ready state.
@@ -143,15 +141,15 @@ func init() {
 }
 
 // RecordClaimStartupLatency records the duration since the provided start time.
-func RecordClaimStartupLatency(startTime time.Time, launchType, templateName, warmPoolName string) {
+func RecordClaimStartupLatency(startTime time.Time, launchType, templateName string) {
 	duration := float64(time.Since(startTime).Milliseconds())
-	ClaimStartupLatency.WithLabelValues(launchType, templateName, warmPoolName).Observe(duration)
+	ClaimStartupLatency.WithLabelValues(launchType, templateName).Observe(duration)
 }
 
 // RecordClaimControllerStartupLatency records the duration since the provided controller start time.
-func RecordClaimControllerStartupLatency(startTime time.Time, launchType, templateName, warmPoolName string) {
+func RecordClaimControllerStartupLatency(startTime time.Time, launchType, templateName string) {
 	duration := float64(time.Since(startTime).Milliseconds())
-	ClaimControllerStartupLatency.WithLabelValues(launchType, templateName, warmPoolName).Observe(duration)
+	ClaimControllerStartupLatency.WithLabelValues(launchType, templateName).Observe(duration)
 }
 
 // RecordSandboxCreationLatency records the measured latency duration for a sandbox creation.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -43,14 +43,14 @@ func TestClaimLatencyRecording(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ClaimStartupLatency.Reset()
-			ClaimStartupLatency.WithLabelValues(tc.launchType, "test-tmpl", "test-pool").Observe(1000)
+			ClaimStartupLatency.WithLabelValues(tc.launchType, "test-tmpl").Observe(1000)
 
 			if testutil.CollectAndCount(ClaimStartupLatency) != 1 {
 				t.Errorf("Expected 1 observation for ClaimStartupLatency")
 			}
 
 			ClaimControllerStartupLatency.Reset()
-			ClaimControllerStartupLatency.WithLabelValues(tc.launchType, "test-tmpl", "test-pool").Observe(1000)
+			ClaimControllerStartupLatency.WithLabelValues(tc.launchType, "test-tmpl").Observe(1000)
 
 			if testutil.CollectAndCount(ClaimControllerStartupLatency) != 1 {
 				t.Errorf("Expected 1 observation for ClaimControllerStartupLatency")


### PR DESCRIPTION
#### What this PR does / why we need it:

Drop the `warmpool_name` label from `ClaimStartupLatency` and `ClaimControllerStartupLatency`, keeping `sandbox_template` + `launch_type`.

Per further discussion on #1051, per-template dashboards need `sandbox_template` on these histograms. `warmpool_name` is the less load-bearing dimension here, claim-rate/KEDA scaling already uses `SandboxClaimCreationTotal{warmpool_name=...}`, so removing it from the latency histograms reduces cardinality without breaking template-level latency views. This also aligns claim latency labeling with `SandboxCreationLatency` (and the resume latency direction in #1111).

Intentionally unchanged:
- `sandbox_template` on these two histograms
- `warmpool_name` on `agent_sandbox_claim_creation_total`

#### Which issue(s) this PR is related to:

Closes #1051 

#### Release Note

```release-note
Removed label `warmpool_name` from `agent_sandbox_claim_startup_latency_ms` and `agent_sandbox_claim_controller_startup_latency_ms`. Queries that filter or group these metrics by `warmpool_name` must drop that selector; use `sandbox_template` (and/or `agent_sandbox_claim_creation_total`) instead.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated claim and controller startup latency metrics to no longer include warm pool name, reducing label cardinality.
  * Simplified the metric recording interface to emit observations using only launch type and sandbox template.
  * Adjusted metric assertions/validation to match the updated label set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->