### PR TITLE
fix: Fix warm-claim cold restart on v0.5.0 upgrade due to un retried optimistic lock conflicts

### DIFF
--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -411,9 +411,6 @@ def create_v1alpha1_objects():
 
     # Explicitly patch the status of upgrade-claim-warm since subresources.status drops status fields on normal apply
     run_cmd(["kubectl", "patch", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-n", "default", "--subresource=status", "--type=merge", "-p", '{"status":{"sandbox":{"name":"upgrade-pool-warm-a1b2c"}}}'])
-    claim_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-n", "default", "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
-    owner_patch = {"metadata":{"ownerReferences":[{"apiVersion":"extensions.agents.x-k8s.io/v1alpha1","kind":"SandboxClaim","name":"upgrade-claim-warm","uid":claim_uid,"controller":True,"blockOwnerDeletion":True}]}}
-    run_cmd(["kubectl", "patch", "sandboxes.v1alpha1.agents.x-k8s.io", "upgrade-pool-warm-a1b2c", "-n", "default", "--type=merge", "-p", json.dumps(owner_patch)])
     
     print("Waiting for upgrade-sandbox-running Pod to be created...")
     pod_exists = False

--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -353,6 +353,7 @@ def install_v1alpha1(method, version):
 def create_v1alpha1_objects():
     print("\n=== Phase 2: Creating v1alpha1 objects ===")
     run_cmd(["kubectl", "apply", "-f", "-"], input_data=V1ALPHA1_RESOURCES)
+    time.sleep(3)
     
     # Explicitly patch the Sandbox with the owner reference pointing to upgrade-claim-warm
     # Use a retry loop to tolerate API server discovery cache lag or transient NotFound errors
@@ -385,8 +386,10 @@ def create_v1alpha1_objects():
     run_cmd(["kubectl", "patch", "sandbox", "upgrade-pool-warm-a1b2c", "-n", "default", "--type=merge", "-p", json.dumps(owner_patch)])
 
     # Explicitly patch the status of upgrade-claim-warm since subresources.status drops status fields on normal apply
-    run_cmd(["kubectl", "patch", "sandboxclaim", "upgrade-claim-warm", "-n", "default", "--subresource=status", "--type=merge", "-p", '{"status":{"sandbox":{"name":"upgrade-pool-warm-a1b2c"}}}'])
-
+    run_cmd(["kubectl", "patch", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-n", "default", "--subresource=status", "--type=merge", "-p", '{"status":{"sandbox":{"name":"upgrade-pool-warm-a1b2c"}}}'])
+    claim_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
+    owner_patch = {"metadata":{"ownerReferences":[{"apiVersion":"extensions.agents.x-k8s.io/v1alpha1","kind":"SandboxClaim","name":"upgrade-claim-warm","uid":claim_uid,"controller":True,"blockOwnerDeletion":True}]}}
+    run_cmd(["kubectl", "patch", "sandboxes.v1alpha1.agents.x-k8s.io", "upgrade-pool-warm-a1b2c", "--type=merge", "-p", json.dumps(owner_patch)])
     
     print("Waiting for upgrade-sandbox-running Pod to be created...")
     pod_exists = False
@@ -420,7 +423,76 @@ def create_v1alpha1_objects():
     pod_creation = pod_data["metadata"]["creationTimestamp"]
     print(f"Captured active pod info - Name: upgrade-sandbox-running, UID: {pod_uid}, CreatedAt: {pod_creation}")
     
-    # Check claim exists and status has reconciled
+    print("Creating 10 warm sandboxes and claims to stress-test upgrade race condition...")
+    flake_manifests = []
+    for i in range(1, 11):
+        sb_name = f"upgrade-pool-warm-flake-{i}"
+        claim_name = f"upgrade-claim-warm-flake-{i}"
+        flake_manifests.append(f"""apiVersion: agents.x-k8s.io/v1alpha1
+kind: Sandbox
+metadata:
+  name: {sb_name}
+  namespace: default
+  labels:
+    agents.x-k8s.io/warmpool: upgrade-pool-warm
+spec:
+  replicas: 1
+  podTemplate:
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.10
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: {claim_name}
+  namespace: default
+spec:
+  sandboxTemplateRef:
+    name: upgrade-template
+  warmpool: "default"
+""")
+    run_cmd(["kubectl", "apply", "-f", "-"], input_data="\n---\n".join(flake_manifests))
+    time.sleep(3)
+
+    print("Initializing status and ownership for 10 stress-test warm claims...")
+    for i in range(1, 11):
+        sb_name = f"upgrade-pool-warm-flake-{i}"
+        claim_name = f"upgrade-claim-warm-flake-{i}"
+        run_cmd(["kubectl", "patch", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", claim_name, "-n", "default", "--subresource=status", "--type=merge", "-p", f'{{"status":{{"sandbox":{{"name":"{sb_name}"}}}}}}'])
+        c_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", claim_name, "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
+        o_patch = {"metadata":{"ownerReferences":[{"apiVersion":"extensions.agents.x-k8s.io/v1alpha1","kind":"SandboxClaim","name":claim_name,"uid":c_uid,"controller":True,"blockOwnerDeletion":True}]}}
+        run_cmd(["kubectl", "patch", "sandboxes.v1alpha1.agents.x-k8s.io", sb_name, "--type=merge", "-p", json.dumps(o_patch)])
+
+    print("Waiting for v1alpha1 claims to be bound...")
+    all_bound = False
+    bound_count = 0
+    for i in range(60):
+        res = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "-n", "default", "-o", "json"], capture_output=True, check=False)
+        if res.returncode == 0 and res.stdout.strip():
+            try:
+                claims_data = json.loads(res.stdout).get("items", [])
+                bound_count = 0
+                for c in claims_data:
+                    if c["metadata"]["name"].startswith("upgrade-claim-warm") and c.get("status", {}).get("sandbox", {}).get("name"):
+                        bound_count += 1
+                if bound_count >= 11:
+                    print(f"All {bound_count} warm claims successfully bound!")
+                    all_bound = True
+                    break
+                if (i + 1) % 5 == 0:
+                    print(f"Waiting for warm claims to bind ({bound_count}/11 bound, attempt {i+1}/60)...")
+            except Exception as e:
+                print(f"Error checking claim bindings: {e}")
+        time.sleep(2)
+
+    if not all_bound:
+        print(f"Not all warm claims were bound in time ({bound_count}/11 bound). Dumping diagnostics:", file=sys.stderr)
+        run_cmd(["kubectl", "get", "sandboxes.v1alpha1.agents.x-k8s.io,sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "-n", "default"], check=False)
+
+    assert all_bound, f"Not all warm claims were bound in time! Only {bound_count}/11 bound."
+
     run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "-n", "default"])
     
     return {"uid": pod_uid, "creationTimestamp": pod_creation}
@@ -594,7 +666,22 @@ def validate_migration(active_pod_info):
         f"Expected warmPoolRef name upgrade-pool-warm, got {claim_warm['spec']['warmPoolRef']['name']}"
     assert "agents.x-k8s.io/storage-migrated-at" in claim_warm["metadata"]["annotations"], \
         "upgrade-claim-warm missing storage-migrated-at annotation!"
+    assert claim_warm.get("status", {}).get("sandbox", {}).get("name") == "upgrade-pool-warm-a1b2c", \
+        f"upgrade-claim-warm lost its bound sandbox during upgrade! Expected upgrade-pool-warm-a1b2c, got: {claim_warm.get('status', {}).get('sandbox', {}).get('name')}"
     print("upgrade-claim-warm validation PASSED.")
+
+    print("Validating all 10 flake stress-test claims preserved their bound sandboxes...")
+    for i in range(1, 11):
+        claim_name = f"upgrade-claim-warm-flake-{i}"
+        claim_obj = claim_by_name.get(claim_name)
+        assert claim_obj is not None, f"Claim {claim_name} missing from migrated claims list!"
+        actual_sb = claim_obj.get("status", {}).get("sandbox", {}).get("name")
+        expected_sb = f"upgrade-pool-warm-flake-{i}"
+        assert actual_sb == expected_sb, \
+            f"Flake triggered! {claim_name} lost its original sandbox during upgrade. Expected {expected_sb}, got: {actual_sb}"
+        assert "agents.x-k8s.io/storage-migrated-at" in claim_obj["metadata"]["annotations"], \
+            f"{claim_name} missing storage-migrated-at annotation!"
+    print("Flake stress-test PASSED (10/10 additional warm claims survived upgrade intact without losing original sandbox).")
     
     # 2. Fetch sandboxes as JSON
     print("Checking Sandboxes...")
@@ -983,7 +1070,7 @@ def main():
         # Backup v1alpha1 resources in memory
         print("Backing up v1alpha1 resources...")
         res = run_cmd([
-            "kubectl", "get", "sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools",
+            "kubectl", "get", "sandboxes.v1alpha1.agents.x-k8s.io,sandboxclaims.v1alpha1.extensions.agents.x-k8s.io,sandboxtemplates.v1alpha1.extensions.agents.x-k8s.io,sandboxwarmpools.v1alpha1.extensions.agents.x-k8s.io",
             "-n", "default", "-o", "yaml"
         ], capture_output=True)
         v1alpha1_backup = res.stdout

--- a/dev/tools/test-migration.py
+++ b/dev/tools/test-migration.py
@@ -21,6 +21,7 @@ Supports both kubectl-based and Helm-based upgrade paths.
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -260,6 +261,25 @@ def cleanup_sandbox_system():
     run_cmd(["kubectl", "delete", "validatingwebhookconfiguration", "agent-sandbox-webhook", "--ignore-not-found"], check=False)
     run_cmd(["kubectl", "delete", "mutatingwebhookconfiguration", "agent-sandbox-webhook", "--ignore-not-found"], check=False)
 
+def get_manifest_filename_and_url(version):
+    """Returns the manifest filename (sandbox.yaml or manifest.yaml) and download URL for the version."""
+    ver_clean = version.lstrip("v")
+    parts = re.split(r"[-+]", ver_clean)[0].split(".")
+    is_old = False
+    try:
+        tuple_version = tuple(int(x) for x in parts[:3])
+        while len(tuple_version) < 3:
+            tuple_version += (0,)
+        if tuple_version < (0, 5, 2):
+            is_old = True
+    except ValueError:
+        pass
+
+    filename = "manifest.yaml" if is_old else "sandbox.yaml"
+    url = f"https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{version}/{filename}"
+    return filename, url
+
+
 def install_v1alpha1(method, version):
     print(f"\n=== Phase 1: Installing v1alpha1 version ({version}) using {method} ===")
     
@@ -272,7 +292,12 @@ def install_v1alpha1(method, version):
 
     if method == "kubectl":
         local_dir = os.path.join(_repo_root, "test/migration/testdata", version)
-        local_manifest = os.path.join(local_dir, "manifest.yaml")
+        local_manifest_name, manifest_url = get_manifest_filename_and_url(version)
+        local_manifest = os.path.join(local_dir, local_manifest_name)
+        if not os.path.exists(local_manifest):
+            alt_name = "sandbox.yaml" if local_manifest_name == "manifest.yaml" else "manifest.yaml"
+            if os.path.exists(os.path.join(local_dir, alt_name)):
+                local_manifest = os.path.join(local_dir, alt_name)
         local_extensions = os.path.join(local_dir, "extensions.yaml")
         
         if os.path.exists(local_manifest) and os.path.exists(local_extensions):
@@ -281,7 +306,6 @@ def install_v1alpha1(method, version):
             print(f"Applying local extensions: {local_extensions}")
             run_cmd(["kubectl", "apply", "-f", local_extensions])
         else:
-            manifest_url = f"https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{version}/manifest.yaml"
             extensions_url = f"https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{version}/extensions.yaml"
             print(f"Applying manifest: {manifest_url}")
             run_cmd(["kubectl", "apply", "-f", manifest_url])
@@ -387,9 +411,9 @@ def create_v1alpha1_objects():
 
     # Explicitly patch the status of upgrade-claim-warm since subresources.status drops status fields on normal apply
     run_cmd(["kubectl", "patch", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-n", "default", "--subresource=status", "--type=merge", "-p", '{"status":{"sandbox":{"name":"upgrade-pool-warm-a1b2c"}}}'])
-    claim_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
+    claim_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", "upgrade-claim-warm", "-n", "default", "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
     owner_patch = {"metadata":{"ownerReferences":[{"apiVersion":"extensions.agents.x-k8s.io/v1alpha1","kind":"SandboxClaim","name":"upgrade-claim-warm","uid":claim_uid,"controller":True,"blockOwnerDeletion":True}]}}
-    run_cmd(["kubectl", "patch", "sandboxes.v1alpha1.agents.x-k8s.io", "upgrade-pool-warm-a1b2c", "--type=merge", "-p", json.dumps(owner_patch)])
+    run_cmd(["kubectl", "patch", "sandboxes.v1alpha1.agents.x-k8s.io", "upgrade-pool-warm-a1b2c", "-n", "default", "--type=merge", "-p", json.dumps(owner_patch)])
     
     print("Waiting for upgrade-sandbox-running Pod to be created...")
     pod_exists = False
@@ -423,18 +447,48 @@ def create_v1alpha1_objects():
     pod_creation = pod_data["metadata"]["creationTimestamp"]
     print(f"Captured active pod info - Name: upgrade-sandbox-running, UID: {pod_uid}, CreatedAt: {pod_creation}")
     
-    print("Creating 10 warm sandboxes and claims to stress-test upgrade race condition...")
-    flake_manifests = []
+    print("Creating 10 SandboxClaims with assigned sandbox annotations/labels to stress-test upgrade race condition...")
+    claim_manifests = []
     for i in range(1, 11):
-        sb_name = f"upgrade-pool-warm-flake-{i}"
         claim_name = f"upgrade-claim-warm-flake-{i}"
-        flake_manifests.append(f"""apiVersion: agents.x-k8s.io/v1alpha1
+        sb_name = f"upgrade-pool-warm-f{i}"
+        claim_manifests.append(f"""apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: {claim_name}
+  namespace: default
+  annotations:
+    agents.x-k8s.io/sandbox-name: {sb_name}
+  labels:
+    agents.x-k8s.io/sandbox-name: {sb_name}
+spec:
+  sandboxTemplateRef:
+    name: upgrade-template
+  warmpool: "default"
+""")
+    run_cmd(["kubectl", "apply", "-f", "-"], input_data="\n---\n".join(claim_manifests))
+    time.sleep(2)
+
+    print("Fetching UIDs and creating 10 corresponding Sandboxes with ownerReferences...")
+    sb_manifests = []
+    for i in range(1, 11):
+        claim_name = f"upgrade-claim-warm-flake-{i}"
+        sb_name = f"upgrade-pool-warm-f{i}"
+        c_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", claim_name, "-n", "default", "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
+        sb_manifests.append(f"""apiVersion: agents.x-k8s.io/v1alpha1
 kind: Sandbox
 metadata:
   name: {sb_name}
   namespace: default
   labels:
     agents.x-k8s.io/warmpool: upgrade-pool-warm
+  ownerReferences:
+  - apiVersion: extensions.agents.x-k8s.io/v1alpha1
+    kind: SandboxClaim
+    name: {claim_name}
+    uid: {c_uid}
+    controller: true
+    blockOwnerDeletion: true
 spec:
   replicas: 1
   podTemplate:
@@ -442,28 +496,15 @@ spec:
       containers:
       - name: pause
         image: registry.k8s.io/pause:3.10
----
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
-kind: SandboxClaim
-metadata:
-  name: {claim_name}
-  namespace: default
-spec:
-  sandboxTemplateRef:
-    name: upgrade-template
-  warmpool: "default"
 """)
-    run_cmd(["kubectl", "apply", "-f", "-"], input_data="\n---\n".join(flake_manifests))
-    time.sleep(3)
+    run_cmd(["kubectl", "apply", "-f", "-"], input_data="\n---\n".join(sb_manifests))
+    time.sleep(2)
 
-    print("Initializing status and ownership for 10 stress-test warm claims...")
+    print("Initializing status for 10 stress-test warm claims...")
     for i in range(1, 11):
-        sb_name = f"upgrade-pool-warm-flake-{i}"
+        sb_name = f"upgrade-pool-warm-f{i}"
         claim_name = f"upgrade-claim-warm-flake-{i}"
         run_cmd(["kubectl", "patch", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", claim_name, "-n", "default", "--subresource=status", "--type=merge", "-p", f'{{"status":{{"sandbox":{{"name":"{sb_name}"}}}}}}'])
-        c_uid = run_cmd(["kubectl", "get", "sandboxclaims.v1alpha1.extensions.agents.x-k8s.io", claim_name, "-o", "jsonpath={.metadata.uid}"], capture_output=True).stdout.strip()
-        o_patch = {"metadata":{"ownerReferences":[{"apiVersion":"extensions.agents.x-k8s.io/v1alpha1","kind":"SandboxClaim","name":claim_name,"uid":c_uid,"controller":True,"blockOwnerDeletion":True}]}}
-        run_cmd(["kubectl", "patch", "sandboxes.v1alpha1.agents.x-k8s.io", sb_name, "--type=merge", "-p", json.dumps(o_patch)])
 
     print("Waiting for v1alpha1 claims to be bound...")
     all_bound = False
@@ -676,7 +717,7 @@ def validate_migration(active_pod_info):
         claim_obj = claim_by_name.get(claim_name)
         assert claim_obj is not None, f"Claim {claim_name} missing from migrated claims list!"
         actual_sb = claim_obj.get("status", {}).get("sandbox", {}).get("name")
-        expected_sb = f"upgrade-pool-warm-flake-{i}"
+        expected_sb = f"upgrade-pool-warm-f{i}"
         assert actual_sb == expected_sb, \
             f"Flake triggered! {claim_name} lost its original sandbox during upgrade. Expected {expected_sb}, got: {actual_sb}"
         assert "agents.x-k8s.io/storage-migrated-at" in claim_obj["metadata"]["annotations"], \
@@ -847,7 +888,12 @@ def test_rollback(method, v1alpha1_version, v1alpha1_backup):
     print("Step 5: Downgrading controller and CRDs to v1alpha1...")
     if method == "kubectl":
         local_dir = os.path.join(_repo_root, "test/migration/testdata", v1alpha1_version)
-        local_manifest = os.path.join(local_dir, "manifest.yaml")
+        local_manifest_name, manifest_url = get_manifest_filename_and_url(v1alpha1_version)
+        local_manifest = os.path.join(local_dir, local_manifest_name)
+        if not os.path.exists(local_manifest):
+            alt_name = "sandbox.yaml" if local_manifest_name == "manifest.yaml" else "manifest.yaml"
+            if os.path.exists(os.path.join(local_dir, alt_name)):
+                local_manifest = os.path.join(local_dir, alt_name)
         local_extensions = os.path.join(local_dir, "extensions.yaml")
         
         if os.path.exists(local_manifest) and os.path.exists(local_extensions):
@@ -856,7 +902,6 @@ def test_rollback(method, v1alpha1_version, v1alpha1_backup):
             print(f"Applying local extensions: {local_extensions}")
             run_cmd(["kubectl", "apply", "-f", local_extensions])
         else:
-            manifest_url = f"https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{v1alpha1_version}/manifest.yaml"
             extensions_url = f"https://github.com/kubernetes-sigs/agent-sandbox/releases/download/{v1alpha1_version}/extensions.yaml"
             run_cmd(["kubectl", "apply", "-f", manifest_url])
             run_cmd(["kubectl", "apply", "-f", extensions_url])

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -18,20 +18,23 @@ The other two CRDs (`SandboxTemplate`, `SandboxWarmPool`) are structurally ident
 
 ## Two phases
 
-The migration script executes in two distinct phases. **Neither phase can happen in an arbitrary order**, and if you have existing cold-start claims, skipping the bootstrap phase will immediately break them upon upgrading to `v0.5.0`.
+The migration script executes in two distinct phases. **Neither phase can happen in an arbitrary order**, and if you have existing cold-start claims, skipping the bootstrap phase will immediately break them upon upgrading to `v0.5.2`.
+
+> [!IMPORTANT]
+> When migrating from `v0.4.x`, always upgrade directly to **`v0.5.2`** (or later) rather than earlier `0.5.x` releases. Release `v0.5.2` includes a critical fix for a controller race condition that caused warm-started claims to undergo pod cold restarts during initial upgrade reconciliation.
 
 ### Phase 1: `--phase=bootstrap` (Conditionally Mandatory, Pre-Upgrade)
 
-- **Mandatory for `v0.5.0`:** Yes, if you have existing cold-start `v1alpha1` claims (claims where `spec.warmpool` is empty/`"none"`/`"default"` AND `status.sandbox.name` matches the claim name or is empty). Note: The script automatically detects whether cold-start claims exist. If none exist, it safely exits without creating anything, so it is recommended to always run it (or use `--dry-run` to inspect) rather than skipping it manually.
-- **Timing:** Strictly **before** upgrading to `v0.5.0` (while `v1alpha1` is still active).
-- **What it does:** Scans existing `v1alpha1` claims and pre-creates `shadow-pool-<template>` warm pools. The `v0.5.0` controller reconciler is written purely against `v1beta1.SandboxClaim`, which requires a valid `spec.warmPoolRef.name`. If you do not pre-create the shadow pools, the conversion webhook will point converted claims to non-existent infrastructure, leaving converted claims stuck with a `WarmPoolNotFound` condition while the controller repeatedly requeues them.
-- **Why it cannot run after upgrade:** Bootstrap relies on `v1alpha1` field inspection. Once `v0.5.0` is installed, `kubectl get sandboxclaims` defaults to returning `v1beta1` objects (which lack `spec.sandboxTemplateRef`). The script will see empty template names, log errors for every claim, and fail to create any shadow pools.
+- **Mandatory for `v0.5.2`:** Yes, if you have existing cold-start `v1alpha1` claims (claims where `spec.warmpool` is empty/`"none"`/`"default"` AND `status.sandbox.name` matches the claim name or is empty). Note: The script automatically detects whether cold-start claims exist. If none exist, it safely exits without creating anything, so it is recommended to always run it (or use `--dry-run` to inspect) rather than skipping it manually.
+- **Timing:** Strictly **before** upgrading to `v0.5.2` (while `v1alpha1` is still active).
+- **What it does:** Scans existing `v1alpha1` claims and pre-creates `shadow-pool-<template>` warm pools. The `v0.5.2` controller reconciler is written purely against `v1beta1.SandboxClaim`, which requires a valid `spec.warmPoolRef.name`. If you do not pre-create the shadow pools, the conversion webhook will point converted claims to non-existent infrastructure, leaving converted claims stuck with a `WarmPoolNotFound` condition while the controller repeatedly requeues them.
+- **Why it cannot run after upgrade:** Bootstrap relies on `v1alpha1` field inspection. Once `v0.5.2` is installed, `kubectl get sandboxclaims` defaults to returning `v1beta1` objects (which lack `spec.sandboxTemplateRef`). The script will see empty template names, log errors for every claim, and fail to create any shadow pools.
 
-### Phase 2: `--phase=migrate` (Optional for `v0.5.0`, Post-Upgrade)
+### Phase 2: `--phase=migrate` (Optional for `v0.5.2`, Post-Upgrade)
 
-- **Optional for `v0.5.0`** (but mandatory before upgrading to a future release that drops `v1alpha1`).
-- **Timing:** Strictly **after** upgrading to `v0.5.0` (when `v1beta1` is established as the storage version and the conversion webhook is live).
-- **What it does:** Patches every existing resource with a benign annotation (`agents.x-k8s.io/storage-migrated-at`). This forces the API server to read the `v1alpha1` etcd record, pass it through the conversion webhook, and rewrite it to etcd in `v1beta1` storage format. While the kube-apiserver can translate older records on the fly for `v0.5.0`, running this phase ensures all objects are re-serialized in `v1beta1` format in etcd, which is required before `v1alpha1` can be safely removed from the CRD definition in a future release.
+- **Optional for `v0.5.2`** (but mandatory before upgrading to a future release that drops `v1alpha1`).
+- **Timing:** Strictly **after** upgrading to `v0.5.2` (when `v1beta1` is established as the storage version and the conversion webhook is live).
+- **What it does:** Patches every existing resource with a benign annotation (`agents.x-k8s.io/storage-migrated-at`). This forces the API server to read the `v1alpha1` etcd record, pass it through the conversion webhook, and rewrite it to etcd in `v1beta1` storage format. While the kube-apiserver can translate older records on the fly for `v0.5.2`, running this phase ensures all objects are re-serialized in `v1beta1` format in etcd, which is required before `v1alpha1` can be safely removed from the CRD definition in a future release.
 - **Why it cannot run before upgrade:** Before upgrading, `v1alpha1` is still the storage version in etcd. Patching the resources will merely write an annotation onto `v1alpha1` etcd records, accomplishing zero storage migration.
 
 Both phases are idempotent — safe to re-run.
@@ -72,8 +75,8 @@ bash dev/tools/migrate.sh --phase=bootstrap
 #    CRDs: SandboxClaim, SandboxTemplate, SandboxWarmPool). Apply both.
 #    Wait until the controller pod is Ready and the webhook Service has
 #    endpoints before proceeding.
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.0/manifest.yaml
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.0/extensions.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/manifest.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/extensions.yaml
 kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system
 kubectl wait --for=condition=Ready pods -l app=agent-sandbox-controller -n agent-sandbox-system
 

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -70,13 +70,16 @@ The official agent-sandbox installation path is `kubectl apply -f` against the r
 bash dev/tools/migrate.sh --phase=bootstrap
 
 # 2. Install the new controller + CRDs (which include the conversion webhook).
-#    The release ships two manifests: manifest.yaml (core controller + base
+#    The release ships two manifests: sandbox.yaml (core controller + base
 #    CRDs + webhook Service) and extensions.yaml (the extensions API group
 #    CRDs: SandboxClaim, SandboxTemplate, SandboxWarmPool). Apply both.
 #    Wait until the controller pod is Ready and the webhook Service has
 #    endpoints before proceeding.
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/manifest.yaml
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v0.5.2/extensions.yaml
+#
+#    Note: For releases older than v0.5.2, the core manifest is named manifest.yaml
+#    instead of sandbox.yaml.
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/sandbox.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/extensions.yaml
 kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system
 kubectl wait --for=condition=Ready pods -l app=agent-sandbox-controller -n agent-sandbox-system
 
@@ -278,9 +281,13 @@ done
 ### Step 6: Revert the CRD manifests and Controller
 Downgrade the installed components back to the old version:
 
-* **For Flow A (kubectl):** Re-apply the old version's manifests (substitute `<old-version>` with your previous version, e.g., `v0.4.6`):
+* **For Flow A (kubectl):** Re-apply the old version's manifests (substitute `<old-version>` with your previous version, e.g., `v0.4.6`). Note that for versions older than `v0.5.2` the core manifest is named `manifest.yaml`, while for `v0.5.2` and newer it is named `sandbox.yaml`:
   ```bash
+  # For <old-version> < v0.5.2:
   kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<old-version>/manifest.yaml
+  # For <old-version> >= v0.5.2:
+  kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<old-version>/sandbox.yaml
+
   kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<old-version>/extensions.yaml
   ```
 * **For Flow B (Helm):** Roll back the Helm release to the pre-migration revision (find the revision number using `helm history agent-sandbox`):

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -75,9 +75,9 @@ bash dev/tools/migrate.sh --phase=bootstrap
 #    CRDs: SandboxClaim, SandboxTemplate, SandboxWarmPool). Apply both.
 #    Wait until the controller pod is Ready and the webhook Service has
 #    endpoints before proceeding.
-#
-#    Note: For releases older than v0.5.2, the core manifest is named manifest.yaml
-#    instead of sandbox.yaml.
+#    Note: Starting from v0.5.2, the core manifest is named `sandbox.yaml`. 
+#    If upgrading to an older release (like v0.5.0 or v0.5.1), apply `manifest.yaml` instead of `sandbox.yaml`:
+#    kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/manifest.yaml
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/sandbox.yaml
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/extensions.yaml
 kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -437,7 +437,7 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 		}
 
 		if template != nil {
-
+			patch := client.MergeFrom(sandbox.DeepCopy())
 			// Check if metadata needs update
 			var mergedMeta v1beta1.PodMetadata
 			template.Spec.PodTemplate.ObjectMeta.DeepCopyInto(&mergedMeta)
@@ -464,10 +464,10 @@ func (r *SandboxClaimReconciler) reconcileActive(ctx context.Context, claim *ext
 			}
 
 			if needsUpdate {
-				logger.Info("Updating sandbox metadata to match claim", "claim", claim.Name, "sandbox", sandbox.Name)
+				logger.V(1).Info("Updating sandbox metadata to match claim", "claim", claim.Name, "sandbox", sandbox.Name)
 				sandbox.Spec.PodTemplate.ObjectMeta = mergedMeta
-				if err := r.Update(ctx, sandbox); err != nil {
-					return nil, err
+				if updateErr := r.Patch(ctx, sandbox, patch); updateErr != nil {
+					return sandbox, fmt.Errorf("failed to patch sandbox metadata for claim %q: %w", claim.Name, updateErr)
 				}
 			}
 		}
@@ -703,7 +703,10 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1beta1.Sa
 	if sandbox != nil {
 		claim.Status.SandboxStatus.Name = sandbox.Name
 		claim.Status.SandboxStatus.PodIPs = sandbox.Status.PodIPs
-	} else {
+	} else if err == nil || errors.Is(err, ErrSandboxNotOwned) {
+		// Only clear bound sandbox identity when there is no error (sandbox legitimately deleted or unbound)
+		// or when ownership verification fails. Never clear on transient lookup or patch errors, as wiping
+		// status.sandbox.name forces a fallback to cold-start on the next reconcile retry.
 		claim.Status.SandboxStatus.Name = ""
 		claim.Status.SandboxStatus.PodIPs = nil
 	}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -4941,3 +4941,124 @@ func TestCreateSandboxClaimVolumeClaimTemplatesErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestSandboxClaimReconcile_PatchErrorPreservesStatus(t *testing.T) {
+	scheme := newScheme(t)
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}},
+		},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			SandboxStatus: extensionsv1beta1.SandboxStatus{Name: "warm-sandbox"},
+		},
+	}
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "warm-sandbox", Namespace: "default",
+			Labels: map[string]string{
+				sandboxv1beta1.SandboxLaunchTypeLabel: sandboxv1beta1.SandboxLaunchTypeWarm,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1", Kind: "SandboxClaim",
+				Name: "test-claim", UID: "claim-uid", Controller: new(true),
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			OperatingMode:    sandboxv1beta1.SandboxOperatingModeRunning,
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, sandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+					return k8errors.NewInternalError(fmt.Errorf("simulated patch failure"))
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	require.Error(t, err)
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	err = fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim)
+	require.NoError(t, err)
+	require.Equal(t, "warm-sandbox", updatedClaim.Status.SandboxStatus.Name, "status.sandbox.name must not be wiped out when metadata patch fails")
+}
+
+func TestSandboxClaimReconcile_TransientLookupErrorPreservesStatus(t *testing.T) {
+	scheme := newScheme(t)
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}}}},
+		},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			SandboxStatus: extensionsv1beta1.SandboxStatus{Name: "warm-sandbox"},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "warm-sandbox" {
+					return k8errors.NewInternalError(fmt.Errorf("simulated transient lookup timeout"))
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	require.Error(t, err)
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	err = fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim)
+	require.NoError(t, err)
+	require.Equal(t, "warm-sandbox", updatedClaim.Status.SandboxStatus.Name, "status.sandbox.name must not be wiped out when sandbox lookup fails with transient error")
+}


### PR DESCRIPTION
# Description

This PR resolves a critical issue during controller upgrades (specifically `v0.5.0`+) where warm-started sandbox claims would lose their bound sandbox status and attempt a cold-restart due to unretried optimistic lock conflicts or transient lookup errors.

## Key Changes

### 1. Fix Status Clearing on Transient Errors
*   **Location**: [`extensions/controllers/sandboxclaim_controller.go`](file:///usr/local/google/home/shrutinair/agent-sandbox-initial-playing/extensions/controllers/sandboxclaim_controller.go)
*   **Fix**: Modified `computeAndSetStatus` to only clear `claim.Status.SandboxStatus.Name` and `PodIPs` when there is no error (sandbox is legitimately deleted/unbound) or when ownership verification fails (`ErrSandboxNotOwned`). Wiping the status on transient lookup or metadata patch errors is now prevented, avoiding fallback to cold-start during retries.
*   **Optimization**: Swapped `r.Update(ctx, sandbox)` for `r.Patch(ctx, sandbox, patch)` using `client.MergeFrom` when updating sandbox metadata to minimize optimistic lock conflicts.

### 2. Unit Testing
*   **Location**: [`extensions/controllers/sandboxclaim_controller_test.go`](file:///usr/local/google/home/shrutinair/agent-sandbox-initial-playing/extensions/controllers/sandboxclaim_controller_test.go)
*   **Tests added**:
    *   `TestSandboxClaimReconcile_PatchErrorPreservesStatus`: Asserts that status is not wiped out when metadata patch fails.
    *   `TestSandboxClaimReconcile_TransientLookupErrorPreservesStatus`: Asserts that status is not wiped out when a transient lookup/get error occurs.

### 3. Migration Integration Test Improvements
*   **Location**: [`dev/tools/test-migration.py`](file:///usr/local/google/home/shrutinair/agent-sandbox-initial-playing/dev/tools/test-migration.py)
*   **Features added**:
    *   Added a 10-claim stress test flake simulation to test upgrade race conditions.
    *   Added dynamic `ownerReferences` and `status` subresource patches to match API server conversion webhook validation.

### 4. Documentation Update
*   **Location**: [`docs/api-migration-guide.md`](file:///usr/local/google/home/shrutinair/agent-sandbox-initial-playing/docs/api-migration-guide.md)
*   **Update**: Bumped all references and upgrade guides from version `v0.5.0` to `v0.5.2`.

---
## Verification Results

### Go Unit Tests
All unit tests in `extensions/controllers/...` pass cleanly:
```bash
go test -v ./extensions/controllers/...
# Output: PASS
