### PR TITLE
feat(python-sdk): allow injecting a pre-configured ApiClient

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -355,10 +355,10 @@ class AsyncK8sHelper:
     async def close(self):
         """Closes the shared Kubernetes API client session.
 
-        A caller-injected ``api_client`` is left open (the caller owns its
-        lifecycle); only a client created internally is closed here.
+        A caller-injected ``api_client`` is left open and remains attached to
+        this helper. Only a client created internally is closed and cleared.
         """
         if self._api_client and self._owns_api_client:
             await self._api_client.close()
-        self._api_client = None
-        self._initialized = False
+            self._api_client = None
+            self._initialized = False

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -42,6 +42,8 @@ class AsyncK8sHelper:
         self._initialized = False
         self._init_lock = asyncio.Lock()
         self._api_client: client.ApiClient | None = api_client
+        # An injected client is caller-owned; only close clients we create.
+        self._owns_api_client = api_client is None
 
     async def _ensure_initialized(self):
         if self._initialized:
@@ -55,6 +57,7 @@ class AsyncK8sHelper:
                 except config.ConfigException:
                     await config.load_kube_config()
                 self._api_client = client.ApiClient()
+                self._owns_api_client = True
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
             self._initialized = True
@@ -350,8 +353,12 @@ class AsyncK8sHelper:
                 await w.close()
 
     async def close(self):
-        """Closes the shared Kubernetes API client session."""
-        if self._api_client:
+        """Closes the shared Kubernetes API client session.
+
+        A caller-injected ``api_client`` is left open (the caller owns its
+        lifecycle); only a client created internally is closed here.
+        """
+        if self._api_client and self._owns_api_client:
             await self._api_client.close()
-            self._api_client = None
-            self._initialized = False
+        self._api_client = None
+        self._initialized = False

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -38,10 +38,10 @@ from .utils import select_pod_ip, is_valid_ip, is_valid_gateway_hostname
 class AsyncK8sHelper:
     """Async helper class for Kubernetes API interactions using kubernetes_asyncio."""
 
-    def __init__(self):
+    def __init__(self, api_client: client.ApiClient | None = None):
         self._initialized = False
         self._init_lock = asyncio.Lock()
-        self._api_client: client.ApiClient | None = None
+        self._api_client: client.ApiClient | None = api_client
 
     async def _ensure_initialized(self):
         if self._initialized:
@@ -49,11 +49,12 @@ class AsyncK8sHelper:
         async with self._init_lock:
             if self._initialized:
                 return
-            try:
-                config.load_incluster_config()
-            except config.ConfigException:
-                await config.load_kube_config()
-            self._api_client = client.ApiClient()
+            if self._api_client is None:
+                try:
+                    config.load_incluster_config()
+                except config.ConfigException:
+                    await config.load_kube_config()
+                self._api_client = client.ApiClient()
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
             self._initialized = True

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -117,6 +117,13 @@ class AsyncSandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         self.k8s_helper = AsyncK8sHelper(api_client=api_client)
+        self._atexit_api_client_configuration = (
+            api_client.configuration if api_client is not None else None
+        )
+        self._atexit_api_client_default_headers = (
+            dict(api_client.default_headers) if api_client is not None else {}
+        )
+        self._atexit_api_client_cookie = api_client.cookie if api_client is not None else None
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()
@@ -377,7 +384,9 @@ class AsyncSandboxClient(Generic[T]):
 
         Uses a snapshot of the tracked claims and a fresh :class:`AsyncK8sHelper`
         so that no loop-bound objects from the original client are reused across
-        event loop boundaries. Per-claim failures and top-level errors emit
+        event loop boundaries. When an ApiClient was injected, its Configuration
+        is reused to target the same cluster from the fresh cleanup loop.
+        Per-claim failures and top-level errors emit
         warnings to ``sys.stderr`` rather than raising — atexit cleanup is
         best-effort.
         """
@@ -386,7 +395,15 @@ class AsyncSandboxClient(Generic[T]):
             return
 
         async def _do_cleanup():
-            helper = AsyncK8sHelper()
+            atexit_api_client = None
+            if self._atexit_api_client_configuration is not None:
+                atexit_api_client = async_client.ApiClient(
+                    configuration=self._atexit_api_client_configuration,
+                    cookie=self._atexit_api_client_cookie,
+                )
+                for name, value in self._atexit_api_client_default_headers.items():
+                    atexit_api_client.set_default_header(name, value)
+            helper = AsyncK8sHelper(api_client=atexit_api_client)
             try:
                 async def _delete_one(ns, claim_name):
                     try:
@@ -402,6 +419,8 @@ class AsyncSandboxClient(Generic[T]):
                 await asyncio.gather(*(_delete_one(ns, claim_name) for ns, claim_name in claims))
             finally:
                 await helper.close()
+                if atexit_api_client is not None:
+                    await atexit_api_client.close()
 
         try:
             asyncio.run(_do_cleanup())

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -27,6 +27,8 @@ import time
 import uuid
 from typing import Generic, TypeVar
 
+from kubernetes_asyncio import client as async_client
+
 from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
@@ -76,6 +78,7 @@ class AsyncSandboxClient(Generic[T]):
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         cleanup: bool = True,
+        api_client: async_client.ApiClient | None = None,
     ):
         """
         Args:
