### PR TITLE
fix(python-router): preserve raw escaped paths

### DIFF
--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -292,7 +292,33 @@ def _env_var_is_truthy(name: str) -> bool:
     return raw.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
 
 
-def _resolve_target(headers, url, scheme: str) -> tuple[str, str]:
+def _raw_path_with_query(url, scope) -> str:
+    """Return the original request path and query without decoding dot segments."""
+    raw_path = scope.get("raw_path") if scope else None
+    if isinstance(raw_path, bytes):
+        path = raw_path.decode("ascii")
+    elif isinstance(raw_path, str):
+        path = raw_path
+    else:
+        path = url.path
+
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    raw_query = scope.get("query_string") if scope else None
+    if isinstance(raw_query, bytes):
+        query = raw_query.decode("ascii")
+    elif isinstance(raw_query, str):
+        query = raw_query
+    else:
+        query = url.query
+
+    if query:
+        return f"{path}?{query}"
+    return path
+
+
+def _resolve_target(headers, url, scheme: str, scope=None) -> tuple[str, str]:
     """Return the backend URL and sandbox ID from routing headers."""
     sandbox_id = headers.get("X-Sandbox-ID")
     if not sandbox_id:
@@ -323,7 +349,7 @@ def _resolve_target(headers, url, scheme: str) -> tuple[str, str]:
     else:
         target_host = f"{sandbox_id}.{namespace}.svc.{cluster_domain}"
 
-    target_url = str(url.replace(scheme=scheme, hostname=target_host, port=port))
+    target_url = f"{scheme}://{target_host}:{port}{_raw_path_with_query(url, scope)}"
     return target_url, sandbox_id
 
 
@@ -646,6 +672,7 @@ async def proxy_websocket(websocket: WebSocket, full_path: str):
             websocket.headers,
             websocket.url,
             "ws",
+            websocket.scope,
         )
     except RoutingError as exc:
         await websocket.close(code=1008, reason=str(exc))
@@ -719,6 +746,7 @@ async def proxy_request(request: Request, full_path: str):
             request.headers,
             request.url,
             "http",
+            request.scope,
         )
     except RoutingError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py
@@ -296,7 +296,10 @@ def _raw_path_with_query(url, scope) -> str:
     """Return the original request path and query without decoding dot segments."""
     raw_path = scope.get("raw_path") if scope else None
     if isinstance(raw_path, bytes):
-        path = raw_path.decode("ascii")
+        try:
+            path = raw_path.decode("ascii")
+        except UnicodeDecodeError:
+            path = url.path
     elif isinstance(raw_path, str):
         path = raw_path
     else:
@@ -307,7 +310,10 @@ def _raw_path_with_query(url, scope) -> str:
 
     raw_query = scope.get("query_string") if scope else None
     if isinstance(raw_query, bytes):
-        query = raw_query.decode("ascii")
+        try:
+            query = raw_query.decode("ascii")
+        except UnicodeDecodeError:
+            query = url.query
     elif isinstance(raw_query, str):
         query = raw_query
     else:

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -527,6 +527,32 @@ class TestProxyRouting:
 
         assert target_url == "http://test-box.prod.svc.cluster.local:9999/list/%2E%2E"
 
