### PR TITLE
dev/tools: fail loudly on unknown or duplicate push-images

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -16,6 +16,7 @@
 import argparse
 import os
 import subprocess
+import sys
 
 from shared import utils
 
@@ -113,6 +114,7 @@ def main(args):
         # TODO: Implement an explicit inclusion strategy for controller only Dockerfile.
         excluded_dirs.update({"examples", "clients"})
 
+    built = set()
     for root, dirs, files in os.walk(".", topdown=True):
         dirs[:] = [d for d in dirs if d not in excluded_dirs]
 
@@ -125,6 +127,8 @@ def main(args):
                 continue
 
             if service_name == ".":
+                # The Dockerfile at the repo root is the controller image.
+                # Single source of truth: do not copy it elsewhere.
                 service_name = "agent-sandbox-controller"
 
             # Per-Dockerfile overrides. The Go sandbox-router needs the repo
@@ -139,6 +143,11 @@ def main(args):
             if args.images and service_name not in args.images:
                 continue
 
+            if service_name in built:
+                sys.exit(f"ERROR: duplicate Dockerfiles for image {service_name!r}: "
+                         f"second one at {dockerfile_path} (whichever builds last "
+                         "would silently win the tag)")
+
             print(f"--- Found Dockerfile at: {dockerfile_path}")
             print(f"--- Service Name: {service_name}")
             print(f"--- Context Dir: {context_dir}")
@@ -147,7 +156,16 @@ def main(args):
             create_buildx_builder_if_not_exists()
             print(f"building image for {service_name}")
             build_and_push_image(args, service_name, context_dir, dockerfile_path, image_tag)
-            # TODO: Handle duplicate service names in different paths
+            built.add(service_name)
+
+    # A requested image with no matching Dockerfile is an error: silently
+    # skipping it leaves stale or missing images in the registry and the
+    # failure only surfaces much later as ImagePullBackOff.
+    if args.images:
+        missing = set(args.images) - built
+        if missing:
+            sys.exit(f"ERROR: no Dockerfile found for requested image(s): {sorted(missing)} "
+                     "(is the directory committed?)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Make `dev/tools/push-images` exit non-zero when `--images` names a Dockerfile that does not exist (previously silently skipped, which only showed up later as ImagePullBackOff).
- Also fail when two Dockerfiles would publish the same image name, instead of letting the last one silently win the tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image build validation by reporting duplicate Dockerfiles that map to the same image.
  * Added clear errors when requested images do not have a matching Dockerfile.
  * Prevented missing or conflicting image builds from being silently skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->