### PR TITLE
fix(warmpool): prevent SandboxClaim from adopting stale pods under Recreate strategy

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -784,6 +784,45 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	var fallbackKey queue.SandboxKey
 	var adoptingFallback bool
 
+	// Lazily resolve, at most once, whether the claim's warm pool uses the Recreate strategy and,
+	// if so, the blueprint hash a current sandbox must carry. The strategy lives on the
+	// SandboxWarmPool spec (not on the pooled Sandboxes), so we read it directly from the pool the
+	// claim references. Under Recreate the pool must only serve sandboxes reflecting the current
+	// template; during an in-place template update stale sandboxes are still being deleted, so a
+	// candidate whose blueprint hash no longer matches must be rejected (issue #764). We compute
+	// the same blueprint hash the pool's staleness check uses (SandboxTemplateHashLabel) so both
+	// sides agree on what "stale under Recreate" means. We also keep the resolved SandboxTemplate so
+	// that, on a hash-label mismatch, we can fall back to the same semantic blueprint comparison the
+	// pool controller uses (see isSandboxStale): a candidate whose hash label is missing or differs
+	// but whose blueprint is semantically identical to the template is kept (not deleted/recreated)
+	// by the pool, so the claim must treat it as fresh too — otherwise a Recreate pool full of
+	// pre-label sandboxes becomes permanently unadoptable after a controller upgrade. OnReplenish
+	// deliberately keeps adopting stale sandboxes, so it never pays the SandboxTemplate lookup below.
+	var expectedBlueprintHash string
+	var expectedTemplate *extensionsv1beta1.SandboxTemplate
+	var isRecreate bool
+	var recreateResolveErr error
+	var recreateResolved bool
+	resolveRecreate := func() (bool, string, *extensionsv1beta1.SandboxTemplate, error) {
+		if !recreateResolved {
+			recreateResolved = true
+			warmPool, err := r.getWarmPool(ctx, claim)
+			if err != nil {
+				recreateResolveErr = err
+			} else if resolveUpdateStrategy(warmPool) == extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType {
+				isRecreate = true
+				template, err := r.getTemplateForWarmPool(ctx, claim.Namespace, warmPool)
+				if err != nil {
+					recreateResolveErr = err
+				} else {
+					expectedTemplate = template
+					expectedBlueprintHash, recreateResolveErr = computeSandboxBlueprintHash(template)
+				}
+			}
+		}
+		return isRecreate, expectedBlueprintHash, expectedTemplate, recreateResolveErr
+	}
+
 	// Instantly returns unused keys the moment we find a valid/ready candidate!
 	defer func() {
 		for _, key := range skipped {
@@ -879,6 +918,32 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			if errors.Is(err, ErrCrossNamespaceAdoption) {
 				skipped = append(skipped, adoptedKey)
 			}
+			continue
+		}
+
+		// Enforce blueprint version consistency only under the Recreate strategy (issue #764).
+		recreate, expectedHash, expectedTemplate, err := resolveRecreate()
+		if err != nil {
+			// We cannot determine the pool's strategy or compute the expected hash. This is likely
+			// a transient lookup error and the candidate may well be fresh, so requeue it rather
+			// than draining it from the pool; but do not adopt it here, since under a possibly
+			// Recreate pool adopting an unverified pod risks handing out a stale version. The claim
+			// retries or cold starts instead.
+			logger.V(1).Info("Requeuing candidate: unable to resolve warm pool update strategy", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name, "error", err.Error())
+			skipped = append(skipped, adoptedKey)
+			continue
+		}
+		// Under Recreate, mirror the pool controller's isSandboxStale semantics: a hash-label match
+		// means fresh, but a missing/mismatched hash label falls back to the same semantic blueprint
+		// comparison rather than being treated as stale outright. Only drop the candidate when the
+		// blueprint also differs semantically. Dropping without requeue is safe there because such a
+		// candidate is genuinely stale, so the pool controller is deleting it and will enqueue a
+		// fresh replacement via the Sandbox watch. Conversely, a semantically-identical candidate is
+		// kept by the pool, so we must adopt it here instead of cold-starting against a "full" pool.
+		if recreate &&
+			adopted.Labels[v1beta1.SandboxTemplateHashLabel] != expectedHash &&
+			!compareSandboxBlueprint(expectedTemplate, &adopted.Spec.SandboxBlueprint) {
+			logger.V(1).Info("Skipping stale candidate under Recreate strategy", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name)
 			continue
 		}
 
@@ -1701,18 +1766,29 @@ func (r *SandboxClaimReconciler) initializeSandboxLaunchTypeLabel(ctx context.Co
 	return r.Patch(ctx, sandbox, patch)
 }
 
-func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*extensionsv1beta1.SandboxTemplate, error) {
+func (r *SandboxClaimReconciler) getWarmPool(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*extensionsv1beta1.SandboxWarmPool, error) {
 	warmPool := &extensionsv1beta1.SandboxWarmPool{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: claim.Spec.WarmPoolRef.Name}, warmPool); err != nil {
 		if k8errors.IsNotFound(err) {
-			return nil, ErrWarmPoolNotFound
+			return nil, fmt.Errorf("SandboxWarmPool %q not found: %w", claim.Spec.WarmPoolRef.Name, ErrWarmPoolNotFound)
 		}
 		return nil, fmt.Errorf("failed to get sandbox warm pool %q: %w", claim.Spec.WarmPoolRef.Name, err)
 	}
+	return warmPool, nil
+}
 