+    def test_target_url_falls_back_when_raw_path_is_not_ascii(self):
+        """Non-ASCII raw path bytes should not crash target URL construction."""
+        target_url, _ = sandbox_router._resolve_target(
+            {"X-Sandbox-ID": "test-box"},
+            URL("http://router/files/%C3%A9?ok=true"),
+            "http",
+            {"raw_path": b"/files/\xff", "query_string": b"ok=true"},
+        )
+
+        assert target_url == (
+            "http://test-box.default.svc.cluster.local:8888/files/%C3%A9?ok=true"
+        )
+
+    def test_target_url_falls_back_when_raw_query_is_not_ascii(self):
+        """Non-ASCII raw query bytes should not crash target URL construction."""
+        target_url, _ = sandbox_router._resolve_target(
+            {"X-Sandbox-ID": "test-box"},
+            URL("http://router/files/%2E?q=%C3%A9"),
+            "http",
+            {"raw_path": b"/files/%2E", "query_string": b"q=\xff"},
+        )
+
+        assert target_url == (
+            "http://test-box.default.svc.cluster.local:8888/files/%2E?q=%C3%A9"
+        )
+
     def test_target_url_pod_ip_construction(self, client):
         """Verify the router builds the correct URL when X-Sandbox-Pod-IP is provided."""
         with patch.object(

--- a/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
+++ b/clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from starlette.datastructures import URL
 from starlette.websockets import WebSocketDisconnect
 
 os.environ["ALLOW_UNAUTHENTICATED_ROUTER"] = "true"
@@ -493,6 +494,38 @@ class TestProxyRouting:
             assert "test-box.prod.svc.cluster.local:9999/some/path" in str(
                 request_obj.url
             )
+
+    def test_target_url_preserves_raw_escaped_path(self):
+        """Escaped dot segments must survive the router hop."""
+        target_url, _ = sandbox_router._resolve_target(
+            {
+                "X-Sandbox-ID": "test-box",
+                "X-Sandbox-Namespace": "prod",
+                "X-Sandbox-Port": "9999",
+            },
+            URL("http://router/list/."),
+            "http",
+            {"raw_path": b"/list/%2E", "query_string": b"marker=%2E"},
+        )
+
+        assert target_url == (
+            "http://test-box.prod.svc.cluster.local:9999/list/%2E?marker=%2E"
+        )
+
+    def test_target_url_preserves_raw_escaped_dotdot_path(self):
+        """Escaped dotdot segments must not be normalized by the router."""
+        target_url, _ = sandbox_router._resolve_target(
+            {
+                "X-Sandbox-ID": "test-box",
+                "X-Sandbox-Namespace": "prod",
+                "X-Sandbox-Port": "9999",
+            },
+            URL("http://router/list/.."),
+            "http",
+            {"raw_path": b"/list/%2E%2E", "query_string": b""},
+        )
+
+        assert target_url == "http://test-box.prod.svc.cluster.local:9999/list/%2E%2E"
 
     def test_target_url_pod_ip_construction(self, client):
         """Verify the router builds the correct URL when X-Sandbox-Pod-IP is provided."""


### PR DESCRIPTION
#### What this PR does / why we need it:
This is a follow-up to #1115. That PR fixed the Go SDK-side dot-path encoding, but review feedback on #1115 showed the encoded path did not survive the Python sandbox-router hop in the actual reported topology.

Preserve the original raw path and query string when the Python sandbox-router proxies HTTP and WebSocket traffic to a sandbox backend.

The router previously rebuilt backend URLs from the decoded Starlette URL object. That decoded percent-encoded dot segments such as `%2E` and `%2E%2E` before forwarding, so a Go SDK request that intentionally encoded `.` or `..` could still reach the backend as `/list/.` or `/list/..` through the router topology.

This change uses the ASGI scope's `raw_path` and `query_string` values when constructing the backend URL, with a fallback to the existing URL object when raw scope values are unavailable. It also adds regression coverage for escaped dot and dotdot path segments.

Validation:
- Temporarily restored the old `url.replace(...)` target URL construction and confirmed the new regression tests fail because `%2E` and `%2E%2E` are decoded before forwarding.
- Restored the fix and confirmed the same regression tests pass:
  `bin/python-venv-sandbox-router/bin/python -m pytest clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py -k "preserves_raw_escaped"`
- `bin/python-venv-sandbox-router/bin/python -m py_compile clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.py clients/python/agentic-sandbox-client/sandbox-router/test_sandbox_router.py`
- `git diff --check`

#### Which issue(s) this PR is related to:
Follow-up to #1115

Ref #1052

#### Release Note
```release-note
The Python sandbox-router now preserves percent-encoded dot path segments when proxying requests to sandboxes.
```
