### PR TITLE
Add langchain-deepagents integration package

### DIFF
--- a/clients/integrations/deepagents/README.md
+++ b/clients/integrations/deepagents/README.md
@@ -1,0 +1,83 @@
+# deepagents-k8s-agent-sandbox
+
+LangChain DeepAgents backend for Kubernetes `agent-sandbox`. This package allows you to run `deepagents` in a secure, isolated Kubernetes sandbox environment instead of running locally.
+
+## Quick Install
+
+```bash
+pip install deepagents-k8s-agent-sandbox
+```
+
+## Basic Usage
+
+```python
+from k8s_agent_sandbox.sandbox_client import SandboxClient
+from deepagents_k8s_agent_sandbox import K8sAgentSandbox
+
+client = SandboxClient()
+
+sandbox = K8sAgentSandbox.from_existing_claim_name(
+    client,
+    claim_name="some-claim",
+    namespace="default"
+)
+
+result = sandbox.execute("echo hello")
+print(result.output)
+```
+
+## Full Graph Example
+
+Here is a full example of creating a `deepagents` agent graph that relies on the `K8sAgentSandbox` backend. In this example, the agent creates a python script, executes it securely in the sandbox, and returns the result.
+
+```python
+import os
+from k8s_agent_sandbox import SandboxClient
+from deepagents_k8s_agent_sandbox import K8sAgentSandbox
+from deepagents_k8s_agent_sandbox.settings import K8sAgentSandboxSettings
+from deepagents import create_deep_agent
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+# 1. Setup the chat model (e.g., using LangChain with Gemini)
+model = ChatGoogleGenerativeAI(model="gemini-3-pro")
+
+# 2. Connect to the Kubernetes Sandbox cluster
+client = SandboxClient()
+
+# 3. Configure the sandbox settings
+# 'warmpool' references a pre-defined SandboxTemplate in your cluster
+settings = K8sAgentSandboxSettings(
+    warmpool="python-deepagent",
+    namespace="default"
+)
+
+# 4. Initialize the sandbox backend
+# This either creates a new sandbox claim or reuses an existing one
+# that matches the "scope" labels for isolation.
+backend = K8sAgentSandbox.from_labels_scope(
+    client=client,
+    sandbox_settings=settings,
+    scope={"thread": "my-graph-thread"},
+)
+
+# 5. Create the DeepAgent graph, injecting the K8s sandbox as the backend
+agent = create_deep_agent(
+    model=model,
+    backend=backend,
+    # (Optional) pass the path to custom skills:
+    # skills=["./skills/python-scripting"]
+)
+
+# 6. Invoke the agent with a task that requires sandbox execution
+query = "Write a python script that prints 'Hello from Sandbox', run it, and tell me the output."
+
+print(f"User: {query}\n")
+response = agent.invoke({
+    "messages": [("user", query)]
+})
+
+# 7. Print the results from the agent
+for msg in response.get("messages", []):
+    if msg.type == "ai":
+        print(f"Agent: {msg.content}")
+```

--- a/clients/integrations/deepagents/README.md
+++ b/clients/integrations/deepagents/README.md
@@ -48,7 +48,7 @@ model = ChatGoogleGenerativeAI(model="gemini-3-pro")
 client = SandboxClient()
 
 # 3. Configure the sandbox settings
-# 'warmpool' references a pre-defined SandboxTemplate in your cluster
+# 'warmpool' references a pre-defined SandboxWarmPool in your cluster
 settings = K8sAgentSandboxSettings(
     warmpool="python-deepagent",
     namespace="default"

--- a/clients/integrations/deepagents/README.md
+++ b/clients/integrations/deepagents/README.md
@@ -19,7 +19,10 @@ client = SandboxClient()
 sandbox = K8sAgentSandbox.from_existing_claim_name(
     client,
     claim_name="some-claim",
-    namespace="default"
+    namespace="default",
+    # The directory the sandbox runtime's file API resolves relative paths
+    # against. This is a property of the sandbox image, not `root_dir`.
+    sandbox_api_cwd="/app",
 )
 
 result = sandbox.execute("echo hello")
@@ -58,6 +61,9 @@ backend = K8sAgentSandbox.from_labels_scope(
     client=client,
     sandbox_settings=settings,
     scope={"thread": "my-graph-thread"},
+    # The directory the sandbox runtime's file API resolves relative paths
+    # against. This is a property of the sandbox image, not `root_dir`.
+    sandbox_api_cwd="/app",
 )
 
 # 5. Create the DeepAgent graph, injecting the K8s sandbox as the backend

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/__init__.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .sandbox import (
+    K8sAgentSandbox,
+)
+
+__all__ = [
+    "K8sAgentSandbox",
+]

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 from collections.abc import Callable
 import logging
 
@@ -25,7 +25,7 @@ from .settings import K8sAgentSandboxSettings
 logger = logging.getLogger(__name__)
 
 
-class K8sAgentSandboxLifecycleManager:
+class K8sAgentSandboxLifecycleManager(ABC):
     """A helper class that takes care of managing the sandbox instance."""
     def __init__(self) -> None:
         self._sandbox = None

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -1,0 +1,116 @@
+from abc import abstractmethod
+from collections.abc import Callable
+import logging
+
+from k8s_agent_sandbox import SandboxClient, SandboxNotFoundError
+from k8s_agent_sandbox.sandbox import Sandbox
+
+from .settings import K8sAgentSandboxSettings
+
+
+logger = logging.getLogger(__name__)
+
+
+class K8sAgentSandboxLifecycleManager:
+    """A helper class that takes care if managing the sandbox instance."""
+    def __init__(self) -> None:
+        self._sandbox = None
+
+    def get_sandbox(self) -> Sandbox:
+        if self._sandbox is not None:
+            return self._sandbox
+
+        self._sandbox = self._get_sandbox()
+        return self._sandbox
+
+    @abstractmethod
+    def _get_sandbox(self) -> Sandbox:
+        pass
+
+class ExistingSandboxInstanceLifecycleManager(K8sAgentSandboxLifecycleManager):
+    """Simple manager that uses existing sandbox instance without managing it."""
+    def __init__(self, sandbox: Sandbox) -> None:
+        super().__init__()
+        self._sandbox = sandbox
+
+    def _get_sandbox(self) -> Sandbox:
+        return self._sandbox
+
+
+class ExistingSandboxClaimLifecycleManager(K8sAgentSandboxLifecycleManager):
+    """Simple manager that uses existing sandbox by its claim, without managing it."""
+    def __init__(
+        self,
+        client: SandboxClient,
+        claim_name: str,
+        namespace: str,
+    ) -> None:
+        super().__init__()
+        self._client = client
+        self._claim_name =claim_name
+        self._namespace = namespace
+
+    def _get_sandbox(self) -> Sandbox:
+        return self._client.get_sandbox(
+            self._claim_name, 
+            namespace=self._namespace
+        )
+
+
+class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
+    """Fully manager the lifecycle of a sandbox based on the provided scope."""
+    def __init__(
+        self, 
+        client: SandboxClient,
+        sandbox_settings: K8sAgentSandboxSettings,
+        scope: dict[str, str],
+        scope_labels_prefix: str,
+    ) -> None:
+        super().__init__()
+        self._client = client
+        self._sandbox_settings = sandbox_settings
+
+        self._labels = {
+            f"{scope_labels_prefix}/{k}":v for k,v in scope.items()
+        }
+        
+        self._label_selector=",".join(
+            [ f"{k}={v}" for k,v in self._labels.items()]
+        )
+
+    def _get_sandbox(self) -> Sandbox:
+        claim_name = self._find_sandbox_claim_by_label_selector()
+
+        if claim_name is not None:
+            try:
+                return self._client.get_sandbox(
+                    claim_name, 
+                    namespace=self._sandbox_settings.namespace
+                )
+            except SandboxNotFoundError:
+                pass
+
+        return self._client.create_sandbox(
+            self._sandbox_settings.warmpool,
+            namespace=self._sandbox_settings.namespace,
+            labels=self._labels,
+        )
+        
+    def _find_sandbox_claim_by_label_selector(self) -> str | None:
+    
+        found = self._client.list_all_sandboxes(
+            namespace=self._sandbox_settings.namespace,
+            label_selector=self._label_selector,
+        )
+
+        if len(found) > 1:
+            raise RuntimeError(
+                "Multiple sandboxes with matching scopes have been found. "
+                f"Relete the orphan sandboxes manualy.\nScope labels: {self._labels}"
+            )
+     
+        if len(found) == 1:
+            return found[0]
+    
+        if len(found) == 0:
+            return None

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -130,8 +130,8 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
 
         if len(found) > 1:
             raise RuntimeError(
-                "Multiple sandboxes with matching scopes have been found. "
-                f"Delete the orphan sandboxes manually.\nScope labels: {self._scope_labels}"
+                f"Expected 1 sandbox for scope {self._scope_labels}, found {len(found)}: "
+                f"{found}. Delete orphan sandboxes manually."
             )
      
         if len(found) == 1:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class K8sAgentSandboxLifecycleManager:
-    """A helper class that takes care if managing the sandbox instance."""
+    """A helper class that takes care of managing the sandbox instance."""
     def __init__(self) -> None:
         self._sandbox = None
 
@@ -61,7 +61,7 @@ class ExistingSandboxClaimLifecycleManager(K8sAgentSandboxLifecycleManager):
     ) -> None:
         super().__init__()
         self._client = client
