### PR TITLE
SDK: support explicit claim_name and adopt_existing in create_sandbox for idempotent creation

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -173,6 +173,8 @@ class AsyncSandboxClient(Generic[T]):
             adopt_existing: When True, a 409 AlreadyExists on claim creation
                 attaches to the existing claim instead of raising, making
                 ``create_sandbox`` safe to retry (at-least-once semantics).
+                The existing claim must reference the same ``warmpool``;
+                a mismatch raises ``ValueError`` without touching the claim.
                 Only meaningful together with an explicit ``claim_name``.
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
@@ -204,12 +206,17 @@ class AsyncSandboxClient(Generic[T]):
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
-        if claim_name is None:
+        generated_claim_name = claim_name is None
+        if generated_claim_name:
             claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
         else:
             validate_claim_name(claim_name)
 
-        claim_created = False
+        # A generated name is unambiguously ours, so failure cleanup is safe
+        # even if the create call errors after the API server persisted the
+        # claim. An explicit name is only cleaned up once creation definitely
+        # succeeded — it may belong to a prior attempt we should not tear down.
+        cleanup_claim_on_failure = generated_claim_name
         try:
             try:
                 await self._create_claim(
@@ -221,10 +228,26 @@ class AsyncSandboxClient(Generic[T]):
                     volume_claim_templates=volume_claim_templates,
                     pod_metadata=pod_metadata
                 )
-                claim_created = True
+                cleanup_claim_on_failure = True
             except ApiException as e:
                 if not (adopt_existing and e.status == 409):
                     raise
+                cleanup_claim_on_failure = False
+                claim_object = await self.k8s_helper.get_sandbox_claim(
+                    claim_name, namespace
+                )
+                existing_warmpool = (
+                    (claim_object or {})
+                    .get("spec", {})
+                    .get("warmPoolRef", {})
+                    .get("name")
+                )
+                if existing_warmpool != warmpool:
+                    raise ValueError(
+                        f"SandboxClaim '{claim_name}' in namespace '{namespace}' "
+                        f"references warmpool '{existing_warmpool}', not "
+                        f"'{warmpool}'. Refusing to adopt."
+                    )
                 logger.info(
                     "SandboxClaim %s already exists; adopting (adopt_existing=True)",
                     claim_name,
@@ -248,9 +271,10 @@ class AsyncSandboxClient(Generic[T]):
                 k8s_helper=self.k8s_helper,
             )
         except (Exception, asyncio.CancelledError):
-            # Don't leave an orphaned claim — but never delete a pre-existing
-            # claim we merely adopted.
-            if claim_created:
+            # Best-effort orphan cleanup for claims this call created (or, for
+            # generated names, may have created) — never a claim we adopted or
+            # an explicit-named claim whose creation never confirmed.
+            if cleanup_claim_on_failure:
                 await asyncio.shield(self._delete_claim(claim_name, namespace))
             raise
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -27,10 +27,12 @@ import time
 import uuid
 from typing import Generic, TypeVar
 
+from kubernetes_asyncio.client.exceptions import ApiException
+
 from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
-from .pod_metadata import build_pod_metadata, validate_labels
+from .pod_metadata import build_pod_metadata, validate_claim_name, validate_labels
 from .utils import construct_sandbox_claim_lifecycle_spec
 from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
 from .trace_manager import async_trace_span, create_tracer_manager, initialize_tracer, trace
@@ -145,6 +147,8 @@ class AsyncSandboxClient(Generic[T]):
         sandbox_ready_timeout: int = 180,
         labels: dict[str, str] | None = None,
         *,
+        claim_name: str | None = None,
+        adopt_existing: bool = False,
         shutdown_after_seconds: int | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_labels: dict[str, str] | None = None,
@@ -158,6 +162,18 @@ class AsyncSandboxClient(Generic[T]):
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
             labels: Optional Kubernetes labels to attach to the claim object
                 (``SandboxClaim.metadata.labels``).
