### PR TITLE
docs(python): clarify Sandbox/AsyncSandbox terminate() idempotency docs

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -139,6 +139,21 @@ class AsyncSandbox:
         logging.info(f"Connection to sandbox claim '{self.claim_name}' has been closed.")
 
     async def terminate(self):
-        """Permanent deletion of all server side infrastructure and client side connection."""
+        """
+        Permanent deletion of all server side infrastructure and client side connection.
+
+        This method is idempotent. After a successful delete, ``claim_name`` is
+        cleared so later calls are a local no-op and do not issue another DELETE.
+        If the claim is already gone remotely, ``delete_sandbox_claim`` treats a
+        404 as success rather than raising.
+        """
         await self._close_connection()
+
+        if not self.claim_name:
+            # Already deleted (or never successfully created a claim).
+            return
+
         await self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
+
+        # Clear only after success so a failed delete can be retried.
+        self.claim_name = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -193,16 +193,18 @@ class AsyncSandbox:
         """
         Permanent deletion of all server side infrastructure and client side connection.
 
-        This method is idempotent. Calling ``terminate()`` repeatedly after a
-        successful deletion is a safe no-op. If the remote infrastructure has
-        already been removed, subsequent calls will handle the API 404 gracefully
-        rather than raising an error.
+        This method is idempotent. After a successful delete, ``claim_name`` is
+        cleared so later calls are a local no-op and do not issue another DELETE.
+        If the claim is already gone remotely, ``delete_sandbox_claim`` treats a
+        404 as success rather than raising.
         """
         await self.close_connection()
 
         if not self.claim_name:
+            # Already deleted (or never successfully created a claim).
             return
 
         await self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
 
+        # Clear only after success so a failed delete can be retried.
         self.claim_name = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -191,10 +191,10 @@ class Sandbox:
         """
         Permanent deletion of all server side infrastructure and client side connection.
 
-        This method is idempotent. Calling ``terminate()`` repeatedly after a
-        successful deletion is a safe no-op. If the remote infrastructure has
-        already been removed, subsequent calls will handle the API 404 gracefully
-        rather than raising an error.
+        This method is idempotent. After a successful delete, ``claim_name`` is
+        cleared so later calls are a local no-op and do not issue another DELETE.
+        If the claim is already gone remotely, ``delete_sandbox_claim`` treats a
+        404 as success rather than raising.
         """
         # Close the client side connection and trace manager lifecycle
         self.close_connection()
@@ -205,7 +205,7 @@ class Sandbox:
 
         self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
 
-        # Clear after successful delete so a retry does not 404.
+        # Clear only after success so a failed delete can be retried.
         self.claim_name = None
 
  

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -192,10 +192,10 @@ class Sandbox:
         """
         Permanent deletion of all server side infrastructure and client side connection.
 
-        This method is idempotent. Calling ``terminate()`` repeatedly after a
-        successful deletion is a safe no-op. If the remote infrastructure has
-        already been removed, subsequent calls will handle the API 404 gracefully
-        rather than raising an error.
+        This method is idempotent. After a successful delete, ``claim_name`` is
+        cleared so later calls are a local no-op and do not issue another DELETE.
+        If the claim is already gone remotely, ``delete_sandbox_claim`` treats a
+        404 as success rather than raising.
         """
         # Close the client side connection and trace manager lifecycle
         self.close_connection()
@@ -206,5 +206,5 @@ class Sandbox:
 
         self.k8s_helper.delete_sandbox_claim(self.claim_name, self.namespace)
 
-        # Clear after successful delete so a retry does not 404.
+        # Clear only after success so a failed delete can be retried.
         self.claim_name = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -467,6 +467,62 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         self.assertIs(callback.__func__, AsyncSandbox.get_pod_ip)
 
 
