### PR TITLE
Add capacity cliff load test recipe

### DIFF
--- a/dev/load-test/test-recipes/README-capacity-cliff.md
+++ b/dev/load-test/test-recipes/README-capacity-cliff.md
@@ -31,6 +31,8 @@ headless Service (`service: false`) and uses no `volumeClaimTemplates`, and the 
 - **Source Code Repositories**: Cloned to your local machine, typically in `$HOME`:
   - `perf-tests`: The official Kubernetes performance testing repository containing ClusterLoader2.
   - `agent-sandbox`: The main project repository.
+- **Command-line Tools**: `jq` (used by the runner to build the CL2 overrides file and by the kwok
+  install snippet below, which also uses `curl`).
 - **`agent-sandbox-controller`**: Installed in the target cluster **without** the `--extensions`
   flag. See [README-rapid-burst.md](README-rapid-burst.md) for how to build/push a local image and
   generate manifests. Recommended controller args for this test:
@@ -147,6 +149,10 @@ Overridable via environment variables on `run_capacity_cliff.sh`:
   means "cannot converge", never "converged slowly".
 - **`KWOK_NODES`**: Set to `true` to pin sandbox pods to kwok fake nodes (default: `false`).
 - **`PROVIDER`**: CL2 provider, e.g. `gke` or `kind` (default: `gke`).
+- **`SANDBOX_IMAGE`**: Sandbox pod container image (default: `registry.k8s.io/pause:3.10`). Must
+  be pullable from the cluster's nodes — private GKE nodes without Cloud NAT cannot reach
+  `registry.k8s.io`, so point this at a `gcr.io`/`pkg.dev`-hosted image there (e.g.
+  `gcr.io/google-containers/pause:3.2`).
 - **`NETWORK_POLICY`**: Set to `true` to apply one NetworkPolicy per test namespace selecting all
   sandbox pods (default: `false`). The policy mirrors the SandboxTemplate extension's "Secure by
   Default" spec (ingress from the sandbox-router only, egress to public internet with private and

