### PR TITLE
test(python-client): cover async terminate idempotency

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -139,6 +139,15 @@ class AsyncSandbox:
         logging.info(f"Connection to sandbox claim '{self.claim_name}' has been closed.")
 
     async def terminate(self):
-        """Permanent deletion of all server side infrastructure and client side connection."""
+        """Permanent deletion of all server side infrastructure and client side connection.
+
+        This method is idempotent. Calling ``terminate()`` repeatedly after a
+        successful deletion is a safe no-op.
+        """
         await self._close_connection()
+
+        if not self.claim_name:
+            return
+
         await self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
+        self.claim_name = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -447,6 +447,25 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(await sandbox.get_pod_ip(), "10.244.0.42")
 
+    async def test_terminate_is_idempotent_after_successful_delete(self):
+        mock_k8s_helper = AsyncMock()
+        mock_k8s_helper.delete_sandbox_claim = AsyncMock()
+        sandbox = AsyncSandbox(
+            claim_name="test-claim",
+            sandbox_id="test-id",
+            namespace="test-ns",
+            connection_config=SandboxDirectConnectionConfig(api_url="http://test-router:8080"),
+            k8s_helper=mock_k8s_helper,
+        )
+
+        await sandbox.terminate()
+        await sandbox.terminate()
+
+        mock_k8s_helper.delete_sandbox_claim.assert_called_once_with(
+            "test-claim", "test-ns"
+        )
+        self.assertIsNone(sandbox.claim_name)
+
     @patch("k8s_agent_sandbox.async_sandbox.AsyncFilesystem")
     @patch("k8s_agent_sandbox.async_sandbox.AsyncCommandExecutor")
     @patch("k8s_agent_sandbox.async_sandbox.create_tracer_manager")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -447,6 +447,23 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(await sandbox.get_pod_ip(), "10.244.0.42")
 
+    async def test_terminate_is_idempotent_after_successful_delete(self):
+        mock_k8s_helper = AsyncMock()
+        mock_k8s_helper.delete_sandbox_claim = AsyncMock()
+        sandbox = AsyncSandbox(
+            claim_name="test-claim",
+            sandbox_id="test-id",
+            namespace="test-ns",
+            connection_config=SandboxDirectConnectionConfig(api_url="http://test-router:8080"),
+            k8s_helper=mock_k8s_helper,
+        )
+
+        await sandbox.terminate()
+        await sandbox.terminate()
+
+        mock_k8s_helper.delete_sandbox_claim.assert_awaited_once_with("test-claim", "test-ns")
+        self.assertIsNone(sandbox.claim_name)
+
     @patch("k8s_agent_sandbox.async_sandbox.AsyncFilesystem")
     @patch("k8s_agent_sandbox.async_sandbox.AsyncCommandExecutor")
     @patch("k8s_agent_sandbox.async_sandbox.create_tracer_manager")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -461,9 +461,7 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         await sandbox.terminate()
         await sandbox.terminate()
 
-        mock_k8s_helper.delete_sandbox_claim.assert_called_once_with(
-            "test-claim", "test-ns"
-        )
+        mock_k8s_helper.delete_sandbox_claim.assert_awaited_once_with("test-claim", "test-ns")
         self.assertIsNone(sandbox.claim_name)
 
     @patch("k8s_agent_sandbox.async_sandbox.AsyncFilesystem")


### PR DESCRIPTION
Avoid repeated delete calls from AsyncSandbox handles after successful termination.

#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Makes `AsyncSandbox.terminate()` idempotent after successful deletion by clearing `claim_name`, matching sync `Sandbox.terminate()`.
Adds a regression test to ensure repeated termination only deletes the claim once.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that terminating an already terminated sandbox is safe and idempotent.
  * Verified that the sandbox deletion request is made only once and sandbox state is cleared after termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->