### PR TITLE
ci: add CNI-parameterized benchmark job scripts under dev/ci

### DIFF
--- a/dev/ci/periodics/benchmarks-kops-gcp-cilium
+++ b/dev/ci/periodics/benchmarks-kops-gcp-cilium
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Periodic variant of the cilium benchmark: same test, run on a schedule
+# against main so we get a continuous performance baseline.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+exec "${REPO_ROOT}/dev/ci/presubmits/benchmarks-kops-gcp-cilium"

--- a/dev/ci/periodics/benchmarks-kops-gcp-kindnet
+++ b/dev/ci/periodics/benchmarks-kops-gcp-kindnet
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Periodic variant of the kindnet benchmark: same test, run on a schedule
+# against main so we get a continuous performance baseline.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+exec "${REPO_ROOT}/dev/ci/presubmits/benchmarks-kops-gcp-kindnet"

--- a/dev/ci/presubmits/benchmarks-kops-gcp-cilium
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-cilium
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the kOps GCP benchmark + stress test with cilium as the CNI.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+export CNI=cilium
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/dev/ci/presubmits/benchmarks-kops-gcp-kindnet
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-kindnet
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the kOps GCP benchmark + stress test with kindnet as the CNI.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+export CNI=kindnet
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -121,6 +121,12 @@ cleanup() {
 
 trap cleanup EXIT
 
+# CNI selects the cluster networking (any kOps --networking value; we
+# exercise cilium and kindnet in CI). Running the same benchmark under two
+# CNIs separates CNI costs from the rest of the sandbox launch pipeline.
+CNI="${CNI:-cilium}"
+echo "Using CNI: ${CNI}"
+
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
 #
@@ -136,6 +142,7 @@ echo "Creating kOps cluster configuration..."
 kops create cluster \
   --cloud=gce \
   --gce-service-account=default \
+  --networking="${CNI}" \
   --name="${CLUSTER_NAME}" \
   --zones="${ZONE}" \
   --project="${PROJECT_ID}" \


### PR DESCRIPTION
The stress-test bottleneck analysis points at the CNI layer (Cilium endpoint-create rate limiting, see #1187/#1194), so we want the same benchmark running under two CNIs to separate CNI costs from the rest of the sandbox launch pipeline.

- Parameterize test/benchmarks/scenarios/benchmarks-kops-gcp/run by $CNI (any kOps --networking value; default cilium, unchanged behavior).
- Add dev/ci wrappers following the existing convention, referenced by prow jobs generated in test-infra (companion PR there adds a generator that derives the job config from these scripts):
  - dev/ci/presubmits/benchmarks-kops-gcp-{cilium,kindnet}
  - dev/ci/periodics/benchmarks-kops-gcp-{cilium,kindnet} (exec the presubmit scripts; scheduled every 24h against main for a continuous baseline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduled and presubmit benchmark scenarios for kOps on GCP using both Cilium and kindnet networking.
  - Added the ability to select the cluster networking plugin during benchmark cluster creation (default: Cilium).
  - Benchmark runs now display which networking plugin was selected.

- **Bug Fixes**
  - Improved benchmark execution reliability with stricter failure handling and consistent repository initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->