--- a/dev/load-test/test-recipes/README-capacity-cliff.md
+++ b/dev/load-test/test-recipes/README-capacity-cliff.md
@@ -1,0 +1,245 @@
+# Agent Sandbox Capacity Cliff Test (Test Recipes)
+
+## Overview
+
+This recipe answers one question: **how many Sandbox objects (each with a backing Pod) can a
+cluster hold before performance falls off a cliff?**
+
+It runs against a Kubernetes cluster using [ClusterLoader2](https://github.com/kubernetes/perf-tests)
+(CL2) and, unlike the other recipes in this directory, **latency is not the primary measurement**.
+The test ratchets the total Sandbox count upward in discrete steps and, at each step, waits for
+every Sandbox to reach `Ready=True`. The pass/fail criterion is *convergence*: slow is acceptable,
+failing to converge is not. The **cliff is the first step whose wait times out** — the previous
+step's count is the cluster's upper bound.
+
+At each plateau the test snapshots capacity metrics (controller memory, controller restarts,
+workqueue depth, stored object counts, etcd DB size) so you can reconstruct the degradation curve
+and identify which component gave out first. Pod startup latency is recorded across the whole run
+as nice-to-know data (it shows where degradation *starts*, before the hard cliff) but never gates
+the test.
+
+Scope is deliberately narrow: only `Sandbox` and its child `Pod`. The Sandbox template disables the
+headless Service (`service: false`) and uses no `volumeClaimTemplates`, and the extensions
+(SandboxClaim / SandboxTemplate / SandboxWarmPool) are not exercised — run the controller **without**
+`--extensions`.
+
+## Prerequisites
+
+- **Go Environment**: A working Go installation is required to compile and run ClusterLoader2.
+- **Kubernetes Cluster**: `kubectl` access configured for the target cluster (config at
+  `$HOME/.kube/config`).
+- **Source Code Repositories**: Cloned to your local machine, typically in `$HOME`:
+  - `perf-tests`: The official Kubernetes performance testing repository containing ClusterLoader2.
+  - `agent-sandbox`: The main project repository.
+- **`agent-sandbox-controller`**: Installed in the target cluster **without** the `--extensions`
+  flag. See [README-rapid-burst.md](README-rapid-burst.md) for how to build/push a local image and
+  generate manifests. Recommended controller args for this test:
+
+  ```yaml
+  containers:
+    - name: agent-sandbox-controller
+      args:
+        - --leader-elect=true
+        - --kube-api-qps=-1
+        - --sandbox-concurrent-workers=1000
+      resources:
+        limits:
+          # Set a fixed, production-representative memory limit. The controller's
+          # informer caches grow with the number of Sandboxes and Pods, and an
+          # OOMKill (visible as ControllerRestartsTotal climbing in the per-step
+          # metrics) is one of the cleanest "capacity reached" signals this test
+          # produces. An unbounded controller hides the cliff.
+          memory: 2Gi
+  ```
+
+  Raising the workers and QPS matters even though this is not a throughput test: with the defaults
+  (`--sandbox-concurrent-workers=1` and a low API burst) you would measure the controller's rate
+  limiter, not the cluster's capacity.
+
+### Node capacity: kwok vs. real nodes
+
+Every Sandbox in this test gets a real Pod, so on real nodes the result is usually just
+`nodes × max-pods-per-node` (110 by default) — a scheduling limit, not the control-plane limit you
+are probably after. To find the **control-plane ceiling** (etcd, apiserver, controller), back the
+test with [kwok](https://kwok.sigs.k8s.io/) fake nodes: pods scheduled to them are marked Running
+and Ready without a kubelet, so the full Sandbox reconcile path is exercised at a fraction of the
+cost.
+
+Install kwok into the test cluster and create fake nodes (see the
+[kwok docs](https://kwok.sigs.k8s.io/docs/user/kwok-in-cluster/) for the current release):
+
+```bash
+KWOK_REPO=kubernetes-sigs/kwok
+KWOK_LATEST_RELEASE=$(curl -s "https://api.github.com/repos/${KWOK_REPO}/releases/latest" | jq -r '.tag_name')
+kubectl apply -f "https://github.com/${KWOK_REPO}/releases/download/${KWOK_LATEST_RELEASE}/kwok.yaml"
+kubectl apply -f "https://github.com/${KWOK_REPO}/releases/download/${KWOK_LATEST_RELEASE}/stage-fast.yaml"
+```
+
+```bash
+# Create enough fake nodes for the target count: e.g. 200 nodes x 256 pods = 51,200 pods.
+for i in $(seq 0 199); do
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Node
+metadata:
+  name: kwok-node-${i}
+  labels:
+    type: kwok
+    kubernetes.io/role: agent
+  annotations:
+    kwok.x-k8s.io/node: fake
+spec:
+  taints:
+  - key: kwok.x-k8s.io/node
+    value: fake
+    effect: NoSchedule
+status:
+  allocatable:
+    cpu: "32"
+    memory: 256Gi
+    pods: "256"
+  capacity:
+    cpu: "32"
+    memory: 256Gi
+    pods: "256"
+EOF
+done
+```
+
+Then run the test with `KWOK_NODES=true`, which adds a `type: kwok` nodeSelector and the kwok taint
+toleration to every sandbox pod. The taint keeps everything else — including the agent-sandbox
+controller and the CL2-managed Prometheus — off the fake nodes.
+
+## Running the Test
+
+```bash
+cd dev/load-test/test-recipes
+chmod +x run_capacity_cliff.sh   # first time only
+./run_capacity_cliff.sh
+```
+
+You can optionally pass a name which will be appended to the output directory for the test
+artifacts:
+
+```bash
+KWOK_NODES=true STEP_SIZE=2000 TOTAL_STEPS=25 ./run_capacity_cliff.sh kwok-50k
+```
+
+Use a coarse first pass to bracket the cliff, then re-run with a smaller `STEP_SIZE` around the
+failure point for a tighter bound. CL2 expands the step loop up front and cannot bisect at runtime,
+so the cliff resolution equals the step size.
+
+## Configuration
+
+Overridable via environment variables on `run_capacity_cliff.sh`:
+
+- **`STEP_SIZE`**: Sandboxes added per namespace at each step (default: `1000`).
+- **`TOTAL_STEPS`**: Number of ramp steps (default: `20`). The maximum attempted count is
+  `STEP_SIZE * TOTAL_STEPS * NAMESPACES`. **Deliberately overshoot the expected ceiling** — the
+  step that fails to converge is the result you are looking for.
+- **`NAMESPACES`**: Namespaces to spread the load across (default: `1`).
+- **`QPS`**: Object creation rate (default: `100`).
+- **`HOLD_DURATION`**: How long to hold each plateau before snapshotting metrics (default: `2m`).
+  The hold exposes steady-state load (resyncs, watch churn) that a pure creation burst hides.
+- **`CONVERGENCE_TIMEOUT`**: Per-step timeout for all Sandboxes to reach `Ready=True`
+  (default: `30m`). This is the operative definition of "does not fit". Size it generously —
+  roughly `STEP_SIZE / conservative-sandboxes-per-second` with a 3–5x margin — so that a timeout
+  means "cannot converge", never "converged slowly".
+- **`KWOK_NODES`**: Set to `true` to pin sandbox pods to kwok fake nodes (default: `false`).
+- **`PROVIDER`**: CL2 provider, e.g. `gke` or `kind` (default: `gke`).
+- **`NETWORK_POLICY`**: Set to `true` to apply one NetworkPolicy per test namespace selecting all
+  sandbox pods (default: `false`). The policy mirrors the SandboxTemplate extension's "Secure by
+  Default" spec (ingress from the sandbox-router only, egress to public internet with private and
+  link-local CIDRs blocked) with the test's shared `group` label standing in for the shared
+  template-ref-hash label. Use this to measure the production configuration — policy enforcement is
+  dataplane work, and an unpoliced run is the dataplane's best case. When comparing runs, watch the
+  `StoredCiliumIdentities` column (Cilium dataplanes only): ~flat means the policy is compatible
+  with shared identities; growing per-sandbox means identity cardinality is exploding through the
+  policy path, which is the dataplane cliff signature.
+
+### Preventing Prometheus OOM
+
+CL2 sets the Prometheus container's memory request **and hard limit** to
+`MEMORY_LIMIT_FACTOR Gi × (1 + nodes/1000)`. The default factor of 2 means a 2 Gi cap on any
+cluster under 1,000 nodes — far too small for the pod counts this test creates, and the usual
+reason CL2's Prometheus OOMs mid-run. Knobs (all runner env vars):
+
+- **`PROMETHEUS_MEMORY_LIMIT_FACTOR`** (default `2`): the multiplier above. Rule of thumb for this
+  test: ~2 Gi base + ~1 Gi per 10k pods at target scale, rounded up generously — the limit is a
+  hard cap, so err high if the node can afford it.
+- **`PROMETHEUS_NODE_SELECTOR`** (default empty): YAML fragment merged into Prometheus's
+  nodeSelector, e.g. `"cloud.google.com/gke-nodepool: big-node-pool"`. Pin Prometheus to a node
+  large enough for the factor you chose (remember: request = limit, so the full amount must be
+  allocatable).
+- **`SCRAPE_KUBE_PROXY`** (default `false` — deviates from CL2's default of `true`): kube-proxy is
+  one scrape target *per node* and contributes nothing to this test; on large clusters it is pure
+  Prometheus memory burn.
+- **`PROMETHEUS_SLOW_APISERVER`** (default `false`): set `true` on large clusters to drop the
+  apiserver scrape interval from 5s to 30s — a large reduction in ingestion load at the cost of
+  coarser (still ample, given multi-minute plateaus) resolution for the per-step snapshots.
+
+Also relevant: kubelet/cAdvisor scraping stays off by default (CL2's default), which is by far the
+largest cardinality source on big clusters — leave it off.
+
+## Interpreting the Results
+
+All artifacts land in a timestamped directory at `${TEST_DIR}/tmp/${RUN_ID}` (full CL2 log,
+generated overrides, per-measurement JSON, Prometheus reports).
+
+1. **Find the cliff step.** Search the CL2 log / `junit.xml` for the first failed
+   `Wait for ... Sandboxes Ready` step. The preceding step's sandbox count is the upper bound. If
+   every step passed, the cluster fits the full `STEP_SIZE * TOTAL_STEPS * NAMESPACES` — raise
+   `TOTAL_STEPS` and go again.
+2. **Identify what gave out.** Each step produces a
+   `GenericPrometheusQuery Sandbox Capacity Step N` JSON file. Tabulating them against the sandbox
+   count shows which resource hit its wall at the cliff:
+   - `ControllerResidentMemoryBytes` — informer caches hold every Sandbox and Pod (both carry a
+     full PodSpec), so this should grow roughly linearly. A flatline near the container limit
+     followed by restarts means the controller OOMed.
+   - `ControllerUptimeSeconds` — a value that *drops* between steps means the controller restarted
+     (e.g. OOMKilled); that is a cliff signal on its own, even if the step eventually converged.
+   - `SandboxWorkqueueDepthMax` / `SandboxWorkqueueSecondsP99` — a queue that stops draining is the
+     leading indicator, usually visible a step or two before convergence fails.
+   - `EtcdDBSizeBytes` and `StoredSandboxObjects` — the per-step slope gives bytes-per-sandbox;
+     extrapolate against the etcd quota (commonly 2–8 GiB) to predict the etcd-bound ceiling.
+     `StoredSandboxObjects`/`StoredPodObjects` need a scrapable apiserver: the runner configures
+     this automatically for kind (apiserver-only scraping on port 6443); managed control planes
+     such as GKE expose nothing. `EtcdDBSizeBytes` additionally needs scrapable etcd, which only
+     kOps/self-managed clusters provide — kind's etcd binds its metrics port to localhost, so
+     expect this column to be empty on kind.
+3. **Read the degradation curve (nice-to-know).** Per-step wall-clock durations in `junit.xml`
+   show convergence time growing with total count — where it bends upward is where degradation
+   begins, typically before the hard cliff. The `PodStartupLatency` summary covers the whole run;
+   its threshold is set to 1h so it reports data without ever failing the test.
+
+### Recommended follow-up at the max plateau
+
+The informer re-list on startup is often the first thing to break at scale, and it is the failure
+you would hit during a controller upgrade. After a successful run (or at the last converged
+plateau), restart the controller and time how long it takes to become Ready and resume
+reconciling — CL2 cannot express this, so do it manually before the sandboxes are deleted:
+
+```bash
+kubectl -n agent-sandbox-system rollout restart deployment agent-sandbox-controller
+kubectl -n agent-sandbox-system rollout status deployment agent-sandbox-controller
+```
+
+## Cleanup
+
+The final test step scales the Sandbox count to zero and CL2 deletes its auto-managed namespaces on
+exit. Two caveats at high object counts:
+
+- Deleting tens of thousands of Sandboxes takes a while, and a wedged controller at the cliff makes
+  it slower — finalizer-bearing objects only go away as fast as the controller can process them.
+  Budget for teardown, and if the run aborted early, sweep manually:
+
+  ```bash
+  kubectl get namespaces -o name | grep sandbox-capacity
+  kubectl delete namespace <each sandbox-capacity-* namespace>
+  ```
+
+- Fake nodes are not managed by the test:
+
+  ```bash
+  kubectl delete nodes -l type=kwok
+  ```

--- a/dev/load-test/test-recipes/plot_capacity_results.py
+++ b/dev/load-test/test-recipes/plot_capacity_results.py
@@ -1,4 +1,18 @@
 #!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Plot degradation curves from sandbox-capacity-cliff-test run artifacts.
 
 Usage:
@@ -35,7 +49,15 @@ def load_run(run_dir):
     counts, conv, metrics = [], {}, {}
     junit = os.path.join(run_dir, "junit.xml")
     if os.path.exists(junit):
-        root = ET.parse(junit).getroot()
+        with open(junit) as fh:
+            text = fh.read()
+        # Tolerate a license comment prepended above the XML declaration
+        # (repo boilerplate tooling does this to artifacts left in the tree),
+        # which is invalid XML if parsed as-is.
+        start = text.find("<?xml")
+        if start == -1:
+            start = text.find("<testsuite")
+        root = ET.fromstring(text[max(start, 0):])
         suite = root if root.tag == "testsuite" else root.find("testsuite")
         for tc in suite.iter("testcase"):
             m = re.search(r"Wait for (\d+) Sandboxes", tc.get("name", ""))
@@ -46,7 +68,8 @@ def load_run(run_dir):
         if not m:
             continue
         count = int(m.group(1))
-        data = json.load(open(f))
+        with open(f) as fh:
+            data = json.load(fh)
         items = data.get("dataItems") or [{}]
         metrics[count] = items[0].get("data", {})
     counts = sorted(set(conv) | set(metrics))
@@ -75,6 +98,8 @@ def main():
     ap.add_argument("-o", "--out", default="capacity-degradation.png")
     ap.add_argument("--labels", nargs="*", help="one label per run dir for the convergence panel")
     args = ap.parse_args()
+    if args.labels and len(args.labels) != len(args.run_dirs):
+        ap.error(f"--labels has {len(args.labels)} entries but {len(args.run_dirs)} run_dirs were given")
 
     runs = [(d, *load_run(d)) for d in args.run_dirs]
     labels = args.labels or [os.path.basename(os.path.normpath(d)) for d in args.run_dirs]

--- a/dev/load-test/test-recipes/plot_capacity_results.py
+++ b/dev/load-test/test-recipes/plot_capacity_results.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Plot degradation curves from sandbox-capacity-cliff-test run artifacts.
+
+Usage:
+    python3 plot_capacity_results.py tmp/<RUN_ID> [tmp/<OTHER_RUN_ID> ...] -o out.png
+
+Reads, per run directory:
+  - junit.xml                      -> per-step convergence wall time ("Wait for N Sandboxes")
+  - GenericPrometheusQuery*.json   -> per-step controller RSS, workqueue depth/p99
+
+All run directories are overlaid on every panel (convergence from junit,
+metric panels from the per-step JSONs), so before/after comparisons read
+consistently across the whole figure. Requires matplotlib.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+# Reference dataviz palette (light mode)
+SURFACE, INK, INK2, MUTED = "#fcfcfb", "#0b0b0b", "#52514e", "#898781"
+GRID, BASELINE = "#e1e0d9", "#c3c2b7"
+SERIES = ["#2a78d6", "#1baf7a", "#eda100", "#008300"]  # fixed order, never cycled
+
+
+def load_run(run_dir):
+    counts, conv, metrics = [], {}, {}
+    junit = os.path.join(run_dir, "junit.xml")
+    if os.path.exists(junit):
+        root = ET.parse(junit).getroot()
+        suite = root if root.tag == "testsuite" else root.find("testsuite")
+        for tc in suite.iter("testcase"):
+            m = re.search(r"Wait for (\d+) Sandboxes", tc.get("name", ""))
+            if m:
+                conv[int(m.group(1))] = float(tc.get("time"))
+    for f in glob.glob(os.path.join(run_dir, "GenericPrometheusQuery*.json")):
+        m = re.search(r"\((\d+) sandboxes\)", f)
+        if not m:
+            continue
+        count = int(m.group(1))
+        data = json.load(open(f))
+        items = data.get("dataItems") or [{}]
+        metrics[count] = items[0].get("data", {})
+    counts = sorted(set(conv) | set(metrics))
+    return counts, conv, metrics
+
+
+def style(ax, title, subtitle):
+    ax.set_facecolor(SURFACE)
+    for side in ("top", "right", "left"):
+        ax.spines[side].set_visible(False)
+    ax.spines["bottom"].set_color(BASELINE)
+    ax.tick_params(colors=MUTED, labelsize=9, length=0)
+    ax.grid(axis="y", color=GRID, linewidth=0.75)
+    ax.set_axisbelow(True)
+    ax.set_title(title, loc="left", fontsize=11.5, color=INK, fontweight="bold", pad=16)
+    ax.text(0, 1.045, subtitle, transform=ax.transAxes, fontsize=9, color=INK2)
+
+
+def kfmt(v):
+    return f"{v // 1000}k" if v >= 1000 else str(v)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_dirs", nargs="+")
+    ap.add_argument("-o", "--out", default="capacity-degradation.png")
+    ap.add_argument("--labels", nargs="*", help="one label per run dir for the convergence panel")
+    args = ap.parse_args()
+
+    runs = [(d, *load_run(d)) for d in args.run_dirs]
+    labels = args.labels or [os.path.basename(os.path.normpath(d)) for d in args.run_dirs]
+    primary_dir, counts, conv, metrics = runs[0]
+    if not counts:
+        sys.exit(f"no junit.xml or metrics JSONs found in {primary_dir}")
+
+    fig, axes = plt.subplots(2, 2, figsize=(12.8, 8.6), dpi=150)
+    fig.patch.set_facecolor(SURFACE)
+    fig.subplots_adjust(hspace=0.52, wspace=0.24, left=0.07, right=0.97, top=0.83, bottom=0.08)
+
+    def add_legend(ax):
+        if len(runs) > 1:
+            ax.legend(loc="upper left", frameon=False, fontsize=8.5, labelcolor=INK2, handlelength=1.6)
+
+    # Panel 1: convergence (all runs, from junit)
+    ax = axes[0][0]
+    style(ax, "Time to converge each batch", "seconds until all sandboxes Ready")
+    for i, (d, cts, cv, _) in enumerate(runs):
+        xs = sorted(cv)
+        ax.plot(xs, [cv[x] for x in xs], color=SERIES[i % len(SERIES)], linewidth=2,
+                marker="o", markersize=5, label=labels[i])
+    add_legend(ax)
+
+    panels = [
+        (axes[0][1], "SandboxWorkqueueSecondsP99", "Sandbox workqueue p99 queue time", "seconds, log scale", True, 1),
+        (axes[1][0], "SandboxWorkqueueDepthMax", "Sandbox workqueue max depth per step", "items", False, 1),
+        (axes[1][1], "ControllerResidentMemoryBytes", "Controller resident memory", "GiB", False, 1 << 30),
+    ]
+    for ax, metric, title, unit, logy, div in panels:
+        style(ax, title, unit)
+        any_data = False
+        for i, (d, cts, cv, mets) in enumerate(runs):
+            xs = [c for c in sorted(mets) if mets[c].get(metric) is not None]
+            if not xs:
+                continue
+            any_data = True
+            ax.plot(xs, [mets[c][metric] / div for c in xs], color=SERIES[i % len(SERIES)],
+                    linewidth=2, marker="o", markersize=5, label=labels[i])
+        if not any_data:
+            ax.text(0.5, 0.5, "no data", transform=ax.transAxes, color=MUTED, ha="center")
+            continue
+        if logy:
+            ax.set_yscale("log")
+        add_legend(ax)
+
+    for ax in axes.flat:
+        ticks = [c for c in counts[1::2]]
+        ax.set_xticks(ticks)
+        ax.set_xticklabels([kfmt(t) for t in ticks])
+
+    fig.suptitle("Sandbox capacity degradation", x=0.07, y=0.98, ha="left",
+                 fontsize=13.5, color=INK, fontweight="bold")
+    fig.text(0.07, 0.945, " · ".join(labels), fontsize=9.5, color=INK2)
+    fig.savefig(args.out, facecolor=SURFACE)
+    print("wrote", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/load-test/test-recipes/run_capacity_cliff.sh
+++ b/dev/load-test/test-recipes/run_capacity_cliff.sh
@@ -31,7 +31,9 @@ HOLD_DURATION="${HOLD_DURATION:-2m}"
 CONVERGENCE_TIMEOUT="${CONVERGENCE_TIMEOUT:-30m}"
 KWOK_NODES="${KWOK_NODES:-false}"
 PROVIDER="${PROVIDER:-gke}"
-KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+# Exported so the pre-flight kubectl checks below target the same cluster as
+# the clusterloader2 run (which receives it via --kubeconfig).
+export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 # Must be pullable from the cluster's nodes. Private GKE nodes without Cloud
 # NAT cannot reach registry.k8s.io — use a gcr.io/pkg.dev-hosted image there.
 SANDBOX_IMAGE="${SANDBOX_IMAGE:-registry.k8s.io/pause:3.10}"
@@ -101,23 +103,36 @@ echo "=== Starting Sandbox Capacity Cliff Test (up to ${MAX_SANDBOXES} sandboxes
 echo "Step Size: $STEP_SIZE, Total Steps: $TOTAL_STEPS, Namespaces: $NAMESPACES, QPS: $QPS"
 echo "Hold: $HOLD_DURATION, Convergence Timeout: $CONVERGENCE_TIMEOUT, kwok Nodes: $KWOK_NODES"
 
-# Create overrides specifying the CL2 parameters
-cat <<JSON_EOF > "${LOGS_DIR}/testoverrides.json"
-{
-  "CL2_STEP_SIZE": $STEP_SIZE,
-  "CL2_TOTAL_STEPS": $TOTAL_STEPS,
-  "CL2_QPS": $QPS,
-  "CL2_NAMESPACES": $NAMESPACES,
-  "CL2_HOLD_DURATION": "$HOLD_DURATION",
-  "CL2_CONVERGENCE_TIMEOUT": "$CONVERGENCE_TIMEOUT",
-  "CL2_KWOK_NODES": "$KWOK_NODES",
-  "CL2_SANDBOX_IMAGE": "$SANDBOX_IMAGE",
-  "CL2_NETWORK_POLICY": "$NETWORK_POLICY",
-  "CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR": $PROMETHEUS_MEMORY_LIMIT_FACTOR,
-  "CL2_PROMETHEUS_NODE_SELECTOR": "$PROMETHEUS_NODE_SELECTOR",
-  "CL2_PROMETHEUS_SLOW_APISERVER": $PROMETHEUS_SLOW_APISERVER
-}
-JSON_EOF
+# Create overrides specifying the CL2 parameters (jq handles JSON escaping —
+# PROMETHEUS_NODE_SELECTOR is a YAML fragment that may contain quotes or
+# newlines, which a heredoc would embed as invalid JSON).
+jq -n \
+  --argjson step_size "$STEP_SIZE" \
+  --argjson total_steps "$TOTAL_STEPS" \
+  --argjson qps "$QPS" \
+  --argjson namespaces "$NAMESPACES" \
+  --arg hold_duration "$HOLD_DURATION" \
+  --arg convergence_timeout "$CONVERGENCE_TIMEOUT" \
+  --arg kwok_nodes "$KWOK_NODES" \
+  --arg sandbox_image "$SANDBOX_IMAGE" \
+  --arg network_policy "$NETWORK_POLICY" \
+  --argjson prometheus_memory_limit_factor "$PROMETHEUS_MEMORY_LIMIT_FACTOR" \
+  --arg prometheus_node_selector "$PROMETHEUS_NODE_SELECTOR" \
+  --argjson prometheus_slow_apiserver "$PROMETHEUS_SLOW_APISERVER" \
+  '{
+    CL2_STEP_SIZE: $step_size,
+    CL2_TOTAL_STEPS: $total_steps,
+    CL2_QPS: $qps,
+    CL2_NAMESPACES: $namespaces,
+    CL2_HOLD_DURATION: $hold_duration,
+    CL2_CONVERGENCE_TIMEOUT: $convergence_timeout,
+    CL2_KWOK_NODES: $kwok_nodes,
+    CL2_SANDBOX_IMAGE: $sandbox_image,
+    CL2_NETWORK_POLICY: $network_policy,
+    CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR: $prometheus_memory_limit_factor,
+    CL2_PROMETHEUS_NODE_SELECTOR: $prometheus_node_selector,
+    CL2_PROMETHEUS_SLOW_APISERVER: $prometheus_slow_apiserver
+  }' > "${LOGS_DIR}/testoverrides.json"
 
 # Execute using the cluster loader2 test.
 # Exec service is disabled: no measurement in this test execs into pods, and

--- a/dev/load-test/test-recipes/run_capacity_cliff.sh
+++ b/dev/load-test/test-recipes/run_capacity_cliff.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+RUN_ID=$(date +%Y%m%d-%H%M%S)
+if [ -n "$1" ]; then
+  RUN_ID+="-${1}"
+fi
+
+# Configuration defaults (overridable via environment variables)
+STEP_SIZE="${STEP_SIZE:-1000}"
+TOTAL_STEPS="${TOTAL_STEPS:-20}"
+QPS="${QPS:-100}"
+NAMESPACES="${NAMESPACES:-1}"
+HOLD_DURATION="${HOLD_DURATION:-2m}"
+CONVERGENCE_TIMEOUT="${CONVERGENCE_TIMEOUT:-30m}"
+KWOK_NODES="${KWOK_NODES:-false}"
+PROVIDER="${PROVIDER:-gke}"
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+# Must be pullable from the cluster's nodes. Private GKE nodes without Cloud
+# NAT cannot reach registry.k8s.io — use a gcr.io/pkg.dev-hosted image there.
+SANDBOX_IMAGE="${SANDBOX_IMAGE:-registry.k8s.io/pause:3.10}"
+# Set to true to apply the SandboxTemplate-shaped NetworkPolicy to sandbox
+# pods (production configuration); false measures the unpoliced best case.
+NETWORK_POLICY="${NETWORK_POLICY:-false}"
+
+# Prometheus OOM guards. CL2 sets the Prometheus container's memory REQUEST
+# AND LIMIT to (MEMORY_LIMIT_FACTOR)Gi x (1 + nodes/1000) — the default factor
+# of 2 means a hard 2Gi cap on clusters under 1k nodes, which OOMs long before
+# the sandbox counts this test targets. Size the factor to the pod count you
+# are ramping to (rule of thumb: ~2Gi base + ~1Gi per 10k pods, then round up
+# generously — the limit is a hard cap) and pin Prometheus to a node that can
+# hold it via PROMETHEUS_NODE_SELECTOR (YAML fragment, e.g.
+# "cloud.google.com/gke-nodepool: my-big-pool").
+# Kube-proxy scraping is one target per node and useless to this test — off.
+# PROMETHEUS_SLOW_APISERVER=true drops the apiserver scrape from 5s to 30s,
+# cutting Prometheus memory/CPU substantially on large clusters.
+PROMETHEUS_MEMORY_LIMIT_FACTOR="${PROMETHEUS_MEMORY_LIMIT_FACTOR:-2}"
+PROMETHEUS_NODE_SELECTOR="${PROMETHEUS_NODE_SELECTOR:-}"
+PROMETHEUS_SLOW_APISERVER="${PROMETHEUS_SLOW_APISERVER:-false}"
+SCRAPE_KUBE_PROXY="${SCRAPE_KUBE_PROXY:-false}"
+
+# kind needs three deviations from CL2's GCE-oriented Prometheus defaults:
+# - The Prometheus PVC defaults to an "ssd" StorageClass backed by the GCE PD
+#   provisioner, which does not exist on kind — use kind's built-in "standard".
+# - kube-scheduler/kube-controller-manager bind to 127.0.0.1 on kind, so their
+#   scrape targets can never come up and CL2's health wait would time out —
+#   scrape only the apiserver among master components.
+# - The apiserver serves on 6443 on kind nodes, not 443.
+PROMETHEUS_EXTRA_FLAGS=""
+if [ "$PROVIDER" = "kind" ]; then
+  PROMETHEUS_PVC_STORAGE_CLASS="${PROMETHEUS_PVC_STORAGE_CLASS:-standard}"
+  PROMETHEUS_EXTRA_FLAGS="--prometheus-scrape-apiserver-only=true --prometheus-apiserver-scrape-port=6443"
+else
+  PROMETHEUS_PVC_STORAGE_CLASS="${PROMETHEUS_PVC_STORAGE_CLASS:-ssd}"
+fi
+
+# Paths to local clones (overridable via environment variables).
+# Clusterloader2 must be cloned or forked from https://github.com/kubernetes/perf-tests
+CL2_DIR="${CL2_DIR:-${HOME}/perf-tests/clusterloader2}"
+AGENTS_DIR="${AGENTS_DIR:-${HOME}/agent-sandbox}"
+TEST_DIR="${AGENTS_DIR}/dev/load-test/test-recipes"
+TEST_CONFIG="${TEST_DIR}/sandbox-capacity-cliff-test.yaml"
+LOGS_DIR="${TEST_DIR}/tmp/${RUN_ID}"
+
+# Pre-flight checks
+echo "Verifying connection to Kubernetes cluster..."
+if ! kubectl cluster-info &> /dev/null; then
+  echo "ERROR: Kubernetes cluster is unreachable. Please check your kubeconfig, context, or network connection." >&2
+  exit 1
+fi
+
+if [ "$KWOK_NODES" = "true" ]; then
+  echo "Checking for kwok fake nodes (label type=kwok)..."
+  if ! kubectl get nodes -l type=kwok -o name | grep -q .; then
+    echo "ERROR: KWOK_NODES=true but no nodes with label type=kwok were found." >&2
+    echo "See README-capacity-cliff.md for kwok setup instructions." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$LOGS_DIR"
+
+MAX_SANDBOXES=$(($STEP_SIZE * $TOTAL_STEPS * $NAMESPACES))
+echo "=== Starting Sandbox Capacity Cliff Test (up to ${MAX_SANDBOXES} sandboxes) ==="
+echo "Step Size: $STEP_SIZE, Total Steps: $TOTAL_STEPS, Namespaces: $NAMESPACES, QPS: $QPS"
+echo "Hold: $HOLD_DURATION, Convergence Timeout: $CONVERGENCE_TIMEOUT, kwok Nodes: $KWOK_NODES"
+
+# Create overrides specifying the CL2 parameters
+cat <<JSON_EOF > "${LOGS_DIR}/testoverrides.json"
+{
+  "CL2_STEP_SIZE": $STEP_SIZE,
+  "CL2_TOTAL_STEPS": $TOTAL_STEPS,
+  "CL2_QPS": $QPS,
+  "CL2_NAMESPACES": $NAMESPACES,
+  "CL2_HOLD_DURATION": "$HOLD_DURATION",
+  "CL2_CONVERGENCE_TIMEOUT": "$CONVERGENCE_TIMEOUT",
+  "CL2_KWOK_NODES": "$KWOK_NODES",
+  "CL2_SANDBOX_IMAGE": "$SANDBOX_IMAGE",
+  "CL2_NETWORK_POLICY": "$NETWORK_POLICY",
+  "CL2_PROMETHEUS_MEMORY_LIMIT_FACTOR": $PROMETHEUS_MEMORY_LIMIT_FACTOR,
+  "CL2_PROMETHEUS_NODE_SELECTOR": "$PROMETHEUS_NODE_SELECTOR",
+  "CL2_PROMETHEUS_SLOW_APISERVER": $PROMETHEUS_SLOW_APISERVER
+}
+JSON_EOF
+
+# Execute using the cluster loader2 test.
+# Exec service is disabled: no measurement in this test execs into pods, and
+# its agnhost helper image (registry.k8s.io) is unpullable from private nodes.
+cd "$CL2_DIR"
+go run cmd/clusterloader.go \
+  --enable-exec-service=false \
+  --enable-prometheus-server=true \
+  --prometheus-pvc-storage-class="${PROMETHEUS_PVC_STORAGE_CLASS}" \
+  --prometheus-scrape-kube-proxy="${SCRAPE_KUBE_PROXY}" \
+  ${PROMETHEUS_EXTRA_FLAGS} \
+  --kubeconfig="${KUBECONFIG}" \
+  --prometheus-additional-monitors-path="${TEST_DIR}/monitor" \
+  --provider="${PROVIDER}" \
+  --report-dir="${LOGS_DIR}" \
+  --testconfig="${TEST_CONFIG}" \
+  --testoverrides="${LOGS_DIR}/testoverrides.json" \
+  --v=2 \
+  2>&1 | tee "${LOGS_DIR}/clusterloader2-${RUN_ID}.log"

--- a/dev/load-test/test-recipes/sandbox-capacity-cliff-test.yaml
+++ b/dev/load-test/test-recipes/sandbox-capacity-cliff-test.yaml
@@ -1,0 +1,241 @@
+# Sandbox capacity cliff test.
+#
+# Finds the maximum number of Sandbox objects (each with a backing Pod) a
+# cluster can sustain before performance falls off a cliff. Unlike the other
+# recipes in this directory, the primary signal is NOT latency — it is
+# convergence: the test ratchets the total Sandbox count upward in steps and
+# the cliff is the first step at which the cluster can no longer drive every
+# Sandbox to Ready=True within the (generous) convergence timeout.
+#
+# Per-step capacity metrics (etcd DB size, controller memory, workqueue depth,
+# stored object counts, controller restarts) are snapshotted at each plateau so
+# the degradation curve can be reconstructed afterwards. Latency measurements
+# are collected as nice-to-know data only and never gate the test.
+#
+# The extensions (SandboxClaim/SandboxTemplate/SandboxWarmPool) are
+# intentionally not exercised: only Sandbox and its child Pod are in scope.
+
+# The number of namespaces to create and spread the test load across.
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+# The maximum rate (Queries Per Second) for cluster loader to create objects.
+{{$qps := DefaultParam .CL2_QPS 100}}
+# The number of Sandboxes added per namespace at each step.
+{{$stepSize := DefaultParam .CL2_STEP_SIZE 1000}}
+# The total number of ramp steps. The final target is
+# STEP_SIZE * TOTAL_STEPS * NAMESPACES sandboxes. Deliberately overshoot the
+# expected ceiling: the step that fails to converge IS the result.
+{{$totalSteps := DefaultParam .CL2_TOTAL_STEPS 20}}
+# How long to hold each plateau before snapshotting metrics. The hold exposes
+# steady-state load (resyncs, watch churn) that a pure creation burst hides.
+{{$holdDuration := DefaultParam .CL2_HOLD_DURATION "2m"}}
+# How long to wait for a step's sandboxes to all become Ready. This is the
+# effective definition of "does not fit": slow is fine, not converging is not.
+# Size it to step size / conservative expected throughput with a wide margin.
+{{$convergenceTimeout := DefaultParam .CL2_CONVERGENCE_TIMEOUT "30m"}}
+# The prefix used for naming the test namespaces.
+{{$namespacePrefix := DefaultParam .CL2_NAMESPACE_PREFIX "sandbox-capacity"}}
+# Set to "true" to pin sandbox pods to kwok fake nodes (nodeSelector type=kwok
+# plus the standard kwok taint toleration). Use this to measure the
+# control-plane ceiling without paying for real nodes.
+{{$kwokNodes := DefaultParam .CL2_KWOK_NODES "false"}}
+# Container image for the sandbox pods. Must be pullable from the test
+# cluster's nodes — private GKE nodes without Cloud NAT cannot reach
+# registry.k8s.io; use a gcr.io/pkg.dev-hosted image there instead.
+{{$sandboxImage := DefaultParam .CL2_SANDBOX_IMAGE "registry.k8s.io/pause:3.10"}}
+# Set to "true" to apply one NetworkPolicy per namespace selecting all sandbox
+# pods, mirroring the SandboxTemplate extension's "Secure by Default" policy.
+# Use to measure the dataplane cost of policy enforcement at scale — the
+# production configuration — vs. the unpoliced best case.
+{{$networkPolicy := DefaultParam .CL2_NETWORK_POLICY "false"}}
+
+name: sandbox-capacity-cliff-test
+
+namespace:
+  number: {{$namespaces}}
+  prefix: {{$namespacePrefix}}
+
+tuningSets:
+- name: RampCreate
+  qpsLoad:
+    qps: {{$qps}}
+
+steps:
+{{if eq $networkPolicy "true"}}
+# Applied before any sandboxes exist so every endpoint is created under policy
+# enforcement, exactly as in a SandboxTemplate-managed production namespace.
+- name: Apply Sandbox NetworkPolicy
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: RampCreate
+    objectBundle:
+    - basename: capacity-netpol
+      objectTemplatePath: templates/cluster-loader-capacity-networkpolicy.yaml
+      templateFillMap:
+        Group: sandbox-capacity-cliff
+{{end}}
+
+# Latency is nice-to-know only: the threshold is set far beyond any plausible
+# value so this measurement never fails the run.
+- name: Start Pod Startup Latency Measurement (informational only)
+  measurements:
+  - Identifier: SandboxPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: "group=sandbox-capacity-cliff"
+      threshold: 1h
+
+# --- START RAMP LOOP ---
+{{range $i := Loop $totalSteps}}
+{{$step := AddInt $i 1}}
+{{$targetPerNamespace := MultiplyInt $step $stepSize}}
+{{$targetTotal := MultiplyInt $targetPerNamespace $namespaces}}
+
+# The metrics window opens BEFORE the ramp so that rate()-based queries (%v
+# resolves to time-since-start at gather) cover the busy ramp/convergence
+# phase, not just the idle hold.
+- name: Step {{$step}} - Begin step metrics window
+  measurements:
+  - Identifier: CapacityMetricsStep{{$step}}
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: Sandbox Capacity Step {{$step}} ({{$targetTotal}} sandboxes)
+      metricVersion: v1
+      unit: count
+      # Recorded as data, not pass/fail: no thresholds on purpose.
+      queries:
+      - name: ControllerResidentMemoryBytes
+        query: max(max_over_time(process_resident_memory_bytes{namespace="agent-sandbox-system"}[%v]))
+      # Uptime dropping between steps means the controller restarted (e.g.
+      # OOMKilled) — sourced from the controller's own /metrics so it works
+      # without kube-state-metrics.
+      - name: ControllerUptimeSeconds
+        query: min(time() - process_start_time_seconds{namespace="agent-sandbox-system"})
+      - name: SandboxWorkqueueDepthMax
+        query: max(max_over_time(workqueue_depth{name="sandbox"}[%v]))
+      - name: SandboxWorkqueueSecondsP99
+        query: histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{name="sandbox"}[%v])) by (le))
+      # Reconcile service time and throughput — the discriminators for why the
+      # workqueue backs up. Service time growing with cluster size while
+      # throughput falls means each reconcile got slower; then the rest_client
+      # rows say whether the time went into API round-trips (latency), 409s
+      # (conflict retries), or 429s (APF throttling), and CPU/GC whether it
+      # went into the process itself.
+      - name: ReconcileTimeP50
+        query: histogram_quantile(0.50, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller="sandbox"}[%v])) by (le))
+      - name: ReconcileTimeP99
+        query: histogram_quantile(0.99, sum(rate(controller_runtime_reconcile_time_seconds_bucket{controller="sandbox"}[%v])) by (le))
+      - name: ReconcilesPerSecond
+        query: sum(rate(controller_runtime_reconcile_total{controller="sandbox"}[%v]))
+      - name: WorkqueueRetriesPerSecond
+        query: sum(rate(workqueue_retries_total{name="sandbox"}[%v]))
+      - name: RestClientPutP99Seconds
+        query: histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{namespace="agent-sandbox-system",verb="PUT"}[%v])) by (le))
+      - name: RestClientGetP99Seconds
+        query: histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{namespace="agent-sandbox-system",verb="GET"}[%v])) by (le))
+      - name: RestClient409PerSecond
+        query: sum(rate(rest_client_requests_total{namespace="agent-sandbox-system",code="409"}[%v]))
+      - name: RestClient429PerSecond
+        query: sum(rate(rest_client_requests_total{namespace="agent-sandbox-system",code="429"}[%v]))
+      - name: ControllerCPUCores
+        query: sum(rate(process_cpu_seconds_total{namespace="agent-sandbox-system"}[%v]))
+      - name: GoGCMaxPauseSeconds
+        query: max(go_gc_duration_seconds{namespace="agent-sandbox-system",quantile="1"})
+      # StoredSandboxObjects/StoredPodObjects need a scrapable apiserver (the
+      # runner configures this automatically for kind; managed control planes
+      # generally expose nothing). EtcdDBSizeBytes additionally needs scrapable
+      # etcd (kOps/self-managed only — kind's etcd binds metrics to localhost).
+      # They record nothing rather than failing when unavailable.
+      - name: StoredSandboxObjects
+        query: max(apiserver_storage_objects{resource=~"sandboxes.*"})
+      - name: StoredPodObjects
+        query: max(apiserver_storage_objects{resource="pods"})
+      # On Cilium-based dataplanes (e.g. GKE Dataplane V2): identity count
+      # growing per-sandbox instead of staying ~flat means unique pod labels
+      # are exploding identity cardinality — the dataplane cliff signature.
+      - name: StoredCiliumIdentities
+        query: max(apiserver_storage_objects{resource="ciliumidentities.cilium.io"})
+      - name: EtcdDBSizeBytes
+        query: max(etcd_mvcc_db_total_size_in_bytes)
+
+- name: Step {{$step}} - Ramp to {{$targetTotal}} Sandboxes
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: {{$targetPerNamespace}}
+    tuningSet: RampCreate
+    objectBundle:
+    - basename: capacity-sandbox
+      objectTemplatePath: templates/cluster-loader-capacity-sandbox.yaml
+      templateFillMap:
+        Group: sandbox-capacity-cliff
+        KwokNodes: "{{$kwokNodes}}"
+        Image: {{$sandboxImage}}
+
+# Convergence is the pass/fail criterion. If this times out, the previous
+# step's count is the cluster's upper bound and the metrics snapshots tell
+# you which component gave out first.
+- name: Step {{$step}} - Wait for {{$targetTotal}} Sandboxes Ready
+  measurements:
+  - Identifier: WaitForSandboxesStep{{$step}}
+    Method: WaitForGenericK8sObjects
+    Params:
+      action: start
+      objectGroup: agents.x-k8s.io
+      objectVersion: v1beta1
+      objectResource: sandboxes
+      namespaceRange: {min: 1, max: {{$namespaces}}}
+      successfulConditions: ["Ready=True"]
+      failedConditions: []
+      minDesiredObjectCount: {{$targetTotal}}
+      maxFailedObjectCount: 0
+      timeout: {{$convergenceTimeout}}
+      # Deliberately slow: polling LISTs are themselves apiserver load at
+      # high object counts and must not distort the measurement.
+      refreshInterval: 10s
+
+- name: Step {{$step}} - Hold plateau for {{$holdDuration}}
+  measurements:
+  - Identifier: HoldStep{{$step}}
+    Method: Sleep
+    Params:
+      duration: {{$holdDuration}}
+
+- name: Step {{$step}} - Snapshot capacity metrics
+  measurements:
+  - Identifier: CapacityMetricsStep{{$step}}
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+      enableViolations: false
+{{end}}
+# --- END RAMP LOOP ---
+
+- name: Pause 1m to allow Prometheus to scrape final metrics
+  measurements:
+  - Identifier: WaitAfterTest
+    Method: Sleep
+    Params:
+      duration: 1m
+
+- name: Gather Pod Startup Latency (informational only)
+  measurements:
+  - Identifier: SandboxPodStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+      labelSelector: "group=sandbox-capacity-cliff"
+
+- name: Delete Sandboxes
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: RampCreate
+    objectBundle:
+    - basename: capacity-sandbox
+      objectTemplatePath: templates/cluster-loader-capacity-sandbox.yaml
+      templateFillMap:
+        Group: sandbox-capacity-cliff
+        KwokNodes: "{{$kwokNodes}}"
+        Image: {{$sandboxImage}}

