### PR TITLE
fix(sandboxclaim): finalize warm-pool adoption in the same pass

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -70,23 +70,6 @@ var ErrSandboxNotOwned = errors.New("sandbox not owned by this claim")
 // ErrWarmPoolNotFound is a sentinel error indicating a SandboxWarmPool was not found.
 var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 
-// errAdoptionTriggeredRetry signals that warm-pool adoption was just completed for a
-// sandbox and the claim must be requeued so a later pass observes the sandbox as
-// controlled by this claim once the informer cache converges. It is a sentinel (not a
-// generic error) so Reconcile can convert it into a bounded requeue instead
-// of returning an error: an error would route through the exponential failure rate
-// limiter, and because the same retry recurs each pass until the cache catches up the
-// backoff compounds and, under concurrent claims, adoption tail latency balloons
-// (#1107).
-var errAdoptionTriggeredRetry = errors.New("triggered adoption completion, retry")
-
-// adoptionCacheLagRequeueDelay is how long to wait before re-checking that a
-// just-completed adoption is visible in the informer cache. Long enough to
-// cover typical watch latency (so most claims converge in one extra pass) and
-// to bound the rate of redundant adoption patches while the cache lags, but
-// far below the multi-second exponential backoff it replaces.
-const adoptionCacheLagRequeueDelay = 50 * time.Millisecond
-
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
 
@@ -147,36 +130,6 @@ func (m *observedTimeMap) LoadOrStore(key types.NamespacedName, entry observedTi
 	return actual.(observedTimeEntry), loaded
 }
 
-// triggeredAdoptionEntry records that completeAdoption already patched the
-// named sandbox over to a claim (identified by UID), so cache-lag requeues
-// can wait for the informer to converge without re-sending the patch.
-type triggeredAdoptionEntry struct {
-	uid     types.UID
-	sandbox string
-}
-
-// triggeredAdoptionMap is a type-safe wrapper around sync.Map that only
-// stores triggeredAdoptionEntry values.
-type triggeredAdoptionMap struct {
-	inner sync.Map
-}
-
-func (m *triggeredAdoptionMap) Load(key types.NamespacedName) (triggeredAdoptionEntry, bool) {
-	val, ok := m.inner.Load(key)
-	if !ok {
-		return triggeredAdoptionEntry{}, false
-	}
-	return val.(triggeredAdoptionEntry), true
-}
-
-func (m *triggeredAdoptionMap) Store(key types.NamespacedName, entry triggeredAdoptionEntry) {
-	m.inner.Store(key, entry)
-}
-
-func (m *triggeredAdoptionMap) Delete(key types.NamespacedName) {
-	m.inner.Delete(key)
-}
-
 // SandboxClaimReconciler reconciles a SandboxClaim object.
 type SandboxClaimReconciler struct {
 	client.Client
@@ -186,7 +139,6 @@ type SandboxClaimReconciler struct {
 	Tracer                  asmetrics.Instrumenter
 	MaxConcurrentReconciles int
 	observedTimes           observedTimeMap
-	triggeredAdoptions      triggeredAdoptionMap
 	AllowedLabelDomains     []string
 }
 
@@ -211,7 +163,6 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if k8errors.IsNotFound(err) {
 			// Fallback cleanup to prevent memory leaks if the delete predicate was missed or a stale request is processed.
 			r.observedTimes.Delete(req.NamespacedName)
-			r.triggeredAdoptions.Delete(req.NamespacedName)
 			logger.V(1).Info("SandboxClaim not found, ignoring", "request", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
@@ -346,25 +297,6 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// TODO: This 1-minute requeue creates a latency regression vs an immediate watch trigger.
 		// Consider adding a lightweight SandboxTemplate -> claims map watch to reconcile promptly.
 		requeueDelay := 1 * time.Minute
-		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
-			requeueDelay = result.RequeueAfter
-		}
-		return ctrl.Result{RequeueAfter: requeueDelay}, nil
-	}
-
-	// Adoption was just triggered for a warm-pool sandbox. The sandbox is now patched
-	// to us, but the informer cache may still show the warm-pool owner. Requeue
-	// with a bounded delay to let the cache converge, WITHOUT returning an
-	// error: returning an error would route through the exponential failure rate
-	// limiter (and, under bursts, the shared 10qps bucket limiter), and because this
-	// same retry recurs on each pass until the cache catches up the backoff compounds
-	// (5ms*(2^k-1)) and adoption tail latency balloons (#1107). The nil error lets the
-	// workqueue Forget the key, resetting the failure counter. Status is intentionally
-	// not finalized with the sandbox on this pass (sandbox is nil here), preserving the
-	// duplicate-adoption protection during cache lag.
-	if errors.Is(reconcileErr, errAdoptionTriggeredRetry) {
-		logger.V(4).Info("Adoption triggered; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
-		requeueDelay := adoptionCacheLagRequeueDelay
 		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
 			requeueDelay = result.RequeueAfter
 		}
@@ -611,17 +543,6 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 				ObservedGeneration: claim.Generation,
 			}
 		}