+func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*extensionsv1beta1.SandboxTemplate, error) {
+	warmPool, err := r.getWarmPool(ctx, claim)
+	if err != nil {
+		return nil, err
+	}
+	return r.getTemplateForWarmPool(ctx, claim.Namespace, warmPool)
+}
+
+func (r *SandboxClaimReconciler) getTemplateForWarmPool(ctx context.Context, namespace string, warmPool *extensionsv1beta1.SandboxWarmPool) (*extensionsv1beta1.SandboxTemplate, error) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: claim.Namespace,
+			Namespace: namespace,
 			Name:      warmPool.Spec.TemplateRef.Name,
 		},
 	}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -906,6 +906,45 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	var adoptingFallback bool
 	var pendingNetworkCandidates int
 
+	// Lazily resolve, at most once, whether the claim's warm pool uses the Recreate strategy and,
+	// if so, the blueprint hash a current sandbox must carry. The strategy lives on the
+	// SandboxWarmPool spec (not on the pooled Sandboxes), so we read it directly from the pool the
+	// claim references. Under Recreate the pool must only serve sandboxes reflecting the current
+	// template; during an in-place template update stale sandboxes are still being deleted, so a
+	// candidate whose blueprint hash no longer matches must be rejected (issue #764). We compute
+	// the same blueprint hash the pool's staleness check uses (SandboxTemplateHashLabel) so both
+	// sides agree on what "stale under Recreate" means. We also keep the resolved SandboxTemplate so
+	// that, on a hash-label mismatch, we can fall back to the same semantic blueprint comparison the
+	// pool controller uses (see isSandboxStale): a candidate whose hash label is missing or differs
+	// but whose blueprint is semantically identical to the template is kept (not deleted/recreated)
+	// by the pool, so the claim must treat it as fresh too — otherwise a Recreate pool full of
+	// pre-label sandboxes becomes permanently unadoptable after a controller upgrade. OnReplenish
+	// deliberately keeps adopting stale sandboxes, so it never pays the SandboxTemplate lookup below.
+	var expectedBlueprintHash string
+	var expectedTemplate *extensionsv1beta1.SandboxTemplate
+	var isRecreate bool
+	var recreateResolveErr error
+	var recreateResolved bool
+	resolveRecreate := func() (bool, string, *extensionsv1beta1.SandboxTemplate, error) {
+		if !recreateResolved {
+			recreateResolved = true
+			warmPool, err := r.getWarmPool(ctx, claim)
+			if err != nil {
+				recreateResolveErr = err
+			} else if resolveUpdateStrategy(warmPool) == extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType {
+				isRecreate = true
+				template, err := r.getTemplateForWarmPool(ctx, claim.Namespace, warmPool)
+				if err != nil {
+					recreateResolveErr = err
+				} else {
+					expectedTemplate = template
+					expectedBlueprintHash, recreateResolveErr = computeSandboxBlueprintHash(template)
+				}
+			}
+		}
+		return isRecreate, expectedBlueprintHash, expectedTemplate, recreateResolveErr
+	}
+
 	// Instantly returns unused keys the moment we find a valid/ready candidate!
 	defer func() {
 		for _, key := range skipped {
@@ -1001,6 +1040,37 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			if errors.Is(err, ErrCrossNamespaceAdoption) {
 				skipped = append(skipped, adoptedKey)
 			}
+			continue
+		}
+
+		// Enforce blueprint version consistency only under the Recreate strategy (issue #764).
+		recreate, expectedHash, expectedTemplate, err := resolveRecreate()
+		if err != nil {
+			// We cannot determine the pool's strategy or compute the expected hash. This is likely
+			// a transient lookup error and the candidate may well be fresh, so requeue it rather
+			// than draining it from the pool; but do not adopt it here, since under a possibly
+			// Recreate pool adopting an unverified pod risks handing out a stale version. The claim
+			// retries or cold starts instead. A candidate whose backing Pod has not been observed
+			// yet (no cached PodIPs) is also a pending-network candidate, so count it the same way
+			// the observation check below does to keep the caller's retry accounting consistent.
+			logger.V(1).Info("Requeuing candidate: unable to resolve warm pool update strategy", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name, "error", err.Error())
+			if len(adopted.Status.PodIPs) == 0 {
+				pendingNetworkCandidates++
+			}
+			skipped = append(skipped, adoptedKey)
+			continue
+		}
+		// Under Recreate, mirror the pool controller's isSandboxStale semantics: a hash-label match
+		// means fresh, but a missing/mismatched hash label falls back to the same semantic blueprint
+		// comparison rather than being treated as stale outright. Only drop the candidate when the
+		// blueprint also differs semantically. Dropping without requeue is safe there because such a
+		// candidate is genuinely stale, so the pool controller is deleting it and will enqueue a
+		// fresh replacement via the Sandbox watch. Conversely, a semantically-identical candidate is
+		// kept by the pool, so we must adopt it here instead of cold-starting against a "full" pool.
+		if recreate &&
+			adopted.Labels[v1beta1.SandboxTemplateHashLabel] != expectedHash &&
+			!compareSandboxBlueprint(expectedTemplate, &adopted.Spec.SandboxBlueprint) {
+			logger.V(1).Info("Skipping stale candidate under Recreate strategy", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name)
 			continue
 		}
 
@@ -2092,18 +2162,29 @@ func (r *SandboxClaimReconciler) initializeSandboxLaunchTypeLabel(ctx context.Co
 	return r.Patch(ctx, sandbox, patch)
 }
 
-func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*extensionsv1beta1.SandboxTemplate, error) {
+func (r *SandboxClaimReconciler) getWarmPool(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*extensionsv1beta1.SandboxWarmPool, error) {
 	warmPool := &extensionsv1beta1.SandboxWarmPool{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: claim.Spec.WarmPoolRef.Name}, warmPool); err != nil {
 		if k8errors.IsNotFound(err) {
-			return nil, ErrWarmPoolNotFound
+			return nil, fmt.Errorf("SandboxWarmPool %q not found: %w", claim.Spec.WarmPoolRef.Name, ErrWarmPoolNotFound)
 		}
 		return nil, fmt.Errorf("failed to get sandbox warm pool %q: %w", claim.Spec.WarmPoolRef.Name, err)
 	}
+	return warmPool, nil
+}
 