--- a/dev/load-test/test-recipes/templates/cluster-loader-capacity-networkpolicy.yaml
+++ b/dev/load-test/test-recipes/templates/cluster-loader-capacity-networkpolicy.yaml
@@ -1,0 +1,43 @@
+# Mirrors the "Secure by Default" NetworkPolicy the SandboxTemplate extension
+# controller creates per template (buildDefaultNetworkPolicySpec in
+# extensions/controllers/sandboxtemplate_controller.go), with the test's shared
+# `group` label standing in for the shared sandbox-template-ref-hash label —
+# same cardinality: ONE policy selecting ALL sandbox pods via a shared label.
+#
+# Ingress admits only the sandbox-router (which does not exist in this test, so
+# ingress is effectively default-deny — faithful to production enforcement
+# work). Egress allows public internet while blocking private/link-local
+# ranges, including the metadata server.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{.Name}}
+spec:
+  podSelector:
+    matchLabels:
+      group: {{.Group}}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: agent-sandbox-system
+      podSelector:
+        matchLabels:
+          app: sandbox-router
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - 169.254.0.0/16
+    - ipBlock:
+        cidr: ::/0
+        except:
+        - fc00::/7
+        - fe80::/10

--- a/dev/load-test/test-recipes/templates/cluster-loader-capacity-sandbox.yaml
+++ b/dev/load-test/test-recipes/templates/cluster-loader-capacity-sandbox.yaml
@@ -1,0 +1,34 @@
+# Minimal Sandbox for capacity testing: one pause container, Service
+# explicitly disabled, no volumeClaimTemplates, no lifecycle shutdown —
+# nothing self-deletes or exits mid-test. The pause image runs indefinitely,
+# unlike the sleep-based images in other recipes whose pods would exit (and
+# flip Ready) partway through a long capacity run.
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  service: false
+  podTemplate:
+    metadata:
+      labels:
+        group: {{.Group}}
+    spec:
+      terminationGracePeriodSeconds: 1
+      {{if eq .KwokNodes "true"}}
+      nodeSelector:
+        type: kwok
+      tolerations:
+      - key: kwok.x-k8s.io/node
+        operator: Exists
+        effect: NoSchedule
+      {{end}}
+      containers:
+      - name: sandbox
+        image: {{.Image}}
+        resources:
+          requests:
+            cpu: 1m
+            memory: 8Mi