@@ -94,6 +97,9 @@ class AsyncSandboxClient(Generic[T]):
                 sandboxes are not leaked when a caller forgets to clean up;
                 pass ``cleanup=False`` to opt out. Note this differs from the
                 synchronous ``SandboxClient``, which defaults to False.
+            api_client: Optional pre-configured ``kubernetes_asyncio`` ``ApiClient``
+                forwarded to the underlying ``AsyncK8sHelper`` to target a specific
+                cluster/context.
         """
         if connection_config is None:
             raise ValueError(
@@ -110,7 +116,7 @@ class AsyncSandboxClient(Generic[T]):
             initialize_tracer(self.tracer_config.trace_service_name)
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
-        self.k8s_helper = AsyncK8sHelper()
+        self.k8s_helper = AsyncK8sHelper(api_client=api_client)
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -34,13 +34,16 @@ from .utils import select_pod_ip
 class K8sHelper:
     """Helper class for Kubernetes API interactions."""
 
-    def __init__(self):
-        try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            config.load_kube_config()
-        self.custom_objects_api = client.CustomObjectsApi()
-        self.core_v1_api = client.CoreV1Api()
+    def __init__(self, api_client: client.ApiClient | None = None):
+        """When ``api_client`` is provided it is used directly; otherwise the
+        default kubeconfig (in-cluster, then ``~/.kube/config``) is loaded."""
+        if api_client is None:
+            try:
+                config.load_incluster_config()
+            except config.ConfigException:
+                config.load_kube_config()
+        self.custom_objects_api = client.CustomObjectsApi(api_client)
+        self.core_v1_api = client.CoreV1Api(api_client)
 
     def create_sandbox_claim(
         self,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -24,6 +24,8 @@ import time
 import logging
 from typing import List, Dict, Tuple, TypeVar, Generic, Type
 
+from kubernetes import client
+
 # Import all tracing components from the trace_manager module
 from .trace_manager import (
     create_tracer_manager, initialize_tracer, trace_span, trace
@@ -58,6 +60,7 @@ class SandboxClient(Generic[T]):
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         cleanup: bool = False,
+        api_client: client.ApiClient | None = None,
     ):
         """
         Initializes the SandboxClient.
@@ -71,6 +74,8 @@ class SandboxClient(Generic[T]):
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
             cleanup: If True, registers an atexit hook to automatically delete 
                 all tracked sandboxes when the program terminates. Defaults to False.
