### PR TITLE
docs: remove stray extra parenthesis in analytics-tool README

### DIFF
--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -3,7 +3,7 @@
 ## Getting Started
 
 ### Prerequisites
-- Running **GKE** cluster (**Standard** or **Autopilot**))
+- Running **GKE** cluster (**Standard** or **Autopilot**)
 - `kubectl` access to a Kubernetes **GKE Standard** or **GKE Autopilot** cluster
 - Agent-sandbox installed on GKE. Here is the [Installation Guide](https://agent-sandbox.sigs.k8s.io/docs/getting_started/install_prerequisites/)
 


### PR DESCRIPTION
The prerequisites line has an extra closing parenthesis: (Standard or Autopilot)). This removes the stray one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a punctuation error in the GKE prerequisite instructions.
  * Improved clarity for setting up a standard or Autopilot GKE cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->