### PR TITLE
docs: use https for raw.githubusercontent.com curl command

### DIFF
--- a/site/content/docs/getting_started/install_prerequisites/_index.md
+++ b/site/content/docs/getting_started/install_prerequisites/_index.md
@@ -53,6 +53,6 @@ description: >
 
 4. Create a Sandbox Template. For example the `python-runtime-sandbox`. More information about this runtime can be found [here](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/examples/python-runtime-sandbox/).
    ```bash
-   curl -sSLO http://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/refs/tags/${VERSION}/clients/python/agentic-sandbox-client/python-sandbox-template.yaml
+   curl -sSLO https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/refs/tags/${VERSION}/clients/python/agentic-sandbox-client/python-sandbox-template.yaml
    kubectl apply -f python-sandbox-template.yaml
    ```


### PR DESCRIPTION
The python-sandbox-template.yaml curl command in the install prerequisites guide used plain `http://`, while the adjacent `sandbox_router.yaml` command right above it already uses `https://`. Fixes the inconsistency.