### PR TITLE
docs: update remaining latest/main manifest.yaml references to sandbox.yaml

### DIFF
--- a/examples/gke-swap/deploy_cluster.sh
+++ b/examples/gke-swap/deploy_cluster.sh
@@ -57,5 +57,4 @@ KUBECONFIG="${KUBECONFIG:-"${REPO_ROOT}/bin/KUBECONFIG"}" gcloud container clust
 echo "Cluster deployed successfully."
 echo "Please ensure the Agent Sandbox controller and CRDs are deployed on this cluster before running the tests."
 # Example installation:
-# export VERSION="main"
-# kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/manifest.yaml
+# kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml

--- a/examples/latebind-storage-gke-sandbox/README.md
+++ b/examples/latebind-storage-gke-sandbox/README.md
@@ -61,8 +61,8 @@ Choose one of the following installation methods.
 To install the standard Open Source Agent Sandbox controller and CRDs, apply the base manifests followed by the extensions for warm pools:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/main/manifest.yaml
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/main/extensions.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/extensions.yaml
 ```
 
 **Note on API Versions**: The OSS controller serves the `v1beta1` API. If you use this installation, you must update the apiVersion in the YAML examples throughout this guide from `extensions.agents.x-k8s.io/v1alpha1` to `extensions.agents.x-k8s.io/v1beta1`.


### PR DESCRIPTION
## What

Follow-up to #1012 (per @janetkuo's [review](https://github.com/kubernetes-sigs/agent-sandbox/pull/1012#pullrequestreview-4675674830)): update the remaining forward-looking `manifest.yaml` references to the new `sandbox.yaml` naming.

- `examples/gke-swap/deploy_cluster.sh` — commented install example: `releases/latest/download/manifest.yaml` → `sandbox.yaml`.
- `examples/latebind-storage-gke-sandbox/README.md` — was pointing at `raw.githubusercontent.com/.../main/manifest.yaml`, which 404s (there is no `manifest.yaml` at repo root). Fixed to the release-download URL **and** renamed: `releases/latest/download/sandbox.yaml` + `extensions.yaml`.

## Intentionally left on `manifest.yaml` (would break if renamed)

These are pinned to historical releases that only shipped `manifest.yaml`, or are not the release asset:

- `docs/api-migration-guide.md` — pinned to `v0.5.0` / `<old-version>` rollback.
- `dev/tools/test-migration.py` — downloads historical `{version}` / v1alpha1 release assets.
- `examples/ray-integration/direct-proxy/README.md` — a **local** `manifest.yaml` in that example dir (its SandboxTemplate/WarmPool), not the release asset.

## Note on timing

The renamed assets exist from the first release **after** v0.5.1 (which carries #1012). `releases/latest/download/sandbox.yaml` therefore resolves once that release is published; until then these doc/example links point ahead of the current `latest`. `extensions.yaml` is unchanged and resolves today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Agent Sandbox installation instructions to use the latest release manifests.
  * Corrected the example cluster deployment command to reference the appropriate sandbox manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->