### PR TITLE
docs: fix invalid port-forward target in chrome-sandbox example

### DIFF
--- a/examples/chrome-sandbox/README.md
+++ b/examples/chrome-sandbox/README.md
@@ -35,7 +35,7 @@ kubectl apply -f chrome-sandbox.yaml
 Port-forward to access Chrome debugging endpoint:
 
 ```bash
-kubectl port-forward sandbox/chrome-sandbox 9222:9222 
+kubectl port-forward pod/chrome-sandbox 9222:9222
 ```
 ---
 


### PR DESCRIPTION
kubectl port-forward only supports pod, deployment, service, etc as target type. sandbox/chrome-sandbox is not valid and the command fails. This changes it to pod/chrome-sandbox, matching every other example in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Chrome sandbox port-forwarding instructions to target the Kubernetes pod correctly.
  * Removed an extra trailing space from the command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->