+            api_client: Optional pre-configured Kubernetes ``ApiClient`` forwarded
+                to the underlying ``K8sHelper`` to target a specific cluster/context.
         """
         # Sandbox related configuration
         self.connection_config = connection_config or SandboxLocalTunnelConnectionConfig()
@@ -82,7 +87,7 @@ class SandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         # Downstream Kubernetes Configuration
-        self.k8s_helper = K8sHelper()
+        self.k8s_helper = K8sHelper(api_client=api_client)
         
         # Tracks all the active client side connections to the created sandbox claims
         self._active_connection_sandboxes: Dict[Tuple[str, str], T] = {}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -629,5 +629,24 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(ip, "192.168.1.1")
 
 
+@patch("k8s_agent_sandbox.async_k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.async_k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.async_k8s_helper.client.ApiClient")
+@patch("k8s_agent_sandbox.async_k8s_helper.config")
+class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
+
+    async def test_injected_api_client_used_and_no_config_loaded(
+        self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
+    ):
+        injected = AsyncMock(name="ApiClient")
+        helper = AsyncK8sHelper(api_client=injected)
+        await helper._ensure_initialized()
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+        mock_api_client_cls.assert_not_called()
+        mock_custom_cls.assert_called_once_with(injected)
+        mock_core_cls.assert_called_once_with(injected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -647,6 +647,23 @@ class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
         mock_custom_cls.assert_called_once_with(injected)
         mock_core_cls.assert_called_once_with(injected)
 
+        # A caller-injected client must not be closed by the helper.
+        await helper.close()
+        injected.close.assert_not_awaited()
+
+    async def test_internally_created_api_client_is_closed(
+        self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
+    ):
+        created = AsyncMock(name="ApiClient")
+        mock_api_client_cls.return_value = created
+        helper = AsyncK8sHelper()
+        await helper._ensure_initialized()
+        mock_api_client_cls.assert_called_once_with()
+
+        # A client the helper created must be closed.
+        await helper.close()
+        created.close.assert_awaited_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -651,6 +651,21 @@ class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
         await helper.close()
         injected.close.assert_not_awaited()
 
+    async def test_injected_api_client_still_used_after_close(
+        self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
+    ):
+        injected = AsyncMock(name="ApiClient")
+        helper = AsyncK8sHelper(api_client=injected)
+
+        await helper.close()
+        await helper._ensure_initialized()
+
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+        mock_api_client_cls.assert_not_called()
+        mock_custom_cls.assert_called_once_with(injected)
+        mock_core_cls.assert_called_once_with(injected)
+
     async def test_internally_created_api_client_is_closed(
         self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
     ):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -211,6 +211,12 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             AsyncSandboxClient(connection_config=None)
         self.assertIn("connection_config is required", str(ctx.exception))
 
+    def test_api_client_forwarded_to_k8s_helper(self):
+        sentinel = MagicMock(name="ApiClient")
+        with patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper") as MockHelper:
+            AsyncSandboxClient(connection_config=self.config, cleanup=False, api_client=sentinel)
+            MockHelper.assert_called_once_with(api_client=sentinel)
+
     def test_cleanup_default_registers_atexit(self):
         """Constructing without cleanup= should default to True and register the hook."""
         with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -252,6 +252,44 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         mock_helper_instance.delete_sandbox_claim.assert_any_call("claim-xyz", "other-ns")
         mock_helper_instance.close.assert_called_once()
 
+    def test_atexit_cleanup_does_not_fall_back_to_default_kubeconfig_with_injected_api_client(self):
+        """Atexit cleanup should preserve the cluster targeted by an injected ApiClient."""
+        injected_api_client = MagicMock(name="InjectedApiClient")
+        injected_configuration = MagicMock(name="InjectedConfiguration")
+        injected_api_client.configuration = injected_configuration
+        injected_api_client.default_headers = {"Impersonate-User": "tenant-a"}
+        injected_api_client.cookie = "session=abc"
+        atexit_api_client = MagicMock(name="AtexitApiClient")
+        atexit_api_client.close = AsyncMock()
+        atexit_api_client.set_default_header = MagicMock()
+        client = AsyncSandboxClient(
+            connection_config=self.config,
+            cleanup=False,
+            api_client=injected_api_client,
+        )
+        client._active_connection_sandboxes = {("tenant-ns", "claim-abc"): MagicMock()}
+        mock_helper_instance = MagicMock()
+        mock_helper_instance.delete_sandbox_claim = AsyncMock()
+        mock_helper_instance.close = AsyncMock()
+
+        with patch(
+            "k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper",
+            return_value=mock_helper_instance,
+        ) as MockHelper, patch(
+            "k8s_agent_sandbox.async_sandbox_client.async_client.ApiClient",
+            return_value=atexit_api_client,
+        ) as MockApiClient:
+            client._atexit_cleanup()
+
+        MockApiClient.assert_called_once_with(
+            configuration=injected_configuration,
+            cookie="session=abc",
+        )
+        atexit_api_client.set_default_header.assert_called_once_with(
+            "Impersonate-User", "tenant-a"
+        )
+        MockHelper.assert_called_once_with(api_client=atexit_api_client)
+
     def test_atexit_cleanup_skips_when_no_sandboxes(self):
         """_atexit_cleanup should be a no-op when there are no tracked sandboxes."""
         self.client._active_connection_sandboxes = {}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -566,5 +566,21 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         self.assertEqual(ip, "192.168.1.1")
 
 
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperApiClientInjection(unittest.TestCase):
+
+    def test_injected_api_client_used_and_no_config_loaded(
+        self, mock_config, mock_custom_cls, mock_core_cls
+    ):
+        sentinel = MagicMock(name="ApiClient")
+        K8sHelper(api_client=sentinel)
+        mock_custom_cls.assert_called_once_with(sentinel)
+        mock_core_cls.assert_called_once_with(sentinel)
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -50,6 +50,12 @@ class TestSandboxClient(unittest.TestCase):
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
 
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_api_client_forwarded_to_k8s_helper(self, MockK8sHelper):
+        sentinel = MagicMock(name="ApiClient")
+        SandboxClient(api_client=sentinel)
+        MockK8sHelper.assert_called_once_with(api_client=sentinel)
+
     @patch('uuid.uuid4')
     def test_create_sandbox_success(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds an optional `api_client` parameter to the Python SDK's `SandboxClient`,
`K8sHelper`, `AsyncSandboxClient`, and `AsyncK8sHelper`. When provided, the
pre-configured `ApiClient` is used directly and kubeconfig auto-loading is
skipped — letting callers target a specific cluster/context (multi-cluster
setups, or tests like `pytest-kind`) instead of relying on `KUBECONFIG` /
`~/.kube/config`. Omitting it preserves the existing behavior.

Unit tests cover the injected and default paths (sync + async); verified
end-to-end against a kind cluster.

#### Which issue(s) this PR is related to:

Fixes #1069

#### Release Note

```release-note
The Python SDK now accepts an optional `api_client` on `SandboxClient`, `K8sHelper`, `AsyncSandboxClient`, and `AsyncK8sHelper` to target a specific cluster/context without relying on `KUBECONFIG` or the default kubeconfig.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python sandbox clients now accept an optional pre-configured Kubernetes API client, making it easier to connect to a specific cluster or context.
  * Async Kubernetes helpers can now reuse an injected client instead of always creating one internally.

* **Tests**
  * Added coverage to verify injected clients are passed through correctly and that default Kubernetes config loading is skipped when a client is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->