### PR TITLE
fix(client/go): make WarmPoolName optional on Client Options

### DIFF
--- a/clients/go/sandbox/client.go
+++ b/clients/go/sandbox/client.go
@@ -50,7 +50,7 @@ type Client struct {
 // NewClient creates a Client with shared configuration.
 func NewClient(_ context.Context, opts Options) (*Client, error) {
 	opts.setDefaults()
-	if err := opts.validate(); err != nil {
+	if err := opts.validateCommon(); err != nil {
 		return nil, err
 	}
 
@@ -78,9 +78,6 @@ func NewClient(_ context.Context, opts Options) (*Client, error) {
 // CreateSandbox provisions a new sandbox and returns a managed handle.
 // On failure, the orphaned claim is cleaned up.
 func (c *Client) CreateSandbox(ctx context.Context, warmPoolName, namespace string) (*Sandbox, error) {
-	if warmPoolName == "" {
-		return nil, fmt.Errorf("sandbox: warm pool name is required")
-	}
 	if namespace == "" {
 		namespace = defaultNamespace
 	}

--- a/clients/go/sandbox/client_test.go
+++ b/clients/go/sandbox/client_test.go
@@ -17,6 +17,7 @@ package sandbox
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -190,6 +191,85 @@ func TestClient_CreateSandbox_EmptyWarmPool(t *testing.T) {
 	_, err := c.CreateSandbox(context.Background(), "", "default")
 	if err == nil {
 		t.Error("expected error for empty warm pool")
+	}
+	if !strings.Contains(err.Error(), "WarmPoolName is required") {
+		t.Errorf("expected WarmPoolName required error, got: %v", err)
+	}
+}
+
+func TestClient_CreateSandbox_InvalidWarmPoolName(t *testing.T) {
+	c, extensionsCS := newTestClient(t)
+
+	createCalled := false
+	extensionsCS.PrependReactor("create", "sandboxclaims", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		createCalled = true
+		return false, nil, nil
+	})
+
+	_, err := c.CreateSandbox(context.Background(), "MyWarmPool", "default")
+	if err == nil {
+		t.Fatal("expected error for invalid warm pool name")
+	}
+	if !strings.Contains(err.Error(), "not a valid Kubernetes DNS subdomain name") {
+		t.Errorf("expected DNS subdomain validation error, got: %v", err)
+	}
+	if createCalled {
+		t.Error("CreateSandbox should reject invalid name before creating a claim")
+	}
+}
+
+func TestClient_GetSandbox_Reattach_WithoutClientWarmPoolName(t *testing.T) {
+	agentsCS := fakeagents.NewSimpleClientset()         //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
+	extensionsCS := fakeextensions.NewSimpleClientset() //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
+
+	const (
+		claimName   = "reattach-claim"
+		sandboxName = "reattach-sandbox"
+	)
+
+	extensionsCS.PrependReactor("get", "sandboxclaims", func(action ktesting.Action) (bool, runtime.Object, error) {
+		ga := action.(ktesting.GetAction)
+		return true, &extv1beta1.SandboxClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: ga.GetName(), Namespace: ga.GetNamespace()},
+			Status: extv1beta1.SandboxClaimStatus{
+				SandboxStatus: extv1beta1.SandboxStatus{Name: sandboxName},
+			},
+		}, nil
+	})
+	agentsCS.PrependReactor("get", "sandboxes", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, readySandbox(sandboxName), nil
+	})
+
+	opts := Options{
+		Namespace:           "default",
+		APIURL:              "http://localhost:9999",
+		SandboxReadyTimeout: 2 * time.Second,
+		Quiet:               true,
+	}
+	opts.setDefaults()
+	opts.K8sHelper = &K8sHelper{
+		AgentsClient:     agentsCS.AgentsV1beta1(),
+		ExtensionsClient: extensionsCS.ExtensionsV1beta1(),
+		Log:              logr.Discard(),
+	}
+
+	c, err := NewClient(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("NewClient() without WarmPoolName: %v", err)
+	}
+
+	sb, err := c.GetSandbox(context.Background(), claimName, "default")
+	if err != nil {
+		t.Fatalf("GetSandbox() re-attach without client WarmPoolName: %v", err)
+	}
+	if !sb.IsReady() {
+		t.Fatal("expected re-attached sandbox to be ready")
+	}
+	if sb.ClaimName() != claimName {
+		t.Errorf("expected claim %q, got %q", claimName, sb.ClaimName())
+	}
+	if sb.SandboxName() != sandboxName {
+		t.Errorf("expected sandbox %q, got %q", sandboxName, sb.SandboxName())
 	}
 }
 

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -42,7 +42,10 @@ const (
 
 // Options configures a Sandbox instance.
 type Options struct {
-	// WarmPoolName is the name of the SandboxWarmPool to use. Required.
+	// WarmPoolName is the name of the SandboxWarmPool to use.
+	// Required in Options before calling Open() to provision a new sandbox.
+	// Optional on Client-level Options; pass the pool name per-sandbox to
+	// CreateSandbox instead.
 	// Must be a valid Kubernetes DNS subdomain (lowercase, [a-z0-9.-]).
 	WarmPoolName string
 
@@ -238,7 +241,18 @@ func isValidDNSLabel(s string) bool {
 	return true
 }
 
-func (o *Options) validate() error {
+// validateWarmPoolName checks that a warm pool name is present and a valid DNS subdomain.
+func validateWarmPoolName(name string) error {
+	if name == "" {
+		return fmt.Errorf("sandbox: WarmPoolName is required")
+	}
+	if !isValidDNSSubdomain(name) {
+		return fmt.Errorf("sandbox: WarmPoolName %q is not a valid Kubernetes DNS subdomain name", name)
+	}
+	return nil
+}
+
+func (o *Options) validateCommon() error {
 	if o.APIURL != "" {
 		u, err := url.Parse(o.APIURL)
 		if err != nil {
@@ -250,12 +264,6 @@ func (o *Options) validate() error {
 		if u.Host == "" {
 			return fmt.Errorf("sandbox: APIURL %q must include a host", o.APIURL)
 		}
-	}
-	if o.WarmPoolName == "" {
-		return fmt.Errorf("sandbox: WarmPoolName is required")
-	}
-	if !isValidDNSSubdomain(o.WarmPoolName) {
-		return fmt.Errorf("sandbox: WarmPoolName %q is not a valid Kubernetes DNS subdomain name", o.WarmPoolName)
 	}
 	if !isValidDNSLabel(o.Namespace) {
 		return fmt.Errorf("sandbox: Namespace %q is not a valid Kubernetes namespace (DNS label)", o.Namespace)

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -65,7 +65,7 @@ var (
 // Call Open() to create a sandbox and establish connectivity.
 func New(_ context.Context, opts Options) (*Sandbox, error) {
 	opts.setDefaults()
-	if err := opts.validate(); err != nil {
+	if err := opts.validateCommon(); err != nil {
 		return nil, err
 	}
 
@@ -235,6 +235,10 @@ func (s *Sandbox) Open(ctx context.Context) (retErr error) {
 
 	if reconnect {
 		return s.reconnect(openCtx)
+	}
+
+	if err := validateWarmPoolName(s.opts.WarmPoolName); err != nil {
+		return err
 	}
 
 	// Create claim.

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -62,6 +62,14 @@ func defaultTestOpts() Options {
 	return opts
 }
 
+// validateAllOptions aggregates validateCommon and validateWarmPoolName for table tests.
+func validateAllOptions(o *Options) error {
+	if err := o.validateCommon(); err != nil {
+		return err
+	}
+	return validateWarmPoolName(o.WarmPoolName)
+}
+
 func newTestSandbox(opts Options) (*Sandbox, *fakeagents.Clientset, *fakeextensions.Clientset) {
 	agentsCS := fakeagents.NewSimpleClientset()         //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
 	extensionsCS := fakeextensions.NewSimpleClientset() //nolint:staticcheck // TODO: regenerate clientsets with --with-applyconfig
@@ -206,18 +214,25 @@ func setupWatchWithReactor(agentsCS *fakeagents.Clientset, extensionsCS *fakeext
 // Validation tests
 // ---------------------------------------------------------------------------
 
-func TestNew_MissingWarmPoolName(t *testing.T) {
-	opts := Options{Namespace: "default"}
+func TestOpen_MissingWarmPoolName(t *testing.T) {
+	opts := Options{Namespace: "default", APIURL: "http://localhost:9999", Quiet: true}
 	opts.setDefaults()
-	if err := opts.validate(); err == nil {
-		t.Fatal("expected error for missing WarmPoolName")
+
+	s, _, _ := newTestSandbox(opts)
+	err := s.Open(context.Background())
+	if err == nil {
+		s.Close(context.Background())
+		t.Fatal("expected error from Open() for missing WarmPoolName")
+	}
+	if !strings.Contains(err.Error(), "WarmPoolName is required") {
+		t.Errorf("expected WarmPoolName required error, got: %v", err)
 	}
 }
 
-func TestNew_InvalidPort(t *testing.T) {
+func TestValidation_InvalidServerPort(t *testing.T) {
 	opts := Options{WarmPoolName: "pool", ServerPort: -1}
 	opts.setDefaults()
-	if err := opts.validate(); err == nil {
+	if err := validateAllOptions(&opts); err == nil {
 		t.Fatal("expected error for negative ServerPort")
 	}
 }
@@ -1551,7 +1566,7 @@ func TestValidation_NegativeTimeouts(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.opts.setDefaults()
-			if err := tc.opts.validate(); err == nil {
+			if err := validateAllOptions(&tc.opts); err == nil {
 				t.Errorf("expected validation error for %s", tc.name)
 			}
 		})
@@ -1570,7 +1585,7 @@ func TestValidation_InvalidNames(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.opts.setDefaults()
-			if err := tc.opts.validate(); err == nil {
+			if err := validateAllOptions(&tc.opts); err == nil {
 				t.Errorf("expected validation error for %s", tc.name)
 			}
 		})
@@ -2304,7 +2319,7 @@ func TestValidation_InvalidAPIURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			opts := Options{WarmPoolName: "pool", APIURL: tc.apiURL}
 			opts.setDefaults()
-			if err := opts.validate(); err == nil {
+			if err := validateAllOptions(&opts); err == nil {
 				t.Errorf("expected validation error for APIURL %q", tc.apiURL)
 			}
 		})
@@ -2321,7 +2336,7 @@ func TestValidation_ValidAPIURL(t *testing.T) {
 		t.Run(apiURL, func(t *testing.T) {
 			opts := Options{WarmPoolName: "pool", APIURL: apiURL}
 			opts.setDefaults()
-			if err := opts.validate(); err != nil {
+			if err := validateAllOptions(&opts); err != nil {
 				t.Errorf("unexpected validation error for APIURL %q: %v", apiURL, err)
 			}
 		})
@@ -2628,7 +2643,7 @@ func TestClose_DeleteFailure_ClearsIdentityButKeepsClaim(t *testing.T) {
 func TestValidation_InvalidGatewayScheme(t *testing.T) {
 	opts := Options{WarmPoolName: "pool", GatewayScheme: "ftp"}
 	opts.setDefaults()
-	if err := opts.validate(); err == nil {
+	if err := validateAllOptions(&opts); err == nil {
 		t.Fatal("expected error for invalid GatewayScheme")
 	}
 }

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -183,7 +183,7 @@ func (c *Client) CreateSandbox(ctx context.Context, warmPoolName, namespace stri
 CreateSandbox provisions a new sandbox and returns a managed handle. On failure, the orphaned claim is cleaned up.
 
 <a name="Client.DeleteAll"></a>
-#### func \(\*Client\) [DeleteAll](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L242>)
+#### func \(\*Client\) [DeleteAll](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L239>)
 
 ```go
 func (c *Client) DeleteAll(ctx context.Context)
@@ -192,7 +192,7 @@ func (c *Client) DeleteAll(ctx context.Context)
 DeleteAll closes and deletes all tracked sandboxes. Best\-effort.
 
 <a name="Client.DeleteSandbox"></a>
-#### func \(\*Client\) [DeleteSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L224>)
+#### func \(\*Client\) [DeleteSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L221>)
 
 ```go
 func (c *Client) DeleteSandbox(ctx context.Context, claimName, namespace string) error
@@ -201,7 +201,7 @@ func (c *Client) DeleteSandbox(ctx context.Context, claimName, namespace string)
 DeleteSandbox closes the handle \(if tracked\) and deletes the claim.
 
 <a name="Client.EnableAutoCleanup"></a>
-#### func \(\*Client\) [EnableAutoCleanup](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L258>)
+#### func \(\*Client\) [EnableAutoCleanup](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L255>)
 
 ```go
 func (c *Client) EnableAutoCleanup() (stop func())
@@ -210,7 +210,7 @@ func (c *Client) EnableAutoCleanup() (stop func())
 EnableAutoCleanup calls DeleteAll on SIGINT/SIGTERM. Call the returned function to stop the signal handler.
 
 <a name="Client.GetSandbox"></a>
-#### func \(\*Client\) [GetSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L111>)
+#### func \(\*Client\) [GetSandbox](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L108>)
 
 ```go
 func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*Sandbox, error)
@@ -219,7 +219,7 @@ func (c *Client) GetSandbox(ctx context.Context, claimName, namespace string) (*
 GetSandbox retrieves an existing sandbox by claim name. Returns the cached handle if connected, otherwise re\-attaches.
 
 <a name="Client.ListActiveSandboxes"></a>
-#### func \(\*Client\) [ListActiveSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L192>)
+#### func \(\*Client\) [ListActiveSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L189>)
 
 ```go
 func (c *Client) ListActiveSandboxes() []Key
@@ -228,7 +228,7 @@ func (c *Client) ListActiveSandboxes() []Key
 ListActiveSandboxes returns tracked sandboxes, pruning inactive handles.
 
 <a name="Client.ListAllSandboxes"></a>
-#### func \(\*Client\) [ListAllSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L208>)
+#### func \(\*Client\) [ListAllSandboxes](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/client.go#L205>)
 
 ```go
 func (c *Client) ListAllSandboxes(ctx context.Context, namespace string) ([]string, error)
@@ -494,13 +494,16 @@ type Key struct {
 ```
 
 <a name="Options"></a>
-### type [Options](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/options.go#L44-L139>)
+### type [Options](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/options.go#L44-L142>)
 
 Options configures a Sandbox instance.
 
 ```go
 type Options struct {
-    // WarmPoolName is the name of the SandboxWarmPool to use. Required.
+    // WarmPoolName is the name of the SandboxWarmPool to use.
+    // Required in Options before calling Open() to provision a new sandbox.
+    // Optional on Client-level Options; pass the pool name per-sandbox to
+    // CreateSandbox instead.
     // Must be a valid Kubernetes DNS subdomain (lowercase, [a-z0-9.-]).
     WarmPoolName string
 
@@ -618,7 +621,7 @@ func New(_ context.Context, opts Options) (*Sandbox, error)
 New creates a new Sandbox with the given options. Call Open\(\) to create a sandbox and establish connectivity.
 
 <a name="Sandbox.Annotations"></a>
-#### func \(\*Sandbox\) [Annotations](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L565>)
+#### func \(\*Sandbox\) [Annotations](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L569>)
 
 ```go
 func (s *Sandbox) Annotations() map[string]string
@@ -627,7 +630,7 @@ func (s *Sandbox) Annotations() map[string]string
 
 
 <a name="Sandbox.ClaimName"></a>
-#### func \(\*Sandbox\) [ClaimName](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L541>)
+#### func \(\*Sandbox\) [ClaimName](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L545>)
 
 ```go
 func (s *Sandbox) ClaimName() string
@@ -636,7 +639,7 @@ func (s *Sandbox) ClaimName() string
 
 
 <a name="Sandbox.Close"></a>
-#### func \(\*Sandbox\) [Close](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L371>)
+#### func \(\*Sandbox\) [Close](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L375>)
 
 ```go
 func (s *Sandbox) Close(ctx context.Context) error
@@ -645,7 +648,7 @@ func (s *Sandbox) Close(ctx context.Context) error
 Close deletes the SandboxClaim and cleans up resources.
 
 <a name="Sandbox.Commands"></a>
-#### func \(\*Sandbox\) [Commands](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L516>)
+#### func \(\*Sandbox\) [Commands](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L520>)
 
 ```go
 func (s *Sandbox) Commands() *Commands
@@ -654,7 +657,7 @@ func (s *Sandbox) Commands() *Commands
 Commands returns the command execution sub\-object.
 
 <a name="Sandbox.Disconnect"></a>
-#### func \(\*Sandbox\) [Disconnect](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L474>)
+#### func \(\*Sandbox\) [Disconnect](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L478>)
 
 ```go
 func (s *Sandbox) Disconnect(ctx context.Context) error
@@ -663,7 +666,7 @@ func (s *Sandbox) Disconnect(ctx context.Context) error
 Disconnect closes the transport connection without deleting the SandboxClaim. The sandbox stays alive on the server. Call Open\(\) to reconnect. Disconnect is safe to call concurrently with Open; an in\-progress Open is cancelled before the transport is torn down.
 
 <a name="Sandbox.Exists"></a>
-#### func \(\*Sandbox\) [Exists](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L535>)
+#### func \(\*Sandbox\) [Exists](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L539>)
 
 ```go
 func (s *Sandbox) Exists(ctx context.Context, path string, opts ...CallOption) (bool, error)
@@ -672,7 +675,7 @@ func (s *Sandbox) Exists(ctx context.Context, path string, opts ...CallOption) (
 
 
 <a name="Sandbox.Files"></a>
-#### func \(\*Sandbox\) [Files](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L519>)
+#### func \(\*Sandbox\) [Files](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L523>)
 
 ```go
 func (s *Sandbox) Files() *Files
@@ -681,7 +684,7 @@ func (s *Sandbox) Files() *Files
 Files returns the file operations sub\-object.
 
 <a name="Sandbox.IsReady"></a>
-#### func \(\*Sandbox\) [IsReady](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L511>)
+#### func \(\*Sandbox\) [IsReady](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L515>)
 
 ```go
 func (s *Sandbox) IsReady() bool
@@ -690,7 +693,7 @@ func (s *Sandbox) IsReady() bool
 IsReady returns true if the sandbox is ready for communication.
 
 <a name="Sandbox.List"></a>
-#### func \(\*Sandbox\) [List](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L532>)
+#### func \(\*Sandbox\) [List](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L536>)
 
 ```go
 func (s *Sandbox) List(ctx context.Context, path string, opts ...CallOption) ([]FileEntry, error)
@@ -708,7 +711,7 @@ func (s *Sandbox) Open(ctx context.Context) (retErr error)
 Open creates a SandboxClaim and waits for the sandbox to become ready, then discovers the API URL based on the configured connection mode. On failure after claim creation, the claim is automatically deleted; if deletion also fails, call Close\(\) to retry.
 
 <a name="Sandbox.PodIP"></a>
-#### func \(\*Sandbox\) [PodIP](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L559>)
+#### func \(\*Sandbox\) [PodIP](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L563>)
 
 ```go
 func (s *Sandbox) PodIP() string
@@ -717,7 +720,7 @@ func (s *Sandbox) PodIP() string
 
 
 <a name="Sandbox.PodName"></a>
-#### func \(\*Sandbox\) [PodName](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L553>)
+#### func \(\*Sandbox\) [PodName](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L557>)
 
 ```go
 func (s *Sandbox) PodName() string
@@ -726,7 +729,7 @@ func (s *Sandbox) PodName() string
 
 
 <a name="Sandbox.Read"></a>
-#### func \(\*Sandbox\) [Read](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L529>)
+#### func \(\*Sandbox\) [Read](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L533>)
 
 ```go
 func (s *Sandbox) Read(ctx context.Context, path string, opts ...CallOption) ([]byte, error)
@@ -735,7 +738,7 @@ func (s *Sandbox) Read(ctx context.Context, path string, opts ...CallOption) ([]
 
 
 <a name="Sandbox.Run"></a>
-#### func \(\*Sandbox\) [Run](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L523>)
+#### func \(\*Sandbox\) [Run](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L527>)
 
 ```go
 func (s *Sandbox) Run(ctx context.Context, command string, opts ...CallOption) (*ExecutionResult, error)
@@ -744,7 +747,7 @@ func (s *Sandbox) Run(ctx context.Context, command string, opts ...CallOption) (
 
 
 <a name="Sandbox.SandboxName"></a>
-#### func \(\*Sandbox\) [SandboxName](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L547>)
+#### func \(\*Sandbox\) [SandboxName](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L551>)
 
 ```go
 func (s *Sandbox) SandboxName() string
@@ -753,7 +756,7 @@ func (s *Sandbox) SandboxName() string
 
 
 <a name="Sandbox.Write"></a>
-#### func \(\*Sandbox\) [Write](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L526>)
+#### func \(\*Sandbox\) [Write](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go#L530>)
 
 ```go
 func (s *Sandbox) Write(ctx context.Context, path string, content []byte, opts ...CallOption) error

--- a/examples/code-interpreter-agent-on-adk/README.md
+++ b/examples/code-interpreter-agent-on-adk/README.md
@@ -86,9 +86,7 @@ The guide walks you through the process of creating a simple [ADK](https://googl
    func executePython(_ tool.Context, args executePythonArgs) (executePythonResult, error) {
    	ctx := context.Background()
 
-   	// WarmPoolName must be set here too to satisfy Options.validate();
-   	// CreateSandbox's own argument below is what actually gets used.
-   	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+   	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
    	if err != nil {
    		return executePythonResult{Error: err.Error()}, nil
    	}

--- a/site/content/docs/filesystem/list-files/_index.md
+++ b/site/content/docs/filesystem/list-files/_index.md
@@ -45,9 +45,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -122,9 +120,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -220,9 +216,7 @@ func printTree(ctx context.Context, sb *sandbox.Sandbox, path string, indent int
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/site/content/docs/filesystem/read-write/_index.md
+++ b/site/content/docs/filesystem/read-write/_index.md
@@ -46,9 +46,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -118,9 +116,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -205,9 +201,7 @@ print(json.dumps(data))
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -283,9 +277,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/site/content/docs/filesystem/upload-download/_index.md
+++ b/site/content/docs/filesystem/upload-download/_index.md
@@ -51,9 +51,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -126,9 +124,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -210,9 +206,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -303,9 +297,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -409,9 +401,7 @@ with open('output.csv', 'w') as f:
 func main() {
 	ctx := context.Background()
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default", WarmPoolName: "python-sandbox-pool"})
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: "default"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/site/content/docs/sandbox/custom_sandbox/custom_environment/_index.md
+++ b/site/content/docs/sandbox/custom_sandbox/custom_environment/_index.md
@@ -369,10 +369,8 @@ func main() {
 	ctx := context.Background()
 	namespace := "default"
 
-	// 1. Initialize the client. WarmPoolName must be set here too to satisfy
-	// Options.validate(); CreateSandbox's own argument below is what
-	// actually gets used.
-	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: namespace, WarmPoolName: "simple-sandbox-pool"})
+	// 1. Initialize the client.
+	client, err := sandbox.NewClient(ctx, sandbox.Options{Namespace: namespace})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/site/content/docs/sandbox/lifecycle/_index.md
+++ b/site/content/docs/sandbox/lifecycle/_index.md
@@ -145,11 +145,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// WarmPoolName must be set here too to satisfy Options.validate();
-	// CreateSandbox's own argument below is what actually gets used.
 	client, err := sandbox.NewClient(ctx, sandbox.Options{
 		Namespace:           namespace,
-		WarmPoolName:        "simple-sandbox-pool",
 		K8sHelper:           helper,
 		SandboxReadyTimeout: 15 * time.Second,
 	})


### PR DESCRIPTION
#### What this PR does / why we need it:

`WarmPoolName` is a per-sandbox concern supplied to `CreateSandbox` or required only when `Open()` provisions a new claim. Split Options validation into `validateCommon` and `validateWarmPoolName` so `NewClient` and `New` accept client-level Options without a pool name, while `Open()` still validates before `createClaim`.

Update docs and examples that documented the old `Options.validate()` workaround. Add regression tests for re-attach and provision validation.

#### Which issue(s) this PR is related to:

Fixes #1119

#### Release Note

```release-note
Fixed the Go client rejecting `sandbox.NewClient` when `Options.WarmPoolName` is unset. Warm pool names are now validated only when provisioning a sandbox via `CreateSandbox` or `Open()`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warm pool selection is now optional when creating a sandbox client.
  * Warm pools can be selected per sandbox during creation.
  * Existing sandboxes can be reattached without specifying a client-level warm pool.

* **Bug Fixes**
  * Invalid warm pool names are rejected before sandbox resources are created.
  * Improved validation and error messages for missing or invalid configuration.
  * Improved handling of concurrent sandbox creation and reattachment to preserve existing connections and claims.

* **Documentation**
  * Updated Go examples and SDK reference documentation to demonstrate per-sandbox warm pool selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->