### PR TITLE
WIP: stress-test: mount container overlayfs volatile

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -127,6 +127,16 @@ trap cleanup EXIT
 CNI="${CNI:-cilium}"
 echo "Using CNI: ${CNI}"
 
+# Cluster-scale experiment: 20 worker nodes instead of 3. Per-node launch
+# throughput is wall-limited at ~5 pods/s (node I/O; see the Node Kernel
+# report page), so cluster throughput scales with node count -- this run
+# pushes ~100 pods/s through the control plane to find the cluster-scale
+# bottlenecks (apiserver CPU hit 4.5-5.5 cores at ~87/s in the 1122-era
+# runs; the sandbox controller workqueue and KCM client QPS are the other
+# candidates).
+STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
+echo "Using node count: ${STRESS_NODE_COUNT}"
+
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
 kops create cluster \
@@ -138,7 +148,7 @@ kops create cluster \
   --project="${PROJECT_ID}" \
   --control-plane-count=1 \
   --control-plane-size=n2-standard-8 \
-  --node-count=3 \
+  --node-count="${STRESS_NODE_COUNT}" \
   --node-size=n2-standard-8
 
 # Spec tuning is applied as separate `kops edit cluster --set` blocks rather
@@ -267,7 +277,7 @@ echo "Running stress test"
 # stress tool itself (metrics.jsonl.gz; see --collect-metrics).
 set +o errexit
 go run ./test/stress \
-  --phases="${STRESS_PHASES:-fill,probe,throughput-mif200,throughput-mif100,throughput-mif50}" \
+  --phases="${STRESS_PHASES:-fill,probe,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
   --fill-per-node="${STRESS_FILL_PER_NODE:-10}" \
   --probe-count="${STRESS_PROBE_COUNT:-30}" \
   --throughput-count="${STRESS_THROUGHPUT_COUNT:-500}" \

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -197,6 +197,37 @@ if [[ "${CNI}" == "cilium" ]]; then
     --set cluster.spec.networking.cilium.enablePrometheusMetrics=true
 fi
 
+# Overlay 'volatile' experiment: mount container overlayfs with the volatile
+# option (kernel 5.10+), which skips ALL syncs of the overlay including the
+# ovl_sync_fs storm at pod teardown that the node profiler measured (run
+# 2078168408230203392). Sandbox pods are ephemeral: after a node crash the
+# upperdir is discarded anyway, which is exactly the volatile contract.
+# The containerd overlayfs snapshotter reads mount_options from its config;
+# kOps configAdditions cannot express TOML arrays, so a node hook appends
+# the snippet to /etc/containerd/config.toml (the file kOps generates and
+# points containerd at) before containerd starts. The base64 payload decodes
+# to:
+#   [plugins."io.containerd.snapshotter.v1.overlayfs"]
+#     mount_options = ["volatile"]
+STRESS_OVERLAY_VOLATILE="${STRESS_OVERLAY_VOLATILE:-true}"
+if [[ "${STRESS_OVERLAY_VOLATILE}" == "true" ]]; then
+  echo "Adding overlayfs volatile hook to cluster spec..."
+  kops get cluster --name "${CLUSTER_NAME}" -o yaml > "${WORKDIR}/cluster.yaml"
+  cat >> "${WORKDIR}/cluster.yaml" <<'HOOK_EOF'
+  hooks:
+  - name: containerd-overlay-volatile
+    before:
+    - containerd.service
+    roles:
+    - Node
+    manifest: |
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/bin/sh -c "echo CltwbHVnaW5zLiJpby5jb250YWluZXJkLnNuYXBzaG90dGVyLnYxLm92ZXJsYXlmcyJdCiAgbW91bnRfb3B0aW9ucyA9IFsidm9sYXRpbGUiXQo= | base64 -d >> /etc/containerd/config.toml"
+HOOK_EOF
+  kops replace -f "${WORKDIR}/cluster.yaml"
+fi
+
 echo "Applying cluster configuration..."
 kops update cluster --name "${CLUSTER_NAME}" --yes
 

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -254,6 +254,46 @@ def main():
         for row in cri_ts_raw
     ]
 
+    # Kubelet pod-start pipeline: pod_start_sli is the kubelet's own measure
+    # of starting a pod (excluding image pulls and scheduling). Comparing it
+    # to run_podsandbox splits node-local latency into "inside the CRI
+    # sandbox call" vs "queued around it in kubelet pod workers".
+    print("Querying kubelet pod start pipeline...")
+    pod_start_by_phase = {
+        row[0]: (row[1], row[2]) for row in metrics_by_phase(
+            conn, metrics_path_str,
+            metrics=["kubelet_pod_start_sli_duration_seconds_count",
+                     "kubelet_pod_start_sli_duration_seconds_sum"])
+        if row[1] > 0
+    }
+    run_podsandbox_by_phase = {
+        row[0]: (row[1], row[2]) for row in metrics_by_phase(
+            conn, metrics_path_str,
+            metrics=["kubelet_runtime_operations_duration_seconds_count",
+                     "kubelet_runtime_operations_duration_seconds_sum"],
+            labels={"operation_type": "operation_type"},
+            group_by=[],
+            where="operation_type = 'run_podsandbox'")
+        if row[1] > 0
+    }
+
+    pod_start = []
+    for phase in summary.get('phases', []):
+        name = phase['name']
+        if name not in pod_start_by_phase:
+            continue
+        n, total = pod_start_by_phase[name]
+        start_avg_s = total / n
+        rp_n, rp_total = run_podsandbox_by_phase.get(name, (0, 0.0))
+        sandbox_avg_s = rp_total / rp_n if rp_n > 0 else 0.0
+        pod_start.append({
+            "phase_name": name,
+            "count": int(n),
+            "start_avg_s": start_avg_s,
+            "sandbox_avg_s": sandbox_avg_s,
+            "other_avg_s": max(start_avg_s - sandbox_avg_s, 0.0)
+        })
+
     print("Querying controller performance by phase...")
     controller_ops_raw = metrics_by_phase(
         conn, metrics_path_str,
@@ -799,6 +839,31 @@ def main():
             "link": "cri.html"
         })
 