+            claim_name: Optional explicit name for the SandboxClaim. When
+                omitted, a random ``sandbox-claim-<uuid8>`` name is generated
+                (existing behaviour). Supplying a deterministic name lets
+                durable-workflow engines (Restate, Temporal, Step Functions)
+                make sandbox creation idempotent: a retried step re-uses the
+                same name and, with ``adopt_existing=True``, attaches to the
+                claim a prior attempt already created. Must be a valid
+                DNS-1123 subdomain.
+            adopt_existing: When True, a 409 AlreadyExists on claim creation
+                attaches to the existing claim instead of raising, making
+                ``create_sandbox`` safe to retry (at-least-once semantics).
+                Only meaningful together with an explicit ``claim_name``.
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
@@ -188,18 +204,31 @@ class AsyncSandboxClient(Generic[T]):
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
-        claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
+        if claim_name is None:
+            claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
+        else:
+            validate_claim_name(claim_name)
 
+        claim_created = False
         try:
-            await self._create_claim(
-                claim_name,
-                warmpool,
-                namespace,
-                labels=labels,
-                lifecycle=lifecycle,
-                volume_claim_templates=volume_claim_templates,
-                pod_metadata=pod_metadata
-            )
+            try:
+                await self._create_claim(
+                    claim_name,
+                    warmpool,
+                    namespace,
+                    labels=labels,
+                    lifecycle=lifecycle,
+                    volume_claim_templates=volume_claim_templates,
+                    pod_metadata=pod_metadata
+                )
+                claim_created = True
+            except ApiException as e:
+                if not (adopt_existing and e.status == 409):
+                    raise
+                logger.info(
+                    "SandboxClaim %s already exists; adopting (adopt_existing=True)",
+                    claim_name,
+                )
             start_time = time.monotonic()
             sandbox_id = await self.k8s_helper.resolve_sandbox_name(
                 claim_name, namespace, sandbox_ready_timeout
@@ -219,7 +248,10 @@ class AsyncSandboxClient(Generic[T]):
                 k8s_helper=self.k8s_helper,
             )
         except (Exception, asyncio.CancelledError):
-            await asyncio.shield(self._delete_claim(claim_name, namespace))
+            # Don't leave an orphaned claim — but never delete a pre-existing
+            # claim we merely adopted.
+            if claim_created:
+                await asyncio.shield(self._delete_claim(claim_name, namespace))
             raise
 
         async with self._lock:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/pod_metadata.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/pod_metadata.py
@@ -36,6 +36,26 @@ def validate_label_name(name: str, context: str):
         )
 
 
+_DNS1123_SUBDOMAIN_RE = re.compile(
+    r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+)
+DNS1123_SUBDOMAIN_MAX_LENGTH = 253
+
+
+def validate_claim_name(name: str):
+    """Validates an explicit SandboxClaim name as a DNS-1123 subdomain."""
+    if (
+        not name
+        or len(name) > DNS1123_SUBDOMAIN_MAX_LENGTH
+        or not _DNS1123_SUBDOMAIN_RE.match(name)
+    ):
+        raise ValueError(
+            f"Claim name '{name}' must be a valid DNS-1123 subdomain "
+            f"(lowercase alphanumerics, '-' and '.', starting and ending with an "
+            f"alphanumeric; max {DNS1123_SUBDOMAIN_MAX_LENGTH} characters)."
+        )
+
+
 def validate_labels(labels: dict[str, str]):
     """Validates label keys and values against Kubernetes constraints."""
     for key, value in labels.items():

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/pod_metadata.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/pod_metadata.py
@@ -40,6 +40,7 @@ _DNS1123_SUBDOMAIN_RE = re.compile(
     r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 )
 DNS1123_SUBDOMAIN_MAX_LENGTH = 253
+DNS1123_LABEL_MAX_LENGTH = 63
 
 
 def validate_claim_name(name: str):
@@ -48,11 +49,13 @@ def validate_claim_name(name: str):
         not name
         or len(name) > DNS1123_SUBDOMAIN_MAX_LENGTH
         or not _DNS1123_SUBDOMAIN_RE.match(name)
+        or any(len(label) > DNS1123_LABEL_MAX_LENGTH for label in name.split("."))
     ):
         raise ValueError(
             f"Claim name '{name}' must be a valid DNS-1123 subdomain "
             f"(lowercase alphanumerics, '-' and '.', starting and ending with an "
-            f"alphanumeric; max {DNS1123_SUBDOMAIN_MAX_LENGTH} characters)."
+            f"alphanumeric; max {DNS1123_SUBDOMAIN_MAX_LENGTH} characters total, "
+            f"{DNS1123_LABEL_MAX_LENGTH} per dot-separated label)."
         )
 
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -24,6 +24,8 @@ import time
 import logging
 from typing import List, Dict, Tuple, TypeVar, Generic, Type
 
