### PR TITLE
controller: don't write sandbox status for a nodeName-only change

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -453,6 +453,20 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 		return nil
 	}
 
+	// Pod scheduling produces a status change containing nothing but the
+	// node name (the pod is bound seconds before it runs, so nodeName lands
+	// in its own reconcile, then podIPs and Ready land together shortly
+	// after). While the sandbox is still transitioning, don't spend an API
+	// request on the node name alone: it rides along with the next status
+	// write instead, normally the Ready transition. Once the sandbox is
+	// Ready the deferral no longer applies -- a node change on a Ready
+	// sandbox should be impossible, but if it happens, write it through
+	// rather than leave a Ready sandbox with a wrong or missing node name.
+	if nodeNameOnlyChange(oldStatus, &sandbox.Status) &&
+		!meta.IsStatusConditionTrue(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady)) {
+		return nil
+	}
+
 	if err := r.Status().Update(ctx, sandbox); err != nil {
 		logger.Error(err, "Failed to update sandbox status")
 		return err
@@ -460,6 +474,17 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 
 	// Surface error
 	return nil
+}
+
+// nodeNameOnlyChange reports whether the node assignment is the only
+// difference between the two statuses.
+func nodeNameOnlyChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bool {
+	if oldStatus.NodeName == newStatus.NodeName {
+		return false
+	}
+	scratch := newStatus.DeepCopy()
+	scratch.NodeName = oldStatus.NodeName
+	return reflect.DeepEqual(oldStatus, scratch)
 }
 
 // GetNumericHash generates a raw FNV-1a hash value.

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -3859,3 +3859,91 @@ func BenchmarkNameHashOld(b *testing.B) {
 		_ = fmt.Sprintf("%08x", GetNumericHash("my-sandbox-name"))
 	}
 }
+
+// TestReconcileCoalescesNodeNameStatusWrite verifies that a status change
+// consisting only of the scheduled pod's node name is not written in its own
+// API request: the node name rides along with the next status write instead,
+// normally the Ready transition.
+func TestReconcileCoalescesNodeNameStatusWrite(t *testing.T) {
+	sandboxName := "sandbox-name"
+	sandboxNs := "sandbox-ns"
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}}
+
+	sb := &sandboxv1beta1.Sandbox{}
+	sb.Name = sandboxName
+	sb.Namespace = sandboxNs
+	sb.UID = sandboxUID
+	sb.Generation = 1
+	sb.Spec = sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+		PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		},
+	}}
+	r := &SandboxReconciler{
+		Client:        newFakeClient(sb),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	// Initial reconcile: creates the pod and writes the initial status.
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	beforeBind := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, beforeBind))
+	require.Empty(t, beforeBind.Status.NodeName)
+
+	// The pod reports Pending (its state from creation until it runs) and
+	// the sandbox status reflects that.
+	pod := &corev1.Pod{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, pod))
+	pod.Status.Phase = corev1.PodPending
+	require.NoError(t, r.Status().Update(t.Context(), pod))
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	beforeBind = &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, beforeBind))
+
+	// Scheduler binds the pod; nothing else about the sandbox changes, so no
+	// status write should happen.
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, pod))
+	pod.Spec.NodeName = "node-1"
+	require.NoError(t, r.Update(t.Context(), pod))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	live := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
+	assert.Empty(t, live.Status.NodeName, "node-name-only change should not be written on its own")
+	assert.Equal(t, beforeBind.ResourceVersion, live.ResourceVersion, "no status write expected for a node-name-only change")
+
+	// Pod becomes Ready: a single status write carries the node name, the
+	// pod IPs and the Ready condition together.
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, pod))
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.PodIPs = []corev1.PodIP{{IP: "10.0.0.8"}}
+	pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	require.NoError(t, r.Status().Update(t.Context(), pod))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
+	assert.Equal(t, "node-1", live.Status.NodeName)
+	assert.Equal(t, []string{"10.0.0.8"}, live.Status.PodIPs)
+	readyCondition := meta.FindStatusCondition(live.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCondition)
+	assert.Equal(t, metav1.ConditionTrue, readyCondition.Status)
+
+	// Once the sandbox is Ready the deferral no longer applies: a node
+	// change with no condition change (impossible in practice, but cheap to
+	// guard) is written through rather than leaving a Ready sandbox with a
+	// stale node name.
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, pod))
+	pod.Spec.NodeName = "node-2"
+	require.NoError(t, r.Update(t.Context(), pod))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
+	assert.Equal(t, "node-2", live.Status.NodeName, "node changes on a Ready sandbox must be written immediately")
+}


### PR DESCRIPTION
Pod scheduling produces a sandbox status update containing nothing but
the node name: the pod is bound seconds before it starts running, so
the controller writes {nodeName} in its own request, then {podIPs,
Ready} together shortly after. The 20-node stress run's watch stream
shows this in 1599 of 1680 sandbox lifecycles (95%) -- one full status
update request per sandbox carrying only status.nodeName.

While the sandbox is still transitioning (Ready is not True), skip the
write when the node assignment is the only status change: the node
name is informational during startup, and it rides along with the next
status write instead, normally the Ready transition a few seconds
later. Once Ready, a nodeName-only change is written through -- it
should be impossible, but if it happens a Ready sandbox must not be
left with a wrong or missing node name. Any other status change still
writes immediately.

The warm-pool queue keyed on Status.NodeName transitions learns the
node at Ready rather than at binding, which is the same event that
previously carried podIPs; a pod that stalls between scheduling and
running keeps an empty status.nodeName until its next condition
change, which is visible on the pod itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary status updates while a sandbox is still starting.
  - Node assignment changes are now recorded together with the sandbox’s Ready status and related connection details.
  - Once a sandbox is Ready, subsequent node assignment changes are reflected immediately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->