### PR TITLE
docs: fix invalid JSON in kubectl patch example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ kubectl patch deployment agent-sandbox-controller \
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-concurrent-workers=10"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-claim-concurrent-workers=100"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-concurrent-workers=10"},
-    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-max-batch-size=500"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-max-batch-size=500"}
   ]'
 ```
 This method safely appends the new flags without overwriting existing necessary arguments like `--leader-elect=true` or `--extensions=true`.


### PR DESCRIPTION
The json patch array in the kubectl patch example has a trailing comma after the last item, which is invalid JSON. The command fails when copied as is. This removes the trailing comma.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `kubectl patch` configuration example to correctly append the sandbox warm pool batch-size flag (`--sandbox-warm-pool-max-batch-size=500`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->