### PR TITLE
Fix RBAC: grant core API group events permission for leader election event recorder

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -177,6 +177,7 @@ type SandboxReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;update;patch,resourceNames=sandboxes.agents.x-k8s.io;sandboxclaims.extensions.agents.x-k8s.io;sandboxtemplates.extensions.agents.x-k8s.io;sandboxwarmpools.extensions.agents.x-k8s.io

--- a/helm/templates/rbac.generated.yaml
+++ b/helm/templates/rbac.generated.yaml
@@ -19,6 +19,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -63,10 +71,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -19,6 +19,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -63,10 +71,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch

--- a/olm/config/rbac/role.yaml
+++ b/olm/config/rbac/role.yaml
@@ -19,6 +19,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - agents.x-k8s.io
   resources:
   - sandboxes
@@ -63,10 +71,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - events.k8s.io
-  resources:
-  - events
-  verbs:
-  - create
-  - patch


### PR DESCRIPTION
## Summary

- Adds missing RBAC permission for core API group (`""`) events, fixing the `events is forbidden` error emitted by the leader election event recorder.
- The existing `events.k8s.io` marker is retained; `controller-gen` merges both groups into a single rule.

Fixes #1079

## Root Cause

The kubebuilder marker only declared `events.k8s.io`, but controller-runtime's leader election uses the legacy `v1.Event` (core API group `""`) to announce leadership transitions. The generated ClusterRole was therefore missing the needed permission.

## Changes

- `controllers/sandbox_controller.go`: Added `//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch`
- `k8s/rbac.generated.yaml`, `helm/templates/rbac.generated.yaml`: Regenerated via `make fix-go-generate`

## Test Plan

- [x] `make build` passes
- [x] `go test -race ./controllers/...` passes
- [x] `make fix-go-generate` produces the expected merged rule
- [ ] Deploy to a kind cluster and verify no `events is forbidden` error in controller logs

/kind bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sandbox controller RBAC permissions to ensure it can reliably create and patch Kubernetes Events.
  * Reorganized generated RBAC rules so Event permissions are consistent across the Helm and Kubernetes deployment manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->