### PR TITLE
stress-test: include pprof flame-graph

### DIFF
--- a/test/stress/generate-report/download_results.py
+++ b/test/stress/generate-report/download_results.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import argparse
+import json
 import ssl
 import sys
 import urllib.request
@@ -81,10 +82,9 @@ def download_file(url, out_path):
 
     # GZIP detection based on magic bytes (0x1f, 0x8b).
     # jsonl artifacts are stored gzipped but without the .gz suffix; restore
-    # it so downstream readers pick the right decoder. Other files keep their
-    # name so formats that are gzip by definition are not renamed.
+    # it so downstream readers pick the right decoder. Other formats (e.g.
+    # .pprof) are gzip-compressed by definition and keep their name.
     is_gzip = len(data) >= 2 and data[0] == 0x1f and data[1] == 0x8b
-
     final_path = out_path
     if is_gzip and out_path.suffix == '.jsonl':
         final_path = out_path.with_name(out_path.name + '.gz')
@@ -125,6 +125,25 @@ def main():
         out_file_path = output_dir / filename
         if download_file(file_url, out_file_path):
             downloaded += 1
+
+    # CPU profile names depend on the phases that ran, so derive them from
+    # summary.json. Older runs used a .pb suffix; save either as .pprof.
+    summary_path = output_dir / "summary.json"
+    if summary_path.exists():
+        with open(summary_path) as f:
+            raw_phases = json.load(f).get("phases", [])
+        # Current schema: a list of {"name": ...}; older runs used a
+        # name-keyed dict or a plain list of names.
+        if isinstance(raw_phases, dict):
+            phases = list(raw_phases.keys())
+        else:
+            phases = [p.get("name", "") if isinstance(p, dict) else str(p) for p in raw_phases]
+        for phase in [p for p in phases if p]:
+            out_file_path = output_dir / f"pprof-apiserver-{phase}.pprof"
+            for candidate in (f"pprof-apiserver-{phase}.pprof", f"pprof-apiserver-{phase}.pb"):
+                if download_file(f"{base_url}/{candidate}", out_file_path):
+                    downloaded += 1
+                    break
 
     print(f"\nCompleted downloading {downloaded} files successfully.")
 

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -797,6 +797,26 @@ def main():
             "sandboxReady_p99": row[12]
         })
 
+    # Discover CPU profiles captured by the stress tool (standard pprof
+    # format: gzip-compressed profile.proto). They are copied next to the
+    # report pages and parsed/rendered client-side by pprof.html.
+    pprof_files = sorted(
+        list(input_dir.glob("pprof-*.pprof"))
+        + list(input_dir.glob("pprof-*.pb"))
+        + list(input_dir.glob("pprof-*.pb.gz")))
+    phase_order = {p["name"]: i for i, p in enumerate(summary.get("phases", []))}
+    pprof_profiles = []
+    for f in pprof_files:
+        label = f.name[len("pprof-"):]
+        for suffix in (".pprof", ".pb.gz", ".pb"):
+            if label.endswith(suffix):
+                label = label[:-len(suffix)]
+                break
+        # Order profiles by when their phase ran, not alphabetically.
+        order = next((i for name, i in phase_order.items() if label.endswith(name)), len(phase_order))
+        pprof_profiles.append({"file": f.name, "label": label, "order": order})
+    pprof_profiles.sort(key=lambda p: (p["order"], p["label"]))
+
     # 5. Render Templates using Jinja2
     output_dir.mkdir(parents=True, exist_ok=True)
     template_dir = Path(__file__).parent / "templates"
@@ -808,6 +828,11 @@ def main():
         if static_file.is_file():
             shutil.copy(static_file, output_dir / static_file.name)
             print(f"Copied static asset: {output_dir / static_file.name}")
+
+    # Copy the profiles so pprof.html can fetch them relative to itself
+    for f in pprof_files:
+        shutil.copy(f, output_dir / f.name)
+        print(f"Copied CPU profile: {output_dir / f.name}")
 
     def render_page(template_name, output_filename, context):
         template = env.get_template(template_name)
@@ -879,6 +904,14 @@ def main():
         "phases": js_phases
     }
     render_page("capacity.html", "capacity.html", capacity_ctx)
