### PR TITLE
stress-test: analyze data and report known problems

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -214,6 +214,21 @@ go run ./test/stress \
 stress_status=$?
 set -o errexit
 capture_stress_diagnostics
+
+# Generate stress test report
+REPORT_OUTPUT_DIR="${ARTIFACTS:-.}/stress-report"
+echo "Generating stress test report to ${REPORT_OUTPUT_DIR}..."
+if python3 -c "import venv" >/dev/null 2>&1; then
+  python3 -m venv "${BINDIR}/report-venv"
+  "${BINDIR}/report-venv/bin/pip" install --quiet 'duckdb>=1,<2' 'jinja2>=3,<4'
+  "${BINDIR}/report-venv/bin/python3" test/stress/generate-report/generate_report.py \
+    --input-dir "${STRESS_OUTPUT_DIR}" \
+    --output-dir "${REPORT_OUTPUT_DIR}"
+  echo "Report generated successfully."
+else
+  echo "Warning: python3 venv module not available, skipping report generation."
+fi
+
 if [[ "${stress_status}" -ne 0 ]]; then
   exit "${stress_status}"
 fi

--- a/test/stress/generate-report/download_results.py
+++ b/test/stress/generate-report/download_results.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import ssl
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+# List of expected files to try downloading from the GCS stress-test/ directory.
+EXPECTED_FILES = [
+    "summary.json",
+    "metrics.jsonl",
+    "sandboxes.jsonl",
+    "timeseries.jsonl",
+    "watch.jsonl",
+    "controller.log",
+    "pods.txt",
+    "nodes.txt",
+    "top-nodes.txt"
+]
+
+def normalize_url(url):
+    url = url.rstrip('/')
+    
+    if url.startswith('gs://'):
+        path = url[5:]
+        return f"https://storage.googleapis.com/{path}"
+        
+    if 'gcsweb.k8s.io/gcs/' in url:
+        idx = url.find('gcsweb.k8s.io/gcs/')
+        path = url[idx + len('gcsweb.k8s.io/gcs/'):]
+        return f"https://storage.googleapis.com/{path}"
+        
+    if url.startswith('https://storage.googleapis.com/'):
+        return url
+        
+    raise ValueError(f"Unsupported URL format: {url}")
+
+def make_ssl_context():
+    # Some Python installs (notably python.org builds on macOS) ship without
+    # access to the system trust store; prefer certifi's CA bundle when available.
+    ctx = ssl.create_default_context()
+    try:
+        import certifi
+        ctx.load_verify_locations(certifi.where())
+    except ImportError:
+        pass
+    return ctx
+
+SSL_CONTEXT = make_ssl_context()
+
+def download_file(url, out_path):
+    print(f"Downloading {url} ...")
+    try:
+        with urllib.request.urlopen(url, timeout=60, context=SSL_CONTEXT) as response:
+            data = response.read()
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            print(f"File not available (HTTP {e.code}), skipping.")
+            return False
+        raise
+    except (urllib.error.URLError, TimeoutError) as e:
+        # Keep going: a stalled connection or transient network error for one
+        # artifact should not lose every artifact after it.
+        print(f"WARNING: download failed ({e}), skipping.", file=sys.stderr)
+        return False
+
+    # GZIP detection based on magic bytes (0x1f, 0x8b).
+    # jsonl artifacts are stored gzipped but without the .gz suffix; restore
+    # it so downstream readers pick the right decoder. Other files keep their
+    # name so formats that are gzip by definition are not renamed.
+    is_gzip = len(data) >= 2 and data[0] == 0x1f and data[1] == 0x8b
+
+    final_path = out_path
+    if is_gzip and out_path.suffix == '.jsonl':
+        final_path = out_path.with_name(out_path.name + '.gz')
+        print(f"-> Detected GZIP magic bytes. Restoring extension: {final_path.name}")
+
+    final_path.write_bytes(data)
+    print(f"-> Saved to {final_path}")
+    return True
+
+def main():
+    parser = argparse.ArgumentParser(description="Download stress test artifacts from GCS and restore .gz extensions.")
+    parser.add_argument("--url", required=True, help="GCS folder URL (gs://... or https://gcsweb.k8s.io/... or https://storage.googleapis.com/...)")
+    parser.add_argument("--output-dir", required=True, help="Local directory to write downloaded artifacts")
+    args = parser.parse_args()
+
+    try:
+        base_url = normalize_url(args.url)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Normalized GCS URL: {base_url}")
+    print(f"Output directory: {output_dir}\n")
+
+    # Clear known artifacts from earlier runs so a file missing from this run
+    # (or present under the other .gz/plain variant) cannot leak stale data
+    # from a previous download into the report.
+    for filename in EXPECTED_FILES:
+        for stale in (output_dir / filename, output_dir / (filename + '.gz')):
+            stale.unlink(missing_ok=True)
+
+    downloaded = 0
+    for filename in EXPECTED_FILES:
+        file_url = f"{base_url}/{filename}"
+        out_file_path = output_dir / filename
+        if download_file(file_url, out_file_path):
+            downloaded += 1
+
+    print(f"\nCompleted downloading {downloaded} files successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import argparse
+import gzip
 import json
 import os
 import shutil
@@ -36,7 +37,10 @@ def main():
     metrics_file = input_dir / "metrics.jsonl"
 
     if not summary_file.exists():
-        print(f"Error: summary.json not found in {input_dir}", file=sys.stderr)
+        summary_file = input_dir / "summary.json.gz"
+
+    if not summary_file.exists():
+        print(f"Error: summary.json or summary.json.gz not found in {input_dir}", file=sys.stderr)
         sys.exit(1)
 
     if not metrics_file.exists():
@@ -55,7 +59,8 @@ def main():
         watch_file = input_dir / "watch.jsonl.gz"
 
     # 1. Load summary data
-    with open(summary_file) as f:
+    opener = gzip.open if summary_file.suffix == '.gz' else open
+    with opener(summary_file, 'rt') as f:
         summary = json.load(f)
 
     # Keep timestamps as naive UTC: DuckDB converts tz-aware values to local

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -1,0 +1,881 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+import duckdb
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate stress test bottleneck report.")
+    parser.add_argument("--input-dir", required=True, help="Directory containing stress test outputs (summary.json, metrics.jsonl)")
+    parser.add_argument("--output-dir", required=True, help="Directory to write static HTML reports")
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+
+    summary_file = input_dir / "summary.json"
+    metrics_file = input_dir / "metrics.jsonl"
+
+    if not summary_file.exists():
+        print(f"Error: summary.json not found in {input_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if not metrics_file.exists():
+        metrics_file = input_dir / "metrics.jsonl.gz"
+
+    if not metrics_file.exists():
+        print(f"Error: metrics.jsonl or metrics.jsonl.gz not found in {input_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    sandboxes_file = input_dir / "sandboxes.jsonl"
+    if not sandboxes_file.exists():
+        sandboxes_file = input_dir / "sandboxes.jsonl.gz"
+
+    watch_file = input_dir / "watch.jsonl"
+    if not watch_file.exists():
+        watch_file = input_dir / "watch.jsonl.gz"
+
+    # 1. Load summary data
+    with open(summary_file) as f:
+        summary = json.load(f)
+
+    # Keep timestamps as naive UTC: DuckDB converts tz-aware values to local
+    # time when storing them in a TIMESTAMP column, which would mis-align the
+    # phases table with the naive-UTC timestamps parsed from the metrics files.
+    start_time = datetime.fromisoformat(summary['startTime'].replace('Z', '+00:00')).replace(tzinfo=None)
+    end_time = datetime.fromisoformat(summary['endTime'].replace('Z', '+00:00')).replace(tzinfo=None)
+    run_duration = int((end_time - start_time).total_seconds())
+
+    # Map phases to time ranges
+    phases = []
+    total_created = 0
+    probe_latency_ms = 0.0
+
+    for phase in summary['phases']:
+        p_start = start_time + timedelta(seconds=phase['startOffsetSeconds'])
+        p_end = p_start + timedelta(seconds=phase['durationSeconds'])
+        phases.append((phase['name'], p_start, p_end))
+        total_created += phase.get('created', 0)
+        if phase['name'] == 'probe':
+            probe_latency_ms = phase['latency']['endToEndReady']['meanMs']
+
+    js_phases = []
+    for phase in summary.get('phases', []):
+        p_start = start_time + timedelta(seconds=phase['startOffsetSeconds'])
+        p_end = p_start + timedelta(seconds=phase['durationSeconds'])
+        js_phases.append({
+            "name": phase["name"],
+            "start_sec": phase["startOffsetSeconds"],
+            "end_sec": phase["startOffsetSeconds"] + phase["durationSeconds"],
+            "start_ts": p_start.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            "end_ts": p_end.strftime('%Y-%m-%dT%H:%M:%SZ')
+        })
+
+    start_time_iso = start_time.strftime('%Y-%m-%d %H:%M:%S.%f')
+    end_time_iso = end_time.strftime('%Y-%m-%d %H:%M:%S.%f')
+
+    # 2. Set up DuckDB and populate phases table
+    conn = duckdb.connect()
+    conn.execute("CREATE TABLE phases (name VARCHAR, start_time TIMESTAMP, end_time TIMESTAMP)")
+    for name, p_start, p_end in phases:
+        conn.execute("INSERT INTO phases VALUES (?, ?, ?)", (name, p_start, p_end))
+
+    # Escape filename for DuckDB
+    metrics_path_str = str(metrics_file).replace("'", "''")
+
+    # 3. Execute queries
+    print("Querying CRI operations by phase...")
+    cri_ops_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                CAST(labels->>'operation_type' AS VARCHAR) as operation_type,
+                metric,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('kubelet_runtime_operations_duration_seconds_count', 'kubelet_runtime_operations_duration_seconds_sum')
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                operation_type,
+                metric,
+                value,
+                value - lag(value) OVER (PARTITION BY instance, operation_type, metric ORDER BY ts) as delta
+            FROM raw
+        ),
+        diffs_with_phase AS (
+            SELECT 
+                p.name as phase_name,
+                d.operation_type,
+                d.metric,
+                d.delta
+            FROM diffs d
+            JOIN phases p ON d.ts >= p.start_time AND d.ts < p.end_time
+            WHERE d.delta >= 0
+        )
+        SELECT 
+            phase_name,
+            operation_type,
+            SUM(CASE WHEN metric = 'kubelet_runtime_operations_duration_seconds_count' THEN delta ELSE 0 END) as count_delta,
+            SUM(CASE WHEN metric = 'kubelet_runtime_operations_duration_seconds_sum' THEN delta ELSE 0 END) as sum_delta
+        FROM diffs_with_phase
+        GROUP BY phase_name, operation_type
+        HAVING count_delta > 0
+        ORDER BY phase_name, count_delta DESC
+    """).fetchall()
+
+    cri_ops = []
+    for row in cri_ops_raw:
+        phase_name, op, count_delta, sum_delta = row
+        avg_latency_ms = (sum_delta / count_delta) * 1000 if count_delta > 0 else 0
+        cri_ops.append({
+            "phase_name": phase_name,
+            "operation_type": op,
+            "count_delta": int(count_delta),
+            "avg_latency_ms": avg_latency_ms
+        })
+
+    print("Querying CRI timeseries...")
+    cri_ts_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT 
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                metric,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('kubelet_runtime_operations_duration_seconds_count', 'kubelet_runtime_operations_duration_seconds_sum')
+              AND CAST(labels->>'operation_type' AS VARCHAR) = 'run_podsandbox'
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                instance,
+                metric,
+                value - lag(value) OVER (PARTITION BY instance, metric ORDER BY ts) as delta
+            FROM raw
+        ),
+        binned AS (
+            SELECT
+                time_bucket(INTERVAL '15 seconds', ts) as bucket_time,
+                instance,
+                SUM(CASE WHEN metric = 'kubelet_runtime_operations_duration_seconds_count' THEN delta ELSE 0 END) as count_delta,
+                SUM(CASE WHEN metric = 'kubelet_runtime_operations_duration_seconds_sum' THEN delta ELSE 0 END) as sum_delta
+            FROM diffs
+            WHERE delta >= 0
+            GROUP BY bucket_time, instance
+        )
+        SELECT 
+            strftime(bucket_time, '%Y-%m-%dT%H:%M:%SZ') as ts,
+            instance,
+            count_delta,
+            CASE WHEN count_delta > 0 THEN sum_delta / count_delta ELSE 0.0 END as avg_latency_s
+        FROM binned
+        ORDER BY ts, instance
+    """).fetchall()
+
+    cri_chart_data = [
+        {"ts": row[0], "instance": row[1], "count": int(row[2]), "avg_latency_s": row[3]}
+        for row in cri_ts_raw
+    ]
+
+    print("Querying controller performance by phase...")
+    controller_ops_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                CAST(labels->>'controller' AS VARCHAR) as controller,
+                metric,
+                COALESCE(CAST(labels->>'result' AS VARCHAR), '') as result,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('controller_runtime_reconcile_total', 'controller_runtime_reconcile_errors_total', 'controller_runtime_reconcile_time_seconds_sum', 'controller_runtime_reconcile_time_seconds_count')
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                controller,
+                metric,
+                result,
+                value - lag(value) OVER (PARTITION BY instance, controller, metric, result ORDER BY ts) as delta
+            FROM raw
+        ),
+        diffs_with_phase AS (
+            SELECT 
+                p.name as phase_name,
+                d.controller,
+                d.metric,
+                d.delta
+            FROM diffs d
+            JOIN phases p ON d.ts >= p.start_time AND d.ts < p.end_time
+            WHERE d.delta >= 0
+        )
+        SELECT 
+            phase_name,
+            controller,
+            SUM(CASE WHEN metric = 'controller_runtime_reconcile_total' THEN delta ELSE 0 END) as total_reconciles,
+            SUM(CASE WHEN metric = 'controller_runtime_reconcile_errors_total' THEN delta ELSE 0 END) as total_errors,
+            SUM(CASE WHEN metric = 'controller_runtime_reconcile_time_seconds_sum' THEN delta ELSE 0 END) as sum_time,
+            SUM(CASE WHEN metric = 'controller_runtime_reconcile_time_seconds_count' THEN delta ELSE 0 END) as count_time
+        FROM diffs_with_phase
+        GROUP BY phase_name, controller
+        ORDER BY phase_name, controller
+    """).fetchall()
+
+    controller_ops = []
+    for row in controller_ops_raw:
+        phase_name, controller, total_reconciles, total_errors, sum_time, count_time = row
+        avg_reconcile_ms = (sum_time / count_time) * 1000 if count_time > 0 else 0
+        error_rate = (total_errors / total_reconciles) * 100 if total_reconciles > 0 else 0
+        controller_ops.append({
+            "phase_name": phase_name,
+            "controller": controller,
+            "total_reconciles": int(total_reconciles),
+            "total_errors": int(total_errors),
+            "error_rate": error_rate,
+            "avg_reconcile_ms": avg_reconcile_ms
+        })
+
+    print("Querying controller timeseries...")
+    controller_ts_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                CAST(labels->>'controller' AS VARCHAR) as controller,
+                CAST(labels->>'result' AS VARCHAR) as result,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric = 'controller_runtime_reconcile_total'
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                controller,
+                result,
+                value - lag(value) OVER (PARTITION BY instance, controller, result ORDER BY ts) as delta
+            FROM raw
+        ),
+        binned AS (
+            SELECT
+                time_bucket(INTERVAL '15 seconds', ts) as bucket_time,
+                controller,
+                SUM(delta) as total_reconciles
+            FROM diffs
+            WHERE delta >= 0
+            GROUP BY bucket_time, controller
+        )
+        SELECT 
+            strftime(bucket_time, '%Y-%m-%dT%H:%M:%SZ') as ts,
+            controller,
+            total_reconciles / 15.0 as reconcile_rate
+        FROM binned
+        ORDER BY ts, controller
+    """).fetchall()
+
+    controller_chart_data = [
+        {"ts": row[0], "controller": row[1], "reconcile_rate": row[2]}
+        for row in controller_ts_raw
+    ]
+
+    print("Querying apiserver operations by phase...")
+    apiserver_ops_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT 
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(labels->>'resource' AS VARCHAR) as resource,
+                CAST(labels->>'subresource' AS VARCHAR) as subresource,
+                CAST(labels->>'verb' AS VARCHAR) as verb,
+                CAST(labels->>'group' AS VARCHAR) as group_label,
+                CAST(labels->>'version' AS VARCHAR) as version,
+                CAST(labels->>'scope' AS VARCHAR) as scope,
+                CAST(labels->>'dry_run' AS VARCHAR) as dry_run,
+                CAST(instance AS VARCHAR) as instance,
+                metric,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('apiserver_request_duration_seconds_count', 'apiserver_request_duration_seconds_sum')
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                resource,
+                verb,
+                metric,
+                value - lag(value) OVER (PARTITION BY instance, group_label, version, resource, subresource, scope, verb, dry_run, metric ORDER BY ts) as delta
+            FROM raw
+        ),
+        diffs_with_phase AS (
+            SELECT 
+                p.name as phase_name,
+                d.resource,
+                d.verb,
+                d.metric,
+                d.delta
+            FROM diffs d
+            JOIN phases p ON d.ts >= p.start_time AND d.ts < p.end_time
+            WHERE d.delta >= 0
+        )
+        SELECT 
+            phase_name,
+            resource,
+            verb,
+            SUM(CASE WHEN metric = 'apiserver_request_duration_seconds_count' THEN delta ELSE 0 END) as count_delta,
+            SUM(CASE WHEN metric = 'apiserver_request_duration_seconds_sum' THEN delta ELSE 0 END) as sum_delta
+        FROM diffs_with_phase
+        GROUP BY phase_name, resource, verb
+        HAVING count_delta > 0
+        ORDER BY phase_name, count_delta DESC
+    """).fetchall()
+
+    apiserver_ops = []
+    for row in apiserver_ops_raw:
+        phase_name, resource, verb, count_delta, sum_delta = row
+        avg_latency_ms = (sum_delta / count_delta) * 1000 if count_delta > 0 else 0
+        apiserver_ops.append({
+            "phase_name": phase_name,
+            "resource": resource,
+            "verb": verb,
+            "count_delta": int(count_delta),
+            "avg_latency_ms": avg_latency_ms
+        })
+
+    print("Querying apiserver timeseries...")
+    apiserver_ts_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT 
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(labels->>'resource' AS VARCHAR) as resource,
+                CAST(labels->>'subresource' AS VARCHAR) as subresource,
+                CAST(labels->>'verb' AS VARCHAR) as verb,
+                CAST(labels->>'group' AS VARCHAR) as group_label,
+                CAST(labels->>'version' AS VARCHAR) as version,
+                CAST(labels->>'scope' AS VARCHAR) as scope,
+                CAST(labels->>'dry_run' AS VARCHAR) as dry_run,
+                CAST(instance AS VARCHAR) as instance,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric = 'apiserver_request_duration_seconds_count'
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                resource,
+                verb,
+                value - lag(value) OVER (PARTITION BY instance, group_label, version, resource, subresource, scope, verb, dry_run ORDER BY ts) as delta
+            FROM raw
+        ),
+        binned AS (
+            SELECT
+                time_bucket(INTERVAL '15 seconds', ts) as bucket_time,
+                resource,
+                verb,
+                SUM(delta) as total_requests
+            FROM diffs
+            WHERE delta >= 0
+            GROUP BY bucket_time, resource, verb
+        )
+        SELECT 
+            strftime(bucket_time, '%Y-%m-%dT%H:%M:%SZ') as ts,
+            resource,
+            verb,
+            total_requests / 15.0 as request_rate
+        FROM binned
+        ORDER BY ts, resource, verb
+    """).fetchall()
+
+    apiserver_chart_data = [
+        {"ts": row[0], "resource": row[1], "verb": row[2], "request_rate": row[3]}
+        for row in apiserver_ts_raw
+    ]
+
+    print("Querying etcd operations by phase...")
+    etcd_ops_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT 
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(labels->>'resource' AS VARCHAR) as resource,
+                CAST(labels->>'operation' AS VARCHAR) as operation,
+                CAST(labels->>'group' AS VARCHAR) as group_label,
+                CAST(instance AS VARCHAR) as instance,
+                metric,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('etcd_request_duration_seconds_count', 'etcd_request_duration_seconds_sum')
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                resource,
+                operation,
+                metric,
+                value - lag(value) OVER (PARTITION BY instance, group_label, resource, operation, metric ORDER BY ts) as delta
+            FROM raw
+        ),
+        diffs_with_phase AS (
+            SELECT 
+                p.name as phase_name,
+                d.resource,
+                d.operation,
+                d.metric,
+                d.delta
+            FROM diffs d
+            JOIN phases p ON d.ts >= p.start_time AND d.ts < p.end_time
+            WHERE d.delta >= 0
+        )
+        SELECT 
+            phase_name,
+            resource,
+            operation,
+            SUM(CASE WHEN metric = 'etcd_request_duration_seconds_count' THEN delta ELSE 0 END) as count_delta,
+            SUM(CASE WHEN metric = 'etcd_request_duration_seconds_sum' THEN delta ELSE 0 END) as sum_delta
+        FROM diffs_with_phase
+        GROUP BY phase_name, resource, operation
+        HAVING count_delta > 0
+        ORDER BY phase_name, count_delta DESC
+    """).fetchall()
+
+    etcd_ops = []
+    for row in etcd_ops_raw:
+        phase_name, resource, operation, count_delta, sum_delta = row
+        avg_latency_ms = (sum_delta / count_delta) * 1000 if count_delta > 0 else 0
+        etcd_ops.append({
+            "phase_name": phase_name,
+            "resource": resource,
+            "operation": operation,
+            "count_delta": int(count_delta),
+            "avg_latency_ms": avg_latency_ms
+        })
+
+    print("Querying etcd timeseries...")
+    etcd_ts_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT 
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(labels->>'resource' AS VARCHAR) as resource,
+                CAST(labels->>'operation' AS VARCHAR) as operation,
+                CAST(labels->>'group' AS VARCHAR) as group_label,
+                CAST(instance AS VARCHAR) as instance,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric = 'etcd_request_duration_seconds_count'
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                resource,
+                operation,
+                value - lag(value) OVER (PARTITION BY instance, group_label, resource, operation ORDER BY ts) as delta
+            FROM raw
+        ),
+        binned AS (
+            SELECT
+                time_bucket(INTERVAL '15 seconds', ts) as bucket_time,
+                resource,
+                operation,
+                SUM(delta) as total_requests
+            FROM diffs
+            WHERE delta >= 0
+            GROUP BY bucket_time, resource, operation
+        )
+        SELECT 
+            strftime(bucket_time, '%Y-%m-%dT%H:%M:%SZ') as ts,
+            resource,
+            operation,
+            total_requests / 15.0 as request_rate
+        FROM binned
+        ORDER BY ts, resource, operation
+    """).fetchall()
+
+    etcd_chart_data = [
+        {"ts": row[0], "resource": row[1], "operation": row[2], "request_rate": row[3]}
+        for row in etcd_ts_raw
+    ]
+
+    # Query active sandboxes and pods capacity timeseries from the watch logs
+    capacity_chart_data = []
+    capacity_summary = []
+    pod_capacity = int(summary.get("cluster", {}).get("podCapacity", 0) or 0)
+    cluster_nodes = int(summary.get("cluster", {}).get("nodes", 0) or 0)
+
+    if watch_file.exists():
+        watch_path_str = str(watch_file).replace("'", "''")
+        print("Querying capacity timeseries from watch stream...")
+        capacity_ts_raw = conn.execute(f"""
+            WITH raw_events AS (
+                SELECT
+                    CAST(timestamp AS TIMESTAMP) as ts,
+                    resource,
+                    -- Key lifecycles by uid: a delete/recreate of the same
+                    -- name is two objects, not one long-lived one.
+                    CAST(object->'metadata'->>'uid' AS VARCHAR) as uid,
+                    type
+                FROM read_json_auto('{watch_path_str}')
+                WHERE resource IN ('pods', 'sandboxes')
+            ),
+            lifecycle_ends AS (
+                SELECT
+                    resource,
+                    uid,
+                    MIN(CASE WHEN type = 'ADDED' THEN ts ELSE NULL END) as first_seen,
+                    MAX(CASE WHEN type = 'DELETED' THEN ts ELSE NULL END) as deleted_at
+                FROM raw_events
+                GROUP BY resource, uid
+            ),
+            object_lifecycles AS (
+                SELECT
+                    resource,
+                    COALESCE(first_seen, (SELECT MIN(ts) FROM raw_events)) as created_at,
+                    deleted_at
+                FROM lifecycle_ends
+            ),
+            time_series AS (
+                -- Sample over the whole run window: undeleted objects would
+                -- otherwise end the series at their creation time.
+                SELECT ts
+                FROM unnest(generate_series(
+                    CAST('{start_time_iso}' AS TIMESTAMP),
+                    CAST('{end_time_iso}' AS TIMESTAMP),
+                    INTERVAL '5 seconds'
+                )) as t(ts)
+            )
+            SELECT 
+                strftime(ts, '%Y-%m-%dT%H:%M:%SZ') as time_str,
+                epoch(ts - CAST('{start_time_iso}' AS TIMESTAMP)) as offset_sec,
+                (
+                    SELECT COUNT(*) 
+                    FROM object_lifecycles o 
+                    WHERE o.resource = 'sandboxes' 
+                      AND o.created_at <= ts 
+                      AND (o.deleted_at IS NULL OR o.deleted_at >= ts)
+                ) as active_sandboxes,
+                (
+                    SELECT COUNT(*) 
+                    FROM object_lifecycles o 
+                    WHERE o.resource = 'pods' 
+                      AND o.created_at <= ts 
+                      AND (o.deleted_at IS NULL OR o.deleted_at >= ts)
+                ) as active_pods
+            FROM time_series
+            ORDER BY ts
+        """).fetchall()
+
+        for row in capacity_ts_raw:
+            capacity_chart_data.append({
+                "ts": row[0],
+                "offset_sec": row[1],
+                "active_sandboxes": int(row[2]),
+                "active_pods": int(row[3])
+            })
+
+        print("Querying peak workload density by phase from watch stream...")
+        capacity_summary_raw = conn.execute(f"""
+            WITH raw_events AS (
+                SELECT
+                    CAST(timestamp AS TIMESTAMP) as ts,
+                    resource,
+                    -- Key lifecycles by uid: a delete/recreate of the same
+                    -- name is two objects, not one long-lived one.
+                    CAST(object->'metadata'->>'uid' AS VARCHAR) as uid,
+                    type
+                FROM read_json_auto('{watch_path_str}')
+                WHERE resource IN ('pods', 'sandboxes')
+            ),
+            lifecycle_ends AS (
+                SELECT
+                    resource,
+                    uid,
+                    MIN(CASE WHEN type = 'ADDED' THEN ts ELSE NULL END) as first_seen,
+                    MAX(CASE WHEN type = 'DELETED' THEN ts ELSE NULL END) as deleted_at
+                FROM raw_events
+                GROUP BY resource, uid
+            ),
+            object_lifecycles AS (
+                SELECT
+                    resource,
+                    COALESCE(first_seen, (SELECT MIN(ts) FROM raw_events)) as created_at,
+                    deleted_at
+                FROM lifecycle_ends
+            ),
+            time_series AS (
+                -- Sample over the whole run window: undeleted objects would
+                -- otherwise end the series at their creation time.
+                SELECT ts
+                FROM unnest(generate_series(
+                    CAST('{start_time_iso}' AS TIMESTAMP),
+                    CAST('{end_time_iso}' AS TIMESTAMP),
+                    INTERVAL '5 seconds'
+                )) as t(ts)
+            ),
+            ts_counts AS (
+                SELECT 
+                    ts,
+                    (
+                        SELECT COUNT(*) 
+                        FROM object_lifecycles o 
+                        WHERE o.resource = 'sandboxes' 
+                          AND o.created_at <= ts 
+                          AND (o.deleted_at IS NULL OR o.deleted_at >= ts)
+                    ) as active_sandboxes,
+                    (
+                        SELECT COUNT(*) 
+                        FROM object_lifecycles o 
+                        WHERE o.resource = 'pods' 
+                          AND o.created_at <= ts 
+                          AND (o.deleted_at IS NULL OR o.deleted_at >= ts)
+                    ) as active_pods
+                FROM time_series
+            )
+            SELECT 
+                p.name as phase_name,
+                MAX(t.active_sandboxes) as peak_sandboxes,
+                MAX(t.active_pods) as peak_pods
+            FROM ts_counts t
+            JOIN phases p ON t.ts >= p.start_time AND t.ts < p.end_time
+            GROUP BY p.name
+            ORDER BY MIN(p.start_time)
+        """).fetchall()
+
+        for row in capacity_summary_raw:
+            capacity_summary.append({
+                "phase_name": row[0],
+                "peak_sandboxes": int(row[1]) if row[1] is not None else 0,
+                "peak_pods": int(row[2]) if row[2] is not None else 0,
+                "limit": pod_capacity
+            })
+
+    # 4. Analyzer rules to identify findings
+    findings = []
+
+    # CRI check
+    cri_run_pod_latency_max = 0.0
+    for op in cri_ops:
+        if op['operation_type'] == 'run_podsandbox' and op['phase_name'].startswith('throughput'):
+            if op['avg_latency_ms'] > cri_run_pod_latency_max:
+                cri_run_pod_latency_max = op['avg_latency_ms']
+
+    if cri_run_pod_latency_max > 5000:
+        findings.append({
+            "severity": "critical",
+            "title": f"CRI Pod Sandbox Creation Bottleneck ({cri_run_pod_latency_max/1000:.1f}s)",
+            "desc": f"Kubelet run_podsandbox average latency spiked to {cri_run_pod_latency_max/1000:.1f} seconds during throughput phases. This indicates a container runtime (gVisor/containerd) or network/CNI (Cilium) setup bottleneck under load.",
+            "link": "cri.html"
+        })
+
+    # Controller check: ratio of reconciles per sandbox created
+    phase_created_map = {p['name']: p.get('created', 0) for p in summary.get('phases', [])}
+    
+    max_reconciles_per_created = 0.0
+    max_reconciles_per_created_phase = ""
+    max_reconciles = 0
+    max_created = 0
+    
+    for row in controller_ops:
+        if row['controller'] == 'sandbox' and row['phase_name'].startswith('throughput'):
+            phase_name = row['phase_name']
+            created = phase_created_map.get(phase_name, 0)
+            if created > 0:
+                ratio = row['total_reconciles'] / created
+                if ratio > max_reconciles_per_created:
+                    max_reconciles_per_created = ratio
+                    max_reconciles_per_created_phase = phase_name
+                    max_reconciles = row['total_reconciles']
+                    max_created = created
+
+    if max_reconciles_per_created > 20.0:
+        findings.append({
+            "severity": "warning",
+            "title": f"High Reconciler Churn ({max_reconciles_per_created:.1f} reconciles/object)",
+            "desc": f"The Sandbox controller reconciliation count per sandbox object created reached {max_reconciles_per_created:.1f} in phase {max_reconciles_per_created_phase} ({max_reconciles:,} reconciles for {max_created:,} objects). This indicates high reconciliation redundancy, where a single sandbox object launch triggers excessive watch event updates in a short window.",
+            "link": "agent-sandbox-controller.html"
+        })
+
+    # etcd check
+    etcd_update_latency_max = 0.0
+    for row in etcd_ops:
+        if row['operation'] == 'update' and row['phase_name'].startswith('throughput'):
+            if row['avg_latency_ms'] > etcd_update_latency_max:
+                etcd_update_latency_max = row['avg_latency_ms']
+
+    if etcd_update_latency_max > 5.0:
+        findings.append({
+            "severity": "warning",
+            "title": f"Elevated etcd Update Latency ({etcd_update_latency_max:.2f}ms)",
+            "desc": f"etcd update operation average latency reached {etcd_update_latency_max:.2f}ms under load. While standard, high write latencies from etcd indicate write disk throughput contention.",
+            "link": "etcd.html"
+        })
+
+    # Capacity saturation finding check
+    max_active_pods = 0
+    for pt in capacity_chart_data:
+        if pt['active_pods'] > max_active_pods:
+            max_active_pods = pt['active_pods']
+
+    if pod_capacity > 0:
+        if max_active_pods >= pod_capacity:
+            findings.append({
+                "severity": "critical",
+                "title": f"Cluster Pod Capacity Exhausted ({max_active_pods} / {pod_capacity})",
+                "desc": f"The number of active workload pods peaked at {max_active_pods}, exceeding the cluster's physical capacity limit of {pod_capacity} pods across {cluster_nodes} worker nodes. This causes scheduling delays (pods stuck in Pending) and saturates Kubelet / containerd resource limits.",
+                "link": "capacity.html"
+            })
+        elif max_active_pods >= 0.9 * pod_capacity:
+            findings.append({
+                "severity": "warning",
+                "title": f"Cluster Pod Capacity Saturated ({max_active_pods} / {pod_capacity})",
+                "desc": f"The number of active workload pods peaked at {max_active_pods}, reaching {max_active_pods / pod_capacity * 100:.1f}% of the cluster's physical capacity limit of {pod_capacity} pods. High density triggers CNI IPAM queuing and Kubelet slow downs.",
+                "link": "capacity.html"
+            })
+
+    # Query sandbox launch latency percentiles by phase
+    print("Querying sandbox percentiles...")
+    sandbox_percentiles_raw = []
+    if sandboxes_file.exists():
+        sandboxes_path_str = str(sandboxes_file).replace("'", "''")
+        sandbox_percentiles_raw = conn.execute(f"""
+            SELECT 
+                phase,
+                count(*) as count,
+                quantile_cont(createAckMs, 0.5) as createAck_p50,
+                quantile_cont(createAckMs, 0.9) as createAck_p90,
+                quantile_cont(podCreatedMs, 0.5) as podCreated_p50,
+                quantile_cont(podCreatedMs, 0.9) as podCreated_p90,
+                quantile_cont(podScheduledMs, 0.5) as podScheduled_p50,
+                quantile_cont(podScheduledMs, 0.9) as podScheduled_p90,
+                quantile_cont(podRunningMs, 0.5) as podRunning_p50,
+                quantile_cont(podRunningMs, 0.9) as podRunning_p90,
+                quantile_cont(sandboxReadyMs, 0.5) as sandboxReady_p50,
+                quantile_cont(sandboxReadyMs, 0.9) as sandboxReady_p90,
+                quantile_cont(sandboxReadyMs, 0.99) as sandboxReady_p99
+            FROM read_json_auto('{sandboxes_path_str}')
+            GROUP BY phase
+            ORDER BY phase
+        """).fetchall()
+
+    sandbox_percentiles = []
+    for row in sandbox_percentiles_raw:
+        sandbox_percentiles.append({
+            "phase": row[0],
+            "count": int(row[1]),
+            "createAck_p50": row[2],
+            "createAck_p90": row[3],
+            "podCreated_p50": row[4],
+            "podCreated_p90": row[5],
+            "podScheduled_p50": row[6],
+            "podScheduled_p90": row[7],
+            "podRunning_p50": row[8],
+            "podRunning_p90": row[9],
+            "sandboxReady_p50": row[10],
+            "sandboxReady_p90": row[11],
+            "sandboxReady_p99": row[12]
+        })
+
+    # 5. Render Templates using Jinja2
+    output_dir.mkdir(parents=True, exist_ok=True)
+    template_dir = Path(__file__).parent / "templates"
+    env = Environment(loader=FileSystemLoader(template_dir), autoescape=select_autoescape(['html']))
+
+    # Copy shared static assets (CSS / JS) referenced by the pages
+    static_dir = Path(__file__).parent / "static"
+    for static_file in sorted(static_dir.iterdir()):
+        if static_file.is_file():
+            shutil.copy(static_file, output_dir / static_file.name)
+            print(f"Copied static asset: {output_dir / static_file.name}")
+
+    def render_page(template_name, output_filename, context):
+        template = env.get_template(template_name)
+        rendered = template.render(context)
+        output_file = output_dir / output_filename
+        with open(output_file, 'w') as f:
+            f.write(rendered)
+        print(f"Generated report page: {output_file}")
+
+    # Index context
+    index_ctx = {
+        "active_page": "index",
+        "summary": summary,
+        "run_duration": run_duration,
+        "total_created": total_created,
+        "probe_latency_ms": probe_latency_ms,
+        "findings": findings,
+        "sandbox_percentiles": sandbox_percentiles
+    }
+    render_page("index.html", "index.html", index_ctx)
+
+    # CRI context
+    cri_ctx = {
+        "active_page": "cri",
+        "summary": summary,
+        "cri_ops": cri_ops,
+        "chart_data": cri_chart_data,
+        "phases": js_phases
+    }
+    render_page("cri.html", "cri.html", cri_ctx)
+
+    # Controller context
+    controller_ctx = {
+        "active_page": "controller",
+        "summary": summary,
+        "controller_ops": controller_ops,
+        "chart_data": controller_chart_data,
+        "phases": js_phases
+    }
+    render_page("agent-sandbox-controller.html", "agent-sandbox-controller.html", controller_ctx)
+
+    # Apiserver context
+    apiserver_ctx = {
+        "active_page": "apiserver",
+        "summary": summary,
+        "apiserver_ops": apiserver_ops,
+        "chart_data": apiserver_chart_data,
+        "phases": js_phases
+    }
+    render_page("apiserver.html", "apiserver.html", apiserver_ctx)
+
+    # etcd context
+    etcd_ctx = {
+        "active_page": "etcd",
+        "summary": summary,
+        "etcd_ops": etcd_ops,
+        "chart_data": etcd_chart_data,
+        "phases": js_phases
+    }
+    render_page("etcd.html", "etcd.html", etcd_ctx)
+
+    # Capacity context
+    capacity_ctx = {
+        "active_page": "capacity",
+        "summary": summary,
+        "pod_capacity": pod_capacity,
+        "chart_data": capacity_chart_data,
+        "capacity_summary": capacity_summary,
+        "phases": js_phases
+    }
+    render_page("capacity.html", "capacity.html", capacity_ctx)
+
+    print("All report pages generated successfully!")
+
+if __name__ == "__main__":
+    main()

