### PR TITLE
WIP: stress-test: surface kubelet pod-start pipeline congestion

### DIFF
--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -252,6 +252,46 @@ def main():
         for row in cri_ts_raw
     ]
 
+    # Kubelet pod-start pipeline: pod_start_sli is the kubelet's own measure
+    # of starting a pod (excluding image pulls and scheduling). Comparing it
+    # to run_podsandbox splits node-local latency into "inside the CRI
+    # sandbox call" vs "queued around it in kubelet pod workers".
+    print("Querying kubelet pod start pipeline...")
+    pod_start_by_phase = {
+        row[0]: (row[1], row[2]) for row in metrics_by_phase(
+            conn, metrics_path_str,
+            metrics=["kubelet_pod_start_sli_duration_seconds_count",
+                     "kubelet_pod_start_sli_duration_seconds_sum"])
+        if row[1] > 0
+    }
+    run_podsandbox_by_phase = {
+        row[0]: (row[1], row[2]) for row in metrics_by_phase(
+            conn, metrics_path_str,
+            metrics=["kubelet_runtime_operations_duration_seconds_count",
+                     "kubelet_runtime_operations_duration_seconds_sum"],
+            labels={"operation_type": "operation_type"},
+            group_by=[],
+            where="operation_type = 'run_podsandbox'")
+        if row[1] > 0
+    }
+
+    pod_start = []
+    for phase in summary.get('phases', []):
+        name = phase['name']
+        if name not in pod_start_by_phase:
+            continue
+        n, total = pod_start_by_phase[name]
+        start_avg_s = total / n
+        rp_n, rp_total = run_podsandbox_by_phase.get(name, (0, 0.0))
+        sandbox_avg_s = rp_total / rp_n if rp_n > 0 else 0.0
+        pod_start.append({
+            "phase_name": name,
+            "count": int(n),
+            "start_avg_s": start_avg_s,
+            "sandbox_avg_s": sandbox_avg_s,
+            "other_avg_s": max(start_avg_s - sandbox_avg_s, 0.0)
+        })
+
     print("Querying controller performance by phase...")
     controller_ops_raw = metrics_by_phase(
         conn, metrics_path_str,
@@ -734,6 +774,31 @@ def main():
             "link": "cri.html"
         })
 
+    # Kubelet pod-start pipeline check: the node-local launch pipeline is
+    # congested even if no single stage below it trips its own threshold.
+    # Baseline against the probe phase (uncontended single-flight launches)
+    # rather than a magic constant.
+    pod_start_baseline_s = None
+    for row in pod_start:
+        if row['phase_name'] == 'probe':
+            pod_start_baseline_s = row['start_avg_s']
+
+    pod_start_worst = None
+    for row in pod_start:
+        if row['phase_name'].startswith('throughput'):
+            if pod_start_worst is None or row['start_avg_s'] > pod_start_worst['start_avg_s']:
+                pod_start_worst = row
+
+    if (pod_start_worst and pod_start_baseline_s is not None
+            and pod_start_worst['start_avg_s'] > max(3.0, 3 * pod_start_baseline_s)):
+        w = pod_start_worst
+        findings.append({
+            "severity": "critical" if w['start_avg_s'] > 10.0 else "warning",
+            "title": f"Kubelet Pod-Start Pipeline Congested ({w['start_avg_s']:.1f}s avg)",
+            "desc": f"During phase {w['phase_name']}, the kubelet took an average of {w['start_avg_s']:.1f}s to start each pod (pod_start_sli, which excludes image pulls and scheduling) against an uncontended baseline of {pod_start_baseline_s:.1f}s in the probe phase. {w['sandbox_avg_s']:.1f}s of that is inside the CRI run_podsandbox call and {w['other_avg_s']:.1f}s is queueing around it in kubelet pod workers — the launch pipeline is saturated on the nodes themselves. See the per-phase breakdown on the CRI page; digging further needs node-level profiling (containerd/CNI plugin execution).",
+            "link": "cri.html"
+        })
+
     # Controller check: ratio of reconciles per sandbox created
     phase_created_map = {p['name']: p.get('created', 0) for p in summary.get('phases', [])}
     
@@ -954,6 +1019,7 @@ def main():
         "active_page": "cri",
         "summary": summary,
         "cri_ops": cri_ops,
