### PR TITLE
feat: support warm pool staleness detection for VolumeClaimTemplates and Service

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -150,6 +150,11 @@ const (
 	SandboxOperatingModeSuspended SandboxOperatingMode = "Suspended"
 )
 
+// NOTE: When adding, removing, or renaming a field in SandboxBlueprint,
+// also update compareSandboxBlueprint() in extensions/controllers/sandboxwarmpool_controller.go
+// so the SandboxWarmPool staleness check accounts for it. A field left out of that comparison
+// is not tracked for drift, so warm sandboxes will not be detected as stale when it changes.
+
 // SandboxBlueprint defines the configuration shared between Sandbox and SandboxTemplate.
 // It deliberately excludes runtime-only fields (operatingMode, lifecycle).
 type SandboxBlueprint struct {

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -64,8 +64,11 @@ const (
 	SandboxLaunchTypeCold = "cold"
 	// SandboxLaunchTypeWarm indicates the Sandbox was pre-provisioned by or adopted from a SandboxWarmPool.
 	SandboxLaunchTypeWarm = "warm"
-	// SandboxPodTemplateHashLabel is the label used to track the pod template hash.
-	SandboxPodTemplateHashLabel = "agents.x-k8s.io/sandbox-pod-template-hash"
+	// DeprecatedSandboxPodTemplateHashLabel is the label used to track the pod template hash.
+	// Deprecated: Use SandboxTemplateHashLabel instead.
+	DeprecatedSandboxPodTemplateHashLabel = "agents.x-k8s.io/sandbox-pod-template-hash"
+	// SandboxTemplateHashLabel is the label used to track the blueprint hash.
+	SandboxTemplateHashLabel = "agents.x-k8s.io/sandbox-template-hash"
 	// SandboxPropagatedLabelsAnnotation is the annotation used to track the labels explicitly propagated from sandbox spec to pod.
 	SandboxPropagatedLabelsAnnotation = "agents.x-k8s.io/propagated-labels"
 	// SandboxPropagatedAnnotationsAnnotation is the annotation used to track the annotations explicitly propagated from sandbox spec to pod.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1126,7 +1126,7 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `Recreate` | RecreateSandboxWarmPoolUpdateStrategyType indicates that stale pods are deleted immediately to ensure the pool only contains fresh pods.<br />Note: This applies to PodTemplate spec changes only. Changes to annotations or labels in the template do not trigger recreate.<br /> |
+| `Recreate` | RecreateSandboxWarmPoolUpdateStrategyType indicates that stale pods are deleted immediately to ensure the pool only contains fresh pods.<br />Note: This applies to changes in the template's SandboxBlueprint only. Changes to annotations or labels in the template do not trigger recreate.<br /> |
 | `OnReplenish` | OnReplenishSandboxWarmPoolUpdateStrategyType indicates that stale pods are only replaced when they are manually deleted or when these stale pods are adopted by sandboxclaims and hence replaced by fresh pods.<br /> |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1126,8 +1126,8 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `Recreate` | RecreateSandboxWarmPoolUpdateStrategyType indicates that stale pods are deleted immediately to ensure the pool only contains fresh pods.<br />Note: This applies to changes in the template's SandboxBlueprint only. Changes to annotations or labels in the template do not trigger recreate.<br /> |
-| `OnReplenish` | OnReplenishSandboxWarmPoolUpdateStrategyType indicates that stale pods are only replaced when they are manually deleted or when these stale pods are adopted by sandboxclaims and hence replaced by fresh pods.<br /> |
+| `Recreate` | RecreateSandboxWarmPoolUpdateStrategyType indicates that stale sandboxes are deleted immediately to ensure the pool only contains fresh sandboxes.<br />Note: This applies to changes in the template's SandboxBlueprint only. Changes to annotations, labels, or template-level policies do not trigger recreate.<br /> |
+| `OnReplenish` | OnReplenishSandboxWarmPoolUpdateStrategyType indicates that stale sandboxes are only replaced when they are manually deleted or when these stale sandboxes are adopted by sandboxclaims and hence replaced by fresh sandboxes.<br /> |
 
 
 #### ShutdownPolicy

--- a/extensions/api/v1beta1/sandboxwarmpool_types.go
+++ b/extensions/api/v1beta1/sandboxwarmpool_types.go
@@ -61,10 +61,10 @@ type SandboxWarmPoolSpec struct {
 type SandboxWarmPoolUpdateStrategyType string
 
 const (
-	// RecreateSandboxWarmPoolUpdateStrategyType indicates that stale pods are deleted immediately to ensure the pool only contains fresh pods.
-	// Note: This applies to changes in the template's SandboxBlueprint only. Changes to annotations or labels in the template do not trigger recreate.
+	// RecreateSandboxWarmPoolUpdateStrategyType indicates that stale sandboxes are deleted immediately to ensure the pool only contains fresh sandboxes.
+	// Note: This applies to changes in the template's SandboxBlueprint only. Changes to annotations, labels, or template-level policies do not trigger recreate.
 	RecreateSandboxWarmPoolUpdateStrategyType SandboxWarmPoolUpdateStrategyType = "Recreate"
-	// OnReplenishSandboxWarmPoolUpdateStrategyType indicates that stale pods are only replaced when they are manually deleted or when these stale pods are adopted by sandboxclaims and hence replaced by fresh pods.
+	// OnReplenishSandboxWarmPoolUpdateStrategyType indicates that stale sandboxes are only replaced when they are manually deleted or when these stale sandboxes are adopted by sandboxclaims and hence replaced by fresh sandboxes.
 	OnReplenishSandboxWarmPoolUpdateStrategyType SandboxWarmPoolUpdateStrategyType = "OnReplenish"
 )
 

--- a/extensions/api/v1beta1/sandboxwarmpool_types.go
+++ b/extensions/api/v1beta1/sandboxwarmpool_types.go
@@ -62,7 +62,7 @@ type SandboxWarmPoolUpdateStrategyType string
 
 const (
 	// RecreateSandboxWarmPoolUpdateStrategyType indicates that stale pods are deleted immediately to ensure the pool only contains fresh pods.
-	// Note: This applies to PodTemplate spec changes only. Changes to annotations or labels in the template do not trigger recreate.
+	// Note: This applies to changes in the template's SandboxBlueprint only. Changes to annotations or labels in the template do not trigger recreate.
 	RecreateSandboxWarmPoolUpdateStrategyType SandboxWarmPoolUpdateStrategyType = "Recreate"
 	// OnReplenishSandboxWarmPoolUpdateStrategyType indicates that stale pods are only replaced when they are manually deleted or when these stale pods are adopted by sandboxclaims and hence replaced by fresh pods.
 	OnReplenishSandboxWarmPoolUpdateStrategyType SandboxWarmPoolUpdateStrategyType = "OnReplenish"

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -961,7 +961,8 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 
 	// Remove warm pool labels so the sandbox no longer appears in warm pool queries
 	delete(adopted.Labels, warmPoolSandboxLabel)
-	delete(adopted.Labels, v1beta1.SandboxPodTemplateHashLabel)
+	delete(adopted.Labels, v1beta1.DeprecatedSandboxPodTemplateHashLabel)
+	delete(adopted.Labels, v1beta1.SandboxTemplateHashLabel)
 	if adopted.Labels == nil {
 		adopted.Labels = make(map[string]string)
 	}

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -523,7 +523,7 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	// In this case, we should log an error and treat it as NOT stale to avoid
 	// mass-deleting existing sandboxes due to a marshal failure.
 	if currentSandboxBlueprintHash == "" {
-		log.FromContext(ctx).Error(nil, "currentSandboxHash is empty, skipping staleness check", "sandbox", sandbox.Name)
+		log.FromContext(ctx).Error(nil, "currentSandboxBlueprintHash is empty, skipping staleness check", "sandbox", sandbox.Name)
 		return false
 	}
 
@@ -560,8 +560,11 @@ func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.
 	return equality.Semantic.DeepEqual(expectedSpec, actualSandboxSpec)
 }
 
-// compareVolumeClaimTemplates checks if the volume claim templates in the sandbox are equal to the template,
-// only comparing the VolumeClaimTemplates names and specs, as changes in metadata (like labels, annotations) are not tracked for staleness.
+// compareVolumeClaimTemplates checks if the volume claim templates in the sandbox are equal to the template.
+// Only each entry's name and spec are compared, as changes in metadata (like labels, annotations) are not tracked for staleness.
+// Note: Comparison is index-based (order-sensitive) to stay consistent with computeSandboxBlueprintHash (+listType=atomic).
+// Making this comparison order-independent without also sorting the templates in computeSandboxBlueprintHash
+// would cause reordered warm sandboxes to fail the hash label check on every reconcile.
 func (r *SandboxWarmPoolReconciler) compareVolumeClaimTemplates(template *extensionsv1beta1.SandboxTemplate, actualVCTs []sandboxv1beta1.PersistentVolumeClaimTemplate) bool {
 	if len(template.Spec.SandboxBlueprint.VolumeClaimTemplates) != len(actualVCTs) {
 		return false

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -123,11 +123,14 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		return err
 	}
 
-	// Fetch template and compute hash once to avoid repeated expensive operations
-	template, currentPodTemplateHash, tmplErr := r.fetchTemplateAndHash(ctx, warmPool)
+	// Fetch template and compute hash once to avoid repeated expensive operations,
+	// only currentSandboxBlueprintHash is used for staleness checks,
+	// currentPodTemplateHash is kept as a value for DeprecatedSandboxPodTemplateHashLabel
+	// for external consumer compatibility
+	template, currentPodTemplateHash, currentSandboxBlueprintHash, tmplErr := r.fetchTemplateAndHash(ctx, warmPool)
 
 	// Delete stale pods, filter pods by ownership and adopt orphans
-	activeSandboxes, allErrors := r.filterActiveSandboxes(ctx, warmPool, sandboxList.Items, template, currentPodTemplateHash, tmplErr)
+	activeSandboxes, allErrors := r.filterActiveSandboxes(ctx, warmPool, sandboxList.Items, template, currentSandboxBlueprintHash, tmplErr)
 
 	const warmPoolReadinessGracePeriod = 5 * time.Minute
 
@@ -179,7 +182,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		sandboxesToCreate := min(desiredReplicas-currentReplicas, maxBatchSize)
 		logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
 
-		sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash)
+		sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash, currentSandboxBlueprintHash)
 		if err != nil {
 			logger.Error(err, "Failed to build sandbox CR blueprint")
 			allErrors = errors.Join(allErrors, err)
@@ -253,7 +256,7 @@ func setWarmLaunchTypeLabelIfNeeded(sb *sandboxv1beta1.Sandbox) bool {
 }
 
 // filterActiveSandboxes filters the list of sandboxes, deleting stale ones and adopting orphans.
-func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, sandboxes []sandboxv1beta1.Sandbox, template *extensionsv1beta1.SandboxTemplate, currentPodTemplateHash string, tmplErr error) ([]sandboxv1beta1.Sandbox, error) {
+func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool, sandboxes []sandboxv1beta1.Sandbox, template *extensionsv1beta1.SandboxTemplate, currentSandboxBlueprintHash string, tmplErr error) ([]sandboxv1beta1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	var activeSandboxes []sandboxv1beta1.Sandbox
 	var allErrors error
@@ -292,7 +295,7 @@ func (r *SandboxWarmPoolReconciler) filterActiveSandboxes(ctx context.Context, w
 		}
 
 		if tmplErr == nil && (updateStrategy == extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType || isOrphan) {
-			if r.isSandboxStale(ctx, &sb, template, currentPodTemplateHash, vettedHashes) {
+			if r.isSandboxStale(ctx, &sb, template, currentSandboxBlueprintHash, vettedHashes) {
 				logger.Info("Deleting stale sandbox", "sandbox", sb.Name, "isOrphan", isOrphan)
 				if err := r.Delete(ctx, &sb); err != nil {
 					logger.Error(err, "Failed to delete stale sandbox", "sandbox", sb.Name)
@@ -333,28 +336,47 @@ func computePodTemplateHash(template *extensionsv1beta1.SandboxTemplate) (string
 	return sandboxcontrollers.NameHash(string(specJSON)), nil
 }
 
+// computeSandboxBlueprintHash computes a hash of the sandbox template's Spec.SandboxBlueprint.
+func computeSandboxBlueprintHash(template *extensionsv1beta1.SandboxTemplate) (string, error) {
+	specJSON, err := json.Marshal(template.Spec.SandboxBlueprint)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal sandbox blueprint for hashing: %w", err)
+	}
+	return sandboxcontrollers.NameHash(string(specJSON)), nil
+}
+
 // fetchTemplateAndHash fetches the sandbox template and computes its hash.
-func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool) (*extensionsv1beta1.SandboxTemplate, string, error) {
+func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool) (*extensionsv1beta1.SandboxTemplate, string, string, error) {
 	logger := log.FromContext(ctx)
 	template, tmplErr := r.getTemplate(ctx, warmPool)
-	var currentPodTemplateHash string
+	var currentPodTemplateHash, currentSandboxBlueprintHash string
 	if tmplErr == nil {
 		currentPodTemplateHash, tmplErr = computePodTemplateHash(template)
+	}
+	if tmplErr == nil {
+		currentSandboxBlueprintHash, tmplErr = computeSandboxBlueprintHash(template)
 	}
 
 	if tmplErr != nil {
 		logger.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
 	}
-	return template, currentPodTemplateHash, tmplErr
+	return template, currentPodTemplateHash, currentSandboxBlueprintHash, tmplErr
 }
 
 // buildSandboxCR constructs the base Sandbox CR (with pod template and volume claim templates) for the warm pool.
-func (r *SandboxWarmPoolReconciler) buildSandboxCR(warmPool *extensionsv1beta1.SandboxWarmPool, poolNameHash string, template *extensionsv1beta1.SandboxTemplate, currentPodTemplateHash string) (*sandboxv1beta1.Sandbox, error) {
+func (r *SandboxWarmPoolReconciler) buildSandboxCR(
+	warmPool *extensionsv1beta1.SandboxWarmPool,
+	poolNameHash string,
+	template *extensionsv1beta1.SandboxTemplate,
+	currentPodTemplateHash string,
+	currentSandboxBlueprintHash string,
+) (*sandboxv1beta1.Sandbox, error) {
 	sandboxLabels := map[string]string{
-		warmPoolSandboxLabel:                       poolNameHash,
-		sandboxTemplateRefHash:                     SandboxTemplateRefHash(warmPool.Spec.TemplateRef.Name),
-		sandboxv1beta1.SandboxLaunchTypeLabel:      sandboxv1beta1.SandboxLaunchTypeWarm,
-		sandboxv1beta1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
+		warmPoolSandboxLabel:                                 poolNameHash,
+		sandboxTemplateRefHash:                               SandboxTemplateRefHash(warmPool.Spec.TemplateRef.Name),
+		sandboxv1beta1.SandboxLaunchTypeLabel:                sandboxv1beta1.SandboxLaunchTypeWarm,
+		sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel: currentPodTemplateHash,
+		sandboxv1beta1.SandboxTemplateHashLabel:              currentSandboxBlueprintHash,
 	}
 
 	// Build annotations for the Sandbox CR
@@ -381,7 +403,8 @@ func (r *SandboxWarmPoolReconciler) buildSandboxCR(warmPool *extensionsv1beta1.S
 	}
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels[warmPoolSandboxLabel] = poolNameHash
 	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxTemplateRefHash] = SandboxTemplateRefHash(warmPool.Spec.TemplateRef.Name)
-	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel] = currentPodTemplateHash
+	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel] = currentPodTemplateHash
+	sandbox.Spec.PodTemplate.ObjectMeta.Labels[sandboxv1beta1.SandboxTemplateHashLabel] = currentSandboxBlueprintHash
 
 	// Respect the template's custom eviction annotation if explicitly specified.
 	// Only apply the default eviction behavior if the annotation is not defined.
@@ -473,10 +496,10 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	ctx context.Context,
 	sandbox *sandboxv1beta1.Sandbox,
 	template *extensionsv1beta1.SandboxTemplate,
-	currentPodTemplateHash string,
+	currentSandboxBlueprintHash string,
 	vettedHashes map[string]bool,
 ) bool {
-	sandboxHash := sandbox.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel]
+	sandboxHash := sandbox.Labels[sandboxv1beta1.SandboxTemplateHashLabel]
 
 	// If the templateRefHash doesn't match, it's stale.
 	if sandbox.Labels[sandboxTemplateRefHash] != SandboxTemplateRefHash(template.Name) {
@@ -488,19 +511,19 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 	isOrphan := controllerRef == nil
 	if isOrphan {
 		// Always perform full semantic comparison for orphans.
-		return !r.comparePodSpecs(template, &sandbox.Spec.PodTemplate.Spec)
+		return !r.compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
 	}
 
 	// If hashes match, it's fresh.
-	if sandboxHash != "" && sandboxHash == currentPodTemplateHash {
+	if sandboxHash != "" && sandboxHash == currentSandboxBlueprintHash {
 		return false
 	}
 
-	// If currentPodTemplateHash is empty, it means we failed to compute it.
+	// If currentSandboxBlueprintHash is empty, it means we failed to compute it.
 	// In this case, we should log an error and treat it as NOT stale to avoid
 	// mass-deleting existing sandboxes due to a marshal failure.
-	if currentPodTemplateHash == "" {
-		log.FromContext(ctx).Error(nil, "currentPodTemplateHash is empty, skipping staleness check", "sandbox", sandbox.Name)
+	if currentSandboxBlueprintHash == "" {
+		log.FromContext(ctx).Error(nil, "currentSandboxHash is empty, skipping staleness check", "sandbox", sandbox.Name)
 		return false
 	}
 
@@ -511,10 +534,10 @@ func (r *SandboxWarmPoolReconciler) isSandboxStale(
 		}
 	}
 
-	// Perform Semantic DeepEqual on the Pod Spec only.
+	// Perform a semantic comparison of the sandbox blueprint.
 	// We normalize the pod spec by applying the same secure defaults
 	// used during creation to avoid false positives from controller-injected fields.
-	isStale := !r.comparePodSpecs(template, &sandbox.Spec.PodTemplate.Spec)
+	isStale := !r.compareSandboxBlueprint(template, &sandbox.Spec.SandboxBlueprint)
 
 	// Save the result for the next sandbox with this same hash.
 	if sandboxHash != "" {
@@ -535,6 +558,31 @@ func (r *SandboxWarmPoolReconciler) comparePodSpecs(template *extensionsv1beta1.
 	// Since both have now undergone the exact same defaulting logic,
 	// any remaining difference is a TRUE template drift.
 	return equality.Semantic.DeepEqual(expectedSpec, actualSandboxSpec)
+}
+
+// compareVolumeClaimTemplates checks if the volume claim templates in the sandbox are equal to the template,
+// only comparing the VolumeClaimTemplates names and specs, as changes in metadata (like labels, annotations) are not tracked for staleness.
+func (r *SandboxWarmPoolReconciler) compareVolumeClaimTemplates(template *extensionsv1beta1.SandboxTemplate, actualVCTs []sandboxv1beta1.PersistentVolumeClaimTemplate) bool {
+	if len(template.Spec.SandboxBlueprint.VolumeClaimTemplates) != len(actualVCTs) {
+		return false
+	}
+
+	for i, tmplVCT := range template.Spec.SandboxBlueprint.VolumeClaimTemplates {
+		actualVCT := actualVCTs[i]
+		if tmplVCT.Name != actualVCT.Name || !equality.Semantic.DeepEqual(tmplVCT.Spec, actualVCT.Spec) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// compareSandboxBlueprint checks if the sandbox blueprint in the sandbox is semantically equal to the template,
+// ignoring metadata differences and only comparing the fields that are relevant for staleness detection.
+func (r *SandboxWarmPoolReconciler) compareSandboxBlueprint(template *extensionsv1beta1.SandboxTemplate, actualSandboxSpec *sandboxv1beta1.SandboxBlueprint) bool {
+	return r.comparePodSpecs(template, &actualSandboxSpec.PodTemplate.Spec) &&
+		r.compareVolumeClaimTemplates(template, actualSandboxSpec.VolumeClaimTemplates) &&
+		equality.Semantic.DeepEqual(template.Spec.Service, actualSandboxSpec.Service)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2231,4 +2233,26 @@ func TestCompareSandboxBlueprint(t *testing.T) {
 			require.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+// TestSandboxBlueprintFieldsAreCompared verifies that compareSandboxBlueprint()
+// accounts for all fields in the SandboxBlueprint struct. A field missing from the
+// comparison logic is not tracked for drift, so a warm sandbox will not be detected
+// as stale when that field changes.
+func TestSandboxBlueprintFieldsAreCompared(t *testing.T) {
+	expectedFields := []string{"PodTemplate", "VolumeClaimTemplates", "Service"}
+
+	var actualFields []string
+	blueprintType := reflect.TypeFor[sandboxv1beta1.SandboxBlueprint]()
+	for field := range blueprintType.Fields() {
+		actualFields = append(actualFields, field.Name)
+	}
+
+	slices.Sort(expectedFields)
+	slices.Sort(actualFields)
+
+	require.Equal(t, expectedFields, actualFields,
+		"SandboxBlueprint fields have changed. Update compareSandboxBlueprint() in "+
+			"sandboxwarmpool_controller.go to compare the new field for staleness detection, then update the "+
+			"expected field list in this test to include it.")
 }

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -48,7 +48,7 @@ func newTestScheme() *runtime.Scheme {
 
 func createPoolSandbox(poolName, namespace, poolNameHash string, template *extensionsv1beta1.SandboxTemplate, suffix string) *sandboxv1beta1.Sandbox {
 	templateRefHash := ""
-	var podTemplateHash string
+	var podTemplateHash, sandboxBlueprintHash string
 	var podSpec corev1.PodSpec
 
 	if template != nil {
@@ -58,9 +58,13 @@ func createPoolSandbox(poolName, namespace, poolNameHash string, template *exten
 		// If template has a version label, we could use it as part of the hash placeholder
 		if v, ok := template.Spec.PodTemplate.ObjectMeta.Labels["version"]; ok {
 			podTemplateHash = "pod-hash-" + v
+			sandboxBlueprintHash = "blueprint-hash-" + v
 		} else {
-			specJSON, _ := json.Marshal(template.Spec.PodTemplate)
-			podTemplateHash = sandboxcontrollers.NameHash(string(specJSON))
+			podTemplateJSON, _ := json.Marshal(template.Spec.PodTemplate)
+			podTemplateHash = sandboxcontrollers.NameHash(string(podTemplateJSON))
+
+			sandboxBlueprintJSON, _ := json.Marshal(template.Spec.SandboxBlueprint)
+			sandboxBlueprintHash = sandboxcontrollers.NameHash(string(sandboxBlueprintJSON))
 		}
 	} else {
 		// Fallback for tests that don't provide a template
@@ -72,8 +76,11 @@ func createPoolSandbox(poolName, namespace, poolNameHash string, template *exten
 				},
 			},
 		}
-		specJSON, _ := json.Marshal(sandboxv1beta1.PodTemplate{Spec: podSpec})
-		podTemplateHash = sandboxcontrollers.NameHash(string(specJSON))
+		podTemplateJSON, _ := json.Marshal(sandboxv1beta1.PodTemplate{Spec: podSpec})
+		podTemplateHash = sandboxcontrollers.NameHash(string(podTemplateJSON))
+
+		sandboxBlueprintJSON, _ := json.Marshal(sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: podSpec}})
+		sandboxBlueprintHash = sandboxcontrollers.NameHash(string(sandboxBlueprintJSON))
 	}
 
 	return &sandboxv1beta1.Sandbox{
@@ -82,17 +89,19 @@ func createPoolSandbox(poolName, namespace, poolNameHash string, template *exten
 			Namespace:         namespace,
 			CreationTimestamp: metav1.Now(),
 			Labels: map[string]string{
-				warmPoolSandboxLabel:                       poolNameHash,
-				sandboxTemplateRefHash:                     templateRefHash,
-				sandboxv1beta1.SandboxPodTemplateHashLabel: podTemplateHash,
+				warmPoolSandboxLabel:                                 poolNameHash,
+				sandboxTemplateRefHash:                               templateRefHash,
+				sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel: podTemplateHash,
+				sandboxv1beta1.SandboxTemplateHashLabel:              sandboxBlueprintHash,
 			},
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
 			ObjectMeta: sandboxv1beta1.PodMetadata{
 				Labels: map[string]string{
-					warmPoolSandboxLabel:                       poolNameHash,
-					sandboxTemplateRefHash:                     templateRefHash,
-					sandboxv1beta1.SandboxPodTemplateHashLabel: podTemplateHash,
+					warmPoolSandboxLabel:                                 poolNameHash,
+					sandboxTemplateRefHash:                               templateRefHash,
+					sandboxv1beta1.DeprecatedSandboxPodTemplateHashLabel: podTemplateHash,
+					sandboxv1beta1.SandboxTemplateHashLabel:              sandboxBlueprintHash,
 				},
 			},
 			Spec: podSpec,
@@ -117,6 +126,19 @@ func createTemplate(namespace string) *extensionsv1beta1.SandboxTemplate {
 				},
 			},
 		}},
+		},
+	}
+}
+
+func createVolumeClaimTemplate(name string, storageClass string) sandboxv1beta1.PersistentVolumeClaimTemplate {
+	return sandboxv1beta1.PersistentVolumeClaimTemplate{
+		EmbeddedObjectMetadata: sandboxv1beta1.EmbeddedObjectMetadata{Name: name},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &storageClass,
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
 		},
 	}
 }
@@ -1006,7 +1028,7 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get initial hash label
-			template, initialHash, err := r.fetchTemplateAndHash(ctx, warmPool)
+			template, _, initialHash, err := r.fetchTemplateAndHash(ctx, warmPool)
 			require.NoError(t, err)
 
 			// Verify sandboxes exist with initial image and hash
@@ -1016,7 +1038,7 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 			require.Len(t, sandboxes.Items, int(replicas))
 			for _, sb := range sandboxes.Items {
 				require.Equal(t, "image-v1", sb.Spec.PodTemplate.Spec.Containers[0].Image)
-				require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel], "Sandbox should have initial template hash label")
+				require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel], "Sandbox should have initial sandbox blueprint hash label")
 			}
 
 			// Update the SandboxTemplate content