+from kubernetes.client.rest import ApiException
+
 # Import all tracing components from the trace_manager module
 from .trace_manager import (
     create_tracer_manager, initialize_tracer, trace_span, trace
@@ -35,13 +37,15 @@ from .models import (
     SandboxTracerConfig,
 )
 from .k8s_helper import K8sHelper
-from .pod_metadata import build_pod_metadata, validate_labels
+from .pod_metadata import build_pod_metadata, validate_claim_name, validate_labels
 from .utils import construct_sandbox_claim_lifecycle_spec
 from .exceptions import SandboxNotFoundError
 
 logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(levelname)s - %(message)s',
                     stream=sys.stdout)
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar('T', bound=Sandbox)
 
@@ -98,6 +102,8 @@ class SandboxClient(Generic[T]):
         sandbox_ready_timeout: int = 180,
         labels: dict[str, str] | None = None,
         *,
+        claim_name: str | None = None,
+        adopt_existing: bool = False,
         shutdown_after_seconds: int | None = None,
         volume_claim_templates: list[dict] | None = None,
         pod_labels: dict[str, str] | None = None, 
@@ -112,6 +118,18 @@ class SandboxClient(Generic[T]):
             sandbox_ready_timeout: Seconds to wait for the sandbox to be ready.
             labels: Optional Kubernetes labels to attach to the claim object
                 (``SandboxClaim.metadata.labels``).
+            claim_name: Optional explicit name for the SandboxClaim. When
+                omitted, a random ``sandbox-claim-<uuid8>`` name is generated
+                (existing behaviour). Supplying a deterministic name lets
+                durable-workflow engines (Restate, Temporal, Step Functions)
+                make sandbox creation idempotent: a retried step re-uses the
+                same name and, with ``adopt_existing=True``, attaches to the
+                claim a prior attempt already created. Must be a valid
+                DNS-1123 subdomain.
+            adopt_existing: When True, a 409 AlreadyExists on claim creation
+                attaches to the existing claim instead of raising, making
+                ``create_sandbox`` safe to retry (at-least-once semantics).
+                Only meaningful together with an explicit ``claim_name``.
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
                 of *now + shutdown_after_seconds* (UTC) and a ``shutdownPolicy``
@@ -142,18 +160,31 @@ class SandboxClient(Generic[T]):
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
-        claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
+        if claim_name is None:
+            claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
+        else:
+            validate_claim_name(claim_name)
 
+        claim_created = False
         try:
-            self._create_claim(
-                claim_name,
-                warmpool,
-                namespace,
-                labels=labels,
-                lifecycle=lifecycle,
-                volume_claim_templates=volume_claim_templates,
-                pod_metadata=pod_metadata,
-            )
+            try:
+                self._create_claim(
+                    claim_name,
+                    warmpool,
+                    namespace,
+                    labels=labels,
+                    lifecycle=lifecycle,
+                    volume_claim_templates=volume_claim_templates,
+                    pod_metadata=pod_metadata,
+                )
+                claim_created = True
+            except ApiException as e:
+                if not (adopt_existing and e.status == 409):
+                    raise
+                logger.info(
+                    "SandboxClaim %s already exists; adopting (adopt_existing=True)",
+                    claim_name,
+                )
             # Resolve the sandbox id from the sandbox claim object.
             # In case of warmpool, sandbox id is not the same as claim name.
             start_time = time.monotonic()
@@ -175,8 +206,10 @@ class SandboxClient(Generic[T]):
                 k8s_helper=self.k8s_helper,
             )
         except Exception:
-            # If creation or waiting fails, ensure we don't leave an orphaned claim
-            self._delete_claim(claim_name, namespace)
+            # If creation or waiting fails, ensure we don't leave an orphaned
+            # claim — but never delete a pre-existing claim we merely adopted.
+            if claim_created:
+                self._delete_claim(claim_name, namespace)
             raise
 
         self._active_connection_sandboxes[(namespace, claim_name)] = sandbox

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -129,6 +129,8 @@ class SandboxClient(Generic[T]):
             adopt_existing: When True, a 409 AlreadyExists on claim creation
                 attaches to the existing claim instead of raising, making
                 ``create_sandbox`` safe to retry (at-least-once semantics).