-        self._claim_name =claim_name
+        self._claim_name = claim_name
         self._namespace = namespace
 
     def _get_sandbox(self) -> Sandbox:
@@ -72,7 +72,7 @@ class ExistingSandboxClaimLifecycleManager(K8sAgentSandboxLifecycleManager):
 
 
 class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
-    """Fully manager the lifecycle of a sandbox based on the provided scope."""
+    """Fully manage the lifecycle of a sandbox based on the provided scope."""
     def __init__(
         self, 
         client: SandboxClient,
@@ -85,11 +85,11 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
         self._sandbox_settings = sandbox_settings
 
         self._labels = {
-            f"{scope_labels_prefix}/{k}":v for k,v in scope.items()
+            f"{scope_labels_prefix}/{k}": v for k, v in scope.items()
         }
         
-        self._label_selector=",".join(
-            [ f"{k}={v}" for k,v in self._labels.items()]
+        self._label_selector = ",".join(
+            [f"{k}={v}" for k, v in self._labels.items()]
         )
 
     def _get_sandbox(self) -> Sandbox:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -84,12 +84,12 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
         self._client = client
         self._sandbox_settings = sandbox_settings
 
-        self._labels = {
+        self._scope_labels = {
             f"{scope_labels_prefix}/{k}": v for k, v in scope.items()
         }
         
-        self._label_selector = ",".join(
-            [f"{k}={v}" for k, v in self._labels.items()]
+        self._scope_label_selector = ",".join(
+            [f"{k}={v}" for k, v in self._scope_labels.items()]
         )
 
     def _get_sandbox(self) -> Sandbox:
@@ -104,23 +104,31 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
             except SandboxNotFoundError:
                 pass
 
+        labels = self._sandbox_settings.labels or {}
+        labels.update(self._scope_labels)
+
         return self._client.create_sandbox(
             self._sandbox_settings.warmpool,
             namespace=self._sandbox_settings.namespace,
-            labels=self._labels,
+            sandbox_ready_timeout=self._sandbox_settings.sandbox_ready_timeout,
+            labels=labels,
+            shutdown_after_seconds=self._sandbox_settings.shutdown_after_seconds,
+            volume_claim_templates=self._sandbox_settings.volume_claim_templates,
+            pod_labels=self._sandbox_settings.pod_labels,
+            pod_annotations=self._sandbox_settings.pod_annotations,
         )
         
     def _find_sandbox_claim_by_label_selector(self) -> str | None:
     
         found = self._client.list_all_sandboxes(
             namespace=self._sandbox_settings.namespace,
-            label_selector=self._label_selector,
+            label_selector=self._scope_label_selector,
         )
 
         if len(found) > 1:
             raise RuntimeError(
                 "Multiple sandboxes with matching scopes have been found. "
-                f"Delete the orphan sandboxes manually.\nScope labels: {self._labels}"
+                f"Delete the orphan sandboxes manually.\nScope labels: {self._scope_labels}"
             )
      
         if len(found) == 1:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -72,7 +72,10 @@ class ExistingSandboxClaimLifecycleManager(K8sAgentSandboxLifecycleManager):
 
 
 class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
-    """Fully manage the lifecycle of a sandbox based on the provided scope."""
+    """
+    Fully manage the lifecycle of a sandbox based on the provided scope.
+    Concurrent first runs for the same scope may create duplicate sandboxes, subsequent runs then fail until the duplicates are deleted.
+    """
     def __init__(
         self, 
         client: SandboxClient,
@@ -104,7 +107,7 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
             except SandboxNotFoundError:
                 pass
 
-        labels = self._sandbox_settings.labels or {}
+        labels = dict(self._sandbox_settings.labels or {})
         labels.update(self._scope_labels)
 
         return self._client.create_sandbox(

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from abc import abstractmethod
 from collections.abc import Callable
 import logging
@@ -106,7 +120,7 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
         if len(found) > 1:
             raise RuntimeError(
                 "Multiple sandboxes with matching scopes have been found. "
-                f"Relete the orphan sandboxes manualy.\nScope labels: {self._labels}"
+                f"Delete the orphan sandboxes manually.\nScope labels: {self._labels}"
             )
      
         if len(found) == 1:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from abc import abstractmethod, ABC
-from collections.abc import Callable
 import logging
 
 from k8s_agent_sandbox import SandboxClient, SandboxNotFoundError

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/lifecycle_manager.py
@@ -100,11 +100,14 @@ class LabelScopedLifecycleManager(K8sAgentSandboxLifecycleManager):
         if claim_name is not None:
             try:
                 return self._client.get_sandbox(
-                    claim_name, 
+                    claim_name,
                     namespace=self._sandbox_settings.namespace
                 )
             except SandboxNotFoundError:
-                pass
+                if self._client.k8s_helper.get_sandbox_claim(
+                    claim_name, namespace=self._sandbox_settings.namespace
+                ) is not None:
+                    raise
 
         labels = dict(self._sandbox_settings.labels or {})
         labels.update(self._scope_labels)

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -1,0 +1,306 @@
+import logging
+import posixpath
+import textwrap
+import shlex
+from typing import (
+    Self,
+)
+
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+    FileDownloadResponse,
+    FileUploadResponse,
+    GlobResult,
+    FileOperationError,
+    FILE_NOT_FOUND,
+    PERMISSION_DENIED,
+    IS_DIRECTORY,
+)
+from deepagents.backends.sandbox import (
+    BaseSandbox,
+)
+from k8s_agent_sandbox import SandboxClient
+from k8s_agent_sandbox.sandbox import Sandbox
+
+from .settings import (
+    K8sAgentSandboxSettings,
+)
+from .lifecycle_manager import (
+    K8sAgentSandboxLifecycleManager,
+    ExistingSandboxInstanceLifecycleManager,
+    ExistingSandboxClaimLifecycleManager,
+    LabelScopedLifecycleManager,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class K8sAgentSandbox(BaseSandbox):
+    """
+    DeepAgents backend for k8s_agent_sandbox.
+
+    Args:
+        lifecycle_manager: the instance of the `K8sAgentSandboxLifecycleManager`
+            which is responsible for managing the sandbox instanse.
+        root_dir: Sandbox's working directory.
+        default_timeout_seconds: Default timeout for various operations.
+    """
+
+    def __init__(
+        self,
+        lifecycle_manager: K8sAgentSandboxLifecycleManager,
+        root_dir: str = "/app",
+        default_timeout_seconds: int = 30 * 60,
+    ) -> None:
+        self._lifecycle_manager = lifecycle_manager
+        self._root_dir = root_dir
+        self._default_timeout_seconds = default_timeout_seconds
+
+
+    @classmethod
+    def from_labels_scope(
+        cls,
+        client: SandboxClient,
+        sandbox_settings: K8sAgentSandboxSettings,
+        scope: dict[str, str],
+        scope_labels_prefix: str = "scope.langchain-deepagents",
+    ) -> Self:
+        """
+        Create DeepAgents backend that re-uses sandbox with matching "scope" labels
+        or creates a new one with these labels, so it can be reused later.
+
+        Args:
+            client: SandboxClient instance.
+            sandbox_settings: Instance with sandbox settings.
+            scope: Dictionaly that respresents labels that are applied to a sandbox claim.
+                This can be used in a graph factory to specify user, thread or 
+                assistant specific labels to isolate sandboxes from different runs.
+            scope_labels_prefix: Perfix for scope label keys.  
+        """
+
+        lifecycle_manager = LabelScopedLifecycleManager(
+            client,
+            sandbox_settings,
+            scope,
+            scope_labels_prefix,
+        )
+
+        return cls(
+            lifecycle_manager,
+        )
+     
+    @classmethod
+    def from_existing_sandbox(
+        cls,
+        sandbox: Sandbox,
+    ) -> Self:
+        """
+        Create Sandbox backend from existing sandbox instance.
+        """
+
+        lifecycle_manager = ExistingSandboxInstanceLifecycleManager(sandbox)
+
+        return cls(
+            lifecycle_manager,
+        )
+
+
+    @classmethod
+    def from_existing_claim_name(
+        cls,
+        client: SandboxClient,
+        claim_name: str,
+        namespace: str,
+    ) -> Self:
+        """
+        Create Sandbox backend from existing sandbox by finding it by its calim name.
+        """
+
+
+        lifecycle_manager = ExistingSandboxClaimLifecycleManager(
+            client,
+            claim_name,
+            namespace,
+        )
+ 
+        return cls(
+            lifecycle_manager,
+        )
+
+    def execute(
+        self,
+        command: str,
+        *,
+        timeout: int | None = None,
+    ) -> ExecuteResponse:
+        """
+        Execute a shell command in the sandbox.
+        """
+
+        wrapped = f"sh -c {shlex.quote(f'cd {self._root_dir} && {command}')}"
+
+        effective_timeout = timeout or self._default_timeout_seconds
+        try:
+            result = self._sandbox.commands.run(wrapped, timeout=effective_timeout)
+        except Exception as e:
+            logger.error("execute failed: %s", e)
+            return ExecuteResponse(
+                output=f"Error: {e}",
+                exit_code=-1,
+                truncated=False,
+            )
+        combined = result.stdout
+        if result.stderr:
+            combined = f"{combined}\n<stderr>\n{result.stderr}\n</stderr>" if combined else result.stderr
+        return ExecuteResponse(
+            output=combined,
+            exit_code=result.exit_code,
+            truncated=False,
+        )
+
+    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
+        path = path or self._root_dir
+        return super().glob(pattern, path)
+
+    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
+        path = path = self._root_dir
+        return await super().aglob(pattern, path)
+
+    def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
+        """Upload multiple files to the sandbox.
+
+        Args:
+            files: Dict or iterable of (path, content) pairs.
+
+        Returns:
+            List of FileUploadResponse for each file.
+        """
+        responses = []
+        for path, content in files:
+            responses.append(self._upload_file(path, content))
+
+        return responses
+
+    def download_files(self, paths: list[str]) -> list[FileDownloadResponse]:
+        """
+        Download multiple files from the sandbox.
+        """
+        responses = []
+        for path in paths:
+            responses.append(self._download_file(path))
+        return responses
+
+    def _upload_file(self, path: str, content: bytes):
+        try:
+            self._upload_file_and_handle_error(path, content)
+            error = None
+        except Exception as e:
+            error = _map_file_error(e)
+ 
+        return FileUploadResponse(path, error=error)
+
+    def _download_file(self, path: str):
+        try:
+            content = self._download_file_and_handle_error(path)
+            error = None
+        except Exception as e:
+            content = None
+            error = _map_file_error(e)
+ 
+        return FileDownloadResponse(path,content=content, error=error)
+
+
+    def _upload_file_and_handle_error(self, path: str, content: bytes):
+        """Temporary workaround for missing SDK structured errors."""
+
+        self._ensure_parent_dir(path)
+        try:
+            self._assert_file_valid_state(path)
+        except FileNotFoundError:
+            pass
+        self._sandbox.files.write(path, content)
+
+    def _download_file_and_handle_error(self, path: str) -> bytes:
+        """Temporary workaround for missing SDK structured errors."""
+
+        self._assert_file_valid_state(path)
+        return self._sandbox.files.read(path)
+
+
+    def _ensure_parent_dir(self, path: str) -> None:
+        parent = posixpath.dirname(path)
+        if parent == "":
+            return
+        command = shlex.join(["mkdir", "-p", parent])
+        result = self._sandbox.commands.run(command)
+        if result.exit_code != 0:
+            error_msg = result.stderr.strip() if result.stderr else f"mkdir failed with exit code {result.exit_code}"
+            raise RuntimeError(f"Cannot create parent directory '{parent}': {error_msg}")
+
+
+    def _assert_file_valid_state(
+        self, path: str,
+    ):
+        """Run the shell command to validate the state of a target file."""
+    
+        quoted_path = shlex.quote(path)
+        cmd = textwrap.dedent(
+            f"""
+            if [ ! -e {quoted_path} ]; then echo missing; exit 0; fi;
+            if [ -d {quoted_path} ]; then echo directory; exit 0; fi;
+            if [ -r {quoted_path} ]; then echo file; else echo denied; fi
+            """
+        )
+
+        result = self._sandbox.commands.run(f"sh -c {shlex.quote(cmd)}")
+        output = result.stdout.strip()
+
+        if result.exit_code != 0:
+            raise RuntimeError(f"Cannot get file state. Error: {result.stderr}")
+
+        if output == "file":
+            return
+
+        if output == "missing":
+            raise FileNotFoundError(f"File {path} is not found.")
+        elif output == "directory":
+            raise IsADirectoryError(f"Path {path} is a directory.")
+        elif output == "denied":
+            raise PermissionError(f"Cannot access file {path}.")
+        else:
+            raise RuntimeError(f"Unknown file state: {output}")
+
+    @property
+    def _sandbox(self):
+        return self._lifecycle_manager.get_sandbox()
+
+    @property
+    def id(self) -> str:
+        """Return a namespace-qualified sandbox identifier.
+
+        Format: ``{namespace}/{claim_name}``. Namespace-qualification
+        prevents collisions when multiple namespaces are in use.
+        Falls back to ``"agent-sandbox"`` before ``__enter__`` is called.
+        """
+        if self._sandbox is not None:
+            ns = getattr(self._sandbox, "namespace", None) or "default"
+            claim = getattr(self._sandbox, "claim_name", None)
+            if claim:
+                return f"{ns}/{claim}"
+        return "agent-sandbox"
+
+
+def _map_file_error(error: Exception) -> FileOperationError | str:
+    """
+    Map a provider filesystem failure to a Deep Agents file error.
+    """
+    if isinstance(error, PermissionError):
+        return PERMISSION_DENIED
+    if isinstance(error, IsADirectoryError):
+        return IS_DIRECTORY
+    if isinstance(error, FileNotFoundError):
+        return FILE_NOT_FOUND
+
+    return str(error)
+

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import posixpath
 import textwrap
@@ -161,7 +175,7 @@ class K8sAgentSandbox(BaseSandbox):
         return super().glob(pattern, path)
 
     async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
-        path = path = self._root_dir
+        path = path or self._root_dir
         return await super().aglob(pattern, path)
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -276,18 +276,11 @@ class K8sAgentSandbox(BaseSandbox):
 
     @property
     def id(self) -> str:
-        """Return a namespace-qualified sandbox identifier.
-
-        Format: ``{namespace}/{claim_name}``. Namespace-qualification
-        prevents collisions when multiple namespaces are in use.
-        Falls back to ``"agent-sandbox"`` before ``__enter__`` is called.
         """
-        if self._sandbox is not None:
-            ns = getattr(self._sandbox, "namespace", None) or "default"
-            claim = getattr(self._sandbox, "claim_name", None)
-            if claim:
-                return f"{ns}/{claim}"
-        return "agent-sandbox"
+        Return a namespace-qualified sandbox identifier.
+        """
+
+        return f"{self._sandbox.namespace}/{self._sandbox.claim_name}"
 
 
 def _map_file_error(error: Exception) -> FileOperationError | str:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -16,6 +16,7 @@ import logging
 import posixpath
 import textwrap
 import shlex
+from typing import Literal
 
 from deepagents.backends.protocol import (
     ExecuteResponse,
@@ -241,7 +242,7 @@ class K8sAgentSandbox(BaseSandbox):
     def _assert_file_valid_state(
         self,
         path: str,
-        access_mode: str,
+        access_mode: Literal["r", "w"],
     ):
         """Run the shell command to validate the state of a target file."""
     

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -75,7 +75,7 @@ class K8sAgentSandbox(BaseSandbox):
         client: SandboxClient,
         sandbox_settings: K8sAgentSandboxSettings,
         scope: dict[str, str],
-        scope_labels_prefix: str = "scope.langchain-deepagents",
+        scope_labels_prefix: str = "deepagents.agents.x-k8s.io",
     ):
         """
         Create DeepAgents backend that re-uses sandbox with matching "scope" labels

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -149,7 +149,8 @@ class K8sAgentSandbox(BaseSandbox):
         Execute a shell command in the sandbox.
         """
 
-        wrapped = f"sh -c {shlex.quote(f'cd {self._root_dir} && {command}')}"
+        inner_shell_command = f"cd {shlex.quote(self._root_dir)} && {command}"
+        wrapped = f"sh -c {shlex.quote(inner_shell_command)}"
 
         effective_timeout = timeout or self._default_timeout_seconds
         try:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -2,9 +2,6 @@ import logging
 import posixpath
 import textwrap
 import shlex
-from typing import (
-    Self,
-)
 
 from deepagents.backends.protocol import (
     ExecuteResponse,
@@ -65,7 +62,7 @@ class K8sAgentSandbox(BaseSandbox):
         sandbox_settings: K8sAgentSandboxSettings,
         scope: dict[str, str],
         scope_labels_prefix: str = "scope.langchain-deepagents",
-    ) -> Self:
+    ):
         """
         Create DeepAgents backend that re-uses sandbox with matching "scope" labels
         or creates a new one with these labels, so it can be reused later.
@@ -94,7 +91,7 @@ class K8sAgentSandbox(BaseSandbox):
     def from_existing_sandbox(
         cls,
         sandbox: Sandbox,
-    ) -> Self:
+    ):
         """
         Create Sandbox backend from existing sandbox instance.
         """
@@ -112,7 +109,7 @@ class K8sAgentSandbox(BaseSandbox):
         client: SandboxClient,
         claim_name: str,
         namespace: str,
-    ) -> Self:
+    ):
         """
         Create Sandbox backend from existing sandbox by finding it by its calim name.
         """

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -207,7 +207,7 @@ class K8sAgentSandbox(BaseSandbox):
         try:
             self._ensure_parent_dir(path)
             try:
-                self._assert_file_valid_state(path)
+                self._assert_file_valid_state(path, "w")
             except FileNotFoundError:
                 pass
             self._sandbox.files.write(path, content)
@@ -219,7 +219,7 @@ class K8sAgentSandbox(BaseSandbox):
 
     def _download_file(self, path: str):
         try:
-            self._assert_file_valid_state(path)
+            self._assert_file_valid_state(path, "r")
             content = self._sandbox.files.read(path)
             error = None
         except Exception as e:
@@ -238,9 +238,10 @@ class K8sAgentSandbox(BaseSandbox):
             error_msg = result.stderr.strip() if result.stderr else f"mkdir failed with exit code {result.exit_code}"
             raise RuntimeError(f"Cannot create parent directory '{parent}': {error_msg}")
 
-
     def _assert_file_valid_state(
-        self, path: str,
+        self,
+        path: str,
+        access_mode: str,
     ):
         """Run the shell command to validate the state of a target file."""
     
@@ -249,7 +250,7 @@ class K8sAgentSandbox(BaseSandbox):
             f"""
             if [ ! -e {quoted_path} ]; then echo missing; exit 0; fi;
             if [ -d {quoted_path} ]; then echo directory; exit 0; fi;
-            if [ -r {quoted_path} ]; then echo file; else echo denied; fi
+            if [ -{access_mode} {quoted_path} ]; then echo file; else echo denied; fi
             """
         )
 

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -53,7 +53,7 @@ class K8sAgentSandbox(BaseSandbox):
 
     Args:
         lifecycle_manager: the instance of the `K8sAgentSandboxLifecycleManager`
-            which is responsible for managing the sandbox instanse.
+            which is responsible for managing the sandbox instance.
         root_dir: Sandbox's working directory.
         default_timeout_seconds: Default timeout for various operations.
     """
@@ -84,10 +84,10 @@ class K8sAgentSandbox(BaseSandbox):
         Args:
             client: SandboxClient instance.
             sandbox_settings: Instance with sandbox settings.
-            scope: Dictionaly that respresents labels that are applied to a sandbox claim.
+            scope: Dictionary that represents labels that are applied to a sandbox claim.
                 This can be used in a graph factory to specify user, thread or 
                 assistant specific labels to isolate sandboxes from different runs.
-            scope_labels_prefix: Perfix for scope label keys.  
+            scope_labels_prefix: Prefix for scope label keys.
         """
 
         lifecycle_manager = LabelScopedLifecycleManager(
@@ -125,7 +125,7 @@ class K8sAgentSandbox(BaseSandbox):
         namespace: str,
     ):
         """
-        Create Sandbox backend from existing sandbox by finding it by its calim name.
+        Create Sandbox backend from existing sandbox by finding it by its claim name.
         """
 
 
@@ -204,7 +204,12 @@ class K8sAgentSandbox(BaseSandbox):
 
     def _upload_file(self, path: str, content: bytes):
         try:
-            self._upload_file_and_handle_error(path, content)
+            self._ensure_parent_dir(path)
+            try:
+                self._assert_file_valid_state(path)
+            except FileNotFoundError:
+                pass
+            self._sandbox.files.write(path, content)
             error = None
         except Exception as e:
             error = _map_file_error(e)
@@ -213,31 +218,14 @@ class K8sAgentSandbox(BaseSandbox):
 
     def _download_file(self, path: str):
         try:
-            content = self._download_file_and_handle_error(path)
+            self._assert_file_valid_state(path)
+            content = self._sandbox.files.read(path)
             error = None
         except Exception as e:
             content = None
             error = _map_file_error(e)
  
-        return FileDownloadResponse(path,content=content, error=error)
-
-
-    def _upload_file_and_handle_error(self, path: str, content: bytes):
-        """Temporary workaround for missing SDK structured errors."""
-
-        self._ensure_parent_dir(path)
-        try:
-            self._assert_file_valid_state(path)
-        except FileNotFoundError:
-            pass
-        self._sandbox.files.write(path, content)
-
-    def _download_file_and_handle_error(self, path: str) -> bytes:
-        """Temporary workaround for missing SDK structured errors."""
-
-        self._assert_file_valid_state(path)
-        return self._sandbox.files.read(path)
-
+        return FileDownloadResponse(path, content=content, error=error)
 
     def _ensure_parent_dir(self, path: str) -> None:
         parent = posixpath.dirname(path)

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -83,6 +83,7 @@ class K8sAgentSandbox(BaseSandbox):
         self._sandbox_api_accepts_relative_paths = sandbox_api_accepts_relative_paths
         self._sandbox_api_cwd = sandbox_api_cwd
         self._root_dir_initialized = False
+        self._last_used_sandbox: Sandbox | None = None
 
 
     @classmethod
@@ -321,13 +322,14 @@ class K8sAgentSandbox(BaseSandbox):
     def _sandbox(self):
         sandbox = self._lifecycle_manager.get_sandbox()
         self._initialize_root_dir(sandbox)
+        self._last_used_sandbox = sandbox
         return sandbox
 
     def _initialize_root_dir(self, sandbox: Sandbox):
         """
         Create a root directory in case it does not exist.
         """
-        if self._root_dir_initialized:
+        if self._root_dir_initialized and self._last_used_sandbox is sandbox:
             return
 
         command = f"mkdir -p {shlex.quote(self._root_dir)}"

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -349,7 +349,8 @@ class K8sAgentSandbox(BaseSandbox):
         Return a namespace-qualified sandbox identifier.
         """
 
-        return f"{self._sandbox.namespace}/{self._sandbox.claim_name}"
+        sandbox = self._lifecycle_manager.get_sandbox()
+        return f"{sandbox.namespace}/{sandbox.claim_name}"
 
     def _get_path_relative_to_cwd_if_needed(self, path: str) -> str:
         if self._sandbox_api_accepts_relative_paths and posixpath.isabs(path):

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -22,7 +22,6 @@ from deepagents.backends.protocol import (
     ExecuteResponse,
     FileDownloadResponse,
     FileUploadResponse,
-    GlobResult,
     FileOperationError,
     FILE_NOT_FOUND,
     PERMISSION_DENIED,
@@ -57,17 +56,33 @@ class K8sAgentSandbox(BaseSandbox):
             which is responsible for managing the sandbox instance.
         root_dir: Sandbox's working directory.
         default_timeout_seconds: Default timeout for various operations.
+        sandbox_api_accepts_relative_paths: When True, all paths that are passed to
+            sandbox operations are transformed to the relative paths agains `sandbox_api_cwd`.
+            Since the DeepAgents backends normally use absolute paths, this option can be
+            used to convert them into relative paths in case when sandbox operations only
+            accept relative paths. This is a temporary workaround until the sandbox SDK provides
+            this as a built-in feature.
+        sandbox_api_cwd: The directory that the sandbox's file API (upload/download)
+            resolves relative paths against. This is a property of the sandbox runtime
+            image, unrelated to `root_dir`.
     """
 
     def __init__(
         self,
         lifecycle_manager: K8sAgentSandboxLifecycleManager,
-        root_dir: str = "/app",
+        root_dir: str = "/app/work",
         default_timeout_seconds: int = 30 * 60,
+        sandbox_api_cwd: str | None = "/app",
+        sandbox_api_accepts_relative_paths: bool = True,
+
     ) -> None:
         self._lifecycle_manager = lifecycle_manager
         self._root_dir = root_dir
         self._default_timeout_seconds = default_timeout_seconds
+
+        self._sandbox_api_accepts_relative_paths = sandbox_api_accepts_relative_paths
+        self._sandbox_api_cwd = sandbox_api_cwd
+        self._root_dir_initialized = False
 
 
     @classmethod
@@ -77,6 +92,8 @@ class K8sAgentSandbox(BaseSandbox):
         sandbox_settings: K8sAgentSandboxSettings,
         scope: dict[str, str],
         scope_labels_prefix: str = "deepagents.agents.x-k8s.io",
+        sandbox_api_cwd: str | None = None,
+        sandbox_api_accepts_relative_paths: bool = True,
     ):
         """
         Create DeepAgents backend that re-uses sandbox with matching "scope" labels
@@ -89,6 +106,8 @@ class K8sAgentSandbox(BaseSandbox):
                 This can be used in a graph factory to specify user, thread or 
                 assistant specific labels to isolate sandboxes from different runs.
             scope_labels_prefix: Prefix for scope label keys.
+            sandbox_api_accepts_relative_paths: See :meth:`__init__` for details.
+            sandbox_api_cwd: See :meth:`__init__` for details.
         """
 
         lifecycle_manager = LabelScopedLifecycleManager(
@@ -100,21 +119,32 @@ class K8sAgentSandbox(BaseSandbox):
 
         return cls(
             lifecycle_manager,
+            sandbox_api_cwd=sandbox_api_cwd,
+            sandbox_api_accepts_relative_paths=sandbox_api_accepts_relative_paths,
         )
      
     @classmethod
     def from_existing_sandbox(
         cls,
         sandbox: Sandbox,
+        sandbox_api_cwd: str | None = None,
+        sandbox_api_accepts_relative_paths: bool = True,
     ):
         """
         Create Sandbox backend from existing sandbox instance.
+
+        Args:
+            sandbox: Existing k8s_agent_sandbox.sandbox.Sandbox instance to use.
+            sandbox_api_accepts_relative_paths: See :meth:`__init__` for details.
+            sandbox_api_cwd: See :meth:`__init__` for details.
         """
 
         lifecycle_manager = ExistingSandboxInstanceLifecycleManager(sandbox)
 
         return cls(
             lifecycle_manager,
+            sandbox_api_cwd=sandbox_api_cwd,
+            sandbox_api_accepts_relative_paths=sandbox_api_accepts_relative_paths,
         )
 
 
@@ -124,9 +154,17 @@ class K8sAgentSandbox(BaseSandbox):
         client: SandboxClient,
         claim_name: str,
         namespace: str,
+        sandbox_api_cwd: str | None = None,
+        sandbox_api_accepts_relative_paths: bool = True,
     ):
         """
         Create Sandbox backend from existing sandbox by finding it by its claim name.
+        Args:
+            client: SandboxClient instance.
+            claim_name: Name of an existing sandbox claim to use.
+            namespace: Namespace with a target sandbox claim.
+            sandbox_api_accepts_relative_paths: See :meth:`__init__` for details.
+            sandbox_api_cwd: See :meth:`__init__` for details.
         """
 
 
@@ -138,6 +176,8 @@ class K8sAgentSandbox(BaseSandbox):
  
         return cls(
             lifecycle_manager,
+            sandbox_api_cwd=sandbox_api_cwd,
+            sandbox_api_accepts_relative_paths=sandbox_api_accepts_relative_paths,
         )
 
     def execute(
@@ -154,6 +194,7 @@ class K8sAgentSandbox(BaseSandbox):
         wrapped = f"sh -c {shlex.quote(inner_shell_command)}"
 
         effective_timeout = timeout or self._default_timeout_seconds
+
         try:
             result = self._sandbox.commands.run(wrapped, timeout=effective_timeout)
         except Exception as e:
@@ -171,14 +212,6 @@ class K8sAgentSandbox(BaseSandbox):
             exit_code=result.exit_code,
             truncated=False,
         )
-
-    def glob(self, pattern: str, path: str | None = None) -> GlobResult:
-        path = path or self._root_dir
-        return super().glob(pattern, path)
-
-    async def aglob(self, pattern: str, path: str | None = None) -> GlobResult:
-        path = path or self._root_dir
-        return await super().aglob(pattern, path)
 
     def upload_files(self, files: list[tuple[str, bytes]]) -> list[FileUploadResponse]:
         """Upload multiple files to the sandbox.
@@ -211,7 +244,8 @@ class K8sAgentSandbox(BaseSandbox):
                 self._assert_file_valid_state(path, "w")
             except FileNotFoundError:
                 pass
-            self._sandbox.files.write(path, content)
+            rel_path = self._get_path_relative_to_cwd_if_needed(path)
+            self._sandbox.files.write(rel_path, content, allow_unsafe_paths=True)
             error = None
         except Exception as e:
             error = _map_file_error(e)
@@ -221,7 +255,8 @@ class K8sAgentSandbox(BaseSandbox):
     def _download_file(self, path: str):
         try:
             self._assert_file_valid_state(path, "r")
-            content = self._sandbox.files.read(path)
+            rel_path = self._get_path_relative_to_cwd_if_needed(path)
+            content = self._sandbox.files.read(rel_path, allow_unsafe_paths=True)
             error = None
         except Exception as e:
             content = None
@@ -275,7 +310,27 @@ class K8sAgentSandbox(BaseSandbox):
 
     @property
     def _sandbox(self):
-        return self._lifecycle_manager.get_sandbox()
+        sandbox = self._lifecycle_manager.get_sandbox()
+        self._initialize_root_dir(sandbox)
+        return sandbox
+
+    def _initialize_root_dir(self, sandbox: Sandbox):
+        """
+        Create a root directory in case it does not exist.
+        """
+        if self._root_dir_initialized:
+            return
+
+        command = f"mkdir -p {shlex.quote(self._root_dir)}"
+        result = sandbox.commands.run(f"sh -c {shlex.quote(command)}")
+
+        if result.exit_code == 0:
+            self._root_dir_initialized = True
+            return
+
+        raise RuntimeError(
+            f"Cannot create working directory {self._root_dir}. Error: {result.stderr}"
+        )
 
     @property
     def id(self) -> str:
@@ -284,6 +339,12 @@ class K8sAgentSandbox(BaseSandbox):
         """
 
         return f"{self._sandbox.namespace}/{self._sandbox.claim_name}"
+
+    def _get_path_relative_to_cwd_if_needed(self, path: str) -> str:
+        if self._sandbox_api_accepts_relative_paths and posixpath.isabs(path):
+            return posixpath.relpath(path, self._sandbox_api_cwd)
+
+        return path
 
 
 def _map_file_error(error: Exception) -> FileOperationError | str:

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -57,7 +57,7 @@ class K8sAgentSandbox(BaseSandbox):
         root_dir: Sandbox's working directory.
         default_timeout_seconds: Default timeout for various operations.
         sandbox_api_accepts_relative_paths: When True, all paths that are passed to
-            sandbox operations are transformed to the relative paths agains `sandbox_api_cwd`.
+            sandbox operations are converted to paths relative to `sandbox_api_cwd`.
             Since the DeepAgents backends normally use absolute paths, this option can be
             used to convert them into relative paths in case when sandbox operations only
             accept relative paths. This is a temporary workaround until the sandbox SDK provides

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/sandbox.py
@@ -72,7 +72,7 @@ class K8sAgentSandbox(BaseSandbox):
         lifecycle_manager: K8sAgentSandboxLifecycleManager,
         root_dir: str = "/app/work",
         default_timeout_seconds: int = 30 * 60,
-        sandbox_api_cwd: str | None = "/app",
+        sandbox_api_cwd: str = "/app",
         sandbox_api_accepts_relative_paths: bool = True,
 
     ) -> None:
@@ -92,7 +92,8 @@ class K8sAgentSandbox(BaseSandbox):
         sandbox_settings: K8sAgentSandboxSettings,
         scope: dict[str, str],
         scope_labels_prefix: str = "deepagents.agents.x-k8s.io",
-        sandbox_api_cwd: str | None = None,
+        root_dir: str = "/app/work",
+        sandbox_api_cwd: str = "/app",
         sandbox_api_accepts_relative_paths: bool = True,
     ):
         """
@@ -106,6 +107,7 @@ class K8sAgentSandbox(BaseSandbox):
                 This can be used in a graph factory to specify user, thread or 
                 assistant specific labels to isolate sandboxes from different runs.
             scope_labels_prefix: Prefix for scope label keys.
+            root_dir: See :meth:`__init__` for details.
             sandbox_api_accepts_relative_paths: See :meth:`__init__` for details.
             sandbox_api_cwd: See :meth:`__init__` for details.
         """
@@ -119,6 +121,7 @@ class K8sAgentSandbox(BaseSandbox):
 
         return cls(
             lifecycle_manager,
+            root_dir=root_dir,
             sandbox_api_cwd=sandbox_api_cwd,
             sandbox_api_accepts_relative_paths=sandbox_api_accepts_relative_paths,
         )
@@ -127,7 +130,8 @@ class K8sAgentSandbox(BaseSandbox):
     def from_existing_sandbox(
         cls,
         sandbox: Sandbox,
-        sandbox_api_cwd: str | None = None,
+        root_dir: str = "/app/work",
+        sandbox_api_cwd: str = "/app",
         sandbox_api_accepts_relative_paths: bool = True,
     ):
         """
@@ -135,6 +139,7 @@ class K8sAgentSandbox(BaseSandbox):
 
         Args:
             sandbox: Existing k8s_agent_sandbox.sandbox.Sandbox instance to use.
+            root_dir: See :meth:`__init__` for details.
             sandbox_api_accepts_relative_paths: See :meth:`__init__` for details.
             sandbox_api_cwd: See :meth:`__init__` for details.
         """