+
+    # CPU profiles context
+    pprof_ctx = {
+        "active_page": "pprof",
+        "summary": summary,
+        "pprof_profiles": pprof_profiles
+    }
+    render_page("pprof.html", "pprof.html", pprof_ctx)
 
     print("All report pages generated successfully!")
 

--- a/test/stress/generate-report/static/flamegraph.js
+++ b/test/stress/generate-report/static/flamegraph.js
@@ -1,0 +1,244 @@
+/*
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Minimal pprof (profile.proto) parser and flame graph tree builder.
+//
+// pprof files are gzip-compressed protobuf messages; the page gunzips with
+// DecompressionStream and this file decodes the protobuf wire format
+// directly, so no protobuf runtime or server-side conversion is needed.
+// Only the fields needed for a CPU flame graph are decoded; everything else
+// (mappings, labels, comments) is skipped.
+//
+// Field numbers below are from
+// https://github.com/google/pprof/blob/main/proto/profile.proto
+
+// readVarint decodes a base-128 varint at pos, returning [value, nextPos].
+// Values are accumulated as doubles: exact up to 2^53, which covers every
+// quantity we care about (ids, counts, nanoseconds); 64-bit addresses may
+// lose low-bit precision but are only used as fallback frame names.
+function readVarint(buf, pos) {
+    let value = 0;
+    let factor = 1;
+    for (;;) {
+        const b = buf[pos++];
+        value += (b & 0x7f) * factor;
+        if ((b & 0x80) === 0) return [value, pos];
+        factor *= 128;
+    }
+}
+
+// forEachField walks one protobuf message, invoking
+// visit(fieldNumber, wireType, value) where value is a number for varint /
+// fixed fields and a Uint8Array subarray for length-delimited fields.
+function forEachField(buf, visit) {
+    let pos = 0;
+    while (pos < buf.length) {
+        let key;
+        [key, pos] = readVarint(buf, pos);
+        const fieldNumber = Math.floor(key / 8);
+        const wireType = key % 8;
+        switch (wireType) {
+            case 0: { // varint
+                let v;
+                [v, pos] = readVarint(buf, pos);
+                visit(fieldNumber, wireType, v);
+                break;
+            }
+            case 1: // fixed64
+                visit(fieldNumber, wireType, 0);
+                pos += 8;
+                break;
+            case 2: { // length-delimited
+                let len;
+                [len, pos] = readVarint(buf, pos);
+                visit(fieldNumber, wireType, buf.subarray(pos, pos + len));
+                pos += len;
+                break;
+            }
+            case 5: // fixed32
+                visit(fieldNumber, wireType, 0);
+                pos += 4;
+                break;
+            default:
+                throw new Error(`unsupported protobuf wire type ${wireType}`);
+        }
+    }
+}
+
+// readPackedVarints decodes a packed repeated varint field into out.
+function readPackedVarints(buf, out) {
+    let pos = 0;
+    while (pos < buf.length) {
+        let v;
+        [v, pos] = readVarint(buf, pos);
+        out.push(v);
+    }
+}
+
+// parsePprof decodes an UNCOMPRESSED profile.proto buffer into
+// {sampleTypes, samples, locations, functions, strings, durationNanos}.
+function parsePprof(buf) {
+    const decoder = new TextDecoder();
+    const profile = {
+        sampleTypes: [],   // [{type, unit}] as string-table indices
+        samples: [],       // [{locationIds, values}]
+        locations: new Map(), // id -> {address, lines: [{functionId}]}
+        functions: new Map(), // id -> {nameIdx}
+        strings: [],
+        durationNanos: 0,
+        defaultSampleType: 0, // string-table index
+    };
+
+    forEachField(buf, (field, wire, value) => {
+        switch (field) {
+            case 1: { // sample_type: ValueType
+                const vt = { type: 0, unit: 0 };
+                forEachField(value, (f, w, v) => {
+                    if (f === 1) vt.type = v;
+                    if (f === 2) vt.unit = v;
+                });
+                profile.sampleTypes.push(vt);
+                break;
+            }
+            case 2: { // sample: Sample
+                const sample = { locationIds: [], values: [] };
+                forEachField(value, (f, w, v) => {
+                    if (f === 1) w === 2 ? readPackedVarints(v, sample.locationIds) : sample.locationIds.push(v);
+                    if (f === 2) w === 2 ? readPackedVarints(v, sample.values) : sample.values.push(v);
+                });
+                profile.samples.push(sample);
+                break;
+            }
+            case 4: { // location: Location
+                const loc = { id: 0, address: 0, lines: [] };
+                forEachField(value, (f, w, v) => {
+                    if (f === 1) loc.id = v;
+                    if (f === 3) loc.address = v;
+                    if (f === 4) { // line: Line
+                        const line = { functionId: 0 };
+                        forEachField(v, (lf, lw, lv) => {
+                            if (lf === 1) line.functionId = lv;
+                        });
+                        loc.lines.push(line);
+                    }
+                });
+                profile.locations.set(loc.id, loc);
+                break;
+            }
+            case 5: { // function: Function
+                const fn = { id: 0, nameIdx: 0 };
+                forEachField(value, (f, w, v) => {
+                    if (f === 1) fn.id = v;
+                    if (f === 2) fn.nameIdx = v;
+                });
+                profile.functions.set(fn.id, fn);
+                break;
+            }
+            case 6: // string_table
+                profile.strings.push(decoder.decode(value));
+                break;
+            case 10: // duration_nanos
+                profile.durationNanos = value;
+                break;
+            case 13: // default_sample_type
+                profile.defaultSampleType = value;
+                break;
+        }
+    });
+    return profile;
+}
+
+// pickSampleType chooses which sample value column to visualize: the
+// profile's default if set, else cpu/nanoseconds, else the last column
+// (the pprof CLI's default). Returns {index, label}.
+function pickSampleType(profile) {
+    const label = i => {
+        const vt = profile.sampleTypes[i];
+        return `${profile.strings[vt.type]}/${profile.strings[vt.unit]}`;
+    };
+    if (profile.defaultSampleType) {
+        const idx = profile.sampleTypes.findIndex(vt => vt.type === profile.defaultSampleType);
+        if (idx >= 0) return { index: idx, label: label(idx) };
+    }
+    const cpu = profile.sampleTypes.findIndex(
+        vt => profile.strings[vt.type] === 'cpu' && profile.strings[vt.unit] === 'nanoseconds');
+    if (cpu >= 0) return { index: cpu, label: label(cpu) };
+    const last = profile.sampleTypes.length - 1;
+    return { index: last, label: label(last) };
+}
+
+// buildFlameTree folds samples into a root->leaf tree of
+// {name, value, children} nodes, the shape d3-flame-graph consumes. Each
+// node's value is the total for its whole subtree (samples are added along
+// the entire path). Sample stacks are leaf-first in pprof, and each
+// location's inline frames are leaf-first too, so both are walked backwards.
+function buildFlameTree(profile, valueIndex) {
+    const root = { name: 'root', value: 0, children: [] };
+    const childByName = new Map(); // node -> Map(name -> child node)
+
+    for (const sample of profile.samples) {
+        const v = sample.values[valueIndex] || 0;
+        if (v <= 0) continue;
+
+        const frames = [];
+        for (let i = sample.locationIds.length - 1; i >= 0; i--) {
+            const loc = profile.locations.get(sample.locationIds[i]);
+            if (!loc) continue;
+            if (loc.lines.length === 0) {
+                frames.push('0x' + loc.address.toString(16));
+                continue;
+            }
+            for (let j = loc.lines.length - 1; j >= 0; j--) {
+                const fn = profile.functions.get(loc.lines[j].functionId);
+                frames.push(fn ? profile.strings[fn.nameIdx] : '??');
+            }
+        }
+
+        root.value += v;
+        let node = root;
+        for (const name of frames) {
+            let index = childByName.get(node);
+            if (!index) {
+                index = new Map();
+                childByName.set(node, index);
+            }
+            let child = index.get(name);
+            if (!child) {
+                child = { name, value: 0, children: [] };
+                index.set(name, child);
+                node.children.push(child);
+            }
+            child.value += v;
+            node = child;
+        }
+    }
+    return root;
+}
+
+// loadPprof fetches a pprof file, gunzips it if needed (pprof files are
+// gzip-compressed by convention), and parses it.
+async function loadPprof(url) {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+        throw new Error(`fetching ${url}: HTTP ${resp.status}`);
+    }
+    let buf = new Uint8Array(await resp.arrayBuffer());
+    if (buf[0] === 0x1f && buf[1] === 0x8b) {
+        const gunzip = new Response(new Blob([buf]).stream().pipeThrough(new DecompressionStream('gzip')));
+        buf = new Uint8Array(await gunzip.arrayBuffer());
+    }
+    return parsePprof(buf);
+}

--- a/test/stress/generate-report/static/report.css
+++ b/test/stress/generate-report/static/report.css
@@ -360,3 +360,43 @@ th.sortable[data-order="desc"]::after {
     opacity: 0.8;
     color: var(--accent-primary);
 }
+
+/* Flame graph page */
+.profile-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+    font-family: var(--font-sans);
+    font-size: 0.9rem;
+}
+
+.profile-controls select,
+.profile-controls input,
+.profile-controls button {
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    padding: 6px 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--card-bg);
+    color: var(--text-primary);
+}
+
+.profile-controls input {
+    flex: 1;
+    max-width: 320px;
+}
+
+.profile-controls button {
+    cursor: pointer;
+}
+
+.profile-controls button:hover {
+    background-color: rgba(28, 26, 23, 0.05);
+}
+
+#flamegraph {
+    font-family: var(--font-sans);
+    overflow-x: auto;
+}

