### PR TITLE
fix(e2e,examples): pin debian base image, remove --no-first-run, add exec readiness probe

### DIFF
--- a/examples/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /chrome-sand
 
 #----------------------
 # Use a base image with a minimal set of packages.
-FROM debian:13-slim
+FROM debian:13-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 
 #----------------------
 # Install general prerequisite packages.

--- a/examples/chrome-sandbox/cmd/chrome-sandbox-entrypoint/main.go
+++ b/examples/chrome-sandbox/cmd/chrome-sandbox-entrypoint/main.go
@@ -32,7 +32,11 @@ func main() {
 	if len(os.Args) > 1 && os.Args[1] == "probe" {
 		client := &http.Client{Timeout: 2 * time.Second}
 		resp, err := client.Get("http://localhost:9222/json/version")
-		if err != nil || resp.StatusCode != http.StatusOK {
+		if err != nil {
+			os.Exit(1)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
 			os.Exit(1)
 		}
 		os.Exit(0)

--- a/examples/chrome-sandbox/cmd/chrome-sandbox-entrypoint/main.go
+++ b/examples/chrome-sandbox/cmd/chrome-sandbox-entrypoint/main.go
@@ -29,6 +29,14 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "probe" {
+		client := &http.Client{Timeout: 2 * time.Second}
+		resp, err := client.Get("http://localhost:9222/json/version")
+		if err != nil || resp.StatusCode != http.StatusOK {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 	ctx := context.Background()
 	if err := run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/examples/chrome-sandbox/scripts/start-chrome
+++ b/examples/chrome-sandbox/scripts/start-chrome
@@ -26,13 +26,13 @@ flags+=(--disable-gpu) # We don't (normally) have a GPU
 flags+=(--disable-dev-shm-usage) # We don't (normally) have a shared memory filesystem
 
 flags+=(--no-default-browser-check) # Avoids hanging with a "set chrome as default browser" dialog
-flags+=(--no-first-run) # Avoids hanging with a "set chrome as default browser" dialog
 
 flags+=(--start-maximized) # We're the only thing running, use the whole screen
 
 flags+=(--disable-field-trial-config) # Keeps things consistent and a little faster (?)
 
 flags+=(--remote-debugging-port=9222) # Enable remote debugging
+flags+=(--remote-debugging-address=0.0.0.0) # Allow external connections (required for Kubernetes readiness probes)
 flags+=(--user-data-dir=/tmp/chrome-data) # DevTools remote debugging requires a non-default data directory. Specify this using --user-data-dir.
 
 

--- a/examples/chrome-sandbox/scripts/start-chrome
+++ b/examples/chrome-sandbox/scripts/start-chrome
@@ -32,7 +32,6 @@ flags+=(--start-maximized) # We're the only thing running, use the whole screen
 flags+=(--disable-field-trial-config) # Keeps things consistent and a little faster (?)
 
 flags+=(--remote-debugging-port=9222) # Enable remote debugging
-flags+=(--remote-debugging-address=0.0.0.0) # Allow external connections (required for Kubernetes readiness probes)
 flags+=(--user-data-dir=/tmp/chrome-data) # DevTools remote debugging requires a non-default data directory. Specify this using --user-data-dir.
 
 

--- a/test/e2e/chromesandbox_test.go
+++ b/test/e2e/chromesandbox_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
@@ -79,6 +80,16 @@ func chromeSandbox(namespace string) *sandboxv1beta1.Sandbox {
 					Name:            "chrome-sandbox",
 					Image:           imageName,
 					ImagePullPolicy: corev1.PullIfNotPresent,
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/json/version",
+								Port: intstr.FromInt(9222),
+							},
+						},
+						InitialDelaySeconds: 1,
+						PeriodSeconds:       1,
+					},
 				},
 			},
 		},

--- a/test/e2e/chromesandbox_test.go
+++ b/test/e2e/chromesandbox_test.go
@@ -87,6 +87,7 @@ func chromeSandbox(namespace string) *sandboxv1beta1.Sandbox {
 						},
 						InitialDelaySeconds: 1,
 						PeriodSeconds:       1,
+						TimeoutSeconds:      2,
 					},
 				},
 			},

--- a/test/e2e/chromesandbox_test.go
+++ b/test/e2e/chromesandbox_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
@@ -82,9 +81,8 @@ func chromeSandbox(namespace string) *sandboxv1beta1.Sandbox {
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
-							HTTPGet: &corev1.HTTPGetAction{
-								Path: "/json/version",
-								Port: intstr.FromInt(9222),
+							Exec: &corev1.ExecAction{
+								Command: []string{"/chrome-sandbox-entrypoint", "probe"},
 							},
 						},
 						InitialDelaySeconds: 1,


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR resolves the e2e test CI failures by addressing both the upstream container startup crash and the underlying race condition:

1. **Pin base image & remove crashing Chromium flag (`examples/chrome-sandbox/`)**:
   - Pins `debian:13-slim` to sha256 `28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2` to prevent upstream unpinned package drift from breaking CI builds.
   - Removes `--no-first-run` from `start-chrome`. Recent upgrades to Chromium 150 in Debian Trixie cause this flag to trigger a fatal `Trace/breakpoint trap (core dumped)` (SIGTRAP) on startup, causing container CrashLoopBackOffs.

2. **Add Kubernetes Readiness Probe (`test/e2e/chromesandbox_test.go` & `cmd/chrome-sandbox-entrypoint/`)**:
   - Adds a `probe` subcommand to `/chrome-sandbox-entrypoint` that queries `http://localhost:9222/json/version` inside the pod network namespace.
   - Configures an Exec `ReadinessProbe` using `/chrome-sandbox-entrypoint probe` on the `chrome-sandbox` test Pod. Using an Exec probe instead of HTTPGet ensures connectivity to localhost without running into Chromium DevTools Host header verification or non-loopback binding restrictions.
   - Ensures Kubernetes holds back Pod readiness until Chromium finishes initializing DevTools, allowing `waitForChromeReady` and `tc.PortForward` to succeed cleanly on the first attempt without stderr spam or retry contention.

#### Which issue(s) this PR is related to:
fixes https://github.com/kubernetes-sigs/agent-sandbox/issues/1095

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chrome sandbox readiness by adding a readiness probe that verifies Chrome is reachable via `http://localhost:9222/json/version` before the pod is marked ready.
* **Chores**
  * Improved build reproducibility by updating the bundled sandbox image to a digest-pinned Debian base.
* **Chores**
  * Simplified Chromium startup by removing the `--no-first-run` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->