### PR TITLE
fix(ci): update kubeadm extraArgs to v1beta4 list format in create-kind-cluster

### DIFF
--- a/dev/tools/create-kind-cluster
+++ b/dev/tools/create-kind-cluster
@@ -33,7 +33,8 @@ def create_kind_config(kubelet_verbosity, containerd_loglevel=None):
             kind: ClusterConfiguration
             apiServer:
               extraArgs:
-                enable-admission-plugins: "NodeRestriction,OwnerReferencesPermissionEnforcement"
+              - name: "enable-admission-plugins"
+                value: "NodeRestriction,OwnerReferencesPermissionEnforcement"
           - |
             kind: KubeletConfiguration
             logging:

--- a/dev/tools/create-kind-cluster
+++ b/dev/tools/create-kind-cluster
@@ -33,8 +33,8 @@ def create_kind_config(kubelet_verbosity, containerd_loglevel=None):
             kind: ClusterConfiguration
             apiServer:
               extraArgs:
-              - name: "enable-admission-plugins"
-                value: "NodeRestriction,OwnerReferencesPermissionEnforcement"
+                - name: "enable-admission-plugins"
+                  value: "NodeRestriction,OwnerReferencesPermissionEnforcement"
           - |
             kind: KubeletConfiguration
             logging:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes Kind cluster creation failures in E2E presubmits caused by a `kubeadm` configuration schema mismatch.

In Kubernetes 1.31+ / 1.36 (`kindest/node:v1.36.1`), `kubeadm` updated `ClusterConfiguration.apiServer.extraArgs` from a map to a list in `kubeadm.k8s.io/v1beta4`. Supplying `apiServer.extraArgs` as a map caused `kubeadm init` inside the Kind control-plane container to fail unmarshaling on startup, leading to systemd boot timeouts and failed cluster creation in Prow.

This PR updates `create-kind-cluster` to use the `v1beta4`-compliant list format for `apiServer.extraArgs`.

#### Which issue(s) this PR is related to:

fixes https://github.com/kubernetes-sigs/agent-sandbox/issues/1125

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated local Kubernetes cluster configuration generation to use the supported admission plugin setting format.
  * Improves compatibility and reliability when creating development clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->