+func (r *SandboxClaimReconciler) getTemplate(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) (*extensionsv1beta1.SandboxTemplate, error) {
+	warmPool, err := r.getWarmPool(ctx, claim)
+	if err != nil {
+		return nil, err
+	}
+	return r.getTemplateForWarmPool(ctx, claim.Namespace, warmPool)
+}
+
+func (r *SandboxClaimReconciler) getTemplateForWarmPool(ctx context.Context, namespace string, warmPool *extensionsv1beta1.SandboxWarmPool) (*extensionsv1beta1.SandboxTemplate, error) {
 	template := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: claim.Namespace,
+			Namespace: namespace,
 			Name:      warmPool.Spec.TemplateRef.Name,
 		},
 	}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1989,9 +1989,27 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		return sb
 	}
 
+	// matchingBlueprintHash is the blueprint hash the warm pool controller would stamp on a
+	// fresh sandbox for this template; a candidate carrying it is considered current under Recreate.
+	matchingBlueprintHash, hashErr := computeSandboxBlueprintHash(template)
+	if hashErr != nil {
+		t.Fatalf("failed to compute blueprint hash: %v", hashErr)
+	}
+
+	// withBlueprintHash stamps the blueprint hash label the SandboxClaim controller inspects
+	// when deciding whether a candidate is fresh under the Recreate strategy (issue #764).
+	withBlueprintHash := func(sb *sandboxv1beta1.Sandbox, blueprintHash string) *sandboxv1beta1.Sandbox {
+		sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel] = blueprintHash
+		return sb
+	}
+
+	recreateStrategy := &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{Type: extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType}
+	onReplenishStrategy := &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{Type: extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType}
+
 	testCases := []struct {
 		name                    string
 		existingObjects         []client.Object
+		warmPoolStrategy        *extensionsv1beta1.SandboxWarmPoolUpdateStrategy
 		expectSandboxAdoption   bool
 		expectedAdoptedSandbox  string
 		expectedAnnotations     map[string]string
@@ -2249,14 +2267,90 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 			expectNewSandboxCreated: false,
 		},
+		{
+			name:             "skips stale candidate under Recreate strategy and cold starts",
+			warmPoolStrategy: recreateStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("stale-recreate", metav1.Now(), true), "stale-hash"),
+			},
+			expectSandboxAdoption:   false,
+			expectNewSandboxCreated: true,
+		},
+		{
+			name:             "adopts fresh candidate under Recreate strategy",
+			warmPoolStrategy: recreateStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("fresh-recreate", metav1.Now(), true), matchingBlueprintHash),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "fresh-recreate",
+			expectNewSandboxCreated: false,
+		},
+		{
+			// Regression for issue #764: a candidate whose blueprint-hash label is missing (e.g. a
+			// sandbox created by an older controller version before the label existed) but whose
+			// blueprint is still semantically current must be adopted, not dropped. The pool
+			// controller's isSandboxStale keeps such a sandbox (falls back to a semantic comparison
+			// on a hash mismatch and finds it fresh), so it is never deleted or replaced. If the
+			// claim dropped it without requeue, a Recreate pool full of pre-label sandboxes would be
+			// permanently unadoptable and every claim would needlessly cold-start against a "full" pool.
+			name:             "adopts semantically-current candidate with missing hash label under Recreate",
+			warmPoolStrategy: recreateStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				func() client.Object {
+					sb := createWarmPoolSandbox("prelabel-recreate", metav1.Now(), true)
+					// No SandboxTemplateHashLabel is stamped, but the blueprint carries the same
+					// secure defaults the controller applies at creation, so it is semantically current.
+					ApplySandboxSecureDefaults(template, &sb.Spec.PodTemplate.Spec)
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "prelabel-recreate",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name:             "adopts stale candidate under OnReplenish strategy (no regression)",
+			warmPoolStrategy: onReplenishStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("stale-onreplenish", metav1.Now(), true), "stale-hash"),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "stale-onreplenish",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name:             "adopts stale candidate when warm pool strategy unset (defaults to OnReplenish)",
+			warmPoolStrategy: nil,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("default-stale", metav1.Now(), true), "stale-hash"),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "default-stale",
+			expectNewSandboxCreated: false,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newScheme(t)
+			// The update strategy lives on the SandboxWarmPool spec; give each case its own pool so
+			// the claim controller reads the intended strategy (issue #764).
+			caseWarmPool := warmPool.DeepCopy()
+			caseWarmPool.Spec.UpdateStrategy = tc.warmPoolStrategy
 			var fakeClient client.Client = fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(append(tc.existingObjects, warmPool)...).