+        "pod_start": pod_start,
         "chart_data": cri_chart_data,
         "phases": js_phases
     }

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -253,9 +253,11 @@ def main():
     ]
 
     # Kubelet pod-start pipeline: pod_start_sli is the kubelet's own measure
-    # of starting a pod (excluding image pulls and scheduling). Comparing it
-    # to run_podsandbox splits node-local latency into "inside the CRI
-    # sandbox call" vs "queued around it in kubelet pod workers".
+    # of starting a pod (excluding image pulls and scheduling). run_podsandbox
+    # is a separately-counted CRI histogram, so the two averages are over
+    # different populations (retries, in-flight-at-scrape) and their
+    # difference is an approximation of the non-CRI portion, not an exact
+    # decomposition -- treat it as "roughly how much is outside the CRI call".
     print("Querying kubelet pod start pipeline...")
     pod_start_by_phase = {
         row[0]: (row[1], row[2]) for row in metrics_by_phase(
@@ -289,6 +291,8 @@ def main():
             "count": int(n),
             "start_avg_s": start_avg_s,
             "sandbox_avg_s": sandbox_avg_s,
+            # Approximate: pod_start_sli and run_podsandbox are different
+            # populations, so this difference is indicative, not exact.
             "other_avg_s": max(start_avg_s - sandbox_avg_s, 0.0)
         })
 
@@ -795,7 +799,7 @@ def main():
         findings.append({
             "severity": "critical" if w['start_avg_s'] > 10.0 else "warning",
             "title": f"Kubelet Pod-Start Pipeline Congested ({w['start_avg_s']:.1f}s avg)",
-            "desc": f"During phase {w['phase_name']}, the kubelet took an average of {w['start_avg_s']:.1f}s to start each pod (pod_start_sli, which excludes image pulls and scheduling) against an uncontended baseline of {pod_start_baseline_s:.1f}s in the probe phase. {w['sandbox_avg_s']:.1f}s of that is inside the CRI run_podsandbox call and {w['other_avg_s']:.1f}s is queueing around it in kubelet pod workers — the launch pipeline is saturated on the nodes themselves. See the per-phase breakdown on the CRI page; digging further needs node-level profiling (containerd/CNI plugin execution).",
+            "desc": f"During phase {w['phase_name']}, the kubelet took an average of {w['start_avg_s']:.1f}s to start each pod (pod_start_sli, which excludes image pulls and scheduling) against an uncontended baseline of {pod_start_baseline_s:.1f}s in the probe phase. The CRI run_podsandbox call averaged {w['sandbox_avg_s']:.1f}s over the same phase (a separately-counted metric, so roughly {w['other_avg_s']:.1f}s of pod start is outside that call — in kubelet pod-worker queueing). The launch pipeline is saturated on the nodes themselves. See the per-phase breakdown on the CRI page; digging further needs node-level profiling (containerd/CNI plugin execution).",
             "link": "cri.html"
         })
 

--- a/test/stress/generate-report/templates/cri.html
+++ b/test/stress/generate-report/templates/cri.html
@@ -34,8 +34,9 @@
     <div class="card-title">Kubelet Pod Start Pipeline by Phase</div>
     <div class="card-desc" style="margin-bottom: 8px;">
         pod_start_sli is the kubelet's own pod-startup time (excludes image pulls and
-        scheduling). The split shows how much of it is inside the CRI run_podsandbox call
-        vs queued around it in kubelet pod workers.
+        scheduling); run_podsandbox is the separately-counted CRI call. They are measured
+        over different populations, so "outside run_podsandbox" is their approximate
+        difference (kubelet pod-worker queueing), not an exact split.
     </div>
     <div class="table-container">
         <table id="pod-start-table"></table>
@@ -58,7 +59,7 @@
         {key: 'count', label: 'Pods Started'},
         {key: 'start_avg_s', label: 'Avg Pod Start (SLI)', render: secBadge(3, 10)},
         {key: 'sandbox_avg_s', label: 'of which run_podsandbox', render: secBadge(2, 5)},
-        {key: 'other_avg_s', label: 'of which kubelet workers', render: secBadge(2, 5)}
+        {key: 'other_avg_s', label: 'outside run_podsandbox (approx)', render: secBadge(2, 5)}
     ], podStart);
 
     const criOps = {{ cri_ops | tojson }};