+                The existing claim must reference the same ``warmpool``;
+                a mismatch raises ``ValueError`` without touching the claim.
                 Only meaningful together with an explicit ``claim_name``.
             shutdown_after_seconds: Optional TTL in seconds. When set, the
                 claim's ``spec.lifecycle`` is populated with a ``shutdownTime``
@@ -160,12 +162,17 @@ class SandboxClient(Generic[T]):
 
         lifecycle = construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds) if shutdown_after_seconds is not None else None
 
-        if claim_name is None:
+        generated_claim_name = claim_name is None
+        if generated_claim_name:
             claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
         else:
             validate_claim_name(claim_name)
 
-        claim_created = False
+        # A generated name is unambiguously ours, so failure cleanup is safe
+        # even if the create call errors after the API server persisted the
+        # claim. An explicit name is only cleaned up once creation definitely
+        # succeeded — it may belong to a prior attempt we should not tear down.
+        cleanup_claim_on_failure = generated_claim_name
         try:
             try:
                 self._create_claim(
@@ -177,10 +184,20 @@ class SandboxClient(Generic[T]):
                     volume_claim_templates=volume_claim_templates,
                     pod_metadata=pod_metadata,
                 )
-                claim_created = True
+                cleanup_claim_on_failure = True
             except ApiException as e:
                 if not (adopt_existing and e.status == 409):
                     raise
+                cleanup_claim_on_failure = False
+                existing_warmpool = self.get_sandbox_claim_warmpool_name(
+                    claim_name, namespace
+                )
+                if existing_warmpool != warmpool:
+                    raise ValueError(
+                        f"SandboxClaim '{claim_name}' in namespace '{namespace}' "
+                        f"references warmpool '{existing_warmpool}', not "
+                        f"'{warmpool}'. Refusing to adopt."
+                    )
                 logger.info(
                     "SandboxClaim %s already exists; adopting (adopt_existing=True)",
                     claim_name,
@@ -206,9 +223,10 @@ class SandboxClient(Generic[T]):
                 k8s_helper=self.k8s_helper,
             )
         except Exception:
-            # If creation or waiting fails, ensure we don't leave an orphaned
-            # claim — but never delete a pre-existing claim we merely adopted.
-            if claim_created:
+            # Best-effort orphan cleanup for claims this call created (or, for
+            # generated names, may have created) — never a claim we adopted or
+            # an explicit-named claim whose creation never confirmed.
+            if cleanup_claim_on_failure:
                 self._delete_claim(claim_name, namespace)
             raise
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -25,6 +25,8 @@ import pytest
 httpx = pytest.importorskip("httpx")
 pytest.importorskip("kubernetes_asyncio")
 
+from kubernetes_asyncio.client.exceptions import ApiException
+
 from k8s_agent_sandbox.async_connector import AsyncSandboxConnector
 from k8s_agent_sandbox.async_sandbox import AsyncSandbox
 from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
@@ -108,6 +110,90 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 await self.client.create_sandbox("test-warmpool", "test-namespace")
 
             mock_delete.assert_called_once()
