### PR TITLE
docs: fix chrome-sandbox example yaml to match Sandbox CRD schema

### DIFF
--- a/examples/chrome-sandbox/README.md
+++ b/examples/chrome-sandbox/README.md
@@ -18,11 +18,13 @@ kind: Sandbox
 metadata:
   name: chrome-sandbox
 spec:
-  containers:
-    - name: chrome
-      image: registry.k8s.io/chrome-sandbox
-      ports:
-        - containerPort: 9222
+  podTemplate:
+    spec:
+      containers:
+        - name: chrome
+          image: registry.k8s.io/chrome-sandbox
+          ports:
+            - containerPort: 9222
 ```
 
 ## How to Run


### PR DESCRIPTION
The example puts containers directly under spec, but the Sandbox CRD requires spec.podTemplate.spec.containers (podTemplate is a required field). This fixes the yaml so it matches the real schema and the other examples in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Chrome sandbox example manifest to use the correct pod template container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->