@@ -1026,7 +1048,7 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get new expected hash label
-			_, updatedHash, err := r.fetchTemplateAndHash(ctx, warmPool)
+			_, _, updatedHash, err := r.fetchTemplateAndHash(ctx, warmPool)
 			require.NoError(t, err)
 			require.NotEqual(t, initialHash, updatedHash, "Hashes should differ after template update")
 
@@ -1043,14 +1065,14 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 				// For Recreate strategy, all should be updated
 				for _, sb := range sandboxes.Items {
 					require.Equal(t, "image-v2", sb.Spec.PodTemplate.Spec.Containers[0].Image, "Sandbox should have updated image")
-					require.Equal(t, updatedHash, sb.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel], "Sandbox should have updated template hash label")
+					require.Equal(t, updatedHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel], "Sandbox should have updated sandbox blueprint hash label")
 				}
 				t.Log("Verified: All sandboxes updated immediately with Recreate strategy")
 			} else {
 				// For OnReplenish (default), all should still be v1
 				for _, sb := range sandboxes.Items {
 					require.Equal(t, "image-v1", sb.Spec.PodTemplate.Spec.Containers[0].Image, "Sandbox should retain original image")
-					require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel], "Sandbox should retain original template hash label")
+					require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel], "Sandbox should retain original sandbox blueprint hash label")
 				}
 				t.Log("Verified: Sandboxes retained original image after update with OnReplenish strategy")
 
