### PR TITLE
fix: reject warm sandboxes on ineligible nodes

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,6 +57,7 @@ import (
 
 const ObservabilityAnnotation = "agents.x-k8s.io/controller-first-observed-at"
 const immediateRequeueDelay = time.Millisecond
+const assignedSandboxNameField = "sandboxclaim.assignedSandboxName"
 
 // ErrTemplateNotFound is a sentinel error indicating a SandboxTemplate was not found.
 var ErrTemplateNotFound = errors.New("SandboxTemplate not found")
@@ -92,6 +94,16 @@ var ErrCrossNamespaceAdoption = errors.New("cross-namespace adoption forbidden")
 
 // ErrEnvVarsInjectionRejected is a sentinel error indicating environment variable injection was rejected.
 var ErrEnvVarsInjectionRejected = errors.New("environment variable injection rejected")
+
+var errSandboxPlacementIneligible = errors.New("sandbox placement is ineligible for adoption")
+
+var errSandboxPlacementRetryable = errors.New("sandbox placement may become eligible for adoption")
+
+var errSandboxPlacementMissing = errors.New("sandbox placement no longer exists")
+
+var errSandboxPlacementLookup = errors.New("sandbox placement lookup failed")
+
+var errAdoptionConflictRetry = errors.New("sandbox adoption conflict requires retry")
 
 // ErrVolumeClaimTemplatesDisallowed is a sentinel error indicating that volumeClaimTemplates are disallowed by the template.
 var ErrVolumeClaimTemplatesDisallowed = errors.New("volume claim templates are disallowed by the template")
@@ -179,12 +191,14 @@ func (m *triggeredAdoptionMap) Delete(key types.NamespacedName) {
 type SandboxClaimReconciler struct {
 	client.Client
 	Scheme                  *runtime.Scheme
+	APIReader               client.Reader
 	WarmSandboxQueue        queue.SandboxQueue
 	Recorder                events.EventRecorder
 	Tracer                  asmetrics.Instrumenter
 	MaxConcurrentReconciles int
 	observedTimes           observedTimeMap
 	triggeredAdoptions      triggeredAdoptionMap
+	pendingAssignments      triggeredAdoptionMap
 	AllowedLabelDomains     []string
 }
 
@@ -194,6 +208,7 @@ type SandboxClaimReconciler struct {
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxtemplates,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=core,resources=nodes,verbs=get
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;delete
@@ -210,6 +225,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// Fallback cleanup to prevent memory leaks if the delete predicate was missed or a stale request is processed.
 			r.observedTimes.Delete(req.NamespacedName)
 			r.triggeredAdoptions.Delete(req.NamespacedName)
+			r.pendingAssignments.Delete(req.NamespacedName)
 			logger.V(1).Info("SandboxClaim not found, ignoring", "request", req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
@@ -236,6 +252,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	defer end()
 
 	if !claim.DeletionTimestamp.IsZero() {
+		r.pendingAssignments.Delete(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -350,18 +367,11 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: requeueDelay}, nil
 	}
 
-	// Adoption was just triggered for a warm-pool sandbox. The sandbox is now patched
-	// to us, but the informer cache may still show the warm-pool owner. Requeue
-	// with a bounded delay to let the cache converge, WITHOUT returning an
-	// error: returning an error would route through the exponential failure rate
-	// limiter (and, under bursts, the shared 10qps bucket limiter), and because this
-	// same retry recurs on each pass until the cache catches up the backoff compounds
-	// (5ms*(2^k-1)) and adoption tail latency balloons (#1107). The nil error lets the
-	// workqueue Forget the key, resetting the failure counter. Status is intentionally
-	// not finalized with the sandbox on this pass (sandbox is nil here), preserving the
-	// duplicate-adoption protection during cache lag.
-	if errors.Is(reconcileErr, errAdoptionTriggeredRetry) {
-		logger.V(4).Info("Adoption triggered; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
+	// Adoption completion and ownership-conflict recovery both wait for the cache
+	// through the bounded retry path. Returning nil resets the workqueue failure
+	// counter, which avoids compounding backoff while the informer converges (#1107).
+	if errors.Is(reconcileErr, errAdoptionTriggeredRetry) || errors.Is(reconcileErr, errAdoptionConflictRetry) {
+		logger.V(4).Info("Adoption pending; requeueing to let cache converge", "claim", claim.Name, "error", reconcileErr)
 		requeueDelay := adoptionCacheLagRequeueDelay
 		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
 			requeueDelay = result.RequeueAfter
@@ -609,14 +619,12 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 				ObservedGeneration: claim.Generation,
 			}
 		}
-		if errors.Is(err, errAdoptionTriggeredRetry) {
-			// Benign retry signal, not a claim failure: adoption was patched and we
-			// are only waiting for the informer cache to converge before finalizing.
+		if errors.Is(err, errAdoptionTriggeredRetry) || errors.Is(err, errAdoptionConflictRetry) {
 			return metav1.Condition{
 				Type:               string(v1beta1.SandboxConditionReady),
 				Status:             metav1.ConditionFalse,
 				Reason:             "AdoptionPending",
-				Message:            "Warm-pool sandbox adoption triggered; waiting for cache to converge",
+				Message:            "Warm-pool sandbox adoption is waiting for cache convergence",
 				ObservedGeneration: claim.Generation,
 			}
 		}
@@ -722,7 +730,7 @@ func (r *SandboxClaimReconciler) computeAndSetStatus(claim *extensionsv1beta1.Sa
 	// claim status was already finalized with a sandbox (the adoption pass itself, or
 	// a controller restart racing a stale informer), leave the recorded Name/PodIPs
 	// and existing conditions untouched instead of transiently wiping them.
-	if sandbox == nil && errors.Is(err, errAdoptionTriggeredRetry) && claim.Status.SandboxStatus.Name != "" {
+	if sandbox == nil && (errors.Is(err, errAdoptionTriggeredRetry) || errors.Is(err, errAdoptionConflictRetry)) && claim.Status.SandboxStatus.Name != "" {
 		return
 	}
 	readyCondition := r.computeReadyCondition(claim, sandbox, err, isClaimExpired)
@@ -783,6 +791,7 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 	var fallbackSandbox *v1beta1.Sandbox
 	var fallbackKey queue.SandboxKey
 	var adoptingFallback bool
+	var placementLookupErr error
 
 	// Instantly returns unused keys the moment we find a valid/ready candidate!
 	defer func() {
@@ -856,6 +865,9 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 				adoptingFallback = true
 				return fallbackSandbox, fallbackKey, nil
 			}
+			if placementLookupErr != nil {
+				return nil, queue.SandboxKey{}, placementLookupErr
+			}
 			return nil, queue.SandboxKey{}, nil
 		}
 
@@ -872,11 +884,19 @@ func (r *SandboxClaimReconciler) getCandidate(ctx context.Context, claim *extens
 			return nil, queue.SandboxKey{}, err
 		}
 
-		if err := verifySandboxCandidate(adopted, claim); err != nil {
+		if err := r.verifySandboxCandidate(ctx, adopted, claim); err != nil {
 			logger.V(1).Info("sandbox candidate can't be adopted", "sandbox", adopted.Name, "warmPool", claim.Spec.WarmPoolRef.Name, "reason", err.Error())
-			// If it is a good sandbox in the wrong namespace, put it back.
-			// (Though pickSmart makes this impossible, we keep it for safety).
-			if errors.Is(err, ErrCrossNamespaceAdoption) {
+			if errors.Is(err, errSandboxPlacementMissing) || errors.Is(err, errSandboxPlacementIneligible) {
+				continue
+			}
+			if errors.Is(err, errSandboxPlacementLookup) {
+				skipped = append(skipped, adoptedKey)
+				if placementLookupErr == nil {
+					placementLookupErr = err
+				}
+				continue
+			}
+			if errors.Is(err, ErrCrossNamespaceAdoption) || errors.Is(err, errSandboxPlacementRetryable) {
 				skipped = append(skipped, adoptedKey)
 			}
 			continue
@@ -938,15 +958,43 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 				logger.Error(err, "Failed to update claim for adoption", "claim", claim.Name, "sandbox", adopted.Name)
 				return false, err
 			}
+			r.pendingAssignments.Store(
+				types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace},
+				triggeredAdoptionEntry{uid: claim.UID, sandbox: adopted.Name},
+			)
+
+			if err := r.verifyRequestingClaimAssignment(ctx, claim, adopted.Name); err != nil {
+				if errors.Is(err, errSandboxPlacementLookup) {
+					return false, err
+				}
+				logger.Info("SandboxClaim changed after recording its assignment", "sandbox", adopted.Name, "claim", claim.Name, "reason", err.Error())
+				if releaseErr := r.releaseCandidateAssignment(ctx, claim, adopted, true); releaseErr != nil {
+					return false, fmt.Errorf("failed to release sandbox candidate %q: %w", adopted.Name, releaseErr)
+				}
+				return false, fmt.Errorf("%w: requesting claim changed", errAdoptionConflictRetry)
+			}
+
+			if err := r.verifySandboxCandidate(ctx, adopted, claim); err != nil {
+				if errors.Is(err, errSandboxPlacementLookup) {
+					return false, err
+				}
+				logger.Info("Sandbox candidate became ineligible before adoption", "sandbox", adopted.Name, "claim", claim.Name, "reason", err.Error())
+				if releaseErr := r.releaseCandidateAssignment(ctx, claim, adopted, errors.Is(err, errSandboxPlacementRetryable)); releaseErr != nil {
+					return false, fmt.Errorf("failed to release sandbox candidate %q: %w", adopted.Name, releaseErr)
+				}
+				return false, fmt.Errorf("%w: candidate became ineligible", errAdoptionConflictRetry)
+			}
 
 			// Call helper to complete adoption (patch sandbox)
 			if err := r.completeAdoption(ctx, claim, adopted); err != nil {
 				if k8errors.IsNotFound(err) {
-					return false, nil
+					if releaseErr := r.releaseCandidateAssignment(ctx, claim, adopted, false); releaseErr != nil {
+						return false, fmt.Errorf("failed to release missing sandbox candidate %q: %w", adopted.Name, releaseErr)
+					}
+					return false, fmt.Errorf("%w: candidate disappeared", errAdoptionConflictRetry)
 				}
-				r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
 				if k8errors.IsConflict(err) {
-					return false, nil
+					return false, r.recoverAdoptionConflict(ctx, claim, adopted)
 				}
 				logger.Error(err, "Failed to complete adoption for candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
 				return false, err
@@ -1084,7 +1132,7 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		}
 	}
 
-	if err := r.Patch(ctx, adopted, client.MergeFrom(originalAdopted)); err != nil {
+	if err := r.Patch(ctx, adopted, client.MergeFromWithOptions(originalAdopted, client.MergeFromWithOptimisticLock{})); err != nil {
 		return err
 	}
 
@@ -1499,6 +1547,184 @@ func validateVolumeClaimTemplates(vcts []v1beta1.PersistentVolumeClaimTemplate) 
 	return nil
 }
 
+func sandboxAssignmentPresent(claim *extensionsv1beta1.SandboxClaim, sandboxName string) bool {
+	return claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] == sandboxName ||
+		claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel] == sandboxName
+}
+
+func assignedSandboxName(claim *extensionsv1beta1.SandboxClaim) string {
+	if name := claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]; name != "" {
+		return name
+	}
+	return claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel]
+}
+
+func assignedSandboxNames(rawObj client.Object) []string {
+	claim, ok := rawObj.(*extensionsv1beta1.SandboxClaim)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, 2)
+	if name := claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]; name != "" {
+		names = append(names, name)
+	}
+	if name := claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel]; name != "" && !slices.Contains(names, name) {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (r *SandboxClaimReconciler) uncachedReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+func (r *SandboxClaimReconciler) syncPendingAssignment(claim *extensionsv1beta1.SandboxClaim) {
+	key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+	name := assignedSandboxName(claim)
+	if !claim.DeletionTimestamp.IsZero() || name == "" {
+		r.pendingAssignments.Delete(key)
+		return
+	}
+	r.pendingAssignments.Store(key, triggeredAdoptionEntry{uid: claim.UID, sandbox: name})
+}
+
+func (r *SandboxClaimReconciler) hydratePendingAssignment(ctx context.Context, claim *extensionsv1beta1.SandboxClaim) error {
+	key := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+	pending, ok := r.pendingAssignments.Load(key)
+	if !ok {
+		return nil
+	}
+	if pending.uid != claim.UID {
+		r.pendingAssignments.Delete(key)
+		return nil
+	}
+
+	current := &extensionsv1beta1.SandboxClaim{}
+	if err := r.uncachedReader().Get(ctx, key, current); err != nil {
+		if k8errors.IsNotFound(err) {
+			r.pendingAssignments.Delete(key)
+			return fmt.Errorf("%w: requesting claim %q no longer exists", errAdoptionConflictRetry, claim.Name)
+		}
+		return fmt.Errorf("%w: get pending claim %q: %w", errSandboxPlacementLookup, claim.Name, err)
+	}
+	if current.UID != claim.UID || !current.DeletionTimestamp.IsZero() {
+		r.pendingAssignments.Delete(key)
+		return fmt.Errorf("%w: requesting claim %q changed", errAdoptionConflictRetry, claim.Name)
+	}
+
+	current.DeepCopyInto(claim)
+	r.syncPendingAssignment(claim)
+	return nil
+}
+
+func (r *SandboxClaimReconciler) requeueCandidateIfStillWarm(
+	ctx context.Context,
+	claim *extensionsv1beta1.SandboxClaim,
+	sandbox *v1beta1.Sandbox,
+) error {
+	if r.WarmSandboxQueue == nil {
+		return nil
+	}
+	fresh := &v1beta1.Sandbox{}
+	if err := r.uncachedReader().Get(ctx, client.ObjectKeyFromObject(sandbox), fresh); err != nil {
+		if k8errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("confirm sandbox %q before requeue: %w", sandbox.Name, err)
+	}
+	if getWarmPoolName(fresh) != claim.Spec.WarmPoolRef.Name || isAdoptable(fresh) != nil {
+		return nil
+	}
+	r.WarmSandboxQueue.Add(
+		queue.GetNamespacedWarmPoolName(claim.Namespace, claim.Spec.WarmPoolRef.Name),
+		queue.SandboxKey{Namespace: fresh.Namespace, Name: fresh.Name, NodeName: fresh.Status.NodeName},
+	)
+	return nil
+}
+
+func (r *SandboxClaimReconciler) releaseCandidateAssignment(
+	ctx context.Context,
+	claim *extensionsv1beta1.SandboxClaim,
+	sandbox *v1beta1.Sandbox,
+	requeue bool,
+) (retErr error) {
+	if requeue {
+		defer func() {
+			retErr = errors.Join(retErr, r.requeueCandidateIfStillWarm(ctx, claim, sandbox))
+		}()
+	}
+
+	current := &extensionsv1beta1.SandboxClaim{}
+	if err := r.uncachedReader().Get(ctx, client.ObjectKeyFromObject(claim), current); err != nil {
+		if k8errors.IsNotFound(err) {
+			r.pendingAssignments.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
+			return nil
+		}
+		return fmt.Errorf("get claim before releasing sandbox assignment: %w", err)
+	}
+	if current.UID != claim.UID {
+		r.pendingAssignments.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
+		return nil
+	}
+	if !sandboxAssignmentPresent(current, sandbox.Name) {
+		r.syncPendingAssignment(current)
+		return nil
+	}
+
+	original := current.DeepCopy()
+	if current.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] == sandbox.Name {
+		delete(current.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+	}
+	if current.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel] == sandbox.Name {
+		delete(current.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+	}
+	if err := r.Patch(ctx, current, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})); err != nil {
+		return err
+	}
+	current.DeepCopyInto(claim)
+	r.syncPendingAssignment(current)
+	return nil
+}
+
+func (r *SandboxClaimReconciler) recoverAdoptionConflict(
+	ctx context.Context,
+	claim *extensionsv1beta1.SandboxClaim,
+	sandbox *v1beta1.Sandbox,
+) error {
+	fresh := &v1beta1.Sandbox{}
+	if err := r.uncachedReader().Get(ctx, client.ObjectKeyFromObject(sandbox), fresh); err != nil {
+		if !k8errors.IsNotFound(err) {
+			return fmt.Errorf("%w: get sandbox %q after adoption conflict: %w", errSandboxPlacementLookup, sandbox.Name, err)
+		}
+		if releaseErr := r.releaseCandidateAssignment(ctx, claim, sandbox, false); releaseErr != nil {
+			return fmt.Errorf("release assignment for missing sandbox %q: %w", sandbox.Name, releaseErr)
+		}
+		return fmt.Errorf("%w: sandbox disappeared", errAdoptionConflictRetry)
+	}
+	r.syncPendingAssignment(claim)
+
+	if metav1.IsControlledBy(fresh, claim) {
+		r.triggeredAdoptions.Store(
+			types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace},
+			triggeredAdoptionEntry{uid: claim.UID, sandbox: sandbox.Name},
+		)
+		return fmt.Errorf("%w: fresh sandbox is already controlled by requesting claim", errAdoptionTriggeredRetry)
+	}
+
+	controllerRef := metav1.GetControllerOf(fresh)
+	if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" && controllerRef.Name == claim.Spec.WarmPoolRef.Name {
+		return fmt.Errorf("%w: sandbox resource version changed", errAdoptionConflictRetry)
+	}
+
+	if err := r.releaseCandidateAssignment(ctx, claim, sandbox, false); err != nil {
+		return fmt.Errorf("release assignment after sandbox ownership conflict: %w", err)
+	}
+	return fmt.Errorf("%w: another owner claimed sandbox", errAdoptionConflictRetry)
+}
+
 // migrateLegacyAssignedSandboxLabel migrates legacy assigned Sandbox name from label to annotation.
 func (r *SandboxClaimReconciler) migrateLegacyAssignedSandboxLabel(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sbName string) error {
 	patch := client.MergeFrom(claim.DeepCopy())
@@ -1522,6 +1748,7 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.V(4).Info("Found existing adopted sandbox from status", "claim.Status.SandboxStatus.Name", statusName, "claim", claim.Name)
 				r.triggeredAdoptions.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
+				r.pendingAssignments.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 				launchType := v1beta1.SandboxLaunchTypeCold
 				if claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] == statusName ||
 					claim.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel] == statusName ||