-		if errors.Is(err, errAdoptionTriggeredRetry) {
-			// Benign retry signal, not a claim failure: adoption was patched and we
-			// are only waiting for the informer cache to converge before finalizing.
-			return metav1.Condition{
-				Type:               string(v1beta1.SandboxConditionReady),
-				Status:             metav1.ConditionFalse,
-				Reason:             "AdoptionPending",
-				Message:            "Warm-pool sandbox adoption triggered; waiting for cache to converge",
-				ObservedGeneration: claim.Generation,
-			}
-		}
 		if errors.Is(err, ErrInvalidMetadata) {
 			reason = "InvalidMetadata"
 			return metav1.Condition{
@@ -720,13 +641,6 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 }
 
 func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1beta1.SandboxClaim, sandbox *v1beta1.Sandbox, err error, isClaimExpired bool) {
-	// A cache-lag adoption retry is a benign look-again, not a state change. If the
-	// claim status was already finalized with a sandbox (the adoption pass itself, or
-	// a controller restart racing a stale informer), leave the recorded Name/PodIPs
-	// and existing conditions untouched instead of transiently wiping them.
-	if sandbox == nil && errors.Is(err, errAdoptionTriggeredRetry) && claim.Status.SandboxStatus.Name != "" {
-		return
-	}
 	readyCondition := r.computeReadyCondition(claim, sandbox, err, isClaimExpired)
 	meta.SetStatusCondition(&claim.Status.Conditions, readyCondition)
 	r.syncFinishedCondition(claim, sandbox, isClaimExpired)
@@ -958,14 +872,6 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			}
 
 			logger.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
-
-			// Record the completed adoption so a later pass that still sees the
-			// stale warm-pool-owned view (informer cache lag) waits via the
-			// bounded requeue instead of re-sending the adoption patch.
-			r.triggeredAdoptions.Store(
-				types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace},
-				triggeredAdoptionEntry{uid: claim.UID, sandbox: adopted.Name},
-			)
 
 			if r.Recorder != nil {
 				r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, "SandboxAdopted", "Adoption", "Adopted warm pool Sandbox %q", adopted.Name)
@@ -1528,7 +1434,6 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: statusName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.V(4).Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
-				r.triggeredAdoptions.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 				launchType := v1beta1.SandboxLaunchTypeCold
 				if claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] == statusName ||
 					claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel] == statusName ||
@@ -1564,7 +1469,6 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.V(4).Info("Found existing adopted sandbox", "sandbox", sbName, "claim", claim.Name)
-				r.triggeredAdoptions.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 				if fromLabel {
 					if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
 						logger.Error(err, "Failed to migrate legacy sandbox label to annotation (non-fatal)", "claim", claim.Name)
@@ -1594,14 +1498,6 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 						return nil, fmt.Errorf("failed to remove invalid sandbox reference: %w", err)
 					}
 				} else {
-					// If we already sent the adoption patch for this exact claim+sandbox,
-					// the cache just hasn't converged yet — keep waiting via the bounded
-					// requeue without re-sending the (idempotent but redundant) patch.
-					adoptionKey := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-					if prev, ok := r.triggeredAdoptions.Load(adoptionKey); ok && prev.uid == claim.UID && prev.sandbox == sbName {
-						logger.V(4).Info("Adoption already triggered, waiting for cache to converge", "sandbox", sbName, "claim", claim.Name)
-						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
-					}
 					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
 						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
 							logger.V(4).Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
@@ -1609,7 +1505,6 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
 						}
 					} else {
-						r.triggeredAdoptions.Store(adoptionKey, triggeredAdoptionEntry{uid: claim.UID, sandbox: sbName})
 						if fromLabel {
 							if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
 								logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
@@ -1617,13 +1512,19 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 								logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 							}
 						}
