### PR TITLE
docs: remove unrelated Go prerequisite from langchain example

### DIFF
--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -23,7 +23,6 @@
 
 ```bash
 # Verify installations
-go version              # Go 1.19+
 make --version          # GNU Make
 python3 --version       # Python 3.13+
 docker --version        # Docker 20.10+
@@ -33,7 +32,6 @@ kubectl version --client # kubectl 1.25+
 
 ### Installation Links
 
-- [Go](https://golang.org/doc/install)
 - [Make](https://www.gnu.org/software/make/)
 - [Python 3](https://www.python.org/downloads/)
 - [Docker](https://docs.docker.com/get-docker/)


### PR DESCRIPTION
This example is pure Python and LangGraph, there is no Go code in the directory. The prerequisites list still asked for Go 1.19+ and linked the Go install page, likely copied from another example. This removes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the LangChain example setup instructions to remove the Go prerequisite and installation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->