### PR TITLE
tests: key stress sandbox records by PhaseNumber

### DIFF
--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -82,12 +82,14 @@ type ClusterInfo struct {
 
 // PhaseSummary holds the aggregate results for one phase.
 type PhaseSummary struct {
-	Name            string  `json:"name"`
-	Requested       int     `json:"requested"`
-	Created         int     `json:"created"`
-	Ready           int     `json:"ready"`
-	Failed          int     `json:"failed"`
-	DurationSeconds float64 `json:"durationSeconds"`
+	// Number is the 1-based index of this entry in Summary.Phases / Config.Phases.
+	Number          PhaseNumber `json:"phaseNumber"`
+	Name            string      `json:"name"`
+	Requested       int         `json:"requested"`
+	Created         int         `json:"created"`
+	Ready           int         `json:"ready"`
+	Failed          int         `json:"failed"`
+	DurationSeconds float64     `json:"durationSeconds"`
 	// StartOffsetSeconds is the phase's start relative to Summary.StartTime.
 	StartOffsetSeconds float64 `json:"startOffsetSeconds"`
 
@@ -300,10 +302,10 @@ func run(ctx context.Context) error {
 		counts := tracker.Snapshot()
 		var line strings.Builder
 		fmt.Fprintf(&line, "[progress +%s]", time.Since(testStartTime).Round(time.Second))
-		for _, phase := range slices.Sorted(maps.Keys(counts)) {
-			c := counts[phase]
-			fmt.Fprintf(&line, " %s: created=%d ready=%d deleted=%d failed=%d |",
-				phase, c.Created, c.Ready, c.Deleted, c.Failed)
+		for _, number := range slices.Sorted(maps.Keys(counts)) {
+			c := counts[number]
+			fmt.Fprintf(&line, " %s#%d: created=%d ready=%d deleted=%d failed=%d |",
+				c.Name, number, c.Created, c.Ready, c.Deleted, c.Failed)
 		}
 		if writeToFileChannel != nil {
 			fmt.Fprintf(&line, " watch-queue=%d/%d", len(writeToFileChannel), cap(writeToFileChannel))
@@ -332,6 +334,7 @@ func run(ctx context.Context) error {
 	var phaseErr error
 	for _, phase := range phaseRuns {
 		result := phaseResult{
+			number: phase.number,
 			name:   phase.name,
 			offset: time.Since(testStartTime),
 		}
@@ -339,7 +342,7 @@ func run(ctx context.Context) error {
 		if err := phase.fn(ctx); err != nil {
 			result.duration = time.Since(start)
 			phaseResults = append(phaseResults, result)
-			phaseErr = fmt.Errorf("%s phase: %w", phase.name, err)
+			phaseErr = fmt.Errorf("%s#%d phase: %w", phase.name, phase.number, err)
 			log.Printf("aborting after error: %v", phaseErr)
 			break
 		}
@@ -376,12 +379,14 @@ func run(ctx context.Context) error {
 }
 
 type phaseRun struct {
-	name Phase
-	fn   func(context.Context) error
+	number PhaseNumber // 1-based index into Config.Phases
+	name   Phase
+	fn     func(context.Context) error
 }
 
 // phaseResult records wall-clock timing for one completed (or aborted) phase.
 type phaseResult struct {
+	number   PhaseNumber
 	name     Phase
 	offset   time.Duration // start relative to the test start
 	duration time.Duration
@@ -390,9 +395,11 @@ type phaseResult struct {
 // buildPhaseRuns turns Config.Phases into concrete runners.
 // Recognized names today: fill, probe, throughput-mifN (N > 0).
 // Bare "throughput" is accepted as an alias for throughput-mif50.
+// Duplicate names are allowed; each entry gets a distinct PhaseNumber.
 func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 	var runs []phaseRun
-	for _, raw := range test.cfg.Phases {
+	for i, raw := range test.cfg.Phases {
+		number := PhaseNumber(i + 1)
 		switch {
 		case raw == string(PhaseFill):
 			if test.cfg.FillCount <= 0 {
@@ -401,7 +408,9 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 			if test.cfg.CreateConcurrency <= 0 {
 				return nil, fmt.Errorf("--create-concurrency must be > 0 for phase %q", raw)
 			}
-			runs = append(runs, phaseRun{PhaseFill, test.runFillPhase})
+			runs = append(runs, phaseRun{number, PhaseFill, func(ctx context.Context) error {
+				return test.runFillPhase(ctx, number)
+			}})
 		case raw == string(PhaseProbe):
 			if test.cfg.ProbeCount <= 0 {
 				return nil, fmt.Errorf("phase %q requires --probe-count > 0", raw)
@@ -409,7 +418,9 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 			if test.cfg.ProbeConcurrency <= 0 {
 				return nil, fmt.Errorf("--probe-concurrency must be > 0 for phase %q", raw)
 			}
-			runs = append(runs, phaseRun{PhaseProbe, test.runProbePhase})
+			runs = append(runs, phaseRun{number, PhaseProbe, func(ctx context.Context) error {
+				return test.runProbePhase(ctx, number)
+			}})
 		default:
 			maxInFlight, ok := throughputMaxInFlight(raw)
 			if !ok {
@@ -426,8 +437,8 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 				name = Phase(fmt.Sprintf("%s-mif%d", PhaseThroughput, maxInFlight))
 			}
 			mif := maxInFlight
-			runs = append(runs, phaseRun{name, func(ctx context.Context) error {
-				return test.runThroughputLevel(ctx, name, mif)
+			runs = append(runs, phaseRun{number, name, func(ctx context.Context) error {
+				return test.runThroughputLevel(ctx, name, number, mif)
 			}})
 		}
 	}
@@ -576,18 +587,19 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 		Phases:    make([]*PhaseSummary, 0, len(phaseResults)),
 	}
 
-	recordsByPhase := make(map[Phase][]SandboxRecord)
+	recordsByPhase := make(map[PhaseNumber][]SandboxRecord)
 	for _, record := range records {
-		recordsByPhase[record.Phase] = append(recordsByPhase[record.Phase], record)
+		recordsByPhase[record.PhaseNumber] = append(recordsByPhase[record.PhaseNumber], record)
 	}
 
 	for _, result := range phaseResults {
-		phaseRecords := recordsByPhase[result.name]
+		phaseRecords := recordsByPhase[result.number]
 		// Throughput levels overshoot the configured count when
 		// -throughput-min-seconds keeps them churning; every record was a
 		// real request.
 		req := max(requested(result.name), len(phaseRecords))
 		ps := &PhaseSummary{
+			Number:             result.number,
 			Name:               string(result.name),
 			Requested:          req,
 			DurationSeconds:    result.duration.Seconds(),
@@ -744,8 +756,8 @@ func printReport(summary *Summary, clusterInfo *ClusterInfo) {
 	}
 
 	for _, ps := range summary.Phases {
-		fmt.Printf("\n--- %s: %d requested, %d created, %d ready, %d failed (%.1fs) ---\n",
-			ps.Name, ps.Requested, ps.Created, ps.Ready, ps.Failed, ps.DurationSeconds)
+		fmt.Printf("\n--- #%d %s: %d requested, %d created, %d ready, %d failed (%.1fs) ---\n",
+			ps.Number, ps.Name, ps.Requested, ps.Created, ps.Ready, ps.Failed, ps.DurationSeconds)
 
 		switch Phase(ps.Name) {
 		case PhaseProbe:

--- a/test/stress/phases.go
+++ b/test/stress/phases.go
@@ -81,13 +81,13 @@ func buildSandboxObject(id types.NamespacedName, image string) *unstructured.Uns
 // createSandbox registers a record and issues the Create call.
 // Create errors are recorded on the SandboxRecord rather than returned:
 // individual failures should not abort the run, they are reported in the summary.
-func (s *stressTest) createSandbox(ctx context.Context, id types.NamespacedName, phase Phase) error {
+func (s *stressTest) createSandbox(ctx context.Context, id types.NamespacedName, name Phase, number PhaseNumber) error {
 	sandbox := buildSandboxObject(id, s.cfg.Image)
-	s.tracker.Register(id, phase)
+	s.tracker.Register(id, name, number)
 	_, err := s.sandboxClient.Create(ctx, sandbox, metav1.CreateOptions{})
 	s.tracker.MarkCreateReturned(id, err)
 	if err != nil {
-		log.Printf("[%s] failed to create sandbox %s: %v", phase, id.Name, err)
+		log.Printf("[%s] failed to create sandbox %s: %v", name, id.Name, err)
 	}
 	return err
 }
@@ -112,21 +112,22 @@ func (s *stressTest) deleteSandbox(ctx context.Context, id types.NamespacedName)
 // runFillPhase creates cfg.FillCount long-running sandboxes and waits for all of
 // them to become Ready. These stay running for the rest of the test, so the
 // probe and throughput phases measure performance on a cluster at scale.
-func (s *stressTest) runFillPhase(ctx context.Context) error {
+func (s *stressTest) runFillPhase(ctx context.Context, number PhaseNumber) error {
 	count := s.cfg.FillCount
 	if count == 0 {
 		return nil
 	}
-	log.Printf("[fill] creating %d background sandboxes (create-concurrency=%d)", count, s.cfg.CreateConcurrency)
+	log.Printf("[fill#%d] creating %d background sandboxes (create-concurrency=%d)", number, count, s.cfg.CreateConcurrency)
 
 	names := make([]types.NamespacedName, 0, count)
 	for i := range count {
-		names = append(names, types.NamespacedName{Name: fmt.Sprintf("fill-%d", i), Namespace: s.namespace})
+		// Include phase number so repeated fill entries do not collide on name.
+		names = append(names, types.NamespacedName{Name: fmt.Sprintf("p%d-fill-%d", number, i), Namespace: s.namespace})
 	}
 
 	if _, err := ForkJoin(ctx, names, s.cfg.CreateConcurrency, func(id types.NamespacedName) (struct{}, error) {
 		// Errors are recorded per-sandbox; do not abort the phase.
-		_ = s.createSandbox(ctx, id, PhaseFill)
+		_ = s.createSandbox(ctx, id, PhaseFill, number)
 		return struct{}{}, nil
 	}); err != nil {
 		return err
@@ -137,13 +138,13 @@ func (s *stressTest) runFillPhase(ctx context.Context) error {
 	lastReady := -1
 	lastProgress := time.Now()
 	for {
-		counts := s.tracker.Snapshot()[PhaseFill]
+		counts := s.tracker.Snapshot()[number]
 		if counts.Created == 0 {
-			return fmt.Errorf("[fill] all %d sandbox creations failed", counts.Failed)
+			return fmt.Errorf("[fill#%d] all %d sandbox creations failed", number, counts.Failed)
 		}
 		if counts.Ready >= counts.Created {
-			log.Printf("[fill] all %d created sandboxes are Ready (%d failed to create)",
-				counts.Created, counts.Failed)
+			log.Printf("[fill#%d] all %d created sandboxes are Ready (%d failed to create)",
+				number, counts.Created, counts.Failed)
 			return nil
 		}
 		if counts.Ready != lastReady {
@@ -151,7 +152,7 @@ func (s *stressTest) runFillPhase(ctx context.Context) error {
 			lastProgress = time.Now()
 		}
 		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
-			return fmt.Errorf("[fill] stalled: %d/%d sandboxes Ready with no progress for %v", counts.Ready, counts.Created, s.cfg.PerSandboxTimeout)
+			return fmt.Errorf("[fill#%d] stalled: %d/%d sandboxes Ready with no progress for %v", number, counts.Ready, counts.Created, s.cfg.PerSandboxTimeout)
 		}
 		select {
 		case <-ctx.Done():
@@ -165,12 +166,12 @@ func (s *stressTest) runFillPhase(ctx context.Context) error {
 // Probes run at low concurrency (default 1) so they never queue on cluster
 // capacity or on each other; each probe is deleted once measured so the
 // background scale stays constant.
-func (s *stressTest) runProbePhase(ctx context.Context) error {
+func (s *stressTest) runProbePhase(ctx context.Context, number PhaseNumber) error {
 	count := s.cfg.ProbeCount
 	if count == 0 {
 		return nil
 	}
-	log.Printf("[probe] launching %d probe sandboxes (concurrency=%d, interval=%v)", count, s.cfg.ProbeConcurrency, s.cfg.ProbeInterval)
+	log.Printf("[probe#%d] launching %d probe sandboxes (concurrency=%d, interval=%v)", number, count, s.cfg.ProbeConcurrency, s.cfg.ProbeInterval)
 
 	indices := make([]int, count)
 	for i := range indices {
@@ -178,12 +179,12 @@ func (s *stressTest) runProbePhase(ctx context.Context) error {
 	}
 
 	_, err := ForkJoin(ctx, indices, s.cfg.ProbeConcurrency, func(i int) (struct{}, error) {
-		id := types.NamespacedName{Name: fmt.Sprintf("probe-%d", i), Namespace: s.namespace}
+		id := types.NamespacedName{Name: fmt.Sprintf("p%d-probe-%d", number, i), Namespace: s.namespace}
 
-		if err := s.createSandbox(ctx, id, PhaseProbe); err == nil {
+		if err := s.createSandbox(ctx, id, PhaseProbe, number); err == nil {
 			if err := s.tracker.WaitReady(ctx, id, s.cfg.PerSandboxTimeout); err != nil && ctx.Err() == nil {
 				s.tracker.MarkError(id, err.Error())
-				log.Printf("[probe] %s: %v", id.Name, err)
+				log.Printf("[probe#%d] %s: %v", number, id.Name, err)
 			}
 
 			// Delete the probe and wait for its Pod to go away, so each probe
@@ -191,7 +192,7 @@ func (s *stressTest) runProbePhase(ctx context.Context) error {
 			s.deleteSandbox(ctx, id)
 			if err := s.tracker.WaitGone(ctx, id, s.cfg.PerSandboxTimeout); err != nil && ctx.Err() == nil {
 				s.tracker.MarkError(id, err.Error())
-				log.Printf("[probe] %s: %v", id.Name, err)
+				log.Printf("[probe#%d] %s: %v", number, id.Name, err)
 			}
 		}
 
@@ -223,16 +224,16 @@ func (s *stressTest) runProbePhase(ctx context.Context) error {
 // Multiple levels run back-to-back as separate phases (a max-in-flight sweep
 // within a single run): each level fully drains (every pod observed deleted)
 // before the next begins, so levels do not contaminate each other.
-func (s *stressTest) runThroughputLevel(ctx context.Context, phase Phase, maxInFlight int) error {
+func (s *stressTest) runThroughputLevel(ctx context.Context, name Phase, number PhaseNumber, maxInFlight int) error {
 	count := s.cfg.ThroughputCount
 	if count == 0 {
 		return nil
 	}
 	minDuration := time.Duration(s.cfg.ThroughputMinSeconds * float64(time.Second))
-	log.Printf("[%s] churning >=%d sandboxes for >=%s (max-in-flight=%d, create-concurrency=%d)", phase, count, minDuration, maxInFlight, s.cfg.CreateConcurrency)
+	log.Printf("[%s#%d] churning >=%d sandboxes for >=%s (max-in-flight=%d, create-concurrency=%d)", name, number, count, minDuration, maxInFlight, s.cfg.CreateConcurrency)
 
 	if maxInFlight < 1 {
-		return fmt.Errorf("[%s] invalid max-in-flight=%d (must be >= 1)", phase, maxInFlight)
+		return fmt.Errorf("[%s#%d] invalid max-in-flight=%d (must be >= 1)", name, number, maxInFlight)
 	}
 
 	slots := make(chan struct{}, maxInFlight)
@@ -243,7 +244,7 @@ func (s *stressTest) runThroughputLevel(ctx context.Context, phase Phase, maxInF
 	// made high-rate levels too short for stable throughput samples and for
 	// correlating with any side-car time series. Because both conditions are
 	// monotonic and indices are handed out in order, the created names are
-	// always a contiguous tp<mif>-[0..n) range.
+	// always a contiguous p<num>-tp<mif>-[0..n) range.
 	start := time.Now()
 	var nextIndex atomic.Int64
 	var createWG sync.WaitGroup
@@ -254,7 +255,7 @@ func (s *stressTest) runThroughputLevel(ctx context.Context, phase Phase, maxInF
 				if i >= count && time.Since(start) >= minDuration {
 					return
 				}
-				id := types.NamespacedName{Name: fmt.Sprintf("tp%d-%d", maxInFlight, i), Namespace: s.namespace}
+				id := types.NamespacedName{Name: fmt.Sprintf("p%d-tp%d-%d", number, maxInFlight, i), Namespace: s.namespace}
 
 				select {
 				case slots <- struct{}{}:
@@ -262,7 +263,7 @@ func (s *stressTest) runThroughputLevel(ctx context.Context, phase Phase, maxInF
 					return
 				}
 
-				if err := s.createSandbox(ctx, id, phase); err != nil {
+				if err := s.createSandbox(ctx, id, name, number); err != nil {
 					<-slots
 					continue
 				}
@@ -272,13 +273,13 @@ func (s *stressTest) runThroughputLevel(ctx context.Context, phase Phase, maxInF
 
 					if err := s.tracker.WaitReady(ctx, id, s.cfg.PerSandboxTimeout); err != nil && ctx.Err() == nil {
 						s.tracker.MarkError(id, err.Error())
-						log.Printf("[%s] %s: %v", phase, id.Name, err)
+						log.Printf("[%s#%d] %s: %v", name, number, id.Name, err)
 					}
 
 					s.deleteSandbox(ctx, id)
 					if err := s.tracker.WaitGone(ctx, id, s.cfg.PerSandboxTimeout); err != nil && ctx.Err() == nil {
 						s.tracker.MarkError(id, err.Error())
-						log.Printf("[%s] %s: %v", phase, id.Name, err)
+						log.Printf("[%s#%d] %s: %v", name, number, id.Name, err)
 					}
 				})
 			}
@@ -290,7 +291,7 @@ func (s *stressTest) runThroughputLevel(ctx context.Context, phase Phase, maxInF
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	counts := s.tracker.Snapshot()[phase]
-	log.Printf("[%s] done: %d created, %d ready, %d failed", phase, counts.Created, counts.Ready, counts.Failed)
+	counts := s.tracker.Snapshot()[number]
+	log.Printf("[%s#%d] done: %d created, %d ready, %d failed", name, number, counts.Created, counts.Ready, counts.Failed)
 	return nil
 }

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -26,7 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-// Phase identifies which part of the stress test a Sandbox belongs to.
+// Phase identifies which part of the stress test a Sandbox belongs to by name
+// (fill, probe, throughput-mifN). Names may repeat across a run when --phases
+// lists the same entry more than once; PhaseNumber distinguishes those entries.
 type Phase string
 
 const (
@@ -37,6 +39,10 @@ const (
 	// PhaseThroughput sandboxes are churned (create -> ready -> delete) to measure sustained throughput.
 	PhaseThroughput Phase = "throughput"
 )
+
+// PhaseNumber is a 1-based index into the run's phase list (Config.Phases /
+// Summary.Phases). The zero value means unset and is never a valid phase.
+type PhaseNumber int
 
 // Future is a future value that can be notified and waited on.
 type Future[T any] struct {
@@ -84,7 +90,11 @@ func (f *Future[T]) Wait(ctx context.Context) (T, error) {
 type SandboxRecord struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
-	Phase     Phase  `json:"phase"`
+	// Phase is the phase name for this sandbox (may repeat if --phases lists
+	// the same name more than once). PhaseNumber is the 1-based index of that
+	// run entry and is the key used when aggregating summary stats.
+	Phase       Phase       `json:"phase"`
+	PhaseNumber PhaseNumber `json:"phaseNumber"`
 
 	// Pod identity, for joining against node-side data sources.
 	// PodUID is the pod's metadata.uid. NodeName selects the right
@@ -137,11 +147,14 @@ func NewTracker() *Tracker {
 
 // Register creates a record for a Sandbox we are about to create,
 // stamping CreateCalled with the current time.
-func (t *Tracker) Register(id types.NamespacedName, phase Phase) *SandboxRecord {
+// number is the 1-based index of the phase entry in this run; name is that
+// entry's phase name (kept for sandboxes.jsonl readability).
+func (t *Tracker) Register(id types.NamespacedName, name Phase, number PhaseNumber) *SandboxRecord {
 	rec := &SandboxRecord{
 		Name:         id.Name,
 		Namespace:    id.Namespace,
-		Phase:        phase,
+		Phase:        name,
+		PhaseNumber:  number,
 		CreateCalled: time.Now(),
 	}
 	rec.ready = newFuture[bool]()
@@ -258,8 +271,9 @@ func (t *Tracker) Records() []SandboxRecord {
 	return out
 }
 
-// PhaseCounts summarizes progress for one phase.
+// PhaseCounts summarizes progress for one phase entry in the run.
 type PhaseCounts struct {
+	Name       Phase
 	Registered int
 	Created    int
 	Ready      int
@@ -268,13 +282,14 @@ type PhaseCounts struct {
 	Failed     int
 }
 
-// Snapshot returns per-phase progress counts.
-func (t *Tracker) Snapshot() map[Phase]PhaseCounts {
+// Snapshot returns per-phase-entry progress counts, keyed by PhaseNumber.
+func (t *Tracker) Snapshot() map[PhaseNumber]PhaseCounts {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	out := make(map[Phase]PhaseCounts)
+	out := make(map[PhaseNumber]PhaseCounts)
 	for _, rec := range t.records {
-		c := out[rec.Phase]
+		c := out[rec.PhaseNumber]
+		c.Name = rec.Phase
 		c.Registered++
 		if !rec.CreateReturned.IsZero() {
 			c.Created++
@@ -291,7 +306,7 @@ func (t *Tracker) Snapshot() map[Phase]PhaseCounts {
 		if rec.Error != "" {
 			c.Failed++
 		}
-		out[rec.Phase] = c
+		out[rec.PhaseNumber] = c
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- Add a 1-based `PhaseNumber` on each `SandboxRecord` (and `PhaseSummary`) so duplicate `--phases` entries do not share a summary bucket.
- `buildSummary` / `Snapshot` group by `PhaseNumber`; phase name remains for readability in `sandboxes.jsonl`.
- Prefix sandbox object names with the phase number so repeated phases do not collide on Create.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stress test reporting when multiple phases share the same name.
  * Phase progress, logs, errors, and final summaries now identify phases with unique numbers.
  * Metrics and sandbox counts are attributed to the correct configured phase.
  * Sandbox names are now unique across repeated phase entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->