-						// Adoption was completed in-place (completeAdoption patched our controllerRef
-						// and the Warm label). Signal a retry so a later pass observes the sandbox as
-						// controlled by us once the cache converges. Returned as a sentinel so
-						// Reconcile requeues immediately with a bounded delay rather than routing
-						// through the exponential failure rate limiter (#1107).
-						logger.Info("Triggered adoption completion for sandbox, requeueing", "sandbox", sbName, "claim", claim.Name)
-						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
+						// The Patch inside completeAdoption wrote the API server's response back
+						// into `sandbox`, so the object we hold now authoritatively shows this
+						// claim as controller (with the Warm launch-type label applied). Return
+						// it so the claim status is finalized in this same pass, just like the
+						// adoptSandboxFromCandidates path does after a fresh adoption.
+						//
+						// Informer cache lag needs no requeue here. A later pass that still
+						// reads the stale warm-pool-owned view simply repeats completeAdoption,
+						// which re-sends the same idempotent patch. And once the cache absorbs
+						// the ownership change, the Owns(&Sandbox{}) watch enqueues this claim
+						// again anyway, so convergence is event-driven (#1107).
+						logger.Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
+						return sandbox, nil
 					}
 				}
 			}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1512,18 +1512,12 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 								logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 							}
 						}
-						// The Patch inside completeAdoption wrote the API server's response back
-						// into `sandbox`, so the object we hold now authoritatively shows this
-						// claim as controller (with the Warm launch-type label applied). Return
-						// it so the claim status is finalized in this same pass, just like the
-						// adoptSandboxFromCandidates path does after a fresh adoption.
-						//
-						// Informer cache lag needs no requeue here. A later pass that still
-						// reads the stale warm-pool-owned view simply repeats completeAdoption,
-						// which re-sends the same idempotent patch. And once the cache absorbs
-						// the ownership change, the Owns(&Sandbox{}) watch enqueues this claim
-						// again anyway, so convergence is event-driven (#1107).
-						logger.V(1).Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
+						// completeAdoption wrote the API server's response back into
+						// `sandbox`, so returning it finalizes the claim status in this same
+						// pass. No requeue for cache lag: a stale pass just re-sends the
+						// idempotent patch, and the Owns(&Sandbox{}) watch drives convergence
+						// once the cache catches up (#1107).
+						logger.V(4).Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
 						return sandbox, nil
 					}
 				}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1523,7 +1523,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 						// which re-sends the same idempotent patch. And once the cache absorbs
 						// the ownership change, the Owns(&Sandbox{}) watch enqueues this claim
 						// again anyway, so convergence is event-driven (#1107).
-						logger.Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
+						logger.V(1).Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
 						return sandbox, nil
 					}
 				}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3646,10 +3646,24 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		},
 	}
 
+	// Simulate informer cache lag: while cacheStale is true, every Get of the
+	// adopted sandbox returns the frozen warm-pool-owned view, no matter what
+	// was patched.
+	cacheStale := true
+	staleSandbox := adoptedSandbox.DeepCopy()
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(template, warmPool, claim, adoptedSandbox, extraSandbox).
 		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" && cacheStale {
+					staleSandbox.DeepCopyInto(sb)
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
 		Build()
 
 	warmSandboxQueue := queue.NewSimpleSandboxQueue()
@@ -3711,11 +3725,32 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		t.Error("expected extra warm sandbox to still have warm pool label, meaning it was not incorrectly adopted during cache lag")
 	}
 
-	// Run reconcile AGAIN. The adoption patch already transferred ownership, so the
-	// second pass takes the fast path (status lookup, IsControlledBy) and is stable.
+	// Run reconcile AGAIN while the cache is STILL stale. The pass re-sends the
+	// idempotent adoption patch and must neither error, nor wipe the finalized
+	// status, nor adopt the extra warm sandbox.
 	_, err = reconciler.Reconcile(context.Background(), req)
 	if err != nil {
-		t.Fatalf("Expected second Reconcile to succeed, but failed: %v", err)
+		t.Fatalf("Expected stale-cache Reconcile to succeed, but failed: %v", err)
+	}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+		t.Fatalf("failed to get claim: %v", err)
+	}
+	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
+		t.Errorf("expected claim status to remain 'adopted-sb' during cache lag, got %q", updatedClaim.Status.SandboxStatus.Name)
+	}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-extra", Namespace: "default"}, &extra); err != nil {
+		t.Fatalf("failed to get extra warm sandbox: %v", err)
+	}
+	if _, ok := extra.Labels[warmPoolSandboxLabel]; !ok {
+		t.Error("expected extra warm sandbox to still have warm pool label during cache lag (should not have been adopted)")
+	}
+
+	// Cache converges: the next pass takes the fast path (status lookup,
+	// IsControlledBy) and is stable.
+	cacheStale = false
+	_, err = reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Expected post-convergence Reconcile to succeed, but failed: %v", err)
 	}
 
 	// Verify that the claim status is unchanged.