### PR DESCRIPTION
## What this adds

A ClusterLoader2 recipe for answering "how many Sandboxes (each with a backing Pod) can this cluster hold before performance falls off a cliff?" — complementing the existing latency-oriented recipes with a capacity-oriented one.

**Design.** The primary signal is convergence, not latency. The test ratchets the total Sandbox count upward in `CL2_STEP_SIZE` increments; each step waits (generously) for every Sandbox to reach `Ready=True`, holds a plateau, and snapshots diagnostics. Slow is fine — the cliff is the first step that cannot converge, and the per-step snapshots identify which component gave out. Latency comes along for free via junit step durations and an ungated `PodStartupLatency` measurement.

**Per-step diagnostics** (GenericPrometheusQuery): controller memory/CPU/uptime, reconcile p50/p99 and throughput, workqueue depth/queue-time/retries, client 409/429 rates, apiserver stored-object counts, CiliumIdentity count (identity-cardinality watchdog for Cilium dataplanes), etcd DB size where scrapable.

**Variants via env vars:**
- `KWOK_NODES=true` — pin sandbox pods to kwok fake nodes to measure the control-plane ceiling without paying for real nodes
- `NETWORK_POLICY=true` — apply a NetworkPolicy per namespace mirroring the SandboxTemplate extension's Secure-by-Default shape (shared-label selector), for production-configuration runs
- `SANDBOX_IMAGE` — pod image override (private GKE nodes without Cloud NAT cannot pull registry.k8s.io)

