### PR TITLE
docs: consolidate small doc fixes (pod count, JSON patch, port-forward, CRD schema, router path)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ kubectl patch deployment agent-sandbox-controller \
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-concurrent-workers=10"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-claim-concurrent-workers=100"},
     {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-concurrent-workers=10"},
-    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-max-batch-size=500"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--sandbox-warm-pool-max-batch-size=500"}
   ]'
 ```
 This method safely appends the new flags without overwriting existing necessary arguments like `--leader-elect=true` or `--extensions=true`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
-- [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 110 to 170 pods per node.
+- [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 120 to 200 pods per node.
 - [**hello-world-sandbox**](./hello-world-sandbox): A simple "Hello World" sandbox example.
 - [**hermes-agent**](./hermes-agent): An example of running Hermes Agent with persistence and custom skills.
 - [**hpa-swp-scaling**](./hpa-swp-scaling): An example of scaling a SandboxWarmPool using Kubernetes Horizontal Pod Autoscaler (HPA).

--- a/examples/chrome-sandbox/README.md
+++ b/examples/chrome-sandbox/README.md
@@ -18,11 +18,13 @@ kind: Sandbox
 metadata:
   name: chrome-sandbox
 spec:
-  containers:
-    - name: chrome
-      image: registry.k8s.io/chrome-sandbox
-      ports:
-        - containerPort: 9222
+  podTemplate:
+    spec:
+      containers:
+        - name: chrome
+          image: registry.k8s.io/chrome-sandbox
+          ports:
+            - containerPort: 9222
 ```
 
 ## How to Run

--- a/examples/chrome-sandbox/README.md
+++ b/examples/chrome-sandbox/README.md
@@ -35,7 +35,7 @@ kubectl apply -f chrome-sandbox.yaml
 Port-forward to access Chrome debugging endpoint:
 
 ```bash
-kubectl port-forward sandbox/chrome-sandbox 9222:9222 
+kubectl port-forward pod/chrome-sandbox 9222:9222
 ```
 ---
 

--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -189,14 +189,14 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
 1.  **Deploy the Router (Required for All Modes):**
     ```bash
     # Deploys the Deployment and Service
-    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox_router/sandbox_router.yaml
+    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
     ```
 
 2.  **Deploy the Gateway (Production Only):**
     If you need external access via a Public IP (GKE), apply the Gateway configuration.
     ```bash
     # Deploys Gateway, HTTPRoute, and HealthCheckPolicy
-    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox_router/gateway.yaml
+    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/gateway.yaml
     ```
 
 **For Production (via Gateway)**

--- a/site/content/docs/use-cases/kata-containers-isolation/_index.md
+++ b/site/content/docs/use-cases/kata-containers-isolation/_index.md
@@ -74,7 +74,7 @@ With Kata runtimes, direct pod port-forwarding is not compatible. Use the [Sandb
 
 ```bash
 # Deploy the router
-kubectl apply -f clients/python/agentic-sandbox-client/sandbox_router/sandbox_router.yaml
+kubectl apply -f clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
 
 # Port-forward to the router service
 kubectl port-forward svc/sandbox-router-svc 8080:8080 -n default
@@ -86,7 +86,7 @@ curl -H "X-Sandbox-ID: sandbox-example" -H "X-Sandbox-Port: 13337" http://localh
 For production external access (e.g., on GKE), deploy the Gateway configuration:
 
 ```bash
-kubectl apply -f clients/python/agentic-sandbox-client/sandbox_router/gateway.yaml
+kubectl apply -f clients/python/agentic-sandbox-client/sandbox-router/gateway.yaml
 ```
 
 ## When to Use Kata Containers


### PR DESCRIPTION
## Summary
Consolidates several small, independent docs fixes into a single PR, as requested in #1169.

- Fix pod count mismatch for gke-swap in examples index (was #1169)
- Remove invalid trailing comma in kubectl patch JSON example (was #1167)
- Fix invalid kubectl port-forward target in chrome-sandbox example (was #1166)
- Fix chrome-sandbox example to match Sandbox CRD schema (was #1165)
- Fix wrong sandbox_router path, should be sandbox-router (was #1164)

Closes #1169
Closes #1167
Closes #1166
Closes #1165
Closes #1164

## Test plan
- [x] Docs-only changes, no code/CI-affecting files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment examples with the sandbox warm pool batch-size setting.
  - Corrected sandbox router and gateway deployment paths.
  - Updated Chrome sandbox manifests and port-forwarding instructions.
  - Revised the documented Chrome pod density improvement range for GKE Swap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->