### PR TITLE
metric(sdk): Add suspend/resume latency prometheus metric

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/__init__.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .sandbox_client import SandboxClient
+from .metrics_utils import get_metrics, print_metrics
 from .exceptions import (
     SandboxError,
     SandboxNotFoundError,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 import logging
+import time
 from kubernetes.client import ApiException
 from k8s_agent_sandbox.exceptions import SnapshotNotFoundError
+from k8s_agent_sandbox.utils import record_latency
+from k8s_agent_sandbox.metrics import (
+    sandbox_client_suspend_latency_ms,
+    sandbox_client_resume_latency_ms,
+    sandbox_client_restore_latency_ms,
+)
 from .snapshot_engine import SnapshotEngine, SnapshotResponse
 from k8s_agent_sandbox.sandbox import Sandbox
 from k8s_agent_sandbox.constants import (
@@ -160,6 +167,7 @@ class SandboxWithSnapshotSupport(Sandbox):
                 return list_result.snapshots[0].snapshot_uid
         return None
 
+    @record_latency(sandbox_client_suspend_latency_ms)
     def suspend(self, snapshot_before_suspend: bool = True, wait_timeout: int = 180) -> SuspendResponse:
         """
         Suspends the sandbox.
@@ -173,6 +181,7 @@ class SandboxWithSnapshotSupport(Sandbox):
         """
         if self.is_suspended():
             logger.info(f"Sandbox '{self.sandbox_id}' is already suspended.")
+            self._skip_latency_metric = True
             return SuspendResponse(
                 success=True,
                 snapshot_response=None,
@@ -249,7 +258,6 @@ class SandboxWithSnapshotSupport(Sandbox):
                 error_reason="",
                 error_code=SUCCESS_CODE
             )
-        
         logger.warning(f"Timed out waiting for Sandbox '{self.sandbox_id}' pod to terminate.")
         return SuspendResponse(
             success=False,
@@ -324,6 +332,7 @@ class SandboxWithSnapshotSupport(Sandbox):
             error_code=ERROR_CODE
         )
 
+    @record_latency(sandbox_client_resume_latency_ms)
     def resume(self, wait_timeout: int = 180) -> ResumeResponse:
         """
         Resumes the sandbox from the latest available snapshot.
@@ -336,6 +345,7 @@ class SandboxWithSnapshotSupport(Sandbox):
         """
         if not self.is_suspended():
             logger.info(f"Sandbox '{self.sandbox_id}' is already running (not suspended).")
+            self._skip_latency_metric = True
             return ResumeResponse(
                 success=True,
                 restored_from_snapshot=False,
@@ -406,12 +416,14 @@ class SandboxWithSnapshotSupport(Sandbox):
         if not any(snap.snapshot_uid == snapshot_uid for snap in list_result.snapshots):
             raise SnapshotNotFoundError(f"Snapshot '{snapshot_uid}' does not exist for this sandbox.")
 
+    @record_latency(sandbox_client_restore_latency_ms)
     def restore(self, snapshot_uid: str, sandbox_ready_timeout: int = 180) -> RestorationResponse:
         """Restores this sandbox from a specific snapshot."""
         try:
             self._verify_snapshot_exists(snapshot_uid)
 
             if not self.is_suspended():
+                self._skip_latency_metric = True
                 return RestorationResponse(
                     success=False,
                     restored_from_snapshot=False,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/sandbox_with_snapshot_support.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import time
 from kubernetes.client import ApiException
 from k8s_agent_sandbox.exceptions import SnapshotNotFoundError
 from k8s_agent_sandbox.utils import record_latency

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/test/unit/test_sandbox_with_snapshot_support.py
@@ -14,6 +14,7 @@
 
 import unittest
 import logging
+import prometheus_client
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch, call
 from kubernetes.client import ApiException
@@ -1132,8 +1133,11 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
                 snapshot_timestamp="2023-01-01T00:00:00Z", error_reason="", error_code=0
             )
             
+            before_count = prometheus_client.REGISTRY.get_sample_value('sandbox_client_suspend_latency_ms_count', labels={'status': 'success'}) or 0.0
             result = self.sandbox.suspend(snapshot_before_suspend=True)
             
+            after_count = prometheus_client.REGISTRY.get_sample_value('sandbox_client_suspend_latency_ms_count', labels={'status': 'success'}) or 0.0
+            self.assertEqual(after_count, before_count + 1.0)
             self.assertTrue(result.success)
             self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once_with(
                 group=SANDBOX_API_GROUP,
@@ -1203,8 +1207,11 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             mock_list.return_value = ListSnapshotResult(success=True, snapshots=[], error_reason="", error_code=0)
             self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.return_value = {"status": "patched"}
             
+            before_count = prometheus_client.REGISTRY.get_sample_value('sandbox_client_resume_latency_ms_count', labels={'status': 'success'}) or 0.0
             result = self.sandbox.resume()
             
+            after_count = prometheus_client.REGISTRY.get_sample_value('sandbox_client_resume_latency_ms_count', labels={'status': 'success'}) or 0.0
+            self.assertEqual(after_count, before_count + 1.0)
             self.assertTrue(result.success)
             self.assertFalse(result.restored_from_snapshot)
             self.mock_k8s_helper.custom_objects_api.patch_namespaced_custom_object.assert_called_once_with(
@@ -1470,8 +1477,11 @@ class TestSandboxWithSnapshotSupport(unittest.TestCase):
             ]
         }
 
+        before_count = prometheus_client.REGISTRY.get_sample_value('sandbox_client_restore_latency_ms_count', labels={'status': 'success'}) or 0.0
         result = self.sandbox.restore(snapshot_uid="snap-uid-123")
-
+        
+        after_count = prometheus_client.REGISTRY.get_sample_value('sandbox_client_restore_latency_ms_count', labels={'status': 'success'}) or 0.0
+        self.assertEqual(after_count, before_count + 1.0)
         self.assertTrue(result.success)
         self.assertEqual(result.snapshot_uid, "snap-uid-123")
         self.mock_k8s_helper.patch_sandbox_claim.assert_called_once_with(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics.py
@@ -14,9 +14,34 @@
 
 from prometheus_client import Histogram
 
+_LATENCY_BUCKETS_MS = (100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000)
+
 sandbox_client_discovery_latency_ms = Histogram(
     'sandbox_client_discovery_latency_ms',
     'Latency of establishing connection to the sandbox in milliseconds',
     ['mode', 'status'],
-    buckets=(100, 250, 500, 750, 1000, 1250, 1500, 2000, 2500, 5000, 10000, 30000, 60000, 120000, 240000)
+    buckets=_LATENCY_BUCKETS_MS
 )
+
+sandbox_client_suspend_latency_ms = Histogram(
+    'sandbox_client_suspend_latency_ms',
+    'Latency of suspending the sandbox in milliseconds',
+    ['status'],
+    buckets=_LATENCY_BUCKETS_MS
+)
+
+sandbox_client_resume_latency_ms = Histogram(
+    'sandbox_client_resume_latency_ms',
+    'Latency of resuming the sandbox in milliseconds',
+    ['status'],
+    buckets=_LATENCY_BUCKETS_MS
+)
+
+sandbox_client_restore_latency_ms = Histogram(
+    'sandbox_client_restore_latency_ms',
+    'Latency of restoring the sandbox from a snapshot in milliseconds',
+    ['status'],
+    buckets=_LATENCY_BUCKETS_MS
+)
+
+

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics_utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/metrics_utils.py
@@ -1,0 +1,27 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for retrieving and exporting Prometheus metrics in the Python client."""
+
+from prometheus_client import generate_latest, REGISTRY
+
+
+def get_metrics() -> str:
+    """Returns the registered Prometheus metrics in plain text format."""
+    return generate_latest(REGISTRY).decode("utf-8")
+
+
+def print_metrics():
+    """Prints the registered Prometheus metrics to stdout."""
+    print(get_metrics())

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
@@ -103,5 +103,18 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(after_count_port_forward, before_count_port_forward)
         self.assertEqual(after_count_gateway, before_count_gateway)
 
+    @patch('builtins.print')
+    def test_metrics_utils(self, mock_print):
+        from k8s_agent_sandbox.metrics_utils import get_metrics, print_metrics
+        
+        # Test get_metrics
+        metrics_output = get_metrics()
+        self.assertIsInstance(metrics_output, str)
+        self.assertIn("sandbox_client_discovery_latency_ms", metrics_output)
+        
+        # Test print_metrics
+        print_metrics()
+        mock_print.assert_called_once_with(metrics_output)
+
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_metrics.py
@@ -112,9 +112,11 @@ class TestMetrics(unittest.TestCase):
         self.assertIsInstance(metrics_output, str)
         self.assertIn("sandbox_client_discovery_latency_ms", metrics_output)
         
-        # Test print_metrics
-        print_metrics()
-        mock_print.assert_called_once_with(metrics_output)
+        # Test print_metrics with a stable mocked string using localized context patch
+        with patch('k8s_agent_sandbox.metrics_utils.get_metrics') as mock_get_metrics:
+            mock_get_metrics.return_value = "mocked_prometheus_metrics"
+            print_metrics()
+            mock_print.assert_called_once_with("mocked_prometheus_metrics")
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -16,7 +16,38 @@
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
+import functools
 import ipaddress
+import time
+
+
+def record_latency(metric):
+    """Decorator to measure and record execution latency to a Prometheus metric.
+
+    Does not record metrics if self._skip_latency_metric is set to True during execution.
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            self._skip_latency_metric = False
+            start_time = time.perf_counter()
+            response = None
+            try:
+                response = func(self, *args, **kwargs)
+                return response
+            except Exception as e:
+                if not getattr(self, "_skip_latency_metric", False):
+                    status = "failure"
+                    duration = (time.perf_counter() - start_time) * 1000.0
+                    metric.labels(status=status).observe(duration)
+                raise e
+            finally:
+                if response is not None and not getattr(self, "_skip_latency_metric", False):
+                    duration = (time.perf_counter() - start_time) * 1000.0
+                    status = "success" if getattr(response, "success", False) else "failure"
+                    metric.labels(status=status).observe(duration)
+        return wrapper
+    return decorator
 
 
 def construct_sandbox_claim_lifecycle_spec(shutdown_after_seconds: int) -> dict[str, str]:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/utils.py
@@ -40,7 +40,7 @@ def record_latency(metric):
                     status = "failure"
                     duration = (time.perf_counter() - start_time) * 1000.0
                     metric.labels(status=status).observe(duration)
-                raise e
+                raise
             finally:
                 if response is not None and not getattr(self, "_skip_latency_metric", False):
                     duration = (time.perf_counter() - start_time) * 1000.0

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -423,24 +423,27 @@ def display_prometheus_latency_metrics():
         ):
             print(f"\nMetric: {metric.name}")
             
-            count_val = 0.0
-            buckets = []
+            series = {}  # label-tuple -> {"count": float, "buckets": [(le, count), ...]}
             
             for sample in metric.samples:
+                label_key = tuple(sorted((k, v) for k, v in sample.labels.items() if k != "le"))
+                entry = series.setdefault(label_key, {"count": 0.0, "buckets": []})
                 if sample.name.endswith("_count"):
-                    count_val = sample.value
+                    entry["count"] = sample.value
                 elif sample.name.endswith("_bucket"):
                     le_str = sample.labels.get("le")
                     le_val = float('inf') if le_str == "+Inf" else float(le_str)
-                    buckets.append((le_val, sample.value))
+                    entry["buckets"].append((le_val, sample.value))
             
-            if count_val > 0:
-                p50 = calculate_quantile(0.5, buckets, count_val)
-                p90 = calculate_quantile(0.9, buckets, count_val)
-                p99 = calculate_quantile(0.99, buckets, count_val)
-                print(f"  p50: {p50:.2f} ms")
-                print(f"  p90: {p90:.2f} ms")
-                print(f"  p99: {p99:.2f} ms")
+            total_count = sum(v["count"] for v in series.values())
+            if total_count > 0:
+                for label_key, v in series.items():
+                    if v["count"] == 0:
+                        continue
+                    p50 = calculate_quantile(0.5, v["buckets"], v["count"])
+                    p90 = calculate_quantile(0.9, v["buckets"], v["count"])
+                    p99 = calculate_quantile(0.99, v["buckets"], v["count"])
+                    print(f"  {dict(label_key)}: p50={p50:.2f}ms p90={p90:.2f}ms p99={p99:.2f}ms")
             else:
                 print("  No metrics recorded (Count: 0)")
 

--- a/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
+++ b/clients/python/agentic-sandbox-client/test_podsnapshot_extension.py
@@ -381,10 +381,68 @@ def main(
     except Exception as e:
         print(f"\n--- An error occurred during the test: {e} ---")
     finally:
+        try:
+            display_prometheus_latency_metrics()
+        except Exception as metrics_err:
+            print(f"Failed to display Prometheus metrics: {metrics_err}")
+            
         print("Cleaning up all sandboxes...")
         if client:
             client.delete_all()
         print("\n--- Sandbox Client Test Finished ---")
+
+
+def display_prometheus_latency_metrics():
+    import prometheus_client
+    print("\n======= Prometheus Client Latency Metrics =======")
+    
+    def calculate_quantile(q: float, buckets: list[tuple[float, float]], total_count: float) -> float:
+        if total_count == 0:
+            return 0.0
+        sorted_buckets = sorted(buckets, key=lambda x: x[0])
+        rank = q * total_count
+        prev_le = 0.0
+        prev_count = 0.0
+        for le, count in sorted_buckets:
+            if count >= rank:
+                if le == float('inf'):
+                    return prev_le
+                if count == prev_count:
+                    return le
+                fraction = (rank - prev_count) / (count - prev_count)
+                return prev_le + (le - prev_le) * fraction
+            prev_le = le
+            prev_count = count
+        return sorted_buckets[-1][0] if sorted_buckets else 0.0
+
+    for metric in prometheus_client.REGISTRY.collect():
+        if metric.name in (
+            "sandbox_client_suspend_latency_ms",
+            "sandbox_client_resume_latency_ms",
+            "sandbox_client_restore_latency_ms",
+        ):
+            print(f"\nMetric: {metric.name}")
+            
+            count_val = 0.0
+            buckets = []
+            
+            for sample in metric.samples:
+                if sample.name.endswith("_count"):
+                    count_val = sample.value
+                elif sample.name.endswith("_bucket"):
+                    le_str = sample.labels.get("le")
+                    le_val = float('inf') if le_str == "+Inf" else float(le_str)
+                    buckets.append((le_val, sample.value))
+            
+            if count_val > 0:
+                p50 = calculate_quantile(0.5, buckets, count_val)
+                p90 = calculate_quantile(0.9, buckets, count_val)
+                p99 = calculate_quantile(0.99, buckets, count_val)
+                print(f"  p50: {p50:.2f} ms")
+                print(f"  p90: {p90:.2f} ms")
+                print(f"  p99: {p99:.2f} ms")
+            else:
+                print("  No metrics recorded (Count: 0)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR introduces Prometheus histogram metrics to benchmark and monitor the latency of sandbox snapshot operations (suspend, resume, and restore). 

Specifically, this PR includes the following changes:
* **Metrics Definition**: Defines `sandbox_client_suspend_latency_ms`, `sandbox_client_resume_latency_ms`, and `sandbox_client_restore_latency_ms` histograms using shared latency buckets.
* **Telemetry Utilities**: Adds a reusable `@record_latency` decorator in `utils.py` to measure and observe method execution times, as well as `get_metrics` and `print_metrics` helper functions in `metrics_utils.py`.
* **Instrumentation**: Instruments the `suspend`, `resume`, and `restore` methods in `sandbox_with_snapshot_support.py` with the new `@record_latency` decorator.
* **Testing**: Adds unit tests asserting that the Prometheus metric counts correctly increment upon success. Also updates the `test_podsnapshot_extension.py` script to calculate and display the p50, p90, and p99 latency percentiles at the end of the test run.

#### Which issue(s) this PR is related to:
<!-- 
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->

#### Release Note
```release-note
Added Prometheus telemetry to the Python sandbox client to track the latency of suspend, resume, and restore snapshot operations.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus latency histograms for sandbox suspend, resume, and restore (with success/failure reporting).
  * Added utilities to retrieve/print the client’s registered Prometheus metrics as plain text, and exposed them at the package level.
  * Added percentile reporting (p50/p90/p99) for suspend/resume/restore latency during snapshot test finalization.
* **Bug Fixes**
  * No-op/“already in expected state” suspend, resume, and restore paths are excluded from latency measurements.
  * Failures while displaying metrics during test cleanup no longer interrupt sandbox cleanup.
* **Tests**
  * Added unit tests validating latency counter increments and metrics utility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->