--- a/test/stress/generate-report/templates/base.html
+++ b/test/stress/generate-report/templates/base.html
@@ -53,6 +53,9 @@
             <li class="sidebar-item {% if active_page == 'capacity' %}active{% endif %}">
                 <a href="capacity.html">Cluster Capacity</a>
             </li>
+            <li class="sidebar-item {% if active_page == 'pprof' %}active{% endif %}">
+                <a href="pprof.html">CPU Profiles</a>
+            </li>
         </ul>
     </div>
 

--- a/test/stress/generate-report/templates/pprof.html
+++ b/test/stress/generate-report/templates/pprof.html
@@ -1,0 +1,101 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}CPU Profiles - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}CPU Profiles (Flame Graphs){% endblock %}
+
+{% block content %}
+{% if pprof_profiles %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.css">
+<div class="card">
+    <div class="card-title">
+        <span>kube-apiserver CPU profile</span>
+        <span class="badge badge-info" id="profile-info"></span>
+    </div>
+    <div class="profile-controls">
+        <label for="profile-select">Profile:</label>
+        <select id="profile-select">
+            {% for p in pprof_profiles %}
+            <option value="{{ p.file }}">{{ p.label }}</option>
+            {% endfor %}
+        </select>
+        <input id="profile-search" type="search" placeholder="Search functions&hellip;">
+        <button id="profile-reset" type="button">Reset zoom</button>
+    </div>
+    <div id="flamegraph"></div>
+    <div class="card-desc" style="margin-top: 12px;">
+        Width is total CPU time (self + callees); click a frame to zoom in, click root to zoom out.
+        The raw files sit next to this page
+        ({% for p in pprof_profiles %}<a href="{{ p.file }}"><code>{{ p.file }}</code></a>{{ ", " if not loop.last }}{% endfor %})
+        and can be analyzed offline with <code>go tool pprof &lt;file&gt;</code>.
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3-flame-graph@4/dist/d3-flamegraph.min.js"></script>
+<script src="flamegraph.js"></script>
+<script>
+    const container = document.getElementById('flamegraph');
+    const select = document.getElementById('profile-select');
+    const info = document.getElementById('profile-info');
+
+    const chart = flamegraph()
+        .width(Math.max(container.clientWidth, 600))
+        .cellHeight(18)
+        .minFrameSize(2)
+        .transitionDuration(250)
+        .sort(true);
+
+    async function show(file) {
+        info.textContent = 'loading…';
+        container.innerHTML = '';
+        try {
+            const profile = await loadPprof(file);
+            const pick = pickSampleType(profile);
+            const tree = buildFlameTree(profile, pick.index);
+            d3.select(container).datum(tree).call(chart);
+            const seconds = profile.durationNanos / 1e9;
+            const cores = profile.durationNanos > 0 ? tree.value / profile.durationNanos : 0;
+            info.textContent = `${pick.label}: ${(tree.value / 1e9).toFixed(1)} cpu-s over ${seconds.toFixed(0)}s (${cores.toFixed(1)} cores)`;
+        } catch (err) {
+            info.textContent = 'load failed';
+            container.innerHTML = `<div class="card-desc">Failed to load <code>${escapeHtml(file)}</code>: ${escapeHtml(err.message)}.<br>` +
+                'Note: the profile is fetched at view time, so this page must be served over HTTP ' +
+                '(a file:// URL cannot fetch sibling files).</div>';
+        }
+    }
+
+    select.addEventListener('change', () => show(select.value));
+    document.getElementById('profile-search').addEventListener('input', e => {
+        if (e.target.value) { chart.search(e.target.value); } else { chart.clear(); }
+    });
+    document.getElementById('profile-reset').addEventListener('click', () => chart.resetZoom());
+    show(select.value);
+</script>
+{% else %}
+<div class="card">
+    <div class="card-title">No CPU profiles in this run</div>
+    <div class="card-desc">
+        No <code>pprof-*.pprof</code> files were found in the input directory. The stress tool
+        captures a kube-apiserver CPU profile during each throughput level when
+        <code>--profile-apiserver</code> is enabled (the default).
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -144,6 +144,10 @@ type Config struct {
 
 	CollectMetrics  bool          `json:"collectMetrics"`
 	MetricsInterval time.Duration `json:"metricsIntervalNanos"`
+
+	// ProfileAPIServer captures a kube-apiserver CPU profile during each
+	// throughput level (pprof-apiserver-<phase>.pprof).
+	ProfileAPIServer bool `json:"profileAPIServer"`
 }
 
 func main() {
@@ -176,6 +180,7 @@ func run(ctx context.Context) error {
 	flag.Float64Var(&cfg.ThroughputMinSeconds, "throughput-min-seconds", 45, "Minimum duration of each throughput phase; levels churn beyond -throughput-count until this much time has elapsed (0 = count-based only)")
 	flag.BoolVar(&cfg.CollectMetrics, "collect-metrics", true, "Whether to scrape Prometheus metrics from the control plane, the sandbox controller, and kubelets to metrics.jsonl.gz")
 	flag.DurationVar(&cfg.MetricsInterval, "metrics-interval", 15*time.Second, "Interval between Prometheus metrics scrapes")
+	flag.BoolVar(&cfg.ProfileAPIServer, "profile-apiserver", true, "Capture a kube-apiserver CPU profile during each throughput level (pprof-apiserver-<phase>.pprof)")
 	flag.Parse()
 
 	for part := range strings.SplitSeq(*phasesFlag, ",") {
@@ -339,10 +344,21 @@ func run(ctx context.Context) error {
 		return nil
 	})
 
+	// CPU-profile the apiserver during each throughput level (it is the
+	// dominant control-plane CPU consumer under churn).
+	var profiler *apiserverProfiler
+	if cfg.ProfileAPIServer {
+		profiler, err = newAPIServerProfiler(restConfig, cfg.OutputDir)
+		if err != nil {
+			return fmt.Errorf("failed to build apiserver profiler: %w", err)
+		}
+	}
+
 	test := &stressTest{
 		cfg:       cfg,
 		tracker:   tracker,
 		namespace: cfg.Namespace,
+		profiler:  profiler,
 		sandboxClient: dynamicClient.Resource(schema.GroupVersionResource{
 			Group:    "agents.x-k8s.io",
 			Version:  "v1beta1",
@@ -468,6 +484,11 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 			}
 			mif := maxInFlight
 			runs = append(runs, phaseRun{number, name, func(ctx context.Context) error {
+				if test.profiler != nil {
+					// 5s in to skip the slot-fill burst; levels last >=45s
+					// (ThroughputMinSeconds), so the 20s window lands inside.
+					go test.profiler.CaptureCPUProfile(ctx, name, 5*time.Second, 20*time.Second)
+				}
 				return test.runThroughputLevel(ctx, name, number, mif)
 			}})
 		}

--- a/test/stress/phases.go
+++ b/test/stress/phases.go
@@ -35,6 +35,9 @@ type stressTest struct {
 	tracker       *Tracker
 	sandboxClient dynamic.ResourceInterface
 	namespace     string
+	// profiler captures apiserver CPU profiles during throughput levels
+	// (nil when --profile-apiserver is false).
+	profiler *apiserverProfiler
 }
 
 // buildSandboxObject returns a minimal long-running Sandbox.

--- a/test/stress/pprof.go
+++ b/test/stress/pprof.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// apiserverProfiler captures Go CPU profiles from the kube-apiserver's
+// /debug/pprof endpoint during test phases. Motivation: at ~87 sandboxes/s
+// the apiserver burns 4.5-5.5 cores of the single control-plane node's 8,
+// and that CPU pressure inflates every client's observed API latency
+// (etcd update 4.4 -> 16ms, PUT sandboxes 8 -> 43ms across the sweep).
+// Profiling overhead is a few percent for the duration of the capture.
+//
+// Requires the admin kubeconfig (cluster-admin covers the /debug/pprof/*
+// nonResourceURLs); capture failures are logged and never fail the run.
+type apiserverProfiler struct {
+	kube      *kubernetes.Clientset
+	outputDir string
+}
+
+func newAPIServerProfiler(restConfig *rest.Config, outputDir string) (*apiserverProfiler, error) {
+	kube, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("building kubernetes client: %w", err)
+	}
+	return &apiserverProfiler{kube: kube, outputDir: outputDir}, nil
+}
+
+// CaptureCPUProfile records one CPU profile of the given duration, starting
+// after delay (to skip a phase's warm-up), and writes it to
+// pprof-apiserver-<phase>.pprof (the standard pprof format: gzip-compressed
+// profile.proto). Synchronous; run it in a goroutine alongside the phase.
+// Analyze with: go tool pprof -top <file>.
+func (p *apiserverProfiler) CaptureCPUProfile(ctx context.Context, phase Phase, delay, duration time.Duration) {
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, duration+30*time.Second)
+	defer cancel()
+
+	raw, err := p.kube.CoreV1().RESTClient().Get().
+		AbsPath("/debug/pprof/profile").
+		Param("seconds", strconv.Itoa(int(duration.Seconds()))).
+		DoRaw(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("[pprof] apiserver CPU profile for %s failed: %v", phase, err)
+		}
+		return
+	}
+
+	path := filepath.Join(p.outputDir, fmt.Sprintf("pprof-apiserver-%s.pprof", phase))
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		log.Printf("[pprof] writing %s: %v", path, err)
+		return
+	}
+	log.Printf("[pprof] captured apiserver CPU profile for %s (%d bytes)", phase, len(raw))
+}


