### PR TITLE
stress-test: enable cilium-agent Prometheus metrics on the kOps cluster

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -133,6 +133,11 @@ echo "Creating kOps cluster configuration..."
 # the upstream default, and kOps liveness probes hit /healthz.
 # Ports 10257/10259 are not internet-reachable: kOps GCE creates a
 # deny-by-default VPC and only control-plane instances can reach them.
+#
+# cilium.enablePrometheusMetrics: serve cilium-agent metrics on :9090 so the
+# stress test can scrape them (promscrape.go already targets this port; the
+# 2077449092094496768 run showed pod-sandbox creation as the launch
+# bottleneck, and CNI endpoint regeneration latency lives in these metrics).
 kops create cluster \
   --cloud=gce \
   --gce-service-account=default \
@@ -150,7 +155,8 @@ kops create cluster \
   --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/healthz \
   --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/readyz \
   --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/livez \
-  --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics
+  --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics \
+  --set cluster.spec.networking.cilium.enablePrometheusMetrics=true
 
 echo "Applying cluster configuration..."
 kops update cluster --name "${CLUSTER_NAME}" --yes

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -519,6 +519,197 @@ def main():
         for row in etcd_ts_raw
     ]
 
+    # Cilium agent metrics (present when the cluster runs Cilium with
+    # enablePrometheusMetrics). The CNI plugin calls the agent's REST API
+    # synchronously during CNI ADD/DEL, so agent API latency is pod sandbox
+    # creation latency. Cilium rate-limits endpoint-create requests
+    # (api-rate-limit, default 0.5/s auto-adjusted), and that limiter's wait
+    # time is where launch throughput ceilings show up.
+    print("Querying cilium agent API latency by phase...")
+    cilium_api_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                CAST(labels->>'method' AS VARCHAR) as method,
+                CAST(labels->>'path' AS VARCHAR) as path,
+                COALESCE(CAST(labels->>'return_code' AS VARCHAR), '') as return_code,
+                metric,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('cilium_agent_api_process_time_seconds_count', 'cilium_agent_api_process_time_seconds_sum')
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                method,
+                path,
+                metric,
+                value - lag(value) OVER (PARTITION BY instance, method, path, return_code, metric ORDER BY ts) as delta
+            FROM raw
+        ),
+        diffs_with_phase AS (
+            SELECT
+                p.name as phase_name,
+                d.method,
+                d.path,
+                d.metric,
+                d.delta
+            FROM diffs d
+            JOIN phases p ON d.ts >= p.start_time AND d.ts < p.end_time
+            WHERE d.delta >= 0
+        )
+        SELECT
+            phase_name,
+            method,
+            path,
+            SUM(CASE WHEN metric LIKE '%_count' THEN delta ELSE 0 END) as count_delta,
+            SUM(CASE WHEN metric LIKE '%_sum' THEN delta ELSE 0 END) as sum_delta
+        FROM diffs_with_phase
+        GROUP BY phase_name, method, path
+        HAVING count_delta > 0
+        ORDER BY phase_name, sum_delta DESC
+    """).fetchall()
+
+    cilium_api_ops = []
+    for row in cilium_api_raw:
+        phase_name, method, path, count_delta, sum_delta = row
+        avg_latency_ms = (sum_delta / count_delta) * 1000 if count_delta > 0 else 0
+        cilium_api_ops.append({
+            "phase_name": phase_name,
+            "method": method,
+            "path": path,
+            "count_delta": int(count_delta),
+            "avg_latency_ms": avg_latency_ms
+        })
+
+    print("Querying cilium endpoint-create limiter by phase...")
+    # These are gauges (running mean / max since agent start), so per-phase
+    # values are scrape averages: good for spotting sustained queueing,
+    # not exact per-phase distributions.
+    cilium_limiter_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                metric,
+                CAST(labels->>'value' AS VARCHAR) as kind,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE CAST(labels->>'api_call' AS VARCHAR) = 'endpoint-create'
+              AND metric IN ('cilium_api_limiter_wait_duration_seconds',
+                             'cilium_api_limiter_rate_limit',
+                             'cilium_api_limiter_requests_in_flight',
+                             'cilium_api_limiter_processing_duration_seconds')
+        )
+        SELECT
+            p.name as phase_name,
+            AVG(CASE WHEN metric = 'cilium_api_limiter_wait_duration_seconds' AND kind = 'mean' THEN value END) as wait_mean_s,
+            MAX(CASE WHEN metric = 'cilium_api_limiter_wait_duration_seconds' AND kind = 'max' THEN value END) as wait_max_s,
+            AVG(CASE WHEN metric = 'cilium_api_limiter_rate_limit' AND kind = 'limit' THEN value END) as rate_limit,
+            AVG(CASE WHEN metric = 'cilium_api_limiter_requests_in_flight' AND kind = 'in-flight' THEN value END) as in_flight,
+            AVG(CASE WHEN metric = 'cilium_api_limiter_processing_duration_seconds' AND kind = 'mean' THEN value END) as processing_mean_s
+        FROM raw r
+        JOIN phases p ON r.ts >= p.start_time AND r.ts < p.end_time
+        GROUP BY p.name
+        ORDER BY MIN(p.start_time)
+    """).fetchall()
+
+    cilium_limiter_summary = []
+    for row in cilium_limiter_raw:
+        cilium_limiter_summary.append({
+            "phase_name": row[0],
+            "wait_mean_s": row[1] or 0.0,
+            "wait_max_s": row[2] or 0.0,
+            "rate_limit": row[3] or 0.0,
+            "in_flight": row[4] or 0.0,
+            "processing_mean_s": row[5] or 0.0
+        })
+
+    print("Querying cilium limiter timeseries...")
+    cilium_limiter_ts_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                metric,
+                CAST(labels->>'value' AS VARCHAR) as kind,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE CAST(labels->>'api_call' AS VARCHAR) = 'endpoint-create'
+              AND metric IN ('cilium_api_limiter_wait_duration_seconds', 'cilium_api_limiter_rate_limit')
+        ),
+        binned AS (
+            SELECT
+                time_bucket(INTERVAL '15 seconds', ts) as bucket_time,
+                instance,
+                AVG(CASE WHEN metric = 'cilium_api_limiter_wait_duration_seconds' AND kind = 'mean' THEN value END) as wait_mean_s,
+                AVG(CASE WHEN metric = 'cilium_api_limiter_rate_limit' AND kind = 'limit' THEN value END) as rate_limit
+            FROM raw
+            GROUP BY bucket_time, instance
+        )
+        SELECT
+            strftime(bucket_time, '%Y-%m-%dT%H:%M:%SZ') as ts,
+            instance,
+            wait_mean_s,
+            rate_limit
+        FROM binned
+        WHERE wait_mean_s IS NOT NULL OR rate_limit IS NOT NULL
+        ORDER BY ts, instance
+    """).fetchall()
+
+    cilium_chart_data = [
+        {"ts": row[0], "instance": row[1], "wait_mean_s": row[2], "rate_limit": row[3]}
+        for row in cilium_limiter_ts_raw
+    ]
+
+    print("Querying cilium endpoint regeneration by phase...")
+    cilium_regen_raw = conn.execute(f"""
+        WITH raw AS (
+            SELECT
+                CAST(ts AS TIMESTAMP) as ts,
+                CAST(instance AS VARCHAR) as instance,
+                metric,
+                value
+            FROM read_json_auto('{metrics_path_str}')
+            WHERE metric IN ('cilium_endpoint_regeneration_time_stats_seconds_count', 'cilium_endpoint_regeneration_time_stats_seconds_sum')
+              AND CAST(labels->>'scope' AS VARCHAR) = 'total'
+              AND CAST(labels->>'status' AS VARCHAR) = 'success'
+        ),
+        diffs AS (
+            SELECT
+                ts,
+                metric,
+                value - lag(value) OVER (PARTITION BY instance, metric ORDER BY ts) as delta
+            FROM raw
+        ),
+        diffs_with_phase AS (
+            SELECT p.name as phase_name, d.metric, d.delta
+            FROM diffs d
+            JOIN phases p ON d.ts >= p.start_time AND d.ts < p.end_time
+            WHERE d.delta >= 0
+        )
+        SELECT
+            phase_name,
+            SUM(CASE WHEN metric LIKE '%_count' THEN delta ELSE 0 END) as count_delta,
+            SUM(CASE WHEN metric LIKE '%_sum' THEN delta ELSE 0 END) as sum_delta
+        FROM diffs_with_phase
+        GROUP BY phase_name
+        HAVING count_delta > 0
+        ORDER BY phase_name
+    """).fetchall()
+
+    cilium_regen = []
+    for row in cilium_regen_raw:
+        phase_name, count_delta, sum_delta = row
+        cilium_regen.append({
+            "phase_name": phase_name,
+            "count_delta": int(count_delta),
+            "avg_ms": (sum_delta / count_delta) * 1000 if count_delta > 0 else 0
+        })
+
+    cilium_available = bool(cilium_api_ops or cilium_limiter_summary)
+
     # Query active sandboxes and pods capacity timeseries from the watch logs
     capacity_chart_data = []
     capacity_summary = []
@@ -732,6 +923,23 @@ def main():
             "link": "etcd.html"
         })
 
+    # Cilium endpoint-create rate limiting check: launch latency spent
+    # queueing in the agent's api-rate-limit, not doing CNI work.
+    cilium_wait_worst = None
+    for row in cilium_limiter_summary:
+        if row['phase_name'].startswith('throughput'):
+            if cilium_wait_worst is None or row['wait_mean_s'] > cilium_wait_worst['wait_mean_s']:
+                cilium_wait_worst = row
+
+    if cilium_wait_worst and cilium_wait_worst['wait_mean_s'] > 0.5:
+        w = cilium_wait_worst
+        findings.append({
+            "severity": "critical" if w['wait_mean_s'] > 5.0 else "warning",
+            "title": f"Cilium endpoint-create API Rate Limited ({w['wait_mean_s']:.1f}s mean wait)",
+            "desc": f"During phase {w['phase_name']}, CNI endpoint-create requests waited a mean of {w['wait_mean_s']:.1f}s (max {w['wait_max_s']:.0f}s) in cilium-agent's API rate limiter, while actual processing took only {w['processing_mean_s']:.2f}s. The auto-adjusted limit averaged {w['rate_limit']:.1f} creates/s per node, which caps pod sandbox creation throughput. Consider raising the endpoint-create limits in Cilium's api-rate-limit configuration.",
+            "link": "cilium.html"
+        })
+
     # Capacity saturation finding check
     max_active_pods = 0
     for pt in capacity_chart_data:
@@ -893,6 +1101,19 @@ def main():
         "phases": js_phases
     }
     render_page("etcd.html", "etcd.html", etcd_ctx)
+
+    # Cilium context
+    cilium_ctx = {
+        "active_page": "cilium",
+        "summary": summary,
+        "cilium_available": cilium_available,
+        "cilium_api_ops": cilium_api_ops,
+        "cilium_limiter_summary": cilium_limiter_summary,
+        "cilium_regen": cilium_regen,
+        "chart_data": cilium_chart_data,
+        "phases": js_phases
+    }
+    render_page("cilium.html", "cilium.html", cilium_ctx)
 
     # Capacity context
     capacity_ctx = {

--- a/test/stress/generate-report/templates/base.html
+++ b/test/stress/generate-report/templates/base.html
@@ -50,6 +50,9 @@
             <li class="sidebar-item {% if active_page == 'etcd' %}active{% endif %}">
                 <a href="etcd.html">etcd Latency</a>
             </li>
+            <li class="sidebar-item {% if active_page == 'cilium' %}active{% endif %}">
+                <a href="cilium.html">Cilium CNI</a>
+            </li>
             <li class="sidebar-item {% if active_page == 'capacity' %}active{% endif %}">
                 <a href="capacity.html">Cluster Capacity</a>
             </li>

--- a/test/stress/generate-report/templates/cilium.html
+++ b/test/stress/generate-report/templates/cilium.html
@@ -1,0 +1,143 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}Cilium CNI - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Cilium CNI & Endpoint Rate Limiting{% endblock %}
+
+{% block content %}
+{% if cilium_available %}
+<div class="grid">
+    <div class="card chart-card">
+        <div class="card-title">endpoint-create Limiter Wait Over Time (per agent)</div>
+        <div class="chart-container">
+            <canvas id="ciliumWaitChart"></canvas>
+        </div>
+    </div>
+</div>
+<div class="grid">
+    <div class="card chart-card">
+        <div class="card-title">endpoint-create Effective Rate Limit Over Time (per agent)</div>
+        <div class="chart-container">
+            <canvas id="ciliumLimitChart"></canvas>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">endpoint-create API Limiter by Phase</div>
+    <div class="card-desc" style="margin-bottom: 8px;">
+        The Cilium CNI plugin creates an endpoint via the agent API during every pod sandbox
+        creation, and cilium-agent rate-limits those requests (<code>api-rate-limit</code>,
+        default 0.5/s with auto-adjust). Wait is time queued in the limiter; processing is the
+        actual endpoint-create work once admitted. Limiter gauges are lifetime running values,
+        so per-phase numbers are scrape averages.
+    </div>
+    <div class="table-container">
+        <table id="cilium-limiter-table"></table>
+    </div>
+</div>
+
+<div class="card" style="margin-top: 32px;">
+    <div class="card-title">Agent API Requests by Phase</div>
+    <div class="table-container">
+        <table id="cilium-api-table"></table>
+    </div>
+</div>
+
+<div class="card" style="margin-top: 32px;">
+    <div class="card-title">Endpoint Regenerations by Phase (scope=total)</div>
+    <div class="table-container">
+        <table id="cilium-regen-table"></table>
+    </div>
+</div>
+
+<script>
+    const limiterSummary = {{ cilium_limiter_summary | tojson }};
+    renderTable('#cilium-limiter-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'wait_mean_s', label: 'Mean Wait', render: v =>
+            badge(v > 5 ? 'danger' : v > 0.5 ? 'warning' : 'success', v.toFixed(2) + 's')},
+        {key: 'wait_max_s', label: 'Max Wait', render: v => v.toFixed(1) + 's'},
+        {key: 'rate_limit', label: 'Rate Limit (req/s)', render: v => v.toFixed(2)},
+        {key: 'in_flight', label: 'Avg In-Flight', render: v => v.toFixed(1)},
+        {key: 'processing_mean_s', label: 'Mean Processing', render: v => v.toFixed(2) + 's'}
+    ], limiterSummary);
+
+    const ciliumApiOps = {{ cilium_api_ops | tojson }};
+    renderTable('#cilium-api-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'method', label: 'Method', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'path', label: 'Path', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'count_delta', label: 'Count'},
+        {key: 'avg_latency_ms', label: 'Average Latency', render: v =>
+            v > 1000 ? badge('danger', (v / 1000).toFixed(2) + 's')
+            : v > 100 ? badge('warning', v.toFixed(2) + 'ms')
+            : badge('success', v.toFixed(2) + 'ms')}
+    ], ciliumApiOps);
+
+    const ciliumRegen = {{ cilium_regen | tojson }};
+    renderTable('#cilium-regen-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'count_delta', label: 'Regenerations'},
+        {key: 'avg_ms', label: 'Average Duration', render: v =>
+            badge(v > 1000 ? 'danger' : v > 250 ? 'warning' : 'success', v.toFixed(0) + 'ms')}
+    ], ciliumRegen);
+
+    const chartData = {{ chart_data | tojson }};
+    const phases = {{ phases | tojson }};
+
+    const agents = [...new Set(chartData.map(d => d.instance))];
+    const timestamps = [...new Set(chartData.map(d => d.ts))].sort();
+    const formattedLabels = timeLabels(timestamps);
+    const pointTimes = timestamps.map(ts => new Date(ts).getTime());
+
+    function agentDatasets(field) {
+        const pointIndex = new Map(chartData.map(d => [`${d.instance}|${d.ts}`, d[field]]));
+        return agents.map((agent, idx) => lineDataset(
+            agent,
+            timestamps.map(ts => pointIndex.get(`${agent}|${ts}`) ?? null),
+            idx));
+    }
+
+    new Chart(document.getElementById('ciliumWaitChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: agentDatasets('wait_mean_s') },
+        options: lineChartOptions('Mean limiter wait (seconds, lifetime gauge)'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+
+    new Chart(document.getElementById('ciliumLimitChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: agentDatasets('rate_limit') },
+        options: lineChartOptions('Rate limit (creates / sec)'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% else %}
+<div class="card">
+    <div class="card-title">No Cilium metrics in this run</div>
+    <div class="card-desc">
+        metrics.jsonl contains no <code>cilium-agent</code> samples. Either the cluster does not
+        run Cilium, or the agent's Prometheus endpoint is disabled — on kOps, set
+        <code>cluster.spec.networking.cilium.enablePrometheusMetrics=true</code> so the stress
+        test can scrape it (the scraper already targets port 9090).
+    </div>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Analysis of the first post-#1183 stress run ([artifacts](https://gcsweb.k8s.io/gcs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_agent-sandbox/1183/presubmit-agent-sandbox-benchmarks-kops-gcp/2077449092094496768/artifacts/stress-test/)) shows the capacity fix landed but throughput is unchanged: launch rate is still ~4.4 ready/s at mif200 and *drops* as concurrency rises.

We suspect the CNI ADD path — Cilium endpoint creation + BPF regeneration — as the prime suspect, and we currently have zero visibility into it: `promscrape.go` already targets cilium-agent on :9090 (merged in #1176), but the kOps cluster never enabled the endpoint, so every scrape fails with connection refused.

This enables `cluster.spec.networking.cilium.enablePrometheusMetrics=true` (agent port defaults to 9090, matching the scraper).

We then add a page to our report that shows the information, and indeed it shows we are client-side rate-limited on PUT on /v1/endpoints, and this accounts for most of the time for pod launch (as much as 20 seconds!).  The client-side rate limiting appears to be Cilium's own rate limiting, not kubernetes rate limiting; a fix to raise the rate limit will follow in a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Cilium Prometheus metrics for kOps GCE benchmark clusters.
  * Metrics are exposed on port 9090 for stress-test monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->