### PR TITLE
docs: fix grammar in install prerequisites description

### DIFF
--- a/site/content/docs/getting_started/install_prerequisites/_index.md
+++ b/site/content/docs/getting_started/install_prerequisites/_index.md
@@ -3,7 +3,7 @@ title: "Agent Sandbox Installation"
 linkTitle: "Agent Sandbox Installation"
 weight: 2
 description: >
-  This guide shows how install Agent Sandbox resources in [Kubernetes in Docker (KinD)](https://kind.sigs.k8s.io/) and in [GKE](https://cloud.google.com/kubernetes-engine).
+  This guide shows how to install Agent Sandbox resources in [Kubernetes in Docker (KinD)](https://kind.sigs.k8s.io/) and in [GKE](https://cloud.google.com/kubernetes-engine).
 ---
 
 ## Prerequisites


### PR DESCRIPTION
The page description says 'shows how install' instead of 'shows how to install'. Small grammar fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected wording in the Agent Sandbox Installation guide for clarity.
  * Preserved the existing Kubernetes-in-Docker and GKE references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->