### PR TITLE
docs: clarify Alpha to Beta API Versioning roadmap status

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -81,7 +81,7 @@ Advanced ingress/egress isolation, lifecycle state retention, and security contr
 Audit trails, custom telemetry, reliability, and automated regression testing.
 
 *   **Alpha to Beta API Versioning** `⏳ In Progress`
-    *   Evolve the existing API schemas from alpha status toward robust beta APIs with deprecation safety.
+    *   `v1beta1` API types now exist alongside `v1alpha1` across all CRDs, and `v1alpha1` is marked deprecated. Remaining work: finish migrating clients/docs/examples fully to `v1beta1` and remove `v1alpha1` once the deprecation window closes.
 *   **Security Fixes** `⏳ In Progress`
     *   Maintain active patching cycles for third-party dependencies and container base image security.
 *   **CI for PodSnapshot & AgentSandbox Regression Prevention** `⏳ In Progress`


### PR DESCRIPTION
The roadmap lists "Alpha to Beta API Versioning" as `In Progress` with no detail on what's actually done. In practice `v1beta1` API types already exist across all CRDs (see #993, #986, #989, #848, #987) and `v1alpha1` already carries a `+kubebuilder:deprecatedversion` warning. This PR only clarifies the description with that context; it leaves the status as `In Progress` since `v1alpha1` hasn't been removed yet. Happy to adjust wording or close if maintainers feel this belongs elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to reflect the availability of `v1beta1` API types across all CRDs.
  * Documented the deprecation of `v1alpha1` and the remaining migration work for clients, documentation, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->