### PR TITLE
fix(sandboxclaim): bounded requeue for adoption-completion cache lag instead of exponential backoff

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -353,7 +353,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// not finalized with the sandbox on this pass (sandbox is nil here), preserving the
 	// duplicate-adoption protection during cache lag.
 	if errors.Is(reconcileErr, errAdoptionTriggeredRetry) {
-		logger.V(1).Info("Adoption triggered; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
+		logger.V(4).Info("Adoption triggered; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
 		requeueDelay := adoptionCacheLagRequeueDelay
 		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
 			requeueDelay = result.RequeueAfter
@@ -577,6 +577,17 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 				Status:             metav1.ConditionFalse,
 				Reason:             reason,
 				Message:            fmt.Sprintf("SandboxWarmPool %q not found", claim.Spec.WarmPoolRef.Name),
+				ObservedGeneration: claim.Generation,
+			}
+		}
+		if errors.Is(err, errAdoptionTriggeredRetry) {
+			// Benign retry signal, not a claim failure: adoption was patched and we
+			// are only waiting for the informer cache to converge before finalizing.
+			return metav1.Condition{
+				Type:               string(v1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             "AdoptionPending",
+				Message:            "Warm-pool sandbox adoption triggered; waiting for cache to converge",
 				ObservedGeneration: claim.Generation,
 			}
 		}
@@ -1522,7 +1533,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 					// requeue without re-sending the (idempotent but redundant) patch.
 					adoptionKey := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
 					if prev, ok := r.triggeredAdoptions.Load(adoptionKey); ok && prev.uid == claim.UID && prev.sandbox == sbName {
-						logger.V(1).Info("Adoption already triggered, waiting for cache to converge", "sandbox", sbName, "claim", claim.Name)
+						logger.V(4).Info("Adoption already triggered, waiting for cache to converge", "sandbox", sbName, "claim", claim.Name)
 						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
 					}
 					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -689,6 +689,13 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 }
 
 func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1beta1.SandboxClaim, sandbox *v1beta1.Sandbox, err error, isClaimExpired bool) {
+	// A cache-lag adoption retry is a benign look-again, not a state change. If the
+	// claim status was already finalized with a sandbox (the adoption pass itself, or
+	// a controller restart racing a stale informer), leave the recorded Name/PodIPs
+	// and existing conditions untouched instead of transiently wiping them.
+	if sandbox == nil && errors.Is(err, errAdoptionTriggeredRetry) && claim.Status.SandboxStatus.Name != "" {
+		return
+	}
 	readyCondition := r.computeReadyCondition(claim, sandbox, err, isClaimExpired)
 	meta.SetStatusCondition(&claim.Status.Conditions, readyCondition)
 	r.syncFinishedCondition(claim, sandbox, isClaimExpired)
@@ -910,6 +917,14 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			}
 
 			logger.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