### PR DESCRIPTION
Spoiler alert: #1122 ended up with kube-apiserver CPU being a bottleneck, so I think it's interesting to track the CPU profile as we go along our journey here.


- **stress-test: capture apiserver CPU profiles during throughput levels**
  Extracted from #1122: fetch /debug/pprof/profile from the kube-apiserver
  during each throughput level (20s window starting 5s in, to skip the
  slot-fill burst) and write it to pprof-apiserver-<phase>.pprof. The
  apiserver is the dominant control-plane CPU consumer under churn, and
  its CPU pressure inflates every client's observed API latency.
  
  The files are standard pprof format (gzip-compressed profile.proto);
  analyze with go tool pprof, or with the report's flamegraph page.
  
  Enabled by default; disable with --profile-apiserver=false. Capture
  failures are logged, never fatal.
  

- **stress-report: render CPU profile flame graphs client-side**
  Add a CPU Profiles page to the stress report that renders flame graphs
  from the pprof files captured during throughput levels. In keeping with
  the report's client-side architecture, the pprof file (gzip-compressed
  profile.proto) is fetched and decoded entirely in the browser: a small
  protobuf wire-format parser in flamegraph.js builds the call tree, and
  d3-flame-graph (CDN) renders it with zoom and search. No server-side
  conversion, and the raw .pprof files sit next to the report for offline
  go tool pprof analysis.
  
  download_results.py now derives pprof filenames from summary.json
  phases (handling both the current and older phases schemas) and saves
  older .pb captures under the canonical .pprof name; the gzip extension
  restore is now limited to .jsonl artifacts since pprof files are
  gzip-compressed by definition.
  