### PR TITLE
stress-test: only apply cilium settings when cilium is the CNI

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -144,6 +144,13 @@ echo "Creating kOps cluster configuration..."
 # stress test can scrape them (promscrape.go already targets this port; the
 # 2077449092094496768 run showed pod-sandbox creation as the launch
 # bottleneck, and CNI endpoint regeneration latency lives in these metrics).
+# Only set when cilium is the CNI: the --set alone materializes a
+# spec.networking.cilium section, and kOps rejects a cluster with two
+# networking options.
+CNI_KOPS_FLAGS=()
+if [[ "${CNI}" == "cilium" ]]; then
+    CNI_KOPS_FLAGS+=("--set" "cluster.spec.networking.cilium.enablePrometheusMetrics=true")
+fi
 kops create cluster \
   --cloud=gce \
   --gce-service-account=default \
@@ -163,7 +170,7 @@ kops create cluster \
   --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/readyz \
   --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/livez \
   --set cluster.spec.kubeScheduler.authorizationAlwaysAllowPaths=/metrics \
-  --set cluster.spec.networking.cilium.enablePrometheusMetrics=true
+  ${CNI_KOPS_FLAGS[@]+"${CNI_KOPS_FLAGS[@]}"}
 
 echo "Applying cluster configuration..."
 kops update cluster --name "${CLUSTER_NAME}" --yes
@@ -174,32 +181,34 @@ kops export kubeconfig --name "${CLUSTER_NAME}" --admin
 echo "Waiting for cluster to be ready..."
 kops validate cluster --wait 10m
 
-# Raise Cilium's endpoint-create API rate limit. The agent rate-limits
-# endpoint creation (the synchronous PUT /v1/endpoint the CNI plugin makes
-# during every pod sandbox creation) to 0.5/s with auto-adjustment anchored
-# to a 2s estimated processing duration. Under churn, queueing pushes mean
-# processing toward that anchor, so the auto-adjusted limit converges to
-# ~2 creates/s per node while actual endpoint work takes ~100ms — capping
-# pod launch throughput at the limiter, not the datapath (see the stress
-# report's Cilium page, e.g. run 2077526390265090048: 20.8s mean limiter
-# wait vs 1.6s processing at throughput-mif200). Raise the limits and
-# disable auto-adjustment so the stress test measures the CNI datapath's
-# real capacity; kOps applies its addons at bootstrap, so this patch is not
-# reverted during the run.
-echo "Raising Cilium endpoint-create API rate limits..."
-# k8s-client-qps/burst: with the endpoint-create limiter raised, the next
-# cork is cilium-agent's client-go QPS limit (default 5/s, burst 10): run
-# 2077921435870826496 showed ~0.4s of client-side throttle wait per POST and
-# ~1.4s per DELETE to the apiserver during churn, ~7s per endpoint create in
-# total, while the apiserver itself answered in ~20ms.
-kubectl --namespace kube-system patch configmap cilium-config --type merge \
-  --patch '{"data":{"api-rate-limit":"endpoint-create=rate-limit:100/s,rate-burst:100,parallel-requests:32,auto-adjust:false","k8s-client-qps":"50","k8s-client-burst":"100"}}'
-# kOps deploys the cilium DaemonSet with updateStrategy=OnDelete, so
-# "rollout restart" never recreates the pods (and "rollout status" errors
-# out). Delete the agent pods so the DaemonSet brings them back with the
-# new config, then re-validate the cluster to wait for them to be Ready.
-kubectl --namespace kube-system delete pods --selector=k8s-app=cilium
-kops validate cluster --wait 5m
+if [[ "${CNI}" == "cilium" ]]; then
+  # Raise Cilium's endpoint-create API rate limit. The agent rate-limits
+  # endpoint creation (the synchronous PUT /v1/endpoint the CNI plugin makes
+  # during every pod sandbox creation) to 0.5/s with auto-adjustment anchored
+  # to a 2s estimated processing duration. Under churn, queueing pushes mean
+  # processing toward that anchor, so the auto-adjusted limit converges to
+  # ~2 creates/s per node while actual endpoint work takes ~100ms — capping
+  # pod launch throughput at the limiter, not the datapath (see the stress
+  # report's Cilium page, e.g. run 2077526390265090048: 20.8s mean limiter
+  # wait vs 1.6s processing at throughput-mif200). Raise the limits and
+  # disable auto-adjustment so the stress test measures the CNI datapath's
+  # real capacity; kOps applies its addons at bootstrap, so this patch is not
+  # reverted during the run.
+  echo "Raising Cilium endpoint-create API rate limits..."
+  # k8s-client-qps/burst: with the endpoint-create limiter raised, the next
+  # cork is cilium-agent's client-go QPS limit (default 5/s, burst 10): run
+  # 2077921435870826496 showed ~0.4s of client-side throttle wait per POST and
+  # ~1.4s per DELETE to the apiserver during churn, ~7s per endpoint create in
+  # total, while the apiserver itself answered in ~20ms.
+  kubectl --namespace kube-system patch configmap cilium-config --type merge \
+    --patch '{"data":{"api-rate-limit":"endpoint-create=rate-limit:100/s,rate-burst:100,parallel-requests:32,auto-adjust:false","k8s-client-qps":"50","k8s-client-burst":"100"}}'
+  # kOps deploys the cilium DaemonSet with updateStrategy=OnDelete, so
+  # "rollout restart" never recreates the pods (and "rollout status" errors
+  # out). Delete the agent pods so the DaemonSet brings them back with the
+  # new config, then re-validate the cluster to wait for them to be Ready.
+  kubectl --namespace kube-system delete pods --selector=k8s-app=cilium
+  kops validate cluster --wait 5m
+fi
 
 # Deploy to cluster
 echo "Deploying to cluster..."


### PR DESCRIPTION
The kindnet benchmark fails at cluster creation: we try to set cilium options when using kindnet, which does not go well.

/test presubmit-agent-sandbox-benchmarks-kops-gcp-kindnet
/test presubmit-agent-sandbox-benchmarks-kops-gcp-cilium

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark setup to apply Cilium-specific configuration only when Cilium is selected.
  * Prevented non-Cilium runs from applying unrelated networking settings or restarting Cilium components.
  * Improved benchmark reliability across different container network interface configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->