@@ -3723,7 +3758,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		t.Fatalf("failed to get claim: %v", err)
 	}
 	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
-		t.Errorf("expected claim status to remain 'adopted-sb' on 2nd pass, got %q", updatedClaim.Status.SandboxStatus.Name)
+		t.Errorf("expected claim status to remain 'adopted-sb' after convergence, got %q", updatedClaim.Status.SandboxStatus.Name)
 	}
 
 	var adopted sandboxv1beta1.Sandbox
@@ -3739,7 +3774,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		t.Fatalf("failed to get extra warm sandbox: %v", err)
 	}
 	if _, ok := extra.Labels[warmPoolSandboxLabel]; !ok {
-		t.Error("expected extra warm sandbox to still have warm pool label after 2nd pass (should not have been adopted)")
+		t.Error("expected extra warm sandbox to still have warm pool label after convergence (should not have been adopted)")
 	}
 }
 

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3692,8 +3692,8 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected reconcile to finalize adoption without error, got error: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Fatalf("Expected no polling requeue (convergence is watch-driven), got RequeueAfter=%v", res.RequeueAfter)
+	if !res.IsZero() {
+		t.Fatalf("Expected no requeue (convergence is watch-driven), got %+v", res)
 	}
 
 	// Verify that the claim status WAS finalized with the adopted sandbox in the same pass.
@@ -3728,9 +3728,12 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	// Run reconcile AGAIN while the cache is STILL stale. The pass re-sends the
 	// idempotent adoption patch and must neither error, nor wipe the finalized
 	// status, nor adopt the extra warm sandbox.
-	_, err = reconciler.Reconcile(context.Background(), req)
+	res, err = reconciler.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Expected stale-cache Reconcile to succeed, but failed: %v", err)
+	}
+	if !res.IsZero() {
+		t.Fatalf("Expected no requeue on the stale-cache pass, got %+v", res)
 	}
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
 		t.Fatalf("failed to get claim: %v", err)
@@ -3748,9 +3751,12 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	// Cache converges: the next pass takes the fast path (status lookup,
 	// IsControlledBy) and is stable.
 	cacheStale = false
-	_, err = reconciler.Reconcile(context.Background(), req)
+	res, err = reconciler.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Expected post-convergence Reconcile to succeed, but failed: %v", err)
+	}
+	if !res.IsZero() {
+		t.Fatalf("Expected no requeue after convergence, got %+v", res)
 	}
 
 	// Verify that the claim status is unchanged.