@@ -1073,10 +1095,10 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 					switch sb.Spec.PodTemplate.Spec.Containers[0].Image {
 					case "image-v1":
 						v1Count++
-						require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel])
+						require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel])
 					case "image-v2":
 						v2Count++
-						require.Equal(t, updatedHash, sb.Labels[sandboxv1beta1.SandboxPodTemplateHashLabel])
+						require.Equal(t, updatedHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel])
 					}
 				}
 				require.Equal(t, 1, v1Count, "Should have one remaining v1 sandbox")
@@ -1462,7 +1484,7 @@ func TestIsSandboxStale_OrphanedSandboxVetting(t *testing.T) {
 		},
 	}
 
-	currentPodTemplateHash, err := computePodTemplateHash(template)
+	currentSandboxBlueprintHash, err := computeSandboxBlueprintHash(template)
 	require.NoError(t, err)
 	templateRefHash := SandboxTemplateRefHash(template.Name)
 
@@ -1479,15 +1501,15 @@ func TestIsSandboxStale_OrphanedSandboxVetting(t *testing.T) {
 			Name:      "spoofed-orphan",
 			Namespace: poolNamespace,
 			Labels: map[string]string{
-				sandboxv1beta1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
-				sandboxTemplateRefHash:                     templateRefHash,
-				warmPoolSandboxLabel:                       sandboxcontrollers.NameHash(poolName),
+				sandboxv1beta1.SandboxTemplateHashLabel: currentSandboxBlueprintHash,
+				sandboxTemplateRefHash:                  templateRefHash,
+				warmPoolSandboxLabel:                    sandboxcontrollers.NameHash(poolName),
 			},
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: *spoofedSpec}}},
 	}
 