+    # Kubelet pod-start pipeline check: the node-local launch pipeline is
+    # congested even if no single stage below it trips its own threshold.
+    # Baseline against the probe phase (uncontended single-flight launches)
+    # rather than a magic constant.
+    pod_start_baseline_s = None
+    for row in pod_start:
+        if row['phase_name'] == 'probe':
+            pod_start_baseline_s = row['start_avg_s']
+
+    pod_start_worst = None
+    for row in pod_start:
+        if row['phase_name'].startswith('throughput'):
+            if pod_start_worst is None or row['start_avg_s'] > pod_start_worst['start_avg_s']:
+                pod_start_worst = row
+
+    if (pod_start_worst and pod_start_baseline_s is not None
+            and pod_start_worst['start_avg_s'] > max(3.0, 3 * pod_start_baseline_s)):
+        w = pod_start_worst
+        findings.append({
+            "severity": "critical" if w['start_avg_s'] > 10.0 else "warning",
+            "title": f"Kubelet Pod-Start Pipeline Congested ({w['start_avg_s']:.1f}s avg)",
+            "desc": f"During phase {w['phase_name']}, the kubelet took an average of {w['start_avg_s']:.1f}s to start each pod (pod_start_sli, which excludes image pulls and scheduling) against an uncontended baseline of {pod_start_baseline_s:.1f}s in the probe phase. {w['sandbox_avg_s']:.1f}s of that is inside the CRI run_podsandbox call and {w['other_avg_s']:.1f}s is queueing around it in kubelet pod workers — the launch pipeline is saturated on the nodes themselves. See the per-phase breakdown on the CRI page; digging further needs node-level profiling (containerd/CNI plugin execution).",
+            "link": "cri.html"
+        })
+
     # Controller check: ratio of reconciles per sandbox created
     phase_created_map = {p['name']: p.get('created', 0) for p in summary.get('phases', [])}
     
@@ -1036,6 +1101,7 @@ def main():
         "active_page": "cri",
         "summary": summary,
         "cri_ops": cri_ops,
+        "pod_start": pod_start,
         "chart_data": cri_chart_data,
         "phases": js_phases
     }

--- a/test/stress/generate-report/templates/cri.html
+++ b/test/stress/generate-report/templates/cri.html
@@ -30,6 +30,18 @@
     </div>
 </div>
 
+<div class="card" style="margin-bottom: 32px;">
+    <div class="card-title">Kubelet Pod Start Pipeline by Phase</div>
+    <div class="card-desc" style="margin-bottom: 8px;">
+        pod_start_sli is the kubelet's own pod-startup time (excludes image pulls and
+        scheduling). The split shows how much of it is inside the CRI run_podsandbox call
+        vs queued around it in kubelet pod workers.
+    </div>
+    <div class="table-container">
+        <table id="pod-start-table"></table>
+    </div>
+</div>
+
 <div class="card">
     <div class="card-title">Kubelet Runtime Operations by Phase</div>
     <div class="table-container">
@@ -38,6 +50,17 @@
 </div>
 
 <script>
+    const podStart = {{ pod_start | tojson }};
+    const secBadge = (warn, bad) => v =>
+        badge(v > bad ? 'danger' : v > warn ? 'warning' : 'success', v.toFixed(2) + 's');
+    renderTable('#pod-start-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'count', label: 'Pods Started'},
+        {key: 'start_avg_s', label: 'Avg Pod Start (SLI)', render: secBadge(3, 10)},
+        {key: 'sandbox_avg_s', label: 'of which run_podsandbox', render: secBadge(2, 5)},
+        {key: 'other_avg_s', label: 'of which kubelet workers', render: secBadge(2, 5)}
+    ], podStart);
+
     const criOps = {{ cri_ops | tojson }};
     renderTable('#cri-ops-table', [
         {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},


### PR DESCRIPTION
Stacked on #1204 (review the last commit only). Node I/O wall experiment 2 of 3: pod teardown syncs the overlay upperdir (`ovl_sync_fs`/`sync_inodes_sb`/jbd2 stacks in the profiler data) — but sandbox pods are ephemeral, and the kernel has a first-class answer: the overlayfs `volatile` mount option (5.10+) skips all overlay syncs, with the contract that the upperdir is discarded after a crash. That is exactly the sandbox lifecycle.

containerd's overlayfs snapshotter takes `mount_options` from config; kOps `configAdditions` can't express TOML arrays, so a node hook appends the two-line snippet to /etc/containerd/config.toml before containerd starts (base64 in the unit to avoid triple quoting; decoded form in the script comment). `STRESS_OVERLAY_VOLATILE=false` reverts. This one is also a candidate for **production node profile docs**, unlike tmpfs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional node-level profiling during stress benchmarks, capturing CPU, I/O wait, kernel, syscall, and container runtime activity.
  - Added Rate Limiting and Node Kernel sections to generated reports, with charts, phase-based analysis, and diagnostic tables.
  - Added Kubelet pod-start pipeline breakdowns to CRI reporting.
  - Added optional tmpfs container storage and volatile overlay filesystem benchmark modes.
  - Added a standalone tool for analyzing fsync and syscall performance.

- **Improvements**
  - Improved CNI-specific cluster configuration and Cilium readiness handling.
  - Standardized metric delta calculations across report analyses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->