@@ -1536,6 +1763,10 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 		} else if !k8errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get sandbox %q from status: %w", statusName, err)
 		}
+	}
+
+	if err := r.hydratePendingAssignment(ctx, claim); err != nil {
+		return nil, err
 	}
 
 	// Check if a previously adopted sandbox is recorded in claim annotations or legacy labels
@@ -1554,10 +1785,12 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 	if sbName != "" {
 		logger.V(1).Info("Checking assigned sandbox name", "sandboxName", sbName, "fromLabel", fromLabel, "claim", claim.Name)
 		sandbox := &v1beta1.Sandbox{}
-		if err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox); err == nil {
+		err := r.Get(ctx, client.ObjectKey{Namespace: claim.Namespace, Name: sbName}, sandbox)
+		if err == nil {
 			if metav1.IsControlledBy(sandbox, claim) {
 				logger.V(4).Info("Found existing adopted sandbox", "sandbox", sbName, "claim", claim.Name)
 				r.triggeredAdoptions.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
+				r.pendingAssignments.Delete(types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace})
 				if fromLabel {
 					if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
 						logger.Error(err, "Failed to migrate legacy sandbox label to annotation (non-fatal)", "claim", claim.Name)
@@ -1575,67 +1808,82 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 			if controllerRef != nil && controllerRef.Kind == "SandboxWarmPool" {
 				// Still in warm pool. Try to complete adoption!
 				logger.Info("Sandbox found in claim metadata still in warm pool, trying to complete adoption", "sandbox", sbName, "claim", claim.Name)
-				if err := verifySandboxCandidate(sandbox, claim); err != nil {
-					logger.Info("Sandbox recorded in claim metadata cannot be adopted, removing stale reference", "sandboxName", sbName, "fromLabel", fromLabel, "claim", claim.Name, "reason", err.Error())
-					patch := client.MergeFrom(claim.DeepCopy())
-					if fromLabel {
-						delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
-					} else {
-						delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+				if err := r.verifyRequestingClaimAssignment(ctx, claim, sbName); err != nil {
+					if errors.Is(err, errSandboxPlacementLookup) {
+						return nil, err
 					}
-					if err := r.Patch(ctx, claim, patch); err != nil {
+					if releaseErr := r.releaseCandidateAssignment(ctx, claim, sandbox, true); releaseErr != nil {
+						return nil, fmt.Errorf("failed to release invalid sandbox reference: %w", releaseErr)
+					}
+					return nil, fmt.Errorf("%w: requesting claim changed", errAdoptionConflictRetry)
+				}
+				if err := r.verifySandboxCandidate(ctx, sandbox, claim); err != nil {
+					if errors.Is(err, errSandboxPlacementLookup) {
+						return nil, err
+					}
+					logger.Info("Sandbox recorded in claim metadata cannot be adopted, removing stale reference", "sandboxName", sbName, "fromLabel", fromLabel, "claim", claim.Name, "reason", err.Error())
+					if err := r.releaseCandidateAssignment(ctx, claim, sandbox, errors.Is(err, errSandboxPlacementRetryable)); err != nil {
 						return nil, fmt.Errorf("failed to remove invalid sandbox reference: %w", err)
 					}
-				} else {
-					// If we already sent the adoption patch for this exact claim+sandbox,
-					// the cache just hasn't converged yet — keep waiting via the bounded
-					// requeue without re-sending the (idempotent but redundant) patch.
-					adoptionKey := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
-					if prev, ok := r.triggeredAdoptions.Load(adoptionKey); ok && prev.uid == claim.UID && prev.sandbox == sbName {
-						logger.V(4).Info("Adoption already triggered, waiting for cache to converge", "sandbox", sbName, "claim", claim.Name)
-						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
+					return nil, fmt.Errorf("%w: assigned sandbox became ineligible", errAdoptionConflictRetry)
+				}
+
+				// A prior patch may be ahead of the informer cache, so wait without sending it again.
+				adoptionKey := types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}
+				if prev, ok := r.triggeredAdoptions.Load(adoptionKey); ok && prev.uid == claim.UID && prev.sandbox == sbName {
+					logger.V(4).Info("Adoption already triggered, waiting for cache to converge", "sandbox", sbName, "claim", claim.Name)
+					return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
+				}
+				if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
+					if k8errors.IsConflict(err) {
+						return nil, r.recoverAdoptionConflict(ctx, claim, sandbox)
 					}
-					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
-						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
-							logger.V(4).Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
-						} else {
-							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
+					if k8errors.IsNotFound(err) {
+						if releaseErr := r.releaseCandidateAssignment(ctx, claim, sandbox, false); releaseErr != nil {
+							return nil, fmt.Errorf("failed to release missing sandbox reference: %w", releaseErr)
 						}
+						return nil, fmt.Errorf("%w: assigned sandbox disappeared", errAdoptionConflictRetry)
+					}
+					return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
+				}
+
+				r.triggeredAdoptions.Store(adoptionKey, triggeredAdoptionEntry{uid: claim.UID, sandbox: sbName})
+				if fromLabel {
+					if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
+						logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 					} else {
-						r.triggeredAdoptions.Store(adoptionKey, triggeredAdoptionEntry{uid: claim.UID, sandbox: sbName})
-						if fromLabel {
-							if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
-								logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
-							} else {
-								logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
-							}
-						}
-						// Adoption was completed in-place (completeAdoption patched our controllerRef
-						// and the Warm label). Signal a retry so a later pass observes the sandbox as
-						// controlled by us once the cache converges. Returned as a sentinel so
-						// Reconcile requeues immediately with a bounded delay rather than routing
-						// through the exponential failure rate limiter (#1107).
-						logger.Info("Triggered adoption completion for sandbox, requeueing", "sandbox", sbName, "claim", claim.Name)
-						return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
+						logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 					}
 				}
+				// The informer may lag the completed patch, so finalize on the bounded retry.
+				logger.Info("Triggered adoption completion for sandbox, requeueing", "sandbox", sbName, "claim", claim.Name)
+				return nil, fmt.Errorf("%w: sandbox %s", errAdoptionTriggeredRetry, sbName)
 			}
-			logger.V(4).Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)
-		} else if k8errors.IsNotFound(err) {
-			logger.Info("Sandbox recorded in claim metadata not found, removing stale reference", "sandboxName", sbName, "claim", claim.Name)
-			patch := client.MergeFrom(claim.DeepCopy())
-			if fromLabel {
-				delete(claim.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
-			} else {
-				delete(claim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+			logger.V(4).Info("Sandbox recorded in claim metadata belongs to another owner", "sandbox", sbName, "claim", claim.Name)
+			if err := r.releaseCandidateAssignment(ctx, claim, sandbox, false); err != nil {
+				return nil, fmt.Errorf("failed to release sandbox reference owned by another controller: %w", err)
 			}
-			if err := r.Patch(ctx, claim, patch); err != nil {
-				return nil, fmt.Errorf("failed to remove stale sandbox reference from claim metadata: %w", err)
-			}
-			logger.Info("Successfully removed stale sandbox reference from claim metadata", "sandbox", sbName, "claim", claim.Name)
-		} else {
+			return nil, fmt.Errorf("%w: assigned sandbox belongs to another owner", errAdoptionConflictRetry)
+		}
+		if !k8errors.IsNotFound(err) {
 			return nil, fmt.Errorf("failed to get sandbox %q for sandbox name lookup: %w", sbName, err)
 		}
+
+		fresh := &v1beta1.Sandbox{}
+		key := client.ObjectKey{Namespace: claim.Namespace, Name: sbName}
+		liveErr := r.uncachedReader().Get(ctx, key, fresh)
+		if liveErr == nil {
+			return nil, fmt.Errorf("%w: assigned sandbox is not visible in cache", errAdoptionConflictRetry)
+		}
+		if !k8errors.IsNotFound(liveErr) {
+			return nil, fmt.Errorf("%w: confirm missing sandbox %q: %w", errSandboxPlacementLookup, sbName, liveErr)
+		}
+
+		missing := &v1beta1.Sandbox{ObjectMeta: metav1.ObjectMeta{Namespace: claim.Namespace, Name: sbName}}
+		if err := r.releaseCandidateAssignment(ctx, claim, missing, false); err != nil {
+			return nil, fmt.Errorf("failed to remove stale sandbox reference from claim metadata: %w", err)
+		}
+		return nil, fmt.Errorf("%w: assigned sandbox no longer exists", errAdoptionConflictRetry)
 	}
 
 	// Try name-based lookup (sandbox created by createSandbox uses claim.Name)
@@ -1807,6 +2055,9 @@ func (r *SandboxClaimReconciler) mapWarmPoolToClaims(ctx context.Context, obj cl
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
 	r.MaxConcurrentReconciles = concurrentWorkers
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
 
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &extensionsv1beta1.SandboxClaim{}, extensionsv1beta1.WarmPoolRefField, func(rawObj client.Object) []string {
 		claim, ok := rawObj.(*extensionsv1beta1.SandboxClaim)
@@ -1818,6 +2069,14 @@ func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWo
 		}
 		return []string{claim.Spec.WarmPoolRef.Name}
 	}); err != nil {
+		return err
+	}
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(),
+		&extensionsv1beta1.SandboxClaim{},
+		assignedSandboxNameField,
+		assignedSandboxNames,
+	); err != nil {
 		return err
 	}
 
@@ -2049,6 +2308,182 @@ func verifySandboxCandidate(candidate *v1beta1.Sandbox, claim *extensionsv1beta1
 		return fmt.Errorf("incorrect warm pool, expected %v", claim.Spec.WarmPoolRef.Name)
 	}
 	return nil
+}
+
+func (r *SandboxClaimReconciler) verifySandboxCandidate(
+	ctx context.Context,
+	candidate *v1beta1.Sandbox,
+	claim *extensionsv1beta1.SandboxClaim,
+) error {
+	if err := verifySandboxCandidate(candidate, claim); err != nil {
+		return err
+	}
+	if err := r.verifySandboxCandidateReservation(ctx, candidate, claim); err != nil {
+		return err
+	}
+	return r.verifySandboxCandidatePlacement(ctx, candidate)
+}
+
+func (r *SandboxClaimReconciler) verifySandboxCandidateReservation(
+	ctx context.Context,
+	candidate *v1beta1.Sandbox,
+	claim *extensionsv1beta1.SandboxClaim,
+) error {
+	claims := &extensionsv1beta1.SandboxClaimList{}
+	if err := r.List(
+		ctx,
+		claims,
+		client.InNamespace(candidate.Namespace),
+		client.MatchingFields{assignedSandboxNameField: candidate.Name},
+	); err != nil {
+		return fmt.Errorf("%w: list cached claims assigned to sandbox %q: %w", errSandboxPlacementLookup, candidate.Name, err)
+	}
+	for i := range claims.Items {
+		cached := &claims.Items[i]
+		if cached.UID == claim.UID || !cached.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		confirmed := &extensionsv1beta1.SandboxClaim{}
+		if err := r.uncachedReader().Get(ctx, client.ObjectKeyFromObject(cached), confirmed); err != nil {
+			if k8errors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("%w: confirm claim %q assigned to sandbox %q: %w", errSandboxPlacementLookup, cached.Name, candidate.Name, err)
+		}
+		if confirmed.UID == claim.UID || !confirmed.DeletionTimestamp.IsZero() || !sandboxAssignmentPresent(confirmed, candidate.Name) {
+			continue
+		}
+		return fmt.Errorf(
+			"%w: sandbox %q is assigned to claim %q",
+			errSandboxPlacementRetryable,
+			candidate.Name,
+			confirmed.Name,
+		)
+	}
+	return nil
+}
+
+func (r *SandboxClaimReconciler) verifyRequestingClaimAssignment(
+	ctx context.Context,
+	claim *extensionsv1beta1.SandboxClaim,
+	sandboxName string,
+) error {
+	current := &extensionsv1beta1.SandboxClaim{}
+	if err := r.uncachedReader().Get(ctx, client.ObjectKeyFromObject(claim), current); err != nil {
+		if k8errors.IsNotFound(err) {
+			return fmt.Errorf("%w: requesting claim %q no longer exists", errSandboxPlacementRetryable, claim.Name)
+		}
+		return fmt.Errorf("%w: get requesting claim %q: %w", errSandboxPlacementLookup, claim.Name, err)
+	}
+	if current.UID != claim.UID {
+		return fmt.Errorf("%w: requesting claim %q was replaced", errSandboxPlacementRetryable, claim.Name)
+	}
+	if !current.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("%w: requesting claim %q is deleting", errSandboxPlacementRetryable, claim.Name)
+	}
+	if !sandboxAssignmentPresent(current, sandboxName) {
+		return fmt.Errorf("%w: requesting claim %q no longer assigns sandbox %q", errSandboxPlacementRetryable, claim.Name, sandboxName)
+	}
+	return nil
+}
+
+func (r *SandboxClaimReconciler) verifySandboxCandidatePlacement(ctx context.Context, candidate *v1beta1.Sandbox) error {
+	reader := r.uncachedReader()
+
+	podName := candidate.Annotations[v1beta1.SandboxPodNameAnnotation]
+	if podName == "" {
+		podName = candidate.Name
+	}
+	pod := &corev1.Pod{}
+	err := reader.Get(ctx, client.ObjectKey{Namespace: candidate.Namespace, Name: podName}, pod)
+	if k8errors.IsNotFound(err) && podName != candidate.Name {
+		podName = candidate.Name
+		err = reader.Get(ctx, client.ObjectKey{Namespace: candidate.Namespace, Name: podName}, pod)
+	}
+	if k8errors.IsNotFound(err) {
+		return fmt.Errorf("%w: pod for sandbox %q", errSandboxPlacementMissing, candidate.Name)
+	}
+	if err != nil {
+		return fmt.Errorf("%w: get pod %q: %w", errSandboxPlacementLookup, podName, err)
+	}
+	if pod.GetDeletionTimestamp() != nil {
+		return fmt.Errorf("%w: pod %q is deleting", errSandboxPlacementIneligible, pod.Name)
+	}
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return fmt.Errorf("%w: pod %q is in terminal phase %s", errSandboxPlacementIneligible, pod.Name, pod.Status.Phase)
+	}
+
+	nodeName := pod.Spec.NodeName
+	if candidate.Status.NodeName != "" && candidate.Status.NodeName != nodeName {
+		return fmt.Errorf(
+			"%w: sandbox reports node %q but pod %q reports node %q",
+			errSandboxPlacementRetryable,
+			candidate.Status.NodeName,
+			pod.Name,
+			nodeName,
+		)
+	}
+	if nodeName == "" {
+		return nil
+	}
+
+	node := &corev1.Node{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		if k8errors.IsNotFound(err) {
+			return fmt.Errorf("%w: node %q", errSandboxPlacementMissing, nodeName)
+		}
+		return fmt.Errorf("%w: get node %q: %w", errSandboxPlacementLookup, nodeName, err)
+	}
+	if node.GetDeletionTimestamp() != nil {
+		return fmt.Errorf("%w: node %q is deleting", errSandboxPlacementIneligible, nodeName)
+	}
+	if node.Spec.Unschedulable {
+		return fmt.Errorf("%w: node %q is unschedulable", errSandboxPlacementRetryable, nodeName)
+	}
+	if !nodeIsReady(node) {
+		return fmt.Errorf("%w: node %q is not Ready", errSandboxPlacementRetryable, nodeName)
+	}
+
+	for i := range node.Spec.Taints {
+		taint := &node.Spec.Taints[i]
+		if taint.Effect != corev1.TaintEffectNoSchedule && taint.Effect != corev1.TaintEffectNoExecute {
+			continue
+		}
+		if !tolerationsPermanentlyTolerateTaint(pod.Spec.Tolerations, taint) {
+			return fmt.Errorf(
+				"%w: node %q has unsafe %s taint %q",
+				errSandboxPlacementRetryable,
+				nodeName,
+				taint.Effect,
+				taint.Key,
+			)
+		}
+	}
+	return nil
+}
+
+func nodeIsReady(node *corev1.Node) bool {
+	for i := range node.Status.Conditions {
+		condition := &node.Status.Conditions[i]
+		if condition.Type == corev1.NodeReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func tolerationsPermanentlyTolerateTaint(tolerations []corev1.Toleration, taint *corev1.Taint) bool {
+	for i := range tolerations {
+		toleration := &tolerations[i]
+		if !toleration.ToleratesTaint(klog.Background(), taint, false) {
+			continue
+		}
+		if taint.Effect != corev1.TaintEffectNoExecute || toleration.TolerationSeconds == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func isAdoptable(candidate *v1beta1.Sandbox) error {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1077,7 +1077,7 @@ func TestSandboxClaimReconcile(t *testing.T) {
 			}
 
 			allObjects := append(tc.existingObjects, claimToUse)
-			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(allObjects...).WithStatusSubresource(claimToUse).Build()
+			client := newSandboxClaimClientBuilder(scheme).WithObjects(allObjects...).WithStatusSubresource(claimToUse).Build()
 
 			reconciler := &SandboxClaimReconciler{
 				Client:              client,
@@ -1335,7 +1335,7 @@ func TestSandboxClaimCleanupPolicy(t *testing.T) {
 				tc.claim.Status.SandboxStatus.Name = sandbox.Name
 			}
 
-			client := fake.NewClientBuilder().WithScheme(scheme).
+			client := newSandboxClaimClientBuilder(scheme).
 				WithObjects(template, warmPool, tc.claim, sandbox).
 				WithStatusSubresource(tc.claim).Build()
 
@@ -1455,7 +1455,7 @@ func TestSandboxClaimMirrorsFinishedConditionAndSchedulesTTL(t *testing.T) {
 		}}},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(scheme).
+	client := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim, template, warmPool, sandbox).
 		WithStatusSubresource(claim).
 		Build()
@@ -1565,7 +1565,7 @@ func TestSandboxClaimTTLAfterFinishedCleanupPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			claim := createClaim(tc.name, tc.policy)
 			sandbox := createSandbox(claim)
-			client := fake.NewClientBuilder().WithScheme(scheme).
+			client := newSandboxClaimClientBuilder(scheme).
 				WithObjects(claim, sandbox, warmPool, template).
 				WithStatusSubresource(claim).
 				Build()
@@ -1679,7 +1679,7 @@ func TestSandboxClaimTTLCleanupRequiresPersistedExpiredStatus(t *testing.T) {
 		}}},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(scheme).
+	client := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim, template, warmPool, sandbox).
 		WithStatusSubresource(claim).
 		Build()
