### PR TITLE
examples: add containarium-ssh-sandbox (SSH-native, MCP-in-the-box access)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**chrome-sandbox**](./chrome-sandbox): An example of running a Chrome browser in a sandbox.
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
+- [**containarium-ssh-sandbox**](./containarium-ssh-sandbox): An example of running Containarium's agent-box runtime in a Sandbox, reached over SSH with an in-container MCP server (no kube-apiserver token held by the agent).
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
 - [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 120 to 200 pods per node.
 - [**hello-world-sandbox**](./hello-world-sandbox): A simple "Hello World" sandbox example.

--- a/examples/containarium-ssh-sandbox/Dockerfile
+++ b/examples/containarium-ssh-sandbox/Dockerfile
@@ -1,0 +1,50 @@
+# Builds Containarium's agent-box image from source, so you don't have to
+# trust the published ghcr.io/footprintai/containarium-agent-box tag sight
+# unseen. Mirrors images/agent-box/Dockerfile in
+# https://github.com/FootprintAI/Containarium 1:1 — same build stage, same
+# runtime hardening (rootless dropbear, forced command) — except the build
+# stage clones the pinned release tag first, since this Dockerfile lives
+# outside that repo and has no local source tree to use as build context.
+#
+#   docker build -t containarium-agent-box:local .
+#   export AGENT_BOX_IMAGE=containarium-agent-box:local
+#   kind load docker-image "${AGENT_BOX_IMAGE}" --name <your-kind-cluster>
+#
+# To build a different release, override the tag (must exist as a git tag in
+# the upstream repo):
+#   docker build --build-arg CONTAINARIUM_REF=v0.53.0 -t containarium-agent-box:local .
+#
+# See the README's "Building agent-box from source" section for how
+# AGENT_BOX_IMAGE feeds into the manifests in this directory.
+
+ARG CONTAINARIUM_REF=v0.52.1
+
+# --- fetch source at the pinned release tag, then build --------------------
+# No `k8s` build tag: agent-box is the in-box MCP and never imports
+# client-go, so this stays a small static binary. (golang's own image
+# ships git, needed to clone the tag.)
+FROM golang:1.26.5-bookworm AS build
+ARG CONTAINARIUM_REF
+WORKDIR /src
+RUN git clone --depth 1 --branch "${CONTAINARIUM_REF}" \
+      https://github.com/FootprintAI/Containarium.git .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/agent-box ./cmd/agent-box
+
+# --- runtime: rootless dropbear + agent-box --------------------------------
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends dropbear-bin ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --shell /bin/bash agent \
+    && mkdir -p /home/agent/.ssh /etc/agent-box \
+    && chown -R agent:agent /home/agent /etc/agent-box
+
+COPY --from=build /out/agent-box /usr/local/bin/agent-box
+COPY --from=build /src/images/agent-box/entrypoint.sh /usr/local/bin/agent-box-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/agent-box-entrypoint.sh
+
+USER agent
+ENV HOME=/home/agent
+# Documentation only; the entrypoint binds this port.
+EXPOSE 2222
+ENTRYPOINT ["/usr/local/bin/agent-box-entrypoint.sh"]

--- a/examples/containarium-ssh-sandbox/README.md
+++ b/examples/containarium-ssh-sandbox/README.md
@@ -1,19 +1,11 @@
 # Containarium SSH Sandbox Example
 
-This example demonstrates how to run [Containarium](https://github.com/FootprintAI/Containarium)'s
-`agent-box` runtime inside an Agent Sandbox, giving an AI agent an
-**SSH-reachable, MCP-native environment** — the agent holds only an SSH key,
-never a kube-apiserver token or cluster credentials.
-
-> **How this relates to Containarium's own backend.** As of v0.52,
-> Containarium's Kubernetes box backend runs *on this CRD*: it replaced a
-> bespoke `StatefulSet`/`Service`/`NetworkPolicy` reconciler with one that
-> reconciles `Sandbox` objects (`pkg/core/box/k8s/`). This example is the same
-> building blocks — the same `agent-box` image, the same SSH+MCP contract —
-> composed by hand so every object is visible, rather than programmed for you
-> by the Containarium daemon. Read it as "here are the pieces Containarium
-> wires together," useful whether you run Containarium or just want its
-> credential-scoped SSH/MCP access pattern as one more agent-sandbox workload.
+This example demonstrates an **SSH-reachable, MCP-native access pattern** for
+the `Sandbox` CRD: the agent holds only an SSH key, never a kube-apiserver
+token or cluster credentials. Every SSH session is pinned by a forced command
+straight into an MCP server, so the key can start that server and nothing
+else — see [See also](#see-also) for the specific runtime image this example
+runs.
 
 ## Why SSH-based access?
 
@@ -239,25 +231,6 @@ credential is spent once, by the operator, at deploy time — the agent's
 ongoing credential is a single SSH key that can do nothing cluster-scoped even
 if it leaks.
 
-This is the pattern [Containarium](https://github.com/FootprintAI/Containarium)'s
-Kubernetes backend automates: its daemon programs one `Pipe` per box and
-manages the key Secrets, so `ssh <box>@<gateway>` just works, and a fleet
-sentinel fronts many clusters behind one public address. See the
-[K8s agent-box runtime design](https://github.com/FootprintAI/Containarium/blob/main/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md)
-for the full topology.
-
-A way to see the division of labor: sshpiper and agent-sandbox are the `nginx`
-and the `kubelet` of this stack — focused, excellent primitives. sshpiper
-terminates and routes the SSH hop; agent-sandbox owns the pod's identity,
-lifecycle, and storage. Containarium is the control plane and the workload on
-top: it decides *what* runs (the `agent-box` MCP image), *how it's reached*
-(one `Pipe` per box, key Secrets kept in sync as boxes come and go), *which
-credential is spent where* (the agent's key never leaves the gateway; the box
-trusts only the upstream key), and *how one address covers a whole fleet* (a
-sentinel chaining many clusters behind a single public endpoint). Adopting the
-`Sandbox` CRD is what let Containarium delete its own low-level reconciler and
-keep only those differentiated parts.
-
 ## Hardening notes
 
 - Constrain the agent's file operations by setting `AGENTBOX_ROOT` in the
@@ -288,11 +261,22 @@ keep only those differentiated parts.
 ```bash
 # gateway path
 kubectl delete --ignore-not-found -f sshpiper.yaml
-kubectl delete --ignore-not-found sandbox box-a box-b
-kubectl delete --ignore-not-found pipe box-a box-b
+kubectl delete --ignore-not-found -f gateway-demo.yaml
 kubectl delete --ignore-not-found secret containarium-ssh-key agent-authorized-keys sshpiper-server-key sshpiper-upstream-key
 
 # or the local smoke test
 kubectl delete --ignore-not-found -f containarium-sandbox.yaml
 kubectl delete --ignore-not-found secret direct-box-authorized-keys
 ```
+
+## See also
+
+This example runs [Containarium](https://github.com/FootprintAI/Containarium)'s
+`agent-box` image as the MCP runtime (dropbear + forced command, as described
+above) — see [Building agent-box from source](#building-agent-box-from-source)
+for how it's built. Containarium's own Kubernetes backend automates this same
+access pattern at fleet scale — one `Pipe` per box, key Secrets kept in sync
+as boxes come and go, a sentinel fronting many clusters behind one public
+address. See its
+[K8s agent-box runtime design doc](https://github.com/FootprintAI/Containarium/blob/main/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md)
+if you want that context.

--- a/examples/containarium-ssh-sandbox/README.md
+++ b/examples/containarium-ssh-sandbox/README.md
@@ -1,0 +1,271 @@
+# Containarium SSH Sandbox Example
+
+This example demonstrates how to run [Containarium](https://github.com/FootprintAI/Containarium)'s
+`agent-box` runtime inside an Agent Sandbox, giving an AI agent an
+**SSH-reachable, MCP-native environment** — the agent holds only an SSH key,
+never a kube-apiserver token or cluster credentials.
+
+> **How this relates to Containarium's own backend.** As of v0.52,
+> Containarium's Kubernetes box backend runs *on this CRD*: it replaced a
+> bespoke `StatefulSet`/`Service`/`NetworkPolicy` reconciler with one that
+> reconciles `Sandbox` objects (`pkg/core/box/k8s/`). This example is the same
+> building blocks — the same `agent-box` image, the same SSH+MCP contract —
+> composed by hand so every object is visible, rather than programmed for you
+> by the Containarium daemon. Read it as "here are the pieces Containarium
+> wires together," useful whether you run Containarium or just want its
+> credential-scoped SSH/MCP access pattern as one more agent-sandbox workload.
+
+## Why SSH-based access?
+
+Most agent runtimes reach a sandbox via `kubectl exec`, which requires the
+agent (or its orchestrator) to hold cluster credentials. This example shows an
+alternative access pattern layered on top of the `Sandbox` CRD.
+
+**Where the cluster credential is actually spent matters.** The sibling
+[mcp-server-sandbox](../mcp-server-sandbox) example in this repo is explicit
+about its own tradeoff: `kubectl exec` is its MCP transport, so — by that
+example's own README — "every MCP request from the host hops through
+`kubectl exec` → kube-apiserver," meaning a cluster-scoped credential is
+spent on *every single agent call, for the life of the session*. Reaching
+this example's box (via `kubectl port-forward`, a `NodePort`, or the
+sshpiper gateway below) is a one-time, **operator-side** exposure step, no
+different in kind from setting up any bastion or tunnel — it still needs
+someone with cluster access to provision. What changes is what the *agent*
+holds afterward: from that point on, every MCP call the agent makes goes
+over the SSH key alone, and that credential surface doesn't grow with usage
+or ever touch kube-apiserver again. That's the property being traded for:
+not "zero cluster access anywhere," but "the agent's ongoing credential
+doesn't scale with the number of calls it makes, and can't be used for
+anything cluster-scoped even if it leaks."
+
+Concretely:
+
+- **SSH as the transport, hard-pinned by a forced command**: the agent
+  connects with a plain SSH keypair to [dropbear](https://matt.ucc.asn.au/dropbear/dropbear.html)
+  (not OpenSSH — it runs cleanly rootless with no privsep/PAM dance). Every
+  session is forced (`-c /usr/local/bin/agent-box`) straight into the MCP
+  server: the key can start `agent-box` and nothing else, no matter what
+  command the client sends. The blast radius of a leaked credential is one
+  box's MCP surface, not a shell on the cluster.
+- **MCP inside the box**: Containarium's `agent-box` binary runs in the
+  container and exposes typed tools (`shell_exec`, `read_file`, `write_file`,
+  `list_directory`, `move_file`, `delete_file`, plus process and log tools)
+  over stdio — reachable by wrapping the MCP command in SSH. Any MCP-speaking
+  agent (Claude Code, Cursor, OpenCode) works with zero client library.
+- **Sandbox CRD as the substrate**: stable identity, persistent workspace via
+  `volumeClaimTemplates`, and lifecycle management come from agent-sandbox;
+  `automountServiceAccountToken: false` keeps the box credential-free.
+
+Because every session is forced into `agent-box`, plain `ssh host 'echo ok'`
+style commands won't do what you expect — see "Reach the box over SSH" below.
+
+## Prerequisites
+
+- A Kubernetes cluster (e.g., [kind](https://kind.sigs.k8s.io/)).
+- `agent-sandbox` controller installed
+  ([installation guide](https://agent-sandbox.sigs.k8s.io/docs/getting_started/)).
+- `ssh`, `ssh-keygen`, and `kubectl` (Usage step 1 generates the keypairs).
+- (Optional) A RuntimeClass such as `gvisor` for stronger isolation; the
+  manifest includes a commented-out `runtimeClassName` line.
+
+
+## Usage
+
+`run-test-kind.sh` runs this whole sequence on kind — the gateway path plus a
+local smoke test — and verifies each with a real MCP handshake. To do it by
+hand:
+
+**1. Generate the keys and create the Secrets.** Three keypairs: the agent's
+(client), the gateway's SSH host key, and the gateway→box upstream key. The
+box authorizes **only the upstream key** — the agent's key lives at the
+gateway, never on the box. That separation is the whole point (see
+[Why SSH-based access?](#why-ssh-based-access)).
+
+```bash
+ssh-keygen -t ed25519 -f ./agent_ed25519       -N ""   # agent  → gateway
+ssh-keygen -t ed25519 -f ./piper_host_ed25519  -N ""   # gateway host key
+ssh-keygen -t ed25519 -f ./upstream_ed25519    -N ""   # gateway → box
+
+# the box trusts only the gateway's upstream key
+kubectl create secret generic containarium-ssh-key \
+  --from-file=authorized_keys=./upstream_ed25519.pub
+# the gateway authenticates clients against the agent's key
+# (each Pipe references this Secret by name)
+kubectl create secret generic agent-authorized-keys \
+  --from-file=authorized_keys=./agent_ed25519.pub
+# the gateway's own host key and its upstream (gateway -> box) key
+kubectl create secret generic sshpiper-server-key \
+  --from-file=server_key=./piper_host_ed25519
+kubectl create secret generic sshpiper-upstream-key --type=kubernetes.io/ssh-auth \
+  --from-file=ssh-privatekey=./upstream_ed25519
+```
+
+**2. Deploy the gateway and the boxes.** The SSH username selects the box, so
+create two and route each with a `Pipe`:
+
+```bash
+# the sshpiper Pipe CRD, then the gateway
+kubectl apply -f https://raw.githubusercontent.com/FootprintAI/Containarium/v0.52.1/charts/containarium-k8s/crds/pipe.yaml
+kubectl apply -f sshpiper.yaml
+
+# two boxes (box-a, box-b) and their routing rules — plain manifests, as-is
+kubectl apply -f gateway-demo.yaml
+# the controller creates each Pod a moment after its Sandbox CR; wait (bounded,
+# ~60s) for the Pod to exist before waiting on readiness, or `kubectl wait` can
+# error with "no matching resources found" on a fresh apply
+for b in box-a box-b; do
+  for _ in $(seq 30); do
+    kubectl get pod --selector="sandbox=$b" -o name | grep -q . && break
+    sleep 2
+  done
+  kubectl wait --for=condition=ready pod --selector="sandbox=$b" --timeout=120s
+done
+```
+
+`gateway-demo.yaml` is two `Sandbox`es plus two `Pipe`s, no templating — each
+Pipe points `from.authorized_keys_secret` at the `agent-authorized-keys`
+Secret above, so the agent's key isn't baked into the manifest.
+
+**3. Reach a box.** One public SSH endpoint, plain TCP, no kubectl in the
+path — the username *is* the box:
+
+```bash
+ssh -i agent_ed25519 -o StrictHostKeyChecking=accept-new \
+  -p 32022 box-a@<node-or-lb-address>
+```
+
+This does **not** open a shell: the box's dropbear is pinned by a forced
+command to `agent-box`, so the session *is* the MCP server. Confirm it with
+one round of MCP:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0.0.1"}}}' \
+  | ssh -i agent_ed25519 -o StrictHostKeyChecking=accept-new \
+      -p 32022 box-a@<node-or-lb-address>
+# -> {"result":{...,"serverInfo":{"name":"containarium-agent-box",...}}}
+```
+
+**4. Point an MCP agent at it.** The per-box config is just the username — no
+per-box tunnels:
+
+```json
+{
+  "mcpServers": {
+    "box-a": { "command": "ssh", "args": ["-i", "agent_ed25519", "-o", "StrictHostKeyChecking=accept-new", "-p", "32022", "box-a@<gateway>"] },
+    "box-b": { "command": "ssh", "args": ["-i", "agent_ed25519", "-o", "StrictHostKeyChecking=accept-new", "-p", "32022", "box-b@<gateway>"] }
+  }
+}
+```
+
+### Local smoke test, without the gateway
+
+For a one-box check on kind you can skip the gateway and `kubectl
+port-forward` straight to the pod. This is a **local convenience, not the
+access model**: the machine running port-forward already holds a kubeconfig,
+so the SSH layer buys you nothing here, and it doesn't work under gVisor
+([agent-sandbox#158](https://github.com/kubernetes-sigs/agent-sandbox/issues/158)).
+In this mode the box must authorize the **agent's** key directly — there is no
+gateway to bridge it, so it uses its own Secret (`direct-box-authorized-keys`),
+distinct from the gateway boxes, which trust only the upstream key:
+
+```bash
+kubectl create secret generic direct-box-authorized-keys \
+  --from-file=authorized_keys=./agent_ed25519.pub
+kubectl apply -f containarium-sandbox.yaml       # a single box: containarium-ssh-sandbox
+# wait (bounded, ~60s) for the Pod to exist before waiting on readiness (see above)
+for _ in $(seq 30); do
+  kubectl get pod --selector=sandbox=containarium-ssh-sandbox -o name | grep -q . && break
+  sleep 2
+done
+kubectl wait --for=condition=ready pod --selector=sandbox=containarium-ssh-sandbox --timeout=120s
+
+kubectl port-forward pod/containarium-ssh-sandbox 2222:2222 &
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"probe","version":"0.0.1"}}}' \
+  | ssh -i ./agent_ed25519 -o StrictHostKeyChecking=accept-new \
+      -p 2222 agent@localhost
+```
+
+> **Why not `ssh agent@box-a.<namespace>.svc.cluster.local` directly?** That
+> name is cluster-internal: CoreDNS resolves it and the pod IP sits on the
+> cluster's pod network, so it's reachable only from *inside* the cluster —
+> which is exactly how the gateway (itself a pod) reaches it. And in the
+> gateway topology the box authorizes only the gateway's key, not yours, so
+> even from inside the cluster your agent key won't authenticate. The gateway
+> is what bridges both gaps — cluster edge and credential.
+
+## How the gateway works
+
+`ssh <box>@<gateway>` crosses the cluster edge and routes to the right pod by
+username, over a two-hop key chain where each key does exactly one thing:
+
+```text
+agent --(agent key)--> sshpiper :22 / NodePort --(upstream key)--> sandbox pod :2222
+                       routes by username              the only key the box trusts
+```
+
+The agent's key starts a session at the gateway under one username; the
+gateway's upstream key — a Secret only sshpiper reads — is what the box's
+dropbear authorizes; and every session still lands in the forced-command MCP
+server. Compare `kubectl exec` as a transport: the client spends a
+cluster-scoped credential on *every* call, forever. Here the cluster
+credential is spent once, by the operator, at deploy time — the agent's
+ongoing credential is a single SSH key that can do nothing cluster-scoped even
+if it leaks.
+
+This is the pattern [Containarium](https://github.com/FootprintAI/Containarium)'s
+Kubernetes backend automates: its daemon programs one `Pipe` per box and
+manages the key Secrets, so `ssh <box>@<gateway>` just works, and a fleet
+sentinel fronts many clusters behind one public address. See the
+[K8s agent-box runtime design](https://github.com/FootprintAI/Containarium/blob/main/docs/K8S-AGENT-BOX-RUNTIME-DESIGN.md)
+for the full topology.
+
+A way to see the division of labor: sshpiper and agent-sandbox are the `nginx`
+and the `kubelet` of this stack — focused, excellent primitives. sshpiper
+terminates and routes the SSH hop; agent-sandbox owns the pod's identity,
+lifecycle, and storage. Containarium is the control plane and the workload on
+top: it decides *what* runs (the `agent-box` MCP image), *how it's reached*
+(one `Pipe` per box, key Secrets kept in sync as boxes come and go), *which
+credential is spent where* (the agent's key never leaves the gateway; the box
+trusts only the upstream key), and *how one address covers a whole fleet* (a
+sentinel chaining many clusters behind a single public endpoint). Adopting the
+`Sandbox` CRD is what let Containarium delete its own low-level reconciler and
+keep only those differentiated parts.
+
+## Hardening notes
+
+- Constrain the agent's file operations by setting `AGENTBOX_ROOT` in the
+  container env; all `agent-box` file-ops paths are then resolved against
+  that root.
+- Pair the Sandbox with a default-deny NetworkPolicy (see
+  [composing-sandbox-nw-policies](../composing-sandbox-nw-policies)) so the
+  box can't reach the cluster network even with shell access.
+- Give the gateway and its boxes a dedicated namespace. The sshpiper Role
+  (`sshpiper.yaml`) grants `get`/`list`/`watch` on Secrets in its own
+  namespace — it has to, since it resolves the Secret each `Pipe` references at
+  connect time. In a shared namespace like `default` that reach extends to
+  every Secret there; isolating the example in its own namespace scopes the
+  Role's blast radius to just the gateway and box Secrets.
+- Pin the image to a digest in production.
+- In the gateway topology, pin the box's host key in the Pipe via
+  `known_hosts_data` instead of `ignore_hostkey: true` (used in the Pipes
+  for demo brevity) — it closes the gateway→box MITM window.
+- For a stable host key (so an SSH gateway/client can pin it across pod
+  restarts instead of trusting-on-first-use every time), mount an OpenSSH
+  keypair Secret at `/etc/agent-box-hostkey/{host_key,host_key_rsa}` — the
+  entrypoint converts and uses it if present, otherwise it generates a fresh
+  ephemeral host key on every start. Omitted from this example for
+  simplicity; see `images/agent-box/entrypoint.sh` in Containarium.
+
+## Cleanup
+
+```bash
+# gateway path
+kubectl delete --ignore-not-found -f sshpiper.yaml
+kubectl delete --ignore-not-found sandbox box-a box-b
+kubectl delete --ignore-not-found pipe box-a box-b
+kubectl delete --ignore-not-found secret containarium-ssh-key agent-authorized-keys sshpiper-server-key sshpiper-upstream-key
+
+# or the local smoke test
+kubectl delete --ignore-not-found -f containarium-sandbox.yaml
+kubectl delete --ignore-not-found secret direct-box-authorized-keys
+```

--- a/examples/containarium-ssh-sandbox/README.md
+++ b/examples/containarium-ssh-sandbox/README.md
@@ -68,6 +68,33 @@ style commands won't do what you expect — see "Reach the box over SSH" below.
 - (Optional) A RuntimeClass such as `gvisor` for stronger isolation; the
   manifest includes a commented-out `runtimeClassName` line.
 
+## Building agent-box from source
+
+By default every manifest here pins the published
+`ghcr.io/footprintai/containarium-agent-box:v0.52.1` tag. If you'd rather not
+trust a pre-built image sight unseen, [`Dockerfile`](Dockerfile) builds the
+same image from source — it clones
+[Containarium](https://github.com/FootprintAI/Containarium) at that same
+release tag and reproduces `images/agent-box/Dockerfile` there stage-for-stage
+(rootless dropbear, forced command into `agent-box`, nothing else):
+
+```bash
+docker build -t containarium-agent-box:local .
+kind load docker-image containarium-agent-box:local --name <your-kind-cluster>
+```
+
+Then point the manifests at your build instead of the published tag — either
+edit `image:` directly in `containarium-sandbox.yaml` / `gateway-demo.yaml`,
+or override it at apply time without touching the files:
+
+```bash
+sed 's#ghcr.io/footprintai/containarium-agent-box:v0.52.1#containarium-agent-box:local#' \
+  containarium-sandbox.yaml | kubectl apply -f -
+```
+
+(and the same `sed` against `gateway-demo.yaml`, which pins the tag twice —
+once per box). To build a different upstream release, pass
+`--build-arg CONTAINARIUM_REF=vX.Y.Z` to `docker build`.
 
 ## Usage
 

--- a/examples/containarium-ssh-sandbox/containarium-sandbox.yaml
+++ b/examples/containarium-ssh-sandbox/containarium-sandbox.yaml
@@ -1,0 +1,91 @@
+# A Sandbox running Containarium's agent-box image: an SSH-reachable,
+# MCP-native runtime environment. The agent connects over SSH (holding
+# only an SSH key — no kube-apiserver token) and every session is pinned
+# by a forced command to the in-container `agent-box` MCP server
+# (shell_exec, read/write_file, ...) — the key can do nothing else.
+#
+# See https://github.com/FootprintAI/Containarium for the runtime, and
+# images/agent-box/Dockerfile + images/agent-box/entrypoint.sh for how
+# this image is built (dropbear, not OpenSSH; forced command).
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: containarium-ssh-sandbox
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: containarium-ssh-sandbox
+    spec:
+      # Optional: uncomment to run under a hardened runtime class.
+      # runtimeClassName: gvisor
+
+      # The whole point of the SSH-based access pattern: the agent inside
+      # (or connecting to) this box never holds cluster credentials.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent-box
+          image: ghcr.io/footprintai/containarium-agent-box:v0.52.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          # No env knobs here on purpose: the image's dropbear SSH server
+          # always listens on :2222 (images/agent-box/entrypoint.sh hardcodes
+          # -p 2222) — there is no SSH_PORT or similar override.
+          ports:
+            - name: ssh
+              containerPort: 2222
+          volumeMounts:
+            # Agent workspace survives pod restarts via the PVC below.
+            - name: workspace
+              mountPath: /home/agent/workspace
+            # Public key(s) authorized to SSH into the box. Mounted as a
+            # *directory* at /etc/agent-box (not directly into ~/.ssh) —
+            # the entrypoint symlinks /etc/agent-box/authorized_keys into
+            # ~/.ssh itself and fails closed if this path is empty.
+            - name: ssh-authorized-keys
+              mountPath: /etc/agent-box
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 3
+            periodSeconds: 5
+      volumes:
+        - name: ssh-authorized-keys
+          secret:
+            # This box is the direct/port-forward smoke test: with no gateway in
+            # front, it authorizes the agent's key directly. The gateway boxes
+            # (gateway-demo.yaml) instead trust ONLY the gateway's upstream key,
+            # so they use a different Secret — the two paths never share one.
+            secretName: direct-box-authorized-keys
+            items:
+              - key: authorized_keys
+                path: authorized_keys
+            defaultMode: 0400
+  # Ask the controller for the headless Service: it gives the pod a stable
+  # DNS name (<sandbox>.<ns>.svc...) that the sshpiper gateway routes to.
+  service: true
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/examples/containarium-ssh-sandbox/containarium-sandbox.yaml
+++ b/examples/containarium-ssh-sandbox/containarium-sandbox.yaml
@@ -6,7 +6,12 @@
 #
 # See https://github.com/FootprintAI/Containarium for the runtime, and
 # images/agent-box/Dockerfile + images/agent-box/entrypoint.sh for how
-# this image is built (dropbear, not OpenSSH; forced command).
+# this image is built (dropbear, not OpenSSH; forced command). Don't want to
+# trust the published tag sight unseen? Build it yourself from the Dockerfile
+# in this directory — see the README's "Building agent-box from source". This
+# manifest applies as-is with the pinned tag below; swap in your own build by
+# overriding `image:` (e.g. `kubectl set image`, or `sed` before apply — see
+# the README).
 apiVersion: agents.x-k8s.io/v1beta1
 kind: Sandbox
 metadata:

--- a/examples/containarium-ssh-sandbox/gateway-demo.yaml
+++ b/examples/containarium-ssh-sandbox/gateway-demo.yaml
@@ -18,6 +18,11 @@
 #     from.authorized_keys_secret; default data key: authorized_keys).
 #   - Secret sshpiper-upstream-key — the gateway→box private key (referenced
 #     by each Pipe's to.private_key_secret).
+#
+# Both boxes pin the published ghcr.io/footprintai/containarium-agent-box tag
+# below. To run your own build instead (see the Dockerfile in this directory
+# and the README's "Building agent-box from source"), override `image:` on
+# both boxes — e.g. `kubectl set image` after apply, or `sed` before it.
 apiVersion: agents.x-k8s.io/v1beta1
 kind: Sandbox
 metadata:

--- a/examples/containarium-ssh-sandbox/gateway-demo.yaml
+++ b/examples/containarium-ssh-sandbox/gateway-demo.yaml
@@ -1,0 +1,183 @@
+# Two boxes behind one sshpiper gateway — the SSH username selects the box.
+#
+# `ssh box-a@<gateway>` lands in box-a; `ssh box-b@<gateway>` lands in box-b,
+# same gateway, same agent key. box-a and box-b are ordinary Sandboxes (see
+# containarium-sandbox.yaml for the field-by-field rationale); each Pipe is a
+# routing rule sshpiper reads.
+#
+# Everything here (boxes, Pipes) and the gateway (sshpiper.yaml) live in the
+# same namespace — the plugin watches its own namespace, which for this
+# example is the one you apply into (default). The Secrets a Pipe references
+# must be in that same namespace.
+#
+# Prereqs (run-test-kind.sh creates these; for manual use, see the README):
+#   - Secret containarium-ssh-key — the box's authorized_keys (the gateway
+#     upstream pubkey; the box trusts only the gateway).
+#   - Secret agent-authorized-keys — the agent's pubkey the gateway
+#     authenticates clients against (referenced by each Pipe's
+#     from.authorized_keys_secret; default data key: authorized_keys).
+#   - Secret sshpiper-upstream-key — the gateway→box private key (referenced
+#     by each Pipe's to.private_key_secret).
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: box-a
+spec:
+  service: true
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: box-a
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent-box
+          image: ghcr.io/footprintai/containarium-agent-box:v0.52.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: ssh
+              containerPort: 2222
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/agent/workspace
+            - name: ssh-authorized-keys
+              mountPath: /etc/agent-box
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 3
+            periodSeconds: 5
+      volumes:
+        - name: ssh-authorized-keys
+          secret:
+            secretName: containarium-ssh-key
+            items:
+              - key: authorized_keys
+                path: authorized_keys
+            defaultMode: 0400
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: box-b
+spec:
+  service: true
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: box-b
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent-box
+          image: ghcr.io/footprintai/containarium-agent-box:v0.52.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: ssh
+              containerPort: 2222
+          volumeMounts:
+            - name: workspace
+              mountPath: /home/agent/workspace
+            - name: ssh-authorized-keys
+              mountPath: /etc/agent-box
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 3
+            periodSeconds: 5
+      volumes:
+        - name: ssh-authorized-keys
+          secret:
+            secretName: containarium-ssh-key
+            items:
+              - key: authorized_keys
+                path: authorized_keys
+            defaultMode: 0400
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+---
+# Route username "box-a" to box-a's pod. from = who may connect at the gateway
+# (the agent's key, from a Secret); to = where the gateway forwards and how it
+# authenticates upstream (the box's DNS name + the gateway's own key).
+apiVersion: sshpiper.com/v1beta1
+kind: Pipe
+metadata:
+  name: box-a
+spec:
+  from:
+    - username: box-a
+      authorized_keys_secret:
+        name: agent-authorized-keys
+  to:
+    # Short Service name, not a hard-coded-namespace FQDN: sshpiper resolves it
+    # through its own pod's DNS search domain, so routing stays correct in
+    # whatever namespace you apply this example into (not only "default").
+    host: box-a:2222
+    username: agent
+    private_key_secret:
+      name: sshpiper-upstream-key
+    # Demo simplification — pin the box host key via known_hosts_data in
+    # anything beyond a demo (see the README's Hardening notes).
+    ignore_hostkey: true
+---
+apiVersion: sshpiper.com/v1beta1
+kind: Pipe
+metadata:
+  name: box-b
+spec:
+  from:
+    - username: box-b
+      authorized_keys_secret:
+        name: agent-authorized-keys
+  to:
+    host: box-b:2222
+    username: agent
+    private_key_secret:
+      name: sshpiper-upstream-key
+    ignore_hostkey: true

--- a/examples/containarium-ssh-sandbox/run-test-kind.sh
+++ b/examples/containarium-ssh-sandbox/run-test-kind.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Smoke test: apply the (raw, unmodified) manifests in this directory, verify
+# no service-account token is mounted, and verify the SSH -> MCP stdio path
+# works end to end — both the direct (port-forward) and the sshpiper gateway
+# paths. Uses the published agent-box + sshpiper images; kubelet pulls them.
+#
+# Note on the last check: images/agent-box/entrypoint.sh runs dropbear with
+# a *forced command* (`-c /usr/local/bin/agent-box`) — every SSH session
+# runs the MCP server regardless of what command the client sends. A plain
+# `ssh ... 'echo ok'` smoke test would NOT prove anything (the echo is
+# silently discarded); instead this script speaks one round of MCP
+# JSON-RPC over the SSH stdio channel and checks for a real response.
+
+set -e
+
+# `kubectl wait --for=create` needs kubectl >= 1.31; poll for the pod to exist
+# instead so this runs on older clients too. Args: <label-selector> [timeout-s].
+wait_for_pod_created() {
+  local selector="$1" timeout="${2:-60}" waited=0
+  until [ -n "$(kubectl get pod --selector="${selector}" -o name 2>/dev/null)" ]; do
+    if [ "${waited}" -ge "${timeout}" ]; then
+      echo "timed out after ${timeout}s waiting for a pod matching ${selector}" >&2
+      return 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+}
+
+echo "Generating throwaway SSH keypairs (agent + gateway upstream + gateway host)..."
+KEYDIR="$(mktemp -d)"
+ssh-keygen -t ed25519 -f "${KEYDIR}/agent_ed25519" -N "" -q
+ssh-keygen -t ed25519 -f "${KEYDIR}/upstream_ed25519" -N "" -q
+ssh-keygen -t ed25519 -f "${KEYDIR}/piper_host_ed25519" -N "" -q
+
+echo "Creating Secrets. The two access paths keep their credentials separate:"
+echo "  - direct-box-authorized-keys: the direct/port-forward box trusts the"
+echo "    agent key (no gateway in front)."
+echo "  - containarium-ssh-key: the gateway boxes trust ONLY the gateway's"
+echo "    upstream key — never the agent key directly."
+echo "  - agent-authorized-keys: the key the gateway authenticates clients against."
+kubectl create secret generic direct-box-authorized-keys \
+  --from-file=authorized_keys="${KEYDIR}/agent_ed25519.pub" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic containarium-ssh-key \
+  --from-file=authorized_keys="${KEYDIR}/upstream_ed25519.pub" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic agent-authorized-keys \
+  --from-file=authorized_keys="${KEYDIR}/agent_ed25519.pub" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Applying the single-box Sandbox (direct/port-forward path)..."
+kubectl apply -f containarium-sandbox.yaml
+
+cleanup() {
+    echo "Cleaning up..."
+    [ -n "${PF_PID:-}" ] && kill "${PF_PID}" 2>/dev/null || true
+    kubectl delete --ignore-not-found -f containarium-sandbox.yaml
+    kubectl delete --ignore-not-found -f gateway-demo.yaml
+    kubectl delete --ignore-not-found -f sshpiper.yaml
+    kubectl delete --ignore-not-found secret direct-box-authorized-keys containarium-ssh-key agent-authorized-keys sshpiper-server-key sshpiper-upstream-key
+    rm -rf "${KEYDIR}"
+}
+trap cleanup EXIT
+
+echo "Waiting for sandbox pod to be ready..."
+# `kubectl wait --for=condition=ready` errors immediately with "no matching
+# resources found" if zero pods match yet — the Sandbox controller needs a
+# moment to reconcile the CR into a Pod. Wait for the pod to exist first.
+wait_for_pod_created sandbox=containarium-ssh-sandbox 60
+kubectl wait --for=condition=ready pod \
+  --selector=sandbox=containarium-ssh-sandbox --timeout=180s
+
+echo "Verifying no service-account token is mounted..."
+POD_NAME=$(kubectl get pods -l sandbox=containarium-ssh-sandbox \
+  -o jsonpath='{.items[0].metadata.name}')
+if kubectl exec "${POD_NAME}" -- \
+  cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>/dev/null; then
+  echo "FAIL: service-account token is mounted in the box" && exit 1
+fi
+echo "OK: no SA token in the box."
+
+echo "Port-forwarding SSH..."
+kubectl port-forward "pod/${POD_NAME}" 2222:2222 &
+PF_PID=$!
+sleep 5
+
+echo "Checking SSH -> MCP stdio (dropbear's forced command runs agent-box,"
+echo "not whatever command the client sends, so we speak MCP directly)..."
+INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"kind-smoke-test","version":"0.0.1"}}}'
+RESPONSE=$(printf '%s\n' "${INIT_REQUEST}" | timeout 10 ssh -i "${KEYDIR}/agent_ed25519" -p 2222 \
+  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  agent@localhost)
+
+if ! printf '%s' "${RESPONSE}" | grep -q '"containarium-agent-box"'; then
+  echo "FAIL: no MCP initialize response from agent-box over SSH" >&2
+  echo "Got: ${RESPONSE}" >&2
+  exit 1
+fi
+echo "OK: agent-box answered an MCP initialize request over SSH stdio."
+
+echo "=== Gateway path: sshpiper (no kubectl in the agent's data path) ==="
+echo "Installing the sshpiper Pipe CRD + gateway..."
+kubectl apply -f https://raw.githubusercontent.com/FootprintAI/Containarium/v0.52.1/charts/containarium-k8s/crds/pipe.yaml
+kubectl create secret generic sshpiper-server-key \
+  --from-file=server_key="${KEYDIR}/piper_host_ed25519" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl create secret generic sshpiper-upstream-key --type=kubernetes.io/ssh-auth \
+  --from-file=ssh-privatekey="${KEYDIR}/upstream_ed25519" \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f sshpiper.yaml
+kubectl rollout status deployment/sshpiper --timeout=180s
+
+echo "Creating TWO boxes behind the one gateway (box-a, box-b) — the SSH"
+echo "username selects which box you land in. Raw manifests, applied as-is:"
+kubectl apply -f gateway-demo.yaml
+for name in box-a box-b; do
+  wait_for_pod_created "sandbox=${name}" 60
+  kubectl wait --for=condition=ready pod --selector=sandbox=${name} --timeout=180s
+done
+
+echo "Switching boxes by SSH username through the gateway (plain TCP to the"
+echo "NodePort — the agent's path holds only its SSH key; kubectl is not"
+echo "involved). Each session runs MCP shell_exec(hostname) to prove which"
+echo "box answered..."
+NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+sleep 5
+INITIALIZED_NOTIF='{"jsonrpc":"2.0","method":"notifications/initialized"}'
+HOSTNAME_CALL='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"shell_exec","arguments":{"command":"hostname"}}}'
+for name in box-a box-b; do
+  RESPONSE=$(printf '%s\n%s\n%s\n' "${INIT_REQUEST}" "${INITIALIZED_NOTIF}" "${HOSTNAME_CALL}" \
+    | timeout 25 ssh -i "${KEYDIR}/agent_ed25519" -p 32022 \
+        -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes \
+        "${name}@${NODE_IP}")
+  if ! printf '%s' "${RESPONSE}" | grep -q '"containarium-agent-box"'; then
+    echo "FAIL: no MCP initialize response from ${name} through the gateway" >&2
+    echo "Got: ${RESPONSE}" >&2
+    kubectl logs deployment/sshpiper --tail=20 >&2 || true
+    exit 1
+  fi
+  # The pod hostname equals the Sandbox name, so shell_exec(hostname) proves
+  # the username routed to the right box — not just to "some" box.
+  if ! printf '%s' "${RESPONSE}" | grep -q "${name}"; then
+    echo "FAIL: ssh ${name}@gateway answered, but hostname was not ${name}" >&2
+    echo "Got: ${RESPONSE}" >&2
+    exit 1
+  fi
+  echo "OK: ssh ${name}@gateway -> MCP shell_exec(hostname) = ${name}"
+done
+echo "OK: same gateway, same key — the username alone switched the box."
+
+echo "Test finished."

--- a/examples/containarium-ssh-sandbox/run-test-kind.sh
+++ b/examples/containarium-ssh-sandbox/run-test-kind.sh
@@ -104,7 +104,7 @@ echo "not whatever command the client sends, so we speak MCP directly)..."
 INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"kind-smoke-test","version":"0.0.1"}}}'
 RESPONSE=$(printf '%s\n' "${INIT_REQUEST}" | timeout 10 ssh -i "${KEYDIR}/agent_ed25519" -p 2222 \
   -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-  agent@localhost)
+  agent@localhost || true)
 
 if ! printf '%s' "${RESPONSE}" | grep -q '"containarium-agent-box"'; then
   echo "FAIL: no MCP initialize response from agent-box over SSH" >&2
@@ -137,6 +137,9 @@ echo "Switching boxes by SSH username through the gateway (plain TCP to the"
 echo "NodePort — the agent's path holds only its SSH key; kubectl is not"
 echo "involved). Each session runs MCP shell_exec(hostname) to prove which"
 echo "box answered..."
+# Assumes a Linux host: on kind with Docker Desktop (macOS/Windows), the node
+# InternalIP is only reachable from inside the Docker VM, so this NodePort
+# check won't reach it from the host. Use kind's extraPortMappings there.
 NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
 sleep 5
 INITIALIZED_NOTIF='{"jsonrpc":"2.0","method":"notifications/initialized"}'
@@ -145,7 +148,7 @@ for name in box-a box-b; do
   RESPONSE=$(printf '%s\n%s\n%s\n' "${INIT_REQUEST}" "${INITIALIZED_NOTIF}" "${HOSTNAME_CALL}" \
     | timeout 25 ssh -i "${KEYDIR}/agent_ed25519" -p 32022 \
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes \
-        "${name}@${NODE_IP}")
+        "${name}@${NODE_IP}" || true)
   if ! printf '%s' "${RESPONSE}" | grep -q '"containarium-agent-box"'; then
     echo "FAIL: no MCP initialize response from ${name} through the gateway" >&2
     echo "Got: ${RESPONSE}" >&2

--- a/examples/containarium-ssh-sandbox/run-test-kind.sh
+++ b/examples/containarium-ssh-sandbox/run-test-kind.sh
@@ -25,7 +25,7 @@
 # silently discarded); instead this script speaks one round of MCP
 # JSON-RPC over the SSH stdio channel and checks for a real response.
 
-set -e
+set -euo pipefail
 
 # `kubectl wait --for=create` needs kubectl >= 1.31; poll for the pod to exist
 # instead so this runs on older clients too. Args: <label-selector> [timeout-s].
@@ -103,7 +103,7 @@ echo "Checking SSH -> MCP stdio (dropbear's forced command runs agent-box,"
 echo "not whatever command the client sends, so we speak MCP directly)..."
 INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"kind-smoke-test","version":"0.0.1"}}}'
 RESPONSE=$(printf '%s\n' "${INIT_REQUEST}" | timeout 10 ssh -i "${KEYDIR}/agent_ed25519" -p 2222 \
-  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes \
   agent@localhost || true)
 
 if ! printf '%s' "${RESPONSE}" | grep -q '"containarium-agent-box"'; then

--- a/examples/containarium-ssh-sandbox/sshpiper.yaml
+++ b/examples/containarium-ssh-sandbox/sshpiper.yaml
@@ -1,0 +1,129 @@
+# sshpiper: the SSH gateway that makes the credential story complete.
+#
+# Without a gateway, reaching the box needs `kubectl port-forward` — which
+# means the client still holds a kubeconfig, and the SSH layer looks
+# redundant next to plain `kubectl exec`. With sshpiper in front, the agent
+# connects to ONE public SSH endpoint (`ssh <sandbox>@<gateway>`) over plain
+# TCP and is routed by username; no kubectl, no kubeconfig, no apiserver
+# anywhere in the agent's path.
+#
+# Two-hop credential chain (each key can do exactly one thing):
+#   agent ──(agent keypair)──▶ sshpiper ──(upstream keypair)──▶ box:2222
+#   - The agent's key is authorized in the Pipe's spec.from — good only for
+#     starting a session at the gateway under this username.
+#   - The upstream key is what the BOX authorizes — its private half lives
+#     in a Secret only the gateway reads.
+#
+# Prereqs (see README / run-test-kind.sh):
+#   kubectl apply -f https://raw.githubusercontent.com/FootprintAI/Containarium/v0.52.1/charts/containarium-k8s/crds/pipe.yaml
+#   kubectl create secret generic sshpiper-server-key   --from-file=server_key=<host key>
+#   kubectl create secret generic sshpiper-upstream-key --type=kubernetes.io/ssh-auth \
+#     --from-file=ssh-privatekey=<upstream private key>
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sshpiper
+---
+# Namespaced: the plugin watches its own namespace by default.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sshpiper
+rules:
+  - apiGroups: [sshpiper.com]
+    resources: [pipes]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sshpiper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sshpiper
+subjects:
+  - kind: ServiceAccount
+    name: sshpiper
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sshpiper
+  labels:
+    app: sshpiper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sshpiper
+  template:
+    metadata:
+      labels:
+        app: sshpiper
+    spec:
+      serviceAccountName: sshpiper
+      # Match the boxes' hardened posture — the gateway runs unprivileged too.
+      # The image already ships USER sshpiper (uid 1000, nologin) and binds an
+      # unprivileged port (2222), so non-root + dropped caps need nothing extra.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sshpiper
+          # Containarium's gateway image: the pinned upstream sshpiperd release
+          # with a kubernetes-plugin entrypoint, published per Containarium
+          # release. Routes by the Pipe CRs in its own namespace.
+          image: ghcr.io/footprintai/containarium-sshpiper:v0.52.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: ssh
+              containerPort: 2222
+          env:
+            - name: PLUGIN
+              value: kubernetes
+            - name: SSHPIPERD_SERVER_KEY
+              value: /serverkey/ssh_host_ed25519_key
+            - name: SSHPIPERD_LOG_LEVEL
+              value: info
+          volumeMounts:
+            - name: server-key
+              mountPath: /serverkey/
+              readOnly: true
+      volumes:
+        - name: server-key
+          secret:
+            secretName: sshpiper-server-key
+            items:
+              - key: server_key
+                path: ssh_host_ed25519_key
+---
+# NodePort for kind/bare clusters; switch to LoadBalancer on cloud.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sshpiper
+spec:
+  type: NodePort
+  selector:
+    app: sshpiper
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: 2222
+      nodePort: 32022

--- a/examples/containarium-ssh-sandbox/sshpiper.yaml
+++ b/examples/containarium-ssh-sandbox/sshpiper.yaml
@@ -112,6 +112,7 @@ spec:
             items:
               - key: server_key
                 path: ssh_host_ed25519_key
+            defaultMode: 0400
 ---
 # NodePort for kind/bare clusters; switch to LoadBalancer on cloud.
 apiVersion: v1


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a new example under `examples/containarium-ssh-sandbox` that runs
[Containarium](https://github.com/FootprintAI/Containarium)'s `agent-box`
runtime as a `Sandbox` workload, giving an AI agent an **SSH-reachable,
MCP-native** environment in which the agent holds only an SSH key — never a
kube-apiserver token or any cluster-scoped credential.

The example demonstrates an access pattern layered on top of the `Sandbox`
CRD that complements the existing `mcp-server-sandbox` example. Where
`mcp-server-sandbox` uses `kubectl exec` as its MCP transport (spending a
cluster-scoped credential on every agent call), here the box runs a dropbear
SSH server pinned by a forced command straight into the in-container MCP
server, so the agent's ongoing credential is a single SSH key that can do
nothing cluster-scoped even if it leaks.

What's included:

- **`agent-box` as a `Sandbox` workload** — `automountServiceAccountToken:
  false`, a persistent workspace via `volumeClaimTemplates`, a headless
  `service`, and a rootless container (`runAsNonRoot`, `drop: [ALL]`,
  `RuntimeDefault` seccomp).
- **A username-routed SSH gateway** (sshpiper): `ssh box-a@<gateway>` and
  `ssh box-b@<gateway>` reach different boxes over the same endpoint and the
  same key, with a two-hop key chain (agent key at the gateway, a separate
  upstream key the box authorizes). Raw manifests, no templating.
- **A local `kubectl port-forward` smoke test** for a single box, documented
  explicitly as a convenience rather than the access model.
- **`run-test-kind.sh`** exercises both paths on kind and verifies each with
  a real MCP `initialize` handshake (and, for the gateway, a
  `shell_exec(hostname)` round-trip proving the username routed to the
  right box).

Everything is pinned to a published Containarium release (`v0.52.1`) — both
the container images and the sshpiper `Pipe` CRD, which is fetched from that
release tag at apply time (not vendored into the repo) — so the example is
reproducible.

For context: as of v0.52, Containarium's own Kubernetes box backend runs on
the `Sandbox` CRD (it replaced a bespoke `StatefulSet` reconciler), so this
example is the same building blocks that backend composes, laid out by hand
so each object is visible.

/kind documentation

#### Which issue(s) this PR is related to:

None — new standalone example.

#### Release Note

```release-note
Added the `containarium-ssh-sandbox` example: run Containarium's agent-box runtime as a Sandbox, reached over SSH with an in-container MCP server, so the agent holds only an SSH key and never a kube-apiserver token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete “Containarium SSH Sandbox” example with an SSH-reachable agent-box runtime and a multi-box setup routed through a shared sshpiper gateway.
  * Included new Kubernetes manifests for box Sandboxes and a hardened sshpiper NodePort gateway with persistent workspaces and key-based access.
* **Documentation**
  * Expanded the example docs with step-by-step SSH/MCP flow, routing/key chain behavior, credential-boundary guidance, and security/hardening and cleanup instructions.
  * Added the example to the main examples index.
* **Tests**
  * Added an end-to-end smoke test covering both direct port-forward SSH and gateway-routed MCP, including automated resource/key setup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
