### PR TITLE
gate webhook implementation

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -172,8 +172,13 @@ func main() {
 		setupLog.V(1).Info("leader election is enabled (--leader-elect=true), but --leader-election-namespace is empty; attempting auto-detection")
 	}
 
-	if !enableWebhook && manageWebhookCerts {
-		setupLog.Info("--manage-webhook-certs has no effect when --enable-webhook=false")
+	if !enableWebhook {
+		setupLog.Info("webhook subsystem disabled (--enable-webhook=false); " +
+			"installed CRDs must use conversion.strategy=None — the stock CRDs in k8s/crds " +
+			"and helm/crds use Webhook conversion and API version conversion will fail without the webhook server")
+		if manageWebhookCerts {
+			setupLog.Info("--manage-webhook-certs has no effect when --enable-webhook=false")
+		}
 	}
 
 	ctx := ctrl.SetupSignalHandler()

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -82,6 +82,7 @@ func main() {
 	var webhookServiceName string
 	var webhookNamespace string
 	var manageWebhookCerts bool
+	var enableWebhook bool
 
 	flag.BoolVar(&printVersion, "version", false, "Print version information and exit.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook server binds to.")
@@ -89,6 +90,7 @@ func main() {
 	flag.StringVar(&webhookServiceName, "webhook-service-name", "agent-sandbox-webhook-service", "The name of the webhook service.")
 	flag.StringVar(&webhookNamespace, "webhook-namespace", "agent-sandbox-system", "The namespace of the webhook service.")
 	flag.BoolVar(&manageWebhookCerts, "manage-webhook-certs", true, "Manage webhook serving certs and patch CRD conversion caBundles on startup. Set to false when certs and CRD/webhook configuration are managed externally (e.g., GKE Dynamic Certificate Delivery).")
+	flag.BoolVar(&enableWebhook, "enable-webhook", true, "Enable webhook server and webhook registrations.")
 	flag.StringVar(&clusterDomain, "cluster-domain", "cluster.local", "Kubernetes cluster domain for service FQDN generation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -170,6 +172,10 @@ func main() {
 		setupLog.V(1).Info("leader election is enabled (--leader-elect=true), but --leader-election-namespace is empty; attempting auto-detection")
 	}
 
+	if !enableWebhook && manageWebhookCerts {
+		setupLog.Info("--manage-webhook-certs has no effect when --enable-webhook=false")
+	}
+
 	ctx := ctrl.SetupSignalHandler()
 
 	// Initialize Tracing Provider
@@ -241,51 +247,55 @@ func main() {
 	restConfig.QPS = float32(kubeAPIQPS)
 	restConfig.Burst = kubeAPIBurst
 
-	if manageWebhookCerts {
-		// Create a temporary client to patch the CRDs and access Secrets
-		tempClient, err := client.New(restConfig, client.Options{Scheme: scheme})
-		if err != nil {
-			setupLog.Error(err, "unable to create temporary client")
-			os.Exit(1)
-		}
-
-		// Generate or load self-signed TLS certificates for the webhook server
-		setupLog.Info("Preparing webhook certificates", "certDir", webhookCertDir)
-		caPEM, err := generateWebhookCerts(ctx, tempClient, webhookCertDir, webhookServiceName, webhookNamespace, clusterDomain)
-		if err != nil {
-			setupLog.Error(err, "unable to prepare webhook certificates")
-			os.Exit(1)
-		}
-
-		setupLog.Info("Patching CRDs with generated CA bundle")
-		if err := patchCRDs(ctx, tempClient, caPEM, webhookServiceName, webhookNamespace); err != nil {
-			setupLog.Error(err, "failed to patch CRDs with CA bundle")
-			os.Exit(1)
-		}
-	} else {
-		setupLog.Info("Webhook cert management and CRD conversion caBundle patching disabled; expecting existing tls.crt/tls.key in certDir and CRDs patched externally",
-			"certDir", webhookCertDir,
-			"serviceName", webhookServiceName,
-			"namespace", webhookNamespace,
-		)
-		for _, f := range []string{"tls.crt", "tls.key"} {
-			p := filepath.Join(webhookCertDir, f)
-			if _, err := os.Stat(p); err != nil {
-				setupLog.Error(err, "required webhook cert file missing", "path", p,
-					"hint", "with --manage-webhook-certs=false you must pre-provision tls.crt/tls.key via cert-manager, GKE, or similar")
+	if enableWebhook {
+		if manageWebhookCerts {
+			// Create a temporary client to patch the CRDs and access Secrets
+			tempClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+			if err != nil {
+				setupLog.Error(err, "unable to create temporary client")
 				os.Exit(1)
+			}
+
+			// Generate or load self-signed TLS certificates for the webhook server
+			setupLog.Info("Preparing webhook certificates", "certDir", webhookCertDir)
+			caPEM, err := generateWebhookCerts(ctx, tempClient, webhookCertDir, webhookServiceName, webhookNamespace, clusterDomain)
+			if err != nil {
+				setupLog.Error(err, "unable to prepare webhook certificates")
+				os.Exit(1)
+			}
+
+			setupLog.Info("Patching CRDs with generated CA bundle")
+			if err := patchCRDs(ctx, tempClient, caPEM, webhookServiceName, webhookNamespace); err != nil {
+				setupLog.Error(err, "failed to patch CRDs with CA bundle")
+				os.Exit(1)
+			}
+		} else {
+			setupLog.Info("Webhook cert management and CRD conversion caBundle patching disabled; expecting existing tls.crt/tls.key in certDir and CRDs patched externally",
+				"certDir", webhookCertDir,
+				"serviceName", webhookServiceName,
+				"namespace", webhookNamespace,
+			)
+			for _, f := range []string{"tls.crt", "tls.key"} {
+				p := filepath.Join(webhookCertDir, f)
+				if _, err := os.Stat(p); err != nil {
+					setupLog.Error(err, "required webhook cert file missing", "path", p,
+						"hint", "with --manage-webhook-certs=false you must pre-provision tls.crt/tls.key via cert-manager, GKE, or similar")
+					os.Exit(1)
+				}
 			}
 		}
 	}
 
-	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme:                  scheme,
 		Metrics:                 metricsOpts,
 		HealthProbeBindAddress:  probeAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionNamespace: leaderElectionNamespace,
 		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
-		WebhookServer: webhook.NewServer(webhook.Options{
+	}
+	if enableWebhook {
+		mgrOpts.WebhookServer = webhook.NewServer(webhook.Options{
 			Port:    webhookPort,
 			CertDir: webhookCertDir,
 			TLSOpts: []func(*tls.Config){
@@ -293,8 +303,10 @@ func main() {
 					cfg.ClientAuth = tls.NoClientCert
 				},
 			},
-		}),
-	})
+		})
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -313,10 +325,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = ctrl.NewWebhookManagedBy(mgr, &sandboxv1beta1.Sandbox{}).
-		Complete(); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Sandbox")
-		os.Exit(1)
+	if enableWebhook {
+		if err = ctrl.NewWebhookManagedBy(mgr, &sandboxv1beta1.Sandbox{}).
+			Complete(); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Sandbox")
+			os.Exit(1)
+		}
 	}
 
 	if extensions {
@@ -373,22 +387,24 @@ func main() {
 			os.Exit(1)
 		}
 
-		if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxClaim{}).
-			Complete(); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "SandboxClaim")
-			os.Exit(1)
-		}
+		if enableWebhook {
+			if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxClaim{}).
+				Complete(); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "SandboxClaim")
+				os.Exit(1)
+			}
 