@@ -3884,8 +3890,8 @@ func TestSandboxClaimAdoptionCacheLagRepatchesIdempotently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pass 1: expected nil error, got: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Fatalf("pass 1: expected no polling requeue, got RequeueAfter=%v", res.RequeueAfter)
+	if !res.IsZero() {
+		t.Fatalf("pass 1: expected no requeue, got %+v", res)
 	}
 	patchesAfterLastPass := sandboxPatches
 	if patchesAfterLastPass == 0 {
@@ -3907,8 +3913,8 @@ func TestSandboxClaimAdoptionCacheLagRepatchesIdempotently(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pass %d: expected nil error, got: %v", pass, err)
 		}
-		if res.RequeueAfter != 0 {
-			t.Fatalf("pass %d: expected no polling requeue, got RequeueAfter=%v", pass, res.RequeueAfter)
+		if !res.IsZero() {
+			t.Fatalf("pass %d: expected no requeue, got %+v", pass, res)
 		}
 		if sandboxPatches <= patchesAfterLastPass {
 			t.Fatalf("pass %d: expected the idempotent adoption re-patch while cache lags, got %d (was %d)", pass, sandboxPatches, patchesAfterLastPass)
@@ -4047,8 +4053,8 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil error during cache lag, got: %v", err)
 	}
-	if res.RequeueAfter != 0 {
-		t.Fatalf("expected no polling requeue, got RequeueAfter=%v", res.RequeueAfter)
+	if !res.IsZero() {
+		t.Fatalf("expected no requeue, got %+v", res)
 	}
 
 	updatedClaim := &extensionsv1beta1.SandboxClaim{}
@@ -4196,8 +4202,8 @@ func TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pass %d: expected nil error, got: %v", pass, err)
 		}
-		if res.RequeueAfter != 0 {
-			t.Fatalf("pass %d: expected no polling requeue, got RequeueAfter=%v", pass, res.RequeueAfter)
+		if !res.IsZero() {
+			t.Fatalf("pass %d: expected no requeue, got %+v", pass, res)
 		}
 		if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
 			t.Fatalf("pass %d: failed to get claim: %v", pass, err)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -3670,37 +3670,36 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
 
-	// Run reconcile. Adoption is triggered on this pass, but the sandbox is not yet
-	// observed as controlled by the claim (cache lag), so the reconcile must NOT finalize
-	// the claim and must requeue to try again. Post-#1107 the requeue is a bounded
-	// fixed-delay requeue with a nil error (not an exponentially-rate-limited error), so
-	// the compounding backoff that inflated adoption tail latency no longer occurs.
+	// Run reconcile. completeAdoption patches the sandbox in place and the client
+	// writes the server response back into the object, so adoption finalizes in this
+	// same pass: no error, no polling requeue (later passes are watch-driven via the
+	// Owns() Sandbox watch), and the claim status records the adopted sandbox.
 	res, err := reconciler.Reconcile(context.Background(), req)
 	if err != nil {
-		t.Fatalf("Expected reconcile to requeue without error during cache lag, got error: %v", err)
+		t.Fatalf("Expected reconcile to finalize adoption without error, got error: %v", err)
 	}
-	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
-		t.Fatalf("Expected the bounded cache-lag requeue (%v), got RequeueAfter=%v", adoptionCacheLagRequeueDelay, res.RequeueAfter)
+	if res.RequeueAfter != 0 {
+		t.Fatalf("Expected no polling requeue (convergence is watch-driven), got RequeueAfter=%v", res.RequeueAfter)
 	}
 
-	// Verify that the claim status was NOT updated with the sandbox name (adoption deferred)
+	// Verify that the claim status WAS finalized with the adopted sandbox in the same pass.
 	updatedClaim := &extensionsv1beta1.SandboxClaim{}
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
 		t.Fatalf("failed to get claim: %v", err)
 	}
 
-	if updatedClaim.Status.SandboxStatus.Name == "adopted-sb" {
-		t.Error("expected claim status to NOT be updated with 'adopted-sb' during cache lag")
+	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
+		t.Errorf("expected claim status to be finalized with 'adopted-sb' in the adoption pass, got %q", updatedClaim.Status.SandboxStatus.Name)
 	}
 
-	// The cache-lag retry is a benign signal: the Ready condition must report the
-	// specific AdoptionPending reason, not a generic reconciler failure.
+	// Adoption is finalized but the sandbox is not Ready yet; the condition reflects
+	// sandbox state, not a reconciler failure.
 	readyCondition := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
 	if readyCondition == nil {
-		t.Fatal("expected Ready condition to be set during cache lag")
+		t.Fatal("expected Ready condition to be set after the adoption pass")
 	}
-	if readyCondition.Reason != "AdoptionPending" {
-		t.Errorf("expected Ready condition reason %q during cache lag, got %q (message: %q)", "AdoptionPending", readyCondition.Reason, readyCondition.Message)
+	if readyCondition.Reason != "SandboxNotReady" {
+		t.Errorf("expected Ready condition reason %q after the adoption pass, got %q (message: %q)", "SandboxNotReady", readyCondition.Reason, readyCondition.Message)
 	}
 
 	// Verify that the extra warm sandbox was NOT adopted (it should still have its warm pool labels)
@@ -3712,37 +3711,22 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		t.Error("expected extra warm sandbox to still have warm pool label, meaning it was not incorrectly adopted during cache lag")
 	}
 
-	// Simulate the cache catching up!
-	// Fetch the adopted sandbox object, add the SandboxClaim owner reference, and update it in fakeClient.
-	var adopted sandboxv1beta1.Sandbox
-	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "adopted-sb", Namespace: "default"}, &adopted); err != nil {
-		t.Fatalf("failed to get adopted sandbox: %v", err)
-	}
-	adopted.OwnerReferences = []metav1.OwnerReference{{
-		APIVersion: "extensions.agents.x-k8s.io/v1beta1",
-		Kind:       "SandboxClaim",
-		Name:       "test-claim",
-		UID:        "claim-uid-123",
-		Controller: ptr.To(true), // nolint:modernize
-	}}
-	if err := fakeClient.Update(context.Background(), &adopted); err != nil {
-		t.Fatalf("failed to update adopted sandbox with claim owner ref: %v", err)
-	}
-
-	// Run reconcile AGAIN
+	// Run reconcile AGAIN. The adoption patch already transferred ownership, so the
+	// second pass takes the fast path (status lookup, IsControlledBy) and is stable.
 	_, err = reconciler.Reconcile(context.Background(), req)
 	if err != nil {
-		t.Fatalf("Expected second Reconcile to succeed after cache caught up, but failed: %v", err)
+		t.Fatalf("Expected second Reconcile to succeed, but failed: %v", err)
 	}
 
