### PR TITLE
Add opt-in Sandbox podFailurePolicy Recreate for Failed pods

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -154,13 +154,26 @@ const (
 	SandboxOperatingModeSuspended SandboxOperatingMode = "Suspended"
 )
 
+// PodFailurePolicy controls behavior when the backing Pod reaches phase Failed.
+// +kubebuilder:validation:Enum=Ignore;Recreate
+type PodFailurePolicy string
+
+const (
+	// PodFailurePolicyIgnore leaves a Failed Pod in place and surfaces Finished=True
+	// (StatefulSet-like). This is the default.
+	PodFailurePolicyIgnore PodFailurePolicy = "Ignore"
+	// PodFailurePolicyRecreate deletes the controller-owned Failed Pod so a new one
+	// is created. The Sandbox identity and any Sandbox-owned PVCs are retained.
+	PodFailurePolicyRecreate PodFailurePolicy = "Recreate"
+)
+
 // NOTE: When adding, removing, or renaming a field in SandboxBlueprint,
 // also update compareSandboxBlueprint() in extensions/controllers/sandboxwarmpool_controller.go
 // so the SandboxWarmPool staleness check accounts for it. A field left out of that comparison
 // is not tracked for drift, so warm sandboxes will not be detected as stale when it changes.
 
 // SandboxBlueprint defines the configuration shared between Sandbox and SandboxTemplate.
-// It deliberately excludes runtime-only fields (operatingMode, lifecycle).
+// It deliberately excludes runtime-only fields (operatingMode, lifecycle, podFailurePolicy).
 type SandboxBlueprint struct {
 	// podTemplate describes the pod that will be created in the sandbox.
 	// Note: When provisioned via a SandboxTemplate (such as by a SandboxClaim or SandboxWarmPool),
@@ -208,6 +221,16 @@ type SandboxSpec struct {
 	// +kubebuilder:validation:Enum=Running;Suspended
 	// +optional
 	OperatingMode SandboxOperatingMode `json:"operatingMode,omitempty"`
+
+	// podFailurePolicy controls what happens when the backing Pod enters phase Failed.
+	// Ignore (default): leave the Failed pod and surface Finished=True (StatefulSet-like).
+	// Recreate: delete the controller-owned Failed pod so a new one is created;
+	// the Sandbox identity and any Sandbox-owned PVCs are retained.
+	// Combined with restartPolicy Never and a container that always exits non-zero,
+	// Recreate can recreate the Pod indefinitely; there is no backoff in this version.
+	// +kubebuilder:default=Ignore
+	// +optional
+	PodFailurePolicy PodFailurePolicy `json:"podFailurePolicy,omitempty"`
 }
 
 // ShutdownPolicy describes the policy for deleting the Sandbox when it expires.

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -839,6 +839,38 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			}
 		}
 
+		// Opt-in Failed-pod recovery: delete the owned Failed pod so the next
+		// reconcile hits the missing-pod create path. Sandbox identity and PVCs
+		// are preserved. See docs/keps/729-opt-in-pod-recreation-on-failure/.
+		if sandbox.Spec.PodFailurePolicy == sandboxv1beta1.PodFailurePolicyRecreate &&
+			pod.Status.Phase == corev1.PodFailed {
+			ownership, controllerRef := checkOwnership(pod, sandbox)
+			switch ownership {
+			case resourceOwnedBySandbox:
+				if pod.DeletionTimestamp.IsZero() {
+					logger.Info("Deleting Failed Pod because .Spec.PodFailurePolicy is Recreate",
+						"Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+					if err := r.Delete(ctx, pod); err != nil {
+						return nil, fmt.Errorf("failed to delete Failed pod for recreate: %w", err)
+					}
+				} else {
+					logger.Info("Failed Pod is already being deleted for recreate",
+						"Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+				}
+				if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
+					return nil, err
+				}
+				return nil, nil
+			case resourceUnowned:
+				logger.Info("Refusing to delete Failed pod for recreate: pod has no controllerRef pointing to this sandbox",
+					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name)
+			case resourceOwnedByOther:
+				logger.Info("Refusing to delete Failed pod for recreate: pod is owned by a different controller",
+					"Pod.Name", pod.Name, "Sandbox.Name", sandbox.Name,
+					"Owner.Kind", controllerRef.Kind, "Owner.Name", controllerRef.Name, "Owner.UID", controllerRef.UID)
+			}
+		}
+
 		if err := ensurePodNameAnnotation(pod.Name); err != nil {
 			return nil, err
 		}

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2486,6 +2486,238 @@ func TestReconcilePod(t *testing.T) {
 				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
 			},
 		},
