### PR TITLE
docs: align troubleshooting and Go quickstart with WarmPool-based SDK API

### DIFF
--- a/site/content/docs/getting_started/go-sdk-quickstart/_index.md
+++ b/site/content/docs/getting_started/go-sdk-quickstart/_index.md
@@ -12,7 +12,7 @@ Agent Sandbox is a quick and easy way to start secure containers that will let a
 
 - A running Kubernetes cluster with the [Agent Sandbox Controller]({{< ref "/docs/getting_started/overview/_index.md#installation" >}}) installed.
 - The [Sandbox Router](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/README.md) deployed in your cluster.
-- A *SandboxTemplate* created in the target namespace, for example [python-sandbox-template](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/python-sandbox-template.yaml).
+- A `SandboxWarmPool` in the target namespace (for example `python-sandbox-pool` backed by `python-sandbox-template`). See the [Filesystem]({{< ref "/docs/filesystem" >}}) guide for a minimal `kubectl apply` example, or apply [python-sandbox-template.yaml](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/python-sandbox-template.yaml) and create a matching `SandboxWarmPool` whose `spec.sandboxTemplateRef.name` is `python-sandbox-template`.
 - Go 1.26+ and Agent Sandbox Go client: `go get sigs.k8s.io/agent-sandbox/clients/go/sandbox`.
 
 ## Connection Modes
