### PR TITLE
stress-test: raise Cilium endpoint-create API rate limit

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -174,6 +174,32 @@ kops export kubeconfig --name "${CLUSTER_NAME}" --admin
 echo "Waiting for cluster to be ready..."
 kops validate cluster --wait 10m
 
+# Raise Cilium's endpoint-create API rate limit. The agent rate-limits
+# endpoint creation (the synchronous PUT /v1/endpoint the CNI plugin makes
+# during every pod sandbox creation) to 0.5/s with auto-adjustment anchored
+# to a 2s estimated processing duration. Under churn, queueing pushes mean
+# processing toward that anchor, so the auto-adjusted limit converges to
+# ~2 creates/s per node while actual endpoint work takes ~100ms — capping
+# pod launch throughput at the limiter, not the datapath (see the stress
+# report's Cilium page, e.g. run 2077526390265090048: 20.8s mean limiter
+# wait vs 1.6s processing at throughput-mif200). Raise the limits and
+# disable auto-adjustment so the stress test measures the CNI datapath's
+# real capacity; kOps applies its addons at bootstrap, so this patch is not
+# reverted during the run.
+echo "Raising Cilium endpoint-create API rate limits..."
+# k8s-client-qps/burst: with the endpoint-create limiter raised, the next
+# cork is cilium-agent's client-go QPS limit (default 5/s, burst 10): run
+# 2077921435870826496 showed ~0.4s of client-side throttle wait per POST and
+# ~1.4s per DELETE to the apiserver during churn, ~7s per endpoint create in
+# total, while the apiserver itself answered in ~20ms.
+kubectl --namespace kube-system patch configmap cilium-config --type merge \
+  --patch '{"data":{"api-rate-limit":"endpoint-create=rate-limit:100/s,rate-burst:100,parallel-requests:32,auto-adjust:false","k8s-client-qps":"50","k8s-client-burst":"100"}}'
+# kOps deploys the cilium DaemonSet with updateStrategy=OnDelete, so
+# "rollout restart" never recreates the pods (and "rollout status" errors
+# out). Delete the agent pods so the DaemonSet brings them back with the
+# new config, then re-validate the cluster to wait for them to be Ready.
+kubectl --namespace kube-system delete pods --selector=k8s-app=cilium
+kops validate cluster --wait 5m
 
 # Deploy to cluster
 echo "Deploying to cluster..."

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -708,7 +708,7 @@ def main():
             "avg_ms": (sum_delta / count_delta) * 1000 if count_delta > 0 else 0
         })
 
-    cilium_available = bool(cilium_api_ops or cilium_limiter_summary)
+    cilium_available = bool(cilium_api_ops or cilium_limiter_summary or cilium_regen)
 
     # Query active sandboxes and pods capacity timeseries from the watch logs
     capacity_chart_data = []
@@ -936,7 +936,7 @@ def main():
         findings.append({
             "severity": "critical" if w['wait_mean_s'] > 5.0 else "warning",
             "title": f"Cilium endpoint-create API Rate Limited ({w['wait_mean_s']:.1f}s mean wait)",
-            "desc": f"During phase {w['phase_name']}, CNI endpoint-create requests waited a mean of {w['wait_mean_s']:.1f}s (max {w['wait_max_s']:.0f}s) in cilium-agent's API rate limiter, while actual processing took only {w['processing_mean_s']:.2f}s. The auto-adjusted limit averaged {w['rate_limit']:.1f} creates/s per node, which caps pod sandbox creation throughput. Consider raising the endpoint-create limits in Cilium's api-rate-limit configuration.",
+            "desc": f"During phase {w['phase_name']}, CNI endpoint-create requests waited a mean of {w['wait_mean_s']:.1f}s (max {w['wait_max_s']:.0f}s) in cilium-agent's API rate limiter, while actual processing took only {w['processing_mean_s']:.2f}s. The effective limit averaged {w['rate_limit']:.1f} creates/s per node, which caps pod sandbox creation throughput. Consider raising the endpoint-create limits in Cilium's api-rate-limit configuration.",
             "link": "cilium.html"
         })
 


### PR DESCRIPTION
Stacked on #1187 (first two commits are that PR; review the last commit here).

#1187's presubmit run gave us the first cilium-agent metrics, and they close the case on the launch-throughput ceiling: it is cilium-agent's own API rate limiter, not the datapath.

- `PUT /v1/endpoint` (the synchronous endpoint-create the CNI plugin issues during every pod sandbox creation) averaged 28.7s at throughput-mif200 — matching CRI `run_podsandbox` (28.9s) almost exactly.
- Of that, the `endpoint-create` API limiter accounted for a 20.8s mean wait (60s max), against 1.6s mean processing once admitted, and ~80ms of actual endpoint regeneration (BPF) work.
- The limiter defaults to 0.5/s (burst 4, 4 parallel) with auto-adjust anchored to a 2s estimated processing duration. Under churn, queueing pushes mean processing toward the anchor, so the adjusted limit converges to ~1.5–2.6 creates/s per node — precisely the ~2 sandboxes/s/node ceiling every stress run has hit. In-flight averaged <2 against a parallel capacity of 30+: the agent throttles itself while nearly idle.

This PR patches `cilium-config` after cluster validation to `endpoint-create=rate-limit:100/s,rate-burst:100,parallel-requests:32,auto-adjust:false` and restarts the cilium DaemonSet, so the stress test measures what the CNI can actually do. The report's new Cilium page distinguishes limiter wait from processing time, so if the bottleneck moves into endpoint processing itself (or somewhere else entirely), the next run's report will say so explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark setup now applies optimized Cilium runtime settings before stress tests begin.
  * Benchmark reports now recognize endpoint regeneration data when determining Cilium availability.

* **Bug Fixes**
  * Updated endpoint-create rate-limit findings to report the effective average create rate per node with clearer wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->