### PR TITLE
refactor: consolidate extension pod labels and add NetworkPolicy unit tests

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -490,6 +490,45 @@ func isSystemLabel(key string) bool {
 	return hasSystemReservedPrefix(key)
 }
 
+// extensionPodLabelKeys must stay in sync with computeExtensionPodLabels so reconcile
+// removes stale extension labels when they are no longer expected on the Pod.
+var extensionPodLabelKeys = []string{
+	sandboxv1beta1.SandboxWarmPoolLabel,
+	sandboxv1beta1.SandboxTemplateRefHashLabel,
+}
+
+// computeExtensionPodLabels returns extension-owned labels that should be propagated
+// from a Sandbox CR to its Pod. Labels are only returned when the Sandbox is owned
+// by an extensions controller (SandboxClaim or SandboxWarmPool).
+func computeExtensionPodLabels(sandbox *sandboxv1beta1.Sandbox) map[string]string {
+	ref := metav1.GetControllerOf(sandbox)
+	if ref == nil {
+		return nil
+	}
+	gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
+	if gvk.Group != extensionsv1beta1.GroupVersion.Group {
+		return nil
+	}
+
+	var labels map[string]string
+
+	if gvk.Kind == "SandboxWarmPool" {
+		if val, ok := sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok && val != "" {
+			if labels == nil {
+				labels = make(map[string]string, 2)
+			}
+			labels[sandboxv1beta1.SandboxWarmPoolLabel] = val
+		}
+	}
+	if val, ok := sandbox.Labels[sandboxv1beta1.SandboxTemplateRefHashLabel]; ok && val != "" {
+		if labels == nil {
+			labels = make(map[string]string, 2)
+		}
+		labels[sandboxv1beta1.SandboxTemplateRefHashLabel] = val
+	}
+	return labels
+}
+
 // isSystemAnnotation reports whether an annotation key is reserved for the sandbox
 // system and therefore must not be settable through a user-supplied PodTemplate.
 func isSystemAnnotation(key string) bool {
@@ -872,20 +911,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 
 	// Propagate extension-owned labels from the Sandbox CR to the Pod, provided the Sandbox is
 	// owned by an extensions controller (SandboxClaim or SandboxWarmPool).
-	if ref := metav1.GetControllerOf(sandbox); ref != nil {
-		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
-		if gvk.Group == extensionsv1beta1.GroupVersion.Group {
-			// The warm pool label is required by the capacity buffer to identify warm pool pods.
-			if gvk.Kind == "SandboxWarmPool" {
-				if val, ok := sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
-					podLabels[sandboxv1beta1.SandboxWarmPoolLabel] = val
-				}
-			}
-			if val, ok := sandbox.Labels[sandboxv1beta1.SandboxTemplateRefHashLabel]; ok {
-				podLabels[sandboxv1beta1.SandboxTemplateRefHashLabel] = val
-			}
-		}
-	}
+	maps.Copy(podLabels, computeExtensionPodLabels(sandbox))
 
 	// Propagate the created-by label from the Sandbox CR labels to the Pod if present,
 	// normalizing it to a known allow-list to prevent invalid values or high cardinality.
@@ -1022,36 +1048,15 @@ func (r *SandboxReconciler) updatePodMetadata(ctx context.Context, pod *corev1.P
 		}
 	}
 	// Reconcile extension-owned labels based on Sandbox ownership.