-		if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxTemplate{}).
-			Complete(); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "SandboxTemplate")
-			os.Exit(1)
-		}
+			if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxTemplate{}).
+				Complete(); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "SandboxTemplate")
+				os.Exit(1)
+			}
 
-		if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxWarmPool{}).
-			Complete(); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "SandboxWarmPool")
-			os.Exit(1)
+			if err = ctrl.NewWebhookManagedBy(mgr, &extensionsv1beta1.SandboxWarmPool{}).
+				Complete(); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "SandboxWarmPool")
+				os.Exit(1)
+			}
 		}
 	}
 


### PR DESCRIPTION
### Summary
This change introduces an `--enable-webhook` flag (default: `true`) to allow operators to explicitly enable or disable the controller-runtime webhook server and webhook registrations independently of certificate management (`--manage-webhook-certs`).

### Problem
Previously, `--manage-webhook-certs` controlled both **how** certificates were managed AND implicitly assumed that the webhook server should always run:
1. When `--manage-webhook-certs=false`, the controller unconditionally checked for `tls.crt`/`tls.key` in `--webhook-cert-dir` on startup and exited with status `1` if they were missing.
2. Even when CRDs did not require webhook conversion (`conversion: strategy: None`) or validating/mutating webhooks, the `WebhookServer` was always initialized and passed to `ctrl.NewManager()`, and all `NewWebhookManagedBy()` calls registered the `/convert` endpoint because the Go types implement `conversion.Hub`.
3. This made it impossible to run the controller cleanly with webhook conversion disabled without either granting unnecessary secret-creation RBAC permissions to the controller or mounting dummy TLS certificate volumes.

### Solution
- **`--enable-webhook` flag (`bool`, default `true`)**: Gates the entire webhook subsystem.
  - When `--enable-webhook=false`:
    - Skips `generateWebhookCerts()` and `patchCRDs()` completely.
    - Skips the `os.Stat` pre-check for `tls.crt` and `tls.key` on disk.
    - Omits configuring `ctrl.Options.WebhookServer` when creating the manager (`ctrl.NewManager()`).
    - Skips calling `ctrl.NewWebhookManagedBy(...).Complete()` for `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool`.
- **Operator Guidance Warning**: Added a startup log warning when `--enable-webhook=false` is combined with `--manage-webhook-certs=true` (`setupLog.Info("--manage-webhook-certs has no effect when --enable-webhook=false")`) to prevent operator confusion regarding flag precedence.

### Impact
- **Non-breaking**: Defaults remain `--enable-webhook=true` and `--manage-webhook-certs=true`, preserving existing behavior for standard deployments and local development.
- **Improved Operator Experience**: Deployments that do not use webhooks (e.g., GKE Addon / distro deployments using `v1beta1` with `conversion: strategy: None`) can set `--enable-webhook=false` to run with zero webhook certificate footprint and reduced RBAC requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable or disable webhook functionality.
  * Webhook setup and webhook-managed resource registration now run only when webhooks are enabled.

* **Bug Fixes**
  * Added a warning when webhook certificate management is requested while webhooks are disabled.
  * Prevented unnecessary webhook configuration and certificate processing when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->