### PR TITLE
Backend proto

### DIFF
--- a/dev/tools/fix-go-generate
+++ b/dev/tools/fix-go-generate
@@ -61,7 +61,7 @@ def main():
         for import_path, binary_name in tools:
             print(f"  Installing {binary_name} ({import_path.split('@')[1]})...")
             # Running go install outside the main module context to avoid modifying go.mod
-            subprocess.check_call(["go", "install", import_path], env=env, cwd=repo_root)
+            subprocess.check_call(["go", "install", import_path], env=env, cwd=os.path.expanduser("~"))
 
         with open(stamp_file, "w") as f:
             f.write(expected_stamp + "\n")

--- a/dev/tools/fix-go-generate
+++ b/dev/tools/fix-go-generate
@@ -61,7 +61,7 @@ def main():
         for import_path, binary_name in tools:
             print(f"  Installing {binary_name} ({import_path.split('@')[1]})...")
             # Running go install outside the main module context to avoid modifying go.mod
-            subprocess.check_call(["go", "install", import_path], env=env, cwd=os.path.expanduser("~"))
+            subprocess.check_call(["go", "install", import_path], env=env, cwd=repo_root)
 
         with open(stamp_file, "w") as f:
             f.write(expected_stamp + "\n")

--- a/packages/sandboxd/spec/filesystem/v1/filesystem.yaml
+++ b/packages/sandboxd/spec/filesystem/v1/filesystem.yaml
@@ -1,0 +1,227 @@
+openapi: "3.0.3"
+info:
+  title: sandboxd Filesystem & Runtime REST API
+  description: >
+    Stateless REST interface for sandbox file system operations and runtime metadata (ASRP).
+    High-performance raw file transfers (read/write) are served over HTTP REST, while interactive
+    process execution is served over gRPC on a dedicated port.
+    Security note: sandboxd listens strictly on localhost or Unix Domain Socket within the isolated
+    container network namespace and must never be exposed on public interfaces.
+  version: "v1"
+
+servers:
+  - url: http://localhost:8080/v1
+    description: sandboxd REST server (default port 8080 or Unix Domain Socket)
+
+paths:
+  /files/{path}:
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+        description: >
+          Sandbox-relative path (e.g. workspace/main.py or workspace/src/).
+          Requests that attempt directory traversal outside the sandbox root are rejected with 403.
+
+    get:
+      summary: Read a file or list a directory
+      description: >
+        If the path points to a file, returns raw file bytes (application/octet-stream).
+        If the path points to a directory, returns a structured directory listing (application/json).
+      responses:
+        "200":
+          description: File contents or directory listing
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectoryListing"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      summary: Write or overwrite a file (Idempotent)
+      description: >
+        Atomically writes request body to the given path using a temporary file and rename strategy.
+        Parent directories are created automatically. Supports both new file creation and overwriting.
+      parameters:
+        - name: mode
+          in: query
+          required: false
+          schema:
+            type: string
+            default: "0644"
+          description: Octal permission bits applied to the written file (e.g. "0755" or "0644").
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "204":
+          description: File written successfully
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+    delete:
+      summary: Remove a file or directory
+      parameters:
+        - name: recursive
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: If true, recursively removes directory and all its contents.
+      responses:
+        "204":
+          description: Removed successfully
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /health:
+    get:
+      summary: Sandbox readiness and heartbeat check
+      description: >
+        Used by orchestrators and Kubernetes liveness/readiness probes to verify sandboxd is healthy.
+      responses:
+        "200":
+          description: Healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /metadata:
+    get:
+      summary: Runtime environment metadata
+      description: >
+        Returns dynamic environment variables and configuration secrets injected by the orchestrator.
+        Security note: This endpoint is strictly restricted to local loopback (localhost) or Unix Domain
+        Socket access within the isolated pod network namespace and must never be exposed externally.
+      responses:
+        "200":
+          description: Runtime metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetadataResponse"
+
+components:
+  schemas:
+    DirectoryListing:
+      type: object
+      required:
+        - path
+        - entries
+      properties:
+        path:
+          type: string
+          example: "/workspace"
+        entries:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileEntry"
+
+    FileEntry:
+      type: object
+      required:
+        - name
+        - size
+        - type
+        - modified_at
+      properties:
+        name:
+          type: string
+          example: "main.py"
+        size:
+          type: integer
+          format: int64
+          example: 1024
+        type:
+          type: string
+          enum: [file, directory]
+          example: "file"
+        modified_at:
+          type: string
+          format: date-time
+        mode:
+          type: string
+          description: Octal permission bits
+          example: "0644"
+
+    HealthResponse:
+      type: object
+      required:
+        - status
+        - uptime_seconds
+      properties:
+        status:
+          type: string
+          enum: [ok]
+          example: "ok"
+        uptime_seconds:
+          type: integer
+          example: 3600
+
+    MetadataResponse:
+      type: object
+      properties:
+        env:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key-value environment variables injected by the orchestrator.
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          example: "PERMISSION_DENIED"
+        message:
+          type: string
+          example: "Path traversal outside sandbox root is forbidden."
+
+  responses:
+    BadRequest:
+      description: Invalid request parameters or payload
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Forbidden:
+      description: Path escapes sandbox root or permission denied
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: Path does not exist within the sandbox
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"