-	var expectedWarmPoolHash string
-	var expectedTemplateRefHash string
-	if ref := metav1.GetControllerOf(sandbox); ref != nil {
-		gvk := schema.FromAPIVersionAndKind(ref.APIVersion, ref.Kind)
-		if gvk.Group == extensionsv1beta1.GroupVersion.Group {
-			if gvk.Kind == "SandboxWarmPool" {
-				expectedWarmPoolHash = sandbox.Labels[sandboxv1beta1.SandboxWarmPoolLabel]
+	extensionLabels := computeExtensionPodLabels(sandbox)
+	for _, key := range extensionPodLabelKeys {
+		if val, ok := extensionLabels[key]; ok {
+			if pod.Labels[key] != val {
+				pod.Labels[key] = val
+				updated = true
 			}
-			expectedTemplateRefHash = sandbox.Labels[sandboxv1beta1.SandboxTemplateRefHashLabel]
-		}
-	}
-	if expectedWarmPoolHash != "" {
-		if pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] != expectedWarmPoolHash {
-			pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel] = expectedWarmPoolHash
-			updated = true
-		}
-	} else {
-		if _, exists := pod.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; exists {
-			delete(pod.Labels, sandboxv1beta1.SandboxWarmPoolLabel)
-			updated = true
-		}
-	}
-	if expectedTemplateRefHash != "" {
-		if pod.Labels[sandboxv1beta1.SandboxTemplateRefHashLabel] != expectedTemplateRefHash {
-			pod.Labels[sandboxv1beta1.SandboxTemplateRefHashLabel] = expectedTemplateRefHash
-			updated = true
-		}
-	} else {
-		if _, exists := pod.Labels[sandboxv1beta1.SandboxTemplateRefHashLabel]; exists {
-			delete(pod.Labels, sandboxv1beta1.SandboxTemplateRefHashLabel)
+		} else if _, exists := pod.Labels[key]; exists {
+			delete(pod.Labels, key)
 			updated = true
 		}
 	}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1888,6 +1888,71 @@ func TestReconcilePod(t *testing.T) {
 			},
 		},
 		{
+			name: "removes template-ref-hash label from Pod when absent from Sandbox labels but still extensions-owned",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"agents.x-k8s.io/sandbox-name-hash":        nameHash,
+							"custom-label":                             "label-val",
+							sandboxv1beta1.SandboxTemplateRefHashLabel: "da1fd924",
+						},
+						Annotations: map[string]string{
+							"agents.x-k8s.io/propagated-labels": "custom-label",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+							Kind:       "SandboxClaim",
+							Name:       "my-claim",
+							UID:        "claim-uid",
+							Controller: new(true),
+						},
+					},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+					ObjectMeta: sandboxv1beta1.PodMetadata{Labels: map[string]string{"custom-label": "label-val"}},
+				}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+						"custom-label":                      "label-val",
+					},
+					Annotations: map[string]string{
+						"agents.x-k8s.io/propagated-labels": "custom-label",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
 			name: "delete pod if mode is Suspended",
 			initialObjs: []runtime.Object{
 				&corev1.Pod{

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -25,6 +25,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,10 +33,33 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
-	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 )
+
+// assertManagedNetworkPolicySelectsTemplateBackedPod verifies the managed
+// NetworkPolicy podSelector matches labels propagated to template-backed Pods
+// by the core Sandbox controller (sandbox-template-ref-hash).
+func assertManagedNetworkPolicySelectsTemplateBackedPod(t *testing.T, templateName string, np *networkingv1.NetworkPolicy) {
+	t.Helper()
+
+	selector, err := metav1.LabelSelectorAsSelector(&np.Spec.PodSelector)
+	if err != nil {
+		t.Fatalf("pod selector: %v", err)
+	}
+
+	expectedHash := SandboxTemplateRefHash(templateName)
+	podLabels := labels.Set{
+		sandboxv1beta1.SandboxTemplateRefHashLabel: expectedHash,
+	}
+	if selector.Empty() {
+		t.Errorf("managed NetworkPolicy podSelector is empty (selects all pods in namespace)")
+	} else if !selector.Matches(podLabels) {
+		gotHash := np.Spec.PodSelector.MatchLabels[sandboxv1beta1.SandboxTemplateRefHashLabel]
+		t.Errorf("managed NetworkPolicy podSelector: %s: expected %q, got %q",
+			sandboxv1beta1.SandboxTemplateRefHashLabel, expectedHash, gotHash)
+	}
+}
 
 func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	templateDefault := &extensionsv1beta1.SandboxTemplate{
@@ -160,10 +184,6 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 				if !hasIPv6LinkLocalExcept {
 					t.Errorf("Expected IPv6 Egress Except list to contain fe80::/10, got %v", ipv6Peer.IPBlock.Except)
 				}
-				expectedLabelKey := sandboxTemplateRefHash
-				if _, ok := np.Spec.PodSelector.MatchLabels[expectedLabelKey]; !ok {
-					t.Errorf("Expected PodSelector MatchLabels to contain %q", expectedLabelKey)
-				}
 			},
 		},
 		{
@@ -172,10 +192,6 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 			existingObjects:     []client.Object{templateWithNP},
 			expectNetworkPolicy: true,
 			validateNetworkPolicy: func(t *testing.T, np *networkingv1.NetworkPolicy) {
-				expectedHash := sandboxcontrollers.NameHash("test-template-custom")
-				if np.Spec.PodSelector.MatchLabels[sandboxTemplateRefHash] != expectedHash {
-					t.Errorf("unexpected pod selector hash")
-				}
 				if np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app"] != "ingress" {
 					t.Errorf("unexpected custom ingress rule")
 				}
@@ -243,6 +259,9 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 
 			if tc.expectNetworkPolicy && tc.validateNetworkPolicy != nil {
 				tc.validateNetworkPolicy(t, &np)
+			}
+			if tc.expectNetworkPolicy {
+				assertManagedNetworkPolicySelectsTemplateBackedPod(t, tc.templateToReconcile.Name, &np)
 			}
 
 			var updatedTemplate extensionsv1beta1.SandboxTemplate


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

Follow-up addressing maintainer feedback in https://github.com/kubernetes-sigs/agent-sandbox/pull/1067#pullrequestreview-4675542926:

- Extract `computeExtensionPodLabels` so extension-owned labels (`warm-pool-sandbox`, `sandbox-template-ref-hash`) are propagated from a single helper used by both `reconcilePod` (create) and `updatePodMetadata` (reconcile). This reduces drift risk when future extension labels are added.
- Add a unit regression case in `sandbox_controller_test.go` verifying `sandbox-template-ref-hash` is removed from an existing Pod when the label is cleared from the Sandbox but ownership remains extensions-group.
- Add a unit contract assertion in `sandboxtemplate_controller_test.go` verifying managed SandboxTemplate NetworkPolicy `podSelector` matches template-backed Pod labels (`sandbox-template-ref-hash`), including rejection of an empty selector.


This is a refactor/test-only PR

#### Which issue(s) this PR is related to:

Follow-up to #1067 

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of extension-owned Sandbox labels on Pods, including conditional warm-pool and template-reference propagation.
  * Automatically removes template-reference labels from Pods when they are no longer applicable, keeping Pod metadata consistent.
* **Tests**
  * Added coverage to ensure template-reference labels are removed when hashes are no longer present on the Sandbox.
  * Strengthened NetworkPolicy reconciliation tests by validating template-backed Pod selectors via a shared assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->