### PR TITLE
WIP: sandbox-controller: don't write the pod-name annotation for the default name

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1007,6 +1007,15 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil
 		}
 
+		// The annotation exists to track a pod whose name differs from the
+		// sandbox name (a warm-pool adoption). Every reader falls back to
+		// the sandbox name when the annotation is absent (resolvePodName,
+		// the Go and Python SDKs), so recording the default would spend an
+		// API request per sandbox to say nothing.
+		if podName == sandbox.Name {
+			return nil
+		}
+
 		patch := client.MergeFrom(sandbox.DeepCopy())
 		if sandbox.Annotations == nil {
 			sandbox.Annotations = make(map[string]string)

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1157,9 +1157,9 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "persists owner reference when adopting unowned pod whose labels are already correct",
@@ -1209,9 +1209,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "adopts unowned pod carrying legacy tracking label when adoptable label is absent",
@@ -1257,9 +1257,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name:    "reconcilePod creates a new Pod",
@@ -1288,9 +1288,9 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "drops user-supplied system-reserved labels and annotations to prevent hijacking",
@@ -1342,9 +1342,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "scrubs stale system labels/annotations recorded by an older controller",
@@ -1396,9 +1396,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "does not propagate system labels from Sandbox metadata to Pod",
@@ -1433,7 +1433,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "does not propagate system labels from Sandbox PodTemplate to Pod",
@@ -1470,7 +1470,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "does not propagate template-ref-hash from Sandbox metadata to Pod",
@@ -1505,7 +1505,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "propagates warm pool label from Sandbox owner reference to Pod",
@@ -1550,7 +1550,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes warm pool label from Pod when Sandbox is no longer owned by SandboxWarmPool",
@@ -1606,9 +1606,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "adds warm pool label to existing Pod when Sandbox is owned by SandboxWarmPool",
@@ -1676,9 +1676,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "propagates template-ref-hash label from Sandbox labels to new Pod",
@@ -1723,7 +1723,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "adds template-ref-hash label to existing Pod during reconciliation",
@@ -1787,7 +1787,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "both warm-pool-sandbox and template-ref-hash coexist on Pod",
@@ -1834,7 +1834,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes template-ref-hash label from Pod when Sandbox is not owned by extensions controller",
@@ -1888,9 +1888,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes template-ref-hash label from Pod when absent from Sandbox labels but still extensions-owned",
@@ -1953,9 +1953,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "delete pod if mode is Suspended",
@@ -2339,9 +2339,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "refuses to adopt unowned pod that lacks pool authorization label",
@@ -2408,9 +2408,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name:        "normalizes invalid created-by label to unknown",
@@ -2443,9 +2443,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "updates and normalizes created-by label on existing Pod",
@@ -2501,9 +2501,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes created-by label from existing Pod when Sandbox lacks it",
@@ -2552,9 +2552,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 	}
 


### PR DESCRIPTION
The sandbox controller patches agents.x-k8s.io/pod-name onto every
sandbox as soon as its pod exists -- one extra API request per sandbox
lifecycle.

This causes an extra cycle through the reconcile loop and hurts performance
because of extra requests to kube-apiserver.  We recently switched to using PATCH (without resourceVersion) to write status, but before that it would also cause conflicts.

All known clients (those in the repo) assume that when the annotation
is not present, that that podName == sandbox.name.  So we continue
to write the annotation if the pod name is not the sandbox name.  That
code path is not reachable from the sandbox controller, but may be reachable
from the sandbox claim / warmpool controllers.

Existing sandboxes that already carry the redundant annotation are
left untouched; removing it would spend the write we are saving.

The alternative path here (which we should consider) is to create a
status field instead.  That update would ride "for free" with other pod-related
status updates, and is arguably more correct than an annotation from an API design perspective.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided creating unnecessary tracking annotations when a sandbox adopts a pod with the same name.
  * Improved warm-pool adoption behavior by treating matching sandbox and pod names as the default case.
  * Updated reconciliation behavior to keep sandbox metadata clean in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->