+
+    async def test_create_sandbox_with_explicit_claim_name(self):
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        mock_sandbox_instance = MagicMock()
+        mock_sandbox_instance.terminate = AsyncMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock) as mock_create, \
+             patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+
+            sandbox = await self.client.create_sandbox(
+                "test-warmpool", "test-namespace", claim_name="sandbox-my-task"
+            )
+
+            mock_create.assert_called_once_with(
+                "sandbox-my-task",
+                "test-warmpool",
+                "test-namespace",
+                labels=None,
+                lifecycle=None,
+                volume_claim_templates=None,
+                pod_metadata=None
+            )
+            self.assertEqual(sandbox, mock_sandbox_instance)
+
+    async def test_create_sandbox_rejects_invalid_claim_name(self):
+        with self.assertRaises(ValueError) as ctx:
+            await self.client.create_sandbox("test-warmpool", claim_name="Invalid_Name")
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    async def test_create_sandbox_adopts_existing_claim_on_409(self):
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        mock_sandbox_instance = MagicMock()
+        mock_sandbox_instance.terminate = AsyncMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=409)), \
+             patch.object(self.client, "_wait_for_sandbox_ready", new_callable=AsyncMock):
+
+            sandbox = await self.client.create_sandbox(
+                "test-warmpool",
+                "test-namespace",
+                claim_name="sandbox-my-task",
+                adopt_existing=True,
+            )
+
+            self.assertEqual(sandbox, mock_sandbox_instance)
+            self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with(
+                "sandbox-my-task", "test-namespace", 180
+            )
+
+    async def test_create_sandbox_409_raises_without_adopt_existing(self):
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=409)), \
+             patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
+
+            with self.assertRaises(ApiException):
+                await self.client.create_sandbox(
+                    "test-warmpool", "test-namespace", claim_name="sandbox-my-task"
+                )
+
+            # The claim was never created by this call, so there is nothing to clean up
+            mock_delete.assert_not_called()
+
+    async def test_create_sandbox_adopted_claim_not_deleted_on_failure(self):
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(
+            side_effect=Exception("Timeout")
+        )
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=409)), \
+             patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
+
+            with self.assertRaises(Exception):
+                await self.client.create_sandbox(
+                    "test-warmpool",
+                    "test-namespace",
+                    claim_name="sandbox-my-task",
+                    adopt_existing=True,
+                )
+
+            # An adopted claim belongs to a prior attempt — never delete it on failure
+            mock_delete.assert_not_called()
 
     async def test_get_sandbox_existing_active(self):
         mock_sandbox = MagicMock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -142,6 +142,9 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
 
     async def test_create_sandbox_adopts_existing_claim_on_409(self):
         self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.get_sandbox_claim = AsyncMock(
+            return_value={"spec": {"warmPoolRef": {"name": "test-warmpool"}}}
+        )
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
@@ -162,6 +165,27 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 "sandbox-my-task", "test-namespace", 180
             )
 
+    async def test_create_sandbox_adopt_rejects_warmpool_mismatch(self):
+        self.mock_k8s_helper.get_sandbox_claim = AsyncMock(
+            return_value={"spec": {"warmPoolRef": {"name": "other-warmpool"}}}
+        )
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=409)), \
+             patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
+
+            with self.assertRaises(ValueError) as ctx:
+                await self.client.create_sandbox(
+                    "test-warmpool",
+                    "test-namespace",
+                    claim_name="sandbox-my-task",
+                    adopt_existing=True,
+                )
+
+            self.assertIn("Refusing to adopt", str(ctx.exception))
+            # The mismatched claim belongs to someone else — never delete it
+            mock_delete.assert_not_called()
+
     async def test_create_sandbox_409_raises_without_adopt_existing(self):
         with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
                           side_effect=ApiException(status=409)), \
@@ -175,16 +199,12 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             # The claim was never created by this call, so there is nothing to clean up
             mock_delete.assert_not_called()
 
-    async def test_create_sandbox_adopted_claim_not_deleted_on_failure(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(
-            side_effect=Exception("Timeout")
-        )
-
+    async def test_create_sandbox_non_409_not_adopted(self):
         with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
-                          side_effect=ApiException(status=409)), \
+                          side_effect=ApiException(status=403)), \
              patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
 
-            with self.assertRaises(Exception):
+            with self.assertRaises(ApiException):
                 await self.client.create_sandbox(
                     "test-warmpool",
                     "test-namespace",
@@ -192,6 +212,55 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                     adopt_existing=True,
                 )
 
