### PR TITLE
ci: add flake reporting, PR failure summaries, and fix-flakes automation

### DIFF
--- a/.agents/skills/fix-flakes/SKILL.md
+++ b/.agents/skills/fix-flakes/SKILL.md
@@ -28,9 +28,12 @@ whose failure output you have not read.
    Fetch a failing run's junit + build log from the GCS links to read the real
    error before touching anything.
 2. Locate the test: `git grep -n "func <TestName>("` (Go) or
-   `git grep -n "def <test_name>("` (Python SDK e2e).
+   `git grep -n "def <test_name>("` (Python SDK e2e). For a Go subtest
+   (`TestFoo/subtest`), grep for the parent (`func TestFoo(`) only — the part
+   before the first `/` — then find the `t.Run("subtest", ...)` inside it.
 3. Stress it:
    - Unit tests: `go test ./<package>/... -run '^<TestName>$' -race -count=50`
+     (for a subtest, `-run '^TestFoo$/^subtest$'`)
    - e2e tests need a cluster: `make deploy-kind` first (see AGENTS.md), then
      `go test ./test/e2e/... -run '^<TestName>$' -count=10` with
      `KUBECONFIG=bin/KUBECONFIG`.

--- a/.agents/skills/fix-flakes/SKILL.md
+++ b/.agents/skills/fix-flakes/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: fix-flakes
+description: Diagnose and fix flaky tests tracked as open kind/flake issues in kubernetes-sigs/agent-sandbox — reproduce the flake, apply a minimal fix, and open a PR linking the issue. Use when asked to fix a flake, work through kind/flake issues, or when run on a schedule after dev/tools/flake-report has filed flake issues.
+---
+
+# Fix flaky tests from kind/flake issues
+
+Work through open `kind/flake` issues (filed nightly by `dev/tools/flake-report`),
+reproduce each flake, land a minimal fix, and open a PR that closes the issue.
+Evidence before edits: never change a test you could not observe failing or
+whose failure output you have not read.
+
+## Inputs
+
+- A specific issue number, if the caller gives one; otherwise discover work:
+  `gh issue list --repo kubernetes-sigs/agent-sandbox --label kind/flake --state open --json number,title,body`
+- Skip any issue that already has an open fix PR: search
+  `gh pr list --repo kubernetes-sigs/agent-sandbox --state open --search "<issue number> in:body"`
+  and check the results actually reference `Fixes #<n>` / `Closes #<n>`.
+- Skip infra-failure issues (title contains "infrastructure failures") unless
+  explicitly asked — those are CI tooling work (`dev/ci/`, prow job config in
+  `kubernetes/test-infra`), not test edits. If you do take one, the fix lives in
+  `dev/ci/shared/runner.py` retries, image prepulls, or job resources.
+
+## Reproduce first
+
+1. Read the issue: test name, tab/job, failure timestamps, job-history link.
+   Fetch a failing run's junit + build log from the GCS links to read the real
+   error before touching anything.
+2. Locate the test: `git grep -n "func <TestName>("` (Go) or
+   `git grep -n "def <test_name>("` (Python SDK e2e).
+3. Stress it:
+   - Unit tests: `go test ./<package>/... -run '^<TestName>$' -race -count=50`
+   - e2e tests need a cluster: `make deploy-kind` first (see AGENTS.md), then
+     `go test ./test/e2e/... -run '^<TestName>$' -count=10` with
+     `KUBECONFIG=bin/KUBECONFIG`.
+4. If it will not reproduce locally after a reasonable stress run, do NOT
+   guess-fix. Analyze the CI failure output instead; if the cause is still
+   unclear, post your findings as a comment on the issue and stop.
+
+## Diagnose — the usual suspects
+
+- Missing eventual-consistency handling: asserting on controller-driven state
+  without polling. Fix by waiting with a deadline (see existing helpers in
+  `test/e2e/`), not by sleeping.
+- Timeouts tuned for fast machines: CI under Docker-in-Docker is slow. If a
+  timeout must grow, justify it in a comment; prefer replacing fixed sleeps
+  with polling.
+- Shared state between parallel tests: cluster-scoped resources, fixed names,
+  fixed ports. Namespace or randomize per test.
+- Ordering assumptions on lists/maps, time-of-day assumptions, leaked
+  goroutines from a previous test (`-race` output helps).
+
+## Fix and verify
+
+- Minimal diff, repo conventions (AGENTS.md). Never disable or skip a test to
+  make it green; quarantine decisions belong to maintainers on the issue.
+- Re-run the stress loop from "Reproduce" — it must pass repeatedly
+  (unit: `-count=50` clean; e2e: `-count=10` clean).
+- Run `make test-unit` (and the affected e2e suite if applicable).
+
+## Deliver
+
+- Branch `flake-fix/issue-<n>`, one issue per branch/PR.
+- Commit style matches recent history (e.g. `fix(e2e): wait for sandbox ready
+  in TestFoo (#<n>)`).
+- PR body: `Fixes #<n>`, the diagnosis in two or three sentences, and the
+  before/after stress-run evidence (command + result).
+- If the fix is a revert-worthy product bug rather than a test bug, say so on
+  the issue and file/label accordingly instead of papering over it in tests.
+
+## Scheduled / automated mode
+
+When invoked non-interactively (e.g. via `dev/tools/flake-fix` on cron):
+
+- Process at most the number of issues the caller specifies (default 1) so a
+  run stays bounded.
+- Only act on issues where reproduction or CI failure output confirms the
+  diagnosis; otherwise leave an analysis comment on the issue and move on.
+- Push the branch and open the PR autonomously, then report: issues examined,
+  PRs opened, issues commented, issues skipped and why.

--- a/dev/ci/shared/runner.py
+++ b/dev/ci/shared/runner.py
@@ -50,50 +50,25 @@ class TestRunner:
     def _get_repo_root(self):
         return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-    def run_with_retry(self, cmd, attempts=2):
-        """Runs a cluster-setup command, retrying on failure.
-
-        Bring-up steps (kind cluster creation, image push, deploys) fail
-        intermittently under CI's Docker-in-Docker; most red presubmit runs
-        die here before any test executes. Each step is safe to re-run
-        (create-kind-cluster is invoked with --recreate and the deploys are
-        idempotent applies), so one retry recovers transient failures without
-        masking persistent breakage.
-        """
-        if attempts < 1:
-            raise ValueError(f"attempts must be >= 1, got {attempts}")
-        result = None
-        for attempt in range(1, attempts + 1):
-            result = subprocess.run(cmd)
-            if result.returncode == 0:
-                return result
-            if attempt < attempts:
-                print(
-                    f"setup step {os.path.basename(cmd[0])} failed with exit code "
-                    f"{result.returncode}; retrying (attempt {attempt + 1} of {attempts})",
-                    file=sys.stderr,
-                )
-        return result
-
     def setup_cluster(self, args, extra_push_images_args=None):
         image_tag = os.environ["IMAGE_TAG"]
-        result = self.run_with_retry([f"{self.repo_root}/dev/tools/create-kind-cluster", self.name, "--recreate", "--kubeconfig", f"{self.repo_root}/bin/KUBECONFIG"])
+        result = subprocess.run([f"{self.repo_root}/dev/tools/create-kind-cluster", self.name, "--recreate", "--kubeconfig", f"{self.repo_root}/bin/KUBECONFIG"])
         if result.returncode != 0:
             return result
-
+        
         push_images_cmd = [f"{self.repo_root}/dev/tools/push-images", "--kind-cluster-name", self.name, "--image-prefix", args.image_prefix, "--image-tag", image_tag]
         if extra_push_images_args:
             push_images_cmd.extend(extra_push_images_args)
-        result = self.run_with_retry(push_images_cmd)
+        result = subprocess.run(push_images_cmd)
         if result.returncode != 0:
             return result
 
         if not getattr(args, "skip_initial_deploy", False):
-            result = self.run_with_retry([f"{self.repo_root}/dev/tools/deploy-to-kube", "--image-prefix", args.image_prefix, "--image-tag", image_tag, "--extensions"])
+            result = subprocess.run([f"{self.repo_root}/dev/tools/deploy-to-kube", "--image-prefix", args.image_prefix, "--image-tag", image_tag, "--extensions"])
             if result.returncode != 0:
                 return result
 
-        result = self.run_with_retry([f"{self.repo_root}/dev/tools/deploy-cloud-provider"])
+        result = subprocess.run([f"{self.repo_root}/dev/tools/deploy-cloud-provider"])
         return result
 
     def run_tests(self, args):