+
+			// Record the completed adoption so a later pass that still sees the
+			// stale warm-pool-owned view (informer cache lag) waits via the
+			// bounded requeue instead of re-sending the adoption patch.
+			r.triggeredAdoptions.Store(
+				types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace},
+				triggeredAdoptionEntry{uid: claim.UID, sandbox: adopted.Name},
+			)
 
 			if r.Recorder != nil {
 				r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxAdopted", "Adoption", "Adopted warm pool Sandbox %q", adopted.Name)

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -69,6 +69,23 @@ var ErrSandboxNotOwned = errors.New("sandbox not owned by this claim")
 // ErrWarmPoolNotFound is a sentinel error indicating a SandboxWarmPool was not found.
 var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 
+// errAdoptionTriggeredRetry signals that warm-pool adoption was just completed for a
+// sandbox and the claim must be requeued so a later pass observes the sandbox as
+// controlled by this claim once the informer cache converges. It is a sentinel (not a
+// generic error) so Reconcile can convert it into a bounded requeue instead
+// of returning an error: an error would route through the exponential failure rate
+// limiter, and because the same retry recurs each pass until the cache catches up the
+// backoff compounds and, under concurrent claims, adoption tail latency balloons
+// (#1107).
+var errAdoptionTriggeredRetry = errors.New("triggered adoption completion, retry")
+
+// adoptionCacheLagRequeueDelay is how long to wait before re-checking that a
+// just-completed adoption is visible in the informer cache. Long enough to
+// cover typical watch latency (so most claims converge in one extra pass) and
+// to bound the rate of redundant adoption patches while the cache lags, but
+// far below the multi-second exponential backoff it replaces.
+const adoptionCacheLagRequeueDelay = 50 * time.Millisecond
+
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 
 var ErrCrossNamespaceAdoption = errors.New("cross-namespace adoption forbidden")
@@ -128,6 +145,36 @@ func (m *observedTimeMap) LoadOrStore(key types.NamespacedName, entry observedTi
 	return actual.(observedTimeEntry), loaded
 }
 
+// triggeredAdoptionEntry records that completeAdoption already patched the
+// named sandbox over to a claim (identified by UID), so cache-lag requeues
+// can wait for the informer to converge without re-sending the patch.
+type triggeredAdoptionEntry struct {
+	uid     types.UID
+	sandbox string
+}
+
+// triggeredAdoptionMap is a type-safe wrapper around sync.Map that only
+// stores triggeredAdoptionEntry values.
+type triggeredAdoptionMap struct {
+	inner sync.Map
+}
+
+func (m *triggeredAdoptionMap) Load(key types.NamespacedName) (triggeredAdoptionEntry, bool) {
+	val, ok := m.inner.Load(key)
+	if !ok {
+		return triggeredAdoptionEntry{}, false
+	}
+	return val.(triggeredAdoptionEntry), true
+}
+
+func (m *triggeredAdoptionMap) Store(key types.NamespacedName, entry triggeredAdoptionEntry) {
+	m.inner.Store(key, entry)
+}
+
+func (m *triggeredAdoptionMap) Delete(key types.NamespacedName) {
+	m.inner.Delete(key)
+}
+
 // SandboxClaimReconciler reconciles a SandboxClaim object.
 type SandboxClaimReconciler struct {
 	client.Client
@@ -137,6 +184,7 @@ type SandboxClaimReconciler struct {
 	Tracer                  asmetrics.Instrumenter
 	MaxConcurrentReconciles int
 	observedTimes           observedTimeMap
+	triggeredAdoptions      triggeredAdoptionMap
 	AllowedLabelDomains     []string
 }
 
@@ -161,6 +209,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if k8errors.IsNotFound(err) {
 			// Fallback cleanup to prevent memory leaks if the delete predicate was missed or a stale request is processed.
 			r.observedTimes.Delete(req.NamespacedName)
+			r.triggeredAdoptions.Delete(req.NamespacedName)
 			logger.V(1).Info("SandboxClaim not found, ignoring", "request", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
@@ -287,6 +336,25 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// TODO: This 1-minute requeue creates a latency regression vs an immediate watch trigger.
 		// Consider adding a lightweight SandboxTemplate -> claims map watch to reconcile promptly.
 		requeueDelay := 1 * time.Minute
+		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
+			requeueDelay = result.RequeueAfter
+		}
+		return ctrl.Result{RequeueAfter: requeueDelay}, nil
+	}
+
+	// Adoption was just triggered for a warm-pool sandbox. The sandbox is now patched
+	// to us, but the informer cache may still show the warm-pool owner. Requeue
+	// with a bounded delay to let the cache converge, WITHOUT returning an
+	// error: returning an error would route through the exponential failure rate
+	// limiter (and, under bursts, the shared 10qps bucket limiter), and because this
+	// same retry recurs on each pass until the cache catches up the backoff compounds
+	// (5ms*(2^k-1)) and adoption tail latency balloons (#1107). The nil error lets the
+	// workqueue Forget the key, resetting the failure counter. Status is intentionally
+	// not finalized with the sandbox on this pass (sandbox is nil here), preserving the
+	// duplicate-adoption protection during cache lag.
+	if errors.Is(reconcileErr, errAdoptionTriggeredRetry) {
+		logger.V(1).Info("Adoption triggered; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
+		requeueDelay := adoptionCacheLagRequeueDelay
 		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
 			requeueDelay = result.RequeueAfter
 		}
@@ -1383,6 +1451,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.V(4).Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
+				r.triggeredAdoptions.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 				launchType := v1beta1.SandboxLaunchTypeCold
 				if claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] == statusName ||
 					claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel] == statusName ||
@@ -1418,6 +1487,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.V(4).Info("Found existing adopted sandbox", "sandbox", sbName, "claim", claim.Name)
+				r.triggeredAdoptions.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 				if fromLabel {
 					if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
 						logger.Error(err, "Failed to migrate legacy sandbox label to annotation (non-fatal)", "claim", claim.Name)
@@ -1447,6 +1517,14 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 						return nil, fmt.Errorf("failed to remove invalid sandbox reference: %w", err)
 					}
 				} else {
+					// If we already sent the adoption patch for this exact claim+sandbox,
+					// the cache just hasn't converged yet — keep waiting via the bounded
+					// requeue without re-sending the (idempotent but redundant) patch.
+					adoptionKey := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+					if prev, ok := r.triggeredAdoptions.Load(adoptionKey); ok && prev.uid == claim.UID && prev.sandbox == sbName {
+						logger.V(1).Info("Adoption already triggered, waiting for cache to converge", "sandbox", sbName, "claim", claim.Name)
+						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
+					}
 					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
 						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
 							logger.V(4).Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
@@ -1454,6 +1532,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
 						}
 					} else {
+						r.triggeredAdoptions.Store(adoptionKey, triggeredAdoptionEntry{uid: claim.UID, sandbox: sbName})
 						if fromLabel {
 							if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
 								logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
@@ -1461,9 +1540,13 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 								logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 							}
 						}