+            mock_delete.assert_not_called()
+
+    async def test_create_sandbox_generated_name_cleanup_when_create_fails(self):
+        # A generated name is unambiguously ours: even when the create call
+        # itself errors (it may have persisted server-side), clean up best-effort
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=500)), \
+             patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
+
+            with self.assertRaises(ApiException):
+                await self.client.create_sandbox("test-warmpool", "test-namespace")
+
+            mock_delete.assert_called_once()
+
+    async def test_create_sandbox_explicit_name_no_cleanup_when_create_fails(self):
+        # An explicit name may belong to a prior attempt; without a confirmed
+        # create, never delete it
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=500)), \
+             patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
+
+            with self.assertRaises(ApiException):
+                await self.client.create_sandbox(
+                    "test-warmpool", "test-namespace", claim_name="sandbox-my-task"
+                )
+
+            mock_delete.assert_not_called()
+
+    async def test_create_sandbox_adopted_claim_not_deleted_on_failure(self):
+        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(
+            side_effect=Exception("Timeout")
+        )
+        self.mock_k8s_helper.get_sandbox_claim = AsyncMock(
+            return_value={"spec": {"warmPoolRef": {"name": "test-warmpool"}}}
+        )
+
+        with patch.object(self.client, "_create_claim", new_callable=AsyncMock,
+                          side_effect=ApiException(status=409)), \
+             patch.object(self.client, "_delete_claim", new_callable=AsyncMock) as mock_delete:
+
+            with self.assertRaises(Exception) as ctx:
+                await self.client.create_sandbox(
+                    "test-warmpool",
+                    "test-namespace",
+                    claim_name="sandbox-my-task",
+                    adopt_existing=True,
+                )
+
+            self.assertEqual(str(ctx.exception), "Timeout")
             # An adopted claim belongs to a prior attempt — never delete it on failure
             mock_delete.assert_not_called()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -132,6 +132,9 @@ class TestSandboxClient(unittest.TestCase):
 
     def test_create_sandbox_adopts_existing_claim_on_409(self):
         self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+        self.mock_k8s_helper.get_sandbox_claim.return_value = {
+            "spec": {"warmPoolRef": {"name": "test-warmpool"}}
+        }
         mock_sandbox_instance = MagicMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
 
@@ -148,6 +151,23 @@ class TestSandboxClient(unittest.TestCase):
             self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with(
                 "sandbox-my-task", "test-namespace", 180
             )
+
+    def test_create_sandbox_adopt_rejects_warmpool_mismatch(self):
+        self.mock_k8s_helper.get_sandbox_claim.return_value = {
+            "spec": {"warmPoolRef": {"name": "other-warmpool"}}
+        }
+
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=409)):
+            with self.assertRaises(ValueError) as ctx:
+                self.client.create_sandbox(
+                    "test-warmpool",
+                    "test-namespace",
+                    claim_name="sandbox-my-task",
+                    adopt_existing=True,
+                )
+        self.assertIn("Refusing to adopt", str(ctx.exception))
+        # The mismatched claim belongs to someone else — never delete it
+        self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
 
     def test_create_sandbox_409_raises_without_adopt_existing(self):
         with patch.object(self.client, '_create_claim', side_effect=ApiException(status=409)):
@@ -169,17 +189,44 @@ class TestSandboxClient(unittest.TestCase):
                 )
         self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
 
+    @patch('uuid.uuid4')
+    def test_create_sandbox_generated_name_cleanup_when_create_fails(self, mock_uuid):
+        mock_uuid.return_value.hex = '1234abcd'
+
+        # A generated name is unambiguously ours: even when the create call
+        # itself errors (it may have persisted server-side), clean up best-effort
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=500)):
+            with self.assertRaises(ApiException):
+                self.client.create_sandbox("test-warmpool", "test-namespace")
+        self.mock_k8s_helper.delete_sandbox_claim.assert_called_once_with(
+            "sandbox-claim-1234abcd", "test-namespace"
+        )
+
+    def test_create_sandbox_explicit_name_no_cleanup_when_create_fails(self):
+        # An explicit name may belong to a prior attempt; without a confirmed
+        # create, never delete it
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=500)):
+            with self.assertRaises(ApiException):
+                self.client.create_sandbox(
+                    "test-warmpool", "test-namespace", claim_name="sandbox-my-task"
+                )
+        self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
+
     def test_create_sandbox_adopted_claim_not_deleted_on_failure(self):
         self.mock_k8s_helper.resolve_sandbox_name.side_effect = Exception("Timeout Error")
+        self.mock_k8s_helper.get_sandbox_claim.return_value = {
+            "spec": {"warmPoolRef": {"name": "test-warmpool"}}
+        }
 
         with patch.object(self.client, '_create_claim', side_effect=ApiException(status=409)):