@@ -1739,7 +1739,7 @@ func TestSandboxProvisionEvent(t *testing.T) {
 	}
 
 	fakeRecorder := events.NewFakeRecorder(10)
-	client := fake.NewClientBuilder().WithScheme(scheme).
+	client := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim, template, warmPool).
 		WithStatusSubresource(claim).Build()
 
@@ -1817,7 +1817,7 @@ func TestCreateSandboxPropagatesVolumeClaimTemplates(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim, template, warmPool).
 		WithStatusSubresource(claim).Build()
 
@@ -1999,7 +1999,6 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 		expectedLabels          map[string]string
 		expectedPodLabels       map[string]string
 		expectNewSandboxCreated bool
-		simulateConflicts       int
 	}{
 		{
 			name: "adopts oldest ready sandbox from warm pool",
@@ -2124,19 +2123,6 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: false,
 		},
 		{
-			name: "retries on conflict when adopting sandbox",
-			existingObjects: []client.Object{
-				template,
-				claim,
-				createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true),
-				createWarmPoolSandbox("pool-sb-2", metav1.Now(), true),
-			},
-			expectSandboxAdoption:   true,
-			expectedAdoptedSandbox:  "pool-sb-2",
-			expectNewSandboxCreated: false,
-			simulateConflicts:       1, // Fail update on the first sandbox, succeed on the second
-		},
-		{
 			name: "preserves template eviction annotation false when adopting sandbox",
 			existingObjects: []client.Object{
 				func() client.Object {
@@ -2254,18 +2240,17 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			scheme := newScheme(t)
-			var fakeClient client.Client = fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(append(tc.existingObjects, warmPool)...).
-				WithStatusSubresource(claim).
-				Build()
-
-			if tc.simulateConflicts > 0 {
-				fakeClient = &conflictClient{
-					Client:       fakeClient,
-					maxConflicts: tc.simulateConflicts,
+			existingObjects := append([]client.Object{}, tc.existingObjects...)
+			for _, obj := range tc.existingObjects {
+				if sandbox, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+					existingObjects = append(existingObjects, podForSandbox(sandbox, sandbox.Status.NodeName))
 				}
 			}
+			existingObjects = append(existingObjects, warmPool)
+			var fakeClient client.Client = newSandboxClaimClientBuilder(scheme).
+				WithObjects(existingObjects...).
+				WithStatusSubresource(claim).
+				Build()
 
 			// 1. Initialize the Queue
 			warmSandboxQueue := queue.NewSimpleSandboxQueue()
@@ -2515,8 +2500,7 @@ func TestSandboxClaimNoReAdoption(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
 		WithObjects(template, warmPool, claim, adoptedSandbox, poolSandbox).
 		WithStatusSubresource(claim).
 		Build()
@@ -2698,7 +2682,7 @@ func TestRecordCreationLatencyMetric(t *testing.T) {
 
 			scheme := newScheme(t)
 			warmPool := &extensionsv1beta1.SandboxWarmPool{ObjectMeta: metav1.ObjectMeta{Name: "test-warmpool", Namespace: "default"}, Spec: extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "tpl"}}}
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(warmPool).Build()
+			fakeClient := newSandboxClaimClientBuilder(scheme).WithObjects(warmPool).Build()
 			r := &SandboxClaimReconciler{Client: fakeClient}
 
 			if tc.setupReconciler != nil {
@@ -2745,7 +2729,7 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 	t.Run("Cold Start", func(t *testing.T) {
 		asmetrics.SandboxClaimCreationTotal.Reset()
 		scheme := newScheme(t)
-		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, warmPool, claim).WithStatusSubresource(claim).Build()
+		client := newSandboxClaimClientBuilder(scheme).WithObjects(template, warmPool, claim).WithStatusSubresource(claim).Build()
 		reconciler := &SandboxClaimReconciler{
 			Client:           client,
 			Scheme:           scheme,
@@ -2815,7 +2799,10 @@ func TestSandboxClaimCreationMetric(t *testing.T) {
 		}
 
 		scheme := newScheme(t)
-		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(template, warmPool, claim, warmSandbox).WithStatusSubresource(claim).Build()
+		client := newSandboxClaimClientBuilder(scheme).
+			WithObjects(template, warmPool, claim, warmSandbox, podForSandbox(warmSandbox, warmSandbox.Status.NodeName)).
+			WithStatusSubresource(claim).
+			Build()
 		warmSandboxQueue := queue.NewSimpleSandboxQueue()
 		if isAdoptable(warmSandbox) == nil {
 			warmPoolName := getWarmPoolName(warmSandbox)
@@ -2947,8 +2934,7 @@ func TestInitializeSandboxLaunchTypeLabel(t *testing.T) {
 				}
 			}
 
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := newSandboxClaimClientBuilder(scheme).
 				WithObjects(sandbox).
 				Build()
 			reconciler := &SandboxClaimReconciler{
@@ -2984,34 +2970,14 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	return scheme
 }
 
+func newSandboxClaimClientBuilder(scheme *runtime.Scheme) *fake.ClientBuilder {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&extensionsv1beta1.SandboxClaim{}, assignedSandboxNameField, assignedSandboxNames)
+}
+
 func ignoreTimestamp(_, _ metav1.Time) bool {
 	return true
-}
-
-type conflictClient struct {
-	client.Client
-	conflictCount int
-	maxConflicts  int
-}
-
-func (c *conflictClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if sandbox, ok := obj.(*sandboxv1beta1.Sandbox); ok {
-		if c.conflictCount < c.maxConflicts {
-			c.conflictCount++
-			return k8errors.NewConflict(sandboxv1beta1.Resource("sandboxes"), sandbox.Name, fmt.Errorf("simulated conflict"))
-		}
-	}
-	return c.Client.Update(ctx, obj, opts...)
-}
-
-func (c *conflictClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	if sandbox, ok := obj.(*sandboxv1beta1.Sandbox); ok {
-		if c.conflictCount < c.maxConflicts {
-			c.conflictCount++
-			return k8errors.NewConflict(sandboxv1beta1.Resource("sandboxes"), sandbox.Name, fmt.Errorf("simulated conflict"))
-		}
-	}
-	return c.Client.Patch(ctx, obj, patch, opts...)
 }
 
 func TestSandboxClaimTimingPredicates(t *testing.T) {
@@ -3226,8 +3192,7 @@ func TestSandboxClaimReconcileCleanup(t *testing.T) {
 		t.Helper()
 		scheme := newScheme(t)
 		objs = append(objs, &extensionsv1beta1.SandboxWarmPool{ObjectMeta: metav1.ObjectMeta{Name: "test-warmpool", Namespace: "default"}, Spec: extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}}})
-		fc := fake.NewClientBuilder().
-			WithScheme(scheme).
+		fc := newSandboxClaimClientBuilder(scheme).
 			WithObjects(objs...).
 			WithStatusSubresource(&extensionsv1beta1.SandboxClaim{}).
 			Build()
@@ -3598,9 +3563,16 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(template, warmPool, claim, adoptedSandbox, extraSandbox).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
+		WithObjects(
+			template,
+			warmPool,
+			claim,
+			adoptedSandbox,
+			extraSandbox,
+			podForSandbox(adoptedSandbox, adoptedSandbox.Status.NodeName),
+			podForSandbox(extraSandbox, extraSandbox.Status.NodeName),
+		).
 		WithStatusSubresource(claim).
 		Build()
 
@@ -3778,11 +3750,11 @@ func TestSandboxClaimAdoptionCacheLagDoesNotRepatch(t *testing.T) {
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
 	// cache that has not converged yet, no matter what was patched.
 	staleSandbox := adoptedSandbox.DeepCopy()
+	staleSandbox.ResourceVersion = "999"
 
 	sandboxPatches := 0
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(template, warmPool, claim, adoptedSandbox).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
+		WithObjects(template, warmPool, claim, adoptedSandbox, podForSandbox(adoptedSandbox, "")).
 		WithStatusSubresource(claim).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -3919,10 +3891,10 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
 	// cache that has not converged yet, no matter what was patched.
 	staleSandbox := adoptedSandbox.DeepCopy()
+	staleSandbox.ResourceVersion = "999"
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(template, warmPool, claim, adoptedSandbox).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
+		WithObjects(template, warmPool, claim, adoptedSandbox, podForSandbox(adoptedSandbox, "")).
 		WithStatusSubresource(claim).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -4035,11 +4007,11 @@ func TestSandboxClaimFreshAdoptionDoesNotRepatchDuringCacheLag(t *testing.T) {
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
 	// cache that never converges within the test, no matter what was patched.
 	staleSandbox := warmSandbox.DeepCopy()
+	staleSandbox.ResourceVersion = "999"
 
 	sandboxPatches := 0
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(template, warmPool, claim, warmSandbox).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
+		WithObjects(template, warmPool, claim, warmSandbox, podForSandbox(warmSandbox, "")).
 		WithStatusSubresource(claim).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -4170,8 +4142,7 @@ func TestSandboxClaimPreventsAdoptionFromWrongWarmPool(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
 		WithObjects(template, warmPool, claim, wrongPoolSandbox).
 		WithStatusSubresource(claim).
 		Build()
@@ -4188,9 +4159,15 @@ func TestSandboxClaimPreventsAdoptionFromWrongWarmPool(t *testing.T) {
 
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
 
-	_, err := reconciler.Reconcile(context.Background(), req)
+	res, err := reconciler.Reconcile(context.Background(), req)
 	if err != nil {
-		t.Fatalf("Expected reconcile to succeed (fall through and create new sandbox), but failed: %v", err)
+		t.Fatalf("Expected reconcile to release the invalid assignment, but failed: %v", err)
+	}
+	if res.RequeueAfter != adoptionCacheLagRequeueDelay {
+		t.Fatalf("expected bounded requeue after releasing the invalid assignment, got %v", res.RequeueAfter)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Expected the next reconcile to create a new sandbox, but failed: %v", err)
 	}
 
 	var sb sandboxv1beta1.Sandbox
@@ -4247,8 +4224,7 @@ func TestSandboxClaimRecoveryWhenTemplateCreated(t *testing.T) {
 	}
 
 	// Step 1: Reconcile without template
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim, warmPool).
 		WithStatusSubresource(claim).
 		Build()
@@ -4325,8 +4301,7 @@ func TestMapWarmPoolToClaims(t *testing.T) {
 	// unless configured with WithIndex.
 
 	// Let's use the WithIndex option on the fake client builder to support the matchingFields query!
-	fakeClientWithIndex := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClientWithIndex := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim1, claim2, claimOther, warmPool).
 		WithIndex(&extensionsv1beta1.SandboxClaim{}, extensionsv1beta1.WarmPoolRefField, func(obj client.Object) []string {
 			c := obj.(*extensionsv1beta1.SandboxClaim)
@@ -4417,8 +4392,7 @@ func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
 		WithObjects(template, warmPool, claim, adoptedSandbox).
 		WithStatusSubresource(claim).
 		Build()
@@ -4503,6 +4477,905 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 	err = isAdoptable(ownedByClaimSandbox)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not managed by warm pool")
+}
+
+func nodeEligibilityClaim() *extensionsv1beta1.SandboxClaim {
+	return &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim", Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+}
+
+func nodeEligibilityQueueName() string {
+	return queue.GetNamespacedWarmPoolName("default", "test-pool")
+}
+
+func adoptableSandboxOnNode(name, nodeName string) *sandboxv1beta1.Sandbox {
+	return &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   sandboxcontrollers.NameHash("test-pool"),
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        "pool-uid",
+				Controller: new(true),
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "agent", Image: "example.test/agent"}},
+				}},
+			},
+		},
+		Status: sandboxv1beta1.SandboxStatus{
+			NodeName: nodeName,
+			Conditions: []metav1.Condition{{
+				Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+func podForSandbox(sandbox *sandboxv1beta1.Sandbox, nodeName string, tolerations ...corev1.Toleration) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: sandbox.Name, Namespace: sandbox.Namespace},
+		Spec:       corev1.PodSpec{NodeName: nodeName, Tolerations: tolerations},
+	}
+}
+
+func readyNode(name string, taints ...corev1.Taint) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.NodeSpec{Taints: taints},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type: corev1.NodeReady, Status: corev1.ConditionTrue,
+		}}},
+	}
+}
+
+func TestVerifySandboxCandidatePlacement(t *testing.T) {
+	scheme := newScheme(t)
+	deletionTime := metav1.Now()
+	drainingTaint := corev1.Taint{
+		Key: "maintenance.example/draining", Value: "rollout-1", Effect: corev1.TaintEffectNoSchedule,
+	}
+	drainingToleration := corev1.Toleration{
+		Key: drainingTaint.Key, Operator: corev1.TolerationOpEqual, Value: drainingTaint.Value, Effect: drainingTaint.Effect,
+	}
+	noExecuteTaint := corev1.Taint{Key: drainingTaint.Key, Effect: corev1.TaintEffectNoExecute}
+	deletingNode := readyNode("node-1")
+	deletingNode.DeletionTimestamp = &deletionTime
+	deletingNode.Finalizers = []string{"test.example/finalizer"}
+	unschedulableNode := readyNode("node-1")
+	unschedulableNode.Spec.Unschedulable = true
+	notReadyNode := readyNode("node-1")
+	notReadyNode.Status.Conditions[0].Status = corev1.ConditionFalse
+
+	tests := []struct {
+		name                string
+		podNodeName         string
+		podPhase            corev1.PodPhase
+		podDeleting         bool
+		unbound             bool
+		annotatedPodName    string
+		templateTolerations []corev1.Toleration
+		podTolerations      []corev1.Toleration
+		node                *corev1.Node
+		omitPod             bool
+		wantError           error
+		wantMessage         string
+	}{
+		{
+			name: "eligible node",
+			node: readyNode("node-1"),
+		},
+		{
+			name:             "annotation resolves the actual pod and its injected toleration",
+			annotatedPodName: "replacement-pod",
+			podTolerations:   []corev1.Toleration{drainingToleration},
+			node:             readyNode("node-1", drainingTaint),
+		},
+		{
+			name:                "template toleration does not replace the actual pod toleration",
+			templateTolerations: []corev1.Toleration{drainingToleration},
+			node:                readyNode("node-1", drainingTaint),
+			wantError:           errSandboxPlacementRetryable,
+			wantMessage:         "unsafe NoSchedule taint",
+		},
+		{
+			name:        "deleting pod",
+			podDeleting: true,
+			wantError:   errSandboxPlacementIneligible,
+			wantMessage: "pod \"candidate\" is deleting",
+		},
+		{
+			name:        "succeeded pod",
+			podPhase:    corev1.PodSucceeded,
+			wantError:   errSandboxPlacementIneligible,
+			wantMessage: "terminal phase Succeeded",
+		},
+		{
+			name:        "failed pod",
+			podPhase:    corev1.PodFailed,
+			wantError:   errSandboxPlacementIneligible,
+			wantMessage: "terminal phase Failed",
+		},
+		{
+			name:        "deleting node",
+			node:        deletingNode,
+			wantError:   errSandboxPlacementIneligible,
+			wantMessage: "is deleting",
+		},
+		{
+			name:        "unschedulable node",
+			node:        unschedulableNode,
+			wantError:   errSandboxPlacementRetryable,
+			wantMessage: "is unschedulable",
+		},
+		{
+			name:        "node without Ready condition",
+			node:        &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}},
+			wantError:   errSandboxPlacementRetryable,
+			wantMessage: "is not Ready",
+		},
+		{
+			name:        "NodeReady false",
+			node:        notReadyNode,
+			wantError:   errSandboxPlacementRetryable,
+			wantMessage: "is not Ready",
+		},
+		{
+			name:        "untolerated NoExecute taint",
+			node:        readyNode("node-1", noExecuteTaint),
+			wantError:   errSandboxPlacementRetryable,
+			wantMessage: "unsafe NoExecute taint",
+		},
+		{
+			name: "permanently tolerated NoExecute taint",
+			podTolerations: []corev1.Toleration{{
+				Key: drainingTaint.Key, Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute,
+			}},
+			node: readyNode("node-1", noExecuteTaint),
+		},
+		{
+			name: "time-limited NoExecute toleration",
+			podTolerations: []corev1.Toleration{{
+				Key: drainingTaint.Key, Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute,
+				TolerationSeconds: ptr.To[int64](300),
+			}},
+			node:        readyNode("node-1", noExecuteTaint),
+			wantError:   errSandboxPlacementRetryable,
+			wantMessage: "unsafe NoExecute taint",
+		},
+		{
+			name: "PreferNoSchedule does not block adoption",
+			node: readyNode("node-1", corev1.Taint{
+				Key: "maintenance.example/prefer-other-nodes", Effect: corev1.TaintEffectPreferNoSchedule,
+			}),
+		},
+		{
+			name:     "unbound pending pod",
+			podPhase: corev1.PodPending,
+			unbound:  true,
+		},
+		{
+			name:     "bound pending pod",
+			podPhase: corev1.PodPending,
+			node:     readyNode("node-1"),
+		},
+		{
+			name:        "sandbox and pod node mismatch",
+			podNodeName: "node-2",
+			wantError:   errSandboxPlacementRetryable,
+			wantMessage: "sandbox reports node",
+		},
+		{
+			name:        "missing pod",
+			omitPod:     true,
+			wantError:   errSandboxPlacementMissing,
+			wantMessage: "pod",
+		},
+		{
+			name:        "missing node",
+			wantError:   errSandboxPlacementMissing,
+			wantMessage: "node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sandboxNodeName := "node-1"
+			podNodeName := "node-1"
+			if tt.unbound {
+				sandboxNodeName = ""
+				podNodeName = ""
+			} else if tt.podNodeName != "" {
+				podNodeName = tt.podNodeName
+			}
+			candidate := adoptableSandboxOnNode("candidate", sandboxNodeName)
+			candidate.Spec.PodTemplate.Spec.Tolerations = tt.templateTolerations
+			if tt.annotatedPodName != "" {
+				candidate.Annotations = map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: tt.annotatedPodName}
+			}
+			objects := []client.Object{}
+			if !tt.omitPod {
+				pod := podForSandbox(candidate, podNodeName, tt.podTolerations...)
+				pod.Status.Phase = tt.podPhase
+				if tt.podDeleting {
+					pod.DeletionTimestamp = &deletionTime
+					pod.Finalizers = []string{"test.example/finalizer"}
+				}
+				if tt.annotatedPodName != "" {
+					pod.Name = tt.annotatedPodName
+				}
+				objects = append(objects, pod)
+			}
+			if tt.node != nil {
+				objects = append(objects, tt.node)
+			}
+			r := &SandboxClaimReconciler{Client: newSandboxClaimClientBuilder(scheme).WithObjects(objects...).Build()}
+
+			err := r.verifySandboxCandidatePlacement(context.Background(), candidate)
+			if tt.wantError == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantError)
+			require.ErrorContains(t, err, tt.wantMessage)
+		})
+	}
+}
+
+func TestVerifySandboxCandidatePlacementFailsClosedOnAPIError(t *testing.T) {
+	scheme := newScheme(t)
+	candidate := adoptableSandboxOnNode("candidate", "node-1")
+	pod := podForSandbox(candidate, "node-1")
+	node := readyNode("node-1")
+
+	for _, resource := range []string{"pod", "node"} {
+		t.Run(resource, func(t *testing.T) {
+			getErr := fmt.Errorf("%s API unavailable", resource)
+			cachedClient := newSandboxClaimClientBuilder(scheme).WithObjects(pod, node).Build()
+			apiReader := interceptor.NewClient(cachedClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if resource == "pod" {
+						if _, ok := obj.(*corev1.Pod); ok {
+							return getErr
+						}
+					} else if _, ok := obj.(*corev1.Node); ok {
+						return getErr
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			})
+			r := &SandboxClaimReconciler{Client: cachedClient, APIReader: apiReader}
+
+			err := r.verifySandboxCandidatePlacement(context.Background(), candidate)
+			require.ErrorIs(t, err, errSandboxPlacementLookup)
+			require.ErrorIs(t, err, getErr)
+		})
+	}
+}
+
+func TestVerifySandboxCandidateReservation(t *testing.T) {
+	scheme := newScheme(t)
+	claim := nodeEligibilityClaim()
+	candidate := adoptableSandboxOnNode("candidate", "node-1")
+	claim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: candidate.Name}
+	other := nodeEligibilityClaim()
+	other.Name = "other"
+	other.UID = "other-uid"
+	other.Labels = map[string]string{extensionsv1beta1.DeprecatedAssignedSandboxNameLabel: candidate.Name}
+
+	t.Run("current claim is allowed", func(t *testing.T) {
+		fc := newSandboxClaimClientBuilder(scheme).WithObjects(claim).Build()
+		r := &SandboxClaimReconciler{Client: fc, APIReader: fc}
+		require.NoError(t, r.verifySandboxCandidateReservation(context.Background(), candidate, claim))
+	})
+
+	t.Run("confirmed legacy assignment blocks", func(t *testing.T) {
+		fc := newSandboxClaimClientBuilder(scheme).WithObjects(claim, other).Build()
+		r := &SandboxClaimReconciler{Client: fc, APIReader: fc}
+		require.ErrorIs(t, r.verifySandboxCandidateReservation(context.Background(), candidate, claim), errSandboxPlacementRetryable)
+	})
+
+	t.Run("stale indexed assignment does not block", func(t *testing.T) {
+		cached := newSandboxClaimClientBuilder(scheme).WithObjects(claim, other).Build()
+		liveOther := other.DeepCopy()
+		liveOther.Labels = nil
+		live := newSandboxClaimClientBuilder(scheme).WithObjects(claim, liveOther).Build()
+		r := &SandboxClaimReconciler{Client: cached, APIReader: live}
+		require.NoError(t, r.verifySandboxCandidateReservation(context.Background(), candidate, claim))
+	})
+
+	t.Run("cached index failure fails closed", func(t *testing.T) {
+		listErr := errors.New("claim cache unavailable")
+		base := newSandboxClaimClientBuilder(scheme).WithObjects(claim).Build()
+		cached := interceptor.NewClient(base, interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return listErr
+			},
+		})
+		r := &SandboxClaimReconciler{Client: cached, APIReader: base}
+		err := r.verifySandboxCandidateReservation(context.Background(), candidate, claim)
+		require.ErrorIs(t, err, errSandboxPlacementLookup)
+		require.ErrorIs(t, err, listErr)
+	})
+
+	t.Run("positive confirmation failure fails closed", func(t *testing.T) {
+		getErr := errors.New("claim API unavailable")
+		cached := newSandboxClaimClientBuilder(scheme).WithObjects(claim, other).Build()
+		live := interceptor.NewClient(cached, interceptor.Funcs{
+			Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+				return getErr
+			},
+		})
+		r := &SandboxClaimReconciler{Client: cached, APIReader: live}
+		err := r.verifySandboxCandidateReservation(context.Background(), candidate, claim)
+		require.ErrorIs(t, err, errSandboxPlacementLookup)
+		require.ErrorIs(t, err, getErr)
+	})
+}
+
+func TestQueueRebuildHonorsClaimReservationUntilDeletion(t *testing.T) {
+	scheme := newScheme(t)
+	claim := nodeEligibilityClaim()
+	claim.Name = "other-claim"
+	claim.UID = "other-claim-uid"
+	claim.Finalizers = []string{"test.example/finalizer"}
+	claim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: "candidate"}
+	requestingClaim := nodeEligibilityClaim()
+	candidate := adoptableSandboxOnNode("candidate", "node-1")
+	fakeClient := newSandboxClaimClientBuilder(scheme).
+		WithObjects(claim, requestingClaim, candidate, podForSandbox(candidate, "node-1"), readyNode("node-1")).
+		Build()
+	warmQueue := queue.NewSimpleSandboxQueue()
+	warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{Namespace: candidate.Namespace, Name: candidate.Name, NodeName: candidate.Status.NodeName})
+	r := &SandboxClaimReconciler{Client: fakeClient, APIReader: fakeClient, WarmSandboxQueue: warmQueue}
+
+	got, _, err := r.getCandidate(context.Background(), requestingClaim)
+	require.NoError(t, err)
+	require.Nil(t, got)
+	requeued, queued := warmQueue.Get(nodeEligibilityQueueName())
+	require.True(t, queued)
+	require.Equal(t, candidate.Name, requeued.Name)
+	warmQueue.Add(nodeEligibilityQueueName(), requeued)
+
+	require.NoError(t, fakeClient.Delete(context.Background(), claim))
+	got, _, err = r.getCandidate(context.Background(), requestingClaim)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, candidate.Name, got.Name)
+}
+
+func TestGetCandidateSkipsIneligibleNode(t *testing.T) {
+	scheme := newScheme(t)
+	claim := nodeEligibilityClaim()
+	drainingCandidate := adoptableSandboxOnNode("draining-candidate", "node-draining")
+	eligibleCandidate := adoptableSandboxOnNode("eligible-candidate", "node-eligible")
+	drainingPod := podForSandbox(drainingCandidate, "node-draining")
+	eligiblePod := podForSandbox(eligibleCandidate, "node-eligible")
+	drainingNode := readyNode("node-draining", corev1.Taint{
+		Key: "maintenance.example/draining", Effect: corev1.TaintEffectNoSchedule,
+	})
+	eligibleNode := readyNode("node-eligible")
+	fakeClient := newSandboxClaimClientBuilder(scheme).
+		WithObjects(claim, drainingCandidate, eligibleCandidate, drainingPod, eligiblePod, drainingNode, eligibleNode).
+		Build()
+	warmQueue := queue.NewSimpleSandboxQueue()
+	warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{Namespace: "default", Name: drainingCandidate.Name, NodeName: drainingCandidate.Status.NodeName})
+	warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{Namespace: "default", Name: eligibleCandidate.Name, NodeName: eligibleCandidate.Status.NodeName})
+	r := &SandboxClaimReconciler{Client: fakeClient, WarmSandboxQueue: warmQueue}
+
+	candidate, key, err := r.getCandidate(context.Background(), claim)
+	require.NoError(t, err)
+	require.Equal(t, eligibleCandidate.Name, candidate.Name)
+	require.Equal(t, eligibleCandidate.Name, key.Name)
+
+	requeued, ok := warmQueue.Get(nodeEligibilityQueueName())
+	require.True(t, ok)
+	require.Equal(t, drainingCandidate.Name, requeued.Name)
+}
+
+func TestGetCandidateRequeuesPlacementLookupFailure(t *testing.T) {
+	scheme := newScheme(t)
+	claim := nodeEligibilityClaim()
+	candidate := adoptableSandboxOnNode("candidate", "node-1")
+	pod := podForSandbox(candidate, "node-1")
+	node := readyNode("node-1")
+	fakeClient := newSandboxClaimClientBuilder(scheme).WithObjects(claim, candidate, pod, node).Build()
+	getErr := errors.New("node API unavailable")
+	apiReader := interceptor.NewClient(fakeClient, interceptor.Funcs{
+		Get: func(ctx context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*corev1.Node); ok {
+				return getErr
+			}
+			return fakeClient.Get(ctx, key, obj, opts...)
+		},
+	})
+	warmQueue := queue.NewSimpleSandboxQueue()
+	warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{Namespace: "default", Name: candidate.Name, NodeName: candidate.Status.NodeName})
+	r := &SandboxClaimReconciler{Client: fakeClient, APIReader: apiReader, WarmSandboxQueue: warmQueue}
+
+	_, _, err := r.getCandidate(context.Background(), claim)
+	require.ErrorIs(t, err, errSandboxPlacementLookup)
+	require.ErrorIs(t, err, getErr)
+
+	requeued, ok := warmQueue.Get(nodeEligibilityQueueName())
+	require.True(t, ok)
+	require.Equal(t, candidate.Name, requeued.Name)
+}
+
+func TestGetCandidatePermanentPlacementFallsBackToCold(t *testing.T) {
+	scheme := newScheme(t)
+
+	for _, condition := range []string{"missing pod", "missing node", "terminal pod"} {
+		t.Run(condition, func(t *testing.T) {
+			claim := nodeEligibilityClaim()
+			candidate := adoptableSandboxOnNode("candidate", "node-1")
+			objects := []client.Object{claim, candidate}
+			if condition != "missing pod" {
+				pod := podForSandbox(candidate, "node-1")
+				if condition == "terminal pod" {
+					pod.Status.Phase = corev1.PodFailed
+				}
+				objects = append(objects, pod)
+			}
+			fakeClient := newSandboxClaimClientBuilder(scheme).WithObjects(objects...).Build()
+			warmQueue := queue.NewSimpleSandboxQueue()
+			warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{Namespace: "default", Name: candidate.Name, NodeName: candidate.Status.NodeName})
+			r := &SandboxClaimReconciler{Client: fakeClient, WarmSandboxQueue: warmQueue}
+
+			got, _, err := r.getCandidate(context.Background(), claim)
+			require.NoError(t, err)
+			require.Nil(t, got)
+			_, ok := warmQueue.Get(nodeEligibilityQueueName())
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestAdoptionRechecksPlacementAfterRecordingAssignment(t *testing.T) {
+	scheme := newScheme(t)
+	drainTaint := corev1.Taint{Key: "maintenance.example/draining", Effect: corev1.TaintEffectNoSchedule}
+
+	tests := []struct {
+		name          string
+		lookupError   error
+		nodeMissing   bool
+		wantAssigned  bool
+		wantCandidate bool
+	}{
+		{
+			name:          "new drain taint releases the assignment",
+			wantCandidate: true,
+		},
+		{
+			name:         "transient lookup error preserves the assignment",
+			lookupError:  errors.New("node API unavailable"),
+			wantAssigned: true,
+		},
+		{
+			name:        "missing node releases the assignment",
+			nodeMissing: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := nodeEligibilityClaim()
+			candidate := adoptableSandboxOnNode("candidate", "node-1")
+			pod := podForSandbox(candidate, "node-1")
+			fakeClient := newSandboxClaimClientBuilder(scheme).
+				WithObjects(claim, candidate, pod, readyNode("node-1")).
+				Build()
+			podReads := 0
+			nodeReads := 0
+			apiReader := interceptor.NewClient(fakeClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*corev1.Pod); ok {
+						podReads++
+						return c.Get(ctx, key, obj, opts...)
+					}
+					node, ok := obj.(*corev1.Node)
+					if !ok {
+						return c.Get(ctx, key, obj, opts...)
+					}
+					nodeReads++
+					if nodeReads >= 2 && tt.nodeMissing {
+						return k8errors.NewNotFound(corev1.Resource("nodes"), key.Name)
+					}
+					if nodeReads >= 2 && tt.lookupError != nil {
+						return tt.lookupError
+					}
+					if err := c.Get(ctx, key, node, opts...); err != nil {
+						return err
+					}
+					if nodeReads >= 2 {
+						node.Spec.Taints = []corev1.Taint{drainTaint}
+					}
+					return nil
+				},
+			})
+			warmQueue := queue.NewSimpleSandboxQueue()
+			warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{Namespace: candidate.Namespace, Name: candidate.Name, NodeName: candidate.Status.NodeName})
+			r := &SandboxClaimReconciler{Client: fakeClient, APIReader: apiReader, WarmSandboxQueue: warmQueue}
+
+			got, err := r.adoptSandboxFromCandidates(context.Background(), claim)
+			if tt.lookupError == nil {
+				require.ErrorIs(t, err, errAdoptionConflictRetry)
+			} else {
+				require.ErrorIs(t, err, errSandboxPlacementLookup)
+				require.ErrorIs(t, err, tt.lookupError)
+			}
+			require.Nil(t, got)
+			require.GreaterOrEqual(t, podReads, 2)
+			require.GreaterOrEqual(t, nodeReads, 2)
+
+			updatedClaim := &extensionsv1beta1.SandboxClaim{}
+			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(claim), updatedClaim))
+			_, assigned := updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]
+			require.Equal(t, tt.wantAssigned, assigned)
+			requeued, queued := warmQueue.Get(nodeEligibilityQueueName())
+			require.Equal(t, tt.wantCandidate, queued)
+			if queued {
+				require.Equal(t, candidate.Name, requeued.Name)
+			}
+
+			updatedCandidate := &sandboxv1beta1.Sandbox{}
+			require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), updatedCandidate))
+			controllerRef := metav1.GetControllerOf(updatedCandidate)
+			require.NotNil(t, controllerRef)
+			require.Equal(t, "SandboxWarmPool", controllerRef.Kind)
+		})
+	}
+}
+
+func TestAdoptionRecheckRejectsInactiveRequestingClaim(t *testing.T) {
+	scheme := newScheme(t)
+
+	for _, tt := range []struct {
+		name           string
+		mutate         func(context.Context, client.WithWatch, *extensionsv1beta1.SandboxClaim) error
+		wantUID        types.UID
+		wantAssignment string
+	}{
+		{
+			name:    "requesting claim starts deleting",
+			wantUID: "claim-uid",
+			mutate: func(ctx context.Context, c client.WithWatch, claim *extensionsv1beta1.SandboxClaim) error {
+				return c.Delete(ctx, claim)
+			},
+		},
+		{
+			name:    "requesting claim is replaced under the same name",
+			wantUID: "replacement-uid",
+			mutate: func(ctx context.Context, c client.WithWatch, claim *extensionsv1beta1.SandboxClaim) error {
+				if err := c.Delete(ctx, claim); err != nil {
+					return err
+				}
+				replacement := nodeEligibilityClaim()
+				replacement.UID = "replacement-uid"
+				return c.Create(ctx, replacement)
+			},
+		},
+		{
+			name:           "requesting claim changes its assignment",
+			wantUID:        "claim-uid",
+			wantAssignment: "other-sandbox",
+			mutate: func(ctx context.Context, c client.WithWatch, claim *extensionsv1beta1.SandboxClaim) error {
+				claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = "other-sandbox"
+				return c.Update(ctx, claim)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := nodeEligibilityClaim()
+			if tt.name == "requesting claim starts deleting" {
+				claim.Finalizers = []string{"test.example/finalizer"}
+			}
+			candidate := adoptableSandboxOnNode("candidate", "node-1")
+			baseClient := newSandboxClaimClientBuilder(scheme).
+				WithObjects(claim, candidate, podForSandbox(candidate, "node-1"), readyNode("node-1")).
+				Build()
+			mutated := false
+			apiReader := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					current, ok := obj.(*extensionsv1beta1.SandboxClaim)
+					if !ok {
+						return c.Get(ctx, key, obj, opts...)
+					}
+					if !mutated {
+						if err := c.Get(ctx, key, current, opts...); err != nil {
+							return err
+						}
+						if err := tt.mutate(ctx, c, current); err != nil {
+							return err
+						}
+						mutated = true
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			})
+			warmQueue := queue.NewSimpleSandboxQueue()
+			warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{
+				Namespace: candidate.Namespace,
+				Name:      candidate.Name,
+				NodeName:  candidate.Status.NodeName,
+			})
+			r := &SandboxClaimReconciler{Client: baseClient, APIReader: apiReader, WarmSandboxQueue: warmQueue}
+
+			got, err := r.adoptSandboxFromCandidates(context.Background(), claim)
+			require.ErrorIs(t, err, errAdoptionConflictRetry)
+			require.Nil(t, got)
+			require.True(t, mutated)
+
+			persistedClaim := &extensionsv1beta1.SandboxClaim{}
+			require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(claim), persistedClaim))
+			require.Equal(t, tt.wantUID, persistedClaim.UID)
+			require.False(t, sandboxAssignmentPresent(persistedClaim, candidate.Name))
+			require.Equal(t, tt.wantAssignment, persistedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+
+			requeued, queued := warmQueue.Get(nodeEligibilityQueueName())
+			require.True(t, queued)
+			require.Equal(t, candidate.Name, requeued.Name)
+
+			persistedCandidate := &sandboxv1beta1.Sandbox{}
+			require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), persistedCandidate))
+			controllerRef := metav1.GetControllerOf(persistedCandidate)
+			require.NotNil(t, controllerRef)
+			require.Equal(t, "SandboxWarmPool", controllerRef.Kind)
+		})
+	}
+}
+
+func TestAdoptionConflictRecovery(t *testing.T) {
+	scheme := newScheme(t)
+
+	for _, tt := range []struct {
+		name         string
+		otherOwner   bool
+		wantAssigned bool
+	}{
+		{name: "another claim wins ownership", otherOwner: true},
+		{name: "unrelated resource version change", wantAssigned: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := nodeEligibilityClaim()
+			candidate := adoptableSandboxOnNode("candidate", "node-1")
+			candidate.Spec.PodTemplate.ObjectMeta.Labels = map[string]string{}
+			baseClient := newSandboxClaimClientBuilder(scheme).
+				WithObjects(claim, candidate, podForSandbox(candidate, "node-1"), readyNode("node-1")).
+				Build()
+			conflictPending := true
+			cachedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if _, ok := obj.(*sandboxv1beta1.Sandbox); !ok || !conflictPending {
+						return c.Patch(ctx, obj, patch, opts...)
+					}
+					conflictPending = false
+					fresh := &sandboxv1beta1.Sandbox{}
+					if err := c.Get(ctx, client.ObjectKeyFromObject(candidate), fresh); err != nil {
+						return err
+					}
+					if tt.otherOwner {
+						fresh.OwnerReferences = []metav1.OwnerReference{{
+							APIVersion: extensionsv1beta1.GroupVersion.String(),
+							Kind:       "SandboxClaim",
+							Name:       "winner",
+							UID:        "winner-uid",
+							Controller: new(true),
+						}}
+					} else {
+						fresh.Annotations = map[string]string{"test.example/revision-bump": "true"}
+					}
+					if err := c.Update(ctx, fresh); err != nil {
+						return err
+					}
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			})
+			warmQueue := queue.NewSimpleSandboxQueue()
+			warmQueue.Add(nodeEligibilityQueueName(), queue.SandboxKey{
+				Namespace: candidate.Namespace,
+				Name:      candidate.Name,
+				NodeName:  candidate.Status.NodeName,
+			})
+			r := &SandboxClaimReconciler{
+				Client:           cachedClient,
+				APIReader:        baseClient,
+				Scheme:           scheme,
+				WarmSandboxQueue: warmQueue,
+			}
+
+			got, err := r.adoptSandboxFromCandidates(context.Background(), claim)
+			require.Nil(t, got)
+			require.ErrorIs(t, err, errAdoptionConflictRetry)
+			require.False(t, conflictPending)
+			_, queued := warmQueue.Get(nodeEligibilityQueueName())
+			require.False(t, queued)
+
+			persistedClaim := &extensionsv1beta1.SandboxClaim{}
+			require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(claim), persistedClaim))
+			require.Equal(t, tt.wantAssigned, sandboxAssignmentPresent(persistedClaim, candidate.Name))
+
+			persistedSandbox := &sandboxv1beta1.Sandbox{}
+			require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), persistedSandbox))
+			owner := metav1.GetControllerOf(persistedSandbox)
+			require.NotNil(t, owner)
+			if tt.otherOwner {
+				require.Equal(t, types.UID("winner-uid"), owner.UID)
+				persistedClaim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: candidate.Name}
+				require.NoError(t, baseClient.Update(context.Background(), persistedClaim))
+				got, err = r.getOrCreateSandbox(context.Background(), persistedClaim, nil)
+				require.Nil(t, got)
+				require.ErrorIs(t, err, errAdoptionConflictRetry)
+				require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(claim), persistedClaim))
+				require.False(t, sandboxAssignmentPresent(persistedClaim, candidate.Name))
+				return
+			}
+
+			staleClaim := nodeEligibilityClaim()
+			got, err = r.getOrCreateSandbox(context.Background(), staleClaim, nil)
+			require.Nil(t, got)
+			require.ErrorIs(t, err, errAdoptionTriggeredRetry)
+			require.True(t, sandboxAssignmentPresent(staleClaim, candidate.Name))
+			require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(candidate), persistedSandbox))
+			require.True(t, metav1.IsControlledBy(persistedSandbox, staleClaim))
+		})
+	}
+}
+
+func TestReleaseCandidateAssignmentRequeuesAfterAmbiguousPatch(t *testing.T) {
+	scheme := newScheme(t)
+	patchErr := errors.New("patch response lost")
+
+	for _, tt := range []struct {
+		name        string
+		applyPatch  bool
+		bothSources bool
+		ownerWins   bool
+	}{
+		{
+			name:       "applied patch makes the candidate adoptable",
+			applyPatch: true,
+		},
+		{
+			name: "unapplied patch keeps the candidate reserved",
+		},
+		{
+			name:        "both assignment sources are cleared",
+			applyPatch:  true,
+			bothSources: true,
+		},
+		{
+			name:       "owned sandbox is not requeued",
+			applyPatch: true,
+			ownerWins:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := nodeEligibilityClaim()
+			claim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: "candidate"}
+			if tt.bothSources {
+				claim.Labels = map[string]string{extensionsv1beta1.DeprecatedAssignedSandboxNameLabel: "candidate"}
+			}
+			otherClaim := nodeEligibilityClaim()
+			otherClaim.Name = "other-claim"
+			otherClaim.UID = "other-claim-uid"
+			candidate := adoptableSandboxOnNode("candidate", "node-1")
+			pod := podForSandbox(candidate, "node-1")
+			baseClient := newSandboxClaimClientBuilder(scheme).
+				WithObjects(claim, otherClaim, candidate, pod, readyNode("node-1")).
+				Build()
+			patchClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if tt.applyPatch {
+						if err := c.Patch(ctx, obj, patch, opts...); err != nil {
+							return err
+						}
+						if tt.ownerWins {
+							fresh := &sandboxv1beta1.Sandbox{}
+							if err := c.Get(ctx, client.ObjectKeyFromObject(candidate), fresh); err != nil {
+								return err
+							}
+							fresh.OwnerReferences = []metav1.OwnerReference{{
+								APIVersion: extensionsv1beta1.GroupVersion.String(),
+								Kind:       "SandboxClaim",
+								Name:       otherClaim.Name,
+								UID:        otherClaim.UID,
+								Controller: new(true),
+							}}
+							if err := c.Update(ctx, fresh); err != nil {
+								return err
+							}
+						}
+					}
+					return patchErr
+				},
+			})
+			warmQueue := queue.NewSimpleSandboxQueue()
+			r := &SandboxClaimReconciler{Client: patchClient, APIReader: baseClient, WarmSandboxQueue: warmQueue}
+
+			err := r.releaseCandidateAssignment(context.Background(), claim, candidate, true)
+			require.ErrorIs(t, err, patchErr)
+
+			persistedClaim := &extensionsv1beta1.SandboxClaim{}
+			require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(claim), persistedClaim))
+			require.Equal(t, !tt.applyPatch, sandboxAssignmentPresent(persistedClaim, candidate.Name))
+			requeued, queued := warmQueue.Get(nodeEligibilityQueueName())
+			require.Equal(t, !tt.ownerWins, queued)
+			if tt.ownerWins {
+				return
+			}
+			require.Equal(t, candidate.Name, requeued.Name)
+			warmQueue.Add(nodeEligibilityQueueName(), requeued)
+
+			got, _, err := r.getCandidate(context.Background(), otherClaim)
+			require.NoError(t, err)
+			if tt.applyPatch {
+				require.NotNil(t, got)
+				require.Equal(t, candidate.Name, got.Name)
+				return
+			}
+			require.Nil(t, got)
+			requeued, queued = warmQueue.Get(nodeEligibilityQueueName())
+			require.True(t, queued)
+			require.Equal(t, candidate.Name, requeued.Name)
+		})
+	}
+}
+
+func TestRecordedAssignmentRecoveryRequeuesIneligibleCandidate(t *testing.T) {
+	scheme := newScheme(t)
+	claim := nodeEligibilityClaim()
+	claim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: "candidate"}
+	candidate := adoptableSandboxOnNode("candidate", "node-1")
+	pod := podForSandbox(candidate, "node-2")
+	fakeClient := newSandboxClaimClientBuilder(scheme).WithObjects(claim, candidate, pod).Build()
+	warmQueue := queue.NewSimpleSandboxQueue()
+	r := &SandboxClaimReconciler{Client: fakeClient, WarmSandboxQueue: warmQueue}
+
+	got, err := r.getOrCreateSandbox(context.Background(), claim, nil)
+	require.ErrorIs(t, err, errAdoptionConflictRetry)
+	require.Nil(t, got)
+
+	requeued, ok := warmQueue.Get(nodeEligibilityQueueName())
+	require.True(t, ok)
+	require.Equal(t, candidate.Name, requeued.Name)
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKeyFromObject(claim), updatedClaim))
+	require.NotContains(t, updatedClaim.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+}
+
+func TestRecordedAssignmentNotFoundPreservesNewAssignment(t *testing.T) {
+	scheme := newScheme(t)
+	liveClaim := nodeEligibilityClaim()
+	liveClaim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: "candidate-b"}
+	staleClaim := liveClaim.DeepCopy()
+	staleClaim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: "candidate-a"}
+	fc := newSandboxClaimClientBuilder(scheme).WithObjects(liveClaim).Build()
+	r := &SandboxClaimReconciler{Client: fc, APIReader: fc, WarmSandboxQueue: queue.NewSimpleSandboxQueue()}
+
+	got, err := r.getOrCreateSandbox(context.Background(), staleClaim, nil)
+	require.Nil(t, got)
+	require.ErrorIs(t, err, errAdoptionConflictRetry)
+
+	persisted := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fc.Get(context.Background(), client.ObjectKeyFromObject(liveClaim), persisted))
+	require.Equal(t, "candidate-b", assignedSandboxName(persisted))
+	pending, ok := r.pendingAssignments.Load(client.ObjectKeyFromObject(liveClaim))
+	require.True(t, ok)
+	require.Equal(t, "candidate-b", pending.sandbox)
 }
 
 func TestSandboxClaimAdoptionStrategy(t *testing.T) {
@@ -4630,12 +5503,18 @@ func TestSandboxClaimAdoptionStrategy(t *testing.T) {
 			var allObjects []client.Object
 			allObjects = append(allObjects, template, claim, warmPool)
 			allObjects = append(allObjects, tc.otherObjects...)
+			nodeNames := map[string]struct{}{}
 			for _, sb := range tc.existingSandboxes {
-				allObjects = append(allObjects, sb)
+				allObjects = append(allObjects, sb, podForSandbox(sb, sb.Status.NodeName))
+				if sb.Status.NodeName != "" {
+					nodeNames[sb.Status.NodeName] = struct{}{}
+				}
+			}
+			for nodeName := range nodeNames {
+				allObjects = append(allObjects, readyNode(nodeName))
 			}
 
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := newSandboxClaimClientBuilder(scheme).
 				WithObjects(allObjects...).
 				WithStatusSubresource(claim).
 				Build()
@@ -4826,12 +5705,11 @@ func TestCreateSandboxClaimVolumeClaimTemplatesSuccess(t *testing.T) {
 						}},
 					},
 				}
