### PR TITLE
fix: include namespace in LocalTunnel router-not-found errors

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -136,14 +136,26 @@ finally:
 Use this for local development or CI. The client automatically opens a secure tunnel to the
 Router Service using `kubectl`.
 
+> **Namespace note:** `router_namespace` controls *where the router service lives*
+> (default: `"agent-sandbox-system"`). This is separate from the `namespace` argument
+> passed to `create_sandbox`, which controls *where sandbox pods are scheduled*.
+> If you deployed the router into a different namespace (e.g. `"default"`), you must
+> set `router_namespace` accordingly — otherwise `kubectl port-forward` will fail with
+> `"services sandbox-router-svc not found"`.
+
 ```python
 from k8s_agent_sandbox import SandboxClient
 from k8s_agent_sandbox.models import SandboxLocalTunnelConnectionConfig
 
-# Automatically tunnels to svc/sandbox-router-svc
+# Router deployed in the default agent-sandbox-system namespace:
 client = SandboxClient(
     connection_config=SandboxLocalTunnelConnectionConfig()
 )
+
+# If the router is deployed in a different namespace (e.g. "default"):
+# client = SandboxClient(
+#     connection_config=SandboxLocalTunnelConnectionConfig(router_namespace="default")
+# )
 
 sandbox = client.create_sandbox(warmpool="python-sandbox-warmpool", namespace="default")
 try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -164,7 +164,7 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
         """
         try:
             result = subprocess.run(
-                ["kubectl", "get", "svc", "sandbox-router-svc",
+                ["kubectl", "get", ROUTER_SERVICE_NAME,
                  "-n", self.config.router_namespace],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -175,7 +175,7 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                 # Exit code 1 with "not found" in stderr is a definitive absence — raise early.
                 if "not found" in stderr_text.lower():
                     raise SandboxPortForwardError(
-                        f"Router service 'sandbox-router-svc' not found in namespace "
+                        f"Router service '{ROUTER_SERVICE_NAME}' not found in namespace "
                         f"'{self.config.router_namespace}'. "
                         f"If the router is deployed in a different namespace, set "
                         f"router_namespace accordingly, e.g. "
@@ -236,7 +236,7 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                     _, stderr = self.port_forward_process.communicate()
                     stderr_text = stderr.decode(errors="replace")
                     raise SandboxPortForwardError(
-                        f"Tunnel to router service 'sandbox-router-svc' in namespace "
+                        f"Tunnel to router service '{ROUTER_SERVICE_NAME}' in namespace "
                         f"'{self.config.router_namespace}' crashed. "
                         f"If the router is deployed in a different namespace, set "
                         f"router_namespace accordingly, e.g. "

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -155,6 +155,52 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
         except (socket.timeout, ConnectionRefusedError):
             return False
 
+    def _preflight_check_router_service(self):
+        """Validates the router service exists in the configured namespace before port-forwarding.
+
+        Raises SandboxPortForwardError with namespace context and a remediation hint if the
+        service is definitively absent. Transient kubectl failures (e.g. network blip, RBAC
+        not covering 'get') are logged and silently ignored so they don't block a valid tunnel.
+        """
+        try:
+            result = subprocess.run(
+                ["kubectl", "get", "svc", "sandbox-router-svc",
+                 "-n", self.config.router_namespace],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                stderr_text = result.stderr.decode(errors="replace").strip()
+                # Exit code 1 with "not found" in stderr is a definitive absence — raise early.
+                if "not found" in stderr_text.lower():
+                    raise SandboxPortForwardError(
+                        f"Router service 'sandbox-router-svc' not found in namespace "
+                        f"'{self.config.router_namespace}'. "
+                        f"If the router is deployed in a different namespace, set "
+                        f"router_namespace accordingly, e.g. "
+                        f"SandboxLocalTunnelConnectionConfig(router_namespace=\"<your-namespace>\"). "
+                        f"kubectl stderr: {stderr_text}"
+                    )
+                # Any other non-zero exit (RBAC, transient) — log and proceed.
+                logging.warning(
+                    "Pre-flight check for router service could not confirm existence "
+                    "(kubectl exited %d). Proceeding with port-forward. "
+                    "kubectl stderr: %s",
+                    result.returncode,
+                    stderr_text,
+                )
+        except SandboxPortForwardError:
+            raise
+        except subprocess.TimeoutExpired:
+            logging.warning(
+                "Pre-flight check for router service timed out after 10s "
+                "(slow API server or network stall). Proceeding with port-forward."
+            )
+        except Exception as e:
+            # subprocess.run itself failed (e.g. kubectl not on PATH) — log and proceed.
+            logging.warning("Pre-flight check for router service skipped: %s", e)
+
     def connect(self) -> str:
         if self.base_url and self.port_forward_process and self.port_forward_process.poll() is None:
              return self.base_url
@@ -164,13 +210,15 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
 
         start_time = time.monotonic()
         status = "success"
-        
+
         try:
+            self._preflight_check_router_service()
+
             local_port = self._get_free_port()
 
             logging.info(
                 f"Starting tunnel for Sandbox {self.sandbox_id}")
-            
+
             self.port_forward_process = subprocess.Popen(
                 [
                     "kubectl", "port-forward",
@@ -186,8 +234,15 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
             while time.monotonic() - start_time < self.config.port_forward_ready_timeout:
                 if self.port_forward_process.poll() is not None:
                     _, stderr = self.port_forward_process.communicate()
+                    stderr_text = stderr.decode(errors="replace")
                     raise SandboxPortForwardError(
-                        f"Tunnel crashed: {stderr.decode(errors='replace')}")
+                        f"Tunnel to router service 'sandbox-router-svc' in namespace "
+                        f"'{self.config.router_namespace}' crashed. "
+                        f"If the router is deployed in a different namespace, set "
+                        f"router_namespace accordingly, e.g. "
+                        f"SandboxLocalTunnelConnectionConfig(router_namespace=\"<your-namespace>\"). "
+                        f"kubectl stderr: {stderr_text}"
+                    )
 
                 if self._is_port_open(local_port):
                     self.base_url = f"http://127.0.0.1:{local_port}"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import requests
 
@@ -24,6 +25,7 @@ from k8s_agent_sandbox.connector import (
     InClusterConnectionStrategy,
     SandboxConnector,
 )
+from k8s_agent_sandbox.exceptions import SandboxPortForwardError
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
     SandboxGatewayConnectionConfig,
@@ -356,6 +358,99 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
         mock_session.request.return_value = mock_resp
 
         connector.send_request("GET", "/execute")
+
+class TestLocalTunnelPreflightCheck(unittest.TestCase):
+    """Unit tests for LocalTunnelConnectionStrategy._preflight_check_router_service."""
+
+    def _make_strategy(self, router_namespace="agent-sandbox-system"):
+        config = SandboxLocalTunnelConnectionConfig(router_namespace=router_namespace)
+        return LocalTunnelConnectionStrategy(
+            sandbox_id="my-sandbox", namespace="default", config=config
+        )
+
+    @patch("subprocess.run")
+    def test_preflight_raises_with_namespace_when_service_not_found(self, mock_run):
+        """SandboxPortForwardError must include the searched namespace when service is absent."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr=b'Error from server (NotFound): services "sandbox-router-svc" not found',
+        )
+        strategy = self._make_strategy(router_namespace="my-custom-ns")
+
+        with self.assertRaises(SandboxPortForwardError) as ctx:
+            strategy._preflight_check_router_service()
+
+        error_msg = str(ctx.exception)
+        self.assertIn("my-custom-ns", error_msg)
+        self.assertIn("router_namespace", error_msg)
+
+    @patch("subprocess.run")
+    def test_preflight_raises_with_router_namespace_hint(self, mock_run):
+        """Error message must contain a hint to configure router_namespace."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr=b'Error from server (NotFound): services "sandbox-router-svc" not found',
+        )
+        strategy = self._make_strategy()
+
+        with self.assertRaises(SandboxPortForwardError) as ctx:
+            strategy._preflight_check_router_service()
+
+        self.assertIn("SandboxLocalTunnelConnectionConfig", str(ctx.exception))
+
+    @patch("subprocess.run")
+    def test_preflight_does_not_raise_on_transient_failure(self, mock_run):
+        """Non-definitive kubectl failures (e.g. RBAC) must not block the tunnel."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr=b"Error from server (Forbidden): services is forbidden",
+        )
+        strategy = self._make_strategy()
+        # Should not raise
+        strategy._preflight_check_router_service()
+
+    @patch("subprocess.run")
+    def test_preflight_does_not_raise_on_success(self, mock_run):
+        """Successful kubectl get means service exists — no exception."""
+        mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+        strategy = self._make_strategy()
+        strategy._preflight_check_router_service()
+
+    @patch("subprocess.run", side_effect=FileNotFoundError("kubectl not found"))
+    def test_preflight_does_not_raise_when_kubectl_missing(self, _mock_run):
+        """Missing kubectl binary must not block the tunnel attempt."""
+        strategy = self._make_strategy()
+        strategy._preflight_check_router_service()
+
+    @patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="kubectl", timeout=10))
+    def test_preflight_does_not_raise_on_timeout(self, _mock_run):
+        """A slow API server timing out the preflight check must not block the tunnel."""
+        strategy = self._make_strategy()
+        strategy._preflight_check_router_service()
+
+    @patch("subprocess.run")
+    def test_connect_error_message_includes_namespace(self, mock_run):
+        """When port-forward crashes, the error message must include router_namespace."""
+        # Pre-flight passes, then the Popen process crashes immediately.
+        mock_run.return_value = MagicMock(returncode=0, stderr=b"")
+        strategy = self._make_strategy(router_namespace="custom-ns")
+
+        mock_proc = MagicMock()
+        # poll() returns non-None → process already exited
+        mock_proc.poll.return_value = 1
+        mock_proc.communicate.return_value = (
+            b"",
+            b'error: services "sandbox-router-svc" not found',
+        )
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with patch.object(strategy, "_get_free_port", return_value=19876):
+                with self.assertRaises(SandboxPortForwardError) as ctx:
+                    strategy.connect()
+
+        self.assertIn("custom-ns", str(ctx.exception))
+        self.assertIn("router_namespace", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

When sandbox-router-svc is deployed outside the default `agent-sandbox-system` namespace, `kubectl port-forward` fails with the cryptic error "services sandbox-router-svc not found" - no namespace context, no actionable hint. This PR fixes that.

#### Which issue(s) this PR is related to:
Fixes #1057 
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validated the sandbox router before starting a local tunnel.
  * Improved tunnel failure messages with router service, namespace details, and troubleshooting guidance.
  * Continued gracefully through transient, permission-related, timeout, or unavailable `kubectl` issues.
  * Preserved the full port-forward readiness timeout after router validation.
* **Documentation**
  * Clarified the difference between router and sandbox scheduling namespaces in the Developer Mode example.
* **Tests**
  * Added coverage for router validation, transient failures, timeout handling, and local tunnel connection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->