--- a/dev/ci/shared/runner.py
+++ b/dev/ci/shared/runner.py
@@ -60,6 +60,8 @@ class TestRunner:
         idempotent applies), so one retry recovers transient failures without
         masking persistent breakage.
         """
+        if attempts < 1:
+            raise ValueError(f"attempts must be >= 1, got {attempts}")
         result = None
         for attempt in range(1, attempts + 1):
             result = subprocess.run(cmd)

--- a/dev/ci/shared/runner.py
+++ b/dev/ci/shared/runner.py
@@ -50,25 +50,48 @@ class TestRunner:
     def _get_repo_root(self):
         return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+    def run_with_retry(self, cmd, attempts=2):
+        """Runs a cluster-setup command, retrying on failure.
+
+        Bring-up steps (kind cluster creation, image push, deploys) fail
+        intermittently under CI's Docker-in-Docker; most red presubmit runs
+        die here before any test executes. Each step is safe to re-run
+        (create-kind-cluster is invoked with --recreate and the deploys are
+        idempotent applies), so one retry recovers transient failures without
+        masking persistent breakage.
+        """
+        result = None
+        for attempt in range(1, attempts + 1):
+            result = subprocess.run(cmd)
+            if result.returncode == 0:
+                return result
+            if attempt < attempts:
+                print(
+                    f"setup step {os.path.basename(cmd[0])} failed with exit code "
+                    f"{result.returncode}; retrying (attempt {attempt + 1} of {attempts})",
+                    file=sys.stderr,
+                )
+        return result
+
     def setup_cluster(self, args, extra_push_images_args=None):
         image_tag = os.environ["IMAGE_TAG"]
-        result = subprocess.run([f"{self.repo_root}/dev/tools/create-kind-cluster", self.name, "--recreate", "--kubeconfig", f"{self.repo_root}/bin/KUBECONFIG"])
+        result = self.run_with_retry([f"{self.repo_root}/dev/tools/create-kind-cluster", self.name, "--recreate", "--kubeconfig", f"{self.repo_root}/bin/KUBECONFIG"])
         if result.returncode != 0:
             return result
-        
+
         push_images_cmd = [f"{self.repo_root}/dev/tools/push-images", "--kind-cluster-name", self.name, "--image-prefix", args.image_prefix, "--image-tag", image_tag]
         if extra_push_images_args:
             push_images_cmd.extend(extra_push_images_args)
-        result = subprocess.run(push_images_cmd)
+        result = self.run_with_retry(push_images_cmd)
         if result.returncode != 0:
             return result
 
         if not getattr(args, "skip_initial_deploy", False):
-            result = subprocess.run([f"{self.repo_root}/dev/tools/deploy-to-kube", "--image-prefix", args.image_prefix, "--image-tag", image_tag, "--extensions"])
+            result = self.run_with_retry([f"{self.repo_root}/dev/tools/deploy-to-kube", "--image-prefix", args.image_prefix, "--image-tag", image_tag, "--extensions"])
             if result.returncode != 0:
                 return result
 
-        result = subprocess.run([f"{self.repo_root}/dev/tools/deploy-cloud-provider"])
+        result = self.run_with_retry([f"{self.repo_root}/dev/tools/deploy-cloud-provider"])
         return result
 
     def run_tests(self, args):

--- a/dev/tools/flake-fix
+++ b/dev/tools/flake-fix
@@ -32,7 +32,8 @@ set -euo pipefail
 LIMIT=${LIMIT:-1}                                  # max issues to fix per run
 REPO=${REPO:-"kubernetes-sigs/agent-sandbox"}
 PUSH_REMOTE=${PUSH_REMOTE:-"origin"}               # where fix branches are pushed
-BASE_REMOTE=${BASE_REMOTE:-"upstream"}             # where main is fetched from
+BASE_REMOTE=${BASE_REMOTE:-"origin"}               # where main is fetched from; set to
+                                                   # e.g. "upstream" in fork checkouts
 # Adjust permission flags to taste for unattended runs.
 CLAUDE_FLAGS=${CLAUDE_FLAGS:-"--permission-mode acceptEdits"}
 

--- a/dev/tools/flake-fix
+++ b/dev/tools/flake-fix
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Local scheduled job that fixes flaky tests.
+#
+# Thin wrapper: all of the actual logic lives in the fix-flakes agent skill
+# (.agents/skills/fix-flakes/SKILL.md). This script just prepares a clean
+# worktree and invokes a headless agent with that skill, so the procedure is
+# reviewable/editable as a skill rather than baked into shell.
+#
+# Requires: gh (authenticated), git, claude. e2e reproduction additionally
+# needs docker + kind (see AGENTS.md).
+#
+# To run this in a crontab, provide absolute paths, e.g.:
+#   0 7 * * *  cd /path/to/agent-sandbox && dev/tools/flake-fix >> ~/flake-fix.log 2>&1
+# Pair it with the nightly report that files the issues this job consumes:
+#   0 6 * * *  cd /path/to/agent-sandbox && dev/tools/flake-report --update-issues
+
+LIMIT=${LIMIT:-1}                                  # max issues to fix per run
+REPO=${REPO:-"kubernetes-sigs/agent-sandbox"}
+PUSH_REMOTE=${PUSH_REMOTE:-"origin"}               # where fix branches are pushed
+BASE_REMOTE=${BASE_REMOTE:-"upstream"}             # where main is fetched from
+# Adjust permission flags to taste for unattended runs.
+CLAUDE_FLAGS=${CLAUDE_FLAGS:-"--permission-mode acceptEdits"}
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+git fetch "$BASE_REMOTE" main
+
+# Work in a throwaway worktree so a half-finished fix never dirties the main
+# checkout; the skill creates one flake-fix/issue-<n> branch per issue.
+worktree=$(mktemp -d)/agent-sandbox-flake-fix
+git worktree add --detach "$worktree" "$BASE_REMOTE/main"
+cleanup() {
+  git worktree remove --force "$worktree" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cd "$worktree"
+
+# shellcheck disable=SC2086
+claude -p $CLAUDE_FLAGS "Use the fix-flakes skill (.agents/skills/fix-flakes/SKILL.md) in scheduled mode.
+Repo: $REPO. Process at most $LIMIT open kind/flake issue(s).
+Push fix branches to the '$PUSH_REMOTE' remote and open PRs against $REPO main.
+Finish with the scheduled-mode report described in the skill."

--- a/dev/tools/flake-fix
+++ b/dev/tools/flake-fix
@@ -44,10 +44,12 @@ git fetch "$BASE_REMOTE" main
 
 # Work in a throwaway worktree so a half-finished fix never dirties the main
 # checkout; the skill creates one flake-fix/issue-<n> branch per issue.
-worktree=$(mktemp -d)/agent-sandbox-flake-fix
+worktree_parent=$(mktemp -d)
+worktree=$worktree_parent/agent-sandbox-flake-fix
 git worktree add --detach "$worktree" "$BASE_REMOTE/main"
 cleanup() {
   git worktree remove --force "$worktree" 2>/dev/null || true
+  rm -rf "$worktree_parent"
 }
 trap cleanup EXIT
 

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -42,9 +42,12 @@ from datetime import datetime, timezone
 TESTGRID = "https://testgrid.k8s.io"
 
 # TestGrid cell status values (see testgrid test_status proto).
-PASS_STATUSES = {1, 2, 3, 4}
-FAIL_STATUSES = {12}
+PASS_STATUSES = {1, 2, 3}  # PASS, PASS_WITH_ERRORS, PASS_WITH_SKIPS
+# All completed-failure shapes, not just FAIL=12: TIMED_OUT=9 (a common flake
+# shape under DinD), CATEGORIZED_FAIL=10, BUILD_FAIL=11, TOOL_FAIL=14.
+FAIL_STATUSES = {9, 10, 11, 12, 14}
 FLAKY_STATUS = 13  # failed, then passed on a rerun of the same column
+RUNNING_STATUS = 4  # still in flight: neither a pass nor a fail yet
 
 # Rows like "<job>.Overall" and "<job>.Pod" describe the prow job itself, not
 # an individual test.
@@ -177,8 +180,9 @@ def analyze_tab(dashboard, tab, window):
             "job_history": job_history,
         }
 
-        # Recent non-empty results all failing => hard breakage, not a flake.
-        recent = [s for s in statuses if s != 0][:3]
+        # Recent completed results all failing => hard breakage, not a flake.
+        # RUNNING cells haven't finished, so they say nothing either way.
+        recent = [s for s in statuses if s not in (0, RUNNING_STATUS)][:3]
         if recent and all(s in FAIL_STATUSES for s in recent):
             consistent.append(finding)
         elif (
@@ -358,7 +362,12 @@ def update_issues(repo, flaky, infra, dry_run):
             body = issue_body_for_flake(f, marker) + f"\n<!-- last-reported-failure={f['last_failure_ts']} -->\n"
             actions.append(f"update #{issue['number']}: {f['short']}")
             if not dry_run:
+                # Refresh the title too: it embeds the tab list, which goes
+                # stale when a flake spreads to another tab. Manually-filed
+                # issues were skipped above, so this only ever rewrites
+                # titles this tool created.
                 gh("issue", "edit", str(issue["number"]), "--repo", repo,
+                   "--title", f"[FLAKE] {f['short']} ({', '.join(f['tabs'])})",
                    "--body", body)
         else:
             body = issue_body_for_flake(f, marker) + f"\n<!-- last-reported-failure={f['last_failure_ts']} -->\n"

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nightly flake report for agent-sandbox Prow jobs.
+
+Pulls recent results from the TestGrid JSON API, classifies each failing test
+as flaky (intermittent), consistently failing, or an infrastructure failure
+(the job died before tests ran), and prints a markdown report.
+
+With --update-issues it also files or refreshes one `kind/flake` GitHub issue
+per flaky test, so the issue tracker is the durable state: reruns are
+idempotent and no local files are written. Requires `gh` to be authenticated
+for --update-issues.
+
+Typical cron usage:
+    dev/tools/flake-report --update-issues
+
+Read-only preview:
+    dev/tools/flake-report
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+
+TESTGRID = "https://testgrid.k8s.io"
+
+# TestGrid cell status values (see testgrid test_status proto).
+PASS_STATUSES = {1, 2, 3, 4}
+FAIL_STATUSES = {12}
+FLAKY_STATUS = 13  # failed, then passed on a rerun of the same column
+
+# Rows like "<job>.Overall" and "<job>.Pod" describe the prow job itself, not
+# an individual test.
+JOB_LEVEL_ROW = re.compile(r"\.(Overall|Pod)$")
+
+ISSUE_MARKER_PREFIX = "<!-- flake-report:test="
+INFRA_MARKER_PREFIX = "<!-- flake-report:infra-tab="
+
+
+def fetch_json(url):
+    # curl rather than urllib: python installs without CA bundles (common on
+    # macOS) fail TLS verification, and curl is already a repo-tooling
+    # prerequisite alongside gh and jq.
+    result = subprocess.run(
+        ["curl", "-fsSL", "--max-time", "60", url],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"fetch {url} failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def gh(*args, input_text=None):
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, input=input_text
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def list_tabs(dashboard):
+    summary = fetch_json(f"{TESTGRID}/{urllib.parse.quote(dashboard)}/summary")
+    return sorted(summary.keys())
+
+
+def decode_statuses(rle):
+    """Expands TestGrid's run-length-encoded status list into a flat list."""
+    out = []
+    for run in rle:
+        out.extend([run["value"]] * run["count"])
+    return out
+
+
+def short_name(test_name):
+    """'sigs.k8s.io/.../e2e.TestFoo' -> 'TestFoo', 'pytest.test_bar' -> 'test_bar'."""
+    return test_name.rsplit(".", 1)[-1]
+
+
+def analyze_tab(dashboard, tab, window):
+    """Returns (flaky, consistent, infra) findings for one TestGrid tab."""
+    table = fetch_json(
+        f"{TESTGRID}/{urllib.parse.quote(dashboard)}/table?"
+        + urllib.parse.urlencode({"tab": tab, "width": window})
+    )
+    tests = table.get("tests") or []
+    if not tests:
+        return [], [], None
+
+    changelists = table.get("changelists") or []
+    timestamps = table.get("timestamps") or []
+    # e.g. "kubernetes-ci-logs/pr-logs/directory/presubmit-agent-sandbox-e2e-test"
+    gcs_query = table.get("query", "")
+    job_history = f"https://prow.k8s.io/job-history/gs/{gcs_query}" if gcs_query else ""
+
+    rows = {t["name"]: decode_statuses(t["statuses"]) for t in tests}
+    overall = next((v for k, v in rows.items() if k.endswith(".Overall")), None)
+    test_rows = {k: v for k, v in rows.items() if not JOB_LEVEL_ROW.search(k)}
+    ncols = max((len(v) for v in rows.values()), default=0)
+
+    def cell(statuses, i):
+        return statuses[i] if i < len(statuses) else 0
+
+    # Columns where a large fraction of tests failed at once are a broken PR
+    # or an environment-wide breakage, not per-test flakiness; exclude them
+    # from flake counting so one bad run doesn't file dozens of issues.
+    mass_cols = set()
+    if test_rows:
+        threshold = max(3, len(test_rows) // 4)
+        for i in range(ncols):
+            failed = sum(1 for s in test_rows.values() if cell(s, i) in FAIL_STATUSES)
+            if failed >= threshold:
+                mass_cols.add(i)
+
+    flaky, consistent = [], []
+    for name, statuses in test_rows.items():
+        fail_cols = [i for i in range(ncols)
+                     if cell(statuses, i) in FAIL_STATUSES and i not in mass_cols]
+        pass_cols = [i for i in range(ncols) if cell(statuses, i) in PASS_STATUSES]
+        flaky_cells = [i for i in range(ncols) if cell(statuses, i) == FLAKY_STATUS]
+        if not fail_cols and not flaky_cells:
+            continue
+
+        # Definite flake: the same changelist (PR) both failed and passed this
+        # test across runs, i.e. a bare retest changed the outcome.
+        retest_flips = 0
+        if changelists:
+            by_cl = {}
+            for i in fail_cols:
+                if i < len(changelists):
+                    by_cl.setdefault(changelists[i], set()).add("fail")
+            for i in pass_cols:
+                if i < len(changelists):
+                    by_cl.setdefault(changelists[i], set()).add("pass")
+            retest_flips = sum(1 for v in by_cl.values() if v == {"fail", "pass"})
+
+        # On presubmit tabs a failure on a single PR is usually that PR's own
+        # bug; flakiness means failures spread across distinct changelists.
+        distinct_cls = len(
+            {changelists[i] for i in fail_cols if i < len(changelists)}
+        ) if changelists else len(fail_cols)
+
+        finding = {
+            "tab": tab,
+            "test": name,
+            "short": short_name(name),
+            "fails": len(fail_cols) + len(flaky_cells),
+            "passes": len(pass_cols),
+            "distinct_changelists": distinct_cls,
+            "retest_flips": retest_flips,
+            "flaky_cells": len(flaky_cells),
+            "last_failure_ts": max(
+                (timestamps[i] for i in fail_cols + flaky_cells if i < len(timestamps)),
+                default=0,
+            ),
+            "job_history": job_history,
+        }
+
+        # Recent non-empty results all failing => hard breakage, not a flake.
+        recent = [s for s in statuses if s != 0][:3]
+        if recent and all(s in FAIL_STATUSES for s in recent):
+            consistent.append(finding)
+        elif (
+            retest_flips
+            or flaky_cells
+            or (distinct_cls >= 2 and len(pass_cols) > len(fail_cols))
+        ):
+            flaky.append(finding)
+
+    # A flaky parent test drags all its failing subtests along; keep only the
+    # parent so we file one issue, not one per subtest.
+    parents = {f["test"] for f in flaky}
+    flaky = [
+        f for f in flaky
+        if not any(f["test"].startswith(p + "/") for p in parents if p != f["test"])
+    ]
+
+    # Infra failure: the job went red but no individual test failed in that
+    # column (cluster bring-up, image push, timeouts before junit was written).
+    # Only meaningful on tabs that report per-test rows; on junit-less tabs
+    # (lint, autogen) a red run is indistinguishable from a legitimately
+    # failing PR.
+    infra = None
+    if overall is not None and test_rows:
+        infra_cols = [
+            i
+            for i in range(ncols)
+            if cell(overall, i) in FAIL_STATUSES
+            and not any(cell(s, i) in FAIL_STATUSES for s in test_rows.values())
+        ]
+        total_red = sum(1 for i in range(ncols) if cell(overall, i) in FAIL_STATUSES)
+        if total_red:
+            infra = {
+                "tab": tab,
+                "red_runs": total_red,
+                "infra_runs": len(infra_cols),
+                "total_runs": sum(1 for i in range(ncols) if cell(overall, i) != 0),
+                "last_failure_ts": max(
+                    (timestamps[i] for i in infra_cols if i < len(timestamps)),
+                    default=0,
+                ),
+                "job_history": job_history,
+            }
+    return flaky, consistent, infra
+
+
+def fmt_ts(ms):
+    if not ms:
+        return "unknown"
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def render_report(dashboard, flaky, consistent, infra, window):
+    lines = [
+        f"# Flake report: {dashboard}",
+        f"Window: last {window} runs per tab. Generated from {TESTGRID}/{dashboard}.",
+        "",
+        "## Flaky tests",
+    ]
+    if flaky:
+        for f in sorted(flaky, key=lambda f: -f["fails"]):
+            lines.append(
+                f"- `{f['test']}` ({f['tab']}): {f['fails']} failure(s) across "
+                f"{f['distinct_changelists']} PR(s)/commit(s), {f['passes']} pass(es), "
+                f"{f['retest_flips']} retest flip(s); "
+                f"last failed {fmt_ts(f['last_failure_ts'])}"
+            )
+    else:
+        lines.append("- none detected")
+    lines += ["", "## Consistently failing (not flakes — investigate as breakage)"]
+    if consistent:
+        for f in consistent:
+            lines.append(f"- `{f['test']}` ({f['tab']}): failing at head")
+    else:
+        lines.append("- none")
+    lines += ["", "## Infrastructure failures (job failed before tests ran)"]
+    infra_tabs = [i for i in infra if i and i["infra_runs"]]
+    if infra_tabs:
+        for i in infra_tabs:
+            lines.append(
+                f"- {i['tab']}: {i['infra_runs']} of {i['red_runs']} red runs "
+                f"(out of {i['total_runs']} total) had no failing test — "
+                f"see {i['job_history']}"
+            )
+    else:
+        lines.append("- none")
+    return "\n".join(lines) + "\n"
+
+
+def find_existing_issue(existing_issues, marker):
+    for issue in existing_issues:
+        if marker in issue.get("body", ""):
+            return issue
+    return None
+
+
+def issue_body_for_flake(f, marker):
+    return f"""{marker}
+**Flaky test detected by [`dev/tools/flake-report`](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/dev/tools/flake-report).**
+
+| | |
+|---|---|
+| Test | `{f['test']}` |
+| Job tab | `{f['tab']}` |
+| Failures in window | {f['fails']} (vs {f['passes']} passes) |
+| Retest flips (same PR failed then passed) | {f['retest_flips']} |
+| Last failure | {fmt_ts(f['last_failure_ts'])} |
+| Job history | {f['job_history']} |
+
+A retest flip means the same PR/commit failed this test and then passed it on
+a bare rerun — a definite flake, not a product regression.
+
+To pick this up, follow the `fix-flakes` agent skill in
+[`.agents/skills/fix-flakes/`](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/.agents/skills/fix-flakes)
+or triage manually per [docs/testing.md](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/docs/testing.md).
+
+/kind flake
+"""
+
+
+def update_issues(repo, flaky, infra, dry_run):
+    existing = json.loads(
+        gh(
+            "issue", "list", "--repo", repo, "--label", "kind/flake",
+            "--state", "open", "--limit", "200", "--json", "number,title,body",
+        )
+    )
+    actions = []
+    for f in flaky:
+        marker = f"{ISSUE_MARKER_PREFIX}{f['test']} -->"
+        issue = find_existing_issue(existing, marker)
+        if issue:
+            # Only bump the issue when there is a failure newer than the last
+            # one we reported, so a quiet flake doesn't get daily noise.
+            m = re.search(r"last-reported-failure=(\d+)", issue["body"])
+            if m and int(m.group(1)) >= f["last_failure_ts"]:
+                actions.append(f"skip #{issue['number']} (no new failures): {f['short']}")
+                continue
+            body = issue_body_for_flake(f, marker) + f"\n<!-- last-reported-failure={f['last_failure_ts']} -->\n"
+            actions.append(f"update #{issue['number']}: {f['short']}")
+            if not dry_run:
+                gh("issue", "edit", str(issue["number"]), "--repo", repo,
+                   "--body", body)
+        else:
+            body = issue_body_for_flake(f, marker) + f"\n<!-- last-reported-failure={f['last_failure_ts']} -->\n"
+            actions.append(f"create: [FLAKE] {f['short']}")
+            if not dry_run:
+                gh("issue", "create", "--repo", repo,
+                   "--title", f"[FLAKE] {f['short']} ({f['tab']})",
+                   "--label", "kind/flake", "--body", body)
+
+    for i in infra:
+        if not i or not i["infra_runs"]:
+            continue
+        marker = f"{INFRA_MARKER_PREFIX}{i['tab']} -->"
+        issue = find_existing_issue(existing, marker)
+        body = f"""{marker}
+**Infrastructure flakes detected by `dev/tools/flake-report`** on `{i['tab']}`:
+{i['infra_runs']} of {i['red_runs']} recent red runs failed before any test ran
+(cluster bring-up, image push, or job timeout — no failing test in junit).
+
+Job history: {i['job_history']}
+
+These are not fixed by editing tests; look at `dev/ci/shared/runner.py` retries,
+image prepulls, or job resources. Note the count is an upper bound: a PR that
+fails before tests run (e.g. does not compile) also produces a red run with no
+junit failures.
+
+/kind flake
+<!-- last-reported-failure={i['last_failure_ts']} -->
+"""
+        if issue:
+            m = re.search(r"last-reported-failure=(\d+)", issue["body"])
+            if m and int(m.group(1)) >= i["last_failure_ts"]:
+                actions.append(f"skip #{issue['number']} (no new failures): infra {i['tab']}")
+                continue
+            actions.append(f"update #{issue['number']}: infra {i['tab']}")
+            if not dry_run:
+                gh("issue", "edit", str(issue["number"]), "--repo", repo, "--body", body)
+        else:
+            actions.append(f"create: [FLAKE] {i['tab']}: infra failures before tests ran")
+            if not dry_run:
+                gh("issue", "create", "--repo", repo,
+                   "--title", f"[FLAKE] {i['tab']}: infrastructure failures before tests ran",
+                   "--label", "kind/flake", "--body", body)
+    return actions
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dashboard", default="sig-apps-agent-sandbox")
+    parser.add_argument("--tabs", default="all",
+                        help="comma-separated TestGrid tab names, or 'all'")
+    parser.add_argument("--window", type=int, default=100,
+                        help="how many recent runs per tab to analyze")
+    parser.add_argument("--repo", default="kubernetes-sigs/agent-sandbox")
+    parser.add_argument("--min-flakes", type=int, default=2,
+                        help="minimum flake events before an issue is filed "
+                             "(retest flips always qualify)")
+    parser.add_argument("--update-issues", action="store_true",
+                        help="file/refresh kind/flake GitHub issues (default: report only)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="with --update-issues, print planned issue actions only")
+    parser.add_argument("--json", dest="json_out", metavar="PATH",
+                        help="also write findings as JSON to PATH ('-' for stdout)")
+    args = parser.parse_args()
+
+    tabs = list_tabs(args.dashboard) if args.tabs == "all" else args.tabs.split(",")
+    flaky, consistent, infra = [], [], []
+    for tab in tabs:
+        try:
+            f, c, i = analyze_tab(args.dashboard, tab, args.window)
+        except Exception as e:  # a missing/renamed tab shouldn't kill the report
+            print(f"warning: skipping tab {tab}: {e}", file=sys.stderr)
+            continue
+        flaky += f
+        consistent += c
+        infra.append(i)
+
+    report = render_report(args.dashboard, flaky, consistent, infra, args.window)
+    print(report)
+
+    if args.json_out:
+        payload = json.dumps(
+            {"flaky": flaky, "consistent": consistent,
+             "infra": [i for i in infra if i]}, indent=2)
+        if args.json_out == "-":
+            print(payload)
+        else:
+            with open(args.json_out, "w") as fh:
+                fh.write(payload)
+
+    if args.update_issues:
+        issue_worthy = [
+            f for f in flaky
+            if f["retest_flips"] or f["flaky_cells"] or f["fails"] >= args.min_flakes
+        ]
+        actions = update_issues(args.repo, issue_worthy, infra, args.dry_run)
+        prefix = "[dry-run] " if args.dry_run else ""
+        for a in actions:
+            print(f"{prefix}{a}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -139,23 +139,27 @@ def analyze_tab(dashboard, tab, window):
             continue
 
         # Definite flake: the same changelist (PR) both failed and passed this
-        # test across runs, i.e. a bare retest changed the outcome.
+        # test across runs, i.e. a bare retest changed the outcome. Periodic
+        # tabs report changelists as empty strings — those runs aren't the
+        # same PR, so they must not be grouped as one changelist.
         retest_flips = 0
         if changelists:
             by_cl = {}
             for i in fail_cols:
-                if i < len(changelists):
+                if i < len(changelists) and changelists[i]:
                     by_cl.setdefault(changelists[i], set()).add("fail")
             for i in pass_cols:
-                if i < len(changelists):
+                if i < len(changelists) and changelists[i]:
                     by_cl.setdefault(changelists[i], set()).add("pass")
             retest_flips = sum(1 for v in by_cl.values() if v == {"fail", "pass"})
 
         # On presubmit tabs a failure on a single PR is usually that PR's own
         # bug; flakiness means failures spread across distinct changelists.
-        distinct_cls = len(
-            {changelists[i] for i in fail_cols if i < len(changelists)}
-        ) if changelists else len(fail_cols)
+        # Without usable changelists (periodics), every failing run is a
+        # distinct commit, so count the runs themselves.
+        fail_cls = {changelists[i] for i in fail_cols
+                    if i < len(changelists) and changelists[i]}
+        distinct_cls = len(fail_cls) if fail_cls else len(fail_cols)
 
         finding = {
             "tab": tab,
@@ -264,10 +268,21 @@ def render_report(dashboard, flaky, consistent, infra, window):
     return "\n".join(lines) + "\n"
 
 
-def find_existing_issue(existing_issues, marker):
+def find_existing_issue(existing_issues, marker, test_name=None):
+    """Finds the open issue tracking a flake, or None.
+
+    Matches our own HTML marker first; falls back to the `[FLAKE] <name>`
+    title convention so a manually filed issue doesn't get a duplicate.
+    """
     for issue in existing_issues:
         if marker in issue.get("body", ""):
             return issue
+    if test_name:
+        names = {test_name, test_name.split("/", 1)[0]}
+        for issue in existing_issues:
+            m = re.match(r"\[FLAKE\]\s+(\S+)", issue.get("title", ""))
+            if m and m.group(1) in names:
+                return issue
     return None
 
 
@@ -326,7 +341,13 @@ def update_issues(repo, flaky, infra, dry_run):
     actions = []
     for f in merge_flaky_by_test(flaky):
         marker = f"{ISSUE_MARKER_PREFIX}{f['test']} -->"
-        issue = find_existing_issue(existing, marker)
+        issue = find_existing_issue(existing, marker, f["short"])
+        if issue and marker not in issue.get("body", ""):
+            # Matched by title only: a maintainer filed it by hand. Don't
+            # clobber their body with our template — just don't duplicate it.
+            actions.append(
+                f"skip #{issue['number']} (manually filed): {f['short']}")
+            continue
         if issue:
             # Only bump the issue when there is a failure newer than the last
             # one we reported, so a quiet flake doesn't get daily noise.

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -339,7 +339,7 @@ def update_issues(repo, flaky, infra, dry_run):
         )
     )
     actions = []
-    for f in merge_flaky_by_test(flaky):
+    for f in flaky:
         marker = f"{ISSUE_MARKER_PREFIX}{f['test']} -->"
         issue = find_existing_issue(existing, marker, f["short"])
         if issue and marker not in issue.get("body", ""):
@@ -458,8 +458,10 @@ def main():
                 fh.write(payload)
 
     if args.update_issues:
+        # Merge per-tab findings before thresholding so a test flaking a
+        # little in several tabs is judged on its total occurrence count.
         issue_worthy = [
-            f for f in flaky
+            f for f in merge_flaky_by_test(flaky)
             if f["retest_flips"] or f["flaky_cells"] or f["fails"] >= args.min_flakes
         ]
         actions = update_issues(args.repo, issue_worthy, infra, args.dry_run)

--- a/dev/tools/flake-report
+++ b/dev/tools/flake-report
@@ -271,6 +271,27 @@ def find_existing_issue(existing_issues, marker):
     return None
 
 
+def merge_flaky_by_test(flaky):
+    """Merges findings for the same test across tabs into one entry.
+
+    One flaky test gets exactly one issue even when it flakes in several
+    jobs; the issue tracks the full set of affected tabs.
+    """
+    merged = {}
+    for f in flaky:
+        m = merged.get(f["test"])
+        if m is None:
+            merged[f["test"]] = dict(f, tabs=[f["tab"]],
+                                     job_histories=[f["job_history"]])
+            continue
+        for key in ("fails", "passes", "retest_flips", "flaky_cells"):
+            m[key] += f[key]
+        m["last_failure_ts"] = max(m["last_failure_ts"], f["last_failure_ts"])
+        m["tabs"].append(f["tab"])
+        m["job_histories"].append(f["job_history"])
+    return list(merged.values())
+
+
 def issue_body_for_flake(f, marker):
     return f"""{marker}
 **Flaky test detected by [`dev/tools/flake-report`](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/dev/tools/flake-report).**
@@ -278,11 +299,11 @@ def issue_body_for_flake(f, marker):
 | | |
 |---|---|
 | Test | `{f['test']}` |
-| Job tab | `{f['tab']}` |
+| Job tab(s) | {', '.join(f'`{t}`' for t in f['tabs'])} |
 | Failures in window | {f['fails']} (vs {f['passes']} passes) |
 | Retest flips (same PR failed then passed) | {f['retest_flips']} |
 | Last failure | {fmt_ts(f['last_failure_ts'])} |
-| Job history | {f['job_history']} |
+| Job history | {' • '.join(f['job_histories'])} |
 
 A retest flip means the same PR/commit failed this test and then passed it on
 a bare rerun — a definite flake, not a product regression.
@@ -303,7 +324,7 @@ def update_issues(repo, flaky, infra, dry_run):
         )
     )
     actions = []
-    for f in flaky:
+    for f in merge_flaky_by_test(flaky):
         marker = f"{ISSUE_MARKER_PREFIX}{f['test']} -->"
         issue = find_existing_issue(existing, marker)
         if issue:
@@ -323,7 +344,7 @@ def update_issues(repo, flaky, infra, dry_run):
             actions.append(f"create: [FLAKE] {f['short']}")
             if not dry_run:
                 gh("issue", "create", "--repo", repo,
-                   "--title", f"[FLAKE] {f['short']} ({f['tab']})",
+                   "--title", f"[FLAKE] {f['short']} ({', '.join(f['tabs'])})",
                    "--label", "kind/flake", "--body", body)
 
     for i in infra:
@@ -384,15 +405,23 @@ def main():
 
     tabs = list_tabs(args.dashboard) if args.tabs == "all" else args.tabs.split(",")
     flaky, consistent, infra = [], [], []
+    analyzed = 0
     for tab in tabs:
         try:
             f, c, i = analyze_tab(args.dashboard, tab, args.window)
         except Exception as e:  # a missing/renamed tab shouldn't kill the report
             print(f"warning: skipping tab {tab}: {e}", file=sys.stderr)
             continue
+        analyzed += 1
         flaky += f
         consistent += c
         infra.append(i)
+
+    if analyzed == 0:
+        # An all-tabs failure is an outage (or a broken dashboard name), not
+        # a clean "no flakes" result; don't let cron mistake it for success.
+        print("error: no TestGrid tabs could be analyzed", file=sys.stderr)
+        return 1
 
     report = render_report(args.dashboard, flaky, consistent, infra, args.window)
     print(report)

--- a/dev/tools/pr-failure-summary
+++ b/dev/tools/pr-failure-summary
@@ -49,7 +49,9 @@ LOG_TAIL_BYTES = 16384
 
 
 def run(cmd, input_text=None, check=True):
-    result = subprocess.run(cmd, capture_output=True, text=True, input=input_text)
+    # timeout so a hung API call can't wedge the whole cron run
+    result = subprocess.run(cmd, capture_output=True, text=True,
+                            input=input_text, timeout=120)
     if check and result.returncode != 0:
         raise RuntimeError(f"{' '.join(cmd[:3])}... failed: {result.stderr.strip()}")
     return result.stdout
@@ -72,14 +74,22 @@ def fetch(url, byte_range=None):
 
 
 def gcs_list(bucket, prefix):
-    url = (
-        f"https://storage.googleapis.com/storage/v1/b/{bucket}/o?"
-        + urllib.parse.urlencode({"prefix": prefix, "fields": "items(name)"})
-    )
-    data = fetch(url)
-    if not data:
-        return []
-    return [item["name"] for item in json.loads(data).get("items", [])]
+    names, page_token = [], None
+    while True:
+        params = {"prefix": prefix, "fields": "items(name),nextPageToken"}
+        if page_token:
+            params["pageToken"] = page_token
+        data = fetch(
+            f"https://storage.googleapis.com/storage/v1/b/{bucket}/o?"
+            + urllib.parse.urlencode(params)
+        )
+        if not data:
+            return names
+        payload = json.loads(data)
+        names += [item["name"] for item in payload.get("items", [])]
+        page_token = payload.get("nextPageToken")
+        if not page_token:
+            return names
 
 
 def gcs_read(bucket, name, byte_range=None):
@@ -90,7 +100,7 @@ def gcs_read(bucket, name, byte_range=None):
 
 
 def parse_junit(xml_text):
-    """Returns [(test_name, message)] for failed testcases in a junit file."""
+    """Returns [(classname, test_name, message)] for failed testcases."""
     failures = []
     try:
         root = ET.fromstring(xml_text)
@@ -100,7 +110,9 @@ def parse_junit(xml_text):
         for child in case:
             if child.tag in ("failure", "error"):
                 msg = (child.text or child.get("message") or "").strip()
-                failures.append((case.get("name", "?"), msg[:MAX_ERROR_CHARS]))
+                failures.append((case.get("classname", ""),
+                                 case.get("name", "?"),
+                                 msg[:MAX_ERROR_CHARS]))
                 break
     return failures
 
@@ -146,7 +158,7 @@ def collect_job_failures(job):
 
 
 def known_flakes(repo):
-    """Maps short test name -> issue number from open kind/flake issues."""
+    """Maps fully-qualified test name -> issue number from open kind/flake issues."""
     issues = json.loads(
         gh("issue", "list", "--repo", repo, "--label", "kind/flake",
            "--state", "open", "--limit", "200", "--json", "number,title,body")
@@ -155,26 +167,51 @@ def known_flakes(repo):
     for issue in issues:
         m = re.search(r"<!-- flake-report:test=(\S+) -->", issue.get("body", ""))
         if m:
-            mapping[m.group(1).rsplit(".", 1)[-1]] = issue["number"]
+            mapping[m.group(1)] = issue["number"]
         else:
-            # Fall back to the [FLAKE] <name> title convention.
+            # Fall back to the [FLAKE] <name> title convention (manual issues,
+            # usually a bare short name).
             t = re.match(r"\[FLAKE\]\s+(\S+)", issue.get("title", ""))
             if t:
                 mapping[t.group(1)] = issue["number"]
     return mapping
 
 
+def match_flake(classname, name, flakes):
+    """Finds the flake issue for a junit testcase, or None.
+
+    Prefer the fully-qualified identity (classname.name) so identically-named
+    tests in different packages don't cross-match; fall back to a short-name
+    match only when it's unambiguous across the known flakes.
+    """
+    base = name.split("/", 1)[0]  # go subtests share the parent's flake issue
+    full_ids = {f"{classname}.{name}", f"{classname}.{base}"} if classname else set()
+    for full, number in flakes.items():
+        if full in full_ids:
+            return number
+    candidates = {number for full, number in flakes.items()
+                  if full.rsplit(".", 1)[-1].split("/", 1)[0] == base}
+    if len(candidates) == 1:
+        return candidates.pop()
+    return None
+
+
+_source_dirs_cache = {}
+
+
 def test_source_dirs(test_name):
     """Best-effort map from a test name to repo dirs containing its source."""
     base = test_name.split("/", 1)[0]  # strip go subtest suffix
-    patterns = [f"func {base}(", f"def {base}("]
+    if base in _source_dirs_cache:
+        return _source_dirs_cache[base]
     dirs = set()
-    for pat in patterns:
+    for pat in (f"func {base}(", f"def {base}("):
         result = subprocess.run(
             ["git", "grep", "-l", "-F", pat], capture_output=True, text=True
         )
         for path in result.stdout.splitlines():
             dirs.add("/".join(path.split("/")[:2]))
+    _source_dirs_cache[base] = dirs
     return dirs
 
 
@@ -185,20 +222,40 @@ def pr_changed_dirs(repo, number):
     return {"/".join(f["path"].split("/")[:2]) for f in files}
 
 
-def classify(test_name, flakes, changed_dirs):
-    short = test_name.rsplit(".", 1)[-1].split("/", 1)[0]
-    if short in flakes:
-        return f"🎲 known flake ([#{flakes[short]}](https://github.com/kubernetes-sigs/agent-sandbox/issues/{flakes[short]})) — likely not caused by this PR", True
+def classify(classname, test_name, flakes, changed_dirs):
+    issue = match_flake(classname, test_name, flakes)
+    if issue:
+        return f"🎲 known flake ([#{issue}](https://github.com/kubernetes-sigs/agent-sandbox/issues/{issue})) — likely not caused by this PR", True
     overlap = test_source_dirs(test_name) & changed_dirs
     if overlap:
         return f"⚠️ exercises code this PR touches (`{sorted(overlap)[0]}`) — likely related to your change", False
     return "❓ not a known flake — check the error below", False
 
 
+def code_fence(text):
+    """A backtick fence longer than any backtick run in text, so junit output
+    containing ``` can't break out of the block and inject markdown."""
+    longest = max((len(m) for m in re.findall(r"`+", text)), default=0)
+    return "`" * max(3, longest + 1)
+
+
+def details_block(summary, text, max_lines=30):
+    fence = code_fence(text)
+    return ["", f"  <details><summary>{summary}</summary>", "",
+            f"  {fence}", *(f"  {l}" for l in text.splitlines()[:max_lines]),
+            f"  {fence}", "  </details>", ""]
+
+
 def build_comment(sha, jobs_summaries, all_known_flakes):
-    state = f"{sha[:12]}:" + hashlib.sha256(
-        ",".join(sorted(j["run_id"] for j, _, _ in jobs_summaries)).encode()
-    ).hexdigest()[:12]
+    # The state fingerprint includes the verdicts, not just the run IDs, so
+    # the comment refreshes when a failure later becomes a known flake (e.g.
+    # after the nightly flake-report files an issue for it).
+    fingerprint = ",".join(sorted(
+        [j["run_id"] for j, _, _ in jobs_summaries]
+        + [f"{name}:{verdict}" for _, failures, _ in jobs_summaries
+           for name, _, verdict, _ in failures]
+    ))
+    state = f"{sha[:12]}:" + hashlib.sha256(fingerprint.encode()).hexdigest()[:12]
     lines = [
         MARKER,
         f"<!-- state={state} -->",
@@ -211,9 +268,7 @@ def build_comment(sha, jobs_summaries, all_known_flakes):
             for name, msg, verdict, _ in failures:
                 lines.append(f"- `{name}` — {verdict}")
                 if msg:
-                    lines += ["", "  <details><summary>error</summary>", "",
-                              "  ```", *(f"  {l}" for l in msg.splitlines()[:30]),
-                              "  ```", "  </details>", ""]
+                    lines += details_block("error", msg)
         else:
             lines.append(
                 "- The job failed **before tests ran** (cluster bring-up / "
@@ -221,9 +276,7 @@ def build_comment(sha, jobs_summaries, all_known_flakes):
                 "not your change — comment `/retest`."
             )
             if log_tail:
-                lines += ["", "  <details><summary>end of build log</summary>", "",
-                          "  ```", *(f"  {l}" for l in log_tail.splitlines()),
-                          "  ```", "  </details>", ""]
+                lines += details_block("end of build log", log_tail, max_lines=25)
         lines.append("")
     if all_known_flakes:
         lines.append("**Every failure matches a known flake or infrastructure "
@@ -285,33 +338,41 @@ def main():
         )
 
     flakes = known_flakes(args.repo)
+    errors = 0
     for pr in prs:
         number, sha = pr["number"], pr["headRefOid"]
-        jobs = failing_prow_statuses(args.repo, sha)
-        if not jobs:
+        # Isolate per-PR failures so one bad PR (rate limit, missing
+        # artifacts) doesn't abort summaries for the rest of the batch.
+        try:
+            jobs = failing_prow_statuses(args.repo, sha)
+            if not jobs:
+                continue
+
+            changed_dirs = pr_changed_dirs(args.repo, number)
+            summaries = []
+            all_ok_to_retest = True
+            for job in jobs:
+                failures, log_tail = collect_job_failures(job)
+                classified = []
+                for classname, name, msg in failures:
+                    verdict, is_flake = classify(classname, name, flakes, changed_dirs)
+                    if not is_flake:
+                        all_ok_to_retest = False
+                    classified.append((name, msg, verdict, is_flake))
+                summaries.append((job, classified, log_tail))
+
+            body, state = build_comment(sha, summaries, all_ok_to_retest)
+            action = upsert_comment(args.repo, number, body, state, args.post)
+        except Exception as e:
+            errors += 1
+            print(f"error: PR #{number}: {e}", file=sys.stderr)
             continue
-
-        changed_dirs = pr_changed_dirs(args.repo, number)
-        summaries = []
-        all_ok_to_retest = True
-        for job in jobs:
-            failures, log_tail = collect_job_failures(job)
-            classified = []
-            for name, msg in failures:
-                verdict, is_flake = classify(name, flakes, changed_dirs)
-                if not is_flake:
-                    all_ok_to_retest = False
-                classified.append((name, msg, verdict, is_flake))
-            summaries.append((job, classified, log_tail))
-
-        body, state = build_comment(sha, summaries, all_ok_to_retest)
-        action = upsert_comment(args.repo, number, body, state, args.post)
         prefix = "" if args.post else "[preview] "
         print(f"{prefix}PR #{number}: {action} "
               f"({len(jobs)} failing job(s))", file=sys.stderr)
         if not args.post and action != "unchanged":
             print(f"\n----- PR #{number} -----\n{body}\n")
-    return 0
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/dev/tools/pr-failure-summary
+++ b/dev/tools/pr-failure-summary
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Posts digestible CI-failure summaries on open PRs.
+
+For each open PR whose Prow presubmits are failing, this pulls the junit
+results (and, for infra failures, the build log tail) from the job's GCS
+artifacts, classifies each failure as a known flake (matching an open
+`kind/flake` issue) or as likely related to the PR's changes, and maintains a
+single sticky comment on the PR summarizing all of it — so contributors don't
+have to dig through Spyglass.
+
+Stateless and idempotent: the comment itself records which head SHA and run
+IDs it covers, so reruns are no-ops until something changes. Requires `gh`
+to be authenticated.
+
+Typical cron usage:
+    dev/tools/pr-failure-summary --post
+
+Read-only preview (prints the comments it would post):
+    dev/tools/pr-failure-summary
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import urllib.parse
+import xml.etree.ElementTree as ET
+
+MARKER = "<!-- agent-sandbox/pr-failure-summary -->"
+STATE_RE = re.compile(r"<!-- state=([0-9a-zA-Z:-]+) -->")
+MAX_ERROR_CHARS = 1500
+LOG_TAIL_BYTES = 16384
+
+
+def run(cmd, input_text=None, check=True):
+    result = subprocess.run(cmd, capture_output=True, text=True, input=input_text)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd[:3])}... failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def gh(*args, input_text=None):
+    return run(["gh", *args], input_text=input_text)
+
+
+def fetch(url, byte_range=None):
+    cmd = ["curl", "-fsSL", "--max-time", "60", url]
+    if byte_range:
+        cmd += ["-r", byte_range]
+    # Decode leniently: a byte-range fetch can split a multibyte character,
+    # and build logs sometimes contain raw binary.
+    result = subprocess.run(cmd, capture_output=True)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.decode("utf-8", errors="replace")
+
+
+def gcs_list(bucket, prefix):
+    url = (
+        f"https://storage.googleapis.com/storage/v1/b/{bucket}/o?"
+        + urllib.parse.urlencode({"prefix": prefix, "fields": "items(name)"})
+    )
+    data = fetch(url)
+    if not data:
+        return []
+    return [item["name"] for item in json.loads(data).get("items", [])]
+
+
+def gcs_read(bucket, name, byte_range=None):
+    return fetch(
+        f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(name)}",
+        byte_range=byte_range,
+    )
+
+
+def parse_junit(xml_text):
+    """Returns [(test_name, message)] for failed testcases in a junit file."""
+    failures = []
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return failures
+    for case in root.iter("testcase"):
+        for child in case:
+            if child.tag in ("failure", "error"):
+                msg = (child.text or child.get("message") or "").strip()
+                failures.append((case.get("name", "?"), msg[:MAX_ERROR_CHARS]))
+                break
+    return failures
+
+
+def failing_prow_statuses(repo, sha):
+    """Failing Prow contexts for a commit, with their GCS artifact paths."""
+    combined = json.loads(gh("api", f"repos/{repo}/commits/{sha}/status"))
+    statuses = combined.get("statuses", [])
+    out = []
+    for s in statuses:
+        if s.get("state") not in ("failure", "error"):
+            continue
+        target = s.get("target_url") or ""
+        if "/view/gs/" not in target:
+            continue  # not a Prow job
+        gcs_path = target.split("/view/gs/", 1)[1].rstrip("/")
+        bucket, _, path = gcs_path.partition("/")
+        out.append({
+            "context": s["context"],
+            "url": target,
+            "bucket": bucket,
+            "path": path,
+            "run_id": path.rsplit("/", 1)[-1],
+        })
+    return out
+
+
+def collect_job_failures(job):
+    """Returns (test_failures, log_tail). Empty test_failures => infra failure."""
+    failures = []
+    for name in gcs_list(job["bucket"], job["path"] + "/artifacts/"):
+        if re.search(r"junit.*\.xml$", name):
+            failures += parse_junit(gcs_read(job["bucket"], name))
+    if failures:
+        return failures, ""
+    tail = gcs_read(job["bucket"], job["path"] + "/build-log.txt",
+                    byte_range=f"-{LOG_TAIL_BYTES}")
+    lines = [l for l in tail.splitlines() if l.strip()]
+    # Prefer error-looking lines from the tail; fall back to the last lines.
+    errors = [l for l in lines
+              if re.search(r"(?i)\b(error|fail|fatal|panic|timed?\s?out)\b", l)]
+    return [], "\n".join((errors or lines)[-25:])
+
+
+def known_flakes(repo):
+    """Maps short test name -> issue number from open kind/flake issues."""
+    issues = json.loads(
+        gh("issue", "list", "--repo", repo, "--label", "kind/flake",
+           "--state", "open", "--limit", "200", "--json", "number,title,body")
+    )
+    mapping = {}
+    for issue in issues:
+        m = re.search(r"<!-- flake-report:test=(\S+) -->", issue.get("body", ""))
+        if m:
+            mapping[m.group(1).rsplit(".", 1)[-1]] = issue["number"]
+        else:
+            # Fall back to the [FLAKE] <name> title convention.
+            t = re.match(r"\[FLAKE\]\s+(\S+)", issue.get("title", ""))
+            if t:
+                mapping[t.group(1)] = issue["number"]
+    return mapping
+
+
+def test_source_dirs(test_name):
+    """Best-effort map from a test name to repo dirs containing its source."""
+    base = test_name.split("/", 1)[0]  # strip go subtest suffix
+    patterns = [f"func {base}(", f"def {base}("]
+    dirs = set()
+    for pat in patterns:
+        result = subprocess.run(
+            ["git", "grep", "-l", "-F", pat], capture_output=True, text=True
+        )
+        for path in result.stdout.splitlines():
+            dirs.add("/".join(path.split("/")[:2]))
+    return dirs
+
+
+def pr_changed_dirs(repo, number):
+    files = json.loads(
+        gh("pr", "view", str(number), "--repo", repo, "--json", "files")
+    ).get("files", [])
+    return {"/".join(f["path"].split("/")[:2]) for f in files}
+
+
+def classify(test_name, flakes, changed_dirs):
+    short = test_name.rsplit(".", 1)[-1].split("/", 1)[0]
+    if short in flakes:
+        return f"🎲 known flake ([#{flakes[short]}](https://github.com/kubernetes-sigs/agent-sandbox/issues/{flakes[short]})) — likely not caused by this PR", True
+    overlap = test_source_dirs(test_name) & changed_dirs
+    if overlap:
+        return f"⚠️ exercises code this PR touches (`{sorted(overlap)[0]}`) — likely related to your change", False
+    return "❓ not a known flake — check the error below", False
+
+
+def build_comment(sha, jobs_summaries, all_known_flakes):
+    state = f"{sha[:12]}:" + hashlib.sha256(
+        ",".join(sorted(j["run_id"] for j, _, _ in jobs_summaries)).encode()
+    ).hexdigest()[:12]
+    lines = [
+        MARKER,
+        f"<!-- state={state} -->",
+        f"## CI failure summary for `{sha[:9]}`",
+        "",
+    ]
+    for job, failures, log_tail in jobs_summaries:
+        lines.append(f"### ❌ `{job['context']}` — [full logs]({job['url']})")
+        if failures:
+            for name, msg, verdict, _ in failures:
+                lines.append(f"- `{name}` — {verdict}")
+                if msg:
+                    lines += ["", "  <details><summary>error</summary>", "",
+                              "  ```", *(f"  {l}" for l in msg.splitlines()[:30]),
+                              "  ```", "  </details>", ""]
+        else:
+            lines.append(
+                "- The job failed **before tests ran** (cluster bring-up / "
+                "image build / timeout). This is an infrastructure failure, "
+                "not your change — comment `/retest`."
+            )
+            if log_tail:
+                lines += ["", "  <details><summary>end of build log</summary>", "",
+                          "  ```", *(f"  {l}" for l in log_tail.splitlines()),
+                          "  ```", "  </details>", ""]
+        lines.append("")
+    if all_known_flakes:
+        lines.append("**Every failure matches a known flake or infrastructure "
+                     "issue — commenting `/retest` should go green.**")
+    lines += [
+        "",
+        "<sub>Generated by [`dev/tools/pr-failure-summary`](https://github.com/"
+        "kubernetes-sigs/agent-sandbox/blob/main/dev/tools/pr-failure-summary). "
+        "It refreshes automatically on new failures.</sub>",
+    ]
+    return "\n".join(lines), state
+
+
+def find_sticky_comment(repo, number):
+    # --slurp wraps each page in an outer array so multi-page output stays
+    # valid JSON.
+    pages = json.loads(
+        gh("api", f"repos/{repo}/issues/{number}/comments", "--paginate", "--slurp")
+    )
+    for c in (c for page in pages for c in page):
+        if MARKER in c.get("body", ""):
+            return c
+    return None
+
+
+def upsert_comment(repo, number, body, state, post):
+    existing = find_sticky_comment(repo, number)
+    if existing:
+        m = STATE_RE.search(existing["body"])
+        if m and m.group(1) == state:
+            return "unchanged"
+        if post:
+            gh("api", "-X", "PATCH",
+               f"repos/{repo}/issues/comments/{existing['id']}",
+               "-f", f"body={body}")
+        return "updated"
+    if post:
+        gh("api", f"repos/{repo}/issues/{number}/comments", "-f", f"body={body}")
+    return "created"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default="kubernetes-sigs/agent-sandbox")
+    parser.add_argument("--limit", type=int, default=30,
+                        help="max open PRs to scan (newest first)")
+    parser.add_argument("--pr", type=int, help="only process this PR number")
+    parser.add_argument("--post", action="store_true",
+                        help="post/update comments (default: print what would be posted)")
+    args = parser.parse_args()
+
+    if args.pr:
+        prs = [json.loads(gh("pr", "view", str(args.pr), "--repo", args.repo,
+                             "--json", "number,headRefOid"))]
+    else:
+        prs = json.loads(
+            gh("pr", "list", "--repo", args.repo, "--state", "open",
+               "--limit", str(args.limit), "--json", "number,headRefOid")
+        )
+
+    flakes = known_flakes(args.repo)
+    for pr in prs:
+        number, sha = pr["number"], pr["headRefOid"]
+        jobs = failing_prow_statuses(args.repo, sha)
+        if not jobs:
+            continue
+
+        changed_dirs = pr_changed_dirs(args.repo, number)
+        summaries = []
+        all_ok_to_retest = True
+        for job in jobs:
+            failures, log_tail = collect_job_failures(job)
+            classified = []
+            for name, msg in failures:
+                verdict, is_flake = classify(name, flakes, changed_dirs)
+                if not is_flake:
+                    all_ok_to_retest = False
+                classified.append((name, msg, verdict, is_flake))
+            summaries.append((job, classified, log_tail))
+
+        body, state = build_comment(sha, summaries, all_ok_to_retest)
+        action = upsert_comment(args.repo, number, body, state, args.post)
+        prefix = "" if args.post else "[preview] "
+        print(f"{prefix}PR #{number}: {action} "
+              f"({len(jobs)} failing job(s))", file=sys.stderr)
+        if not args.post and action != "unchanged":
+            print(f"\n----- PR #{number} -----\n{body}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/tools/pr-failure-summary
+++ b/dev/tools/pr-failure-summary
@@ -46,6 +46,9 @@ MARKER = "<!-- agent-sandbox/pr-failure-summary -->"
 STATE_RE = re.compile(r"<!-- state=([0-9a-zA-Z:-]+) -->")
 MAX_ERROR_CHARS = 1500
 LOG_TAIL_BYTES = 16384
+# Cap rendered failures per job so a mass failure can't blow past GitHub's
+# ~64KB comment-size limit; the full list is always in the linked logs.
+MAX_FAILURES_PER_JOB = 15
 
 
 def run(cmd, input_text=None, check=True):
@@ -84,7 +87,11 @@ def gcs_list(bucket, prefix):
             + urllib.parse.urlencode(params)
         )
         if not data:
-            return names
+            # A failed listing must not masquerade as an empty one: returning
+            # partial results here would make a job with real junit failures
+            # look junit-less and tell the author to just `/retest`. Raise so
+            # the per-PR try/except skips this PR for the run instead.
+            raise RuntimeError(f"GCS listing failed for gs://{bucket}/{prefix}")
         payload = json.loads(data)
         names += [item["name"] for item in payload.get("items", [])]
         page_token = payload.get("nextPageToken")
@@ -231,10 +238,15 @@ def test_source_dirs(test_name):
 
 
 def pr_changed_dirs(repo, number):
-    files = json.loads(
-        gh("pr", "view", str(number), "--repo", repo, "--json", "files")
-    ).get("files", [])
-    return {d for d in (top_dirs(f["path"]) for f in files) if d}
+    # Paginate the REST files endpoint: `gh pr view --json files` caps at the
+    # first 100 changed files, which would silently degrade overlap detection
+    # on large PRs. --slurp wraps each page in an outer array.
+    pages = json.loads(
+        gh("api", f"repos/{repo}/pulls/{number}/files",
+           "--paginate", "--slurp")
+    )
+    return {d for d in (top_dirs(f["filename"]) for page in pages for f in page)
+            if d}
 
 
 def classify(classname, test_name, flakes, changed_dirs):
