### PR TITLE
docs: fix wrong step description in analytics-tool README

### DIFF
--- a/examples/analytics-tool/README.md
+++ b/examples/analytics-tool/README.md
@@ -27,7 +27,7 @@ gcloud artifacts repositories create analytics \
     --description="Analytics Repo"
 ```
 
-Create a repository in Artifact Registry.
+Build and push the Docker image:
 
 ```bash
 gcloud builds submit .


### PR DESCRIPTION
The step right before gcloud builds submit said 'Create a repository in Artifact Registry', copied from the step above it. That command builds and pushes the Docker image, not a repository. This fixes the description to match the command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the analytics tools deployment guide to accurately label the Docker image build and push step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->