### PR TITLE
ci: retry cluster bring-up steps in presubmit runner

### DIFF
--- a/dev/ci/shared/runner.py
+++ b/dev/ci/shared/runner.py
@@ -17,6 +17,7 @@ import os
 import argparse
 import sys
 import subprocess
+import time
 
 from dev.tools.shared import utils as tools_utils
 
@@ -50,25 +51,54 @@ class TestRunner:
     def _get_repo_root(self):
         return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+    def run_with_retry(self, cmd, attempts=2, retry_delay_seconds=10):
+        """Runs a cluster-setup command, retrying on failure.
+
+        Bring-up steps (kind cluster creation, image push, deploys) fail
+        intermittently under CI's Docker-in-Docker; most red presubmit runs
+        die here before any test executes. Each step is safe to re-run
+        (create-kind-cluster is invoked with --recreate and the deploys are
+        idempotent applies), so one retry recovers transient failures without
+        masking persistent breakage. The delay before retrying gives
+        transient daemon states (socket contention, container cleanup races)
+        time to clear; an immediate retry tends to hit the same condition.
+        """
+        if attempts < 1:
+            raise ValueError(f"attempts must be >= 1, got {attempts}")
+        result = None
+        for attempt in range(1, attempts + 1):
+            result = subprocess.run(cmd)
+            if result.returncode == 0:
+                return result
+            if attempt < attempts:
+                print(
+                    f"setup step {os.path.basename(cmd[0])} failed with exit code "
+                    f"{result.returncode}; retrying in {retry_delay_seconds}s "
+                    f"(attempt {attempt + 1} of {attempts})",
+                    file=sys.stderr,
+                )
+                time.sleep(retry_delay_seconds)
+        return result
+
     def setup_cluster(self, args, extra_push_images_args=None):
         image_tag = os.environ["IMAGE_TAG"]
-        result = subprocess.run([f"{self.repo_root}/dev/tools/create-kind-cluster", self.name, "--recreate", "--kubeconfig", f"{self.repo_root}/bin/KUBECONFIG"])
+        result = self.run_with_retry([f"{self.repo_root}/dev/tools/create-kind-cluster", self.name, "--recreate", "--kubeconfig", f"{self.repo_root}/bin/KUBECONFIG"])
         if result.returncode != 0:
             return result
-        
+
         push_images_cmd = [f"{self.repo_root}/dev/tools/push-images", "--kind-cluster-name", self.name, "--image-prefix", args.image_prefix, "--image-tag", image_tag]
         if extra_push_images_args:
             push_images_cmd.extend(extra_push_images_args)
-        result = subprocess.run(push_images_cmd)
+        result = self.run_with_retry(push_images_cmd)
         if result.returncode != 0:
             return result
 
         if not getattr(args, "skip_initial_deploy", False):
-            result = subprocess.run([f"{self.repo_root}/dev/tools/deploy-to-kube", "--image-prefix", args.image_prefix, "--image-tag", image_tag, "--extensions"])
+            result = self.run_with_retry([f"{self.repo_root}/dev/tools/deploy-to-kube", "--image-prefix", args.image_prefix, "--image-tag", image_tag, "--extensions"])
             if result.returncode != 0:
                 return result
 
-        result = subprocess.run([f"{self.repo_root}/dev/tools/deploy-cloud-provider"])
+        result = self.run_with_retry([f"{self.repo_root}/dev/tools/deploy-cloud-provider"])
         return result
 
     def run_tests(self, args):


### PR DESCRIPTION
## What this does

Retries each cluster-setup step (kind creation, image push, controller/cloud-provider deploy) once in `dev/ci/shared/runner.py`.

## Why

TestGrid data for `sig-apps-agent-sandbox` shows **119 of 122 recent red `presubmit-agent-sandbox-e2e-test` runs had no failing test** — the job died during bring-up under CI's Docker-in-Docker before junit was ever written (similar ratios on the unit-test job: 62 of 65). These transient infra failures are the dominant reason contributors see red presubmits and have to `/retest`.

All retried steps are safe to re-run: `create-kind-cluster` is invoked with `--recreate`, and the deploys are idempotent applies. A single retry recovers the transient class without masking persistent breakage (a real failure still fails the job, just one attempt later). `run_with_retry` rejects `attempts < 1` explicitly.

Split out of #1097 (flake reporting/summary tooling) so this small, high-leverage fix can merge independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster setup reliability by automatically retrying failed setup steps.
  * Added clearer error handling for failed commands and invalid retry settings.
  * Reduced flaky failures during environment preparation for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->