@@ -36,12 +36,13 @@ import (
 func main() {
 	ctx := context.Background()
 
-	templateName := "my-sandbox-template"
+	warmPoolName := "python-sandbox-pool"
+	namespace := "default"
 
-	// Create client with shared configuration.
+	// Create client with shared configuration (Port-Forward mode by default).
 	client, err := sandbox.NewClient(ctx, sandbox.Options{
-		TemplateName: templateName,
-		Namespace:    "default",
+		WarmPoolName: warmPoolName,
+		Namespace:    namespace,
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -50,8 +51,8 @@ func main() {
 	defer stop()
 	defer client.DeleteAll(ctx)
 
-	// Create a sandbox.
-	sb, err := client.CreateSandbox(ctx, templateName, "default")
+	// Create a sandbox from the warm pool.
+	sb, err := client.CreateSandbox(ctx, warmPoolName, namespace)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/site/content/docs/getting_started/troubleshooting/_index.md
+++ b/site/content/docs/getting_started/troubleshooting/_index.md
@@ -18,7 +18,7 @@ While standard errors are often surfaced directly in your script, the `k8s_agent
 
 - A running Kubernetes cluster with the [Agent Sandbox Controller]({{< ref "/docs/getting_started/overview" >}}) installed.
 - The [Sandbox Router](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/sandbox-router/README.md) deployed in your cluster.
-- A `SandboxTemplate` named `python-sandbox-template` applied to your cluster. See the [Python Runtime Sandbox]({{< ref "/docs/runtime-templates/python" >}}) guide for setup instructions.
+- A `SandboxWarmPool` named `python-sandbox-pool` (backed by a `SandboxTemplate` named `python-sandbox-template`) applied to your cluster. See the [Filesystem]({{< ref "/docs/filesystem" >}}) guide for a minimal `kubectl apply` example, or the [Python Runtime Sandbox]({{< ref "/docs/runtime-templates/python" >}}) guide.
 - The [Python SDK]({{< ref "/docs/python-client" >}}) installed with the tracing extra: `pip install "k8s-agent-sandbox[tracing]"`.
 
 ### SDK Logging
@@ -34,7 +34,7 @@ from k8s_agent_sandbox import SandboxClient
 logging.basicConfig(level=logging.INFO)
 
 client = SandboxClient()
-sandbox = client.create_sandbox("simple-sandbox-template")
+sandbox = client.create_sandbox(warmpool="python-sandbox-pool")
 payload = "echo 'Hello World!'"
 response = sandbox.commands.run(payload)
 
@@ -43,7 +43,7 @@ print(response)
 
 Example output:
 ```log
-Creating SandboxClaim 'sandbox-claim-66ae1a5e' in namespace 'default' using template 'python-sandbox-template'...
+Creating SandboxClaim 'sandbox-claim-66ae1a5e' in namespace 'default' using warm pool 'python-sandbox-pool'...
 2026-04-15 16:52:11,634 - INFO - Resolving sandbox name from claim 'sandbox-claim-66ae1a5e'...
 2026-04-15 16:52:11,651 - INFO - Resolved sandbox name 'sandbox-claim-66ae1a5e' from claim status
 2026-04-15 16:52:11,651 - INFO - Watching for Sandbox sandbox-claim-66ae1a5e to become ready...
@@ -59,7 +59,7 @@ stdout='Hello World!\n' stderr='' exit_code=0
 
 ### Custom Sandbox Images and Output Inspection
 
-Often, agent code fails because the environment lacks necessary system packages or dependencies. If your agent requires a specific setup, you should build a custom Docker image, push it to your registry, and reference it in your Kubernetes `SandboxTemplate`.
+Often, agent code fails because the environment lacks necessary system packages or dependencies. If your agent requires a specific setup, you should build a custom Docker image, push it to your registry, and reference it in your Kubernetes `SandboxTemplate`. You must also create a `SandboxWarmPool` that references that template before calling `create_sandbox(warmpool=...)`.
 
 When executing commands inside this custom environment, the `response` object is your primary debugging tool. It strictly separates standard output, standard error, and the exit code.
 
@@ -72,8 +72,8 @@ from k8s_agent_sandbox import SandboxClient
 
 client = SandboxClient()
 
-# 1. Create a sandbox using a template that references your custom Docker image
-sandbox = client.create_sandbox("python-sandbox-template")
+# 1. Create a sandbox from a warm pool backed by a template with your custom Docker image
+sandbox = client.create_sandbox(warmpool="python-sandbox-pool")
 
 # 2. Run a command that might fail (e.g., executing a script with missing dependencies)
 response = sandbox.commands.run("python3 /app/agent_script.py")
@@ -121,10 +121,14 @@ You can run the following commands in your terminal to diagnose the Sandbox Cont
 
 #### Essential Diagnostic Commands
 
-Check the status of your sandbox templates to ensure your custom images are properly registered:
+Check the status of your sandbox templates and warm pools to ensure your custom images are properly registered:
 ```bash
-# Verify the template exists and is ready
+# Verify the template exists
 kubectl get sandboxtemplates
+
+# Verify the warm pool exists and has ready replicas
+kubectl get sandboxwarmpools
+kubectl describe sandboxwarmpool python-sandbox-pool
 ```
 
 When `create_sandbox()` hangs, it usually means the controller cannot fulfill the claim (e.g., due to insufficient node resources or an exhausted warm pool). Inspect the claims:

--- a/site/content/docs/getting_started/troubleshooting/source/template.yaml
+++ b/site/content/docs/getting_started/troubleshooting/source/template.yaml
@@ -1,7 +1,7 @@
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
-  name: simple-sandbox-template
+  name: python-sandbox-template
   namespace: default
   labels:
     app: my-app

--- a/site/content/docs/getting_started/troubleshooting/source/warmpool.yaml
+++ b/site/content/docs/getting_started/troubleshooting/source/warmpool.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: python-sandbox-pool
+  namespace: default
+spec:
+  sandboxTemplateRef:
+    name: python-sandbox-template


### PR DESCRIPTION
#### What this PR does / why we need it:

Align getting-started docs with the v1beta1 WarmPool-based SDK API (KEP-208):

- **Troubleshooting**: prerequisites now require `SandboxWarmPool` + `SandboxTemplate`; Python examples use `create_sandbox(warmpool=...)`; sample log output and kubectl diagnostics updated; source manifests bumped to v1beta1 and add `warmpool.yaml`.
- **Go quickstart**: remove obsolete `TemplateName` from `Options`; use `CreateSandbox(ctx, warmPoolName, namespace)` per `clients/go/README.md`.

Without these fixes, new users following troubleshooting or Go quickstart hit `WarmPoolNotFound` / compile errors while other docs (e.g. filesystem) already use the correct API.

#### Which issue(s) this PR is related to:

None.

#### Release Note

```release-note
NONE
```