+				WithObjects(append(tc.existingObjects, caseWarmPool)...).
 				WithStatusSubresource(claim).
 				Build()
 
@@ -2393,6 +2487,94 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		})
 	}
 }
+
+// TestGetCandidateRequeuesRecreateCandidateOnTemplateLookupError verifies that when a Recreate
+// candidate is encountered but the expected pod template hash cannot be computed (here because the
+// SandboxTemplate lookup fails), getCandidate does not adopt the unverified candidate and instead
+// requeues it so a later reconcile can retry. Draining it would empty a pool that may hold fresh
+// pods, while adopting it risks handing out a stale version (issue #764).
+func TestGetCandidateRequeuesRecreateCandidateOnTemplateLookupError(t *testing.T) {
+	scheme := newScheme(t)
+
+	warmPoolUID := types.UID("warmpool-uid-req")
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	// The Recreate warm pool exists but its referenced SandboxTemplate does not, so
+	// getTemplateForWarmPool returns ErrTemplateNotFound and the lazy hash computation fails.
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: warmPoolUID},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			TemplateRef:    extensionsv1beta1.SandboxTemplateRef{Name: "missing-template"},
+			UpdateStrategy: &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{Type: extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType},
+		},
+	}
+
+	candidate := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recreate-candidate",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:                    sandboxcontrollers.NameHash("test-pool"),
+				sandboxTemplateRefHash:                  SandboxTemplateRefHash("missing-template"),
+				sandboxv1beta1.SandboxLaunchTypeLabel:   sandboxv1beta1.SandboxLaunchTypeWarm,
+				sandboxv1beta1.SandboxTemplateHashLabel: "some-hash",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        warmPoolUID,
+				Controller: new(true),
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(warmPool, claim, candidate).Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(candidate.Namespace, "test-pool")
+	key := queue.SandboxKey{Namespace: candidate.Namespace, Name: candidate.Name}
+	warmSandboxQueue.Add(namespacedWarmPoolName, key)
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	sb, _, err := reconciler.getCandidate(context.Background(), claim)
+	if err != nil {
+		t.Fatalf("getCandidate returned unexpected error: %v", err)
+	}
+	if sb != nil {
+		t.Fatalf("expected no candidate to be adopted, got %q", sb.Name)
+	}
+
+	// The candidate must have been requeued rather than drained.
+	got, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
+	if !ok {
+		t.Fatalf("expected Recreate candidate to be requeued, but queue is empty")
+	}
+	if got.Name != candidate.Name {
+		t.Fatalf("expected requeued candidate %q, got %q", candidate.Name, got.Name)
+	}
+}
+
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
 	q := queue.NewSimpleSandboxQueue()
 	handler := &sandboxEventHandler{sandboxQueue: q}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2040,9 +2040,27 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		return sb
 	}
 
+	// matchingBlueprintHash is the blueprint hash the warm pool controller would stamp on a
+	// fresh sandbox for this template; a candidate carrying it is considered current under Recreate.
+	matchingBlueprintHash, hashErr := computeSandboxBlueprintHash(template)
+	if hashErr != nil {
+		t.Fatalf("failed to compute blueprint hash: %v", hashErr)
+	}
+
+	// withBlueprintHash stamps the blueprint hash label the SandboxClaim controller inspects
+	// when deciding whether a candidate is fresh under the Recreate strategy (issue #764).
+	withBlueprintHash := func(sb *sandboxv1beta1.Sandbox, blueprintHash string) *sandboxv1beta1.Sandbox {
+		sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel] = blueprintHash
+		return sb
+	}
+
+	recreateStrategy := &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{Type: extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType}
+	onReplenishStrategy := &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{Type: extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType}
+
 	testCases := []struct {
 		name                    string
 		existingObjects         []client.Object
+		warmPoolStrategy        *extensionsv1beta1.SandboxWarmPoolUpdateStrategy
 		expectSandboxAdoption   bool
 		expectedAdoptedSandbox  string
 		expectedAnnotations     map[string]string
@@ -2352,14 +2370,90 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			},
 			expectNewSandboxCreated: false,
 		},