@@ -143,6 +148,7 @@ class K8sAgentSandbox(BaseSandbox):
 
         return cls(
             lifecycle_manager,
+            root_dir=root_dir,
             sandbox_api_cwd=sandbox_api_cwd,
             sandbox_api_accepts_relative_paths=sandbox_api_accepts_relative_paths,
         )
@@ -154,7 +160,8 @@ class K8sAgentSandbox(BaseSandbox):
         client: SandboxClient,
         claim_name: str,
         namespace: str,
-        sandbox_api_cwd: str | None = None,
+        root_dir: str = "/app/work",
+        sandbox_api_cwd: str = "/app",
         sandbox_api_accepts_relative_paths: bool = True,
     ):
         """
@@ -163,6 +170,7 @@ class K8sAgentSandbox(BaseSandbox):
             client: SandboxClient instance.
             claim_name: Name of an existing sandbox claim to use.
             namespace: Namespace with a target sandbox claim.
+            root_dir: See :meth:`__init__` for details.
             sandbox_api_accepts_relative_paths: See :meth:`__init__` for details.
             sandbox_api_cwd: See :meth:`__init__` for details.
         """
@@ -176,6 +184,7 @@ class K8sAgentSandbox(BaseSandbox):
  
         return cls(
             lifecycle_manager,
+            root_dir=root_dir,
             sandbox_api_cwd=sandbox_api_cwd,
             sandbox_api_accepts_relative_paths=sandbox_api_accepts_relative_paths,
         )

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/settings.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/settings.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from dataclasses import (
     dataclass,
 )

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/settings.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/settings.py
@@ -1,0 +1,19 @@
+from dataclasses import (
+    dataclass,
+)
+
+
+@dataclass
+class K8sAgentSandboxSettings:
+    """
+    The dataclass that stores sandbox settings. 
+    The signature fully matches the `SandboxClient.create_sandbox`.
+    """
+
+    warmpool: str
+    namespace: str
+    sandbox_ready_timeout: int = 180
+    labels: dict[str, str] | None = None
+    shutdown_after_seconds: int | None = None
+    pod_labels: dict[str, str] | None = None
+    pod_annotations: dict[str, str] | None = None

