### PR TITLE
docs: fix wrong sandbox_router path in kubectl apply commands

### DIFF
--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -189,14 +189,14 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
 1.  **Deploy the Router (Required for All Modes):**
     ```bash
     # Deploys the Deployment and Service
-    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox_router/sandbox_router.yaml
+    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
     ```
 
 2.  **Deploy the Gateway (Production Only):**
     If you need external access via a Public IP (GKE), apply the Gateway configuration.
     ```bash
     # Deploys Gateway, HTTPRoute, and HealthCheckPolicy
-    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox_router/gateway.yaml
+    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/gateway.yaml
     ```
 
 **For Production (via Gateway)**

--- a/site/content/docs/use-cases/kata-containers-isolation/_index.md
+++ b/site/content/docs/use-cases/kata-containers-isolation/_index.md
@@ -74,7 +74,7 @@ With Kata runtimes, direct pod port-forwarding is not compatible. Use the [Sandb
 
 ```bash
 # Deploy the router
-kubectl apply -f clients/python/agentic-sandbox-client/sandbox_router/sandbox_router.yaml
+kubectl apply -f clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
 
 # Port-forward to the router service
 kubectl port-forward svc/sandbox-router-svc 8080:8080 -n default
@@ -86,7 +86,7 @@ curl -H "X-Sandbox-ID: sandbox-example" -H "X-Sandbox-Port: 13337" http://localh
 For production external access (e.g., on GKE), deploy the Gateway configuration:
 
 ```bash
-kubectl apply -f clients/python/agentic-sandbox-client/sandbox_router/gateway.yaml
+kubectl apply -f clients/python/agentic-sandbox-client/sandbox-router/gateway.yaml
 ```
 
 ## When to Use Kata Containers


### PR DESCRIPTION
The kata-containers-isolation doc and vscode-sandbox example use clients/python/agentic-sandbox-client/sandbox_router/ but the real directory is sandbox-router (with a dash). The commands fail as written. This fixes the path in both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected Kubernetes manifest paths in the VS Code sandbox deployment instructions.
  * Updated Kata Containers isolation documentation with the correct Sandbox Router and production Gateway paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->