-	// Verify that the claim status WAS updated this time!
+	// Verify that the claim status is unchanged.
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
 		t.Fatalf("failed to get claim: %v", err)
 	}
 	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
-		t.Errorf("expected claim status to be updated with 'adopted-sb' on 2nd pass, got %q", updatedClaim.Status.SandboxStatus.Name)
+		t.Errorf("expected claim status to remain 'adopted-sb' on 2nd pass, got %q", updatedClaim.Status.SandboxStatus.Name)
 	}
 
+	var adopted sandboxv1beta1.Sandbox
 	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "adopted-sb", Namespace: "default"}, &adopted); err != nil {
 		t.Fatalf("failed to get adopted sandbox: %v", err)
 	}
@@ -3759,11 +3743,13 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	}
 }
 
-// TestSandboxClaimAdoptionCacheLagDoesNotRepatch verifies that while the informer cache
-// keeps returning the stale (warm-pool-owned) view of an already-adopted sandbox, the
-// bounded cache-lag requeues wait for convergence WITHOUT re-sending the adoption patch
-// on every pass.
-func TestSandboxClaimAdoptionCacheLagDoesNotRepatch(t *testing.T) {
+// TestSandboxClaimAdoptionCacheLagRepatchesIdempotently verifies that while the informer
+// cache keeps returning the stale (warm-pool-owned) view of an already-adopted sandbox,
+// every pass finalizes the claim from the freshly re-patched object: no error, no polling
+// requeue (convergence is watch-driven via the Owns() Sandbox watch), and the finalized
+// status is never wiped. The idempotent adoption re-patch on stale passes is an accepted
+// trade-off of finalizing in-pass without per-claim in-memory dedup state.
+func TestSandboxClaimAdoptionCacheLagRepatchesIdempotently(t *testing.T) {
 	scheme := newScheme(t)
 
 	claim := &extensionsv1beta1.SandboxClaim{
@@ -3858,30 +3844,46 @@ func TestSandboxClaimAdoptionCacheLagDoesNotRepatch(t *testing.T) {
 	}
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
 
-	// Pass 1: adoption is triggered (patches the sandbox) and defers via bounded requeue.
+	// Pass 1: adoption patches the sandbox and finalizes the claim in the same pass.
 	res, err := reconciler.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("pass 1: expected nil error, got: %v", err)
 	}
-	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
-		t.Fatalf("pass 1: expected RequeueAfter=%v, got %v", adoptionCacheLagRequeueDelay, res.RequeueAfter)
+	if res.RequeueAfter != 0 {
+		t.Fatalf("pass 1: expected no polling requeue, got RequeueAfter=%v", res.RequeueAfter)
 	}
-	patchesAfterFirstPass := sandboxPatches
-	if patchesAfterFirstPass == 0 {
+	patchesAfterLastPass := sandboxPatches
+	if patchesAfterLastPass == 0 {
 		t.Fatal("pass 1: expected the adoption patch to be sent")
 	}
 
-	// Passes 2 and 3: cache still stale — must keep requeueing WITHOUT re-patching.
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+		t.Fatalf("pass 1: failed to get claim: %v", err)
+	}
+	if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
+		t.Fatalf("pass 1: expected status to be finalized with 'adopted-sb', got %q", updatedClaim.Status.SandboxStatus.Name)
+	}
+
+	// Passes 2 and 3: cache still stale — each pass re-sends the idempotent adoption
+	// patch, returns without error, and leaves the finalized status intact.
 	for pass := 2; pass <= 3; pass++ {
 		res, err = reconciler.Reconcile(context.Background(), req)
 		if err != nil {
 			t.Fatalf("pass %d: expected nil error, got: %v", pass, err)
 		}
-		if res.RequeueAfter != adoptionCacheLagRequeueDelay {
-			t.Fatalf("pass %d: expected RequeueAfter=%v, got %v", pass, adoptionCacheLagRequeueDelay, res.RequeueAfter)
+		if res.RequeueAfter != 0 {
+			t.Fatalf("pass %d: expected no polling requeue, got RequeueAfter=%v", pass, res.RequeueAfter)
 		}
-		if sandboxPatches != patchesAfterFirstPass {
-			t.Fatalf("pass %d: expected no additional sandbox patches while cache lags, got %d (was %d)", pass, sandboxPatches, patchesAfterFirstPass)
+		if sandboxPatches <= patchesAfterLastPass {
+			t.Fatalf("pass %d: expected the idempotent adoption re-patch while cache lags, got %d (was %d)", pass, sandboxPatches, patchesAfterLastPass)
+		}
+		patchesAfterLastPass = sandboxPatches
+		if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
+			t.Fatalf("pass %d: failed to get claim: %v", pass, err)
+		}
+		if updatedClaim.Status.SandboxStatus.Name != "adopted-sb" {
+			t.Errorf("pass %d: expected finalized status to be preserved during cache lag, got %q", pass, updatedClaim.Status.SandboxStatus.Name)
 		}
 	}
 }
@@ -3889,7 +3891,8 @@ func TestSandboxClaimAdoptionCacheLagDoesNotRepatch(t *testing.T) {
 // TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus verifies that a claim whose
 // status was already finalized with a sandbox (e.g. a controller restart racing a stale
 // informer) does NOT have its SandboxStatus.Name/PodIPs wiped or its Ready condition
-// downgraded by a benign cache-lag adoption retry pass.
+// downgraded by a pass that reads the stale (warm-pool-owned) view: the pass re-sends
+// the idempotent adoption patch and re-finalizes from the authoritative object.
 func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 	scheme := newScheme(t)
 
@@ -3962,6 +3965,18 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 			},
 		}},
 		},