--- a/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/settings.py
+++ b/clients/integrations/deepagents/deepagents_k8s_agent_sandbox/settings.py
@@ -29,5 +29,6 @@ class K8sAgentSandboxSettings:
     sandbox_ready_timeout: int = 180
     labels: dict[str, str] | None = None
     shutdown_after_seconds: int | None = None
+    volume_claim_templates: list[dict] | None = None
     pod_labels: dict[str, str] | None = None
     pod_annotations: dict[str, str] | None = None

--- a/clients/integrations/deepagents/pyproject.toml
+++ b/clients/integrations/deepagents/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "deepagents-k8s-agent-sandbox"
+description = "LangChain DeepAgents backend for Kubernetes agent-sandbox."
+readme = "README.md"
+
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "deepagents>=0.6.0,<0.7.0",
+    "k8s-agent-sandbox~=0.5.0",
+    "langgraph-cli[inmem]>=0.4.30",
+]
+
+[project.urls]
+Homepage = "https://github.com/kubernetes-sigs/agent-sandbox/clients/integrations/deepagents"
+Repository = "https://github.com/kubernetes-sigs/agent-sandbox"
+Documentation = "https://github.com/kubernetes-sigs/agent-sandbox/clients/integrations/deepagents"
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["deepagents_k8s_agent_sandbox*"]
+exclude = ["tests*"]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-xdist",
+    "pytest-asyncio",
+]

