### PR TITLE
Index pod cache by sandbox label to fix O(n) List in reconcilePod

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -695,6 +695,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		client.MatchingFields{podSandboxNameHashIndex: nameHash},
 	); err != nil {
 		logger.Error(err, "Failed to list pods")
+		return nil, fmt.Errorf("pod list failed: %w", err)
 	}
 
 	if len(podList.Items) > 1 {
@@ -1285,15 +1286,20 @@ func sandboxMarkedExpired(sandbox *sandboxv1beta1.Sandbox) bool {
 	return cond != nil && (cond.Reason == sandboxv1beta1.SandboxReasonExpired)
 }
 
+// podSandboxNameHashIndexer extracts the sandboxLabel value for the
+// podSandboxNameHashIndex cache field index. Shared with tests so fake
+// clients register the same index the manager does.
+func podSandboxNameHashIndexer(obj client.Object) []string {
+	if v, ok := obj.GetLabels()[sandboxLabel]; ok {
+		return []string{v}
+	}
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, podSandboxNameHashIndex,
-		func(obj client.Object) []string {
-			if v, ok := obj.GetLabels()[sandboxLabel]; ok {
-				return []string{v}
-			}
-			return nil
-		}); err != nil {
+		podSandboxNameHashIndexer); err != nil {
 		return fmt.Errorf("failed to index pods by sandbox label: %w", err)
 	}
 

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -50,9 +50,8 @@ import (
 const (
 	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
 	// podSandboxNameHashIndex is the cache field index over the sandboxLabel
-	// value on Pods, so per-reconcile pod lookups are O(1) instead of a
-	// linear label-match over every pod in the namespace.
-	podSandboxNameHashIndex = ".metadata.labels[agents.x-k8s.io/sandbox-name-hash]"
+	// value on Pods, so per-reconcile pod lookups are O(1).
+	podSandboxNameHashIndex = ".metadata.labels[" + sandboxLabel + "]"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
 )
@@ -687,9 +686,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	ctx, end := r.Tracer.StartSpan(ctx, nil, "reconcilePod", nil)
 	defer end()
 
-	// List all pods with the pool label matching the warm pool name hash,
-	// via the cache field index registered in SetupWithManager — a plain
-	// label-selector List here degrades to an O(pods-in-namespace) scan.
+	// List all pods carrying this sandbox's tracking label (sandboxLabel),
+	// via the cache field index registered in SetupWithManager.
 	// TODO: find a better way to make sure one sandbox has at most one pod
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList,

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -29,7 +29,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,6 +49,10 @@ import (
 
 const (
 	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
+	// podSandboxNameHashIndex is the cache field index over the sandboxLabel
+	// value on Pods, so per-reconcile pod lookups are O(1) instead of a
+	// linear label-match over every pod in the namespace.
+	podSandboxNameHashIndex = ".metadata.labels[agents.x-k8s.io/sandbox-name-hash]"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
 )
@@ -684,17 +687,15 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	ctx, end := r.Tracer.StartSpan(ctx, nil, "reconcilePod", nil)
 	defer end()
 
-	// List all pods with the pool label matching the warm pool name hash
+	// List all pods with the pool label matching the warm pool name hash,
+	// via the cache field index registered in SetupWithManager — a plain
+	// label-selector List here degrades to an O(pods-in-namespace) scan.
 	// TODO: find a better way to make sure one sandbox has at most one pod
 	podList := &corev1.PodList{}
-	labelSelector := labels.SelectorFromSet(labels.Set{
-		sandboxLabel: nameHash,
-	})
-
-	if err := r.List(ctx, podList, &client.ListOptions{
-		LabelSelector: labelSelector,
-		Namespace:     sandbox.Namespace,
-	}); err != nil {
+	if err := r.List(ctx, podList,
+		client.InNamespace(sandbox.Namespace),
+		client.MatchingFields{podSandboxNameHashIndex: nameHash},
+	); err != nil {
 		logger.Error(err, "Failed to list pods")
 	}
 
@@ -1288,6 +1289,16 @@ func sandboxMarkedExpired(sandbox *sandboxv1beta1.Sandbox) bool {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, podSandboxNameHashIndex,
+		func(obj client.Object) []string {
+			if v, ok := obj.GetLabels()[sandboxLabel]; ok {
+				return []string{v}
+			}
+			return nil
+		}); err != nil {
+		return fmt.Errorf("failed to index pods by sandbox label: %w", err)
+	}
+
 	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -48,10 +48,10 @@ import (
 )
 
 const (
-	sandboxLabel                = "agents.x-k8s.io/sandbox-name-hash"
+	sandboxLabel = "agents.x-k8s.io/sandbox-name-hash"
 	// podSandboxNameHashIndex is the cache field index over the sandboxLabel
 	// value on Pods, so per-reconcile pod lookups are O(1).
-	podSandboxNameHashIndex = ".metadata.labels[" + sandboxLabel + "]"
+	podSandboxNameHashIndex     = ".metadata.labels[" + sandboxLabel + "]"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
 )

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -44,6 +44,7 @@ func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
 	return fake.NewClientBuilder().
 		WithScheme(Scheme).
 		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
+		WithIndex(&corev1.Pod{}, podSandboxNameHashIndex, podSandboxNameHashIndexer).
 		WithRuntimeObjects(initialObjs...).
 		Build()
 }


### PR DESCRIPTION
## What this fixes

`reconcilePod` lists pods by the `agents.x-k8s.io/sandbox-name-hash` label on every reconcile. The informer cache has no index on that label, so `CacheReader.List` falls back to the namespace index and label-matches **every pod in the namespace** per call — O(pods-in-namespace) per reconcile, O(n²) per batch of sandbox creations, with all workers contending on the same cache RWMutex while scanning. (The existing TODO on this List already hints at the problem.)

## How it was found

Capacity testing on a 753-node GKE cluster (ClusterLoader2 ramp, 10k sandboxes per step at 100 creations/s, single namespace, controller at `--sandbox-concurrent-workers=100`):

- Sandbox workqueue depth pinned near the batch size from \~50k sandboxes onward; per-batch convergence time grew linearly (\~+65 s per additional 10k).
- Per-step metrics showed reconcile p50 growing linearly with pod count (13 ms @10k → 211 ms @80k) and controller CPU climbing to ~19 cores; zero 429s, negligible GC.
- A CPU profile during the degraded phase attributed **92.6% of controller CPU to `CacheReader.List`** (dominated by `memeqbody`/`mapaccess_faststr` — label matching across the namespace); goroutine dumps showed ~60/100 workers inside the cache List.
- A control experiment raising workers to 400 made 80k convergence **3× slower** (223 s → 626 s) while tripling 409 status-update conflicts — negative scaling, confirming a lock/CPU-bound hot path rather than API latency.

## The change

Register a field index over the sandbox label in `SetupWithManager` and List with `MatchingFields`, making the per-reconcile lookup O(1). ~15 lines, no behavior change.

## Validation

Identical load-test shape #1100 re-run with this change (same cluster, same parameters):

| At 80,000 sandboxes | before | after |
|---|---|---|
| Convergence per 10k batch | 223 s (growing) | **96 s, flat at every step** |
| Reconcile p50 | 211 ms (linear in n) | **4 ms, constant** |
| Workqueue max depth | 6,587 | **≤ 10** |
| Controller CPU | 19.3 cores | **1.2 cores** |

<img width="1920" height="1290" alt="image" src="https://github.com/user-attachments/assets/3819ed4c-0268-4460-96cd-07cb34547500" />

409 conflict rate also stopped scaling with cluster size (constant ~26/s, proportional to creation rate). Switching status Update to Patch would reduce those further and can be a follow-up; with this index in place they no longer affect convergence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod lookup reliability during sandbox reconciliation by switching from label-based discovery to cache-indexed retrieval.
  * Reduced lookup overhead by leveraging an indexed cache path keyed by the sandbox tracking value, leading to more consistent and responsive sandbox-related operations.

* **Tests**
  * Updated the test environment to register the new pod index so indexed lookups are reflected in controller tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->