-	isStaleSpoofed := r.isSandboxStale(ctx, spoofedOrphan, template, currentPodTemplateHash, vettedHashes)
+	isStaleSpoofed := r.isSandboxStale(ctx, spoofedOrphan, template, currentSandboxBlueprintHash, vettedHashes)
 	require.True(t, isStaleSpoofed, "Orphaned sandbox with spoofed hash but modified PodSpec should be stale")
 
 	// Case 2: Orphaned sandbox with matching hash label and genuine/fully vetted PodSpec.
@@ -1500,15 +1522,15 @@ func TestIsSandboxStale_OrphanedSandboxVetting(t *testing.T) {
 			Name:      "genuine-orphan",
 			Namespace: poolNamespace,
 			Labels: map[string]string{
-				sandboxv1beta1.SandboxPodTemplateHashLabel: currentPodTemplateHash,
-				sandboxTemplateRefHash:                     templateRefHash,
-				warmPoolSandboxLabel:                       sandboxcontrollers.NameHash(poolName),
+				sandboxv1beta1.SandboxTemplateHashLabel: currentSandboxBlueprintHash,
+				sandboxTemplateRefHash:                  templateRefHash,
+				warmPoolSandboxLabel:                    sandboxcontrollers.NameHash(poolName),
 			},
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: *genuineSpec}}},
 	}
 
