### PR TITLE
fix(extensions): warm-adopt sandboxes owned by pre-v1beta1 warm pools

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
@@ -2069,7 +2070,12 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	if controllerRef == nil {
 		return fmt.Errorf("sandbox %s/%s is unowned and cannot be safely adopted", candidate.Namespace, candidate.Name)
 	}
-	if controllerRef.APIVersion != extensionsv1beta1.GroupVersion.String() || controllerRef.Kind != "SandboxWarmPool" {
+	// Owner references keep the apiVersion that was current when they were
+	// written and are not rewritten by storage migration, so warm sandboxes
+	// created by a pre-v1beta1 pool controller still carry the v1alpha1
+	// group version after an upgrade. Match on group+kind, not version.
+	refGV, err := schema.ParseGroupVersion(controllerRef.APIVersion)
+	if err != nil || refGV.Group != extensionsv1beta1.GroupVersion.Group || controllerRef.Kind != "SandboxWarmPool" {
 		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
 	}
 	return nil

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -2075,7 +2075,10 @@ func isAdoptable(candidate *v1beta1.Sandbox) error {
 	// created by a pre-v1beta1 pool controller still carry the v1alpha1
 	// group version after an upgrade. Match on group+kind, not version.
 	refGV, err := schema.ParseGroupVersion(controllerRef.APIVersion)
-	if err != nil || refGV.Group != extensionsv1beta1.GroupVersion.Group || controllerRef.Kind != "SandboxWarmPool" {
+	if err != nil {
+		return fmt.Errorf("parsing owner reference apiVersion %q of sandbox %s/%s: %w", controllerRef.APIVersion, candidate.Namespace, candidate.Name, err)
+	}
+	if refGV.Group != extensionsv1beta1.GroupVersion.Group || controllerRef.Kind != "SandboxWarmPool" {
 		return fmt.Errorf("sandbox %s/%s is not managed by warm pool. Controller: %v", candidate.Namespace, candidate.Name, controllerRef)
 	}
 	return nil

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -4487,6 +4487,39 @@ func TestIsAdoptable_RejectsUnowned(t *testing.T) {
 	err = isAdoptable(ownedSandbox)
 	require.NoError(t, err)
 
+	// 5b. Mock a warm Sandbox created by a pre-v1beta1 pool controller: the
+	// owner reference apiVersion stays v1alpha1 across an in-place upgrade
+	// because storage migration never rewrites owner references.
+	legacyOwnedSandbox := unownedSandbox.DeepCopy()
+	legacyOwnedSandbox.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+			Kind:       "SandboxWarmPool",
+			Name:       "test-pool",
+			UID:        "pool-uid-123",
+			Controller: ptr.To(true), // nolint:modernize
+		},
+	}
+
+	// 5c. Verify it is still adoptable (version-agnostic group+kind match)
+	err = isAdoptable(legacyOwnedSandbox)
+	require.NoError(t, err)
+
+	// 5d. A controller from a different group must still be rejected
+	foreignGroupSandbox := unownedSandbox.DeepCopy()
+	foreignGroupSandbox.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "SandboxWarmPool",
+			Name:       "test-pool",
+			UID:        "pool-uid-123",
+			Controller: ptr.To(true), // nolint:modernize
+		},
+	}
+	err = isAdoptable(foreignGroupSandbox)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not managed by warm pool")
+
 	// 6. Mock an owned Sandbox pointing to a different kind (e.g. SandboxClaim, which is NOT WarmPool)
 	ownedByClaimSandbox := unownedSandbox.DeepCopy()
 	ownedByClaimSandbox.OwnerReferences = []metav1.OwnerReference{

--- a/internal/metrics/sandbox_collector.go
+++ b/internal/metrics/sandbox_collector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -134,10 +135,13 @@ func (c *SandboxCollector) Collect(ch chan<- prometheus.Metric) {
 			sandboxTemplateStr = template
 		}
 
-		apiVersion := extensionsv1beta1.GroupVersion.String()
 		ownedByStr := "None"
 		if controllerRef := metav1.GetControllerOf(&sandbox); controllerRef != nil {
-			if controllerRef.APIVersion == apiVersion {
+			// Owner references keep the apiVersion that was current when they
+			// were written; sandboxes created before the v1beta1 upgrade still
+			// carry the v1alpha1 group version. Match on group, not version.
+			refGV, err := schema.ParseGroupVersion(controllerRef.APIVersion)
+			if err == nil && refGV.Group == extensionsv1beta1.GroupVersion.Group {
 				switch controllerRef.Kind {
 				case "SandboxClaim":
 					ownedByStr = "SandboxClaim"

--- a/internal/metrics/sandbox_collector_test.go
+++ b/internal/metrics/sandbox_collector_test.go
@@ -264,6 +264,41 @@ func TestSandboxCollector(t *testing.T) {
 			},
 		},
 		{
+			// Owner references written by a pre-v1beta1 pool controller keep
+			// the v1alpha1 apiVersion after an in-place upgrade; the owned_by
+			// label must still attribute the sandbox to its warm pool.
+			name: "legacy v1alpha1-owned warmpool sandbox",
+			sandboxes: []runtime.Object{
+				&sandboxv1beta1.Sandbox{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sandbox-warmpool-legacy",
+						Namespace: "default",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "extensions.agents.x-k8s.io/v1alpha1",
+								Kind:       "SandboxWarmPool",
+								Name:       "my-warmpool",
+								UID:        "9012",
+								Controller: &trueVal,
+							},
+						},
+					},
+					Status: sandboxv1beta1.SandboxStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(sandboxv1beta1.SandboxConditionReady),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedLabels: map[string]int{
+				"created_by:unknown expired:false launch_type:cold namespace:default owned_by:SandboxWarmPool ready_condition:true sandbox_template:unknown": 1,
+			},
+		},
+		{
 			name: "client-created sandbox",
 			sandboxes: []runtime.Object{
 				&sandboxv1beta1.Sandbox{


### PR DESCRIPTION
#### What this PR does / why we need it:

`isAdoptable` in the SandboxClaim controller rejects any warm-pool candidate whose controller owner reference `apiVersion` is not exactly `extensions.agents.x-k8s.io/v1beta1`. Owner references keep the apiVersion that was current when they were written — CRD storage migration never rewrites them — so warm Sandboxes created by a v0.4.x (v1alpha1) pool controller still carry `extensions.agents.x-k8s.io/v1alpha1` after an in-place upgrade to v0.5.x. Every candidate then fails with `sandbox ... is not managed by warm pool`, and each new SandboxClaim logs `Failed to adopt any sandbox after checking all candidates` and silently cold-starts (~5-8s) instead of warm-adopting (sub-second). This blocks in-place v0.4.x → v0.5.x fleet migrations with long-lived warm pools, as reported by Vertex AI Agent Engine.

This PR fixes both occurrences of the strict-version match (a repo-wide sweep for `.APIVersion ==`/`!=` comparisons shows these are the only two):

1. **Adoption path** (`extensions/controllers/sandboxclaim_controller.go`): the controller reference is parsed with `schema.ParseGroupVersion` and matched on **group + kind** only. References from other groups (e.g. a `SandboxWarmPool` kind in a foreign group) are still rejected.
2. **Metrics collector** (`internal/metrics/sandbox_collector.go`, found in review): the `owned_by` label used the same exact-`v1beta1` string comparison, so legacy v1alpha1-owned sandboxes were reported as `owned_by="None"` after an upgrade, breaking fleet observability. The collector now matches on group only, so they correctly report `SandboxWarmPool`/`SandboxClaim`.

**Verification** (kind cluster, controller built at unfixed `e2a18b5` vs. this branch):
1. Created a v1beta1 SandboxTemplate + SandboxWarmPool (replicas 3), waited for all warm Sandboxes Ready, then patched each warm Sandbox's `ownerReferences[0].apiVersion` to `extensions.agents.x-k8s.io/v1alpha1` to recreate the post-upgrade state.
2. Unfixed controller: a new claim logged `Failed to adopt any sandbox after checking all candidates` → `creating sandbox from template`; all 3 warm Sandboxes untouched (reproduces the report exactly).
3. This branch, same cluster/objects: the next claim logged `Attempting sandbox adoption` → `Successfully adopted sandbox from warm pool` for a v1alpha1-ownerRef Sandbox, and the pool refilled.

**Regression tests** (each verified to fail against the unfixed code and pass with the fix):
- `TestIsAdoptable_RejectsUnowned` extension: a v1alpha1-ownerRef warm Sandbox is adoptable, and a same-kind reference from a foreign group (`apps/v1`) is still rejected, so the check does not become group-blind.
- `TestSandboxCollector` new case `legacy v1alpha1-owned warmpool sandbox`: asserts `owned_by:SandboxWarmPool` for a v1alpha1-ownerRef sandbox.

#### Which issue(s) this PR is related to:

Fixes #1190

#### Release Note

```release-note
Fixed two places where owner references written by pre-v1beta1 (v0.4.x) controllers were not recognized after an in-place upgrade: SandboxClaims failed to warm-adopt Ready sandboxes from pre-upgrade SandboxWarmPools and silently cold-started, and the agent_sandboxes metric reported owned_by="None" for pre-upgrade sandboxes. Owner references are now matched by group and kind instead of the exact apiVersion.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of sandbox ownership across legacy and current API versions.
  * Warm-pool sandboxes are now correctly adoptable when using supported legacy API versions.
  * Metrics now accurately attribute sandboxes to their warm pool or claim, while rejecting unrelated API groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->