--- a/packages/sandboxd/spec/filesystem/v1/filesystem.yaml
+++ b/packages/sandboxd/spec/filesystem/v1/filesystem.yaml
@@ -2,7 +2,8 @@ openapi: "3.0.3"
 info:
   title: sandboxd Filesystem & Runtime REST API
   description: >
-    Stateless REST interface for sandbox file system operations and runtime metadata (ASRP).
+    Stateless REST interface for sandbox file system operations and runtime metadata.
+    Part of the Agent Runtime Protocol hybrid gRPC/REST architecture.
     High-performance raw file transfers (read/write) are served over HTTP REST, while interactive
     process execution is served over gRPC on a dedicated port.
     Security note: sandboxd listens strictly on localhost or Unix Domain Socket within the isolated
@@ -23,7 +24,9 @@ paths:
           type: string
         description: >
           Sandbox-relative path (e.g. workspace/main.py or workspace/src/).
-          Requests that attempt directory traversal outside the sandbox root are rejected with 403.
+          Path segments containing '/' must be URL-encoded (%2F) by clients
+          when constructing the request URL. The server decodes the full path
+          before resolving it against the sandbox root.
 
     get:
       summary: Read a file or list a directory
@@ -57,6 +60,7 @@ paths:
           required: false
           schema:
             type: string
+            pattern: "^0[0-7]{3}$"
             default: "0644"
           description: Octal permission bits applied to the written file (e.g. "0755" or "0644").
       requestBody:
@@ -69,6 +73,8 @@ paths:
           multipart/form-data:
             schema:
               type: object
+              required:
+                - file
               properties:
                 file:
                   type: string
@@ -111,14 +117,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HealthResponse"
+        "503":
+          description: Service unavailable or not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /metadata:
     get:
       summary: Runtime environment metadata
       description: >
-        Returns dynamic environment variables and configuration secrets injected by the orchestrator.
-        Security note: This endpoint is strictly restricted to local loopback (localhost) or Unix Domain
-        Socket access within the isolated pod network namespace and must never be exposed externally.
+        Returns dynamic environment variables and secrets injected by the orchestrator.
+        This endpoint is intentionally reachable only via localhost or Unix Domain Socket
+        and must not be exposed on a public network interface. No additional authentication
+        is applied beyond network-level containment.
       responses:
         "200":
           description: Runtime metadata
@@ -174,7 +187,6 @@ components:
       type: object
       required:
         - status
-        - uptime_seconds
       properties:
         status:
           type: string

--- a/packages/sandboxd/spec/filesystem/v1/filesystem.yaml
+++ b/packages/sandboxd/spec/filesystem/v1/filesystem.yaml
@@ -1,11 +1,29 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 openapi: "3.0.3"
 info:
   title: sandboxd Filesystem & Runtime REST API
   description: >
     Stateless REST interface for sandbox file system operations and runtime metadata.