The runner also encodes the environment fixups needed to keep CL2's Prometheus alive on kind and at scale (storage class, apiserver scrape port/scope, memory-limit sizing — CL2's default gives Prometheus a hard 2Gi cap below 1k nodes — kube-proxy scrape disabled, exec service disabled), and `plot_capacity_results.py` renders comparison charts from the run artifacts with multi-run overlay.

## Results from using it

On a 753-node GKE Dataplane V2 cluster this recipe located a hard cliff at ~65k sandboxes (Cilium identity explosion from unique per-sandbox pod labels; fixed via identity label exclusion, after which 150k sandboxes converge cleanly with and without NetworkPolicy), and its diagnostics isolated the O(n) pod List in `reconcilePod` fixed by #1099 — including the counterintuitive result that raising `--sandbox-concurrent-workers` to 400 made convergence 3× slower before that fix.

## Testing

Validated end-to-end on kind (with kwok) and on GKE (runs to 150k sandboxes). junit and artifact layout verified with the plotting script; NetworkPolicy template server-side dry-run validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Agent Sandbox Capacity Cliff” load test recipe to find the first scaling step where sandboxes stop converging to Ready=true within the configured timeout.
  * Added a capacity-cliff test runner with configurable ramping, concurrency/QPS, Prometheus settings, and optional KWOK fake-node pinning.
  * Added a plotting CLI to overlay multiple runs and visualize convergence time and capacity-related controller/workqueue metrics.
  * Added sandbox workload and optional NetworkPolicy templates to support minimal-capacity testing and traffic restriction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->