-            with self.assertRaises(Exception):
+            with self.assertRaises(Exception) as context:
                 self.client.create_sandbox(
                     "test-warmpool",
                     "test-namespace",
                     claim_name="sandbox-my-task",
                     adopt_existing=True,
                 )
+        self.assertEqual(str(context.exception), "Timeout Error")
         # An adopted claim belongs to a prior attempt — never delete it on failure
         self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
 
@@ -512,6 +559,14 @@ class TestSandboxClient(unittest.TestCase):
     def test_validate_claim_name_rejects_too_long(self):
         with self.assertRaises(ValueError) as ctx:
             validate_claim_name("a" * 254)
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    def test_validate_claim_name_accepts_max_length_label(self):
+        validate_claim_name("a" * 63 + ".example")
+
+    def test_validate_claim_name_rejects_too_long_label(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("a" * 64 + ".example")
         self.assertIn("DNS-1123", str(ctx.exception))
 
     def test_wait_for_sandbox_ready(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -24,9 +24,10 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
 from k8s_agent_sandbox.sandbox_client import SandboxClient
 from k8s_agent_sandbox.connector import SandboxConnector
-from k8s_agent_sandbox.pod_metadata import validate_labels
+from k8s_agent_sandbox.pod_metadata import validate_claim_name, validate_labels
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
     SandboxInClusterConnectionConfig,
@@ -96,6 +97,91 @@ class TestSandboxClient(unittest.TestCase):
             self.assertEqual(str(context.exception), "Timeout Error")
             # Ensure delete_sandbox_claim is called to cleanup orphan claim on failure
             self.mock_k8s_helper.delete_sandbox_claim.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace")
+
+    def test_create_sandbox_with_explicit_claim_name(self):
+        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+        mock_sandbox_instance = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        with patch.object(self.client, '_create_claim') as mock_create_claim, \
+             patch.object(self.client, '_wait_for_sandbox_ready'):
+            sandbox = self.client.create_sandbox(
+                "test-warmpool", "test-namespace", claim_name="sandbox-my-task"
+            )
+
+            mock_create_claim.assert_called_once_with(
+                "sandbox-my-task",
+                "test-warmpool",
+                "test-namespace",
+                labels=None,
+                lifecycle=None,
+                volume_claim_templates=None,
+                pod_metadata=None,
+            )
+            self.assertEqual(sandbox, mock_sandbox_instance)
+            self.assertIn(
+                ("test-namespace", "sandbox-my-task"),
+                self.client._active_connection_sandboxes,
+            )
+
+    def test_create_sandbox_rejects_invalid_claim_name(self):
+        with self.assertRaises(ValueError) as ctx:
+            self.client.create_sandbox("test-warmpool", claim_name="Invalid_Name")
+        self.assertIn("DNS-1123", str(ctx.exception))
+        self.mock_k8s_helper.create_sandbox_claim.assert_not_called()
+
+    def test_create_sandbox_adopts_existing_claim_on_409(self):
+        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+        mock_sandbox_instance = MagicMock()
+        self.mock_sandbox_class.return_value = mock_sandbox_instance
+
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=409)), \
+             patch.object(self.client, '_wait_for_sandbox_ready'):
+            sandbox = self.client.create_sandbox(
+                "test-warmpool",
+                "test-namespace",
+                claim_name="sandbox-my-task",
+                adopt_existing=True,
+            )
+
+            self.assertEqual(sandbox, mock_sandbox_instance)
+            self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with(
+                "sandbox-my-task", "test-namespace", 180
+            )
+
+    def test_create_sandbox_409_raises_without_adopt_existing(self):
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=409)):
+            with self.assertRaises(ApiException):
+                self.client.create_sandbox(
+                    "test-warmpool", "test-namespace", claim_name="sandbox-my-task"
+                )
+        # The claim was never created by this call, so there is nothing to clean up
+        self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
+
+    def test_create_sandbox_non_409_not_adopted(self):
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=403)):
+            with self.assertRaises(ApiException):
+                self.client.create_sandbox(
+                    "test-warmpool",
+                    "test-namespace",
+                    claim_name="sandbox-my-task",
+                    adopt_existing=True,
+                )
+        self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
+
+    def test_create_sandbox_adopted_claim_not_deleted_on_failure(self):
+        self.mock_k8s_helper.resolve_sandbox_name.side_effect = Exception("Timeout Error")
+
+        with patch.object(self.client, '_create_claim', side_effect=ApiException(status=409)):
+            with self.assertRaises(Exception):
+                self.client.create_sandbox(
+                    "test-warmpool",
+                    "test-namespace",
+                    claim_name="sandbox-my-task",
+                    adopt_existing=True,
+                )
+        # An adopted claim belongs to a prior attempt — never delete it on failure
+        self.mock_k8s_helper.delete_sandbox_claim.assert_not_called()
 
     def test_get_sandbox_existing_active(self):
         mock_sandbox = MagicMock()