--- a/test/stress/generate-report/templates/cri.html
+++ b/test/stress/generate-report/templates/cri.html
@@ -30,6 +30,18 @@
     </div>
 </div>
 
+<div class="card" style="margin-bottom: 32px;">
+    <div class="card-title">Kubelet Pod Start Pipeline by Phase</div>
+    <div class="card-desc" style="margin-bottom: 8px;">
+        pod_start_sli is the kubelet's own pod-startup time (excludes image pulls and
+        scheduling). The split shows how much of it is inside the CRI run_podsandbox call
+        vs queued around it in kubelet pod workers.
+    </div>
+    <div class="table-container">
+        <table id="pod-start-table"></table>
+    </div>
+</div>
+
 <div class="card">
     <div class="card-title">Kubelet Runtime Operations by Phase</div>
     <div class="table-container">
@@ -38,6 +50,17 @@
 </div>
 
 <script>
+    const podStart = {{ pod_start | tojson }};
+    const secBadge = (warn, bad) => v =>
+        badge(v > bad ? 'danger' : v > warn ? 'warning' : 'success', v.toFixed(2) + 's');
+    renderTable('#pod-start-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'count', label: 'Pods Started'},
+        {key: 'start_avg_s', label: 'Avg Pod Start (SLI)', render: secBadge(3, 10)},
+        {key: 'sandbox_avg_s', label: 'of which run_podsandbox', render: secBadge(2, 5)},
+        {key: 'other_avg_s', label: 'of which kubelet workers', render: secBadge(2, 5)}
+    ], podStart);
+
     const criOps = {{ cri_ops | tojson }};
     renderTable('#cri-ops-table', [
         {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},


### PR DESCRIPTION
Stacked on #1194 (first two commits) and #1202 (next two); **review the last commit only**. Stacking all of it means this PR's presubmit runs the full tuned configuration and its report demonstrates the new finding on real data.

The tuning sequence so far took throughput-mif200 from 4.4 → 8.5 → **15.6 ready/s** (mean launch latency 31s → 9.3s → 7.8s). But the latest run's report was silent: `run_podsandbox` dropped to 3.4s, under the CRI finding's 5s threshold, and nothing else tripped — no warning about what limits us now.

What limits us now, from run 2078062675492868096: the node-local pod-start pipeline. `kubelet_pod_start_sli` (kubelet's own pod-startup time, excluding image pulls and scheduling) averages **7.1s at mif200 vs a 1.5s uncontended probe baseline** — 3.4s inside the CRI `run_podsandbox` call and 3.7s queued around it in kubelet pod workers — while every control-plane stage is healthy (apiserver 4ms, scheduler 4ms, controller ack ~0, Cilium limiter/processing/client-throttle all near zero).

This commit adds:
- A **Kubelet Pod Start Pipeline** table on the CRI page: per phase, average pod start (SLI) split into `run_podsandbox` vs kubelet-worker time. On the pre-tuning run it cleanly shows the old story too (30.1s start, 28.9s of it in the sandbox call); on the new run it shows the even CRI/worker split.
- A finding — **Kubelet Pod-Start Pipeline Congested** — that fires when a throughput phase's average pod start exceeds 3× the probe baseline (and 3s absolute); critical above 10s. Baselining against the probe phase avoids a magic constant that goes stale as we keep tuning.

With this, the report for the tuned configuration says: `Kubelet Pod-Start Pipeline Congested (7.1s avg)` — and, from the #1202 page, `Client-side API Throttling in kube-controller-manager (0.19s avg wait)`, which is the next layer already becoming visible at 15.6 pods/s. Digging into the kubelet/containerd side will need node-level data (containerd metrics or the bpftrace profiler from #1122).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Rate Limiting** page to stress test reports, covering client-side throttling and API Priority & Fairness queueing.
  * Added pod-start pipeline breakdowns showing overall latency, sandbox creation time, and worker queue time.
  * Added visual severity indicators, charts, and tables for rate-limiting and pod-start metrics.
* **Bug Fixes**
  * Improved metric calculations and phase attribution for more consistent report results.
  * Updated benchmark setup to apply optimized Cilium rate-limit settings before testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->