### PR TITLE
fix: correct typos in TODO comments (#1082)

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -840,7 +840,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil, err
 		}
 
-		// TODO - Do we enfore (change) spec if a pod exists ?
+		// TODO - Do we enforce (change) spec if a pod exists ?
 		// r.Patch(ctx, pod, client.Apply, client.ForceOwnership, client.FieldOwner("sandbox-controller"))
 		return pod, nil
 	}

--- a/dev/load-test/test-recipes/warmpool-burst-test.yaml
+++ b/dev/load-test/test-recipes/warmpool-burst-test.yaml
@@ -54,7 +54,7 @@ steps:
       labelSelector: "agents.x-k8s.io/pool"
 
 # --- 2. DRAIN WARMPOOL (Excluded from Cold Measurement) ---
-# TODO: Add a measurement once we have the metric to measure acquistion from warmpool.
+# TODO: Add a measurement once we have the metric to measure acquisition from warmpool.
 - name: Claim with Warmpool
   phases:
   - name: Drain Pool


### PR DESCRIPTION
Thanks for the confirmation! Closing as superseded by #1084 which already merged the fix on 2026-07-07. Thanks for the opportunity to contribute!