+		{
+			name:             "skips stale candidate under Recreate strategy and cold starts",
+			warmPoolStrategy: recreateStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("stale-recreate", metav1.Now(), true), "stale-hash"),
+			},
+			expectSandboxAdoption:   false,
+			expectNewSandboxCreated: true,
+		},
+		{
+			name:             "adopts fresh candidate under Recreate strategy",
+			warmPoolStrategy: recreateStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("fresh-recreate", metav1.Now(), true), matchingBlueprintHash),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "fresh-recreate",
+			expectNewSandboxCreated: false,
+		},
+		{
+			// Regression for issue #764: a candidate whose blueprint-hash label is missing (e.g. a
+			// sandbox created by an older controller version before the label existed) but whose
+			// blueprint is still semantically current must be adopted, not dropped. The pool
+			// controller's isSandboxStale keeps such a sandbox (falls back to a semantic comparison
+			// on a hash mismatch and finds it fresh), so it is never deleted or replaced. If the
+			// claim dropped it without requeue, a Recreate pool full of pre-label sandboxes would be
+			// permanently unadoptable and every claim would needlessly cold-start against a "full" pool.
+			name:             "adopts semantically-current candidate with missing hash label under Recreate",
+			warmPoolStrategy: recreateStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				func() client.Object {
+					sb := createWarmPoolSandbox("prelabel-recreate", metav1.Now(), true)
+					// No SandboxTemplateHashLabel is stamped, but the blueprint carries the same
+					// secure defaults the controller applies at creation, so it is semantically current.
+					ApplySandboxSecureDefaults(template, &sb.Spec.PodTemplate.Spec)
+					return sb
+				}(),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "prelabel-recreate",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name:             "adopts stale candidate under OnReplenish strategy (no regression)",
+			warmPoolStrategy: onReplenishStrategy,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("stale-onreplenish", metav1.Now(), true), "stale-hash"),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "stale-onreplenish",
+			expectNewSandboxCreated: false,
+		},
+		{
+			name:             "adopts stale candidate when warm pool strategy unset (defaults to OnReplenish)",
+			warmPoolStrategy: nil,
+			existingObjects: []client.Object{
+				template,
+				claim,
+				withBlueprintHash(createWarmPoolSandbox("default-stale", metav1.Now(), true), "stale-hash"),
+			},
+			expectSandboxAdoption:   true,
+			expectedAdoptedSandbox:  "default-stale",
+			expectNewSandboxCreated: false,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newScheme(t)
+			// The update strategy lives on the SandboxWarmPool spec; give each case its own pool so
+			// the claim controller reads the intended strategy (issue #764).
+			caseWarmPool := warmPool.DeepCopy()
+			caseWarmPool.Spec.UpdateStrategy = tc.warmPoolStrategy
 			var fakeClient client.Client = fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(append(tc.existingObjects, warmPool)...).
+				WithObjects(append(tc.existingObjects, caseWarmPool)...).
 				WithStatusSubresource(claim).
 				Build()
 
@@ -2789,6 +2883,87 @@ func TestSandboxClaimAdoptsCandidateThatBecomesNetworkReadyDuringGrace(t *testin
 	require.Equal(t, candidate.Name, claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
 }
 
+func TestGetCandidateRequeuesRecreateCandidateOnTemplateLookupError(t *testing.T) {
+	scheme := newScheme(t)
+
+	warmPoolUID := types.UID("warmpool-uid-req")
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	// The Recreate warm pool exists but its referenced SandboxTemplate does not, so
+	// getTemplateForWarmPool returns ErrTemplateNotFound and the lazy hash computation fails.
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: warmPoolUID},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			TemplateRef:    extensionsv1beta1.SandboxTemplateRef{Name: "missing-template"},
+			UpdateStrategy: &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{Type: extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType},
+		},
+	}
+
+	candidate := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recreate-candidate",
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:                    sandboxcontrollers.NameHash("test-pool"),
+				sandboxTemplateRefHash:                  SandboxTemplateRefHash("missing-template"),
+				sandboxv1beta1.SandboxLaunchTypeLabel:   sandboxv1beta1.SandboxLaunchTypeWarm,
+				sandboxv1beta1.SandboxTemplateHashLabel: "some-hash",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        warmPoolUID,
+				Controller: new(true),
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(warmPool, claim, candidate).Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	namespacedWarmPoolName := queue.GetNamespacedWarmPoolName(candidate.Namespace, "test-pool")
+	key := queue.SandboxKey{Namespace: candidate.Namespace, Name: candidate.Name}
+	warmSandboxQueue.Add(namespacedWarmPoolName, key)
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		WarmSandboxQueue: warmSandboxQueue,
+		Tracer:           asmetrics.NewNoOp(),
+	}
+
+	sb, _, _, err := reconciler.getCandidate(context.Background(), claim)
+	if err != nil {
+		t.Fatalf("getCandidate returned unexpected error: %v", err)
+	}
+	if sb != nil {
+		t.Fatalf("expected no candidate to be adopted, got %q", sb.Name)
+	}
+
+	// The candidate must have been requeued rather than drained.
+	got, ok := warmSandboxQueue.Get(namespacedWarmPoolName)
+	if !ok {
+		t.Fatalf("expected Recreate candidate to be requeued, but queue is empty")
+	}
+	if got.Name != candidate.Name {
+		t.Fatalf("expected requeued candidate %q, got %q", candidate.Name, got.Name)
+	}
+}
 func TestSandboxEventHandler_Delete_RemovesGhostPods(t *testing.T) {
 	q := queue.NewSimpleSandboxQueue()
 	handler := &sandboxEventHandler{sandboxQueue: q}

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -235,10 +235,24 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	return allErrors
 }
 
