### PR TITLE
stress-test report: client-side watch event explorer

### DIFF
--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -1011,6 +1011,19 @@ def main():
         shutil.copy(f, output_dir / f.name)
         print(f"Copied CPU profile: {output_dir / f.name}")
 
+    # Copy the watch stream so watch.html can fetch and parse it client-side.
+    # Always name the copy watch.jsonl, even when the input is watch.jsonl.gz:
+    # prow's GCS artifact uploader strips a .gz suffix on upload (the run
+    # artifacts show watch.jsonl.gz stored as watch.jsonl), so a page
+    # referencing the .gz name 404s in CI. The client detects gzip by magic
+    # bytes rather than by extension, so the bare name works for both
+    # compressed and uncompressed inputs.
+    watch_log_name = None
+    if watch_file.exists():
+        watch_log_name = "watch.jsonl"
+        shutil.copy(watch_file, output_dir / watch_log_name)
+        print(f"Copied watch log: {output_dir / watch_log_name}")
+
     def render_page(template_name, output_filename, context):
         template = env.get_template(template_name)
         rendered = template.render(context)
@@ -1115,6 +1128,15 @@ def main():
         "pprof_profiles": pprof_profiles
     }
     render_page("pprof.html", "pprof.html", pprof_ctx)
+
+    # Watch events context
+    watch_ctx = {
+        "active_page": "watch",
+        "summary": summary,
+        "watch_log": watch_log_name,
+        "phases": js_phases
+    }
+    render_page("watch.html", "watch.html", watch_ctx)
 
     print("All report pages generated successfully!")
 

--- a/test/stress/generate-report/static/report.css
+++ b/test/stress/generate-report/static/report.css
@@ -426,6 +426,11 @@ th.sortable[data-order="desc"]::after {
     white-space: nowrap;
 }
 
