### PR TITLE
tests: enrich stress harness with milestone latency breakdown

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -160,5 +160,5 @@ echo "Benchmark completed successfully."
 
 # Run the stress test
 echo "Running stress test"
-go run ./test/stress --sandbox-count 1000 --create-concurrency 100 --output-dir="${ARTIFACTS:-.}/stress-test/"
+go run ./test/stress --sandbox-count 200 --create-concurrency 50 --output-dir="${ARTIFACTS:-.}/stress-test/"
 echo "Stress test completed successfully."

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -318,6 +318,12 @@ func runCreatePhase(ctx context.Context, cfg Config, tracker *Tracker, sandboxCl
 	}
 
 	if _, err := ForkJoin(ctx, names, cfg.CreateConcurrency, func(id types.NamespacedName) (struct{}, error) {
+		// The command traps SIGTERM and exits immediately: a bare `sleep` as PID 1
+		// gets no default SIGTERM disposition, so the kubelet would wait out the full
+		// grace period and SIGKILL (observed as exit code 137 and ~1s of extra
+		// deletion latency). The `& wait` is required because sh does not run traps
+		// while a foreground child is running.
+		// terminationGracePeriodSeconds=1 is the backstop if the trap fails.
 		sandbox := &unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": "agents.x-k8s.io/v1beta1",
@@ -329,13 +335,14 @@ func runCreatePhase(ctx context.Context, cfg Config, tracker *Tracker, sandboxCl
 				"spec": map[string]any{
 					"podTemplate": map[string]any{
 						"spec": map[string]any{
-							"restartPolicy": "Never",
+							"restartPolicy":                 "Never",
+							"terminationGracePeriodSeconds": int64(1),
 							"containers": []any{
 								map[string]any{
 									"name":            "main",
 									"image":           cfg.Image,
 									"imagePullPolicy": "IfNotPresent",
-									"command":         []string{"sleep", "infinity"},
+									"command":         []string{"sh", "-c", "trap 'exit 0' TERM INT; sleep 5 & wait"},
 								},
 							},
 						},

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -12,10 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// stress is a load-testing harness for the Sandbox controller.
+//
+// It creates N sandboxes and waits for them to become Ready, recording a
+// per-stage latency breakdown (controller, scheduler, kubelet, status
+// propagation) plus create/ready throughput.
+//
+// Outputs (in --output-dir):
+//
+//   - summary.json: aggregate metrics
+//   - sandboxes.jsonl: per-sandbox lifecycle milestones (client + server timestamps)
+//   - timeseries.jsonl: per-second event counts and gauges
+//   - watch.jsonl.gz: full watch streams (pods, nodes, events, sandboxes) for offline analysis
 package main
 
 import (
 	"bufio"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -26,8 +39,8 @@ import (
 	"os/signal"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -37,12 +50,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// WatchEventRecord defines the schema for each line in watch.jsonl.
+// WatchEventRecord defines the schema for each line in watch.jsonl.gz.
 type WatchEventRecord struct {
 	Timestamp time.Time       `json:"timestamp"`
 	Resource  string          `json:"resource"`
@@ -50,36 +64,56 @@ type WatchEventRecord struct {
 	Object    any             `json:"object"`
 }
 
-// LatencyStats holds calculated latency percentiles.
-type LatencyStats struct {
-	P50Ms float64 `json:"p50_ms"`
-	P90Ms float64 `json:"p90_ms"`
-	P95Ms float64 `json:"p95_ms"`
-	P99Ms float64 `json:"p99_ms"`
+// ClusterInfo describes the cluster the test ran against.
+// Nodes / PodCapacity / PreexistingPods count only worker nodes: control-plane
+// nodes are excluded because sandboxes are not scheduled there.
+type ClusterInfo struct {
+	KubernetesVersion string `json:"kubernetesVersion"`
+	Nodes             int    `json:"nodes"`
+	PodCapacity       int    `json:"podCapacity"`
+	PreexistingPods   int    `json:"preexistingPods"`
 }
 
-// StressTestSummary is written to summary.json at the end of the test.
-type StressTestSummary struct {
-	TotalCreated         int          `json:"totalCreated"`
-	TotalReady           int          `json:"totalReady"`
-	TotalFinished        int          `json:"totalFinished"`
-	TotalDurationMs      float64      `json:"totalDurationMs"`
-	CreateLatencyStats   LatencyStats `json:"createLatencyStats"`
-	ReadyLatencyStats    LatencyStats `json:"readyLatencyStats"`
-	FinishedLatencyStats LatencyStats `json:"finishedLatencyStats"`
+// PhaseSummary holds the aggregate results for one phase.
+type PhaseSummary struct {
+	Requested       int     `json:"requested"`
+	Created         int     `json:"created"`
+	Ready           int     `json:"ready"`
+	Failed          int     `json:"failed"`
+	DurationSeconds float64 `json:"durationSeconds"`
+
+	Latency LatencyBreakdown `json:"latency"`
+
+	CreateThroughput *ThroughputStats `json:"createThroughput,omitempty"`
+	ReadyThroughput  *ThroughputStats `json:"readyThroughput,omitempty"`
+
+	// Per-worker-node rates, alongside the raw aggregates above.
+	CreateThroughputPerNode *PerNodeRates `json:"createThroughputPerNode,omitempty"`
+	ReadyThroughputPerNode  *PerNodeRates `json:"readyThroughputPerNode,omitempty"`
 }
 
-var (
-	createdCount  atomic.Int32
-	readyCount    atomic.Int32
-	finishedCount atomic.Int32
+// Summary is written to summary.json at the end of the test.
+type Summary struct {
+	RunID     string                  `json:"runID"`
+	StartTime time.Time               `json:"startTime"`
+	EndTime   time.Time               `json:"endTime"`
+	Config    Config                  `json:"config"`
+	Cluster   *ClusterInfo            `json:"cluster,omitempty"`
+	Phases    map[Phase]*PhaseSummary `json:"phases"`
+}
 
-	stateMu                  sync.Mutex
-	sandboxCreatedMap        = make(map[types.NamespacedName]time.Time)
-	sandboxCreatedSuccessMap = make(map[types.NamespacedName]time.Time)
-	sandboxReadyMap          = make(map[types.NamespacedName]time.Time)
-	sandboxFinishedMap       = make(map[types.NamespacedName]time.Time)
-)
+// Config holds the test parameters.
+type Config struct {
+	Namespace         string        `json:"namespace"`
+	OutputDir         string        `json:"outputDir"`
+	Image             string        `json:"image"`
+	Cleanup           bool          `json:"cleanup"`
+	Timeout           time.Duration `json:"timeout"`
+	PerSandboxTimeout time.Duration `json:"perSandboxTimeout"`
+
+	SandboxCount      int `json:"sandboxCount"`
+	CreateConcurrency int `json:"createConcurrency"`
+}
 
 func main() {
 	// Setup context that cancels on timeout or signal
@@ -94,34 +128,35 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	sandboxCount := 100
-	flag.IntVar(&sandboxCount, "sandbox-count", sandboxCount, "Number of Sandboxes to create")
-
-	createConcurrency := 10
-	flag.IntVar(&createConcurrency, "create-concurrency", createConcurrency, "Number of concurrent workers creating Sandboxes")
-	namespace := flag.String("namespace", "sandbox-stress-test", "Kubernetes namespace to run the test in. If default, a timestamp suffix is added.")
-	outputDir := "./stress-results"
-	flag.StringVar(&outputDir, "output-dir", outputDir, "Directory to write results to")
-	cleanup := flag.Bool("cleanup", true, "Whether to delete the namespace at the end of the test")
-	imageName := flag.String("image", "debian:latest", "Container image to use for Sandboxes")
-	timeout := flag.Duration("timeout", 15*time.Minute, "Timeout for the entire test run")
+	var cfg Config
+	flag.IntVar(&cfg.SandboxCount, "sandbox-count", 100, "Number of Sandboxes to create")
+	flag.IntVar(&cfg.CreateConcurrency, "create-concurrency", 10, "Number of concurrent workers creating Sandboxes")
+	flag.StringVar(&cfg.Namespace, "namespace", "", "Kubernetes namespace to run the test in. If empty, a timestamped name is generated.")
+	flag.StringVar(&cfg.OutputDir, "output-dir", "./stress-results", "Directory to write results to")
+	flag.BoolVar(&cfg.Cleanup, "cleanup", true, "Whether to delete the namespace at the end of the test")
+	flag.StringVar(&cfg.Image, "image", "debian:latest", "Container image to use for Sandboxes (must provide sh and sleep)")
+	flag.DurationVar(&cfg.Timeout, "timeout", 15*time.Minute, "Timeout for the entire test run")
+	flag.DurationVar(&cfg.PerSandboxTimeout, "per-sandbox-timeout", 5*time.Minute, "Timeout waiting for sandboxes to become Ready after creates finish")
 	flag.Parse()
 
-	ctx, cancel := context.WithTimeout(ctx, *timeout)
-	defer cancel()
+	if cfg.SandboxCount <= 0 {
+		return fmt.Errorf("--sandbox-count must be > 0")
+	}
 
-	log.Printf("Starting stress test: creating %d Sandboxes using %s, create-concurrency=%d", sandboxCount, *imageName, createConcurrency)
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
 
 	// Create unique run ID and directories
 	runID := time.Now().Format("20060102-150405")
-	if *namespace == "sandbox-stress-test" {
-		*namespace = fmt.Sprintf("sandbox-stress-%s", runID)
+	if cfg.Namespace == "" {
+		cfg.Namespace = fmt.Sprintf("sandbox-stress-%s", runID)
 	}
 
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return fmt.Errorf("failed to create run directory %s: %w", outputDir, err)
+	if err := os.MkdirAll(cfg.OutputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create run directory %s: %w", cfg.OutputDir, err)
 	}
-	log.Printf("Writing watch events and results to directory: %s", outputDir)
+	log.Printf("Starting stress test run %s: creating %d Sandboxes (create-concurrency=%d), writing results to %s",
+		runID, cfg.SandboxCount, cfg.CreateConcurrency, cfg.OutputDir)
 
 	// Initialize kubernetes client config
 	restConfig, err := getRestConfig()
@@ -135,6 +170,14 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("failed to build dynamic client: %w", err)
 	}
 
+	clusterInfo, err := inspectCluster(ctx, restConfig, dynamicClient)
+	if err != nil {
+		return fmt.Errorf("failed to inspect cluster: %w", err)
+	}
+	log.Printf("Cluster: kubernetes %s, %d worker nodes, pod capacity %d, %d pre-existing worker pods",
+		clusterInfo.KubernetesVersion, clusterInfo.Nodes, clusterInfo.PodCapacity, clusterInfo.PreexistingPods)
+	checkClusterCapacity(cfg, clusterInfo)
+
 	// Create namespace
 	nsClient := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"})
 	nsObj := &unstructured.Unstructured{
@@ -142,39 +185,38 @@ func run(ctx context.Context) error {
 			"apiVersion": "v1",
 			"kind":       "Namespace",
 			"metadata": map[string]any{
-				"name": *namespace,
+				"name": cfg.Namespace,
 			},
 		},
 	}
-	log.Printf("Creating namespace: %s", *namespace)
-	_, err = nsClient.Create(ctx, nsObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create namespace %s: %w", *namespace, err)
+	log.Printf("Creating namespace: %s", cfg.Namespace)
+	if _, err := nsClient.Create(ctx, nsObj, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", cfg.Namespace, err)
 	}
 
 	// Clean up namespace at the end if requested
-	if *cleanup {
+	if cfg.Cleanup {
 		defer func() {
-			log.Printf("Cleaning up namespace: %s", *namespace)
+			log.Printf("Cleaning up namespace: %s", cfg.Namespace)
 			cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
 			defer cleanupCancel()
-			if err := nsClient.Delete(cleanupCtx, *namespace, metav1.DeleteOptions{}); err != nil {
-				log.Printf("failed to delete namespace %s: %v", *namespace, err)
+			if err := nsClient.Delete(cleanupCtx, cfg.Namespace, metav1.DeleteOptions{}); err != nil {
+				log.Printf("failed to delete namespace %s: %v", cfg.Namespace, err)
 			}
 		}()
 	}
 
+	tracker := NewTracker()
 	taskRunner := NewTaskRunner(cancel)
 
 	// Start watch recording to file
-	writeToFileChannel := make(chan WatchEventRecord, 1024)
-	watchFilePath := filepath.Join(outputDir, "watch.jsonl")
-
+	writeToFileChannel := make(chan WatchEventRecord, 4096)
+	watchFilePath := filepath.Join(cfg.OutputDir, "watch.jsonl.gz")
 	taskRunner.RunAsync(ctx, func(ctx context.Context) error {
 		return runWriter(ctx, watchFilePath, writeToFileChannel)
 	})
 
-	// Setup and start watchers
+	// Setup and start watchers.
 	// We capture cluster-wide, we want as much data as possible,
 	// and expect this test to be run on a dedicated cluster.
 	gvrList := []schema.GroupVersionResource{
@@ -187,20 +229,21 @@ func run(ctx context.Context) error {
 	for _, gvr := range gvrList {
 		taskRunner.RunAsync(ctx, func(ctx context.Context) error {
 			return watchResource(ctx, dynamicClient, gvr, func(event WatchEventRecord) error {
-				select {
-				case writeToFileChannel <- event:
-				case <-ctx.Done():
-					return ctx.Err()
+				// Update milestone tracking first: it is cheap and time-sensitive,
+				// while the file write may block briefly on the writer.
+				if u, ok := event.Object.(*unstructured.Unstructured); ok {
+					tracker.HandleWatchEvent(gvr.Resource, event.Type, u)
+				} else if event.Object != nil {
+					return fmt.Errorf("unhandled type in event %T", event.Object)
 				}
 
-				if event.Object != nil {
-					if u, ok := event.Object.(*unstructured.Unstructured); ok {
-						handleWatchEvent(gvr, event.Type, u)
-					} else {
-						return fmt.Errorf("unhandled type in event %T", event.Object)
+				if writeToFileChannel != nil {
+					select {
+					case writeToFileChannel <- event:
+					case <-ctx.Done():
+						return ctx.Err()
 					}
 				}
-
 				return nil
 			})
 		})
@@ -210,33 +253,71 @@ func run(ctx context.Context) error {
 	time.Sleep(2 * time.Second)
 
 	// Start progress reporter
+	testStartTime := time.Now()
 	taskRunner.RunPeriodic(ctx, 5*time.Second, func() error {
-		created := createdCount.Load()
-		ready := readyCount.Load()
-		finished := finishedCount.Load()
-		log.Printf("[Progress] Created: %d/%d | Ready: %d | Finished: %d", created, sandboxCount, ready, finished)
+		counts := tracker.Snapshot()[PhaseCreate]
+		line := fmt.Sprintf("[progress +%s] created=%d ready=%d failed=%d",
+			time.Since(testStartTime).Round(time.Second), counts.Created, counts.Ready, counts.Failed)
+		if writeToFileChannel != nil {
+			line += fmt.Sprintf(" | watch-queue=%d/%d", len(writeToFileChannel), cap(writeToFileChannel))
+		}
+		log.Print(line)
 		return nil
 	})
 
-	testStartTime := time.Now()
-
-	// Launch Sandbox creation workers
 	sandboxClient := dynamicClient.Resource(schema.GroupVersionResource{
 		Group:    "agents.x-k8s.io",
 		Version:  "v1beta1",
 		Resource: "sandboxes",
-	}).Namespace(*namespace)
+	}).Namespace(cfg.Namespace)
 
-	var names []types.NamespacedName
-	for i := 0; i < sandboxCount; i++ {
-		name := fmt.Sprintf("stress-%d", i)
-		names = append(names, types.NamespacedName{
-			Name:      name,
-			Namespace: *namespace,
-		})
+	phaseStart := time.Now()
+	phaseErr := runCreatePhase(ctx, cfg, tracker, sandboxClient)
+	phaseDuration := time.Since(phaseStart)
+	if phaseErr != nil {
+		log.Printf("create phase error: %v", phaseErr)
 	}
 
-	if _, err := ForkJoin(ctx, names, createConcurrency, func(id types.NamespacedName) (types.UID, error) {
+	// Give the watchers a moment to observe trailing events.
+	if ctx.Err() == nil {
+		time.Sleep(2 * time.Second)
+	}
+
+	// Write outputs even if the phase failed: partial data is still useful.
+	summary := buildSummary(runID, testStartTime, cfg, clusterInfo, tracker, phaseDuration)
+	if err := writeOutputs(cfg.OutputDir, summary, tracker); err != nil {
+		if phaseErr == nil {
+			phaseErr = err
+		} else {
+			log.Printf("failed to write outputs: %v", err)
+		}
+	}
+
+	printReport(summary, clusterInfo)
+
+	// Stop the watchers and wait for the watch log to be flushed,
+	// even when the phase failed.
+	cancel()
+	waitErr := taskRunner.Wait()
+
+	if phaseErr != nil {
+		return phaseErr
+	}
+	return waitErr
+}
+
+// runCreatePhase creates cfg.SandboxCount long-running sandboxes and waits for
+// them to become Ready. Readiness is the measured event; sandboxes sleep forever
+// so Finished latency is not conflated with the workload duration.
+func runCreatePhase(ctx context.Context, cfg Config, tracker *Tracker, sandboxClient dynamic.ResourceInterface) error {
+	log.Printf("[create] creating %d sandboxes (create-concurrency=%d)", cfg.SandboxCount, cfg.CreateConcurrency)
+
+	names := make([]types.NamespacedName, 0, cfg.SandboxCount)
+	for i := range cfg.SandboxCount {
+		names = append(names, types.NamespacedName{Name: fmt.Sprintf("stress-%d", i), Namespace: cfg.Namespace})
+	}
+
+	if _, err := ForkJoin(ctx, names, cfg.CreateConcurrency, func(id types.NamespacedName) (struct{}, error) {
 		sandbox := &unstructured.Unstructured{
 			Object: map[string]any{
 				"apiVersion": "agents.x-k8s.io/v1beta1",
@@ -252,9 +333,9 @@ func run(ctx context.Context) error {
 							"containers": []any{
 								map[string]any{
 									"name":            "main",
-									"image":           *imageName,
+									"image":           cfg.Image,
 									"imagePullPolicy": "IfNotPresent",
-									"command":         []string{"sleep", "5"},
+									"command":         []string{"sleep", "infinity"},
 								},
 							},
 						},
@@ -263,127 +344,310 @@ func run(ctx context.Context) error {
 			},
 		}
 
-		startTime := time.Now()
-		stateMu.Lock()
-		sandboxCreatedMap[id] = startTime
-		stateMu.Unlock()
-
-		created, err := sandboxClient.Create(ctx, sandbox, metav1.CreateOptions{})
+		tracker.Register(id, PhaseCreate)
+		_, err := sandboxClient.Create(ctx, sandbox, metav1.CreateOptions{})
+		tracker.MarkCreateReturned(id, err)
 		if err != nil {
-			return "", fmt.Errorf("creating sandbox %q: %w", id, err)
+			log.Printf("[create] failed to create sandbox %s: %v", id.Name, err)
 		}
-
-		endTime := time.Now()
-		stateMu.Lock()
-		sandboxCreatedSuccessMap[id] = endTime
-		stateMu.Unlock()
-
-		createdCount.Add(1)
-		return created.GetUID(), nil
+		// Per-sandbox create failures are recorded; do not abort the phase.
+		return struct{}{}, nil
 	}); err != nil {
 		return err
 	}
-	log.Printf("All Sandbox creation workers finished. Waiting for Sandboxes to settle...")
 
-	// Wait until all successfully created Sandboxes are Finished, or timeout.
-	// Since Pods sleep for 5 seconds, they should finish shortly after readiness.
+	log.Printf("[create] all create workers finished; waiting for Ready...")
 
+	lastReady := -1
+	lastProgress := time.Now()
 	for {
-		// Note: we don't necessarily see a pod become Ready before it is Finished,
-		// so we only wait for finished.
-
-		created := createdCount.Load()
-		finished := finishedCount.Load()
-		if finished == created {
-			log.Printf("All %d created Sandboxes reached Finished state", created)
-			break
+		counts := tracker.Snapshot()[PhaseCreate]
+		if counts.Created == 0 {
+			return fmt.Errorf("[create] all %d sandbox creations failed", counts.Failed)
 		}
-		if err := ctx.Err(); err != nil {
-			return err
+		if counts.Ready >= counts.Created {
+			log.Printf("[create] all %d created sandboxes are Ready (%d failed to create)", counts.Created, counts.Failed)
+			return nil
 		}
-		// This is not timing critical, the timestamps in the maps are authoritative
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	testDuration := time.Since(testStartTime)
-
-	// Generate summary & percentiles
-	stateMu.Lock()
-	var createDurations []time.Duration
-	var readyDurations []time.Duration
-	var finishedDurations []time.Duration
-
-	for name, createStart := range sandboxCreatedMap {
-		if createEnd, ok := sandboxCreatedSuccessMap[name]; ok {
-			createDurations = append(createDurations, createEnd.Sub(createStart))
+		if counts.Ready != lastReady {
+			lastReady = counts.Ready
+			lastProgress = time.Now()
 		}
-		if readyTime, ok := sandboxReadyMap[name]; ok {
-			readyDurations = append(readyDurations, readyTime.Sub(createStart))
+		if time.Since(lastProgress) > cfg.PerSandboxTimeout {
+			return fmt.Errorf("[create] stalled: %d/%d sandboxes Ready with no progress for %v", counts.Ready, counts.Created, cfg.PerSandboxTimeout)
 		}
-		if finishedTime, ok := sandboxFinishedMap[name]; ok {
-			finishedDurations = append(finishedDurations, finishedTime.Sub(createStart))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
 		}
 	}
-	stateMu.Unlock()
+}
 
-	summary := StressTestSummary{
-		TotalCreated:    int(createdCount.Load()),
-		TotalReady:      int(readyCount.Load()),
-		TotalFinished:   int(finishedCount.Load()),
-		TotalDurationMs: toMs(testDuration),
-		CreateLatencyStats: LatencyStats{
-			P50Ms: toMs(getPercentile(createDurations, 50)),
-			P90Ms: toMs(getPercentile(createDurations, 90)),
-			P95Ms: toMs(getPercentile(createDurations, 95)),
-			P99Ms: toMs(getPercentile(createDurations, 99)),
-		},
-		ReadyLatencyStats: LatencyStats{
-			P50Ms: toMs(getPercentile(readyDurations, 50)),
-			P90Ms: toMs(getPercentile(readyDurations, 90)),
-			P95Ms: toMs(getPercentile(readyDurations, 95)),
-			P99Ms: toMs(getPercentile(readyDurations, 99)),
-		},
-		FinishedLatencyStats: LatencyStats{
-			P50Ms: toMs(getPercentile(finishedDurations, 50)),
-			P90Ms: toMs(getPercentile(finishedDurations, 90)),
-			P95Ms: toMs(getPercentile(finishedDurations, 95)),
-			P99Ms: toMs(getPercentile(finishedDurations, 99)),
-		},
+// checkClusterCapacity warns when the test configuration will exceed spare cluster
+// pod capacity: in that case latency and throughput results measure queueing
+// for capacity rather than the sandbox launch pipeline.
+func checkClusterCapacity(cfg Config, info *ClusterInfo) {
+	needed := cfg.SandboxCount
+	spare := info.PodCapacity - info.PreexistingPods
+	if spare <= 0 {
+		log.Printf("WARNING: cluster has no spare pod slots.")
+		return
+	}
+	switch {
+	case needed > spare:
+		log.Printf("WARNING: test needs up to %d concurrent pods but the cluster only has %d spare pod slots; results will measure capacity queueing, not launch performance. Reduce --sandbox-count or add nodes.", needed, spare)
+	case needed > spare*9/10:
+		log.Printf("WARNING: test needs up to %d concurrent pods, over 90%% of the %d spare pod slots; scheduling may interfere with measurements.", needed, spare)
+	}
+}
+
+// inspectCluster records the apiserver version and counts worker-node pod
+// capacity / pre-existing pods. Control-plane nodes are excluded: their pod
+// slots are not available to sandboxes, and including them would understate
+// how close the test is to the capacity cliff.
+func inspectCluster(ctx context.Context, restConfig *rest.Config, dynamicClient dynamic.Interface) (*ClusterInfo, error) {
+	info := &ClusterInfo{}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("building discovery client: %w", err)
+	}
+	version, err := discoveryClient.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("getting server version: %w", err)
+	}
+	info.KubernetesVersion = version.GitVersion
+
+	nodeList, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+	controlPlaneNodes := make(map[string]struct{})
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if isControlPlaneNode(node) {
+			controlPlaneNodes[node.GetName()] = struct{}{}
+			continue
+		}
+		info.Nodes++
+		podCapacityString, found, err := unstructured.NestedString(node.Object, "status", "capacity", "pods")
+		if err != nil || !found {
+			continue
+		}
+		if podCapacity, err := strconv.Atoi(podCapacityString); err == nil {
+			info.PodCapacity += podCapacity
+		}
 	}
 
+	podList, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing pods: %w", err)
+	}
+	for i := range podList.Items {
+		nodeName, _, _ := unstructured.NestedString(podList.Items[i].Object, "spec", "nodeName")
+		if _, onControlPlane := controlPlaneNodes[nodeName]; onControlPlane {
+			continue
+		}
+		info.PreexistingPods++
+	}
+
+	return info, nil
+}
+
+// isControlPlaneNode reports whether a node carries a control-plane / master role label.
+func isControlPlaneNode(u *unstructured.Unstructured) bool {
+	labels := u.GetLabels()
+	if labels == nil {
+		return false
+	}
+	if _, ok := labels["node-role.kubernetes.io/control-plane"]; ok {
+		return true
+	}
+	if _, ok := labels["node-role.kubernetes.io/master"]; ok {
+		return true
+	}
+	return false
+}
+
+func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *ClusterInfo, tracker *Tracker, phaseDuration time.Duration) *Summary {
+	records := tracker.Records()
+
+	summary := &Summary{
+		RunID:     runID,
+		StartTime: startTime,
+		EndTime:   time.Now(),
+		Config:    cfg,
+		Cluster:   clusterInfo,
+		Phases:    make(map[Phase]*PhaseSummary),
+	}
+
+	ps := &PhaseSummary{
+		Requested:       cfg.SandboxCount,
+		DurationSeconds: phaseDuration.Seconds(),
+		Latency:         computeLatencyBreakdown(records),
+	}
+	var createTimes, readyTimes []time.Time
+	for i := range records {
+		rec := &records[i]
+		if !rec.CreateReturned.IsZero() {
+			ps.Created++
+			createTimes = append(createTimes, rec.CreateReturned)
+		}
+		if !rec.SandboxReady.IsZero() {
+			ps.Ready++
+			readyTimes = append(readyTimes, rec.SandboxReady)
+		}
+		if rec.Error != "" {
+			ps.Failed++
+		}
+	}
+	ps.CreateThroughput = computeThroughputStats(createTimes)
+	ps.ReadyThroughput = computeThroughputStats(readyTimes)
+	if clusterInfo != nil {
+		ps.CreateThroughputPerNode = ps.CreateThroughput.perNode(clusterInfo.Nodes)
+		ps.ReadyThroughputPerNode = ps.ReadyThroughput.perNode(clusterInfo.Nodes)
+	}
+	summary.Phases[PhaseCreate] = ps
+
+	return summary
+}
+
+// sandboxRecordJSON builds the sandboxes.jsonl object for a record:
+// zero times and empty strings are omitted, and *Ms offsets from CreateCalled
+// are added for convenient offline analysis.
+func sandboxRecordJSON(rec *SandboxRecord) map[string]any {
+	out := map[string]any{
+		"name":      rec.Name,
+		"namespace": rec.Namespace,
+		"phase":     rec.Phase,
+	}
+	if rec.Error != "" {
+		out["error"] = rec.Error
+	}
+
+func sandboxRecordJSON(rec *SandboxRecord) sandboxRecordExport {
+	msSinceCreate := func(t time.Time) *float64 {
+		if t.IsZero() || rec.CreateCalled.IsZero() {
+			return nil
+		}
+		ms := toMs(t.Sub(rec.CreateCalled))
+		return &ms
+	}
+	return sandboxRecordExport{
+		SandboxRecord:  rec,
+		CreateAckMs:    msSinceCreate(rec.CreateReturned),
+		PodCreatedMs:   msSinceCreate(rec.PodCreated),
+		PodScheduledMs: msSinceCreate(rec.PodScheduled),
+		PodRunningMs:   msSinceCreate(rec.PodRunning),
+		PodReadyMs:     msSinceCreate(rec.PodReady),
+		SandboxReadyMs: msSinceCreate(rec.SandboxReady),
+	}
+}
+
+func writeOutputs(outputDir string, summary *Summary, tracker *Tracker) error {
+	records := tracker.Records()
+	slices.SortFunc(records, func(a, b SandboxRecord) int { return a.CreateCalled.Compare(b.CreateCalled) })
+
+	// Per-sandbox milestone records.
+	recordsFile, err := os.Create(filepath.Join(outputDir, "sandboxes.jsonl"))
+	if err != nil {
+		return fmt.Errorf("failed to create sandboxes.jsonl: %w", err)
+	}
+	defer recordsFile.Close()
+	encoder := json.NewEncoder(recordsFile)
+	for i := range records {
+		if err := encoder.Encode(sandboxRecordJSON(&records[i])); err != nil {
+			return fmt.Errorf("failed to encode sandbox record: %w", err)
+		}
+	}
+
+	// Per-second timeseries.
+	timeseriesFile, err := os.Create(filepath.Join(outputDir, "timeseries.jsonl"))
+	if err != nil {
+		return fmt.Errorf("failed to create timeseries.jsonl: %w", err)
+	}
+	defer timeseriesFile.Close()
+	timeseriesEncoder := json.NewEncoder(timeseriesFile)
+	for _, point := range buildTimeseries(records) {
+		if err := timeseriesEncoder.Encode(point); err != nil {
+			return fmt.Errorf("failed to encode timeseries point: %w", err)
+		}
+	}
+
+	// Aggregate summary.
 	summaryBytes, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal summary: %w", err)
 	}
-
-	summaryPath := filepath.Join(outputDir, "summary.json")
-	if err := os.WriteFile(summaryPath, summaryBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(outputDir, "summary.json"), summaryBytes, 0644); err != nil {
 		return fmt.Errorf("failed to write summary file: %w", err)
 	}
 
-	fmt.Println("\n================= STRESS TEST RESULTS =================")
-	fmt.Printf("Total Duration:      %.2fs\n", testDuration.Seconds())
-	fmt.Printf("Created:            %d sandboxes\n", summary.TotalCreated)
-	fmt.Printf("Ready:              %d sandboxes\n", summary.TotalReady)
-	fmt.Printf("Finished:           %d sandboxes\n", summary.TotalFinished)
-	fmt.Println("\nLatency Percentiles (ms):")
-	fmt.Printf("  Create:   p50=%.1fms, p90=%.1fms, p95=%.1fms, p99=%.1fms\n",
-		summary.CreateLatencyStats.P50Ms, summary.CreateLatencyStats.P90Ms,
-		summary.CreateLatencyStats.P95Ms, summary.CreateLatencyStats.P99Ms)
-	fmt.Printf("  Ready:    p50=%.1fms, p90=%.1fms, p95=%.1fms, p99=%.1fms\n",
-		summary.ReadyLatencyStats.P50Ms, summary.ReadyLatencyStats.P90Ms,
-		summary.ReadyLatencyStats.P95Ms, summary.ReadyLatencyStats.P99Ms)
-	fmt.Printf("  Finished: p50=%.1fms, p90=%.1fms, p95=%.1fms, p99=%.1fms\n",
-		summary.FinishedLatencyStats.P50Ms, summary.FinishedLatencyStats.P90Ms,
-		summary.FinishedLatencyStats.P95Ms, summary.FinishedLatencyStats.P99Ms)
-	fmt.Println("=======================================================")
-
-	fmt.Println("\nWrote detailed events to:", outputDir)
-
-	cancel()
-	return taskRunner.Wait()
+	return nil
 }
 
+func formatLatency(stats *LatencyStats) string {
+	if stats == nil {
+		return "n=0"
+	}
+	return fmt.Sprintf("n=%-5d min=%-8s mean=%-8s p50=%-8s p90=%-8s p99=%-8s max=%s",
+		stats.Count, formatMs(stats.MinMs), formatMs(stats.MeanMs), formatMs(stats.P50Ms), formatMs(stats.P90Ms), formatMs(stats.P99Ms), formatMs(stats.MaxMs))
+}
+
+func formatMs(ms float64) string {
+	if ms >= 10000 {
+		return fmt.Sprintf("%.1fs", ms/1000)
+	}
+	return fmt.Sprintf("%.0fms", ms)
+}
+
+func formatThroughput(stats *ThroughputStats) string {
+	if stats == nil {
+		return "n/a"
+	}
+	return fmt.Sprintf("overall=%.2f/s steady=%.2f/s best10s=%.2f/s best60s=%.2f/s (n=%d over %.1fs)",
+		stats.OverallPerSecond, stats.SteadyStatePerSecond, stats.Best10sPerSecond, stats.Best60sPerSecond, stats.Count, stats.DurationSeconds)
+}
+
+func formatPerNodeRates(rates *PerNodeRates) string {
+	if rates == nil {
+		return "n/a"
+	}
+	return fmt.Sprintf("overall=%.2f/s steady=%.2f/s best10s=%.2f/s best60s=%.2f/s (%d worker nodes)",
+		rates.OverallPerSecond, rates.SteadyStatePerSecond, rates.Best10sPerSecond, rates.Best60sPerSecond, rates.WorkerNodes)
+}
+
+func printReport(summary *Summary, clusterInfo *ClusterInfo) {
+	fmt.Println("\n================= STRESS TEST RESULTS =================")
+	if clusterInfo != nil {
+		fmt.Printf("Cluster: kubernetes %s, %d worker nodes, pod capacity %d, %d pre-existing worker pods\n",
+			clusterInfo.KubernetesVersion, clusterInfo.Nodes, clusterInfo.PodCapacity, clusterInfo.PreexistingPods)
+	}
+
+	ps, ok := summary.Phases[PhaseCreate]
+	if !ok {
+		fmt.Println("(no results)")
+		fmt.Println("=======================================================")
+		return
+	}
+	fmt.Printf("\n--- create: %d requested, %d created, %d ready, %d failed (%.1fs) ---\n",
+		ps.Requested, ps.Created, ps.Ready, ps.Failed, ps.DurationSeconds)
+	fmt.Println("  Launch latency breakdown:")
+	b := ps.Latency
+	fmt.Printf("    create ack (apiserver):        %s\n", formatLatency(b.CreateAck))
+	fmt.Printf("    create -> pod created:         %s\n", formatLatency(b.CreateToPodCreated))
+	fmt.Printf("    pod created -> scheduled:      %s\n", formatLatency(b.PodCreatedToScheduled))
+	fmt.Printf("    scheduled -> pod running:      %s\n", formatLatency(b.ScheduledToPodRunning))
+	fmt.Printf("    pod running -> pod ready:      %s\n", formatLatency(b.PodRunningToPodReady))
+	fmt.Printf("    pod ready -> sandbox ready:    %s\n", formatLatency(b.PodReadyToSandboxReady))
+	fmt.Printf("    END-TO-END (create -> ready):  %s\n", formatLatency(b.EndToEndReady))
+	fmt.Printf("  create throughput:               %s\n", formatThroughput(ps.CreateThroughput))
+	fmt.Printf("  ready throughput:                %s\n", formatThroughput(ps.ReadyThroughput))
+	fmt.Printf("  ready throughput per node:       %s\n", formatPerNodeRates(ps.ReadyThroughputPerNode))
+	fmt.Println("\n=======================================================")
+	fmt.Println("Detailed outputs: summary.json, sandboxes.jsonl, timeseries.jsonl, watch.jsonl.gz")
+}
 func getRestConfig() (*rest.Config, error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
@@ -457,10 +721,8 @@ func watchResource(ctx context.Context, dynamicClient dynamic.Interface, gvr sch
 				}
 
 				if event.Object != nil {
-					if u, ok := event.Object.(*unstructured.Unstructured); ok {
+					if u, ok := event.Object.(metav1.Object); ok {
 						resourceVersion = u.GetResourceVersion()
-					} else if metaObj, ok := event.Object.(metav1.Object); ok {
-						resourceVersion = metaObj.GetResourceVersion()
 					} else {
 						return fmt.Errorf("unhandled type in event %T", event.Object)
 					}
@@ -481,75 +743,8 @@ func watchResource(ctx context.Context, dynamicClient dynamic.Interface, gvr sch
 	}
 }
 
-func handleWatchEvent(gvr schema.GroupVersionResource, _ watch.EventType, u *unstructured.Unstructured) {
-	if gvr.Resource != "sandboxes" {
-		return
-	}
-
-	id := types.NamespacedName{
-		Name:      u.GetName(),
-		Namespace: u.GetNamespace(),
-	}
-	stateMu.Lock()
-	defer stateMu.Unlock()
-
-	if _, ok := sandboxCreatedMap[id]; !ok {
-		return
-	}
-
-	if isSandboxReady(u) {
-		if _, ok := sandboxReadyMap[id]; !ok {
-			sandboxReadyMap[id] = time.Now()
-			readyCount.Add(1)
-		}
-	}
-
-	if isSandboxFinished(u) {
-		if _, ok := sandboxFinishedMap[id]; !ok {
-			sandboxFinishedMap[id] = time.Now()
-			finishedCount.Add(1)
-		}
-	}
-}
-
-func isSandboxReady(obj *unstructured.Unstructured) bool {
-	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
-	if err != nil || !found {
-		return false
-	}
-	for _, condVal := range conditions {
-		cond, ok := condVal.(map[string]any)
-		if !ok {
-			continue
-		}
-		cType, _ := cond["type"].(string)
-		cStatus, _ := cond["status"].(string)
-		if cType == "Ready" && cStatus == "True" {
-			return true
-		}
-	}
-	return false
-}
-
-func isSandboxFinished(obj *unstructured.Unstructured) bool {
-	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
-	if err != nil || !found {
-		return false
-	}
-	for _, condVal := range conditions {
-		cond, ok := condVal.(map[string]any)
-		if !ok {
-			continue
-		}
-		cType, _ := cond["type"].(string)
-		cStatus, _ := cond["status"].(string)
-		if cType == "Finished" && cStatus == "True" {
-			return true
-		}
-	}
-	return false
-}
-
+// runWriter drains eventChan to a gzip-compressed JSONL file.
+// The full watch stream (particularly pods and events) is large at scale, so we compress it.
 func runWriter(ctx context.Context, filePath string, eventChan <-chan WatchEventRecord) error {
 	f, err := os.Create(filePath)
 	if err != nil {
@@ -557,9 +752,13 @@ func runWriter(ctx context.Context, filePath string, eventChan <-chan WatchEvent
 	}
 	defer f.Close()
 
-	bufWriter := bufio.NewWriter(f)
+	bufWriter := bufio.NewWriterSize(f, 1<<20)
 	defer bufWriter.Flush()
-	encoder := json.NewEncoder(bufWriter)
+
+	gzWriter := gzip.NewWriter(bufWriter)
+	defer gzWriter.Close()
+
+	encoder := json.NewEncoder(gzWriter)
 
 	for {
 		select {
@@ -568,26 +767,19 @@ func runWriter(ctx context.Context, filePath string, eventChan <-chan WatchEvent
 				return fmt.Errorf("failed to encode event: %w", err)
 			}
 		case <-ctx.Done():
-			return ctx.Err()
+			// Drain any events that are already queued before exiting.
+			for {
+				select {
+				case event := <-eventChan:
+					if err := encoder.Encode(event); err != nil {
+						return fmt.Errorf("failed to encode event: %w", err)
+					}
+				default:
+					return ctx.Err()
+				}
+			}
 		}
 	}
-}
-
-func getPercentile(durations []time.Duration, pct float64) time.Duration {
-	if len(durations) == 0 {
-		return 0
-	}
-	slices.Sort(durations)
-	// Note this is not accurate for small N, but should be fine for large N.
-	idx := int(float64(len(durations)) * pct / 100.0)
-	if idx >= len(durations) {
-		idx = len(durations) - 1
-	}
-	return durations[idx]
-}
-
-func toMs(d time.Duration) float64 {
-	return float64(d) / float64(time.Millisecond)
 }
 
 // TaskRunner manages multiple tasks that are run in parallel,
@@ -734,7 +926,7 @@ func (r *TaskRunner) Error() error {
 	for _, task := range r.tasks {
 		task.mutex.Lock()
 		if task.err != nil {
-			if !errors.Is(task.err, context.Canceled) {
+			if !errors.Is(task.err, context.Canceled) && !errors.Is(task.err, context.DeadlineExceeded) {
 				errs = append(errs, task.err)
 			}
 		}
@@ -763,6 +955,7 @@ func (r *TaskRunner) Wait() error {
 		if allDone {
 			break
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	return r.Error()

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -513,18 +513,18 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 	return summary
 }
 
-// sandboxRecordJSON builds the sandboxes.jsonl object for a record:
-// zero times and empty strings are omitted, and *Ms offsets from CreateCalled
-// are added for convenient offline analysis.
-func sandboxRecordJSON(rec *SandboxRecord) map[string]any {
-	out := map[string]any{
-		"name":      rec.Name,
-		"namespace": rec.Namespace,
-		"phase":     rec.Phase,
-	}
-	if rec.Error != "" {
-		out["error"] = rec.Error
-	}
+// sandboxRecordExport is the sandboxes.jsonl shape: SandboxRecord fields
+// (flattened via embedding; zeros omitted by omitempty/omitzero tags) plus
+// *Ms offsets from CreateCalled for offline analysis.
+type sandboxRecordExport struct {
+	*SandboxRecord
+	CreateAckMs    *float64 `json:"createAckMs,omitempty"`
+	PodCreatedMs   *float64 `json:"podCreatedMs,omitempty"`
+	PodScheduledMs *float64 `json:"podScheduledMs,omitempty"`
+	PodRunningMs   *float64 `json:"podRunningMs,omitempty"`
+	PodReadyMs     *float64 `json:"podReadyMs,omitempty"`
+	SandboxReadyMs *float64 `json:"sandboxReadyMs,omitempty"`
+}
 
 func sandboxRecordJSON(rec *SandboxRecord) sandboxRecordExport {
 	msSinceCreate := func(t time.Time) *float64 {

--- a/test/stress/stats.go
+++ b/test/stress/stats.go
@@ -1,0 +1,303 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"math"
+	"slices"
+	"time"
+)
+
+// LatencyStats holds summary statistics for a set of measured durations.
+type LatencyStats struct {
+	Count  int     `json:"count"`
+	MinMs  float64 `json:"minMs"`
+	MeanMs float64 `json:"meanMs"`
+	P50Ms  float64 `json:"p50Ms"`
+	P90Ms  float64 `json:"p90Ms"`
+	P95Ms  float64 `json:"p95Ms"`
+	P99Ms  float64 `json:"p99Ms"`
+	MaxMs  float64 `json:"maxMs"`
+}
+
+// computeLatencyStats summarizes the given durations; returns nil if there are none.
+func computeLatencyStats(durations []time.Duration) *LatencyStats {
+	if len(durations) == 0 {
+		return nil
+	}
+	sorted := slices.Clone(durations)
+	slices.Sort(sorted)
+
+	var sum time.Duration
+	for _, d := range sorted {
+		sum += d
+	}
+
+	return &LatencyStats{
+		Count:  len(sorted),
+		MinMs:  toMs(sorted[0]),
+		MeanMs: toMs(sum / time.Duration(len(sorted))),
+		P50Ms:  toMs(percentileSorted(sorted, 50)),
+		P90Ms:  toMs(percentileSorted(sorted, 90)),
+		P95Ms:  toMs(percentileSorted(sorted, 95)),
+		P99Ms:  toMs(percentileSorted(sorted, 99)),
+		MaxMs:  toMs(sorted[len(sorted)-1]),
+	}
+}
+
+// percentileSorted returns the nearest-rank percentile of an already-sorted slice.
+func percentileSorted(sorted []time.Duration, pct float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := min(max(int(math.Ceil(pct/100.0*float64(len(sorted)))), 1), len(sorted))
+	return sorted[rank-1] // nearest-rank, 1-indexed
+}
+
+func toMs(d time.Duration) float64 {
+	return float64(d) / float64(time.Millisecond)
+}
+
+// LatencyBreakdown decomposes end-to-end sandbox launch latency into stages,
+// each computed from client-observed watch timestamps.
+type LatencyBreakdown struct {
+	// CreateAck: Create call issued -> Create call returned (apiserver write path).
+	CreateAck *LatencyStats `json:"createAck,omitempty"`
+	// CreateToPodCreated: Create call issued -> backing Pod first observed
+	// (sandbox controller reconcile + Pod write).
+	CreateToPodCreated *LatencyStats `json:"createToPodCreated,omitempty"`
+	// PodCreatedToScheduled: Pod first observed -> PodScheduled=True (scheduler).
+	PodCreatedToScheduled *LatencyStats `json:"podCreatedToScheduled,omitempty"`
+	// ScheduledToPodRunning: PodScheduled=True -> phase=Running (kubelet, image pull, container start).
+	ScheduledToPodRunning *LatencyStats `json:"scheduledToPodRunning,omitempty"`
+	// PodRunningToPodReady: phase=Running -> Pod Ready=True (readiness propagation).
+	PodRunningToPodReady *LatencyStats `json:"podRunningToPodReady,omitempty"`
+	// PodReadyToSandboxReady: Pod Ready=True -> Sandbox Ready=True (sandbox controller status propagation).
+	PodReadyToSandboxReady *LatencyStats `json:"podReadyToSandboxReady,omitempty"`
+	// EndToEndReady: Create call issued -> Sandbox Ready=True.
+	EndToEndReady *LatencyStats `json:"endToEndReady,omitempty"`
+}
+
+func computeLatencyBreakdown(records []SandboxRecord) LatencyBreakdown {
+	interval := func(from, to func(*SandboxRecord) time.Time) *LatencyStats {
+		var durations []time.Duration
+		for i := range records {
+			rec := &records[i]
+			start, end := from(rec), to(rec)
+			if start.IsZero() || end.IsZero() {
+				continue
+			}
+			durations = append(durations, end.Sub(start))
+		}
+		return computeLatencyStats(durations)
+	}
+
+	createCalled := func(r *SandboxRecord) time.Time { return r.CreateCalled }
+	createReturned := func(r *SandboxRecord) time.Time { return r.CreateReturned }
+	podCreated := func(r *SandboxRecord) time.Time { return r.PodCreated }
+	podScheduled := func(r *SandboxRecord) time.Time { return r.PodScheduled }
+	podRunning := func(r *SandboxRecord) time.Time { return r.PodRunning }
+	podReady := func(r *SandboxRecord) time.Time { return r.PodReady }
+	sandboxReady := func(r *SandboxRecord) time.Time { return r.SandboxReady }
+
+	return LatencyBreakdown{
+		CreateAck:              interval(createCalled, createReturned),
+		CreateToPodCreated:     interval(createCalled, podCreated),
+		PodCreatedToScheduled:  interval(podCreated, podScheduled),
+		ScheduledToPodRunning:  interval(podScheduled, podRunning),
+		PodRunningToPodReady:   interval(podRunning, podReady),
+		PodReadyToSandboxReady: interval(podReady, sandboxReady),
+		EndToEndReady:          interval(createCalled, sandboxReady),
+	}
+}
+
+// ThroughputStats summarizes the rate at which a set of events occurred.
+type ThroughputStats struct {
+	Count           int     `json:"count"`
+	DurationSeconds float64 `json:"durationSeconds"`
+	// OverallPerSecond is count / (last - first).
+	OverallPerSecond float64 `json:"overallPerSecond"`
+	// SteadyStatePerSecond excludes the first and last 10% of events,
+	// removing ramp-up and drain effects.
+	SteadyStatePerSecond float64 `json:"steadyStatePerSecond"`
+	// BestWindow rates report the highest rate seen in any sliding window.
+	Best10sPerSecond float64 `json:"best10sPerSecond"`
+	Best60sPerSecond float64 `json:"best60sPerSecond"`
+}
+
+// PerNodeRates is a ThroughputStats scaled to a single worker node.
+// Node-side pod startup is typically the bottleneck, so aggregate throughput
+// scales with worker count; per-node rates are comparable across cluster sizes.
+type PerNodeRates struct {
+	WorkerNodes          int     `json:"workerNodes"`
+	OverallPerSecond     float64 `json:"overallPerSecond"`
+	SteadyStatePerSecond float64 `json:"steadyStatePerSecond"`
+	Best10sPerSecond     float64 `json:"best10sPerSecond"`
+	Best60sPerSecond     float64 `json:"best60sPerSecond"`
+}
+
+// perNode divides the rates across workerNodes; returns nil if either is unknown.
+func (t *ThroughputStats) perNode(workerNodes int) *PerNodeRates {
+	if t == nil || workerNodes <= 0 {
+		return nil
+	}
+	return &PerNodeRates{
+		WorkerNodes:          workerNodes,
+		OverallPerSecond:     t.OverallPerSecond / float64(workerNodes),
+		SteadyStatePerSecond: t.SteadyStatePerSecond / float64(workerNodes),
+		Best10sPerSecond:     t.Best10sPerSecond / float64(workerNodes),
+		Best60sPerSecond:     t.Best60sPerSecond / float64(workerNodes),
+	}
+}
+
+// computeThroughputStats summarizes the rate of the given event times; returns nil if there are fewer than 2.
+func computeThroughputStats(times []time.Time) *ThroughputStats {
+	if len(times) < 2 {
+		return nil
+	}
+	sorted := slices.Clone(times)
+	slices.SortFunc(sorted, func(a, b time.Time) int { return a.Compare(b) })
+
+	n := len(sorted)
+	duration := sorted[n-1].Sub(sorted[0])
+
+	stats := &ThroughputStats{
+		Count:           n,
+		DurationSeconds: duration.Seconds(),
+	}
+	if duration > 0 {
+		stats.OverallPerSecond = float64(n) / duration.Seconds()
+	}
+
+	// Steady state: middle 80% of events by rank.
+	lo, hi := n/10, n-1-n/10
+	if hi > lo {
+		steadyDuration := sorted[hi].Sub(sorted[lo])
+		if steadyDuration > 0 {
+			stats.SteadyStatePerSecond = float64(hi-lo+1) / steadyDuration.Seconds()
+		}
+	}
+
+	stats.Best10sPerSecond = bestWindowRate(sorted, 10*time.Second)
+	stats.Best60sPerSecond = bestWindowRate(sorted, 60*time.Second)
+	return stats
+}
+
+// bestWindowRate returns the highest events-per-second seen in any sliding window of the given size.
+func bestWindowRate(sorted []time.Time, window time.Duration) float64 {
+	best := 0
+	i := 0
+	for j := range sorted {
+		for sorted[j].Sub(sorted[i]) > window {
+			i++
+		}
+		if count := j - i + 1; count > best {
+			best = count
+		}
+	}
+	return float64(best) / window.Seconds()
+}
+
+// TimeseriesPoint is one line of timeseries.jsonl: per-second event counts
+// plus gauges, useful for plotting throughput and detecting stalls.
+type TimeseriesPoint struct {
+	Time          time.Time `json:"time"`
+	OffsetSeconds int       `json:"offsetSeconds"`
+
+	CreateCalled int `json:"createCalled,omitempty"`
+	PodCreated   int `json:"podCreated,omitempty"`
+	PodScheduled int `json:"podScheduled,omitempty"`
+	PodRunning   int `json:"podRunning,omitempty"`
+	SandboxReady int `json:"sandboxReady,omitempty"`
+	PodDeleted   int `json:"podDeleted,omitempty"`
+
+	// LivePods is the number of test Pods that exist at the end of this second
+	// (observed created and not yet observed deleted).
+	LivePods int `json:"livePods"`
+	// CumulativeReady is the total number of sandboxes observed Ready so far.
+	CumulativeReady int `json:"cumulativeReady"`
+}
+
+// buildTimeseries aggregates per-sandbox milestones into per-second buckets.
+func buildTimeseries(records []SandboxRecord) []TimeseriesPoint {
+	var base, last time.Time
+	for i := range records {
+		for _, ts := range []time.Time{records[i].CreateCalled, records[i].SandboxReady, records[i].PodDeleted} {
+			if ts.IsZero() {
+				continue
+			}
+			if base.IsZero() || ts.Before(base) {
+				base = ts
+			}
+			if ts.After(last) {
+				last = ts
+			}
+		}
+	}
+	if base.IsZero() {
+		return nil
+	}
+
+	base = base.Truncate(time.Second)
+	numBuckets := int(last.Sub(base)/time.Second) + 1
+	points := make([]TimeseriesPoint, numBuckets)
+	for i := range points {
+		points[i].Time = base.Add(time.Duration(i) * time.Second)
+		points[i].OffsetSeconds = i
+	}
+
+	bucket := func(ts time.Time) int {
+		if ts.IsZero() {
+			return -1
+		}
+		idx := int(ts.Sub(base) / time.Second)
+		if idx < 0 || idx >= numBuckets {
+			return -1
+		}
+		return idx
+	}
+
+	for i := range records {
+		rec := &records[i]
+		if idx := bucket(rec.CreateCalled); idx >= 0 {
+			points[idx].CreateCalled++
+		}
+		if idx := bucket(rec.PodCreated); idx >= 0 {
+			points[idx].PodCreated++
+		}
+		if idx := bucket(rec.PodScheduled); idx >= 0 {
+			points[idx].PodScheduled++
+		}
+		if idx := bucket(rec.PodRunning); idx >= 0 {
+			points[idx].PodRunning++
+		}
+		if idx := bucket(rec.SandboxReady); idx >= 0 {
+			points[idx].SandboxReady++
+		}
+		if idx := bucket(rec.PodDeleted); idx >= 0 {
+			points[idx].PodDeleted++
+		}
+	}
+
+	livePods := 0
+	cumulativeReady := 0
+	for i := range points {
+		livePods += points[i].PodCreated - points[i].PodDeleted
+		cumulativeReady += points[i].SandboxReady
+		points[i].LivePods = livePods
+		points[i].CumulativeReady = cumulativeReady
+	}
+	return points
+}

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -1,0 +1,418 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// Phase identifies which part of the stress test a Sandbox belongs to.
+type Phase string
+
+const (
+	// PhaseCreate is the single create-and-wait phase used by --sandbox-count.
+	PhaseCreate Phase = "create"
+)
+
+// Future is a future value that can be notified and waited on.
+type Future[T any] struct {
+	ch    chan struct{}
+	val   T
+	done  bool
+	mutex sync.Mutex
+}
+
+func newFuture[T any]() *Future[T] {
+	return &Future[T]{
+		ch: make(chan struct{}),
+	}
+}
+
+// Done marks the future complete with the value t.
+func (f *Future[T]) Done(t T) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	f.val = t
+
+	if !f.done {
+		f.done = true
+
+		close(f.ch)
+	}
+}
+
+// Wait blocks until Done is called or ctx is cancelled.
+func (f *Future[T]) Wait(ctx context.Context) (T, error) {
+	var zero T
+	select {
+	case <-f.ch:
+		return f.val, nil
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	}
+}
+
+// SandboxRecord tracks the lifecycle milestones of a single Sandbox and its backing Pod.
+// Client-observed timestamps are taken with time.Now() when we issue a request or observe
+// a watch event; server timestamps come from the objects themselves (typically 1s granularity).
+// All fields are guarded by the Tracker mutex.
+type SandboxRecord struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Phase     Phase  `json:"phase"`
+
+	// Client-observed milestones.
+	CreateCalled    time.Time `json:"createCalled,omitzero"`    // just before the Create API call
+	CreateReturned  time.Time `json:"createReturned,omitzero"`  // Create API call returned successfully
+	PodCreated      time.Time `json:"podCreated,omitzero"`      // first watch event for the backing Pod
+	PodScheduled    time.Time `json:"podScheduled,omitzero"`    // Pod observed with condition PodScheduled=True
+	PodRunning      time.Time `json:"podRunning,omitzero"`      // Pod observed with phase=Running
+	PodReady        time.Time `json:"podReady,omitzero"`        // Pod observed with condition Ready=True
+	SandboxReady    time.Time `json:"sandboxReady,omitzero"`    // Sandbox observed with condition Ready=True
+	SandboxFinished time.Time `json:"sandboxFinished,omitzero"` // Sandbox observed with condition Finished=True
+	DeleteCalled    time.Time `json:"deleteCalled,omitzero"`    // just before the Delete API call
+	PodDeleted      time.Time `json:"podDeleted,omitzero"`      // watch DELETED event for the backing Pod
+	SandboxDeleted  time.Time `json:"sandboxDeleted,omitzero"`  // watch DELETED event for the Sandbox
+
+	// Server-reported timestamps for cross-checking watch lag
+	// (1s granularity; may be skewed relative to the client clock).
+	ServerSandboxCreated time.Time `json:"serverSandboxCreated,omitzero"` // sandbox metadata.creationTimestamp
+	ServerPodCreated     time.Time `json:"serverPodCreated,omitzero"`     // pod metadata.creationTimestamp
+	ServerPodScheduled   time.Time `json:"serverPodScheduled,omitzero"`   // PodScheduled condition lastTransitionTime
+	ServerPodReady       time.Time `json:"serverPodReady,omitzero"`       // pod Ready condition lastTransitionTime
+	ServerSandboxReady   time.Time `json:"serverSandboxReady,omitzero"`   // sandbox Ready condition lastTransitionTime
+
+	Error string `json:"error,omitempty"`
+
+	ready *Future[bool]
+	gone  *Future[bool]
+}
+
+// Tracker correlates watch events with the Sandboxes created by the test,
+// building a per-sandbox lifecycle record.
+type Tracker struct {
+	mu      sync.Mutex
+	records map[types.NamespacedName]*SandboxRecord
+}
+
+func NewTracker() *Tracker {
+	return &Tracker{
+		records: make(map[types.NamespacedName]*SandboxRecord),
+	}
+}
+
+// Register creates a record for a Sandbox we are about to create,
+// stamping CreateCalled with the current time.
+func (t *Tracker) Register(id types.NamespacedName, phase Phase) *SandboxRecord {
+	rec := &SandboxRecord{
+		Name:         id.Name,
+		Namespace:    id.Namespace,
+		Phase:        phase,
+		CreateCalled: time.Now(),
+	}
+	rec.ready = newFuture[bool]()
+	rec.gone = newFuture[bool]()
+	t.mu.Lock()
+	t.records[id] = rec
+	t.mu.Unlock()
+	return rec
+}
+
+func (t *Tracker) mutate(id types.NamespacedName, fn func(rec *SandboxRecord)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	rec, ok := t.records[id]
+	if !ok {
+		return
+	}
+	fn(rec)
+}
+
+// MarkCreateReturned records the completion of the Create API call.
+func (t *Tracker) MarkCreateReturned(id types.NamespacedName, err error) {
+	now := time.Now()
+	t.mutate(id, func(rec *SandboxRecord) {
+		if err != nil {
+			t.setErrorLocked(rec, fmt.Sprintf("create failed: %v", err))
+			return
+		}
+		rec.CreateReturned = now
+	})
+}
+
+// MarkDeleteCalled records that we issued a Delete for the Sandbox.
+func (t *Tracker) MarkDeleteCalled(id types.NamespacedName) {
+	now := time.Now()
+	t.mutate(id, func(rec *SandboxRecord) {
+		if rec.DeleteCalled.IsZero() {
+			rec.DeleteCalled = now
+		}
+	})
+}
+
+// MarkError records a per-sandbox error (first error wins).
+func (t *Tracker) MarkError(id types.NamespacedName, msg string) {
+	t.mutate(id, func(rec *SandboxRecord) {
+		t.setErrorLocked(rec, msg)
+	})
+}
+
+// MarkGone unblocks WaitGone without a watch event, e.g. when a Delete call
+// finds the sandbox already absent.
+func (t *Tracker) MarkGone(id types.NamespacedName) {
+	t.mutate(id, func(rec *SandboxRecord) {
+		rec.gone.Done(true)
+	})
+}
+
+// setErrorLocked must be called with t.mu held.
+func (t *Tracker) setErrorLocked(rec *SandboxRecord, msg string) {
+	if rec.Error == "" {
+		rec.Error = msg
+	}
+}
+
+// WaitReady blocks until the Sandbox is observed Ready, the timeout expires, or ctx is done.
+func (t *Tracker) WaitReady(ctx context.Context, id types.NamespacedName, timeout time.Duration) error {
+	rec := t.get(id)
+	if rec == nil {
+		return fmt.Errorf("no record for sandbox %v", id)
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := rec.ready.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("timed out after %v waiting for sandbox %v to become ready", timeout, id)
+	}
+	return nil
+}
+
+// WaitGone blocks until the backing Pod is observed deleted (freeing cluster capacity),
+// the timeout expires, or ctx is done.
+func (t *Tracker) WaitGone(ctx context.Context, id types.NamespacedName, timeout time.Duration) error {
+	rec := t.get(id)
+	if rec == nil {
+		return fmt.Errorf("no record for sandbox %v", id)
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := rec.gone.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("timed out after %v waiting for sandbox %v pod to be deleted", timeout, id)
+	}
+	return err
+}
+
+func (t *Tracker) get(id types.NamespacedName) *SandboxRecord {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.records[id]
+}
+
+// Records returns a copy of all records, safe to read without locking.
+func (t *Tracker) Records() []SandboxRecord {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]SandboxRecord, 0, len(t.records))
+	for _, rec := range t.records {
+		c := *rec
+		// Drop waitables so the copy does not share channels with the live record.
+		c.ready = nil
+		c.gone = nil
+		out = append(out, c)
+	}
+	return out
+}
+
+// PhaseCounts summarizes progress for one phase.
+type PhaseCounts struct {
+	Registered int
+	Created    int
+	Ready      int
+	Finished   int
+	Deleted    int
+	Failed     int
+}
+
+// Snapshot returns per-phase progress counts.
+func (t *Tracker) Snapshot() map[Phase]PhaseCounts {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make(map[Phase]PhaseCounts)
+	for _, rec := range t.records {
+		c := out[rec.Phase]
+		c.Registered++
+		if !rec.CreateReturned.IsZero() {
+			c.Created++
+		}
+		if !rec.SandboxReady.IsZero() {
+			c.Ready++
+		}
+		if !rec.SandboxFinished.IsZero() {
+			c.Finished++
+		}
+		if !rec.PodDeleted.IsZero() || !rec.SandboxDeleted.IsZero() {
+			c.Deleted++
+		}
+		if rec.Error != "" {
+			c.Failed++
+		}
+		out[rec.Phase] = c
+	}
+	return out
+}
+
+// HandleWatchEvent updates milestone records from a watch event.
+// It must be fast: it runs on the watch decode path.
+func (t *Tracker) HandleWatchEvent(resource string, eventType watch.EventType, u *unstructured.Unstructured) {
+	switch resource {
+	case "sandboxes":
+		t.handleSandboxEvent(eventType, u)
+	case "pods":
+		t.handlePodEvent(eventType, u)
+	}
+}
+
+func (t *Tracker) handleSandboxEvent(eventType watch.EventType, u *unstructured.Unstructured) {
+	id := types.NamespacedName{Name: u.GetName(), Namespace: u.GetNamespace()}
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	rec, ok := t.records[id]
+	if !ok {
+		return
+	}
+
+	if eventType == watch.Deleted {
+		if rec.SandboxDeleted.IsZero() {
+			rec.SandboxDeleted = now
+		}
+		// If no Pod was ever observed there is nothing else to wait for.
+		if rec.PodCreated.IsZero() {
+			rec.gone.Done(true)
+		}
+		return
+	}
+
+	if rec.ServerSandboxCreated.IsZero() {
+		rec.ServerSandboxCreated = u.GetCreationTimestamp().Time
+	}
+
+	if ready, ltt := conditionTrue(u, "Ready"); ready && rec.SandboxReady.IsZero() {
+		rec.SandboxReady = now
+		rec.ServerSandboxReady = ltt
+		rec.ready.Done(true)
+	}
+
+	if finished, _ := conditionTrue(u, "Finished"); finished && rec.SandboxFinished.IsZero() {
+		rec.SandboxFinished = now
+	}
+}
+
+func (t *Tracker) handlePodEvent(eventType watch.EventType, u *unstructured.Unstructured) {
+	// The controller names the backing Pod after the Sandbox
+	// (replacement pods can differ, but stress sandboxes are never replaced).
+	id := types.NamespacedName{Name: u.GetName(), Namespace: u.GetNamespace()}
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	rec, ok := t.records[id]
+	if !ok {
+		return
+	}
+
+	if eventType == watch.Deleted {
+		if rec.PodDeleted.IsZero() {
+			rec.PodDeleted = now
+		}
+		rec.gone.Done(true)
+		return
+	}
+
+	if rec.PodCreated.IsZero() {
+		rec.PodCreated = now
+		rec.ServerPodCreated = u.GetCreationTimestamp().Time
+	}
+
+	if scheduled, ltt := conditionTrue(u, "PodScheduled"); scheduled && rec.PodScheduled.IsZero() {
+		rec.PodScheduled = now
+		rec.ServerPodScheduled = ltt
+	}
+
+	if phase, _, _ := unstructured.NestedString(u.Object, "status", "phase"); phase == "Running" && rec.PodRunning.IsZero() {
+		// Client-observed: first watch event where phase=Running.
+		// Prefer this over containerStatuses[].state.running.startedAt, which
+		// is on the node's clock and can be skewed relative to ours.
+		rec.PodRunning = now
+	}
+
+	if ready, ltt := conditionTrue(u, "Ready"); ready && rec.PodReady.IsZero() {
+		rec.PodReady = now
+		rec.ServerPodReady = ltt
+	}
+}
+
+// closeReadyLocked must be called with t.mu held.
+func (t *Tracker) closeReadyLocked(rec *SandboxRecord) {
+	if !rec.readyClosed {
+		rec.readyClosed = true
+		close(rec.readyCh)
+	}
+}
+
+// closeGoneLocked must be called with t.mu held.
+func (t *Tracker) closeGoneLocked(rec *SandboxRecord) {
+	if !rec.goneClosed {
+		rec.goneClosed = true
+		close(rec.goneCh)
+	}
+}
+
+// conditionTrue reports whether the given condition type has status True,
+// and returns its lastTransitionTime if present.
+func conditionTrue(u *unstructured.Unstructured, condType string) (bool, time.Time) {
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return false, time.Time{}
+	}
+	for _, condVal := range conditions {
+		cond, ok := condVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		cType, _ := cond["type"].(string)
+		cStatus, _ := cond["status"].(string)
+		if cType == condType && cStatus == "True" {
+			var ltt time.Time
+			if s, ok := cond["lastTransitionTime"].(string); ok {
+				if parsed, err := time.Parse(time.RFC3339, s); err == nil {
+					ltt = parsed
+				}
+			}
+			return true, ltt
+		}
+	}
+	return false, time.Time{}
+}

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,6 +81,15 @@ type SandboxRecord struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 	Phase     Phase  `json:"phase"`
+
+	// Pod identity, for joining against node-side data sources.
+	// PodUID is the pod's metadata.uid. NodeName selects the right
+	// profiler-*-<node>.log. ContainerID is the main container's runtime ID
+	// with the scheme (e.g. "containerd://") stripped, matching the
+	// container_id in containerd's event stream (ctr events).
+	PodUID      string `json:"podUID,omitempty"`
+	NodeName    string `json:"nodeName,omitempty"`
+	ContainerID string `json:"containerID,omitempty"`
 
 	// Client-observed milestones.
 	CreateCalled    time.Time `json:"createCalled,omitzero"`    // just before the Create API call
@@ -354,6 +364,17 @@ func (t *Tracker) handlePodEvent(eventType watch.EventType, u *unstructured.Unst
 	if rec.PodCreated.IsZero() {
 		rec.PodCreated = now
 		rec.ServerPodCreated = u.GetCreationTimestamp().Time
+		rec.PodUID = string(u.GetUID())
+	}
+
+	if rec.NodeName == "" {
+		if nodeName, _, _ := unstructured.NestedString(u.Object, "spec", "nodeName"); nodeName != "" {
+			rec.NodeName = nodeName
+		}
+	}
+
+	if rec.ContainerID == "" {
+		rec.ContainerID = mainContainerID(u)
 	}
 
 	if scheduled, ltt := conditionTrue(u, "PodScheduled"); scheduled && rec.PodScheduled.IsZero() {
@@ -374,20 +395,29 @@ func (t *Tracker) handlePodEvent(eventType watch.EventType, u *unstructured.Unst
 	}
 }
 
-// closeReadyLocked must be called with t.mu held.
-func (t *Tracker) closeReadyLocked(rec *SandboxRecord) {
-	if !rec.readyClosed {
-		rec.readyClosed = true
-		close(rec.readyCh)
+// mainContainerID returns the pod's main container runtime ID with the
+// scheme prefix (e.g. "containerd://") stripped, or "" if not yet assigned.
+// The runtime only assigns the ID once the container is created on the node.
+func mainContainerID(u *unstructured.Unstructured) string {
+	statuses, found, err := unstructured.NestedSlice(u.Object, "status", "containerStatuses")
+	if err != nil || !found {
+		return ""
 	}
-}
-
-// closeGoneLocked must be called with t.mu held.
-func (t *Tracker) closeGoneLocked(rec *SandboxRecord) {
-	if !rec.goneClosed {
-		rec.goneClosed = true
-		close(rec.goneCh)
+	for _, sVal := range statuses {
+		s, ok := sVal.(map[string]any)
+		if !ok {
+			continue
+		}
+		containerID, _ := s["containerID"].(string)
+		if containerID == "" {
+			continue
+		}
+		if _, id, ok := strings.Cut(containerID, "://"); ok {
+			return id
+		}
+		return containerID
 	}
+	return ""
 }
 
 // conditionTrue reports whether the given condition type has status True,


### PR DESCRIPTION
This PR is primarily setting up the "auto research" feedback loop for an AI-driven optimizer.  We can see that loop in action in https://github.com/kubernetes-sigs/agent-sandbox/pull/1122 (I'm still driving it, but it's doing the heavy lifting).  Then I'm pulling out the bits that we want to keep.  We're setting up more realistic benchmarking here so that we can push the system a little harder than our simple test did, and understand where it goes wrong.

## Summary
- Measure stress harness latency from Ready (not Finished/`sleep 5`), with per-stage latency, throughput, and per-sandbox timelines (`stats.go` / `tracker.go`).
- Record `podUID`, `nodeName`, and `containerID` on each sandbox for later node-side joins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added config-driven stress-test runs with stronger orchestration, cluster logging, and validation.
  * Produces structured outputs: **compressed watch JSONL**, summary, sandbox timelines, and per-second time-series.
  * Expanded metrics with **latency percentiles/breakdowns** and **throughput** (steady-state/peak, per-node scaling).

* **Bug Fixes**
  * Improved watch correlation, resource-version handling, and shutdown flushing for more consistent reporting.
  * Refined timeout/cancellation behavior and milestone progression.

* **Refactor**
  * Reworked lifecycle tracking to improve create/delete correlation and progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->