@@ -392,6 +478,41 @@ class TestSandboxClient(unittest.TestCase):
 
     def test_validate_labels_accepts_valid(self):
         validate_labels({"agent": "code-agent", "team": "platform-123"})
+
+    def test_validate_claim_name_accepts_valid(self):
+        validate_claim_name("sandbox-task-123")
+        validate_claim_name("a")
+        validate_claim_name("sandbox.task-1.example")
+
+    def test_validate_claim_name_rejects_empty(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("")
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    def test_validate_claim_name_rejects_uppercase(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("Sandbox-Task")
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    def test_validate_claim_name_rejects_underscore(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("sandbox_task")
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    def test_validate_claim_name_rejects_leading_hyphen(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("-leading")
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    def test_validate_claim_name_rejects_trailing_hyphen(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("trailing-")
+        self.assertIn("DNS-1123", str(ctx.exception))
+
+    def test_validate_claim_name_rejects_too_long(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_claim_name("a" * 254)
+        self.assertIn("DNS-1123", str(ctx.exception))
 
     def test_wait_for_sandbox_ready(self):
         self.client._wait_for_sandbox_ready("sandbox-id", "test-namespace", 45)


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds two backward-compatible, keyword-only parameters to the Python SDK's `SandboxClient.create_sandbox()` and `AsyncSandboxClient.create_sandbox()`:

- **`claim_name: str | None = None`** — an optional explicit name for the SandboxClaim, validated as a DNS-1123 subdomain (new shared `validate_claim_name` in `pod_metadata.py`). When omitted, the existing random `sandbox-claim-<uuid8>` name is generated, exactly as today.
- **`adopt_existing: bool = False`** — when True, a `409 AlreadyExists` from claim creation attaches to the existing claim (continuing into the normal resolve → wait-for-ready path) instead of raising.

Together these make sandbox creation idempotent for callers driving lifecycle from durable-workflow engines (Restate, Temporal, Step Functions, ...), which execute steps with at-least-once semantics. Today a re-executed step generates a fresh random name and creates a second sandbox, orphaning the first. With a deterministic `claim_name` derived from the workflow's own id and `adopt_existing=True`, the first attempt creates the claim and a retry adopts it:

```python
sandbox = client.create_sandbox(
    warmpool="python-sandbox-pool",
    namespace="agents",
    claim_name=f"sandbox-{task_id}",   # derived from the workflow's own id
    adopt_existing=True,               # 409 on retry -> attach, not error
)
```

The failure-cleanup path is updated to only delete claims **this call actually created**: deleting an *adopted* claim on a later failure (e.g. ready-timeout) would tear down a sandbox owned by a prior successful attempt.

Default behavior is unchanged: no `claim_name` → random name; `adopt_existing=False` → 409 raises as today.

Includes unit tests for both clients (explicit name plumbed through to claim creation, DNS-1123 rejection, adopt-on-409, 409 still raising without opt-in, non-409 errors never adopted, and adopted claims surviving failure cleanup) plus `validate_claim_name` cases.

#### Which issue(s) this PR is related to:

Fixes #1089

#### Release Note

```release-note
Python SDK: `create_sandbox` (sync and async) now accepts optional keyword-only `claim_name` and `adopt_existing` parameters, enabling idempotent, retry-safe sandbox creation with deterministic claim names.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now provide an explicit sandbox claim name when creating a sandbox.
  * Existing claims can be safely adopted during creation, improving retry behavior.

* **Bug Fixes**
  * Claim names are now validated against Kubernetes naming rules before use.
  * Failed sandbox creation no longer deletes a claim that was already present and adopted.
  * Conflicts from pre-existing claims are handled more gracefully instead of always failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->