### PR TITLE
fix(sandbox-router): replace time.After with reusable time.NewTimer in retry loop

### DIFF
--- a/sandbox-router/proxy/retry.go
+++ b/sandbox-router/proxy/retry.go
@@ -63,6 +63,10 @@ func newRetryTransport(base http.RoundTripper, attempts int, initialDelay, maxDe
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	delay := t.initialDelay
 	var lastErr error
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
 	for attempt := 1; attempt <= t.maxAttempts; attempt++ {
 		resp, err := t.base.RoundTrip(req)
 		if err == nil {
@@ -76,8 +80,15 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			t.onRetry(req, err, attempt)
 		}
 
+		timer.Stop()
 		select {
-		case <-time.After(delay):
+		case <-timer.C:
+		default:
+		}
+		timer.Reset(delay)
+
+		select {
+		case <-timer.C:
 		case <-req.Context().Done():
 			// Surface the original dial error rather than the context error so
 			// the proxy ErrorHandler reports the actual upstream failure.

--- a/sandbox-router/proxy/retry_test.go
+++ b/sandbox-router/proxy/retry_test.go
@@ -261,8 +261,8 @@ func TestRetryTransport_TimerDrainToleratesAlreadyConsumedChannel(t *testing.T) 
 		}
 		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("ok"))}, nil
 	})
-	// 1ms delay guarantees the timer fires before context cancellation,
-	// so each iteration's select takes the <-timer.C branch — meaning the
+	// 1ms delay is short enough that the timer fires during each select
+	// wait, so the <-timer.C branch is taken every iteration — meaning the
 	// channel is empty when the next iteration's drain runs.
 	tr := newRetryTransport(base, 5, 1*time.Millisecond, 5*time.Millisecond, nil)
 

--- a/sandbox-router/proxy/retry_test.go
+++ b/sandbox-router/proxy/retry_test.go
@@ -210,3 +210,81 @@ func TestRetryTransport_BackoffGrowsAndCaps(t *testing.T) {
 		t.Errorf("expected at least 70ms elapsed, got %s", elapsed)
 	}
 }
+
+// TestRetryTransport_TimerReuseAcrossManyRetries validates that the shared
+// time.Timer is correctly Stop/drain/Reset across many retry iterations.
+//
+// This guards against a subtle deadlock: if the drain after Stop() is
+// blocking (instead of non-blocking), the second retry iteration would hang
+// forever because the prior select already consumed the timer value from the
+// channel. Running with a done channel + timeout ensures the test fails
+// (rather than hangs) if the drain logic regresses.
+func TestRetryTransport_TimerReuseAcrossManyRetries(t *testing.T) {
+	const attempts = 20
+	var calls atomic.Int32
+	base := rtFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, dialErr()
+	})
+	// Short delays so the test runs fast; the timer fires every iteration,
+	// exercising the full Stop → drain → Reset cycle each time.
+	tr := newRetryTransport(base, attempts, 1*time.Millisecond, 5*time.Millisecond, nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = tr.RoundTrip(newRequest(t.Context(), t))
+	}()
+
+	select {
+	case <-done:
+		// Completed without deadlocking.
+	case <-time.After(10 * time.Second):
+		t.Fatal("RoundTrip deadlocked — likely a timer drain bug")
+	}
+
+	if got := calls.Load(); got != attempts {
+		t.Errorf("expected %d attempts, got %d", attempts, got)
+	}
+}
+
+// TestRetryTransport_TimerDrainToleratesAlreadyConsumedChannel specifically
+// targets the scenario where the timer fires, the select consumes timer.C,
+// and then the next iteration's Stop() returns false. The non-blocking drain
+// must not hang in this case.
+func TestRetryTransport_TimerDrainToleratesAlreadyConsumedChannel(t *testing.T) {
+	var calls atomic.Int32
+	base := rtFunc(func(*http.Request) (*http.Response, error) {
+		n := calls.Add(1)
+		if n <= 3 {
+			return nil, dialErr()
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+	})
+	// 1ms delay guarantees the timer fires before context cancellation,
+	// so each iteration's select takes the <-timer.C branch — meaning the
+	// channel is empty when the next iteration's drain runs.
+	tr := newRetryTransport(base, 5, 1*time.Millisecond, 5*time.Millisecond, nil)
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var err error
+	go func() {
+		defer close(done)
+		resp, err = tr.RoundTrip(newRequest(t.Context(), t))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RoundTrip deadlocked on timer drain after consumed channel")
+	}
+
+	if err != nil {
+		t.Fatalf("expected success on attempt 4, got %v", err)
+	}
+	resp.Body.Close()
+	if got := calls.Load(); got != 4 {
+		t.Errorf("expected 4 attempts, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace `time.After` in `retryTransport.RoundTrip` with a single `time.NewTimer` reused across all retry iterations via `Stop` + non-blocking drain + `Reset`.
- `time.After` allocates a new timer per iteration that is not GC'd until it fires; in a retry loop this causes unnecessary timer allocations.
- The drain must be non-blocking (`select` with `default`) because the prior `select` may have already consumed the timer value — a blocking read would deadlock on the second retry iteration.

ref: https://pkg.go.dev/time#Timer

## Changes
- `sandbox-router/proxy/retry.go`: refactor `RoundTrip` to reuse a single timer.
- `sandbox-router/proxy/retry_test.go`: add two regression tests:
  - `TestRetryTransport_TimerReuseAcrossManyRetries`: 20 retries with 1ms delay, guarded by a 10s timeout so a drain regression fails rather than hangs.
  - `TestRetryTransport_TimerDrainToleratesAlreadyConsumedChannel`: targets the exact bug scenario where the timer fires, `select` consumes `timer.C`, and the next iteration's `Stop` returns false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry timing to reuse a wait mechanism across repeated connection failures, reducing the risk of requests hanging.
  * Kept retry cancellation behavior consistent while waiting between attempts.
* **Tests**
  * Added coverage for many rapid retries to ensure requests complete without timing deadlocks.
  * Added coverage to ensure retry waiting remains safe even when the wait mechanism fires/has already been consumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->