### PR TITLE
fix: build sandbox-router-go from its own Dockerfile in push-images

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -74,7 +74,12 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
         build_cmd.extend(["-t", extra_tag])
     build_cmd.extend([
         "-f",
-        os.path.basename(dockerfile_path),
+        # Resolve the Dockerfile relative to the build context (the command
+        # runs with cwd=srcdir): when a per-Dockerfile override sets the
+        # context to another directory (sandbox-router-go uses the repo
+        # root), the basename would silently pick that directory's
+        # Dockerfile instead.
+        os.path.relpath(dockerfile_path, srcdir),
         ".",
     ])
     # Inject version info into Go binaries

--- a/dev/tools/push_images_test.py
+++ b/dev/tools/push_images_test.py
@@ -1,0 +1,101 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the buildx invocation in dev/tools/push-images."""
+
+import argparse
+import importlib.util
+import os
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+
+# The push-images tool is an extensionless script, so load it via importlib
+# rather than a normal import (same pattern as release_test.py). The tools dir
+# must be on sys.path first so its `from shared import utils` import resolves.
+_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _TOOLS_DIR)
+_PUSH_IMAGES_PATH = os.path.join(_TOOLS_DIR, "push-images")
+_loader = SourceFileLoader("push_images", _PUSH_IMAGES_PATH)
+_spec = importlib.util.spec_from_loader("push_images", _loader)
+push_images = importlib.util.module_from_spec(_spec)
+_loader.exec_module(push_images)
+
+
+class BuildxDockerfileArgTest(unittest.TestCase):
+    """The -f argument must resolve relative to the build context (cwd).
+
+    The sandbox-router-go image overrides the build context to the repo root
+    while its Dockerfile stays at sandbox-router/Dockerfile; passing only the
+    basename made buildx silently build the repo-root (controller) Dockerfile
+    instead (issue #1123).
+    """
+
+    def _captured_build_cmd(self, srcdir, dockerfile_path):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["cwd"] = kwargs.get("cwd")
+
+        orig_run = push_images.subprocess.run
+        orig_version_args = push_images._get_version_build_args
+        orig_image_name = push_images.utils.get_full_image_name
+        push_images.subprocess.run = fake_run
+        push_images._get_version_build_args = lambda: []
+        push_images.utils.get_full_image_name = (
+            lambda args, service_name, tag: f"example.local/{service_name}:{tag}"
+        )
+        try:
+            args = argparse.Namespace(
+                docker_build_output_type="docker",
+                extra_image_tags=[],
+            )
+            push_images.build_and_push_image_with_docker_buildx(
+                args, "svc", srcdir, dockerfile_path, "testtag"
+            )
+        finally:
+            push_images.subprocess.run = orig_run
+            push_images._get_version_build_args = orig_version_args
+            push_images.utils.get_full_image_name = orig_image_name
+
+        return captured
+
+    def _dockerfile_arg(self, cmd):
+        return cmd[cmd.index("-f") + 1]
+
+    def test_per_directory_dockerfile_uses_basename(self):
+        captured = self._captured_build_cmd(
+            srcdir=os.path.join(".", "frobber"),
+            dockerfile_path=os.path.join(".", "frobber", "Dockerfile"),
+        )
+        self.assertEqual(self._dockerfile_arg(captured["cmd"]), "Dockerfile")
+        self.assertEqual(captured["cwd"], os.path.join(".", "frobber"))
+
+    def test_context_override_keeps_dockerfile_path(self):
+        # Mirrors the sandbox-router-go override in main(): context is the
+        # repo root, the Dockerfile is not at the context root.
+        captured = self._captured_build_cmd(
+            srcdir=".",
+            dockerfile_path=os.path.join(".", "sandbox-router", "Dockerfile"),
+        )
+        self.assertEqual(
+            self._dockerfile_arg(captured["cmd"]),
+            os.path.join("sandbox-router", "Dockerfile"),
+        )
+        self.assertEqual(captured["cwd"], ".")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:

`dev/tools/push-images` passes only the basename of the Dockerfile to `docker buildx build -f` and runs the command with `cwd=<build context>`. For images whose Dockerfile sits next to their build context that is fine, but the `sandbox-router-go` image overrides its build context to the repo root (it imports the shared Go module) while its Dockerfile stays at `sandbox-router/Dockerfile`. The basename `Dockerfile` then resolves to the repo-root (controller) Dockerfile, so the pushed `sandbox-router-go` image silently ships the controller binary — its entrypoint is `/agent-sandbox-controller` instead of `/sandbox-router`.

This resolves the `-f` argument relative to the build context instead (`os.path.relpath(dockerfile_path, srcdir)`), which is identical to the basename for every per-directory image and the correct relative path for the context-override case.

Verified locally (macOS arm64, Docker 27.4):

- running the unfixed script with `--images sandbox-router-go --image-prefix repro.local/ --kind-cluster-name …` produces an image with `Entrypoint: [/agent-sandbox-controller]`; with this fix the same invocation produces `Entrypoint: [/sandbox-router]`;
- new unit test `dev/tools/push_images_test.py` (importlib pattern from `release_test.py`, subprocess stubbed) asserts the `-f` value for both the per-directory and the context-override cases — the override case fails against the current script and passes with the fix.

Prepared with AI assistance (Claude Code); happy to adjust anything in review.

#### Which issue(s) this PR is related to:

Fixes #1123

#### Release Note

```release-note
Fixed the sandbox-router-go image being built from the controller Dockerfile in dev/tools/push-images.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Docker image builds using the correct Dockerfile when the build context differs from the Dockerfile’s directory.
  - Improved reliability for builds with custom context paths.

- **Tests**
  - Added coverage for Dockerfile path handling across standard and overridden build contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->