--- a/clients/integrations/deepagents/pyproject.toml
+++ b/clients/integrations/deepagents/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-ynamic = ["version"]
+dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "deepagents>=0.6.0,<0.7.0",

--- a/clients/integrations/deepagents/pyproject.toml
+++ b/clients/integrations/deepagents/pyproject.toml
@@ -17,7 +17,6 @@ requires-python = ">=3.10"
 dependencies = [
     "deepagents>=0.6.0,<0.7.0",
     "k8s-agent-sandbox~=0.5.0",
-    "langgraph-cli[inmem]>=0.4.30",
 ]
 
 [project.urls]

--- a/clients/integrations/deepagents/pyproject.toml
+++ b/clients/integrations/deepagents/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-version = "0.1.0"
+ynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "deepagents>=0.6.0,<0.7.0",
@@ -34,6 +34,14 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["deepagents_k8s_agent_sandbox*"]
 exclude = ["tests*"]
+
+[tool.setuptools.exclude-package-data]
+# setuptools_scm automatically bundles tracked files as package data.
+# We need to explicitly exclude test directories and files from being bundled.
+"*" = ["test/*", "tests/*", "*/test/*", "*/tests/*", "test_*.py", "*_test.py"]
+
+[tool.setuptools_scm]
+root = "../../.."
 
 [project.optional-dependencies]
 test = [

--- a/clients/integrations/deepagents/pyproject.toml
+++ b/clients/integrations/deepagents/pyproject.toml
@@ -45,6 +45,4 @@ root = "../../.."
 [project.optional-dependencies]
 test = [
     "pytest",
-    "pytest-xdist",
-    "pytest-asyncio",
 ]

--- a/clients/integrations/deepagents/tests/unit/conftest.py
+++ b/clients/integrations/deepagents/tests/unit/conftest.py
@@ -14,7 +14,6 @@
 
 from unittest.mock import MagicMock
 
-from _pytest.mark import param
 import pytest
 
 

--- a/clients/integrations/deepagents/tests/unit/conftest.py
+++ b/clients/integrations/deepagents/tests/unit/conftest.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+
+from _pytest.mark import param
+import pytest
+
+
+from deepagents_k8s_agent_sandbox.lifecycle_manager import (
+    ExistingSandboxClaimLifecycleManager, 
+    ExistingSandboxInstanceLifecycleManager, 
+    LabelScopedLifecycleManager,
+)
+from deepagents_k8s_agent_sandbox.settings import (
+    K8sAgentSandboxSettings,
+)
+
+
+@pytest.fixture
+def mock_sandbox():
+    return MagicMock()
+
+@pytest.fixture
+def mock_sandbox_client(mock_sandbox):
+    client = MagicMock()
+    client.create_sandbox.return_value = mock_sandbox
+    client.get_sandbox.return_value = mock_sandbox
+    return client
+
+
+@pytest.fixture
+def sample_sandbox_settings():
+    return K8sAgentSandboxSettings(
+        "my-warmpool",
+        "my-namespace",
+    )
+
+@pytest.fixture(params=[
+    "existing-sandbox-instance", 
+    "existing-sandbox-claim", 
+    "label-scoped"
+])
+def lifecycle_manager(request, mock_sandbox, mock_sandbox_client, sample_sandbox_settings):
+    if request.param == "existing-sandbox-instance":
+        return ExistingSandboxInstanceLifecycleManager(mock_sandbox)
+    elif request.param == "existing-sandbox-claim":
+        return ExistingSandboxClaimLifecycleManager(mock_sandbox_client, "my-claim", "my-namespace")
+    elif request.param == "label-scoped":
+        return LabelScopedLifecycleManager(
+            mock_sandbox_client,
+            sample_sandbox_settings,
+            scope={
+                "thread-id": "1",
+                "assistant-id": "2",
+            },
+            scope_labels_prefix="my-prefix"
+        )
+    else:
+        raise ValueError(f"Unknown lifecycle manager type: {request.param}")
+

--- a/clients/integrations/deepagents/tests/unit/conftest.py
+++ b/clients/integrations/deepagents/tests/unit/conftest.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import MagicMock
 
 from _pytest.mark import param

--- a/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
+++ b/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
@@ -39,7 +39,9 @@ class TestExistingSandbox:
 
         assert sandbox == mock_sandbox
 
-        mock_sandbox_client.get_sandbox.assert_called_once_with("my-claim", namespace="my-namespace")
+        mock_sandbox_client.get_sandbox.assert_called_once_with(
+            "my-claim", namespace="my-namespace"
+        )
         assert mock_sandbox_client.create_sandbox.call_count == 0
 
 

--- a/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
+++ b/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
@@ -78,7 +78,12 @@ class TestLabelScopedManager:
         mock_sandbox_client.create_sandbox.assert_called_once_with(
             sample_sandbox_settings.warmpool,
             namespace=sample_sandbox_settings.namespace,
+            sandbox_ready_timeout=sample_sandbox_settings.sandbox_ready_timeout,
             labels={'my-prefix/thread-id': '1', 'my-prefix/assistant-id': '2'},
+            shutdown_after_seconds=sample_sandbox_settings.shutdown_after_seconds,
+            volume_claim_templates=sample_sandbox_settings.volume_claim_templates,
+            pod_labels=sample_sandbox_settings.pod_labels,
+            pod_annotations=sample_sandbox_settings.pod_annotations,
         )
     
     def test_with_existing_sandbox(self, mock_sandbox_client, mock_sandbox, sample_sandbox_settings, manager):

--- a/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
+++ b/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from k8s_agent_sandbox import SandboxNotFoundError
 import pytest
 

--- a/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
+++ b/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
@@ -1,0 +1,88 @@
+from k8s_agent_sandbox import SandboxNotFoundError
+import pytest
+
+from deepagents_k8s_agent_sandbox.lifecycle_manager import (
+    ExistingSandboxInstanceLifecycleManager,
+    ExistingSandboxClaimLifecycleManager,
+    LabelScopedLifecycleManager,
+)
+
+
+class TestExistingSandbox:
+    def test_existing_instance(self, mock_sandbox):
+        manager = ExistingSandboxInstanceLifecycleManager(mock_sandbox)
+
+        assert manager.get_sandbox() == mock_sandbox
+    
+    def test_existing_claim(self, mock_sandbox, mock_sandbox_client):
+        manager = ExistingSandboxClaimLifecycleManager(
+            mock_sandbox_client,
+            "my-claim",
+            "my-namespace",
+        )
+
+        sandbox = manager.get_sandbox()
+
+        assert sandbox == mock_sandbox
+
+        mock_sandbox_client.get_sandbox.assert_called_once_with("my-claim", namespace="my-namespace")
+        assert mock_sandbox_client.create_sandbox.call_count == 0
+
+
+class TestLabelScopedManager:
+    @pytest.fixture
+    def manager(self, mock_sandbox_client, sample_sandbox_settings):
+        return LabelScopedLifecycleManager(
+            mock_sandbox_client,
+            sample_sandbox_settings,
+            scope={
+                "thread-id": "1",
+                "assistant-id": "2",
+            },
+            scope_labels_prefix="my-prefix"
+        )
+    def test_with_new_sandbox(self, mock_sandbox_client, mock_sandbox, sample_sandbox_settings, manager):
+
+        mock_sandbox_client.list_all_sandboxes.return_value = ["my-claim"]
+        mock_sandbox_client.get_sandbox.side_effect = SandboxNotFoundError
+
+        sandbox = manager.get_sandbox()
+
+        assert sandbox == mock_sandbox
+
+        mock_sandbox_client.list_all_sandboxes.assert_called_once_with(
+            namespace=sample_sandbox_settings.namespace,
+            label_selector="my-prefix/thread-id=1,my-prefix/assistant-id=2"
+        )
+
+        mock_sandbox_client.get_sandbox.assert_called_once_with(
+            "my-claim", namespace=sample_sandbox_settings.namespace
+        )
+
+        mock_sandbox_client.create_sandbox.assert_called_once_with(
+            sample_sandbox_settings.warmpool,
+            namespace=sample_sandbox_settings.namespace,
+            labels={'my-prefix/thread-id': '1', 'my-prefix/assistant-id': '2'},
+        )
+    
+    def test_with_existing_sandbox(self, mock_sandbox_client, mock_sandbox, sample_sandbox_settings, manager):
+        mock_sandbox_client.list_all_sandboxes.return_value = ["my-claim"]
+
+        sandbox = manager.get_sandbox()
+
+        assert sandbox == mock_sandbox
+        
+        mock_sandbox_client.list_all_sandboxes.assert_called_once_with(
+            namespace=sample_sandbox_settings.namespace,
+            label_selector="my-prefix/thread-id=1,my-prefix/assistant-id=2"
+        )
+
+        mock_sandbox_client.get_sandbox.assert_called_once_with(
+            "my-claim", namespace=sample_sandbox_settings.namespace
+        )
+
+        assert mock_sandbox_client.create_sandbox.call_count == 0
+
+
+
+

--- a/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
+++ b/clients/integrations/deepagents/tests/unit/test_lifecycle_manager.py
@@ -59,8 +59,9 @@ class TestLabelScopedManager:
         )
     def test_with_new_sandbox(self, mock_sandbox_client, mock_sandbox, sample_sandbox_settings, manager):
 