+class TestAsyncSandboxTerminateIdempotent(unittest.IsolatedAsyncioTestCase):
+    """`AsyncSandbox.terminate()` must be idempotent — a second call must not
+    issue a redundant DELETE."""
+
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncFilesystem")
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncCommandExecutor")
+    @patch("k8s_agent_sandbox.async_sandbox.create_tracer_manager")
+    @patch("k8s_agent_sandbox.async_sandbox.AsyncSandboxConnector")
+    def _build_sandbox(self, mock_connector, mock_tracer, mock_cmd, mock_files):
+        mock_tracer.return_value = (MagicMock(), MagicMock())
+        mock_connector.return_value.close = AsyncMock()
+        k8s_helper = MagicMock()
+        k8s_helper.delete_sandbox_claim = AsyncMock()
+        return AsyncSandbox(
+            claim_name="my-claim",
+            sandbox_id="my-claim",
+            namespace="demo",
+            connection_config=SandboxDirectConnectionConfig(
+                api_url="http://test-router:8080", server_port=8888
+            ),
+            k8s_helper=k8s_helper,
+        ), k8s_helper
+
+    async def test_second_terminate_does_not_redelete(self):
+        sandbox, helper = self._build_sandbox()
+
+        await sandbox.terminate()
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 1)
+        self.assertIsNone(sandbox.claim_name)
+
+        # Second call must be a no-op.
+        await sandbox.terminate()
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 1)
+
+    async def test_failed_terminate_preserves_claim_name_for_retry(self):
+        """When delete_sandbox_claim raises, claim_name must NOT be cleared —
+        otherwise a transient 5xx / network blip would hide the error and
+        the caller would have no handle to retry or clean up manually."""
+        sandbox, helper = self._build_sandbox()
+
+        helper.delete_sandbox_claim.side_effect = RuntimeError("transient 500")
+
+        with self.assertRaisesRegex(RuntimeError, "transient 500"):
+            await sandbox.terminate()
+
+        # claim_name must be preserved so the caller can retry.
+        self.assertEqual(sandbox.claim_name, "my-claim")
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 1)
+
+        # Retry succeeds and clears the handle.
+        helper.delete_sandbox_claim.side_effect = None
+        await sandbox.terminate()
+        self.assertEqual(helper.delete_sandbox_claim.call_count, 2)
+        self.assertIsNone(sandbox.claim_name)
+
+
 class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -305,7 +305,7 @@ class TestSandbox(unittest.TestCase):
 
 class TestSandboxTerminateIdempotent(unittest.TestCase):
     """`Sandbox.terminate()` must be idempotent — a second call must not
-    issue a redundant DELETE that would return 404."""
+    issue a redundant DELETE."""
 
     @patch('k8s_agent_sandbox.sandbox.Filesystem')
     @patch('k8s_agent_sandbox.sandbox.CommandExecutor')


### PR DESCRIPTION
#### What this PR does / why we need it:

The idempotency guard this PR originally added to `AsyncSandbox.terminate()` has since landed via #999. Rebased on top of that, so this PR is now just a docs/comments accuracy fix:
- Clarify the `terminate()` docstring on both `Sandbox` and `AsyncSandbox`: idempotency comes from the local `claim_name` guard, not from "handling API 404s" as the old wording implied (404-as-success is `delete_sandbox_claim`'s job).
- Tighten the inline comments and test docstring to match. No behavior change.

<details>
<summary>original description (obsolete)</summary>

`AsyncSandbox.terminate()` missed the idempotency guard that sync `Sandbox.terminate()` already has:

https://github.com/kubernetes-sigs/agent-sandbox/blob/b2a5fe9beac93c5d4d6ffee9ce98f52502b2f89f/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py#L190-L209

https://github.com/kubernetes-sigs/agent-sandbox/blob/b2a5fe9beac93c5d4d6ffee9ce98f52502b2f89f/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py#L141-L144

after a successful delete it kept calling `delete_sandbox_claim` on subsequent calls, and a `None` `claim_name` could be passed to the API.

This PR mirrors the sync Sandbox guard:
- skip delete when `claim_name` is unset
- clear `claim_name` only after a successful delete (preserve it on failure for retry)
- add unit tests matching the sync suite
- clarify terminate comments so they accurately describe local no-op vs helper 404 handling

</details>

#### Which issue(s) this PR is related to:

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified sandbox termination behavior, including successful deletion, repeated termination calls, and handling of already-deleted resources.
  * Documented that failed deletion attempts remain retryable.
  * Updated test documentation to reflect idempotent termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->