### PR TITLE
tests: collect Prometheus metrics during stress runs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/bridges/prometheus v0.69.0
 	go.opentelemetry.io/otel v1.44.0
@@ -71,7 +72,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -123,6 +123,16 @@ trap cleanup EXIT
 
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
+#
+# authorizationAlwaysAllowPaths: allow unauthenticated GETs of /metrics on
+# kube-controller-manager and kube-scheduler so the stress test can scrape
+# them through the apiserver pod proxy (the apiserver strips the
+# Authorization header after authenticating, so the proxied request is
+# anonymous and the default delegated authorization rejects it with 403).
+# The health probe paths must be repeated because setting the field replaces
+# the upstream default, and kOps liveness probes hit /healthz.
+# Ports 10257/10259 are not internet-reachable: kOps GCE creates a
+# deny-by-default VPC and only control-plane instances can reach them.
 kops create cluster \
   --cloud=gce \
   --gce-service-account=default \
@@ -132,7 +142,15 @@ kops create cluster \
   --control-plane-count=1 \
   --control-plane-size=n2-standard-8 \
   --node-count=3 \
-  --node-size=n2-standard-8
+  --node-size=n2-standard-8 \
+  --set cluster.spec.kubeControllerManager.authorizationAlwaysAllowPaths=/healthz \
+  --set cluster.spec.kubeControllerManager.authorizationAlwaysAllowPaths=/readyz \
+  --set cluster.spec.kubeControllerManager.authorizationAlwaysAllowPaths=/livez \
+  --set cluster.spec.kubeControllerManager.authorizationAlwaysAllowPaths=/metrics \
+  --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz \
+  --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/readyz \
+  --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/livez \
+  --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics
 
 echo "Applying cluster configuration..."
 kops update cluster --name "${CLUSTER_NAME}" --yes
@@ -180,6 +198,9 @@ capture_stress_diagnostics() {
 }
 
 echo "Running stress test"
+# Prometheus metrics from the apiserver, kube-controller-manager,
+# kube-scheduler, the sandbox controller, and kubelets are collected by the
+# stress tool itself (metrics.jsonl.gz; see --collect-metrics).
 set +o errexit
 go run ./test/stress \
   --phases="${STRESS_PHASES:-fill,probe,throughput-mif200,throughput-mif100,throughput-mif50}" \

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -29,6 +29,9 @@
 //   - sandboxes.jsonl: per-sandbox lifecycle milestones (client + server timestamps)
 //   - timeseries.jsonl: per-second event counts and gauges
 //   - watch.jsonl.gz: full watch streams (pods, nodes, events, sandboxes) for offline analysis
+//   - metrics.jsonl.gz: Prometheus samples scraped from the apiserver,
+//     kube-controller-manager, kube-scheduler, the sandbox controller, and
+//     kubelets (optional; see --collect-metrics)
 package main
 
 import (
@@ -136,6 +139,9 @@ type Config struct {
 	// levels keep churning past ThroughputCount until this much time has
 	// elapsed (0 = count-based only).
 	ThroughputMinSeconds float64 `json:"throughputMinSeconds"`
+
+	CollectMetrics  bool          `json:"collectMetrics"`
+	MetricsInterval time.Duration `json:"metricsIntervalNanos"`
 }
 
 func main() {
@@ -166,6 +172,8 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.ProbeInterval, "probe-interval", 0, "Delay between latency probes")
 	flag.IntVar(&cfg.ThroughputCount, "throughput-count", 200, "Number of Sandboxes to churn per throughput phase (before --throughput-min-seconds)")
 	flag.Float64Var(&cfg.ThroughputMinSeconds, "throughput-min-seconds", 45, "Minimum duration of each throughput phase; levels churn beyond -throughput-count until this much time has elapsed (0 = count-based only)")
+	flag.BoolVar(&cfg.CollectMetrics, "collect-metrics", true, "Whether to scrape Prometheus metrics from the control plane, the sandbox controller, and kubelets to metrics.jsonl.gz")
+	flag.DurationVar(&cfg.MetricsInterval, "metrics-interval", 15*time.Second, "Interval between Prometheus metrics scrapes")
 	flag.Parse()
 
 	for part := range strings.SplitSeq(*phasesFlag, ",") {
@@ -291,6 +299,23 @@ func run(ctx context.Context) error {
 		})
 	}
 
