### PR TITLE
docs: fix sandboxTemplateRef in KEP-208 and Sandbox wording in lifecycle guide

### DIFF
--- a/docs/keps/208-mutually-exclusive-field-in-sandboxclaim/README.md
+++ b/docs/keps/208-mutually-exclusive-field-in-sandboxclaim/README.md
@@ -35,10 +35,10 @@ Before we even implement #2, I think we should decide if it is even worth having
 
 The user only provides a warm pool reference in `SandboxClaim` spec. The concept of "template" is hidden from the end-user API when claiming a sandbox. The controller looks at the specified warm pool to adopt a sandbox. 
 
-1. If the warmpool's `spec.replicas` is 0, the controller falls back to a cold start using the `spec.templateRef` configured in the warmpool. 
-2. If a user provides custom environment variables, the controller will implicitly bypass the warm pool and provision a Sandbox from scratch based on the template configured in the warmpool.
+1. If the warmpool's `spec.replicas` is 0, the controller falls back to a cold start using the `spec.sandboxTemplateRef` configured in the warmpool. 
+2. If the claim sets `spec.env` or `spec.volumeClaimTemplates`, the controller will implicitly bypass the warm pool and provision a Sandbox from scratch based on the warmpool's `spec.sandboxTemplateRef`.
 3. If the warmpool has been deleted by the cluster admin, the claim controller will throw a permanent failure error.
-4. If the warmpool's `spec.replicas` > 0 and no `spec.env` is provided by the user, the Sandbox is adopted from the warmpool specified in `spec.warmpoolRef`. 
+4. If the warmpool's `spec.replicas` > 0 and the claim sets neither `spec.env` nor `spec.volumeClaimTemplates`, the Sandbox is adopted from the warm pool referenced by the claim's `spec.warmPoolRef`. 
 
 ```go
 type SandboxClaimSpec struct {

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -27,7 +27,7 @@ Unlike manual termination, setting a `shutdownTime` provides a guaranteed, hard 
 
 #### Basic Workflow Example with kubectl
 
-The following example demonstrates how to define a sandbox claim with an explicit `shutdownTime`, apply it directly to your cluster using `kubectl`, and verify the scheduled cleanup.
+The following example demonstrates how to define a `Sandbox` with an explicit `shutdownTime`, apply it directly to your cluster using `kubectl`, and verify the scheduled cleanup.
 
 Define the shutdown time (in this example it's the current time plus 1 minute):
 


### PR DESCRIPTION
#### What this PR does / why we need it:

- KEP-208: correct WarmPool field name `spec.templateRef` → `spec.sandboxTemplateRef` (lines 38–39)
- lifecycle guide: align prose with the kubectl example (`Sandbox`, not "sandbox claim")

#### Which issue(s) this PR is related to:

None.

```release-note
NONE
```