### PR TITLE
chore: fix comment typos in controller and load-test recipe

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -827,7 +827,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil, err
 		}
 
-		// TODO - Do we enfore (change) spec if a pod exists ?
+		// TODO - Do we enforce (change) spec if a pod exists ?
 		// r.Patch(ctx, pod, client.Apply, client.ForceOwnership, client.FieldOwner("sandbox-controller"))
 		return pod, nil
 	}

--- a/dev/load-test/test-recipes/warmpool-burst-test.yaml
+++ b/dev/load-test/test-recipes/warmpool-burst-test.yaml
@@ -54,7 +54,7 @@ steps:
       labelSelector: "agents.x-k8s.io/pool"
 
 # --- 2. DRAIN WARMPOOL (Excluded from Cold Measurement) ---
-# TODO: Add a measurement once we have the metric to measure acquistion from warmpool.
+# TODO: Add a measurement once we have the metric to measure acquisition from warmpool.
 - name: Claim with Warmpool
   phases:
   - name: Drain Pool


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix two comment typos reported in #1082 (no behavior change):

- `controllers/sandbox_controller.go`: `enfore` → `enforce` in a `reconcilePod` TODO
- `dev/load-test/test-recipes/warmpool-burst-test.yaml`: `acquistion` → `acquisition` in a TODO

Comment-only; no tests required.

#### Which issue(s) this PR is related to:

Fixes #1082

```release-note
NONE
```