+	// Periodically scrape Prometheus metrics from the control plane, the
+	// sandbox controller, and kubelets. Cumulative counters snapshotted on
+	// an interval can be diffed per phase offline.
+	var scraper *promScraper
+	if cfg.CollectMetrics {
+		scraper, err = newPromScraper(restConfig, filepath.Join(cfg.OutputDir, "metrics.jsonl.gz"))
+		if err != nil {
+			return fmt.Errorf("failed to start metrics scraper: %w", err)
+		}
+		defer scraper.Close()
+		scraper.ScrapeAll(ctx) // baseline snapshot before any load
+		taskRunner.RunPeriodic(ctx, cfg.MetricsInterval, func() error {
+			scraper.ScrapeAll(ctx)
+			return nil
+		})
+	}
+
 	// Wait briefly for watches to establish
 	time.Sleep(2 * time.Second)
 
@@ -350,6 +375,11 @@ func run(ctx context.Context) error {
 	// Give the watchers a moment to observe trailing events.
 	if ctx.Err() == nil {
 		time.Sleep(2 * time.Second)
+	}
+
+	// Final metrics snapshot so cumulative counters cover the whole run.
+	if scraper != nil && ctx.Err() == nil {
+		scraper.ScrapeAll(ctx)
 	}
 
 	// Write outputs even if a phase failed: partial data is still useful.

--- a/test/stress/promscrape.go
+++ b/test/stress/promscrape.go
@@ -1,0 +1,300 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"maps"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// metricSample is one line of metrics.jsonl.gz: a single Prometheus sample
+// from one component at one scrape. Long/narrow format for direct DuckDB
+// ingestion; counters and histogram buckets are cumulative, so per-window
+// rates come from diffing consecutive scrapes (see analyze-fsync.py for the
+// same pattern).
+type metricSample struct {
+	TS       time.Time       `json:"ts"`
+	Source   string          `json:"source"`   // kube-apiserver | kube-controller-manager | kube-scheduler | agent-sandbox-controller | kubelet
+	Instance string          `json:"instance"` // pod or node name
+	Metric   string          `json:"metric"`   // family name (+ _bucket/_sum/_count for histograms and summaries)
+	Labels   json.RawMessage `json:"labels,omitempty"`
+	Value    float64         `json:"value"`
+}
+
+// promScraper periodically collects Prometheus metrics from the control
+// plane (apiserver, kube-controller-manager, kube-scheduler), the
+// agent-sandbox controller, and every kubelet, writing parsed samples to
+// metrics.jsonl.gz. Everything is best-effort: a source that fails to
+// resolve or scrape is logged and skipped, never fatal.
+//
+// Not scraped (deliberately): cadvisor (very large, container-level resource
+// data) and etcd (requires client certificates).
+type promScraper struct {
+	kube *kubernetes.Clientset
+
+	mu   sync.Mutex
+	file *os.File
+	bufw *bufio.Writer
+	gzw  *gzip.Writer
+	enc  *json.Encoder
+
+	samples int
+	closed  bool
+}
+
+func newPromScraper(restConfig *rest.Config, filePath string) (*promScraper, error) {
+	kube, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("building kubernetes client: %w", err)
+	}
+	f, err := os.Create(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("creating metrics file %s: %w", filePath, err)
+	}
+	bufw := bufio.NewWriterSize(f, 1<<20)
+	gzw := gzip.NewWriter(bufw)
+	return &promScraper{
+		kube: kube,
+		file: f,
+		bufw: bufw,
+		gzw:  gzw,
+		enc:  json.NewEncoder(gzw),
+	}, nil
+}
+
+// Close flushes and closes the output file. Safe to call more than once.
+func (s *promScraper) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	log.Printf("[metrics] wrote %d samples", s.samples)
+	if err := s.gzw.Close(); err != nil {
+		return err
+	}
+	if err := s.bufw.Flush(); err != nil {
+		return err
+	}
+	return s.file.Close()
+}
+
+// promSource is one metrics endpoint, addressed via the apiserver
+// (direct for the apiserver itself, pod/node proxy for everything else),
+// so no direct network path to nodes or the control plane is needed.
+type promSource struct {
+	source   string
+	instance string
+	path     string
+}
+
+// resolveSources discovers the current scrape targets. Re-resolved on every
+// cycle so pod restarts and node changes are picked up.
+func (s *promScraper) resolveSources(ctx context.Context) []promSource {
+	sources := []promSource{{source: "kube-apiserver", instance: "kube-apiserver", path: "/metrics"}}
+
+	forPods := func(namespace, source, scheme string, port int, labelSelectors ...string) {
+		for _, labelSelector := range labelSelectors {
+			pods, err := s.kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+			if err != nil {
+				log.Printf("[metrics] listing %s pods: %v", source, err)
+				continue
+			}
+			if len(pods.Items) == 0 {
+				continue
+			}
+			for i := range pods.Items {
+				name := pods.Items[i].Name
+				sources = append(sources, promSource{
+					source:   source,
+					instance: name,
+					path:     fmt.Sprintf("/api/v1/namespaces/%s/pods/%s:%s:%d/proxy/metrics", namespace, scheme, name, port),
+				})
+			}
+			return
+		}
+	}
+	// Control-plane components serve HTTPS with delegated authz; the
+	// apiserver pod proxy handles that when given the https scheme prefix.
+	// kOps labels control-plane pods k8s-app=..., kubeadm/kind use component=...
+	forPods("kube-system", "kube-controller-manager", "https", 10257, "k8s-app=kube-controller-manager", "component=kube-controller-manager")
+	forPods("kube-system", "kube-scheduler", "https", 10259, "k8s-app=kube-scheduler", "component=kube-scheduler")
+	forPods("agent-sandbox-system", "agent-sandbox-controller", "http", 8080, "app=agent-sandbox-controller")
+	// cilium-agent: CNI/endpoint latency lives here when cilium is the CNI
+	// and prometheus metrics are enabled (e.g. kOps
+	// cluster.spec.networking.cilium.enablePrometheusMetrics=true, which
+	// serves the agent on :9090 — verified empirically; 9962, upstream
+	// cilium's newer default, is not listening on kOps). Best-effort: if
+	// cilium is absent or metrics are disabled, the scrape is logged and
+	// skipped.
+	forPods("kube-system", "cilium-agent", "http", 9090, "k8s-app=cilium")
+
+	nodes, err := s.kube.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Printf("[metrics] listing nodes: %v", err)
+	} else {
+		for i := range nodes.Items {
+			name := nodes.Items[i].Name
+			sources = append(sources, promSource{
+				source:   "kubelet",
+				instance: name,
+				path:     fmt.Sprintf("/api/v1/nodes/%s/proxy/metrics", name),
+			})
+		}
+	}
+	return sources
+}
+
+// ScrapeAll fetches and records all sources once, concurrently.
+func (s *promScraper) ScrapeAll(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, 25*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, src := range s.resolveSources(ctx) {
+		wg.Go(func() {
+			if err := s.scrapeOne(ctx, src); err != nil && ctx.Err() == nil {
+				log.Printf("[metrics] scraping %s (%s): %v", src.source, src.instance, err)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func (s *promScraper) scrapeOne(ctx context.Context, src promSource) error {
+	ts := time.Now()
+	raw, err := s.kube.CoreV1().RESTClient().Get().AbsPath(src.path).DoRaw(ctx)
+	if err != nil {
+		// Component metrics endpoints often return non-Status error bodies,
+		// which client-go reports as just "unknown"; include the HTTP code
+		// and body so failures (401/403 vs 503) are distinguishable in CI.
+		var statusErr *apierrors.StatusError
+		if errors.As(err, &statusErr) {
+			return fmt.Errorf("HTTP %d: %s (%w)", statusErr.Status().Code, strings.TrimSpace(string(raw)), err)
+		}
+		return err
+	}
+
+	// The parser panics if constructed without a validation scheme.
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(bytes.NewReader(raw))
+	if err != nil {
+		return fmt.Errorf("parsing metrics: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	for name, family := range families {
+		for _, m := range family.Metric {
+			if err := s.encodeMetricLocked(ts, src, name, family.GetType(), m); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// encodeMetricLocked writes the samples for one metric. Must hold s.mu.
+func (s *promScraper) encodeMetricLocked(ts time.Time, src promSource, name string, mtype dto.MetricType, m *dto.Metric) error {
+	labels := make(map[string]string, len(m.Label)+1)
+	for _, lp := range m.Label {
+		labels[lp.GetName()] = lp.GetValue()
+	}
+
+	emit := func(metric string, extraKey, extraVal string, value float64) error {
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return nil
+		}
+		var labelsJSON json.RawMessage
+		if len(labels) > 0 || extraKey != "" {
+			all := labels
+			if extraKey != "" {
+				all = make(map[string]string, len(labels)+1)
+				maps.Copy(all, labels)
+				all[extraKey] = extraVal
+			}
+			b, err := json.Marshal(all)
+			if err != nil {
+				return err
+			}
+			labelsJSON = b
+		}
+		s.samples++
+		return s.enc.Encode(metricSample{
+			TS: ts, Source: src.source, Instance: src.instance,
+			Metric: metric, Labels: labelsJSON, Value: value,
+		})
+	}
+
+	switch mtype {
+	case dto.MetricType_COUNTER:
+		return emit(name, "", "", m.Counter.GetValue())
+	case dto.MetricType_GAUGE:
+		return emit(name, "", "", m.Gauge.GetValue())
+	case dto.MetricType_UNTYPED:
+		return emit(name, "", "", m.Untyped.GetValue())
+	case dto.MetricType_HISTOGRAM:
+		h := m.Histogram
+		for _, b := range h.Bucket {
+			le := strconv.FormatFloat(b.GetUpperBound(), 'g', -1, 64)
+			if err := emit(name+"_bucket", "le", le, float64(b.GetCumulativeCount())); err != nil {
+				return err
+			}
+		}
+		if err := emit(name+"_sum", "", "", h.GetSampleSum()); err != nil {
+			return err
+		}
+		return emit(name+"_count", "", "", float64(h.GetSampleCount()))
+	case dto.MetricType_SUMMARY:
+		sm := m.Summary
+		for _, q := range sm.Quantile {
+			qv := strconv.FormatFloat(q.GetQuantile(), 'g', -1, 64)
+			if err := emit(name, "quantile", qv, q.GetValue()); err != nil {
+				return err
+			}
+		}
+		if err := emit(name+"_sum", "", "", sm.GetSampleSum()); err != nil {
+			return err
+		}
+		return emit(name+"_count", "", "", float64(sm.GetSampleCount()))
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
What we're doing here is adding prometheus metrics scraping, so we can use the metrics to justify changes.  We know from #1122 that we hit client-side rate limits basically in every kube component, along with some more subtle issues!

## Summary
- Add `test/stress/promscrape.go` to scrape control-plane, sandbox-controller, kubelet (and cilium-agent when present) metrics into `metrics.jsonl.gz` via the apiserver proxy.
- Wire `--collect-metrics` / `--metrics-interval` into the stress harness.
- On the kOps benchmark scenario, set `authorizationAlwaysAllowPaths` to include `/metrics` (and the health paths it replaces) on kube-controller-manager and kube-scheduler so proxied scrapes are not rejected as anonymous.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Prometheus metrics collection to stress tests.
  * Metrics are collected from control-plane, agent, CNI, and kubelet endpoints.
  * Scraped metrics are saved in compressed JSON Lines format for later analysis.
  * Added configurable collection intervals and baseline/final snapshots.

* **Documentation**
  * Clarified benchmark configuration and metrics collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->