-    Part of the Agent Runtime Protocol hybrid gRPC/REST architecture.
+    Part of the Agent Runtime Protocol hybrid gRPC/REST architecture defined in KEP-539.2.
     High-performance raw file transfers (read/write) are served over HTTP REST, while interactive
     process execution is served over gRPC on a dedicated port.
+    Compatibility & Migration Note: This specification replaces the unversioned python-runtime
+    endpoints (/upload, /download, /list, /exists) and FileEntry wire representation. Existing
+    SDK clients migrate to this versioned /v1/ surface using the dynamic endpoint discovery and
+    breaking change rollout strategy documented in KEP-539.2.
     Security note: sandboxd listens strictly on localhost or Unix Domain Socket within the isolated
     container network namespace and must never be exposed on public interfaces.
   version: "v1"
@@ -104,6 +122,8 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
 
   /health:
     get:
@@ -128,10 +148,12 @@ paths:
     get:
       summary: Runtime environment metadata
       description: >
-        Returns dynamic environment variables and secrets injected by the orchestrator.
-        This endpoint is intentionally reachable only via localhost or Unix Domain Socket
-        and must not be exposed on a public network interface. No additional authentication
-        is applied beyond network-level containment.
+        Returns workload-scoped environment configuration injected by the orchestrator
+        (e.g. sandbox ID, workspace path, resource limits).
+        Security restriction: this endpoint must only serve non-sensitive configuration.
+        Orchestrator credentials, Kubernetes API tokens, and cloud provider IAM keys must NEVER
+        be served or placed in /v1/metadata since untrusted agent code running in the sandbox
+        can query localhost.
       responses:
         "200":
           description: Runtime metadata
@@ -233,6 +255,12 @@ components:
             $ref: "#/components/schemas/Error"
     NotFound:
       description: Path does not exist within the sandbox
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Conflict:
+      description: Directory not empty when recursive=false
       content:
         application/json:
           schema:

--- a/packages/sandboxd/spec/process/v1/process.proto
+++ b/packages/sandboxd/spec/process/v1/process.proto
@@ -1,3 +1,17 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 syntax = "proto3";
 
 package process.v1;


### PR DESCRIPTION
# Description

This PR introduces the OpenAPI 3.0.3 specification for the **`sandboxd` Filesystem & Runtime REST API** (`packages/sandboxd/spec/filesystem/v1/filesystem.yaml`).

This establishes a stateless REST interface for high-performance file operations inside the sandbox , complementing the gRPC `ProcessService`.

## Key Endpoints Defined

### 1. Core Filesystem Operations (`/v1/files/{path}`)
* **`GET /v1/files/{path}`**:
  * For files: Directly returns raw binary bytes (`application/octet-stream`) with zero JSON/base64 serialization overhead.
  * For directories: Returns a structured JSON directory listing (`DirectoryListing`).
* **`PUT /v1/files/{path}`**:
  * Atomically creates or overwrites files using a temporary-file-then-rename strategy (`os.Rename`).
  * Automatically creates parent directories.
  * Supports both raw binary (`application/octet-stream`) and form uploads (`multipart/form-data`).
  * Accepts an optional `mode` query parameter (default `"0644"`) to set octal permission bits.
* **`DELETE /v1/files/{path}`**:
  * Removes files or directories.
  * Supports optional `recursive=true` query parameter for `rm -rf` behavior.

### 2. Operational & Metadata Probes
* **`GET /v1/health`**: Readiness probe endpoint for Kubernetes liveness/readiness checks (`{"status": "ok"}`).
* **`GET /v1/metadata`**: Dynamic discovery endpoint allowing agents to retrieve orchestrator-injected environment variables and runtime secrets.

---

## Architectural Rationale

* **Process Execution** is handled via **gRPC (`:9090`)** for full-duplex bidirectional streaming (`Start`).
* **Filesystem Transfers** are handled via **HTTP REST (`:8080`)** to transfer raw byte streams directly, avoiding protobuf wrapper serialization overhead when reading or writing large code files and packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API documentation for filesystem and runtime operations, including reading, writing, deleting, and listing files.
  * Documented health-check and environment metadata endpoints with response and error details.
  * Added guidance to prevent sensitive credentials and tokens from being exposed through metadata.

* **Documentation**
  * Added standardized licensing information to the process API specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->