### PR TITLE
docs: remove nonexistent v0.0.1 tag reference in roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -118,7 +118,7 @@ Lowering the barrier to entry, beautiful guides, interactive tools, and UI dashb
     *   Document production-ready reference designs for multi-user cloud environments.
 
 
-## Completed (Since v0.0.1)
+## Completed
 *   **Golang SDK Support** `✅ Completed`
     *   Deliver high-level Go client libraries to programmatically manage sandboxes and route connections. [[#227](https://github.com/kubernetes-sigs/agent-sandbox/issues/227)]
 *   **PyPI Distribution (`k8s-agent-sandbox`)** `✅ Completed`


### PR DESCRIPTION
The Completed section header says (Since v0.0.1) but that tag was never released, the earliest tag is v0.1.0. This drops the incorrect version reference from the heading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the “Completed” section heading in the roadmap without changing its listed initiatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->