-						// If succeeded, return error to retry so next reconcile sees it controlled by us!
-						logger.Info("Triggered adoption completion for sandbox, retry", "sandbox", sbName, "claim", claim.Name)
-						return nil, fmt.Errorf("triggered adoption completion for sandbox %s, retry", sbName)
+						// Adoption was completed in-place (completeAdoption patched our controllerRef
+						// and the Warm label). Signal a retry so a later pass observes the sandbox as
+						// controlled by us once the cache converges. Returned as a sentinel so
+						// Reconcile requeues immediately with a bounded delay rather than routing
+						// through the exponential failure rate limiter (#1107).
+						logger.Info("Triggered adoption completion for sandbox, requeueing", "sandbox", sbName, "claim", claim.Name)
+						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
 					}
 				}
 			}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3748,6 +3748,281 @@ func TestSandboxClaimAdoptionCacheLagDoesNotRepatch(t *testing.T) {
 	}
 }
 
+// TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus verifies that a claim whose
+// status was already finalized with a sandbox (e.g. a controller restart racing a stale
+// informer) does NOT have its SandboxStatus.Name/PodIPs wiped or its Ready condition
+// downgraded by a benign cache-lag adoption retry pass.
+func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
+	scheme := newScheme(t)
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "adopted-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+		// Status already finalized on a previous pass.
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(sandboxv1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				Message:            "Sandbox is ready",
+				LastTransitionTime: metav1.Now(),
+			}},
+			SandboxStatus: extensionsv1beta1.SandboxStatus{
+				Name:   "adopted-sb",
+				PodIPs: []string{"10.1.2.3"},
+			},
+		},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "img"}},
+			},
+		}},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: "warmpool-uid-123"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	adoptedSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adopted-sb",
+			Namespace: "default",
+			UID:       "adopted-sb-uid",
+			Labels: map[string]string{
+				extensionsv1beta1.SandboxIDLabel: "claim-uid-123",
+				sandboxTemplateRefHash:           sandboxcontrollers.NameHash("test-template"),
+				warmPoolSandboxLabel:             sandboxcontrollers.NameHash("test-pool"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        "warmpool-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			ObjectMeta: sandboxv1beta1.PodMetadata{
+				Labels: map[string]string{
+					extensionsv1beta1.SandboxIDLabel: "claim-uid-123",
+				},
+			},
+		}},
+		},
+	}
+
+	// Frozen warm-pool-owned view: served on every Get to simulate an informer
+	// cache that has not converged yet, no matter what was patched.
+	staleSandbox := adoptedSandbox.DeepCopy()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, adoptedSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" {
+					staleSandbox.DeepCopyInto(sb)
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	// Fresh reconciler (empty triggeredAdoptions), as after a controller restart.
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+
+	res, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected nil error during cache lag, got: %v", err)
+	}
+	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
+		t.Fatalf("expected RequeueAfter=%v, got %v", adoptionCacheLagRequeueDelay, res.RequeueAfter)
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+		t.Fatalf("failed to get claim: %v", err)
+	}
+	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
+		t.Errorf("expected finalized SandboxStatus.Name to be preserved, got %q", updatedClaim.Status.SandboxStatus.Name)
+	}
+	if len(updatedClaim.Status.SandboxStatus.PodIPs) != 1 || updatedClaim.Status.SandboxStatus.PodIPs[0] != "10.1.2.3" {
+		t.Errorf("expected finalized PodIPs to be preserved, got %v", updatedClaim.Status.SandboxStatus.PodIPs)
+	}
+	readyCondition := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	if readyCondition == nil {
+		t.Fatal("expected Ready condition to still be present")
+	}
+	if readyCondition.Status != metav1.ConditionTrue || readyCondition.Reason != "Ready" {
+		t.Errorf("expected Ready condition to be preserved (True/Ready), got %s/%s", readyCondition.Status, readyCondition.Reason)
+	}
+}
+
+// TestSandboxClaimFreshAdoptionDoesNotRepatchDuringCacheLag verifies that the primary
+// warm-adoption entry point (adoptSandboxFromCandidates) records the completed adoption
+// in the dedup cache, so the very next cache-lag pass waits via the bounded requeue
+// without re-sending the adoption patch — and without wiping the status finalized on
+// the adoption pass.
+func TestSandboxClaimFreshAdoptionDoesNotRepatchDuringCacheLag(t *testing.T) {
+	scheme := newScheme(t)
+
+	// No assigned-sandbox annotation: adoption goes through the candidate queue.
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "img"}},
+			},
+		}},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: "warmpool-uid-123"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	warmSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "warm-sb",
+			Namespace: "default",
+			UID:       "warm-sb-uid",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   sandboxcontrollers.NameHash("test-pool"),
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        "warmpool-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}}},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue, Reason: "Ready",
+			}},
+		},
+	}
+
+	// Frozen warm-pool-owned view: served on every Get to simulate an informer
+	// cache that never converges within the test, no matter what was patched.
+	staleSandbox := warmSandbox.DeepCopy()
+
+	sandboxPatches := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, warmSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "warm-sb" {
+					staleSandbox.DeepCopyInto(sb)
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+					sandboxPatches++
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	warmSandboxQueue.Add(
+		queue.GetNamespacedWarmPoolName("default", "test-pool"),
+		queue.SandboxKey{Namespace: "default", Name: "warm-sb"},
+	)
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: warmSandboxQueue,
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+
+	// Pass 1: fresh adoption through adoptSandboxFromCandidates; status is finalized.
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("pass 1: expected nil error, got: %v", err)
+	}
+	patchesAfterFirstPass := sandboxPatches
+	if patchesAfterFirstPass == 0 {
+		t.Fatal("pass 1: expected the adoption patch to be sent")
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+		t.Fatalf("failed to get claim: %v", err)
+	}
+	if updatedClaim.Status.SandboxStatus.Name != "warm-sb" {
+		t.Fatalf("pass 1: expected status to be finalized with 'warm-sb', got %q", updatedClaim.Status.SandboxStatus.Name)
+	}
+
+	// Passes 2 and 3: cache still shows the warm-pool owner — must wait via the
+	// bounded requeue WITHOUT re-sending the adoption patch, and WITHOUT wiping
+	// the status finalized on pass 1.
+	for pass := 2; pass <= 3; pass++ {
+		res, err := reconciler.Reconcile(context.Background(), req)
+		if err != nil {
+			t.Fatalf("pass %d: expected nil error, got: %v", pass, err)
+		}
+		if res.RequeueAfter != adoptionCacheLagRequeueDelay {
+			t.Fatalf("pass %d: expected RequeueAfter=%v, got %v", pass, adoptionCacheLagRequeueDelay, res.RequeueAfter)
+		}
+		if sandboxPatches != patchesAfterFirstPass {
+			t.Fatalf("pass %d: expected no additional sandbox patches while cache lags, got %d (was %d)", pass, sandboxPatches, patchesAfterFirstPass)
+		}
+		if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+			t.Fatalf("pass %d: failed to get claim: %v", pass, err)
+		}
+		if updatedClaim.Status.SandboxStatus.Name != "warm-sb" {
+			t.Errorf("pass %d: expected finalized status to be preserved during cache lag, got %q", pass, updatedClaim.Status.SandboxStatus.Name)
+		}
+	}
+}
+
 func TestSandboxClaimPreventsAdoptionFromWrongWarmPool(t *testing.T) {
 	scheme := newScheme(t)
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3555,6 +3555,16 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		t.Error("expected claim status to NOT be updated with 'adopted-sb' during cache lag")
 	}
 