+		// The sandbox is live and Ready; informer lag on the ownership patch does not
+		// erase its status, so the stale view still carries it.
+		Status: sandboxv1beta1.SandboxStatus{
+			PodIPs: []string{"10.1.2.3"},
+			Conditions: []metav1.Condition{{
+				Type:               string(sandboxv1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				Message:            "Sandbox is ready",
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
 	}
 
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
@@ -3983,7 +3998,7 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 		}).
 		Build()
 
-	// Fresh reconciler (empty triggeredAdoptions), as after a controller restart.
+	// Fresh reconciler, as after a controller restart.
 	reconciler := &SandboxClaimReconciler{
 		Client:           fakeClient,
 		Scheme:           scheme,
@@ -3997,8 +4012,8 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil error during cache lag, got: %v", err)
 	}
-	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
-		t.Fatalf("expected RequeueAfter=%v, got %v", adoptionCacheLagRequeueDelay, res.RequeueAfter)
+	if res.RequeueAfter != 0 {
+		t.Fatalf("expected no polling requeue, got RequeueAfter=%v", res.RequeueAfter)
 	}
 
 	updatedClaim := &extensionsv1beta1.SandboxClaim{}
@@ -4020,12 +4035,12 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 	}
 }
 
-// TestSandboxClaimFreshAdoptionDoesNotRepatchDuringCacheLag verifies that the primary
-// warm-adoption entry point (adoptSandboxFromCandidates) records the completed adoption
-// in the dedup cache, so the very next cache-lag pass waits via the bounded requeue
-// without re-sending the adoption patch — and without wiping the status finalized on
-// the adoption pass.
-func TestSandboxClaimFreshAdoptionDoesNotRepatchDuringCacheLag(t *testing.T) {
+// TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus verifies that after the
+// primary warm-adoption entry point (adoptSandboxFromCandidates) finalizes status on the
+// adoption pass, later passes that still read the stale (warm-pool-owned) view stay
+// error-free, need no polling requeue, and never wipe the finalized status — the stale
+// pass just re-sends the idempotent adoption patch.
+func TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus(t *testing.T) {
 	scheme := newScheme(t)
 
 	// No assigned-sandbox annotation: adoption goes through the candidate queue.
@@ -4138,19 +4153,16 @@ func TestSandboxClaimFreshAdoptionDoesNotRepatchDuringCacheLag(t *testing.T) {
 		t.Fatalf("pass 1: expected status to be finalized with 'warm-sb', got %q", updatedClaim.Status.SandboxStatus.Name)
 	}
 
-	// Passes 2 and 3: cache still shows the warm-pool owner — must wait via the
-	// bounded requeue WITHOUT re-sending the adoption patch, and WITHOUT wiping
-	// the status finalized on pass 1.
+	// Passes 2 and 3: cache still shows the warm-pool owner — each pass re-finalizes
+	// from the freshly re-patched object without error, without a polling requeue,
+	// and without wiping the status finalized on pass 1.
 	for pass := 2; pass <= 3; pass++ {
 		res, err := reconciler.Reconcile(context.Background(), req)
 		if err != nil {
 			t.Fatalf("pass %d: expected nil error, got: %v", pass, err)
 		}
-		if res.RequeueAfter != adoptionCacheLagRequeueDelay {
-			t.Fatalf("pass %d: expected RequeueAfter=%v, got %v", pass, adoptionCacheLagRequeueDelay, res.RequeueAfter)
-		}
-		if sandboxPatches != patchesAfterFirstPass {
-			t.Fatalf("pass %d: expected no additional sandbox patches while cache lags, got %d (was %d)", pass, sandboxPatches, patchesAfterFirstPass)
+		if res.RequeueAfter != 0 {
+			t.Fatalf("pass %d: expected no polling requeue, got RequeueAfter=%v", pass, res.RequeueAfter)
 		}
 		if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-claim", Namespace: "default"}, updatedClaim); err != nil {
 			t.Fatalf("pass %d: failed to get claim: %v", pass, err)


### PR DESCRIPTION
#### What this PR does / why we need it

Follow-up to #1108. After `completeAdoption` succeeds, controller-runtime's typed client writes the server response back into the sandbox object, so the annotation-recovery path already holds the authoritative claim-owned object. Return it and finalize status in the same pass — the convention `adoptSandboxFromCandidates` already follows — instead of deferring behind a cache-lag requeue.

This removes the deferral machinery from #1108 — the `errAdoptionTriggeredRetry` sentinel, the 50ms polling requeue, the `triggeredAdoptions` dedup map, the `AdoptionPending` condition branch, and the `computeAndSetStatus` guard. Convergence remains event-driven via the existing `Owns(&Sandbox{})` watch; a pass that reads a stale cache view degrades to one idempotent re-patch, the same behavior the previous design had after a controller restart.

Duplicate-adoption protection is unchanged. The annotation path returns before the candidate queue is consulted, still covered by `TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag`.

#### Evidence

Interleaved A/B benchmarks on GKE (1000-claim warm bursts, controller-side millisecond latency histograms, 6 rounds per variant) show this change is statistically indistinguishable from #1108 at mean, p50, p90, and p99. Reproducing #1107's scenario at N=300 against pre-#1108 code showed the cache-lag retry fires at most once per claim (≈5ms of backoff), so removing the bounded-requeue path carries no regression risk.

#### Tests

Cache-lag tests updated to the finalize-in-pass contract (the adoption pass finalizes status; stale passes re-patch idempotently without wiping it). Full `extensions/controllers` suite passes; `go vet` and `gofmt` clean.

#### Which issue(s) this PR is related to

Follow-up to #1108, related to #1107.

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sandbox adoption now finalizes promptly in the same reconcile pass, avoiding unnecessary polling during temporary cache/informer staleness.
  - Reconciliation is now idempotent under stale views, preserving finalized status without downgrades or unintended additional adoption.
  - Duplicate adoption during cache lag is prevented.
- **Validation & Reliability Improvements**
  - User-supplied pod metadata is validated and merged more strictly, rejecting invalid or conflicting label/annotation overrides.
  - Misconfiguration/validation failures are handled gracefully to prevent crash-loop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->