-        mock_sandbox_client.list_all_sandboxes.return_value = ["my-claim"]
+        mock_sandbox_client.list_all_sandboxes.return_value = []
         mock_sandbox_client.get_sandbox.side_effect = SandboxNotFoundError
+        mock_sandbox_client.k8s_helper.get_sandbox_claim.return_value = None
 
         sandbox = manager.get_sandbox()
 
@@ -71,9 +72,8 @@ class TestLabelScopedManager:
             label_selector="my-prefix/thread-id=1,my-prefix/assistant-id=2"
         )
 
-        mock_sandbox_client.get_sandbox.assert_called_once_with(
-            "my-claim", namespace=sample_sandbox_settings.namespace
-        )
+
+        mock_sandbox_client.get_sandbox.assert_not_called()
 
         mock_sandbox_client.create_sandbox.assert_called_once_with(
             sample_sandbox_settings.warmpool,
@@ -85,7 +85,25 @@ class TestLabelScopedManager:
             pod_labels=sample_sandbox_settings.pod_labels,
             pod_annotations=sample_sandbox_settings.pod_annotations,
         )
-    
+
+    def test_with_existing_stale_sandbox(self, mock_sandbox_client, sample_sandbox_settings, manager):
+        """Claim was found by the label selector and still exists, but get_sandbox()
+        failed to resolve it (transient error, timeout, etc). Must not create a
+        duplicate claim for the same scope -> propagate the error instead."""
+
+        mock_sandbox_client.list_all_sandboxes.return_value = ["my-claim"]
+        mock_sandbox_client.get_sandbox.side_effect = SandboxNotFoundError
+        mock_sandbox_client.k8s_helper.get_sandbox_claim.return_value = {"metadata": {"name": "my-claim"}}
+
+        with pytest.raises(SandboxNotFoundError):
+            manager.get_sandbox()
+
+        mock_sandbox_client.k8s_helper.get_sandbox_claim.assert_called_once_with(
+            "my-claim", namespace=sample_sandbox_settings.namespace
+        )
+
+        assert mock_sandbox_client.create_sandbox.call_count == 0
+
     def test_with_existing_sandbox(self, mock_sandbox_client, mock_sandbox, sample_sandbox_settings, manager):
         mock_sandbox_client.list_all_sandboxes.return_value = ["my-claim"]
 

