### PR TITLE
chore: update default value in helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,7 +39,7 @@ controller:
   # pprofMutexProfileFraction: 10
   # kubeApiQps: -1.0
   # kubeApiBurst: 10
-  # sandboxConcurrentWorkers: 1
+  # sandboxConcurrentWorkers: 100
   ##### The following are only active when controller.extensions=true.
   # sandboxClaimConcurrentWorkers: 50
   # sandboxWarmPoolConcurrentWorkers: 1


### PR DESCRIPTION
We raised the default number of reconcilers for the sandbox controller
to 100, and I should have reflected this in the helm chart.

It's only a comment, so this is a no-op change,
but it will help avoid confusion in the future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Increased the default number of concurrent sandbox workers from 1 to 100, enabling more sandbox tasks to run in parallel by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->