-	isStaleGenuine := r.isSandboxStale(ctx, genuineOrphan, template, currentPodTemplateHash, vettedHashes)
+	isStaleGenuine := r.isSandboxStale(ctx, genuineOrphan, template, currentSandboxBlueprintHash, vettedHashes)
 	require.False(t, isStaleGenuine, "Orphaned sandbox with genuine fully vetted PodSpec should be fresh")
 }
 
@@ -1696,6 +1718,517 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			} else {
 				require.False(t, exists, "expected eviction annotation to NOT exist")
 			}
+		})
+	}
+}
+
+func TestReconcilePool_TemplateUpdateRecreate(t *testing.T) {
+	poolNamespace := "default"
+	templateName := "test-template"
+
+	trueVal := true
+	falseVal := false
+	replicas := int32(1)
+
+	baseSandboxBlueprint := sandboxv1beta1.SandboxBlueprint{
+		PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: &falseVal,
+				Containers:                   []corev1.Container{{Name: "app", Image: "image-v1"}},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		updateBaseFn     func(*sandboxv1beta1.SandboxBlueprint)
+		updateFn         func(*extensionsv1beta1.SandboxTemplate)
+		verifyFn         func(*testing.T, sandboxv1beta1.Sandbox)
+		expectRecreation bool
+	}{
+		{
+			name:             "Template spec unchanged should NOT recreate",
+			expectRecreation: false,
+		},
+		{
+			name: "Pod template annotation drift should NOT recreate",
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				if tmpl.Spec.PodTemplate.ObjectMeta.Annotations == nil {
+					tmpl.Spec.PodTemplate.ObjectMeta.Annotations = make(map[string]string)
+				}
+				tmpl.Spec.PodTemplate.ObjectMeta.Annotations["new-annotation"] = "value"
+			},
+			expectRecreation: false,
+		},
+		{
+			name: "Pod template label drift should NOT recreate",
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				if tmpl.Spec.PodTemplate.ObjectMeta.Labels == nil {
+					tmpl.Spec.PodTemplate.ObjectMeta.Labels = make(map[string]string)
+				}
+				tmpl.Spec.PodTemplate.ObjectMeta.Labels["new-label"] = "value"
+			},
+			expectRecreation: false,
+		},
+		{
+			name: "VCT annotation drift should NOT recreate",
+			updateBaseFn: func(bp *sandboxv1beta1.SandboxBlueprint) {
+				bp.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					createVolumeClaimTemplate("data", "standard"),
+				}
+			},
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				if tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].EmbeddedObjectMetadata.Annotations == nil {
+					tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].EmbeddedObjectMetadata.Annotations = make(map[string]string)
+				}
+				tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].EmbeddedObjectMetadata.Annotations["new-annotation"] = "value"
+			},
+			expectRecreation: false,
+		},
+		{
+			name: "VCT label drift should NOT recreate",
+			updateBaseFn: func(bp *sandboxv1beta1.SandboxBlueprint) {
+				bp.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					createVolumeClaimTemplate("data", "standard"),
+				}
+			},
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				if tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].EmbeddedObjectMetadata.Labels == nil {
+					tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].EmbeddedObjectMetadata.Labels = make(map[string]string)
+				}
+				tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].EmbeddedObjectMetadata.Labels["new-label"] = "value"
+			},
+			expectRecreation: false,
+		},
+		{
+			name: "Image change should recreate",
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				tmpl.Spec.PodTemplate.Spec.Containers[0].Image = "image-v2"
+			},
+			verifyFn: func(t *testing.T, sb sandboxv1beta1.Sandbox) {
+				require.Equal(t, "image-v2", sb.Spec.PodTemplate.Spec.Containers[0].Image)
+			},
+			expectRecreation: true,
+		},
+		{
+			name: "VCT addition should recreate",
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					createVolumeClaimTemplate("data", "standard"),
+				}
+			},
+			verifyFn: func(t *testing.T, sb sandboxv1beta1.Sandbox) {
+				require.Len(t, sb.Spec.SandboxBlueprint.VolumeClaimTemplates, 1)
+				require.Equal(t, "data", sb.Spec.SandboxBlueprint.VolumeClaimTemplates[0].Name)
+			},
+			expectRecreation: true,
+		},
+		{
+			name: "VCT spec change should recreate",
+			updateBaseFn: func(bp *sandboxv1beta1.SandboxBlueprint) {
+				bp.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")}
+			},
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				newSC := "fast-ssd"
+				tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates[0].Spec.StorageClassName = &newSC
+			},
+			verifyFn: func(t *testing.T, sb sandboxv1beta1.Sandbox) {
+				require.Len(t, sb.Spec.SandboxBlueprint.VolumeClaimTemplates, 1)
+				require.Equal(t, "fast-ssd", *sb.Spec.SandboxBlueprint.VolumeClaimTemplates[0].Spec.StorageClassName)
+			},
+			expectRecreation: true,
+		},
+		{
+			name: "VCT removal should recreate",
+			updateBaseFn: func(bp *sandboxv1beta1.SandboxBlueprint) {
+				bp.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")}
+			},
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				tmpl.Spec.SandboxBlueprint.VolumeClaimTemplates = nil
+			},
+			verifyFn: func(t *testing.T, sb sandboxv1beta1.Sandbox) {
+				require.Empty(t, sb.Spec.SandboxBlueprint.VolumeClaimTemplates)
+			},
+			expectRecreation: true,
+		},
+		{
+			name: "Service addition should recreate",
+			updateFn: func(tmpl *extensionsv1beta1.SandboxTemplate) {
+				tmpl.Spec.SandboxBlueprint.Service = &trueVal
+			},
+			verifyFn: func(t *testing.T, sb sandboxv1beta1.Sandbox) {
+				require.NotNil(t, sb.Spec.SandboxBlueprint.Service)
+				require.True(t, *sb.Spec.SandboxBlueprint.Service)
+			},
+			expectRecreation: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			initialSandboxBlueprint := (&baseSandboxBlueprint).DeepCopy()
+			if tt.updateBaseFn != nil {
+				tt.updateBaseFn(initialSandboxBlueprint)
+			}
+
+			template := &extensionsv1beta1.SandboxTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      templateName,
+					Namespace: poolNamespace,
+				},
+				Spec: extensionsv1beta1.SandboxTemplateSpec{
+					NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementUnmanaged,
+					SandboxBlueprint:        *initialSandboxBlueprint,
+				},
+			}
+
+			warmPool := &extensionsv1beta1.SandboxWarmPool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pool",
+					Namespace: poolNamespace,
+					UID:       "warmpool-uid-456",
+				},
+				Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+					Replicas:    &replicas,
+					TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: templateName},
+					UpdateStrategy: &extensionsv1beta1.SandboxWarmPoolUpdateStrategy{
+						Type: extensionsv1beta1.RecreateSandboxWarmPoolUpdateStrategyType,
+					},
+				},
+			}
+
+			scheme := newTestScheme()
+			r := SandboxWarmPoolReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithRuntimeObjects(template, warmPool).
+					Build(),
+				Scheme:       scheme,
+				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
+			}
+
+			ctx := context.Background()
+
+			// Initial reconcile
+			err := r.reconcilePool(ctx, warmPool)
+			require.NoError(t, err)
+
+			sandboxes := &sandboxv1beta1.SandboxList{}
+			err = r.List(ctx, sandboxes, client.InNamespace(poolNamespace))
+			require.NoError(t, err)
+			require.Len(t, sandboxes.Items, int(replicas), "expected warm sandbox after initial reconcile")
+
+			// Capture initial sandboxblueprint hash
+			_, _, initialHash, err := r.fetchTemplateAndHash(ctx, warmPool)
+			require.NoError(t, err)
+
+			// Capture initial sandbox names to verify recreation later
+			initialName := sandboxes.Items[0].Name
+
+			// Apply the template drift
+			if tt.updateFn != nil {
+				updatedTemplate := template.DeepCopy()
+				tt.updateFn(updatedTemplate)
+				err = r.Update(ctx, updatedTemplate)
+				require.NoError(t, err)
+			}
+
+			// Capture updated sandbox blueprint hash after template update
+			_, _, updatedHash, err := r.fetchTemplateAndHash(ctx, warmPool)
+			require.NoError(t, err)
+			if tt.expectRecreation {
+				require.NotEqual(t, initialHash, updatedHash, "sandbox blueprint hash should change after template update")
+			}
+
+			// Recreate strategy should delete stale sandbox and create a fresh one
+			err = r.reconcilePool(ctx, warmPool)
+			require.NoError(t, err)
+
+			err = r.List(ctx, sandboxes, client.InNamespace(poolNamespace))
+			require.NoError(t, err)
+			require.Len(t, sandboxes.Items, int(replicas), "expected same replica count after recreation")
+
+			for _, sb := range sandboxes.Items {
+				if tt.expectRecreation {
+					require.Equal(t, updatedHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel],
+						"recreated sandbox should carry the updated sandbox blueprint hash")
+					require.NotEqual(t, initialName, sb.Name, "recreated sandbox should have a new name")
+				} else {
+					require.Equal(t, initialHash, sb.Labels[sandboxv1beta1.SandboxTemplateHashLabel],
+						"unchanged sandbox should retain the initial sandbox blueprint hash")
+					require.Equal(t, initialName, sb.Name, "unchanged sandbox should retain the same name")
+				}
+				if tt.verifyFn != nil {
+					tt.verifyFn(t, sb)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeSandboxBlueprintHash(t *testing.T) {
+	namespace := "default"
+
+	template := createTemplate(namespace)
+
+	diffImage := template.DeepCopy()
+	diffImage.Spec.PodTemplate.Spec.Containers[0].Image = "image-v2"
+
+	withVCT := template.DeepCopy()
+	withVCT.Spec.VolumeClaimTemplates = []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")}
+
+	svcEnabled := template.DeepCopy()
+	svcEnabled.Spec.Service = new(true)
+
+	testCases := []struct {
+		name        string
+		template    *extensionsv1beta1.SandboxTemplate
+		equalToBase bool
+	}{
+		{
+			name:        "same template produces same hash",
+			template:    template.DeepCopy(),
+			equalToBase: true,
+		},
+		{
+			name:        "pod spec change produces different hash",
+			template:    diffImage,
+			equalToBase: false,
+		},
+		{
+			name:        "VCT addition produces different hash",
+			template:    withVCT,
+			equalToBase: false,
+		},
+		{
+			name:        "Service toggle produces different hash",
+			template:    svcEnabled,
+			equalToBase: false,
+		},
+	}
+
+	currentSandboxHash, err := computeSandboxBlueprintHash(template)
+	require.NoError(t, err)
+	require.NotEmpty(t, currentSandboxHash)
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			sandboxHash, err := computeSandboxBlueprintHash(tt.template)
+			require.NoError(t, err)
+			require.NotEmpty(t, sandboxHash)
+			if tt.equalToBase {
+				require.Equal(t, currentSandboxHash, sandboxHash)
+			} else {
+				require.NotEqual(t, currentSandboxHash, sandboxHash)
+			}
+		})
+	}
+}
+
+func TestCompareSandboxBlueprint(t *testing.T) {
+	falseVal := false
+	trueVal := true
+
+	basePodTemplate := sandboxv1beta1.PodTemplate{
+		Spec: corev1.PodSpec{
+			AutomountServiceAccountToken: &falseVal,
+			Containers:                   []corev1.Container{{Name: "app", Image: "image-v1"}},
+		},
+	}
+
+	testCases := []struct {
+		name                     string
+		templateSandboxBlueprint sandboxv1beta1.SandboxBlueprint
+		actualSandboxBlueprint   sandboxv1beta1.SandboxBlueprint
+		expectedResult           bool
+	}{
+		{
+			name:                     "Identical sandbox blueprint with no VCTs and no service should match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: basePodTemplate},
+			actualSandboxBlueprint:   sandboxv1beta1.SandboxBlueprint{PodTemplate: basePodTemplate},
+			expectedResult:           true,
+		},
+		{
+			name: "Identical sandbox blueprint with VCTs should match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Identical sandbox blueprint with service enabled should match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+				Service:              &trueVal,
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+				Service:              &trueVal,
+			},
+			expectedResult: true,
+		},
+		{
+			name: "VCT label drift should match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					{
+						EmbeddedObjectMetadata: sandboxv1beta1.EmbeddedObjectMetadata{
+							Name:   "data",
+							Labels: map[string]string{"extra": "label"},
+						},
+						Spec: createVolumeClaimTemplate("data", "standard").Spec,
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "VCT annotation drift should match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					{
+						EmbeddedObjectMetadata: sandboxv1beta1.EmbeddedObjectMetadata{
+							Name:        "data",
+							Annotations: map[string]string{"extra": "annotation"},
+						},
+						Spec: createVolumeClaimTemplate("data", "standard").Spec,
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "Pod spec image drift should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: &falseVal,
+						Containers:                   []corev1.Container{{Name: "app", Image: "image-v1"}},
+					},
+				},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: &falseVal,
+						Containers:                   []corev1.Container{{Name: "app", Image: "image-v2"}},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "VCT count drift should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					createVolumeClaimTemplate("data", "standard"),
+					createVolumeClaimTemplate("cache", "standard"),
+				},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "VCTs reordered should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					createVolumeClaimTemplate("data", "standard"),
+					createVolumeClaimTemplate("cache", "standard"),
+				},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{
+					createVolumeClaimTemplate("cache", "standard"),
+					createVolumeClaimTemplate("data", "standard"),
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "VCT name drift should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("renamed-data", "standard")},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "VCT spec storage class drift should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "standard")},
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate:          basePodTemplate,
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{createVolumeClaimTemplate("data", "fast-ssd")},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Service enabled vs disabled should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				Service:     &trueVal,
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				Service:     &falseVal,
+			},
+			expectedResult: false,
+		},
+		{
+			name: "Service set vs nil should NOT match",
+			templateSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				Service:     &trueVal,
+			},
+			actualSandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: basePodTemplate,
+				Service:     nil,
+			},
+			expectedResult: false,
+		},
+	}
+
+	r := &SandboxWarmPoolReconciler{}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			template := &extensionsv1beta1.SandboxTemplate{
+				Spec: extensionsv1beta1.SandboxTemplateSpec{
+					NetworkPolicyManagement: extensionsv1beta1.NetworkPolicyManagementUnmanaged,
+					SandboxBlueprint:        tt.templateSandboxBlueprint,
+				},
+			}
+			result := r.compareSandboxBlueprint(template, &tt.actualSandboxBlueprint)
+			require.Equal(t, tt.expectedResult, result)
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

