### PR TITLE
Introduces --manage-webhook-certs allow disabling in-binary certificate management and CRD patching

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -87,7 +87,7 @@ func main() {
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory that contains the certificates.")
 	flag.StringVar(&webhookServiceName, "webhook-service-name", "agent-sandbox-webhook-service", "The name of the webhook service.")
 	flag.StringVar(&webhookNamespace, "webhook-namespace", "agent-sandbox-system", "The namespace of the webhook service.")
-	flag.BoolVar(&manageWebhookCerts, "manage-webhook-certs", true, "Enable the controller to automatically generate certificates and patch CRDs. Set to false if certificates and webhooks are managed externally (e.g., in GKE).")
+	flag.BoolVar(&manageWebhookCerts, "manage-webhook-certs", true, "Manage webhook serving certs and patch CRD conversion caBundles on startup. Set to false when certs and CRD/webhook configuration are managed externally (e.g., GKE Dynamic Certificate Delivery).")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -262,7 +262,11 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		setupLog.Info("Webhook certificate management and CRD patching is disabled")
+		setupLog.Info("Webhook cert management and CRD conversion caBundle patching disabled; expecting existing tls.crt/tls.key in certDir and CRDs patched externally",
+			"certDir", webhookCertDir,
+			"serviceName", webhookServiceName,
+			"namespace", webhookNamespace,
+		)
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -267,6 +268,14 @@ func main() {
 			"serviceName", webhookServiceName,
 			"namespace", webhookNamespace,
 		)
+		for _, f := range []string{"tls.crt", "tls.key"} {
+			p := filepath.Join(webhookCertDir, f)
+			if _, err := os.Stat(p); err != nil {
+				setupLog.Error(err, "required webhook cert file missing", "path", p,
+					"hint", "with --manage-webhook-certs=false you must pre-provision tls.crt/tls.key via cert-manager, GKE, or similar")
+				os.Exit(1)
+			}
+		}
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -80,12 +80,14 @@ func main() {
 	var webhookCertDir string
 	var webhookServiceName string
 	var webhookNamespace string
+	var manageWebhookCerts bool
 
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook server binds to.")
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs", "The directory that contains the certificates.")
 	flag.StringVar(&webhookServiceName, "webhook-service-name", "agent-sandbox-webhook-service", "The name of the webhook service.")
 	flag.StringVar(&webhookNamespace, "webhook-namespace", "agent-sandbox-system", "The namespace of the webhook service.")
+	flag.BoolVar(&manageWebhookCerts, "manage-webhook-certs", true, "Enable the controller to automatically generate certificates and patch CRDs. Set to false if certificates and webhooks are managed externally (e.g., in GKE).")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -238,25 +240,29 @@ func main() {
 	restConfig.QPS = float32(kubeAPIQPS)
 	restConfig.Burst = kubeAPIBurst
 
-	// Create a temporary client to patch the CRDs and access Secrets
-	tempClient, err := client.New(restConfig, client.Options{Scheme: scheme})
-	if err != nil {
-		setupLog.Error(err, "unable to create temporary client")
-		os.Exit(1)
-	}
+	if manageWebhookCerts {
+		// Create a temporary client to patch the CRDs and access Secrets
+		tempClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+		if err != nil {
+			setupLog.Error(err, "unable to create temporary client")
+			os.Exit(1)
+		}
 
-	// Generate or load self-signed TLS certificates for the webhook server
-	setupLog.Info("Preparing webhook certificates", "certDir", webhookCertDir)
-	caPEM, err := generateWebhookCerts(ctx, tempClient, webhookCertDir, webhookServiceName, webhookNamespace, clusterDomain)
-	if err != nil {
-		setupLog.Error(err, "unable to prepare webhook certificates")
-		os.Exit(1)
-	}
+		// Generate or load self-signed TLS certificates for the webhook server
+		setupLog.Info("Preparing webhook certificates", "certDir", webhookCertDir)
+		caPEM, err := generateWebhookCerts(ctx, tempClient, webhookCertDir, webhookServiceName, webhookNamespace, clusterDomain)
+		if err != nil {
+			setupLog.Error(err, "unable to prepare webhook certificates")
+			os.Exit(1)
+		}
 
-	setupLog.Info("Patching CRDs with generated CA bundle")
-	if err := patchCRDs(ctx, tempClient, caPEM, webhookServiceName, webhookNamespace); err != nil {
-		setupLog.Error(err, "failed to patch CRDs with CA bundle")
-		os.Exit(1)
+		setupLog.Info("Patching CRDs with generated CA bundle")
+		if err := patchCRDs(ctx, tempClient, caPEM, webhookServiceName, webhookNamespace); err != nil {
+			setupLog.Error(err, "failed to patch CRDs with CA bundle")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("Webhook certificate management and CRD patching is disabled")
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{


### PR DESCRIPTION
#### What this PR does / why we need it
This PR introduces the `--manage-webhook-certs` flag to `agent-sandbox-controller` to allow disabling in-binary certificate management and CRD patching:

- **`--manage-webhook-certs=true` (Default OSS behavior)**: The controller automatically generates self-signed TLS certificates, creates a Secret, and patches CRD `caBundle` fields on startup.
- **`--manage-webhook-certs=false`**: Skips in-binary certificate generation and CRD patching. This allows the controller to run in managed environments (such as GKE) where certificates and CRDs are managed externally by platform tooling (e.g., via GKE Auth / Dynamic Certificate Delivery).

#### Which issue(s) this PR fixes
N/A

#### Special notes for your reviewer
- **Backward Compatible**: The flag defaults to `true`. All existing OSS deployments, manifests, and Helm charts will continue to behave exactly as before with zero breaking changes.

#### How Has This Been Tested?
- Verified default execution (`--manage-webhook-certs=true`): Controller self-signs certificates and patches CRDs as normal.
- Verified external cert execution (`--manage-webhook-certs=false`): Controller skips self-signing and CRD patching, loading externally supplied TLS serving certificates without crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new startup option to control whether webhook TLS certificates are managed automatically.
  * When certificate management is disabled, the app now expects existing webhook certificate files and will clearly fail to start if they are missing.
  * Webhook certificate and CA bundle handling now supports both automated and externally provisioned setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->