@@ -297,10 +309,15 @@ def build_comment(sha, jobs_summaries, all_known_flakes):
     for job, failures, log_tail, pr_fault in jobs_summaries:
         lines.append(f"### ❌ `{job['context']}` — [full logs]({job['url']})")
         if failures:
-            for name, msg, verdict, _ in failures:
+            for name, msg, verdict, _ in failures[:MAX_FAILURES_PER_JOB]:
                 lines.append(f"- `{name}` — {verdict}")
                 if msg:
                     lines += details_block("error", msg)
+            if len(failures) > MAX_FAILURES_PER_JOB:
+                lines.append(
+                    f"- …and {len(failures) - MAX_FAILURES_PER_JOB} more "
+                    "failure(s) in this job — see the full logs above."
+                )
         elif pr_fault:
             lines.append(
                 "- The job failed **without producing test results** — the "
@@ -358,6 +375,31 @@ def upsert_comment(repo, number, body, state, post):
     return "created"
 
 
+def resolve_sticky_comment(repo, number, sha, post):
+    """Collapses a stale failure summary once the PR has no failing jobs.
+
+    A summary left as the last sticky comment on a now-green PR reads as
+    noise, so rewrite it to a one-liner. Idempotent via the state marker.
+    """
+    existing = find_sticky_comment(repo, number)
+    if not existing:
+        return None
+    state = f"{sha[:12]}:resolved"
+    m = STATE_RE.search(existing["body"])
+    if m and m.group(1) == state:
+        return "unchanged"
+    body = "\n".join([
+        MARKER,
+        f"<!-- state={state} -->",
+        f"✅ The CI failures summarized earlier are resolved as of `{sha[:9]}`.",
+    ])
+    if post:
+        gh("api", "-X", "PATCH",
+           f"repos/{repo}/issues/comments/{existing['id']}",
+           "-f", f"body={body}")
+    return "resolved"
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--repo", default="kubernetes-sigs/agent-sandbox")
@@ -386,6 +428,11 @@ def main():
         try:
             jobs = failing_prow_statuses(args.repo, sha)
             if not jobs:
+                action = resolve_sticky_comment(args.repo, number, sha, args.post)
+                if action == "resolved":
+                    prefix = "" if args.post else "[preview] "
+                    print(f"{prefix}PR #{number}: collapsed stale summary "
+                          "(no failing jobs)", file=sys.stderr)
                 continue
 
             changed_dirs = pr_changed_dirs(args.repo, number)

--- a/dev/tools/pr-failure-summary
+++ b/dev/tools/pr-failure-summary
@@ -206,9 +206,16 @@ def test_source_dirs(test_name):
         return _source_dirs_cache[base]
     dirs = set()
     for pat in (f"func {base}(", f"def {base}("):
-        result = subprocess.run(
-            ["git", "grep", "-l", "-F", pat], capture_output=True, text=True
-        )
+        try:
+            result = subprocess.run(
+                ["git", "grep", "-l", "-F", pat],
+                capture_output=True, text=True, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            # Degrade to "source unknown" (classification falls through to
+            # ❓) rather than wedging the cron; cached so a stuck git isn't
+            # re-invoked for every failure.
+            break
         for path in result.stdout.splitlines():
             dirs.add("/".join(path.split("/")[:2]))
     _source_dirs_cache[base] = dirs

--- a/dev/tools/pr-failure-summary
+++ b/dev/tools/pr-failure-summary
@@ -199,6 +199,15 @@ def match_flake(classname, name, flakes):
 _source_dirs_cache = {}
 
 
+def top_dirs(path):
+    """'controllers/foo_test.go' -> 'controllers', 'test/e2e/x/y.go' -> 'test/e2e'.
+
+    Drops the filename before truncating so foo.go and foo_test.go in the same
+    package map to the same dir; top-level files map to '' (callers drop it).
+    """
+    return "/".join(path.split("/")[:-1][:2])
+
+
 def test_source_dirs(test_name):
     """Best-effort map from a test name to repo dirs containing its source."""
     base = test_name.split("/", 1)[0]  # strip go subtest suffix
@@ -216,8 +225,7 @@ def test_source_dirs(test_name):
             # ❓) rather than wedging the cron; cached so a stuck git isn't
             # re-invoked for every failure.
             break
-        for path in result.stdout.splitlines():
-            dirs.add("/".join(path.split("/")[:2]))
+        dirs.update(d for d in map(top_dirs, result.stdout.splitlines()) if d)
     _source_dirs_cache[base] = dirs
     return dirs
 
@@ -226,7 +234,7 @@ def pr_changed_dirs(repo, number):
     files = json.loads(
         gh("pr", "view", str(number), "--repo", repo, "--json", "files")
     ).get("files", [])
-    return {"/".join(f["path"].split("/")[:2]) for f in files}
+    return {d for d in (top_dirs(f["path"]) for f in files) if d}
 
 
 def classify(classname, test_name, flakes, changed_dirs):
@@ -237,6 +245,23 @@ def classify(classname, test_name, flakes, changed_dirs):
     if overlap:
         return f"⚠️ exercises code this PR touches (`{sorted(overlap)[0]}`) — likely related to your change", False
     return "❓ not a known flake — check the error below", False
+
+
+# Output that shows the job died on the PR's own code (compile error, vet or
+# lint finding) rather than on infrastructure — no junit either way, so the
+# log tail is the only way to tell them apart.
+BUILD_FAILURE_RE = re.compile(
+    r"\.go:\d+:\d+:|\bundefined:|\bsyntax error\b|\bcannot find package\b"
+    r"|\bgolangci-lint\b|\bvet: "
+)
+
+
+def looks_like_pr_fault(job, log_tail):
+    """True when a junit-less failure is likely the PR's fault, not infra."""
+    # Lint/verify jobs never write junit; their failures are ~always the PR's.
+    if re.search(r"\b(lint|verify)\b", job["context"]):
+        return True
+    return bool(BUILD_FAILURE_RE.search(log_tail))
 
 
 def code_fence(text):
@@ -258,8 +283,8 @@ def build_comment(sha, jobs_summaries, all_known_flakes):
     # the comment refreshes when a failure later becomes a known flake (e.g.
     # after the nightly flake-report files an issue for it).
     fingerprint = ",".join(sorted(
-        [j["run_id"] for j, _, _ in jobs_summaries]
-        + [f"{name}:{verdict}" for _, failures, _ in jobs_summaries
+        [j["run_id"] for j, _, _, _ in jobs_summaries]
+        + [f"{name}:{verdict}" for _, failures, _, _ in jobs_summaries
            for name, _, verdict, _ in failures]
     ))
     state = f"{sha[:12]}:" + hashlib.sha256(fingerprint.encode()).hexdigest()[:12]
@@ -269,18 +294,26 @@ def build_comment(sha, jobs_summaries, all_known_flakes):
         f"## CI failure summary for `{sha[:9]}`",
         "",
     ]
-    for job, failures, log_tail in jobs_summaries:
+    for job, failures, log_tail, pr_fault in jobs_summaries:
         lines.append(f"### ❌ `{job['context']}` — [full logs]({job['url']})")
         if failures:
             for name, msg, verdict, _ in failures:
                 lines.append(f"- `{name}` — {verdict}")
                 if msg:
                     lines += details_block("error", msg)
+        elif pr_fault:
+            lines.append(
+                "- The job failed **without producing test results** — the "
+                "log ends in what looks like a build/vet/lint failure, so it "
+                "is likely caused by this PR. See the log below."
+            )
+            if log_tail:
+                lines += details_block("end of build log", log_tail, max_lines=25)
         else:
             lines.append(
                 "- The job failed **before tests ran** (cluster bring-up / "
-                "image build / timeout). This is an infrastructure failure, "
-                "not your change — comment `/retest`."
+                "image build / timeout). This looks like an infrastructure "
+                "failure, not your change — comment `/retest`."
             )
             if log_tail:
                 lines += details_block("end of build log", log_tail, max_lines=25)
@@ -366,7 +399,10 @@ def main():
                     if not is_flake:
                         all_ok_to_retest = False
                     classified.append((name, msg, verdict, is_flake))
-                summaries.append((job, classified, log_tail))
+                pr_fault = not failures and looks_like_pr_fault(job, log_tail)
+                if pr_fault:
+                    all_ok_to_retest = False
+                summaries.append((job, classified, log_tail, pr_fault))
 
             body, state = build_comment(sha, summaries, all_ok_to_retest)
             action = upsert_comment(args.repo, number, body, state, args.post)


### PR DESCRIPTION
## What this does

CI flakes and undigestible failure logs are costing contributors real time. TestGrid data for `sig-apps-agent-sandbox` shows most red presubmit runs are infrastructure failures (no failing test at all), and the rest trace to a small set of flaky tests (e.g. `TestRunChromeSandbox`). This PR adds the detection/reporting/fixing tooling; the CI runner retry hardening was **split out to #1101** so it can merge independently.

### `dev/tools/flake-report` (nightly)
Pulls recent runs from the TestGrid JSON API and classifies each failing test as **flaky** (fails across ≥2 distinct PRs while mostly passing, or a retest flip), **consistently failing** (breakage, not a flake), or an **infra failure** (red run with no junit failure). Files/refreshes one `kind/flake` issue per flaky test — findings for the same test across multiple job tabs are merged into a single issue tracking all affected tabs. Stateless: the issues are the only durable state, so reruns are idempotent. Mass-failure runs (one broken PR failing dozens of tests) and single-PR failures are excluded to avoid false positives. Exits non-zero if no TestGrid tab could be analyzed.

### `dev/tools/pr-failure-summary`
For each open PR with failing Prow presubmits, pulls the junit results (or build-log tail for infra failures) from GCS and maintains **one sticky comment** summarizing: which tests failed, the actual assertion text, and a per-failure verdict — 🎲 known flake (linked issue, safe to `/retest`), ⚠️ exercises code the PR touches, or an explicit "failed before tests ran — this is infrastructure, `/retest`". Flakes are matched by fully-qualified test identity (classname + name). The sticky comment's state hash covers head SHA, run IDs, *and* verdicts, so it refreshes when a failure is later confirmed as a known flake. Junit output is fenced safely against markdown injection; GCS listings are paginated; per-PR errors don't abort the batch.

### `.agents/skills/fix-flakes` + `dev/tools/flake-fix`
An agent skill (next to the existing skills in `.agents/skills/`) encoding the flake-fixing procedure: reproduce under stress (`-race -count=50` / e2e on kind), diagnose the usual suspects (missing eventual-consistency polling, DinD-hostile timeouts, shared state between parallel tests), fix minimally with evidence, and open a PR that `Fixes #<n>`. Never skips/disables tests. `dev/tools/flake-fix` is a thin cron wrapper (same pattern as `dev/tools/ai-review`) that runs the skill headlessly in a throwaway worktree, bounded to `LIMIT` issues per run.

## Validation

- `flake-report` run against live TestGrid: correctly surfaces `TestRunChromeSandbox` (3 failures across 3 PRs) and `TestSandboxClaimCreationMetric` (2 across 2), rejects a mass-failure run that would otherwise have filed ~30 bogus issues, and quantifies infra failure rates per tab. Issue actions verified with `--dry-run`.
- `pr-failure-summary` exercised against real red runs from GCS: junit failure extraction verified on an actual `TestRunChromeSandbox` failure; infra-failure path verified on a run that died during image build. Helper behavior (fence escaping, flake matching, multi-tab merge) covered by assertion checks run against both scripts.
- Neither script posts by default (`--update-issues` / `--post` opt in), so they can be dry-run safely; both are stateless and idempotent.

## Review feedback

All findings from the CodeRabbit and Copilot reviews are addressed in commit 6f7a8ac; per-comment replies inline.

## Suggested rollout

1. Merge #1101 (runner retries) and this PR; run `flake-report --update-issues` + `pr-failure-summary --post` on a schedule (cron or a Prow periodic later).
2. Watch a week of infra-failure counts to confirm the retries move the needle.
3. Start `flake-fix` on the filed issues (first candidate: `TestRunChromeSandbox`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated flaky-test fixing workflow (runbook skill + local scheduled launcher) to identify likely flaky Kubernetes-sigs/agent-sandbox tests, reproduce, apply minimal fixes, and open PRs when evidence supports it.
  * Added a nightly flake reporting CLI that summarizes flaky vs consistently failing vs infrastructure failures and can optionally create/update matching `kind/flake` issues.
  * Added/expanded a PR CI failure summary CLI that posts/updates an idempotent sticky comment with links and parsed failure details.
* **Bug Fixes**
  * Improved flake report accuracy (mass-failure filtering, de-duplication under parent tests) and enhanced PR-fault detection for failures without JUnit data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->