After the introduction of `VolumeClaimTemplates` and `Service` fields in `Sandbox`, warm pool staleness detection still only evaluated the `PodTemplate` spec. This PR expands pool staleness detection to cover the full `SandboxBlueprint` (`podTemplate`, `volumeClaimTemplates`, and `Service`), instead of only the pod template. Specifically, this PR:
- Introduces a new blueprint hash: Replaces the current hash which only relied on the pod template with one based on the template's full SandboxBlueprint. This new hash is then saved on pool sandboxes as the label `agents.x-k8s.io/sandbox-template-hash`.
- Updates the comparison logic: Adds a new comparison for `SandboxBlueprint` fields to replace the current pod spec comparison. It reuses the existing pod spec comparison logic while also validating `volumeClaimTemplates` (by name and spec) and `Service`. Pod template and VCT metadata (labels and annotations) are excluded from this semantic comparison, ensuring that metadata-only template edits do not trigger recreation.
- Updates adoption behavior: SandboxClaim adoption now deletes the new hash label upon adoption along with the deprecated one.

Backward Compatibility (No Breaking Changes):
- The existing `agents.x-k8s.io/sandbox-pod-template-hash` label remains untouched and is still saved on new pool sandboxes. However, it is no longer used for staleness detection.

#### Which issue(s) this PR is related to:

Fixes #1047

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
Expanded Warm Pool Staleness Detection: Warm pool staleness detection now tracks `volumeClaimTemplates` and `service` configuration alongside `podTemplate`. Updates to storage or service settings in a `SandboxTemplate` will now trigger warm pool recreation under the `Recreate` update strategy.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warm pool updates now compute and apply a sandbox blueprint hash, enabling more precise recreation decisions based on blueprint-relevant changes (including service and volume claim template differences).
  * Improved label handling to support legacy and current hash selectors.
* **Bug Fixes**
  * Reduced unnecessary recreation and deletion by shifting staleness evaluation to blueprint changes and skipping cleanup when the current blueprint hash can’t be determined.
  * Orphaned sandboxes are now vetted using full sandbox blueprint semantics rather than pod-spec-only checks.
* **Documentation**
  * Clarified that the “Recreate” strategy triggers only on SandboxBlueprint changes; annotation/label and template-level policy changes do not trigger recreate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->