### PR TITLE
controller: default sandbox-concurrent-workers to 100

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -113,7 +113,7 @@ func main() {
 			"<=0 disables; 1 samples all events; N>1 samples ~1/N events (e.g. 10 ~= 1/10, 100 ~= 1/100).")
 	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", -1.0, "Client-side QPS limit for the Kubernetes API client (default: -1, no client-side rate limiting)")
 	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 10, "The maximum burst for client-side throttling of the Kubernetes API client.")
-	flag.IntVar(&sandboxConcurrentWorkers, "sandbox-concurrent-workers", 1, "Max concurrent reconciles for the Sandbox controller")
+	flag.IntVar(&sandboxConcurrentWorkers, "sandbox-concurrent-workers", 100, "Max concurrent reconciles for the Sandbox controller")
 	flag.IntVar(&sandboxClaimConcurrentWorkers, "sandbox-claim-concurrent-workers", 50, "Max concurrent reconciles for the SandboxClaim controller")
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")

--- a/dev/load-test/test-recipes/README-capacity-cliff.md
+++ b/dev/load-test/test-recipes/README-capacity-cliff.md
@@ -54,9 +54,9 @@ headless Service (`service: false`) and uses no `volumeClaimTemplates`, and the 
           memory: 2Gi
   ```
 
-  Raising the workers and QPS matters even though this is not a throughput test: with the defaults
-  (`--sandbox-concurrent-workers=1` and a low API burst) you would measure the controller's rate
-  limiter, not the cluster's capacity.
+  The number of sandbox workers matters even though this is not a throughput test:
+  with the defaults (`--sandbox-concurrent-workers=100`) you would measure the controller's sandbox
+  reconcile limiter, not the cluster's capacity.
 
 ### Node capacity: kwok vs. real nodes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,7 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 
 ## Concurrency Settings
 
-* `--sandbox-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the Sandbox controller.
+* `--sandbox-concurrent-workers` (default: 100): The maximum number of concurrent reconciles for the Sandbox controller.
 * `--sandbox-claim-concurrent-workers` (default: 50): The maximum number of concurrent reconciles for the SandboxClaim controller.
 * `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller.
 * `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch.

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -481,7 +481,7 @@ the controller Deployment's container args, namespace `agent-sandbox-system`):
 |---|---:|---:|---|
 | `--kube-api-qps` | `-1` | **`-1`** (leave) | `-1` disables client-side rate limiting entirely — already optimal. |
 | `--kube-api-burst` | `10` | n/a | **Moot while `qps=-1`** (burst is only consulted when QPS > 0). Only raise if you set a positive QPS. |
-| `--sandbox-concurrent-workers` | `1` | **`1000`** | Sandbox reconciles (claim binding → Ready) are the main serializer; match your peak concurrent sandboxes. |
+| `--sandbox-concurrent-workers` | `100` | **`1000`** | Sandbox reconciles (claim binding → Ready) are the main serializer; match your peak concurrent sandboxes. |
 | `--sandbox-claim-concurrent-workers` | `50` | **`1000`** | Concurrent `SandboxClaim` reconciles; match peak in-flight claims. |
 | `--sandbox-warm-pool-concurrent-workers` | `1` | **`1000`** | Parallel warm-pool reconciles (one per image pool); raise so many pools warm at once. |
 | `--sandbox-template-concurrent-workers` | `1` | **`1000`** | Parallel template reconciles. |


### PR DESCRIPTION
The stress test shows the sandbox controller queueing rather than
reconciling: we see sustained sandbox
workqueue depth, with items waiting in the queue far longer than the
actual reconcile work takes. With the default of 1, a single
reconciler thread serializes every Sandbox in the cluster.

Raise the default to 100. Sandbox reconciles are I/O-bound API calls,
so workers are cheap; the client is unthrottled by default
(kube-api-qps=-1), so the added workers do not just move the wait
into the client-side rate limiter; and the new worker total
(100 + 50 + 1 + 1) stays well under main.go's 1000-worker resource
warning. Users can still lower it with --sandbox-concurrent-workers.

Update the docs that quoted the old default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `--sandbox-concurrent-workers` guidance across configuration docs, examples, and load-test capacity materials to reflect the new default of **100** (previously **1**).
  * Clarified that default worker settings help measure the sandbox reconcile limiter behavior rather than raw cluster capacity, and updated the recommended test/scale values accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->