### PR TITLE
stress-test: raise kube-scheduler and KCM client QPS to 500/500

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -172,10 +172,25 @@ kops edit cluster --name "${CLUSTER_NAME}" \
 # throughput-mif100..600 (saturation), and KCM's garbage collector is on
 # the sandbox delete path (sandbox -> ownerRef cascade -> pod delete), so
 # the closed-loop delete drain paces the whole benchmark: mif200 slots
-# cycled in ~8.8s of which only 1.6s was launch.
+# cycled in ~8.8s of which only 1.6s was launch. Raising to 100/200 still
+# left KCM throttling client-side, so go to 500/500 to take the client
+# limiter out of the measurement entirely.
 kops edit cluster --name "${CLUSTER_NAME}" \
-  --set cluster.spec.kubeControllerManager.kubeAPIQPS=100 \
-  --set cluster.spec.kubeControllerManager.kubeAPIBurst=200
+  --set cluster.spec.kubeControllerManager.kubeAPIQPS=500 \
+  --set cluster.spec.kubeControllerManager.kubeAPIBurst=500
+
+# kubeScheduler.qps/burst: the scheduler's client defaults (50/100) throttle
+# it under churn -- every sandbox is a pod to schedule, and each pod costs
+# the scheduler a binding plus status writes, which shows up as
+# kube-scheduler client-side throttle wait on the stress report's Rate
+# Limiting page. Match KCM at 500/500. Note these fields render into the
+# KubeSchedulerConfiguration file's clientConnection.qps/burst (the
+# scheduler's kubeAPIQPS/kubeAPIBurst spec fields map to the legacy
+# --kube-api-qps/--kube-api-burst flags, which current kube-schedulers no
+# longer accept).
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set cluster.spec.kubeScheduler.qps=500 \
+  --set cluster.spec.kubeScheduler.burst=500
 
 
 if [[ "${CNI}" == "cilium" ]]; then


### PR DESCRIPTION
Runs are showing kube-scheduler client-side throttling: the scheduler's
clientConnection defaults (50 QPS / 100 burst) rate-limit its binding
and status writes under sandbox churn, which surfaces as kube-scheduler
throttle wait on the stress report's Rate Limiting page.

Raise the scheduler to qps=500 / burst=500.

Also raise kube-controller-manager from 100/200 to the same 500/500:
matching the two takes both client limiters out of the measurement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased Kubernetes control-plane API throughput limits for benchmark configurations.
  * Applied matching throughput limits to the scheduler to support higher-load testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->