+	// The cache-lag retry is a benign signal: the Ready condition must report the
+	// specific AdoptionPending reason, not a generic reconciler failure.
+	readyCondition := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	if readyCondition == nil {
+		t.Fatal("expected Ready condition to be set during cache lag")
+	}
+	if readyCondition.Reason != "AdoptionPending" {
+		t.Errorf("expected Ready condition reason %q during cache lag, got %q (message: %q)", "AdoptionPending", readyCondition.Reason, readyCondition.Message)
+	}
+
 	// Verify that the extra warm sandbox was NOT adopted (it should still have its warm pool labels)
 	var extra sandboxv1beta1.Sandbox
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-extra", Namespace: "default"}, &extra); err != nil {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -3531,16 +3532,20 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
 
-	// Run reconcile
-	_, err := reconciler.Reconcile(context.Background(), req)
-	expectedErr := "triggered adoption completion for sandbox adopted-sb, retry"
-	if err == nil {
-		t.Fatal("Expected reconcile to fail with cache lag error, but it succeeded")
-	} else if err.Error() != expectedErr {
-		t.Errorf("Expected error %q, got: %q", expectedErr, err.Error())
+	// Run reconcile. Adoption is triggered on this pass, but the sandbox is not yet
+	// observed as controlled by the claim (cache lag), so the reconcile must NOT finalize
+	// the claim and must requeue to try again. Post-#1107 the requeue is a bounded
+	// fixed-delay requeue with a nil error (not an exponentially-rate-limited error), so
+	// the compounding backoff that inflated adoption tail latency no longer occurs.
+	res, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected reconcile to requeue without error during cache lag, got error: %v", err)
+	}
+	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
+		t.Fatalf("Expected the bounded cache-lag requeue (%v), got RequeueAfter=%v", adoptionCacheLagRequeueDelay, res.RequeueAfter)
 	}
 