--- a/clients/integrations/deepagents/tests/unit/test_sandbox.py
+++ b/clients/integrations/deepagents/tests/unit/test_sandbox.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import pytest
 
 from k8s_agent_sandbox.models import ExecutionResult

--- a/clients/integrations/deepagents/tests/unit/test_sandbox.py
+++ b/clients/integrations/deepagents/tests/unit/test_sandbox.py
@@ -1,0 +1,53 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from k8s_agent_sandbox.models import ExecutionResult
+from deepagents.backends.protocol import (
+    ExecuteResponse,
+)
+from deepagents_k8s_agent_sandbox import (
+    K8sAgentSandbox,
+)
+
+
+def test_execute(lifecycle_manager, mock_sandbox):
+    backend = K8sAgentSandbox(
+        lifecycle_manager,
+    )
+
+    mock_sandbox.commands.run.return_value = ExecutionResult(
+        exit_code=0,
+        stdout="some output",
+        stderr="some logs",
+    )
+    
+    result = backend.execute("some-command", timeout=180)
+
+    assert result == ExecuteResponse(
+        output='some output\n<stderr>\nsome logs\n</stderr>', 
+        exit_code=0, 
+        truncated=False
+    )
+
+
+
+
+
+
+
+
+

--- a/clients/integrations/deepagents/tests/unit/test_sandbox.py
+++ b/clients/integrations/deepagents/tests/unit/test_sandbox.py
@@ -18,6 +18,11 @@ import pytest
 from k8s_agent_sandbox.models import ExecutionResult
 from deepagents.backends.protocol import (
     ExecuteResponse,
+    FileUploadResponse,
+    FileDownloadResponse,
+    FILE_NOT_FOUND,
+    PERMISSION_DENIED,
+    IS_DIRECTORY,
 )
 from deepagents_k8s_agent_sandbox import (
     K8sAgentSandbox,
@@ -44,8 +49,51 @@ def test_execute(lifecycle_manager, mock_sandbox):
     )
 
 
+@pytest.mark.parametrize("state,expected_error", [
+    ("missing", None),
+    ("file", None),
+    ("directory", IS_DIRECTORY),
+    ("denied", PERMISSION_DENIED),
+])
+def test_upload_files(lifecycle_manager, mock_sandbox, state, expected_error):
+    backend = K8sAgentSandbox(lifecycle_manager)
+
+    def run_side_effect(cmd, *args, **kwargs):
+        if "mkdir" in cmd:
+            return ExecutionResult(exit_code=0, stdout="", stderr="")
+        return ExecutionResult(exit_code=0, stdout=state, stderr="")
+
+    mock_sandbox.commands.run.side_effect = run_side_effect
+    mock_sandbox.files.write.return_value = None
+
+    result = backend.upload_files([("some/path.txt", b"content")])
+
+    assert len(result) == 1
+    assert result[0] == FileUploadResponse(path="some/path.txt", error=expected_error)
 
 
+@pytest.mark.parametrize("state,expected_error,expected_content", [
+    ("file", None, b"file content"),
+    ("missing", FILE_NOT_FOUND, None),
+    ("directory", IS_DIRECTORY, None),
+    ("denied", PERMISSION_DENIED, None),
+])
+def test_download_files(lifecycle_manager, mock_sandbox, state, expected_error, expected_content):
+    backend = K8sAgentSandbox(lifecycle_manager)
 
+    mock_sandbox.commands.run.return_value = ExecutionResult(
+        exit_code=0,
+        stdout=state, 
+        stderr=""
+    )
 
+    mock_sandbox.files.read.return_value = b"file content"
 
+    result = backend.download_files(["some/path.txt"])
+
+    assert len(result) == 1
+    assert result[0] == FileDownloadResponse(
+        path="some/path.txt",
+        content=expected_content,
+        error=expected_error,
+    )

--- a/clients/integrations/deepagents/tests/unit/test_sandbox.py
+++ b/clients/integrations/deepagents/tests/unit/test_sandbox.py
@@ -60,6 +60,8 @@ def test_upload_files(lifecycle_manager, mock_sandbox, state, expected_error):
     def run_side_effect(cmd, *args, **kwargs):
         if "mkdir" in cmd:
             return ExecutionResult(exit_code=0, stdout="", stderr="")
+        else:
+            assert "if [ -w" in cmd
         return ExecutionResult(exit_code=0, stdout=state, stderr="")
 
     mock_sandbox.commands.run.side_effect = run_side_effect
@@ -89,6 +91,8 @@ def test_download_files(lifecycle_manager, mock_sandbox, state, expected_error, 
     mock_sandbox.files.read.return_value = b"file content"
 
     result = backend.download_files(["some/path.txt"])
+
+    assert "if [ -r" in mock_sandbox.commands.run.call_args.args[0]
 
     assert len(result) == 1
     assert result[0] == FileDownloadResponse(

--- a/clients/integrations/deepagents/tests/unit/test_sandbox.py
+++ b/clients/integrations/deepagents/tests/unit/test_sandbox.py
@@ -49,5 +49,3 @@ def test_execute(lifecycle_manager, mock_sandbox):
 
 
 
-
-

--- a/clients/integrations/deepagents/tests/unit/test_sandbox.py
+++ b/clients/integrations/deepagents/tests/unit/test_sandbox.py
@@ -67,10 +67,10 @@ def test_upload_files(lifecycle_manager, mock_sandbox, state, expected_error):
     mock_sandbox.commands.run.side_effect = run_side_effect
     mock_sandbox.files.write.return_value = None
 
-    result = backend.upload_files([("some/path.txt", b"content")])
+    result = backend.upload_files([("/some/path.txt", b"content")])
 
     assert len(result) == 1
-    assert result[0] == FileUploadResponse(path="some/path.txt", error=expected_error)
+    assert result[0] == FileUploadResponse(path="/some/path.txt", error=expected_error)
 
 
 @pytest.mark.parametrize("state,expected_error,expected_content", [
@@ -90,13 +90,13 @@ def test_download_files(lifecycle_manager, mock_sandbox, state, expected_error, 
 
     mock_sandbox.files.read.return_value = b"file content"
 
-    result = backend.download_files(["some/path.txt"])
+    result = backend.download_files(["/some/path.txt"])
 
     assert "if [ -r" in mock_sandbox.commands.run.call_args.args[0]
 
     assert len(result) == 1
     assert result[0] == FileDownloadResponse(
-        path="some/path.txt",
+        path="/some/path.txt",
         content=expected_content,
         error=expected_error,
     )

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -55,8 +55,14 @@ PYTHON_TEST_SUITES = [
         "dir": os.path.join("clients", "integrations", "mcp-server"),
         "editable_installs": [
             (os.path.join("clients", "integrations", "mcp-server"), "[test]"),
+        ]
+    },
+    {
+        "name": "integrations-deepagents",
+        "dir": os.path.join("clients", "integrations", "deepagents"),
+        "editable_installs": [
+            (os.path.join("clients", "integrations", "deepagents"), "[test]"),
         ],
-
     }
 ]
 


### PR DESCRIPTION
This PR adds package with Langchain-deepagents backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes-backed sandbox integration for DeepAgents, including sandbox lifecycle management.
  * Enables command execution plus file upload and download via the sandbox backend.
  * Supports creating/reusing sandboxes from labels/scope or existing claim/instance.
  * Added integration documentation and configuration for the sandbox runtime.
* **Tests**
  * Added unit tests covering lifecycle manager and sandbox execute/upload/download behavior.
* **Chores**
  * Updated ignore rules to stop tracking `*.egg-info/` metadata.
  * Added a new test suite for the DeepAgents integration and introduced its packaging configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->