### PR TITLE
docs: fix pod count mismatch in examples index for gke-swap

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
-- [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 110 to 170 pods per node.
+- [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 120 to 200 pods per node.
 - [**hello-world-sandbox**](./hello-world-sandbox): A simple "Hello World" sandbox example.
 - [**hermes-agent**](./hermes-agent): An example of running Hermes Agent with persistence and custom skills.
 - [**hpa-swp-scaling**](./hpa-swp-scaling): An example of scaling a SandboxWarmPool using Kubernetes Horizontal Pod Autoscaler (HPA).


### PR DESCRIPTION
The examples index says the gke-swap example goes from 110 to 170 pods per node, but the gke-swap README itself reports 120 to 200 pods (a 66% increase). This updates the index to match the actual numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `gke-swap` example to document the revised Chrome pod density range on GKE nodes (120–200 pods per node).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->