+// resolveUpdateStrategy returns the effective update strategy for the warm pool,
+// defaulting to OnReplenish when unspecified or unknown.
+func resolveUpdateStrategy(warmPool *extensionsv1beta1.SandboxWarmPool) extensionsv1beta1.SandboxWarmPoolUpdateStrategyType {
+	if warmPool.Spec.UpdateStrategy == nil {
+		return extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
+	}
+	switch warmPool.Spec.UpdateStrategy.Type {
+	case extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType:
+		return extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType
+	default:
+		return extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
+	}
+}
+
 // adoptSandbox sets this warmpool as the owner of an orphaned sandbox.
 func (r *SandboxWarmPoolReconciler) adoptSandbox(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, sb *sandboxv1beta1.Sandbox) error {
 	if err := controllerutil.SetControllerReference(warmPool, sb, r.Scheme); err != nil {
-		return err
+		return fmt.Errorf("set controller reference for warm pool sandbox %s/%s: %w", sb.Namespace, sb.Name, err)
 	}
 	setWarmLaunchTypeLabelIfNeeded(sb)
 	return r.Update(ctx, sb)
@@ -264,20 +278,12 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 	vettedHashes := make(map[string]bool)
 
 	// Determine the update strategy, defaulting to OnReplenish if not specified or unknown.
-	var updateStrategyType extensionsv1beta1.SandboxWarmPoolUpdateStrategyType
-	if warmPool.Spec.UpdateStrategy != nil {
-		updateStrategyType = warmPool.Spec.UpdateStrategy.Type
-	}
-
-	var updateStrategy extensionsv1beta1.SandboxWarmPoolUpdateStrategyType
-	switch updateStrategyType {
-	case extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType:
-		updateStrategy = extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType
-	case extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType, "":
-		updateStrategy = extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
-	default:
-		logger.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", updateStrategyType)
-		updateStrategy = extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
+	updateStrategy := resolveUpdateStrategy(warmPool)
+	if raw := warmPool.Spec.UpdateStrategy; raw != nil &&
+		raw.Type != "" &&
+		raw.Type != extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType &&
+		raw.Type != extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType {
+		logger.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", raw.Type)
 	}
 
 	for _, sb := range sandboxes {
@@ -512,7 +518,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	isOrphan := controllerRef == nil
 	if isOrphan {
 		// Always perform full semantic comparison for orphans.
-		return !r.compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
+		return !compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
 	}
 
 	// If hashes match, it's fresh.
@@ -538,7 +544,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	// Perform a semantic comparison of the sandbox blueprint.
 	// We normalize the pod spec by applying the same secure defaults
 	// used during creation to avoid false positives from controller-injected fields.
-	isStale := !r.compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
+	isStale := !compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
 
 	// Save the result for the next sandbox with this same hash.
 	if sandboxHash != "" {
@@ -550,7 +556,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 
 // comparePodSpecs checks if the pod spec in the sandbox is semantically equal to the template,
 // normalizing for fields that the controller populates by default.
-func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *corev1.PodSpec) bool {
+func comparePodSpecs(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *corev1.PodSpec) bool {
 	// Create what the sandbox SHOULD look like if it were created from the current template.
 	expectedSpec := template.Spec.PodTemplate.Spec.DeepCopy()
 	ApplySandboxSecureDefaults(template, expectedSpec)
@@ -566,7 +572,7 @@ func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.
 // Note: Comparison is index-based (order-sensitive) to stay consistent with computeSandboxBlueprintHash (+listType=atomic).
 // Making this comparison order-independent without also sorting the templates in computeSandboxBlueprintHash
 // would cause reordered warm sandboxes to fail the hash label check on every reconcile.
-func (r *SandboxWarmPoolReconciler) compareVolumeClaimTemplates(template *extensionsv1beta1.SandboxTemplate, actualVCTs []sandboxv1beta1.PersistentVolumeClaimTemplate) bool {
+func compareVolumeClaimTemplates(template *extensionsv1beta1.SandboxTemplate, actualVCTs []sandboxv1beta1.PersistentVolumeClaimTemplate) bool {
 	if len(template.Spec.SandboxBlueprint.VolumeClaimTemplates) != len(actualVCTs) {
 		return false
 	}
@@ -583,9 +589,9 @@ func (r *SandboxWarmPoolReconciler) compareVolumeClaimTemplates(template *extens
 
 // compareSandboxBlueprint checks if the sandbox blueprint in the sandbox is semantically equal to the template,
 // ignoring metadata differences and only comparing the fields that are relevant for staleness detection.
-func (r *SandboxWarmPoolReconciler) compareSandboxBlueprint(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *sandboxv1beta1.SandboxBlueprint) bool {
-	return r.comparePodSpecs(template, &actualSandboxSpec.PodTemplate.Spec) &&
-		r.compareVolumeClaimTemplates(template, actualSandboxSpec.VolumeClaimTemplates) &&
+func compareSandboxBlueprint(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *sandboxv1beta1.SandboxBlueprint) bool {
+	return comparePodSpecs(template, &actualSandboxSpec.PodTemplate.Spec) &&
+		compareVolumeClaimTemplates(template, actualSandboxSpec.VolumeClaimTemplates) &&
 		equality.Semantic.DeepEqual(template.Spec.Service, actualSandboxSpec.Service)
 }
 

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -867,10 +867,24 @@ func (r *SandboxWarmPoolReconciler) isSandboxPodUnschedulable(ctx context.Contex
 	return false
 }
 
+// resolveUpdateStrategy returns the effective update strategy for the warm pool,
+// defaulting to OnReplenish when unspecified or unknown.
+func resolveUpdateStrategy(warmPool *extensionsv1beta1.SandboxWarmPool) extensionsv1beta1.SandboxWarmPoolUpdateStrategyType {
+	if warmPool.Spec.UpdateStrategy == nil {
+		return extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
+	}
+	switch warmPool.Spec.UpdateStrategy.Type {
+	case extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType:
+		return extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType
+	default:
+		return extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
+	}
+}
+
 // adoptSandbox sets this warmpool as the owner of an orphaned sandbox.
 func (r *SandboxWarmPoolReconciler) adoptSandbox(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, sb *sandboxv1beta1.Sandbox) error {
 	if err := controllerutil.SetControllerReference(warmPool, sb, r.Scheme); err != nil {
-		return err
+		return fmt.Errorf("set controller reference for warm pool sandbox %s/%s: %w", sb.Namespace, sb.Name, err)
 	}
 	setWarmLaunchTypeLabelIfNeeded(sb)
 	return r.Update(ctx, sb)
@@ -903,20 +917,12 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, p
 	vettedHashes := make(map[string]bool)
 
 	// Determine the update strategy, defaulting to OnReplenish if not specified or unknown.
-	var updateStrategyType extensionsv1beta1.SandboxWarmPoolUpdateStrategyType
-	if warmPool.Spec.UpdateStrategy != nil {
-		updateStrategyType = warmPool.Spec.UpdateStrategy.Type
-	}
-
-	var updateStrategy extensionsv1beta1.SandboxWarmPoolUpdateStrategyType
-	switch updateStrategyType {
-	case extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType:
-		updateStrategy = extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType
-	case extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType, "":
-		updateStrategy = extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
-	default:
-		logger.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", updateStrategyType)
-		updateStrategy = extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType
+	updateStrategy := resolveUpdateStrategy(warmPool)
+	if raw := warmPool.Spec.UpdateStrategy; raw != nil &&
+		raw.Type != "" &&
+		raw.Type != extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType &&
+		raw.Type != extensionsv1beta1.OnReplenishSandboxWarmPoolUpdateStrategyType {
+		logger.Info("Unknown update strategy, defaulting to OnReplenish", "strategy", raw.Type)
 	}
 
 	for _, sb := range sandboxes {
@@ -1166,7 +1172,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	isOrphan := controllerRef == nil
 	if isOrphan {
 		// Always perform full semantic comparison for orphans.
-		return !r.compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
+		return !compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
 	}
 
 	// If hashes match, it's fresh.
@@ -1192,7 +1198,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	// Perform a semantic comparison of the sandbox blueprint.
 	// We normalize the pod spec by applying the same secure defaults
 	// used during creation to avoid false positives from controller-injected fields.
-	isStale := !r.compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
+	isStale := !compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
 
 	// Save the result for the next sandbox with this same hash.
 	if sandboxHash != "" {
@@ -1204,7 +1210,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 
 // comparePodSpecs checks if the pod spec in the sandbox is semantically equal to the template,
 // normalizing for fields that the controller populates by default.
-func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *corev1.PodSpec) bool {
+func comparePodSpecs(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *corev1.PodSpec) bool {
 	// Create what the sandbox SHOULD look like if it were created from the current template.
 	expectedSpec := template.Spec.PodTemplate.Spec.DeepCopy()
 	ApplySandboxSecureDefaults(template, expectedSpec)
@@ -1220,7 +1226,7 @@ func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.
 // Note: Comparison is index-based (order-sensitive) to stay consistent with computeSandboxBlueprintHash (+listType=atomic).
 // Making this comparison order-independent without also sorting the templates in computeSandboxBlueprintHash
 // would cause reordered warm sandboxes to fail the hash label check on every reconcile.
-func (r *SandboxWarmPoolReconciler) compareVolumeClaimTemplates(template *extensionsv1beta1.SandboxTemplate, actualVCTs []sandboxv1beta1.PersistentVolumeClaimTemplate) bool {
+func compareVolumeClaimTemplates(template *extensionsv1beta1.SandboxTemplate, actualVCTs []sandboxv1beta1.PersistentVolumeClaimTemplate) bool {
 	if len(template.Spec.SandboxBlueprint.VolumeClaimTemplates) != len(actualVCTs) {
 		return false
 	}
@@ -1237,9 +1243,9 @@ func (r *SandboxWarmPoolReconciler) compareVolumeClaimTemplates(template *extens
 
 // compareSandboxBlueprint checks if the sandbox blueprint in the sandbox is semantically equal to the template,
 // ignoring metadata differences and only comparing the fields that are relevant for staleness detection.
-func (r *SandboxWarmPoolReconciler) compareSandboxBlueprint(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *sandboxv1beta1.SandboxBlueprint) bool {
-	return r.comparePodSpecs(template, &actualSandboxSpec.PodTemplate.Spec) &&
-		r.compareVolumeClaimTemplates(template, actualSandboxSpec.VolumeClaimTemplates) &&
+func compareSandboxBlueprint(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *sandboxv1beta1.SandboxBlueprint) bool {
+	return comparePodSpecs(template, &actualSandboxSpec.PodTemplate.Spec) &&
+		compareVolumeClaimTemplates(template, actualSandboxSpec.VolumeClaimTemplates) &&
 		equality.Semantic.DeepEqual(template.Spec.Service, actualSandboxSpec.Service)
 }
 

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -1348,8 +1348,6 @@ func TestComparePodSpecsNormalization(t *testing.T) {
 		},
 	}
 
-	r := &SandboxWarmPoolReconciler{}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			template := &extensionsv1beta1.SandboxTemplate{
@@ -1372,7 +1370,7 @@ func TestComparePodSpecsNormalization(t *testing.T) {
 				ApplySandboxSecureDefaults(template, actualSpecCopy)
 			}
 
-			result := r.comparePodSpecs(template, actualSpecCopy)
+			result := comparePodSpecs(template, actualSpecCopy)
 			if result != tt.expectedResult {
 				t.Errorf("comparePodSpecs() = %v, want %v", result, tt.expectedResult)
 			}
@@ -2219,8 +2217,6 @@ func TestCompareSandboxBlueprint(t *testing.T) {
 		},
 	}
 
-	r := &SandboxWarmPoolReconciler{}
-
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			template := &extensionsv1beta1.SandboxTemplate{
@@ -2229,7 +2225,7 @@ func TestCompareSandboxBlueprint(t *testing.T) {
 					SandboxBlueprint:        tt.templateSandboxBlueprint,
 				},
 			}
-			result := r.compareSandboxBlueprint(template, &tt.actualSandboxBlueprint)
+			result := compareSandboxBlueprint(template, &tt.actualSandboxBlueprint)
 			require.Equal(t, tt.expectedResult, result)
 		})
 	}

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -1409,8 +1409,6 @@ func TestComparePodSpecsNormalization(t *testing.T) {
 		},
 	}
 
-	r := &SandboxWarmPoolReconciler{}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			template := &extensionsv1beta1.SandboxTemplate{
@@ -1433,7 +1431,7 @@ func TestComparePodSpecsNormalization(t *testing.T) {
 				ApplySandboxSecureDefaults(template, actualSpecCopy)
 			}
 
-			result := r.comparePodSpecs(template, actualSpecCopy)
+			result := comparePodSpecs(template, actualSpecCopy)
 			if result != tt.expectedResult {
 				t.Errorf("comparePodSpecs() = %v, want %v", result, tt.expectedResult)
 			}
@@ -2283,8 +2281,6 @@ func TestCompareSandboxBlueprint(t *testing.T) {
 		},
 	}
 
-	r := &SandboxWarmPoolReconciler{}
-
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			template := &extensionsv1beta1.SandboxTemplate{
@@ -2293,7 +2289,7 @@ func TestCompareSandboxBlueprint(t *testing.T) {
 					SandboxBlueprint:        tt.templateSandboxBlueprint,
 				},
 			}
-			result := r.compareSandboxBlueprint(template, &tt.actualSandboxBlueprint)
+			result := compareSandboxBlueprint(template, &tt.actualSandboxBlueprint)
 			require.Equal(t, tt.expectedResult, result)
 		})
 	}


### PR DESCRIPTION
  ### What this PR does / why we need it:

  #### The bug
A warm pool with the `Recreate` strategy is supposed to only hand out pods that match the current SandboxTemplate. But when you update a template in place (change its content, keep the same name), a SandboxClaim can still adopt an old pod.

Here is the sequence that triggers it:

1. The pool has 3 pods running the old template (v1).
2. You edit the SandboxTemplate content (now v2). The name is unchanged.
3. The SandboxWarmPool controller starts deleting the v1 pods and creating v2 pods. This takes time (delete calls, image pulls, pods becoming Ready).
4. In that window a SandboxClaim comes in, sees a v1 pod that hasn't been deleted yet, and adopts it.
5. The user gets a v1 pod, even though Recreate promised only v2.


  #### The fix
Enforce the content-hash check on the adoption path only under Recreate, reading the strategy straight from the warm pool spec (no new labels):
  
1. Since #899, the SandboxClaim controller already references the warm pool directly and fetches it (getTemplate). So the adoption path reads warmPool.Spec.UpdateStrategy directly instead of relying on a label propagated onto each Sandbox.
2. When adopting, the SandboxClaim controller resolves the strategy once:
  
  | Warm pool update strategy | Pod template hash matches? | Result                          |
  |---------------------------|----------------------------|---------------------------------|
  | Recreate                  | yes                        | adopt                           |
  | Recreate                  | no (stale)                 | skip it, claim cold-starts      |
  | OnReplenish               | not checked                | adopt (unchanged behavior)      |
  | unset / unknown           | not checked                | adopt (defaults to OnReplenish) |
  
2. A skipped stale pod is dropped, not requeued: the warm pool controller is already deleting it and will create a fresh replacement, which the Sandbox watch adds back to the queue. So the claim converges on a v2 pod (or cold-starts one).
3. The warm pool lookup and expected hash are resolved lazily — the first time adoption runs for a claim — and the SandboxTemplate is only fetched when the strategy is Recreate, so the common OnReplenish path does no extra SandboxTemplate lookup.


  #### Which issue this PR is related to:
  
  Fixes #764 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warm-pool sandbox adoption now fully honors the configured update strategy, including correct handling of **Recreate** vs **OnReplenish**.
  * Under **Recreate**, stale warm-pool candidates are rejected and warm-pool entries aren’t incorrectly adopted.
  * Fresh warm-pool candidates continue to be adopted as expected.
  * If template details can’t be resolved, candidates are requeued (rather than adopted), preserving warm-pool queue integrity.
  * Unknown or unset strategies now reliably default to **OnReplenish** behavior.
* **Tests**
  * Expanded adoption coverage for multiple update-strategy scenarios, including new requeue behavior when template lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->