+.watch-row-head:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: -2px;
+}
+
 .watch-time {
     color: var(--text-secondary);
     flex-shrink: 0;

--- a/test/stress/generate-report/static/report.css
+++ b/test/stress/generate-report/static/report.css
@@ -400,3 +400,146 @@ th.sortable[data-order="desc"]::after {
     font-family: var(--font-sans);
     overflow-x: auto;
 }
+
+/* Watch events page */
+.watch-results {
+    margin-top: 16px;
+    border-top: 2px solid var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+}
+
+.watch-row {
+    border-bottom: 1px solid #e5e5e0;
+    cursor: pointer;
+}
+
+.watch-row:hover {
+    background-color: #faf9f6;
+}
+
+.watch-row-head {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 6px 8px;
+    white-space: nowrap;
+}
+
+.watch-time {
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.watch-offset {
+    color: #a3a19b;
+    font-size: 0.9em;
+}
+
+.watch-phase {
+    color: var(--accent-primary);
+    font-family: var(--font-sans);
+    font-size: 0.7rem;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.watch-kind {
+    font-weight: 500;
+    flex-shrink: 0;
+}
+
+.watch-name {
+    color: var(--accent-primary);
+    text-decoration: none;
+    flex-shrink: 0;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.watch-name:hover {
+    text-decoration: underline;
+}
+
+.watch-summary {
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+}
+
+.watch-reason {
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.watch-muted {
+    color: #a3a19b;
+}
+
+.diff-old {
+    color: var(--accent-danger);
+    background-color: #fef2f2;
+    padding: 0 3px;
+    border-radius: 2px;
+    text-decoration: line-through;
+    text-decoration-color: rgba(185, 28, 28, 0.45);
+}
+
+.diff-new {
+    color: var(--accent-success);
+    background-color: #f0fdf4;
+    padding: 0 3px;
+    border-radius: 2px;
+}
+
+.diff-arrow {
+    color: var(--text-secondary);
+}
+
+.watch-row-detail {
+    padding: 4px 8px 14px 8px;
+    cursor: auto;
+}
+
+.watch-diff-table {
+    font-size: 0.8rem;
+}
+
+.watch-diff-table td {
+    padding: 4px 12px;
+    vertical-align: top;
+}
+
+.watch-diff-table td:last-child {
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.watch-object {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    background-color: #f1f0ea;
+    border-radius: 4px;
+    padding: 12px;
+    max-height: 480px;
+    overflow: auto;
+    white-space: pre-wrap;
+}
+
+.watch-more {
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+    padding: 6px 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--card-bg);
+    color: var(--text-primary);
+    cursor: pointer;
+}
+
+.watch-more:hover {
+    background-color: rgba(28, 26, 23, 0.05);
+}

--- a/test/stress/generate-report/static/watch.js
+++ b/test/stress/generate-report/static/watch.js
@@ -170,19 +170,23 @@ function parseQuery(text) {
     return terms;
 }
 
-function singular(word) {
-    return word.endsWith('s') ? word.slice(0, -1) : word;
+// kindMatches reports whether a query token names the given kind (already
+// lower-cased and singular, e.g. "pod", "sandbox"). Plural queries match by
+// appending "s"/"es" to the kind rather than stripping suffixes from the
+// query: singularizing "sandboxes" naively yields "sandboxe", which would
+// never equal "sandbox". An empty kind (no involvedObject) matches nothing.
+function kindMatches(kindLower, query) {
+    return kindLower !== '' &&
+        (kindLower === query || kindLower + 's' === query || kindLower + 'es' === query);
 }
 
 function matchesEvent(ev, terms) {
     for (const term of terms) {
         const v = term.value;
         switch (term.key) {
-            case 'kind': {
-                const want = singular(v);
-                if (singular(ev.kindLower) !== want && singular(ev.targetKindLower) !== want) return false;
+            case 'kind':
+                if (!kindMatches(ev.kindLower, v) && !kindMatches(ev.targetKindLower, v)) return false;
                 break;
-            }
             case 'name':
                 if (!ev.nameLower.includes(v)) return false;
                 break;
@@ -193,7 +197,9 @@ function matchesEvent(ev, terms) {
                 if (!ev.type.toLowerCase().startsWith(v)) return false;
                 break;
             case 'resource':
-                if (!singular(ev.resource.toLowerCase()).startsWith(singular(v))) return false;
+                // Resource names are plural ("pods"); a singular query is a
+                // prefix of the plural, so prefix matching covers both.
+                if (!ev.resource.toLowerCase().startsWith(v)) return false;
                 break;
             case 'uid':
                 if (!ev.uid.startsWith(v) && !ev.targetUid.startsWith(v)) return false;

--- a/test/stress/generate-report/static/watch.js
+++ b/test/stress/generate-report/static/watch.js
@@ -1,0 +1,322 @@
+/*
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Client-side watch.jsonl viewer: loader, index, query engine and object
+// differ for the Kubernetes watch stream captured by the stress tool.
+//
+// The file is one JSON object per line:
+//   {"timestamp": "...", "resource": "pods", "type": "MODIFIED", "object": {...}}
+// and can be large (tens of thousands of events, ~100MB decompressed), so
+// the design mirrors flamegraph.js: fetch the whole file (gunzipping if
+// needed), keep the decompressed bytes as a single Uint8Array, and retain
+// only a small index record per event. Full objects are decoded and parsed
+// on demand (detail view, diff computation), never held all at once.
+
+// loadWatchLog fetches the watch log, gunzips it if the bytes are gzip
+// (the file may be stored compressed with or without a .gz name, or the
+// server may have already transparently decoded it), and indexes it.
+// onProgress(stage, detail) is called as loading advances.
+async function loadWatchLog(url, onProgress) {
+    const progress = onProgress || (() => {});
+    progress('downloading', '');
+    let resp = await fetch(url);
+    if (!resp.ok) {
+        // The same bytes may sit under either name: prow's GCS uploader
+        // strips a .gz suffix on upload, while download_results.py restores
+        // it locally. Retry with the suffix toggled before giving up.
+        const alt = url.endsWith('.gz') ? url.slice(0, -3) : url + '.gz';
+        const altResp = await fetch(alt);
+        if (!altResp.ok) {
+            throw new Error(`fetching ${url}: HTTP ${resp.status}`);
+        }
+        resp = altResp;
+    }
+    let buf = new Uint8Array(await resp.arrayBuffer());
+    if (buf[0] === 0x1f && buf[1] === 0x8b) {
+        progress('decompressing', '');
+        const gunzip = new Response(new Blob([buf]).stream().pipeThrough(new DecompressionStream('gzip')));
+        buf = new Uint8Array(await gunzip.arrayBuffer());
+    }
+    return indexWatchLog(buf, progress);
+}
+
+// indexWatchLog scans the decompressed buffer once, JSON-parsing each line
+// to extract a small per-event index record, then discards the parsed
+// object. Yields to the event loop periodically so the page stays live.
+//
+// For Event objects the searchable identity (kind/namespace/name/uid) is
+// taken from involvedObject, so "kind:pod name:foo" surfaces both the pod's
+// own watch events and the Events emitted about it.
+async function indexWatchLog(buf, onProgress) {
+    const progress = onProgress || (() => {});
+    const decoder = new TextDecoder();
+    const events = [];
+    // Last event index per stored object (resource + object uid), linking
+    // each event to the previous state of the same object for diffing.
+    const lastByObject = new Map();
+
+    let start = 0;
+    while (start < buf.length) {
+        let end = buf.indexOf(0x0a, start); // '\n'
+        if (end === -1) end = buf.length;
+        if (end > start) {
+            let entry;
+            try {
+                entry = JSON.parse(decoder.decode(buf.subarray(start, end)));
+            } catch (err) {
+                entry = null; // tolerate a truncated final line
+            }
+            if (entry && entry.object) {
+                events.push(makeIndexRecord(entry, start, end, events.length, lastByObject));
+            }
+        }
+        start = end + 1;
+        if (events.length % 5000 === 0) {
+            progress('indexing', `${events.length.toLocaleString()} events`);
+            await new Promise(resolve => setTimeout(resolve, 0));
+        }
+    }
+    progress('done', `${events.length.toLocaleString()} events`);
+    return { buf, events };
+}
+
+function makeIndexRecord(entry, start, end, index, lastByObject) {
+    const obj = entry.object;
+    const meta = obj.metadata || {};
+    const isEvent = obj.kind === 'Event';
+    // Events are indexed under the object they describe.
+    const involved = isEvent ? (obj.involvedObject || {}) : null;
+
+    const kind = obj.kind || entry.resource || '?';
+    const targetKind = involved ? (involved.kind || '') : '';
+    const name = involved ? (involved.name || meta.name || '') : (meta.name || '');
+    const namespace = (involved ? involved.namespace : meta.namespace) || meta.namespace || '';
+    const reason = isEvent ? (obj.reason || '') : '';
+    const message = isEvent ? (obj.message || '') : '';
+
+    const objectKey = `${entry.resource}:${meta.uid || meta.name || ''}`;
+    const prev = lastByObject.has(objectKey) ? lastByObject.get(objectKey) : -1;
+    lastByObject.set(objectKey, index);
+
+    return {
+        start, end,
+        t: Date.parse(entry.timestamp),
+        resource: entry.resource || '',
+        type: entry.type || '',
+        kind,
+        kindLower: kind.toLowerCase(),
+        targetKind,
+        targetKindLower: targetKind.toLowerCase(),
+        namespace,
+        name,
+        nameLower: name.toLowerCase(),
+        namespaceLower: namespace.toLowerCase(),
+        uid: meta.uid || '',
+        targetUid: involved ? (involved.uid || '') : '',
+        reason,
+        reasonLower: reason.toLowerCase(),
+        message,
+        prev,
+        hay: `${kind} ${targetKind} ${namespace}/${name} ${reason} ${message} ${entry.type} ${entry.resource}`.toLowerCase(),
+    };
+}
+
+// getEntry re-decodes and parses one line on demand, returning the full
+// {timestamp, resource, type, object} record.
+function getEntry(log, index) {
+    const ev = log.events[index];
+    return JSON.parse(new TextDecoder().decode(log.buf.subarray(ev.start, ev.end)));
+}
+
+// ---- Query engine ----
+//
+// A query is whitespace-separated terms, ANDed together:
+//   key:value  -- keys: kind, name, namespace/ns, type, resource, uid, reason
+//   bare text  -- substring match over kind, namespace/name, reason, message
+// Matching is case-insensitive; kind tolerates singular/plural (pod == pods);
+// name/namespace/reason/text are substring matches; type/resource are prefix
+// matches (type:mod == MODIFIED); uid is a prefix match.
+
+const QUERY_KEYS = ['kind', 'name', 'namespace', 'ns', 'type', 'resource', 'uid', 'reason'];
+
+function parseQuery(text) {
+    const terms = [];
+    for (const token of (text || '').trim().split(/\s+/)) {
+        if (!token) continue;
+        const sep = token.indexOf(':');
+        const key = sep > 0 ? token.slice(0, sep).toLowerCase() : '';
+        if (QUERY_KEYS.includes(key) && sep < token.length - 1) {
+            terms.push({
+                key: key === 'ns' ? 'namespace' : key,
+                value: token.slice(sep + 1).toLowerCase(),
+            });
+        } else {
+            terms.push({ key: 'text', value: token.toLowerCase() });
+        }
+    }
+    return terms;
+}
+
+function singular(word) {
+    return word.endsWith('s') ? word.slice(0, -1) : word;
+}
+
+function matchesEvent(ev, terms) {
+    for (const term of terms) {
+        const v = term.value;
+        switch (term.key) {
+            case 'kind': {
+                const want = singular(v);
+                if (singular(ev.kindLower) !== want && singular(ev.targetKindLower) !== want) return false;
+                break;
+            }
+            case 'name':
+                if (!ev.nameLower.includes(v)) return false;
+                break;
+            case 'namespace':
+                if (!ev.namespaceLower.includes(v)) return false;
+                break;
+            case 'type':
+                if (!ev.type.toLowerCase().startsWith(v)) return false;
+                break;
+            case 'resource':
+                if (!singular(ev.resource.toLowerCase()).startsWith(singular(v))) return false;
+                break;
+            case 'uid':
+                if (!ev.uid.startsWith(v) && !ev.targetUid.startsWith(v)) return false;
+                break;
+            case 'reason':
+                if (!ev.reasonLower.includes(v)) return false;
+                break;
+            default:
+                if (!ev.hay.includes(v)) return false;
+        }
+    }
+    return true;
+}
+
+function searchEvents(log, queryText, limit) {
+    const terms = parseQuery(queryText);
+    const matches = [];
+    for (let i = 0; i < log.events.length; i++) {
+        if (matchesEvent(log.events[i], terms)) {
+            matches.push(i);
+            if (limit && matches.length >= limit) break;
+        }
+    }
+    return matches;
+}
+
+// ---- Object diffing ----
+
+// Paths whose churn is noise, never worth showing.
+const DIFF_SKIP_PATHS = new Set(['metadata.managedFields']);
+
+// Candidate identity fields for aligning array elements, in preference
+// order — the same fields Kubernetes strategic-merge-patch keys lists by
+// (conditions by type, containers/statuses by name, ...).
+const ARRAY_MERGE_KEYS = ['type', 'name', 'key', 'ip'];
+
+// arrayMergeKey returns a field name that uniquely identifies every element
+// of both arrays, or null to fall back to index alignment.
+function arrayMergeKey(a, b) {
+    for (const key of ARRAY_MERGE_KEYS) {
+        const ok = arr => {
+            const seen = new Set();
+            for (const el of arr) {
+                if (el === null || typeof el !== 'object' || Array.isArray(el)) return false;
+                const v = el[key];
+                if (typeof v !== 'string' || seen.has(v)) return false;
+                seen.add(v);
+            }
+            return true;
+        };
+        if ((a.length || b.length) && ok(a) && ok(b)) return key;
+    }
+    return null;
+}
+
+// diffObjects compares two plain JSON values and returns leaf-level changes
+// as [{path, from, to}] where from === undefined means the field was added
+// and to === undefined means it was removed. Arrays of keyed objects (e.g.
+// status.conditions) are aligned by their identity field so an inserted
+// element doesn't read as every later element changing; other arrays are
+// compared by index.
+function diffObjects(before, after) {
+    const out = [];
+    walk('', before, after);
+    return out;
+
+    function walk(path, a, b) {
+        if (DIFF_SKIP_PATHS.has(path)) return;
+        if (a === b) return;
+        const aIsObj = a !== null && typeof a === 'object';
+        const bIsObj = b !== null && typeof b === 'object';
+        if (aIsObj && bIsObj && Array.isArray(a) && Array.isArray(b)) {
+            const mergeKey = arrayMergeKey(a, b);
+            if (mergeKey) {
+                const byKey = arr => new Map(arr.map(el => [el[mergeKey], el]));
+                const aMap = byKey(a), bMap = byKey(b);
+                for (const key of new Set([...aMap.keys(), ...bMap.keys()])) {
+                    walk(`${path}[${key}]`, aMap.get(key), bMap.get(key));
+                }
+            } else {
+                for (let i = 0; i < Math.max(a.length, b.length); i++) {
+                    walk(`${path}[${i}]`, a[i], b[i]);
+                }
+            }
+            return;
+        }
+        if (aIsObj && bIsObj && !Array.isArray(a) && !Array.isArray(b)) {
+            for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+                walk(path ? `${path}.${key}` : String(key), a[key], b[key]);
+            }
+            return;
+        }
+        out.push({ path, from: a, to: b });
+    }
+}
+
+// diffForEvent computes the diff between this MODIFIED/DELETED event's
+// object and the previous captured state of the same object, or null when
+// there is no earlier state in the log.
+function diffForEvent(log, index) {
+    const ev = log.events[index];
+    if (ev.prev < 0) return null;
+    const before = getEntry(log, ev.prev).object;
+    const after = getEntry(log, index).object;
+    return diffObjects(before, after);
+}
+
+// formatDiffValue renders one side of a change compactly.
+function formatDiffValue(value, maxLen) {
+    if (value === undefined) return '∅';
+    let text = typeof value === 'string' ? value : JSON.stringify(value);
+    if (maxLen && text.length > maxLen) text = text.slice(0, maxLen - 1) + '…';
+    return text;
+}
+
+// Changes shown last in inline summaries: they accompany every write, so
+// they only add signal when nothing else changed.
+const DIFF_LOW_SIGNAL = new Set(['metadata.resourceVersion', 'metadata.generation']);
+
+function sortDiffForDisplay(changes) {
+    return changes.slice().sort((a, b) => {
+        const aLow = DIFF_LOW_SIGNAL.has(a.path) ? 1 : 0;
+        const bLow = DIFF_LOW_SIGNAL.has(b.path) ? 1 : 0;
+        return aLow - bLow || a.path.localeCompare(b.path);
+    });
+}

--- a/test/stress/generate-report/templates/base.html
+++ b/test/stress/generate-report/templates/base.html
@@ -62,6 +62,9 @@
             <li class="sidebar-item {% if active_page == 'pprof' %}active{% endif %}">
                 <a href="pprof.html">CPU Profiles</a>
             </li>
+            <li class="sidebar-item {% if active_page == 'watch' %}active{% endif %}">
+                <a href="watch.html">Watch Events</a>
+            </li>
         </ul>
     </div>
 

--- a/test/stress/generate-report/templates/watch.html
+++ b/test/stress/generate-report/templates/watch.html
@@ -78,10 +78,17 @@
         return phase ? phase.name : '';
     }
 
+    // tMs is NaN when the record's timestamp was missing or unparseable;
+    // toISOString() throws on invalid dates, which would abort rendering of
+    // the whole result batch over one bad line.
     function formatTime(tMs) {
+        if (!Number.isFinite(tMs)) {
+            return '<span class="watch-offset">no timestamp</span>';
+        }
         const iso = new Date(tMs).toISOString();
         const offset = (tMs - START_MS) / 1000;
-        return `${iso.slice(11, 23)} <span class="watch-offset">+${offset.toFixed(1)}s</span>`;
+        const offsetHtml = Number.isFinite(offset) ? ` <span class="watch-offset">+${offset.toFixed(1)}s</span>` : '';
+        return `${iso.slice(11, 23)}${offsetHtml}`;
     }
 
     function changeHtml(change, maxLen) {

--- a/test/stress/generate-report/templates/watch.html
+++ b/test/stress/generate-report/templates/watch.html
@@ -138,7 +138,7 @@
         const kindLabel = ev.resource === 'events' && ev.targetKind
             ? `Event·${escapeHtml(ev.targetKind)}` : escapeHtml(ev.kind);
         return `<div class="watch-row" data-i="${i}">
-            <div class="watch-row-head">
+            <div class="watch-row-head" tabindex="0" role="button" aria-expanded="false">
                 <span class="watch-time">${formatTime(ev.t)}</span>
                 ${phase ? `<span class="watch-phase">${escapeHtml(phase)}</span>` : ''}
                 ${badge(TYPE_BADGE[ev.type] || 'info', ev.type)}
@@ -178,6 +178,15 @@
 
     moreEl.addEventListener('click', renderMore);
 
+    function toggleRow(row) {
+        const detail = row.querySelector('.watch-row-detail');
+        if (detail.hidden && !detail.innerHTML) {
+            detail.innerHTML = renderDetail(Number(row.dataset.i));
+        }
+        detail.hidden = !detail.hidden;
+        row.querySelector('.watch-row-head').setAttribute('aria-expanded', String(!detail.hidden));
+    }
+
     resultsEl.addEventListener('click', e => {
         const nameLink = e.target.closest('.watch-name');
         if (nameLink) {
@@ -189,11 +198,19 @@
         }
         const row = e.target.closest('.watch-row');
         if (!row || window.getSelection().toString()) return;
-        const detail = row.querySelector('.watch-row-detail');
-        if (detail.hidden && !detail.innerHTML) {
-            detail.innerHTML = renderDetail(Number(row.dataset.i));
-        }
-        detail.hidden = !detail.hidden;
+        toggleRow(row);
+    });
+
+    // Keyboard equivalent of the click handler: the row heads are focusable
+    // buttons, so Enter/Space must expand them. Keys on the name link are
+    // left to its own native Enter -> click behavior.
+    resultsEl.addEventListener('keydown', e => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        if (e.target.closest('.watch-name')) return;
+        const head = e.target.closest('.watch-row-head');
+        if (!head) return;
+        e.preventDefault();
+        toggleRow(head.closest('.watch-row'));
     });
 
     (async () => {

--- a/test/stress/generate-report/templates/watch.html
+++ b/test/stress/generate-report/templates/watch.html
@@ -1,0 +1,226 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}Watch Events - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Kubernetes Watch Events{% endblock %}
+
+{% block content %}
+{% if watch_log %}
+<div class="card">
+    <div class="card-title">
+        <span>Watch stream explorer</span>
+        <span class="badge badge-info" id="watch-status">loading…</span>
+    </div>
+    <div class="profile-controls">
+        <input id="watch-search" type="search" style="max-width: none;"
+               placeholder="Search, e.g.  kind:pod name:fill-23   kind:sandbox type:deleted   reason:failedscheduling">
+    </div>
+    <div class="card-desc">
+        Terms are ANDed. <code>kind:</code>, <code>name:</code>, <code>ns:</code>, <code>type:</code>
+        (ADDED / MODIFIED / DELETED), <code>resource:</code>, <code>uid:</code>, <code>reason:</code>,
+        or bare text (matches name, reason and message). Kubernetes <code>Event</code> objects are
+        indexed under the object they describe, so <code>kind:pod name:foo</code> shows the pod's
+        watch events <em>and</em> the Events about it; use <code>resource:pods</code> /
+        <code>resource:events</code> to separate them. Click a row to expand the full change;
+        click a name to pull up that object's history.
+        MODIFIED rows show changed fields versus the previous captured state
+        (<code>metadata.managedFields</code> churn is hidden).
+    </div>
+    <div id="watch-results" class="watch-results"></div>
+    <div style="text-align: center; margin-top: 12px;">
+        <button id="watch-more" type="button" class="watch-more" hidden>Show more</button>
+    </div>
+    <div class="card-desc" style="margin-top: 12px;">
+        The raw stream sits next to this page (<a href="{{ watch_log }}"><code>{{ watch_log }}</code></a>),
+        one JSON watch event per line, and is parsed entirely in your browser at view time — so this
+        page must be served over HTTP (a <code>file://</code> URL cannot fetch sibling files).
+    </div>
+</div>
+
+<script src="watch.js"></script>
+<script>
+    const WATCH_LOG = {{ watch_log | tojson }};
+    const PHASES = {{ phases | tojson }};
+    const START_MS = Date.parse({{ summary.startTime | tojson }});
+    const RENDER_CHUNK = 300;
+
+    const statusEl = document.getElementById('watch-status');
+    const searchEl = document.getElementById('watch-search');
+    const resultsEl = document.getElementById('watch-results');
+    const moreEl = document.getElementById('watch-more');
+
+    let log = null;
+    let matches = [];
+    let rendered = 0;
+    const summaryCache = new Map(); // event index -> inline summary HTML
+
+    const TYPE_BADGE = { ADDED: 'success', MODIFIED: 'info', DELETED: 'danger' };
+
+    function phaseAt(tMs) {
+        const sec = (tMs - START_MS) / 1000;
+        const phase = PHASES.find(p => sec >= p.start_sec && sec < p.end_sec);
+        return phase ? phase.name : '';
+    }
+
+    function formatTime(tMs) {
+        const iso = new Date(tMs).toISOString();
+        const offset = (tMs - START_MS) / 1000;
+        return `${iso.slice(11, 23)} <span class="watch-offset">+${offset.toFixed(1)}s</span>`;
+    }
+
+    function changeHtml(change, maxLen) {
+        const from = escapeHtml(formatDiffValue(change.from, maxLen));
+        const to = escapeHtml(formatDiffValue(change.to, maxLen));
+        if (change.from === undefined) return `<span class="diff-new">${to}</span>`;
+        if (change.to === undefined) return `<span class="diff-old">${from}</span>`;
+        return `<span class="diff-old">${from}</span> <span class="diff-arrow">→</span> <span class="diff-new">${to}</span>`;
+    }
+
+    // Inline one-line summary: Events show reason+message, MODIFIED objects
+    // show their first few changed fields, ADDED/DELETED label themselves.
+    function rowSummary(i) {
+        if (summaryCache.has(i)) return summaryCache.get(i);
+        const ev = log.events[i];
+        let html;
+        if (ev.resource === 'events') {
+            html = `<span class="watch-reason">${escapeHtml(ev.reason)}</span> ${escapeHtml(ev.message)}`;
+        } else if (ev.type === 'MODIFIED') {
+            const changes = sortDiffForDisplay(diffForEvent(log, i) || []);
+            if (!changes.length) {
+                html = `<span class="watch-muted">${ev.prev < 0 ? 'no earlier state captured' : 'no visible change'}</span>`;
+            } else {
+                const shown = changes.slice(0, 3).map(c =>
+                    `<code>${escapeHtml(c.path)}</code>: ${changeHtml(c, 48)}`).join('<span class="watch-muted">, </span>');
+                const more = changes.length > 3 ? ` <span class="watch-muted">+${changes.length - 3} more</span>` : '';
+                html = shown + more;
+            }
+        } else {
+            html = `<span class="watch-muted">object ${ev.type === 'DELETED' ? 'deleted' : 'created'}</span>`;
+        }
+        summaryCache.set(i, html);
+        return html;
+    }
+
+    function renderDetail(i) {
+        const ev = log.events[i];
+        if (ev.type === 'MODIFIED' && ev.prev >= 0) {
+            const changes = sortDiffForDisplay(diffForEvent(log, i) || []);
+            if (changes.length) {
+                return '<table class="watch-diff-table"><thead><tr><th>Field</th><th>Change</th></tr></thead><tbody>' +
+                    changes.map(c => `<tr><td><code>${escapeHtml(c.path)}</code></td><td>${changeHtml(c, 2000)}</td></tr>`).join('') +
+                    '</tbody></table>';
+            }
+        }
+        const entry = getEntry(log, i);
+        return `<pre class="watch-object">${escapeHtml(JSON.stringify(entry.object, null, 2))}</pre>`;
+    }
+
+    function rowHtml(i) {
+        const ev = log.events[i];
+        const phase = phaseAt(ev.t);
+        const ident = ev.namespace ? `${ev.namespace}/${ev.name}` : ev.name;
+        const kindLabel = ev.resource === 'events' && ev.targetKind
+            ? `Event·${escapeHtml(ev.targetKind)}` : escapeHtml(ev.kind);
+        return `<div class="watch-row" data-i="${i}">
+            <div class="watch-row-head">
+                <span class="watch-time">${formatTime(ev.t)}</span>
+                ${phase ? `<span class="watch-phase">${escapeHtml(phase)}</span>` : ''}
+                ${badge(TYPE_BADGE[ev.type] || 'info', ev.type)}
+                <span class="watch-kind">${kindLabel}</span>
+                <a class="watch-name" href="#" data-uid="${escapeHtml(ev.targetUid || ev.uid)}" title="Show this object's history">${escapeHtml(ident)}</a>
+                <span class="watch-summary">${rowSummary(i)}</span>
+            </div>
+            <div class="watch-row-detail" hidden></div>
+        </div>`;
+    }
+
+    function renderMore() {
+        const next = matches.slice(rendered, rendered + RENDER_CHUNK);
+        resultsEl.insertAdjacentHTML('beforeend', next.map(rowHtml).join(''));
+        rendered += next.length;
+        moreEl.hidden = rendered >= matches.length;
+        moreEl.textContent = `Show more (${(matches.length - rendered).toLocaleString()} remaining)`;
+    }
+
+    function runSearch() {
+        if (!log) return;
+        matches = searchEvents(log, searchEl.value);
+        resultsEl.innerHTML = '';
+        rendered = 0;
+        statusEl.textContent = `${matches.length.toLocaleString()} / ${log.events.length.toLocaleString()} events`;
+        renderMore();
+    }
+
+    let debounce = null;
+    searchEl.addEventListener('input', () => {
+        clearTimeout(debounce);
+        debounce = setTimeout(() => {
+            history.replaceState(null, '', searchEl.value ? '#q=' + encodeURIComponent(searchEl.value) : '#');
+            runSearch();
+        }, 150);
+    });
+
+    moreEl.addEventListener('click', renderMore);
+
+    resultsEl.addEventListener('click', e => {
+        const nameLink = e.target.closest('.watch-name');
+        if (nameLink) {
+            e.preventDefault();
+            searchEl.value = 'uid:' + nameLink.dataset.uid;
+            history.replaceState(null, '', '#q=' + encodeURIComponent(searchEl.value));
+            runSearch();
+            return;
+        }
+        const row = e.target.closest('.watch-row');
+        if (!row || window.getSelection().toString()) return;
+        const detail = row.querySelector('.watch-row-detail');
+        if (detail.hidden && !detail.innerHTML) {
+            detail.innerHTML = renderDetail(Number(row.dataset.i));
+        }
+        detail.hidden = !detail.hidden;
+    });
+
+    (async () => {
+        try {
+            log = await loadWatchLog(WATCH_LOG, (stage, detail) => {
+                statusEl.textContent = detail ? `${stage} (${detail})` : stage + '…';
+            });
+            if (location.hash.startsWith('#q=')) {
+                searchEl.value = decodeURIComponent(location.hash.slice(3));
+            }
+            runSearch();
+        } catch (err) {
+            statusEl.textContent = 'load failed';
+            resultsEl.innerHTML = `<div class="card-desc">Failed to load <code>${escapeHtml(WATCH_LOG)}</code>: ${escapeHtml(err.message)}.<br>` +
+                'Note: the watch log is fetched at view time, so this page must be served over HTTP ' +
+                '(a file:// URL cannot fetch sibling files).</div>';
+        }
+    })();
+</script>
+{% else %}
+<div class="card">
+    <div class="card-title">No watch log in this run</div>
+    <div class="card-desc">
+        No <code>watch.jsonl</code> or <code>watch.jsonl.gz</code> file was found in the input
+        directory. The stress tool records the Kubernetes watch stream (pods, sandboxes, events,
+        nodes) while the test runs.
+    </div>
+</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Add a Watch Events page that loads watch.jsonl(.gz) entirely in the
browser, following the pprof.html pattern: fetch the file, gunzip via
DecompressionStream when the bytes are gzip, keep the decompressed
bytes as a single buffer, and retain only a small index record per
event; full objects are re-parsed on demand.

Queries are ANDed terms (kind:, name:, ns:, type:, resource:, uid:,
reason:, or bare text over name/reason/message) and live in the URL
hash so searches are shareable. Kubernetes Event objects are indexed
under their involvedObject, so kind:pod name:foo shows the pod's own
watch events and the Events about it in one timeline.

MODIFIED rows show changed fields versus the previous captured state
of the same object as "field: old -> new" with highlighting. Arrays
of keyed objects (conditions by type, containers by name) are aligned
by their identity field, strategic-merge style, so an inserted
condition doesn't read as every later element changing.
metadata.managedFields churn is hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Watch Events page to stress test reports.
  * View and search watch logs from `watch.jsonl` / `watch.jsonl.gz`.
  * Expand watch events to inspect JSON details and field-level changes (including prior-state diffs).
  * Incrementally load matching results and navigate between related object states.

* **UI Improvements**
  * Added “Watch Events” navigation in the report sidebar with an active state.
  * Added dedicated styling for the watch results list, expandable rows, and inline diffs.
  * Enhanced error/missing-log messaging when the watch file isn’t available at view time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->