--- a/test/stress/generate-report/static/report.css
+++ b/test/stress/generate-report/static/report.css
@@ -1,0 +1,362 @@
+/*
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+:root {
+    --bg-color: #fbfaf7;         /* Warm cream paper background */
+    --sidebar-bg: #f4f3ef;      /* Muted light warm grey sidebar */
+    --card-bg: #ffffff;
+    --border-color: #d1cfc7;     /* Soft warm grey borders */
+    --text-primary: #1c1a17;    /* Ink/Charcoal high-contrast text */
+    --text-secondary: #4b4945;  /* Soft dark charcoal for details */
+    --accent-primary: #1d4ed8;  /* Royal Blue (LaTeX style link) */
+    --accent-success: #15803d;  /* Muted Green */
+    --accent-warning: #b45309;  /* Muted Orange */
+    --accent-danger: #b91c1c;   /* Muted Red */
+    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-serif: 'Lora', 'Georgia', 'Times New Roman', serif;
+    --font-mono: 'Fira Mono', 'Courier New', monospace;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--font-serif);
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    display: flex;
+    min-height: 100vh;
+    overflow-x: hidden;
+    line-height: 1.6;
+}
+
+/* Sidebar styling */
+.sidebar {
+    width: 260px;
+    background-color: var(--sidebar-bg);
+    border-right: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    padding: 28px 24px;
+    z-index: 100;
+    font-family: var(--font-sans);
+}
+
+.sidebar-brand {
+    font-family: var(--font-serif);
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin-bottom: 36px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--text-primary);
+    text-decoration: none;
+    border-bottom: 2px solid var(--text-primary);
+    padding-bottom: 8px;
+}
+
+.sidebar-brand span {
+    color: var(--text-primary);
+}
+
+.sidebar-menu {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.sidebar-item a {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 500;
+    transition: all 0.15s ease;
+}
+
+.sidebar-item a:hover {
+    color: var(--text-primary);
+    background-color: rgba(28, 26, 23, 0.05);
+}
+
+.sidebar-item.active a {
+    color: #ffffff;
+    background-color: var(--text-primary);
+}
+
+/* Main Content Container */
+.main-content {
+    margin-left: 260px;
+    flex: 1;
+    padding: 48px;
+    max-width: 1400px;
+    width: calc(100% - 260px);
+}
+
+.header {
+    margin-bottom: 40px;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 16px;
+}
+
+.header h1 {
+    font-size: 2.25rem;
+    font-weight: 700;
+    margin-bottom: 12px;
+    font-family: var(--font-serif);
+}
+
+.header-meta {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    display: flex;
+    gap: 28px;
+    font-family: var(--font-sans);
+}
+
+/* Cards and Layout Grid */
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 28px;
+    margin-bottom: 40px;
+}
+
+.card {
+    background-color: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 24px;
+    box-shadow: none;
+}
+
+.card-title {
+    font-family: var(--font-serif);
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.card-value {
+    font-family: var(--font-mono);
+    font-size: 2.25rem;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.card-desc {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    font-family: var(--font-sans);
+}
+
+/* Tables (LaTeX Booktabs Style) */
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+    border: none;
+    border-radius: 0;
+    margin-top: 20px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+    font-size: 0.9rem;
+    font-family: var(--font-sans);
+}
+
+thead tr {
+    border-top: 2px solid var(--text-primary);
+    border-bottom: 1.2px solid var(--text-primary);
+}
+
+th {
+    background-color: transparent;
+    color: var(--text-primary);
+    font-weight: 700;
+    padding: 10px 12px;
+    border-bottom: none;
+}
+
+td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #e5e5e0;
+    color: var(--text-secondary);
+}
+
+tbody tr:last-child {
+    border-bottom: 2px solid var(--text-primary);
+}
+
+tr:hover td {
+    color: var(--text-primary);
+    background-color: transparent;
+}
+
+code {
+    font-family: var(--font-mono);
+    background-color: #f1f0ea;
+    padding: 2px 4px;
+    border-radius: 2px;
+    font-size: 0.85em;
+    color: var(--text-primary);
+}
+
+/* Badges */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 6px;
+    border-radius: 2px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    font-family: var(--font-sans);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border: 1px solid transparent;
+}
+
+.badge-success { background-color: #f0fdf4; color: var(--accent-success); border-color: #bbf7d0; }
+.badge-warning { background-color: #fffbeb; color: var(--accent-warning); border-color: #fde68a; }
+.badge-danger { background-color: #fef2f2; color: var(--accent-danger); border-color: #fecaca; }
+.badge-info { background-color: #eff6ff; color: var(--accent-primary); border-color: #bfdbfe; }
+
+/* Threshold-colored numeric cells */
+.num-good { color: var(--accent-success); }
+.num-warn { color: var(--accent-warning); font-weight: 600; }
+.num-bad { color: var(--accent-danger); font-weight: 600; }
+
+/* Findings styling (Academic Theorem Block style) */
+.findings-list {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.finding-item {
+    padding: 20px;
+    border-radius: 4px;
+    border: 1px solid var(--border-color);
+    border-left: 5px solid var(--accent-primary);
+    background-color: #faf9f6;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.finding-item.critical { border-left-color: var(--accent-danger); }
+.finding-item.warning { border-left-color: var(--accent-warning); }
+.finding-item.info { border-left-color: var(--accent-primary); }
+
+.finding-title {
+    font-family: var(--font-serif);
+    font-weight: 700;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    color: var(--text-primary);
+}
+
+.finding-desc {
+    font-family: var(--font-serif);
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.finding-link {
+    font-family: var(--font-sans);
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--accent-primary);
+    text-decoration: none;
+    align-self: flex-start;
+    margin-top: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.finding-link:hover {
+    text-decoration: underline;
+}
+
+/* Chart card styling */
+.chart-card {
+    grid-column: span 2;
+}
+
+.chart-container {
+    position: relative;
+    height: 350px;
+    width: 100%;
+    margin-top: 16px;
+}
+
+/* Sortable tables styling */
+th.sortable {
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    padding-right: 28px;
+}
+
+th.sortable:hover {
+    background-color: rgba(0, 0, 0, 0.04);
+    color: var(--text-primary);
+}
+
+th.sortable::after {
+    content: '↕';
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary);
+    opacity: 0.4;
+    font-size: 0.8rem;
+}
+
+th.sortable[data-order="asc"]::after {
+    content: '▲';
+    opacity: 0.8;
+    color: var(--accent-primary);
+}
+
+th.sortable[data-order="desc"]::after {
+    content: '▼';
+    opacity: 0.8;
+    color: var(--accent-primary);
+}

--- a/test/stress/generate-report/static/report.js
+++ b/test/stress/generate-report/static/report.js
@@ -1,0 +1,178 @@
+/*
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Shared client-side code for the stress test report pages.
+//
+// Tables: pages pass raw row objects and column specs, so sorting always
+// compares raw values, never formatted text.
+
+function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, c => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+}
+
+function badge(kind, text) {
+    return `<span class="badge badge-${kind}">${escapeHtml(text)}</span>`;
+}
+
+// Threshold coloring for numeric cells: above `bad` -> red, above
+// `warn` -> orange, otherwise green.
+function numClass(value, warn, bad) {
+    return value > bad ? 'num-bad' : value > warn ? 'num-warn' : 'num-good';
+}
+
+// columns: [{key, label, render?}] where render(value, row) returns
+// trusted HTML. Without render, the value is escaped and shown as-is
+// (null/undefined -> "-").
+function renderTable(selector, columns, rows) {
+    const table = document.querySelector(selector);
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    const tbody = document.createElement('tbody');
+    let sorted = rows.slice();
+
+    const renderBody = () => {
+        tbody.innerHTML = sorted.map(row => '<tr>' + columns.map(col => {
+            const value = row[col.key];
+            if (col.render) return `<td>${col.render(value, row)}</td>`;
+            if (value === null || value === undefined) return '<td>-</td>';
+            return `<td>${escapeHtml(value)}</td>`;
+        }).join('') + '</tr>').join('');
+    };
+
+    columns.forEach(col => {
+        const th = document.createElement('th');
+        th.className = 'sortable';
+        th.textContent = col.label;
+        th.addEventListener('click', () => {
+            const ascending = th.dataset.order !== 'asc';
+            headRow.querySelectorAll('th').forEach(sibling => {
+                if (sibling !== th) delete sibling.dataset.order;
+            });
+            th.dataset.order = ascending ? 'asc' : 'desc';
+            sorted = rows.slice().sort((a, b) => {
+                let va = a[col.key], vb = b[col.key];
+                // Numeric columns: missing values sort below all numbers.
+                if (typeof va === 'number' || typeof vb === 'number') {
+                    va = typeof va === 'number' ? va : -Infinity;
+                    vb = typeof vb === 'number' ? vb : -Infinity;
+                    return ascending ? va - vb : vb - va;
+                }
+                va = va == null ? '' : String(va);
+                vb = vb == null ? '' : String(vb);
+                return ascending ? va.localeCompare(vb) : vb.localeCompare(va);
+            });
+            renderBody();
+        });
+        headRow.appendChild(th);
+    });
+
+    thead.appendChild(headRow);
+    renderBody();
+    table.replaceChildren(thead, tbody);
+}
+
+// ---- Chart helpers ----
+
+const CHART_COLORS = [
+    '#6366f1', // indigo
+    '#10b981', // emerald
+    '#f59e0b', // amber
+    '#ef4444', // rose
+    '#06b6d4', // cyan
+    '#ec4899', // pink
+    '#8b5cf6', // violet
+    '#14b8a6'  // teal
+];
+
+// Tick labels for a list of ISO timestamps.
+function timeLabels(timestamps) {
+    return timestamps.map(ts => new Date(ts).toLocaleTimeString());
+}
+
+// Standard styling for one time-series line dataset.
+function lineDataset(label, data, idx) {
+    const color = CHART_COLORS[idx % CHART_COLORS.length];
+    return {
+        label: label,
+        data: data,
+        borderColor: color,
+        backgroundColor: color + '20',
+        borderWidth: 2,
+        tension: 0.1,
+        spanGaps: true
+    };
+}
+
+// Standard options for the time-series line charts.
+function lineChartOptions(yTitle) {
+    const axis = title => ({
+        grid: { color: '#e5e5e0' },
+        ticks: { color: '#575551' },
+        title: { display: true, text: title, color: '#575551' }
+    });
+    return {
+        animation: false,
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: { x: axis('Time'), y: axis(yTitle) },
+        plugins: {
+            legend: {
+                labels: {
+                    color: '#1c1a17',
+                    usePointStyle: true,
+                    pointStyle: 'line',
+                    boxWidth: 20
+                }
+            }
+        }
+    };
+}
+
+// Chart.js plugin drawing a dashed vertical line and label at each phase
+// start. pointTimes holds epoch ms for each data point; labels holds the
+// matching tick label (getPixelForValue needs the label on category scales).
+function phaseBands(phases, pointTimes, labels) {
+    return {
+        id: 'phaseBands',
+        beforeDraw: (chart) => {
+            const { ctx, chartArea: { top, bottom }, scales: { x } } = chart;
+
+            phases.forEach((phase) => {
+                const phaseStartMs = new Date(phase.start_ts).getTime();
+                const startIdx = pointTimes.findIndex(t => t >= phaseStartMs);
+                if (startIdx === -1) return;
+
+                const startX = x.getPixelForValue(labels[startIdx]);
+
+                ctx.strokeStyle = '#1d4ed8';
+                ctx.lineWidth = 1.5;
+                ctx.setLineDash([5, 5]);
+                ctx.beginPath();
+                ctx.moveTo(startX, top);
+                ctx.lineTo(startX, bottom);
+                ctx.stroke();
+                ctx.setLineDash([]);
+
+                ctx.fillStyle = '#1d4ed8';
+                ctx.font = 'bold 11px ' + getComputedStyle(document.documentElement).getPropertyValue('--font-sans').trim();
+                ctx.textAlign = 'left';
+                ctx.fillText(phase.name, startX + 6, top + 18);
+            });
+        }
+    };
+}

--- a/test/stress/generate-report/templates/agent-sandbox-controller.html
+++ b/test/stress/generate-report/templates/agent-sandbox-controller.html
@@ -1,0 +1,76 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}Sandbox Controller Performance - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Sandbox Reconciler & Workqueue Performance{% endblock %}
+
+{% block content %}
+<div class="grid">
+    <div class="card chart-card" id="controller-chart-card">
+        <div class="card-title">Reconciliation Rate Over Time</div>
+        <div class="chart-container">
+            <canvas id="reconcileRateChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Reconciliations by Phase</div>
+    <div class="table-container">
+        <table id="controller-ops-table"></table>
+    </div>
+</div>
+
+<script>
+    const controllerOps = {{ controller_ops | tojson }};
+    renderTable('#controller-ops-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'controller', label: 'Controller', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'total_reconciles', label: 'Total Reconciles'},
+        {key: 'total_errors', label: 'Errors'},
+        {key: 'error_rate', label: 'Error Rate', render: v =>
+            badge(v > 5 ? 'danger' : v > 0 ? 'warning' : 'success', v.toFixed(2) + '%')},
+        {key: 'avg_reconcile_ms', label: 'Average Duration', render: v =>
+            badge(v > 50 ? 'danger' : v > 10 ? 'warning' : 'success', v.toFixed(2) + 'ms')}
+    ], controllerOps);
+
+    const chartData = {{ chart_data | tojson }};
+    const phases = {{ phases | tojson }};
+
+    const controllers = [...new Set(chartData.map(d => d.controller))];
+    const timestamps = [...new Set(chartData.map(d => d.ts))].sort();
+    const formattedLabels = timeLabels(timestamps);
+    const pointTimes = timestamps.map(ts => new Date(ts).getTime());
+
+    // Index points by controller|ts so building each series is a lookup, not
+    // a scan of the whole chartData array per point.
+    const pointIndex = new Map(chartData.map(d => [`${d.controller}|${d.ts}`, d.reconcile_rate]));
+    const datasets = controllers.map((ctrl, idx) => lineDataset(
+        `${ctrl} (reconciles/sec)`,
+        timestamps.map(ts => pointIndex.get(`${ctrl}|${ts}`) ?? null),
+        idx));
+
+    new Chart(document.getElementById('reconcileRateChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: datasets },
+        options: lineChartOptions('Reconciles / sec'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% endblock %}

--- a/test/stress/generate-report/templates/apiserver.html
+++ b/test/stress/generate-report/templates/apiserver.html
@@ -1,0 +1,82 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}API Server Performance - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Kubernetes API Server Performance{% endblock %}
+
+{% block content %}
+<div class="grid">
+    <div class="card chart-card" id="apiserver-chart-card">
+        <div class="card-title">API Server Request Rates Over Time</div>
+        <div class="chart-container">
+            <canvas id="apiRateChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">apiserver Requests by Phase</div>
+    <div class="table-container">
+        <table id="apiserver-ops-table"></table>
+    </div>
+</div>
+
+<script>
+    const apiserverOps = {{ apiserver_ops | tojson }};
+    renderTable('#apiserver-ops-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'resource', label: 'Resource', render: v => `<code>${escapeHtml(v || '(none)')}</code>`},
+        {key: 'verb', label: 'Verb', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'count_delta', label: 'Count'},
+        {key: 'avg_latency_ms', label: 'Average Latency', render: v =>
+            v > 1000 ? badge('danger', (v / 1000).toFixed(2) + 's')
+            : v > 100 ? badge('warning', v.toFixed(2) + 'ms')
+            : badge('success', v.toFixed(2) + 'ms')}
+    ], apiserverOps);
+
+    const chartData = {{ chart_data | tojson }};
+    const phases = {{ phases | tojson }};
+
+    const timestamps = [...new Set(chartData.map(d => d.ts))].sort();
+    const formattedLabels = timeLabels(timestamps);
+    const pointTimes = timestamps.map(ts => new Date(ts).getTime());
+
+    // Keep the 8 busiest resource/verb series (by total request rate), and
+    // index points by series|ts so each series is built by lookup.
+    const seriesTotals = new Map();
+    const pointIndex = new Map();
+    for (const d of chartData) {
+        const key = `${d.resource || 'other'} ${d.verb}`;
+        seriesTotals.set(key, (seriesTotals.get(key) || 0) + d.request_rate);
+        pointIndex.set(`${key}|${d.ts}`, d.request_rate);
+    }
+    const topSeries = [...seriesTotals.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8).map(([key]) => key);
+    const datasets = topSeries.map((key, idx) => lineDataset(
+        key,
+        timestamps.map(ts => pointIndex.get(`${key}|${ts}`) ?? null),
+        idx));
+
+    new Chart(document.getElementById('apiRateChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: datasets },
+        options: lineChartOptions('Requests / sec'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% endblock %}

--- a/test/stress/generate-report/templates/base.html
+++ b/test/stress/generate-report/templates/base.html
@@ -1,0 +1,74 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Sandbox Stress Test Report{% endblock %}</title>
+    <!-- Google Fonts: Lora, Inter, Fira Mono -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+    <!-- Chart.js -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <script src="report.js"></script>
+    <link rel="stylesheet" href="report.css">
+</head>
+<body>
+    <div class="sidebar">
+        <a href="index.html" class="sidebar-brand">
+            <span>Agent Sandbox</span>
+        </a>
+        <ul class="sidebar-menu">
+            <li class="sidebar-item {% if active_page == 'index' %}active{% endif %}">
+                <a href="index.html">Overview</a>
+            </li>
+            <li class="sidebar-item {% if active_page == 'cri' %}active{% endif %}">
+                <a href="cri.html">CRI Runtime</a>
+            </li>
+            <li class="sidebar-item {% if active_page == 'controller' %}active{% endif %}">
+                <a href="agent-sandbox-controller.html">Sandbox Controller</a>
+            </li>
+            <li class="sidebar-item {% if active_page == 'apiserver' %}active{% endif %}">
+                <a href="apiserver.html">API Server</a>
+            </li>
+            <li class="sidebar-item {% if active_page == 'etcd' %}active{% endif %}">
+                <a href="etcd.html">etcd Latency</a>
+            </li>
+            <li class="sidebar-item {% if active_page == 'capacity' %}active{% endif %}">
+                <a href="capacity.html">Cluster Capacity</a>
+            </li>
+        </ul>
+    </div>
+
+    <div class="main-content">
+        <div class="header">
+            <h1>{% block header_title %}Stress Test Report{% endblock %}</h1>
+            <div class="header-meta">
+                <span>Run ID: <strong>{{ summary.runID }}</strong></span>
+                <span>Cluster Version: <strong>{{ summary.cluster.kubernetesVersion }}</strong></span>
+                <span>Nodes: <strong>{{ summary.cluster.nodes }}</strong></span>
+                <span>Start Time: <strong>{{ summary.startTime }}</strong></span>
+            </div>
+        </div>
+
+        {% block content %}{% endblock %}
+    </div>
+
+</body>
+</html>

--- a/test/stress/generate-report/templates/capacity.html
+++ b/test/stress/generate-report/templates/capacity.html
@@ -1,0 +1,108 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}Cluster Capacity - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Cluster Capacity & Saturation Analysis{% endblock %}
+
+{% block content %}
+<div class="grid">
+    <div class="card chart-card" id="capacity-chart-card">
+        <div class="card-title">Workload Density & Pod Limits Over Time</div>
+        <div class="chart-container">
+            <canvas id="capacityChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Peak Workload Density by Phase</div>
+    <div class="table-container">
+        <table id="capacity-table"></table>
+    </div>
+</div>
+
+<script>
+    const capacityRows = {{ capacity_summary | tojson }}.map(row => ({
+        ...row,
+        ratio: row.limit > 0 ? row.peak_pods / row.limit * 100 : 0
+    }));
+    renderTable('#capacity-table', [
+        {key: 'phase_name', label: 'Phase Name', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'peak_sandboxes', label: 'Peak Active Sandboxes'},
+        {key: 'peak_pods', label: 'Peak Active Workload Pods'},
+        {key: 'limit', label: 'Physical Pod Capacity Limit'},
+        {key: 'ratio', label: 'Capacity Saturation Ratio', render: v =>
+            v >= 100 ? badge('danger', v.toFixed(1) + '% (Exceeded)')
+            : v >= 90 ? badge('warning', v.toFixed(1) + '% (Saturated)')
+            : badge('success', v.toFixed(1) + '% (Healthy)')}
+    ], capacityRows);
+
+    const chartData = {{ chart_data | tojson }};
+    const podLimit = {{ pod_capacity | tojson }};
+    const phases = {{ phases | tojson }};
+
+    const formattedLabels = chartData.map(d => {
+        const date = new Date(d.ts);
+        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    });
+    const pointTimes = chartData.map(d => new Date(d.ts).getTime());
+
+    new Chart(document.getElementById('capacityChart').getContext('2d'), {
+        type: 'line',
+        data: {
+            labels: formattedLabels,
+            datasets: [
+                {
+                    label: 'Active Workload Pods',
+                    data: chartData.map(d => d.active_pods),
+                    borderColor: '#b91c1c',
+                    backgroundColor: '#b91c1c',
+                    borderWidth: 2.5,
+                    tension: 0.1,
+                    pointRadius: 1,
+                    fill: false
+                },
+                {
+                    label: 'Active Sandboxes',
+                    data: chartData.map(d => d.active_sandboxes),
+                    borderColor: '#1d4ed8',
+                    backgroundColor: '#1d4ed8',
+                    borderWidth: 2,
+                    tension: 0.1,
+                    pointRadius: 1,
+                    fill: false
+                },
+                {
+                    label: `Physical Pod Limit (${podLimit} Pods)`,
+                    data: Array(chartData.length).fill(podLimit),
+                    borderColor: '#b45309',
+                    borderWidth: 2,
+                    borderDash: [6, 6],
+                    pointStyle: 'none',
+                    pointRadius: 0,
+                    fill: false,
+                    tension: 0
+                }
+            ]
+        },
+        options: lineChartOptions('Active Objects Count'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% endblock %}

--- a/test/stress/generate-report/templates/cri.html
+++ b/test/stress/generate-report/templates/cri.html
@@ -1,0 +1,76 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}CRI Runtime Performance - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}CRI Container Runtime Performance{% endblock %}
+
+{% block content %}
+<div class="grid">
+    <div class="card chart-card" id="cri-chart-card">
+        <div class="card-title">run_podsandbox Latency & Scrape Rates Over Time</div>
+        <div class="chart-container">
+            <canvas id="criTimeseriesChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Kubelet Runtime Operations by Phase</div>
+    <div class="table-container">
+        <table id="cri-ops-table"></table>
+    </div>
+</div>
+
+<script>
+    const criOps = {{ cri_ops | tojson }};
+    renderTable('#cri-ops-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'operation_type', label: 'Operation Type', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'count_delta', label: 'Count'},
+        {key: 'avg_latency_ms', label: 'Average Latency', render: v =>
+            v > 10000 ? badge('danger', (v / 1000).toFixed(2) + 's')
+            : v > 2000 ? badge('warning', (v / 1000).toFixed(2) + 's')
+            : badge('success', v.toFixed(2) + 'ms')}
+    ], criOps);
+
+    const chartData = {{ chart_data | tojson }};
+    const phases = {{ phases | tojson }};
+
+    // One series per node (instance)
+    const nodes = [...new Set(chartData.map(d => d.instance))];
+    const timestamps = [...new Set(chartData.map(d => d.ts))].sort();
+    const formattedLabels = timeLabels(timestamps);
+    const pointTimes = timestamps.map(ts => new Date(ts).getTime());
+
+    // Index points by instance|ts so building each series is a lookup, not a
+    // scan of the whole chartData array per point.
+    const pointIndex = new Map(chartData.map(d => [`${d.instance}|${d.ts}`, d.avg_latency_s]));
+    const datasets = nodes.map((node, idx) => lineDataset(
+        `${node} (run_podsandbox)`,
+        timestamps.map(ts => pointIndex.get(`${node}|${ts}`) ?? null),
+        idx));
+
+    new Chart(document.getElementById('criTimeseriesChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: datasets },
+        options: lineChartOptions('Avg Latency (seconds)'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% endblock %}

--- a/test/stress/generate-report/templates/etcd.html
+++ b/test/stress/generate-report/templates/etcd.html
@@ -1,0 +1,80 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}etcd Performance - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}etcd Latency & Operations{% endblock %}
+
+{% block content %}
+<div class="grid">
+    <div class="card chart-card" id="etcd-chart-card">
+        <div class="card-title">etcd Request Rates Over Time</div>
+        <div class="chart-container">
+            <canvas id="etcdRateChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">etcd Requests by Phase</div>
+    <div class="table-container">
+        <table id="etcd-ops-table"></table>
+    </div>
+</div>
+
+<script>
+    const etcdOps = {{ etcd_ops | tojson }};
+    renderTable('#etcd-ops-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'resource', label: 'Resource', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'operation', label: 'Operation', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'count_delta', label: 'Count'},
+        {key: 'avg_latency_ms', label: 'Average Latency', render: v =>
+            badge(v > 20 ? 'danger' : v > 5 ? 'warning' : 'success', v.toFixed(2) + 'ms')}
+    ], etcdOps);
+
+    const chartData = {{ chart_data | tojson }};
+    const phases = {{ phases | tojson }};
+
+    const timestamps = [...new Set(chartData.map(d => d.ts))].sort();
+    const formattedLabels = timeLabels(timestamps);
+    const pointTimes = timestamps.map(ts => new Date(ts).getTime());
+
+    // Keep the 8 busiest resource/operation series (by total request rate),
+    // and index points by series|ts so each series is built by lookup.
+    const seriesTotals = new Map();
+    const pointIndex = new Map();
+    for (const d of chartData) {
+        const key = `${d.resource} ${d.operation}`;
+        seriesTotals.set(key, (seriesTotals.get(key) || 0) + d.request_rate);
+        pointIndex.set(`${key}|${d.ts}`, d.request_rate);
+    }
+    const topSeries = [...seriesTotals.entries()].sort((a, b) => b[1] - a[1]).slice(0, 8).map(([key]) => key);
+    const datasets = topSeries.map((key, idx) => lineDataset(
+        key,
+        timestamps.map(ts => pointIndex.get(`${key}|${ts}`) ?? null),
+        idx));
+
+    new Chart(document.getElementById('etcdRateChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: datasets },
+        options: lineChartOptions('Requests / sec'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% endblock %}

--- a/test/stress/generate-report/templates/index.html
+++ b/test/stress/generate-report/templates/index.html
@@ -1,0 +1,121 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}Overview - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Overview & Bottleneck Analysis{% endblock %}
+
+{% block content %}
+<div class="grid">
+    <div class="card">
+        <div class="card-title">Total Run Duration</div>
+        <div class="card-value">{{ run_duration }}s</div>
+        <div class="card-desc">From start to end of all phases</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Total Sandboxes Launched</div>
+        <div class="card-value">{{ total_created }}</div>
+        <div class="card-desc">Created across all phases</div>
+    </div>
+    <div class="card">
+        <div class="card-title">Avg Launch Latency (Probe)</div>
+        <div class="card-value">{{ "%.2f"|format(probe_latency_ms) }}ms</div>
+        <div class="card-desc">End-to-end sandbox launch time in probe phase</div>
+    </div>
+</div>
+
+<div class="card" style="margin-bottom: 32px;">
+    <div class="card-title">
+        <span>Detected Bottlenecks & Findings</span>
+        <span class="badge badge-info">{{ findings|length }} Findings</span>
+    </div>
+    <div class="findings-list">
+        {% for finding in findings %}
+        <div class="finding-item {{ finding.severity }}">
+            <div class="finding-title">
+                {% if finding.severity == 'critical' %}
+                <span class="badge badge-danger">Critical</span>
+                {% elif finding.severity == 'warning' %}
+                <span class="badge badge-warning">Warning</span>
+                {% else %}
+                <span class="badge badge-info">Info</span>
+                {% endif %}
+                {{ finding.title }}
+            </div>
+            <div class="finding-desc">{{ finding.desc }}</div>
+            <a class="finding-link" href="{{ finding.link }}">View Details / Graph &rarr;</a>
+        </div>
+        {% else %}
+        <div class="finding-desc">No major bottlenecks detected. All components performed within normal thresholds.</div>
+        {% endfor %}
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Test Run Phases</div>
+    <div class="table-container">
+        <table id="phases-table"></table>
+    </div>
+</div>
+
+<div class="card" style="margin-top: 32px;">
+    <div class="card-title">Sandbox Launch Latency Percentiles by Phase</div>
+    <div class="table-container">
+        <table id="percentiles-table"></table>
+    </div>
+</div>
+
+<script>
+    const phaseRows = {{ summary.phases | tojson }}.map(p => ({
+        ...p,
+        create_rate: p.createThroughput ? p.createThroughput.overallPerSecond : null,
+        ready_rate: p.readyThroughput ? p.readyThroughput.overallPerSecond : null
+    }));
+    renderTable('#phases-table', [
+        {key: 'name', label: 'Phase Name', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'requested', label: 'Requested'},
+        {key: 'created', label: 'Created'},
+        {key: 'ready', label: 'Ready'},
+        {key: 'failed', label: 'Failed'},
+        {key: 'durationSeconds', label: 'Duration (s)', render: v => v.toFixed(2)},
+        {key: 'create_rate', label: 'Create Rate (ops/s)', render: v => v == null ? '-' : v.toFixed(2)},
+        {key: 'ready_rate', label: 'Ready Rate (ops/s)', render: v => v == null ? '-' : v.toFixed(2)}
+    ], phaseRows);
+
+    // Latency percentile cells: raw values are milliseconds; short stages are
+    // displayed in ms, longer stages in seconds.
+    const msCell = v => v == null ? '-' : `<span class="${numClass(v, 30, 100)}">${v.toFixed(1)}ms</span>`;
+    const secCell = v => v == null ? '-' : `<span class="${numClass(v, 3000, 10000)}">${(v / 1000).toFixed(1)}s</span>`;
+    const sandboxPercentiles = {{ sandbox_percentiles | tojson }};
+    renderTable('#percentiles-table', [
+        {key: 'phase', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'count', label: 'Count'},
+        {key: 'createAck_p50', label: 'Ack P50', render: msCell},
+        {key: 'createAck_p90', label: 'Ack P90', render: msCell},
+        {key: 'podCreated_p50', label: 'Pod Created P50', render: secCell},
+        {key: 'podCreated_p90', label: 'Pod Created P90', render: secCell},
+        {key: 'podScheduled_p50', label: 'Scheduled P50', render: secCell},
+        {key: 'podScheduled_p90', label: 'Scheduled P90', render: secCell},
+        {key: 'podRunning_p50', label: 'Running P50', render: secCell},
+        {key: 'podRunning_p90', label: 'Running P90', render: secCell},
+        {key: 'sandboxReady_p50', label: 'Ready P50', render: secCell},
+        {key: 'sandboxReady_p90', label: 'Ready P90', render: secCell},
+        {key: 'sandboxReady_p99', label: 'Ready P99', render: secCell}
+    ], sandboxPercentiles);
+</script>
+{% endblock %}


### PR DESCRIPTION
We create a HTML report of the data using DuckDB, and we highlight any known problems.

This creates an iterative pipeline:
* We create a stress test for a metric
* We make sure that stress test collects lots of data (too much data is fine, too little data is a problem)
* We analyze the data using our human intuition and/or AI to identify the problem
* We make sure the problem is visible in the report (ideally called out with a specific finding)
* We can then send a PR to fix that next bottleneck

The mechanics of the report generation (the SQL queries, the python code, the html templates) are AI generated, although I iterated to make sure it was showing the information I think we care about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added best-effort generation of a post–stress-test static HTML report in a dedicated output directory, including an overview dashboard plus detailed performance pages (CRI, sandbox controller, API server, etcd, capacity) with interactive charts, phase markers, findings, and sortable tables.
  - Added a CLI to download required stress artifacts from common GCS URL formats, with gzip-aware output handling.

- **Bug Fixes**
  - Improved resilience: report generation and artifact downloads skip missing/optional inputs or transient failures instead of aborting, while preserving final stress-test status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->