### PR TITLE
fix: index sandbox cache by warm pool label to avoid O(n) List in reconcilePool

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -49,6 +49,10 @@ const (
 	warmPoolSandboxLabel            = sandboxv1beta1.SandboxWarmPoolLabel
 	sandboxCreateDeleteMaxBatchSize = 300
 	warmPoolEvictionAnnotation      = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	// sandboxWarmPoolLabelIndex is the cache field index over the warmPoolSandboxLabel
+	// value on warm sandboxes, so reconcilePool's member lookup is O(pool members) instead
+	// of O(sandboxes-in-namespace).
+	sandboxWarmPoolLabelIndex = ".metadata.labels[" + warmPoolSandboxLabel + "]"
 )
 
 // SandboxWarmPoolReconciler reconciles a SandboxWarmPool object.
@@ -115,10 +119,10 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		warmPoolSandboxLabel: poolNameHash,
 	})
 
-	if err := r.List(ctx, sandboxList, &client.ListOptions{
-		LabelSelector: labelSelector,
-		Namespace:     warmPool.Namespace,
-	}); err != nil {
+	if err := r.List(ctx, sandboxList,
+		client.InNamespace(warmPool.Namespace),
+		client.MatchingFields{sandboxWarmPoolLabelIndex: poolNameHash},
+	); err != nil {
 		logger.Error(err, "Failed to list sandboxes")
 		return err
 	}
@@ -589,19 +593,43 @@ func (r *SandboxWarmPoolReconciler) compareSandboxBlueprint(template *extensions
 		equality.Semantic.DeepEqual(template.Spec.Service, actualSandboxSpec.Service)
 }
 
+// sandboxWarmPoolLabelIndexer extracts the warmPoolSandboxLabel value for the
+// sandboxWarmPoolLabelIndex cache field index. Shared with tests so fake clients
+// register the same index the manager does.
+func sandboxWarmPoolLabelIndexer(obj client.Object) []string {
+	if v, ok := obj.GetLabels()[warmPoolSandboxLabel]; ok {
+		return []string{v}
+	}
+	return nil
+}
+
+// sandboxTemplateRefNameIndexer extracts the template reference name for the
+// TemplateRefField cache field index. Shared with tests so fake clients
+// register the same index the manager does.
+func sandboxTemplateRefNameIndexer(obj client.Object) []string {
+	wp := obj.(*extensionsv1beta1.SandboxWarmPool)
+	if wp.Spec.TemplateRef.Name == "" {
+		return nil
+	}
+	return []string{wp.Spec.TemplateRef.Name}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *SandboxWarmPoolReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers int) error {
 	if r.MaxBatchSize <= 0 {
 		r.MaxBatchSize = sandboxCreateDeleteMaxBatchSize
 	}
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &extensionsv1beta1.SandboxWarmPool{}, extensionsv1beta1.TemplateRefField, func(rawObj client.Object) []string {
-		wp := rawObj.(*extensionsv1beta1.SandboxWarmPool)
-		if wp.Spec.TemplateRef.Name == "" {
-			return nil
-		}
-		return []string{wp.Spec.TemplateRef.Name}
-	}); err != nil {
-		return err
+
+	// Index sandboxes by the warm pool label value
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &sandboxv1beta1.Sandbox{},
+		sandboxWarmPoolLabelIndex, sandboxWarmPoolLabelIndexer); err != nil {
+		return fmt.Errorf("failed to index sandboxes by warm pool label: %w", err)
+	}
+
+	// Index warm pools by the template reference name
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &extensionsv1beta1.SandboxWarmPool{},
+		extensionsv1beta1.TemplateRefField, sandboxTemplateRefNameIndexer); err != nil {
+		return fmt.Errorf("failed to index warm pools by template reference name: %w", err)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -48,6 +48,16 @@ func newTestScheme() *runtime.Scheme {
 	return scheme
 }
 
+func newFakeClient(scheme *runtime.Scheme, initialObjs ...runtime.Object) client.WithWatch {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&extensionsv1beta1.SandboxWarmPool{}).
+		WithIndex(&sandboxv1beta1.Sandbox{}, sandboxWarmPoolLabelIndex, sandboxWarmPoolLabelIndexer).
+		WithIndex(&extensionsv1beta1.SandboxWarmPool{}, extensionsv1beta1.TemplateRefField, sandboxTemplateRefNameIndexer).
+		WithRuntimeObjects(initialObjs...).
+		Build()
+}
+
 func createPoolSandbox(poolName, namespace, poolNameHash string, template *extensionsv1beta1.SandboxTemplate, suffix string) *sandboxv1beta1.Sandbox {
 	templateRefHash := ""
 	var podTemplateHash, sandboxBlueprintHash string
@@ -238,10 +248,7 @@ func TestReconcilePool(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			warmPool.Spec.Replicas = tc.replicas
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(tc.initialObjs...).
-					Build(),
+				Client:       newFakeClient(scheme, tc.initialObjs...),
 				Scheme:       scheme,
 				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
@@ -377,10 +384,7 @@ func TestReconcilePoolControllerRef(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(tc.initialObjs...).
-					Build(),
+				Client:       newFakeClient(scheme, tc.initialObjs...),
 				Scheme:       scheme,
 				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
@@ -467,10 +471,7 @@ func TestPoolLabelValueInIntegration(t *testing.T) {
 		}
 
 		r := SandboxWarmPoolReconciler{
-			Client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithRuntimeObjects(template).
-				Build(),
+			Client:                 newFakeClient(scheme, template),
 			Scheme:                 scheme,
 			MaxBatchSize:           sandboxCreateDeleteMaxBatchSize,
 			EnableWarmPoolEviction: true,
@@ -568,10 +569,7 @@ func TestCreatePoolSandboxPropagatesVolumeClaimTemplates(t *testing.T) {
 	}
 
 	r := SandboxWarmPoolReconciler{
-		Client: fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithRuntimeObjects(template).
-			Build(),
+		Client:       newFakeClient(scheme, template),
 		Scheme:       scheme,
 		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 	}
@@ -666,10 +664,7 @@ func TestCreatePoolSandboxAppliesSecureDefaults(t *testing.T) {
 			}
 
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(template).
-					Build(),
+				Client:       newFakeClient(scheme, template),
 				Scheme:       scheme,
 				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
@@ -781,10 +776,7 @@ func TestReconcilePoolReadyReplicas(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(tc.initialObjs...).
-					Build(),
+				Client: newFakeClient(scheme, tc.initialObjs...),
 				Scheme: scheme,
 			}
 
@@ -816,11 +808,7 @@ func TestUpdateStatusClearsZeroValues(t *testing.T) {
 	}
 
 	r := SandboxWarmPoolReconciler{
-		Client: fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithObjects(warmPool.DeepCopy()).
-			WithStatusSubresource(&extensionsv1beta1.SandboxWarmPool{}).
-			Build(),
+		Client: newFakeClient(scheme, warmPool),
 		Scheme: scheme,
 	}
 
@@ -878,14 +866,11 @@ func TestReconcilePoolGCStuckSandboxes(t *testing.T) {
 
 	t.Run("deletes non-ready sandbox older than grace period", func(t *testing.T) {
 		r := SandboxWarmPoolReconciler{
-			Client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithRuntimeObjects(
-					template,
-					createSandboxWithAge("-stuck", metav1.ConditionFalse, 10*time.Minute),
-					createSandboxWithAge("-healthy", metav1.ConditionTrue, 10*time.Minute),
-				).
-				Build(),
+			Client: newFakeClient(scheme,
+				template,
+				createSandboxWithAge("-stuck", metav1.ConditionFalse, 10*time.Minute),
+				createSandboxWithAge("-healthy", metav1.ConditionTrue, 10*time.Minute),
+			),
 			Scheme:       scheme,
 			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 		}
@@ -911,14 +896,11 @@ func TestReconcilePoolGCStuckSandboxes(t *testing.T) {
 
 	t.Run("keeps non-ready sandbox within grace period", func(t *testing.T) {
 		r := SandboxWarmPoolReconciler{
-			Client: fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithRuntimeObjects(
-					template,
-					createSandboxWithAge("-starting", metav1.ConditionFalse, 2*time.Minute),
-					createSandboxWithAge("-healthy", metav1.ConditionTrue, 10*time.Minute),
-				).
-				Build(),
+			Client: newFakeClient(scheme,
+				template,
+				createSandboxWithAge("-starting", metav1.ConditionFalse, 2*time.Minute),
+				createSandboxWithAge("-healthy", metav1.ConditionTrue, 10*time.Minute),
+			),
 			Scheme:       scheme,
 			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 		}
@@ -1015,10 +997,7 @@ func TestReconcilePool_TemplateUpdateRollout(t *testing.T) {
 
 			scheme := newTestScheme()
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(template, warmPool).
-					Build(),
+				Client:       newFakeClient(scheme, template, warmPool),
 				Scheme:       scheme,
 				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}
@@ -1160,10 +1139,7 @@ func TestReconcilePool_TemplateRefUpdate_SameSpec(t *testing.T) {
 
 	scheme := newTestScheme()
 	r := SandboxWarmPoolReconciler{
-		Client: fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithRuntimeObjects(template1, warmPool).
-			Build(),
+		Client:       newFakeClient(scheme, template1, warmPool),
 		Scheme:       scheme,
 		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 	}
@@ -1259,14 +1235,7 @@ func TestFindWarmPoolsForTemplate(t *testing.T) {
 
 	scheme := newTestScheme()
 	r := SandboxWarmPoolReconciler{
-		Client: fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithIndex(&extensionsv1beta1.SandboxWarmPool{}, extensionsv1beta1.TemplateRefField, func(rawObj client.Object) []string {
-				wp := rawObj.(*extensionsv1beta1.SandboxWarmPool)
-				return []string{wp.Spec.TemplateRef.Name}
-			}).
-			WithRuntimeObjects(wp1, wp2).
-			Build(),
+		Client: newFakeClient(scheme, wp1, wp2),
 		Scheme: scheme,
 	}
 
@@ -1424,10 +1393,7 @@ func TestReconcilePool_TemplateUpdate_DNSPolicy(t *testing.T) {
 	}
 
 	r := SandboxWarmPoolReconciler{
-		Client: fake.NewClientBuilder().
-			WithScheme(scheme).
-			WithRuntimeObjects(template, warmPool).
-			Build(),
+		Client:       newFakeClient(scheme, template, warmPool),
 		Scheme:       scheme,
 		MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 	}
@@ -1695,10 +1661,7 @@ func TestReconcilePool_EvictionOverride(t *testing.T) {
 			}
 
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(testTemplate).
-					Build(),
+				Client:                 newFakeClient(scheme, testTemplate),
 				Scheme:                 scheme,
 				MaxBatchSize:           sandboxCreateDeleteMaxBatchSize,
 				EnableWarmPoolEviction: tc.controllerEnable,
@@ -1901,10 +1864,7 @@ func TestReconcilePool_TemplateUpdateRecreate(t *testing.T) {
 
 			scheme := newTestScheme()
 			r := SandboxWarmPoolReconciler{
-				Client: fake.NewClientBuilder().
-					WithScheme(scheme).
-					WithRuntimeObjects(template, warmPool).
-					Build(),
+				Client:       newFakeClient(scheme, template, warmPool),
 				Scheme:       scheme,
 				MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
 			}


### PR DESCRIPTION
#### What this PR does / why we need it:

The warm pool controller's `reconcilePool` listed the pool's member sandboxes by the`agents.x-k8s.io/warm-pool-sandbox` label. Because controller-runtime's cache has no index for that label, the lookup fell back to the namespace index and then label-matched every Sandbox in the namespace on each reconcile, costing O(sandboxes-in-namespace) per pool reconcile.

This PR registers a field index on Sandbox over the `agents.x-k8s.io/warm-pool-sandbox` label in SetupWithManager and replaces the label-selector List in `reconcilePool` with `client.MatchingFields`, making pool-member lookup O(pool member) instead of O(sandboxes-in-namespace).

This mirrors the same fix already merged for the pod reconciler in #1099.

Tests are also updated to register the indexes on the fake clients via a new `newFakeClient` helper.

#### Which issue(s) this PR is related to:

Fixes #1121

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warm-pool sandbox management for more efficient and reliable reconciliation.
  * Updated sandbox discovery to provide more consistent results when associating sandboxes with warm pools.

* **Tests**
  * Expanded automated coverage to verify warm-pool behavior across supported sandbox and template configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->