-				existingObjects = append(existingObjects, readyWarmSandbox)
+				existingObjects = append(existingObjects, readyWarmSandbox, podForSandbox(readyWarmSandbox, readyWarmSandbox.Status.NodeName))
 				warmSandboxQueue.Add(queue.GetNamespacedWarmPoolName("default", "vct-warmpool"), queue.SandboxKey{Namespace: "default", Name: "warm-sandbox"})
 			}
 
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := newSandboxClaimClientBuilder(scheme).
 				WithObjects(existingObjects...).
 				WithStatusSubresource(claim).
 				Build()
@@ -5000,8 +5878,7 @@ func TestCreateSandboxClaimVolumeClaimTemplatesErrors(t *testing.T) {
 			templateCopy.Spec.VolumeClaimTemplates = tc.templateVCTs
 			templateCopy.Spec.VolumeClaimTemplatesPolicy = tc.policy
 
-			fakeClient := fake.NewClientBuilder().
-				WithScheme(scheme).
+			fakeClient := newSandboxClaimClientBuilder(scheme).
 				WithObjects(claim, templateCopy, warmPool).
 				WithStatusSubresource(claim).
 				Build()
@@ -5071,8 +5948,7 @@ func TestReconcile_TracingNormalization(t *testing.T) {
 	}
 
 	scheme := newScheme(t)
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
+	fakeClient := newSandboxClaimClientBuilder(scheme).
 		WithObjects(claim).
 		WithStatusSubresource(claim).
 		Build()

--- a/extensions/controllers/sandboxclaim_pod_exclusivity_test.go
+++ b/extensions/controllers/sandboxclaim_pod_exclusivity_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
@@ -117,9 +116,15 @@ func TestWarmPoolPodExclusivity(t *testing.T) {
 		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "tpl"}},
 	}
 