-	// Verify that the claim status was NOT updated with the sandbox name (due to error)
+	// Verify that the claim status was NOT updated with the sandbox name (adoption deferred)
 	updatedClaim := &extensionsv1beta1.SandboxClaim{}
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
 		t.Fatalf("failed to get claim: %v", err)
@@ -3603,6 +3608,133 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	}
 	if _, ok := extra.Labels[warmPoolSandboxLabel]; !ok {
 		t.Error("expected extra warm sandbox to still have warm pool label after 2nd pass (should not have been adopted)")
+	}
+}
+
+// TestSandboxClaimAdoptionCacheLagDoesNotRepatch verifies that while the informer cache
+// keeps returning the stale (warm-pool-owned) view of an already-adopted sandbox, the
+// bounded cache-lag requeues wait for convergence WITHOUT re-sending the adoption patch
+// on every pass.
+func TestSandboxClaimAdoptionCacheLagDoesNotRepatch(t *testing.T) {
+	scheme := newScheme(t)
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "adopted-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "img"}},
+			},
+		}},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: "warmpool-uid-123"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	adoptedSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adopted-sb",
+			Namespace: "default",
+			UID:       "adopted-sb-uid",
+			Labels: map[string]string{
+				extensionsv1beta1.SandboxIDLabel: "claim-uid-123",
+				sandboxTemplateRefHash:           sandboxcontrollers.NameHash("test-template"),
+				warmPoolSandboxLabel:             sandboxcontrollers.NameHash("test-pool"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        "warmpool-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			ObjectMeta: sandboxv1beta1.PodMetadata{
+				Labels: map[string]string{
+					extensionsv1beta1.SandboxIDLabel: "claim-uid-123",
+				},
+			},
+		}},
+		},
+	}
+
+	// Frozen warm-pool-owned view: served on every Get to simulate an informer
+	// cache that has not converged yet, no matter what was patched.
+	staleSandbox := adoptedSandbox.DeepCopy()
+
+	sandboxPatches := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, adoptedSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" {
+					staleSandbox.DeepCopyInto(sb)
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+					sandboxPatches++
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+
+	// Pass 1: adoption is triggered (patches the sandbox) and defers via bounded requeue.
+	res, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("pass 1: expected nil error, got: %v", err)
+	}
+	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
+		t.Fatalf("pass 1: expected RequeueAfter=%v, got %v", adoptionCacheLagRequeueDelay, res.RequeueAfter)
+	}
+	patchesAfterFirstPass := sandboxPatches
+	if patchesAfterFirstPass == 0 {
+		t.Fatal("pass 1: expected the adoption patch to be sent")
+	}
+
+	// Passes 2 and 3: cache still stale — must keep requeueing WITHOUT re-patching.
+	for pass := 2; pass <= 3; pass++ {
+		res, err = reconciler.Reconcile(context.Background(), req)
+		if err != nil {
+			t.Fatalf("pass %d: expected nil error, got: %v", pass, err)
+		}
+		if res.RequeueAfter != adoptionCacheLagRequeueDelay {
+			t.Fatalf("pass %d: expected RequeueAfter=%v, got %v", pass, adoptionCacheLagRequeueDelay, res.RequeueAfter)
+		}
+		if sandboxPatches != patchesAfterFirstPass {
+			t.Fatalf("pass %d: expected no additional sandbox patches while cache lags, got %d (was %d)", pass, sandboxPatches, patchesAfterFirstPass)
+		}
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

After `completeAdoption()` successfully patches a warm-pool sandbox's controllerRef over to a SandboxClaim, `getOrCreateSandbox` deliberately returned an error so the next reconcile could observe the ownership change once the informer cache converges. That error exited `Reconcile` unsuppressed and rode controller-runtime's default rate limiters — the per-item exponential limiter (5ms base, doubling, never `Forget`'d while passes keep erroring) plus, under bursts, the shared 10qps/100-burst bucket limiter. Since the same look-again recurs every pass until the cache catches up, K lag passes cost ~5ms·(2^K−1), and concurrent claim bursts compound it further through the shared bucket — inflating warm-adoption tail latency to multiple seconds.

This PR signals the look-again with a sentinel (`errAdoptionTriggeredRetry`) that `Reconcile` maps via `errors.Is` to `ctrl.Result{RequeueAfter: adoptionCacheLagRequeueDelay}` (50ms) with a **nil** error — mirroring the existing `ErrWarmPoolNotFound`/`ErrTemplateNotFound` bounded-requeue pattern. The nil error lets the workqueue `Forget` the key (resetting the exponential counter) and `RequeueAfter` bypasses both rate limiters. 50ms rather than the 1ms `immediateRequeueDelay`: it covers typical watch latency in a single extra pass and bounds the rate of redundant adoption re-patches while the cache lags.

**Duplicate-adoption protection is intentionally unchanged**: the first pass still does not finalize status and still adopts no extra warm sandbox during cache lag. Alternatives were considered and rejected — returning `(sandbox, nil)` on the first pass or using an APIReader read both erode that protection (see `TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag`).

#### Tests

- `TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag` now asserts the first pass returns **nil error + exactly the bounded requeue delay** (previously it asserted the raw error string), keeps all duplicate-adoption invariants (status not finalized, extra warm sandbox untouched), and verifies full second-pass convergence after the cache catches up (status set, launch-type label applied, extra sandbox still unadopted).
- Falsifiability verified: disabling the sentinel→requeue conversion flips the test to FAIL.
- Full `./extensions/controllers` suite passes; `go vet` and `gofmt` clean.

#### Which issue(s) this PR is related to:

Fixes #1107

#### Credit

Root-cause analysis and the original patch are by @AlexBulankou ([honest-bench §S4](https://github.com/AlexBulankou/honest-bench/blob/main/UPSTREAM_BLOCKERS_DETAIL.md#s4--sandboxclaim-adoption-completion-cache-race-exponential-backoff-amplifier), branch `AlexBulankou/agent-sandbox@adoption-completion-bounded-requeue`) — adapted here onto current main with a bounded 50ms look-again delay (vs 1ms) and an exact-delay + convergence test tightening; commit carries Co-authored-by.

#### Release Note
```
Fixed SandboxClaim warm-pool adoption latency spikes under concurrent claim bursts: the post-adoption cache-lag retry no longer rides the exponential failure backoff and instead requeues with a bounded 50ms delay.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox claim adoption handling during informer cache lag with a bounded, delayed requeue (nil error) to avoid backoff/retry escalation.
  * Added clearer readiness behavior during cache convergence using `AdoptionPending`.
  * Prevented duplicate warm-pool adoption completion/patching while adoption is already recorded but cache ownership hasn’t yet updated.
  * Preserved finalized claim status during cache-lag retries.

* **Tests**
  * Updated cache-lag expectations for bounded requeue and readiness signaling.
  * Added coverage to ensure no re-patching under stale cache, and that finalized status is not wiped on retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->