### PR TITLE
fix(go-sdk): encode dot file paths

### DIFF
--- a/clients/go/sandbox/files.go
+++ b/clients/go/sandbox/files.go
@@ -54,6 +54,18 @@ func percentEncode(s string) string {
 	return b.String()
 }
 
+func encodeFilePath(path string) string {
+	encoded := percentEncode(path)
+	switch encoded {
+	case ".":
+		return "%2E"
+	case "..":
+		return "%2E%2E"
+	default:
+		return encoded
+	}
+}
+
 // applyCallOpts applies per-call options, returning a context with any
 // WithTimeout deadline and the configured max retry count (0 = default).
 func applyCallOpts(ctx context.Context, opts []CallOption) (context.Context, context.CancelFunc, int) {
@@ -155,7 +167,7 @@ func (f *Files) Read(ctx context.Context, path string, opts ...CallOption) ([]by
 		return nil, err
 	}
 
-	encoded := percentEncode(path)
+	encoded := encodeFilePath(path)
 	resp, err := f.connector.SendRequest(ctx, http.MethodGet, "download/"+encoded, nil, "", maxAttempts)
 	if err != nil {
 		recordError(span, err)
@@ -199,7 +211,7 @@ func (f *Files) List(ctx context.Context, path string, opts ...CallOption) ([]Fi
 		return nil, err
 	}
 
-	encoded := percentEncode(path)
+	encoded := encodeFilePath(path)
 	resp, err := f.connector.SendRequest(ctx, http.MethodGet, "list/"+encoded, nil, "", maxAttempts)
 	if err != nil {
 		recordError(span, err)
@@ -248,7 +260,7 @@ func (f *Files) Exists(ctx context.Context, path string, opts ...CallOption) (bo
 		return false, err
 	}
 
-	encoded := percentEncode(path)
+	encoded := encodeFilePath(path)
 	resp, err := f.connector.SendRequest(ctx, http.MethodGet, "exists/"+encoded, nil, "", maxAttempts)
 	if err != nil {
 		recordError(span, err)

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -225,6 +225,7 @@ func TestOperations_URLEncodesSpecialChars(t *testing.T) {
 		{"Read_spaces", "path with spaces/file.txt", "path%20with%20spaces%2Ffile.txt", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
 		{"List_spaces", "path with spaces/dir", "path%20with%20spaces%2Fdir", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
 		{"List_dot", ".", "%2E", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
+		{"List_dotdot", "..", "%2E%2E", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
 		{"Exists_special", "file@special!.txt", "file%40special%21.txt", func(c *Sandbox, p string) error { _, err := c.Exists(context.Background(), p); return err }},
 		{"Read_slashes", "subdir/nested/file.txt", "subdir%2Fnested%2Ffile.txt", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
 	}
@@ -264,7 +265,8 @@ func TestList_DotPathDoesNotRedirect(t *testing.T) {
 			return
 		}
 		if r.URL.EscapedPath() != "/list/%2E" {
-			t.Fatalf("expected /list/%%2E, got %s", r.URL.EscapedPath())
+			t.Errorf("expected /list/%%2E, got %s", r.URL.EscapedPath())
+			return
 		}
 		_ = json.NewEncoder(w).Encode([]FileEntry{})
 	}))

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -224,6 +224,7 @@ func TestOperations_URLEncodesSpecialChars(t *testing.T) {
 	}{
 		{"Read_spaces", "path with spaces/file.txt", "path%20with%20spaces%2Ffile.txt", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
 		{"List_spaces", "path with spaces/dir", "path%20with%20spaces%2Fdir", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
+		{"List_dot", ".", "%2E", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
 		{"Exists_special", "file@special!.txt", "file%40special%21.txt", func(c *Sandbox, p string) error { _, err := c.Exists(context.Background(), p); return err }},
 		{"Read_slashes", "subdir/nested/file.txt", "subdir%2Fnested%2Ffile.txt", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
 	}
@@ -253,6 +254,29 @@ func TestOperations_URLEncodesSpecialChars(t *testing.T) {
 				t.Errorf("expected URL path containing %q, got %s", tc.expected, receivedPath)
 			}
 		})
+	}
+}
+
+func TestList_DotPathDoesNotRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.EscapedPath() == "/list/." {
+			http.Redirect(w, r, "/list/", http.StatusTemporaryRedirect)
+			return
+		}
+		if r.URL.EscapedPath() != "/list/%2E" {
+			t.Fatalf("expected /list/%%2E, got %s", r.URL.EscapedPath())
+		}
+		_ = json.NewEncoder(w).Encode([]FileEntry{})
+	}))
+	defer server.Close()
+
+	c := newReadyTestSandbox(server.URL)
+	entries, err := c.List(context.Background(), ".")
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %d", len(entries))
 	}
 }
 

--- a/clients/go/sandbox/files_test.go
+++ b/clients/go/sandbox/files_test.go
@@ -223,10 +223,14 @@ func TestOperations_URLEncodesSpecialChars(t *testing.T) {
 		callOp   func(*Sandbox, string) error
 	}{
 		{"Read_spaces", "path with spaces/file.txt", "path%20with%20spaces%2Ffile.txt", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
+		{"Read_dot", ".", "%2E", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
+		{"Read_dotdot", "..", "%2E%2E", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
 		{"List_spaces", "path with spaces/dir", "path%20with%20spaces%2Fdir", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
 		{"List_dot", ".", "%2E", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
 		{"List_dotdot", "..", "%2E%2E", func(c *Sandbox, p string) error { _, err := c.List(context.Background(), p); return err }},
 		{"Exists_special", "file@special!.txt", "file%40special%21.txt", func(c *Sandbox, p string) error { _, err := c.Exists(context.Background(), p); return err }},
+		{"Exists_dot", ".", "%2E", func(c *Sandbox, p string) error { _, err := c.Exists(context.Background(), p); return err }},
+		{"Exists_dotdot", "..", "%2E%2E", func(c *Sandbox, p string) error { _, err := c.Exists(context.Background(), p); return err }},
 		{"Read_slashes", "subdir/nested/file.txt", "subdir%2Fnested%2Ffile.txt", func(c *Sandbox, p string) error { _, err := c.Read(context.Background(), p); return err }},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes Go SDK file operation paths that are exactly `.` or `..` by encoding those path segments before sending them to the sandbox API.

Previously, `Sandbox.List(ctx, ".")` sent `/list/.`, which can be normalized by the upstream HTTP server and returned as a `307 Temporary Redirect`. The Go SDK intentionally does not follow redirects, so the call failed. The fix preserves the existing percent-encoding behavior for ordinary paths while encoding dot-only file paths as `%2E` / `%2E%2E`.

A regression test now simulates a backend that redirects `/list/.` and verifies the SDK sends `/list/%2E` instead.

#### Which issue(s) this PR is related to:
Fixes #1052

#### Release Note
```release-note
Fixed Go SDK file operations for dot paths such as List(".") so they avoid server-side path normalization redirects.
```

#### Testing
```
GOCACHE=/tmp/go-build go test ./clients/go/sandbox -run 'TestOperations_URLEncodesSpecialChars/List_dot|TestList_DotPathDoesNotRedirect' -count=1
GOCACHE=/tmp/go-build go test ./clients/go/sandbox -count=1
git diff --check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling so special path values like `.` and `..` are encoded safely in requests.
  * Prevented unintended redirects when listing files with a dot path.
  * Expanded coverage to verify special-character encoding and dot-path listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->