-	builder := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(template, warmPool, poolSb0, poolSb1).
+	builder := newSandboxClaimClientBuilder(scheme).
+		WithObjects(
+			template,
+			warmPool,
+			poolSb0,
+			poolSb1,
+			podForSandbox(poolSb0, poolSb0.Status.NodeName),
+			podForSandbox(poolSb1, poolSb1.Status.NodeName),
+		).
 		WithStatusSubresource(&extensionsv1beta1.SandboxClaim{})
 	for _, cl := range claims {
 		builder = builder.WithObjects(cl)

--- a/helm/templates/extensions-rbac.generated.yaml
+++ b/helm/templates/extensions-rbac.generated.yaml
@@ -7,6 +7,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/k8s/extensions-rbac.generated.yaml
+++ b/k8s/extensions-rbac.generated.yaml
@@ -7,6 +7,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get


### PR DESCRIPTION
#### What this PR does / why we need it:
Warm-pool claims can currently adopt a Ready Sandbox after its node starts draining. This change checks the live Pod and Node before adoption, rejects deleting, unschedulable, NotReady, and untolerated placements, and uses optimistic ownership transfer so concurrent claims cannot adopt the same Sandbox while informer caches lag.

`make all`, the full controller race suite, and the focused reservation and eligibility cases with `-race -count=100` pass.

#### Which issue(s) this PR is related to:
NONE

#### Release Note
```release-note
Reject warm-pool Sandboxes on ineligible nodes during claim adoption.
```