+		{
+			name: "Failed pod with default Ignore policy is retained",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				},
+			},
+			sandbox: sandboxObj,
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						sandboxLabel:   nameHash,
+						"custom-label": "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name: "Failed pod with Recreate policy is deleted and annotation cleared",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+						"other-annotation":                      "keep-me",
+					},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodFailurePolicy: sandboxv1beta1.PodFailurePolicyRecreate,
+				},
+			},
+			wantPod: nil,
+			wantSandboxAnnotations: map[string]string{
+				"other-annotation": "keep-me",
+			},
+		},
+		{
+			name: "Failed pod with Recreate policy owned by another controller is not deleted",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "Deployment",
+								Name:               "other-deployment",
+								UID:                "other-uid",
+								Controller:         new(true),
+								BlockOwnerDeletion: new(true),
+							},
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+					},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodFailurePolicy: sandboxv1beta1.PodFailurePolicyRecreate,
+				},
+			},
+			wantPod:         nil,
+			expectErr:       true,
+			wantPodSurvives: sandboxName,
+			wantSandboxAnnotations: map[string]string{
+				// owned-by-other path clears the pod-name annotation
+			},
+		},
+		{
+			name: "Succeeded pod with Recreate policy is retained",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+				},
+				Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+					ObjectMeta: sandboxv1beta1.PodMetadata{
+						Labels: map[string]string{
+							"custom-label": "label-val",
+						},
+						Annotations: map[string]string{
+							"custom-annotation": "anno-val",
+						},
+					},
+				}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+					PodFailurePolicy: sandboxv1beta1.PodFailurePolicyRecreate,
+				},
+			},
+			wantPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						sandboxLabel:   nameHash,
+						"custom-label": "label-val",
+					},
+					Annotations: map[string]string{
+						"custom-annotation":                      "anno-val",
+						"agents.x-k8s.io/propagated-labels":      "custom-label",
+						"agents.x-k8s.io/propagated-annotations": "custom-annotation",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test-container"}},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+			},
+			wantSandboxAnnotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		{
+			name: "Failed pod with Recreate policy while Suspended uses suspend delete path",
+			initialObjs: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				},
+			},
+			sandbox: &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sandboxName,
+					Namespace: sandboxNs,
+					UID:       sandboxUID,
+					Annotations: map[string]string{
+						sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+					},
+				},
+				Spec: sandboxv1beta1.SandboxSpec{
+					OperatingMode:    sandboxv1beta1.SandboxOperatingModeSuspended,
+					PodFailurePolicy: sandboxv1beta1.PodFailurePolicyRecreate,
+				},
+			},
+			wantPod:                nil,
+			wantSandboxAnnotations: map[string]string{},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2524,22 +2756,20 @@ func TestReconcilePod(t *testing.T) {
 				err = r.Get(t.Context(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, livePod)
 				require.NoError(t, err)
 				require.Equal(t, tc.wantPod, livePod)
+			} else if tc.wantPodSurvives != "" {
+				// Pod should still exist (ownership check blocked deletion)
+				livePod := &corev1.Pod{}
+				err = r.Get(t.Context(), types.NamespacedName{Name: tc.wantPodSurvives, Namespace: sandboxNs}, livePod)
+				require.NoError(t, err, "expected pod %q to survive but it was deleted", tc.wantPodSurvives)
 			} else if !tc.expectErr {
-				if tc.wantPodSurvives != "" {
-					// Pod should still exist (ownership check blocked deletion)
-					livePod := &corev1.Pod{}
-					err = r.Get(t.Context(), types.NamespacedName{Name: tc.wantPodSurvives, Namespace: sandboxNs}, livePod)
-					require.NoError(t, err, "expected pod %q to survive but it was deleted", tc.wantPodSurvives)
-				} else {
-					// When wantPod is nil and no error expected, verify pod doesn't exist
-					livePod := &corev1.Pod{}
-					podName := sandboxName
-					if annotatedPod, exists := tc.sandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation]; exists && annotatedPod != "" {
-						podName = annotatedPod
-					}
-					err = r.Get(t.Context(), types.NamespacedName{Name: podName, Namespace: sandboxNs}, livePod)
-					require.True(t, k8serrors.IsNotFound(err))
+				// When wantPod is nil and no error expected, verify pod doesn't exist
+				livePod := &corev1.Pod{}
+				podName := sandboxName
+				if annotatedPod, exists := tc.sandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation]; exists && annotatedPod != "" {
+					podName = annotatedPod
 				}
+				err = r.Get(t.Context(), types.NamespacedName{Name: podName, Namespace: sandboxNs}, livePod)
+				require.True(t, k8serrors.IsNotFound(err))
 			}
 
 			if tc.wantSandboxAnnotations != nil {
@@ -2554,6 +2784,71 @@ func TestReconcilePod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcilePodFailurePolicyRecreateCreatesReplacement(t *testing.T) {
+	sandboxName := "sandbox-name"
+	sandboxNs := "sandbox-ns"
+	nameHash := "name-hash"
+
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: sandboxNs,
+			UID:       sandboxUID,
+			Annotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
+			},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "test-container"}},
+			},
+			ObjectMeta: sandboxv1beta1.PodMetadata{
+				Labels: map[string]string{"custom-label": "label-val"},
+			},
+		}}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+			PodFailurePolicy: sandboxv1beta1.PodFailurePolicyRecreate,
+		},
+	}
+	failedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sandboxName,
+			Namespace:       sandboxNs,
+			ResourceVersion: "1",
+			Labels:          map[string]string{sandboxLabel: nameHash},
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+		},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		Status: corev1.PodStatus{Phase: corev1.PodFailed},
+	}
+
+	r := SandboxReconciler{
+		Client:        newFakeClient(failedPod, sandbox),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+	require.NoError(t, err)
+	require.Nil(t, pod)
+
+	livePod := &corev1.Pod{}
+	err = r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, livePod)
+	require.True(t, k8serrors.IsNotFound(err))
+
+	liveSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, liveSandbox))
+	_, hasAnnotation := liveSandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation]
+	require.False(t, hasAnnotation)
+
+	replacement, err := r.reconcilePod(t.Context(), liveSandbox, nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+	require.Equal(t, sandboxName, replacement.Name)
+	require.Equal(t, corev1.PodPhase(""), replacement.Status.Phase)
+	require.Equal(t, []metav1.OwnerReference{sandboxControllerRef(sandboxName)}, replacement.OwnerReferences)
 }
 
 func TestReconcileService(t *testing.T) {

--- a/docs/keps/729-opt-in-pod-recreation-on-failure/README.md
+++ b/docs/keps/729-opt-in-pod-recreation-on-failure/README.md
@@ -1,0 +1,119 @@
+# KEP-729: Opt-in Pod Recreation on PodFailed
+
+<!--
+TOC is auto-generated via `make toc-update`.
+-->
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+  - [High-Level Design](#high-level-design)
+    - [API Changes](#api-changes)
+    - [Implementation Guidance](#implementation-guidance)
+- [Scalability](#scalability)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+Add an opt-in `Sandbox.spec.podFailurePolicy` field. When set to `Recreate`, the Sandbox controller deletes a controller-owned backing Pod that has entered `phase=Failed`, clears the pod-name annotation, and relies on the existing missing-pod create path to provision a fresh Pod. The Sandbox identity and any PVCs owned by the Sandbox are preserved. The default `Ignore` keeps today's StatefulSet-like behavior.
+
+## Motivation
+
+When a Sandbox's Pod ends in `phase=Failed` (for example after node-pressure eviction by the kubelet), the controller marks `Finished=True/reason=PodFailed` and stops. The Sandbox CR and PVC remain, but no new Pod is created, leaving long-running interactive workloads permanently stuck.
+
+This is distinct from the already-supported case where the Pod object is gone from etcd: with `operatingMode=Running`, the controller recreates a missing Pod. Failed Pods still exist, so that path is never reached.
+
+Core workload precedence:
+- **StatefulSet**: leaves Failed pods in etcd (requires user intervention). Agent Sandbox matches this today.
+- **ReplicaSet**: ignores Failed pods when counting replicas and creates replacements.
+
+Auto-recreation must remain opt-in so platforms that rely on terminal `Finished` for cleanup (for example Claim `ttlSecondsAfterFinished`) are not broken.
+
+### Goals
+
+- Opt-in recovery from `PodFailed` without deleting the Sandbox or its PVCs.
+- Place the control on the Sandbox API (Claim does not manage Pods).
+- Preserve default Ignore behavior (non-breaking).
+
+### Non-Goals
+
+- Recreating on `PodSucceeded`.
+- SandboxClaim-level passthrough of the policy.
+- Template-drift / `podTemplate` update recreation ([#612](https://github.com/kubernetes-sigs/agent-sandbox/issues/612)).
+- In-place resource resize ([#1054](https://github.com/kubernetes-sigs/agent-sandbox/issues/1054)).
+- Recreate backoff / max-retry limits in the first version.
+
+## Proposal
+
+### User Stories
+
+- As an operator of long-running sandboxes with user data on a PVC, I want a Failed Pod (for example after eviction) to be replaced automatically so the session recovers without data loss.
+- As a platform that uses `Finished` + Claim TTL for one-shot jobs, I want the default Ignore behavior so Failed sandboxes still surface `Finished` and can be cleaned up.
+
+### High-Level Design
+
+```text
+reconcilePod sees existing Pod
+  → if phase=Failed AND podFailurePolicy=Recreate AND owned by Sandbox
+      → Delete Pod, clear agents.x-k8s.io/pod-name annotation, return nil
+  → next reconcile: Pod missing → existing create path builds a new Pod
+  → PVCs from volumeClaimTemplates remain Sandbox-owned and are remounted
+```
+
+Expiry handling already short-circuits before child reconcile, so expired Sandboxes do not recreate Failed Pods. Suspend continues to delete the Pod for suspension and does not create while `operatingMode=Suspended`.
+
+With Recreate, `Finished` must not stick on the Failed Pod being replaced: `reconcilePod` runs before `computeFinishedCondition`, and returning a nil Pod after delete clears Finished for that reconcile.
+
+**Crash-loop tradeoff:** `Recreate` combined with `restartPolicy: Never` and a container that always exits non-zero can recreate indefinitely. Document this; backoff is deferred.
+
+#### API Changes
+
+On `SandboxSpec` (runtime field next to `operatingMode`, not in `SandboxBlueprint`):
+
+```go
+// PodFailurePolicy controls behavior when the backing Pod reaches phase Failed.
+// +kubebuilder:validation:Enum=Ignore;Recreate
+type PodFailurePolicy string
+
+const (
+	PodFailurePolicyIgnore   PodFailurePolicy = "Ignore"
+	PodFailurePolicyRecreate PodFailurePolicy = "Recreate"
+)
+
+// podFailurePolicy controls what happens when the backing Pod enters phase Failed.
+// Ignore (default): leave the Failed pod and surface Finished=True (StatefulSet-like).
+// Recreate: delete the controller-owned Failed pod so a new one is created; PVC/Sandbox retained.
+// +kubebuilder:default=Ignore
+// +optional
+PodFailurePolicy PodFailurePolicy `json:"podFailurePolicy,omitempty"`
+```
+
+Enum (not bool) matches project API conventions and `ShutdownPolicy`. A plain enum (not a WarmPool-style `{type:}` struct) is enough because no nested strategy fields are expected.
+
+#### Implementation Guidance
+
+- Modify `reconcileExistingPod` in `controllers/sandbox_controller.go` after ownership is established.
+- Only delete when ownership is `resourceOwnedBySandbox` and `DeletionTimestamp` is zero.
+- Refuse delete for foreign-owned pods (same logging pattern as suspend).
+- Log the recreate delete at `Info` (major lifecycle event).
+- Unit-test Ignore vs Recreate, ownership refusal, Succeeded+Recreate (no recreate), and Suspended (suspend path only).
+- Optional e2e: Fail once, recreate, remount PVC with surviving data.
+
+## Scalability
+
+Recreate adds at most one Delete + one Create per Failed Pod transition. No new watches, indexes, or unbounded status lists. Controllers that opt many sandboxes into Recreate with crashing workloads may increase Pod churn; that is an operator configuration concern, not a default-path cost.
+
+## Alternatives
+
+| Option | Why it falls short |
+| --- | --- |
+| `ttlSecondsAfterFinished` + Claim `shutdownPolicy: Delete/Retain` | Deletes Claim and/or Sandbox and can cascade PVC loss. |
+| Pod `restartPolicy: Always` | Only restarts containers inside a non-terminal Pod; does not recreate a Failed Pod object. |
+| External cron deleting Failed pods | Works via the missing-pod path, but every consumer reimplements it. |
+| Claim `lifecycle.recreateOnPodFailure` | Claim does not manage Pods; maintainers prefer Sandbox API. |
+| Fold into a broader `updateStrategy` (#612) | Template-drift recreation is a different problem; keep Failed-pod recovery separate. |

--- a/docs/keps/729-opt-in-pod-recreation-on-failure/kep.yaml
+++ b/docs/keps/729-opt-in-pod-recreation-on-failure/kep.yaml
@@ -1,0 +1,17 @@
+title: Opt-in Pod Recreation on PodFailed
+kep-number: 729
+authors:
+  - "@Eitan1112"
+status: implementable
+creation-date: "2026-07-14"
+last-updated: "2026-07-14"
+stage: alpha
+reviewers:
+  - "@janetkuo"
+  - "@barney-s"
+approvers:
+  - "@janetkuo"
+see-also:
+  - "https://github.com/kubernetes-sigs/agent-sandbox/issues/729"
+  - "https://github.com/kubernetes-sigs/agent-sandbox/issues/612"
+  - "https://github.com/kubernetes-sigs/agent-sandbox/issues/1054"

--- a/helm/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/helm/crds/agents.x-k8s.io_sandboxes.yaml
@@ -43,6 +43,12 @@ spec:
                 - Running
                 - Suspended
                 type: string
+              podFailurePolicy:
+                default: Ignore
+                enum:
+                - Ignore
+                - Recreate
+                type: string
               podTemplate:
                 properties:
                   metadata:

--- a/k8s/crds/agents.x-k8s.io_sandboxes.yaml
+++ b/k8s/crds/agents.x-k8s.io_sandboxes.yaml
@@ -43,6 +43,12 @@ spec:
                 - Running
                 - Suspended
                 type: string
+              podFailurePolicy:
+                default: Ignore
+                enum:
+                - Ignore
+                - Recreate
+                type: string
               podTemplate:
                 properties:
                   metadata:

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -209,3 +209,29 @@ func main() {
   {{< /blocks/tab >}}
 {{< /blocks/tabs >}}
 
+## Opt-in recovery from Failed pods
+
+By default, when a Sandbox's backing Pod reaches `phase=Failed` (for example after node-pressure eviction), the controller surfaces `Finished=True` with reason `PodFailed` and does not create a replacement. That matches StatefulSet behavior and keeps one-shot workloads compatible with Claim `ttlSecondsAfterFinished`.
+
+For long-running sandboxes that should recover while preserving Sandbox identity and PVCs, set:
+
+```yaml
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: resilient-sandbox
+spec:
+  podFailurePolicy: Recreate
+  operatingMode: Running
+  podTemplate:
+    spec:
+      containers:
+      - name: workspace
+        image: alpine:latest
+        command: ["sleep", "infinity"]
+```
+
+With `podFailurePolicy: Recreate`, the controller deletes the controller-owned Failed Pod and creates a new one from `podTemplate`. PVCs from `volumeClaimTemplates` stay owned by the Sandbox and are remounted.
+
+`PodSucceeded` is unchanged (still terminal). Combining `Recreate` with `restartPolicy: Never` and a container that always exits non-zero can recreate indefinitely; there is no backoff in this version. See [KEP-729](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/docs/keps/729-opt-in-pod-recreation-on-failure/README.md).
+

--- a/site/content/docs/volumes/volume-claim-template/_index.md
+++ b/site/content/docs/volumes/volume-claim-template/_index.md
@@ -132,10 +132,12 @@ kubectl exec -it my-stateful-sandbox -- cat /data/evidence.txt
 ```
 
 **3. Simulate a failure by deleting the pod**
-Because sandboxes are managed by the Sandbox controller, deleting the pod directly simulates an unexpected failure. 
+Because sandboxes are managed by the Sandbox controller, deleting the pod directly simulates an unexpected failure (the Pod object is gone). Missing pods are recreated automatically when `operatingMode` is `Running`.
 ```bash
 kubectl delete pod my-stateful-sandbox
 ```
+
+> **Note:** If the Pod remains in etcd with `phase=Failed` (for example after node-pressure eviction), the controller does **not** recreate it by default (StatefulSet-like). Set `spec.podFailurePolicy: Recreate` on the Sandbox to delete the Failed Pod and create a replacement while keeping the Sandbox and its PVCs. See [KEP-729](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/docs/keps/729-opt-in-pod-recreation-on-failure/README.md).
 
 **4. Wait for the controller to recreate the sandbox**
 The Sandbox controller will detect that the pod is missing and automatically recreate it. Because `volumeClaimTemplates` use StatefulSet-like semantics, the controller will reattach the *exact same PVC* to the new pod.

--- a/test/e2e/pod_failure_policy_test.go
+++ b/test/e2e/pod_failure_policy_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework/predicates"
+)
+
+// TestSandboxPodFailurePolicyRecreate verifies that a Failed pod is deleted and
+// replaced when podFailurePolicy=Recreate, and that PVC data survives across the
+// recreation (first boot writes a marker and exits 1; second boot sees it and sleeps).
+func TestSandboxPodFailurePolicyRecreate(t *testing.T) {
+	tc := framework.NewTestContext(t)
+
+	ns := &corev1.Namespace{}
+	ns.Name = fmt.Sprintf("sandbox-pod-failure-recreate-%d", time.Now().UnixNano())
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), ns))
+
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recreate-failed-sandbox",
+			Namespace: ns.Name,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				Service: new(true),
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers: []corev1.Container{{
+							Name:  "busybox",
+							Image: "busybox:1.36",
+							Command: []string{"sh", "-c",
+								`if [ -f /data/booted ]; then sleep infinity; else echo surviving > /data/booted; exit 1; fi`,
+							},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "data",
+								MountPath: "/data",
+							}},
+						}},
+					},
+				},
+				VolumeClaimTemplates: []sandboxv1beta1.PersistentVolumeClaimTemplate{{
+					EmbeddedObjectMetadata: sandboxv1beta1.EmbeddedObjectMetadata{Name: "data"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				}},
+			},
+			OperatingMode:    sandboxv1beta1.SandboxOperatingModeRunning,
+			PodFailurePolicy: sandboxv1beta1.PodFailurePolicyRecreate,
+		},
+	}
+	require.NoError(t, tc.CreateWithCleanup(t.Context(), sandbox))
+
+	nameHash := NameHash(sandbox.Name)
+	require.NoError(t, tc.WaitForObject(t.Context(), sandbox, predicates.SandboxHasStatus(sandboxv1beta1.SandboxStatus{
+		Service:       sandbox.Name,
+		ServiceFQDN:   fmt.Sprintf("%s.%s.svc.cluster.local", sandbox.Name, ns.Name),
+		LabelSelector: "agents.x-k8s.io/sandbox-name-hash=" + nameHash,
+		Conditions: []metav1.Condition{{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 1,
+			Reason:             sandboxv1beta1.SandboxReasonDependenciesReady,
+			Message:            "Pod is Ready; Service Exists",
+		}},
+	})))
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvcName := "data-" + sandbox.Name
+	require.NoError(t, tc.Get(t.Context(), types.NamespacedName{Name: pvcName, Namespace: ns.Name}, pvc))
+	require.Equal(t, sandbox.UID, pvc.OwnerReferences[0].UID)
+
+	pod := &corev1.Pod{}
+	require.NoError(t, tc.Get(t.Context(), types.NamespacedName{Name: sandbox.Name, Namespace: ns.Name}, pod))
+	require.Equal(t, corev1.PodRunning, pod.Status.Phase)
+
+	var foundVolume bool
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == "data" && vol.PersistentVolumeClaim != nil {
+			require.Equal(t, pvcName, vol.PersistentVolumeClaim.ClaimName)
+			foundVolume = true
+			break
+		}
+	}
+	require.True(t, foundVolume, "expected remounted PVC volume on recreated pod")
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `Sandbox.spec.podFailurePolicy` (`Ignore` default | `Recreate`) so operators can opt into deleting a controller-owned Failed Pod and recreating it from `podTemplate`, while preserving Sandbox identity and Sandbox-owned PVCs. Default behavior stays StatefulSet-like (Failed pods left in place with `Finished=True`).

Includes KEP-729, controller logic, unit tests, an e2e covering Recreate + PVC remount, and docs notes. Out of scope: template-drift recreation (#612), in-place resize (#1054), Claim passthrough, `PodSucceeded` recreation, and recreate backoff.

#### Which issue(s) this PR is related to:
Fixes #729

#### Release Note
```release-note
Add optional Sandbox.spec.podFailurePolicy (Ignore|Recreate). Default Ignore is unchanged; Recreate deletes a Failed owned Pod so a replacement is created while keeping the Sandbox and PVCs.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional recovery for Failed Sandbox Pods through `spec.podFailurePolicy`.
  * The default `Ignore` setting retains Failed Pods; `Recreate` replaces controller-owned Failed Pods while preserving the Sandbox identity and PVCs.

* **Documentation**
  * Added configuration guidance, examples, lifecycle details, and persistence notes for Pod failure recovery.

* **Tests**
  * Added unit and end-to-end coverage for pod replacement, ownership safeguards, suspension behavior, and PVC remounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->