### PR TITLE
stress-test: capture etcd server-side metrics

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -189,6 +189,26 @@ kops edit cluster --name "${CLUSTER_NAME}" \
   --set cluster.spec.kubeControllerManager.kubeAPIQPS=500 \
   --set cluster.spec.kubeControllerManager.kubeAPIBurst=500
 
+# etcdClusters[].manager.listenMetricsURLs: have etcd serve its dedicated
+# plain-HTTP metrics listener. etcd's client port requires mTLS, so the
+# stress tool deliberately does not scrape it; the metrics listener carries
+# /metrics without auth, and the tool reaches it through the apiserver pod
+# proxy like every other component. WAL fsync and backend-commit latency
+# live here -- the direct way to tell etcd disk stalls from control-plane
+# CPU starvation (run 2079306544964440064 needed exactly this distinction).
+# The ports differ because both etcd-manager pods (main and events) run
+# hostNetwork on the control-plane node, and neither can be etcd's
+# conventional 2381: kOps assigns 2380/2381/2382 as the main/events/cilium
+# PEER ports (pkg/model/components/etcdmanager PortsForCluster), so binding
+# the metrics listener there collides with etcd-events' peer listener and
+# etcd never comes up (run 2079330812058144768). 2391/2392 are outside
+# kOps' wellknownports range. Index addressing matches the order
+# `kops create cluster` emits: [0]=main, [1]=events. Not internet-reachable:
+# same deny-by-default VPC as the 10257/10259 note above.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set 'cluster.spec.etcdClusters[0].manager.listenMetricsURLs=http://0.0.0.0:2391' \
+  --set 'cluster.spec.etcdClusters[1].manager.listenMetricsURLs=http://0.0.0.0:2392'
+
 # kubeScheduler.qps/burst: the scheduler's client defaults (50/100) throttle
 # it under churn -- every sandbox is a pod to schedule, and each pod costs
 # the scheduler a binding plus status writes, which shows up as

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -438,6 +438,73 @@ def main():
             "avg_latency_ms": avg_latency_ms
         })
 
+    # etcd server-side disk latency (present when the cluster serves etcd's
+    # plain-HTTP metrics listener; see promscrape.go). WAL fsync is the write
+    # path's disk wait and backend commit is the boltdb flush: elevated
+    # client-observed etcd latency with FLAT fsync/commit numbers means the
+    # time is going to CPU starvation or queueing on the control-plane node,
+    # not storage (run 2079306544964440064 needed exactly this distinction).
+    print("Querying etcd disk latency by phase...")
+    etcd_disk_avg_raw = metrics_by_phase(
+        conn, metrics_path_str,
+        metrics=["etcd_disk_wal_fsync_duration_seconds_count",
+                 "etcd_disk_wal_fsync_duration_seconds_sum",
+                 "etcd_disk_backend_commit_duration_seconds_count",
+                 "etcd_disk_backend_commit_duration_seconds_sum"],
+        group_by=["source"],
+        where="source IN ('etcd-main', 'etcd-events')")
+
+    # p99 needs the histogram buckets: sum per-scrape bucket deltas per phase,
+    # then interpolate within the bucket that crosses the 99th percentile.
+    etcd_disk_bucket_raw = metrics_by_phase(
+        conn, metrics_path_str,
+        metrics=["etcd_disk_wal_fsync_duration_seconds_bucket",
+                 "etcd_disk_backend_commit_duration_seconds_bucket"],
+        labels={"le": "le"},
+        group_by=["source", "le"],
+        where="source IN ('etcd-main', 'etcd-events')")
+
+    def bucket_p99(buckets):
+        """buckets: {le(float): cumulative count delta} including +Inf."""
+        total = buckets.get(float("inf"), 0.0)
+        if total <= 0:
+            return 0.0
+        target = 0.99 * total
+        cum_prev, le_prev = 0.0, 0.0
+        for le in sorted(buckets):
+            cum = buckets[le]
+            if cum >= target:
+                if le == float("inf"):
+                    return le_prev * 1000
+                frac = (target - cum_prev) / max(cum - cum_prev, 1e-9)
+                return (le_prev + frac * (le - le_prev)) * 1000
+            cum_prev, le_prev = cum, le
+        return le_prev * 1000
+
+    etcd_disk_buckets = {}
+    for phase_name, source, le, fsync_delta, commit_delta in etcd_disk_bucket_raw:
+        le_f = float("inf") if le == "+Inf" else float(le)
+        entry = etcd_disk_buckets.setdefault((phase_name, source), ({}, {}))
+        entry[0][le_f] = entry[0].get(le_f, 0.0) + fsync_delta
+        entry[1][le_f] = entry[1].get(le_f, 0.0) + commit_delta
+
+    etcd_disk = []
+    for row in etcd_disk_avg_raw:
+        phase_name, source, fsync_n, fsync_sum, commit_n, commit_sum = row
+        if fsync_n <= 0 and commit_n <= 0:
+            continue
+        fsync_buckets, commit_buckets = etcd_disk_buckets.get((phase_name, source), ({}, {}))
+        etcd_disk.append({
+            "phase_name": phase_name,
+            "source": source,
+            "fsync_n": int(fsync_n),
+            "fsync_avg_ms": (fsync_sum / fsync_n * 1000) if fsync_n > 0 else 0.0,
+            "fsync_p99_ms": bucket_p99(fsync_buckets),
+            "commit_avg_ms": (commit_sum / commit_n * 1000) if commit_n > 0 else 0.0,
+            "commit_p99_ms": bucket_p99(commit_buckets),
+        })
+    etcd_disk.sort(key=lambda r: (phase_order_map_early.get(r["phase_name"], 99), r["source"]))
+
     print("Querying etcd timeseries...")
     etcd_ts_raw = metrics_timeseries(
         conn, metrics_path_str,
@@ -882,7 +949,25 @@ def main():
         findings.append({
             "severity": "warning",
             "title": f"Elevated etcd Update Latency ({etcd_update_latency_max:.2f}ms)",
-            "desc": f"etcd update operation average latency reached {etcd_update_latency_max:.2f}ms under load. While standard, high write latencies from etcd indicate write disk throughput contention.",
+            "desc": f"etcd update operation average latency reached {etcd_update_latency_max:.2f}ms under load. This is the apiserver's client-side view: check the etcd page's server-side WAL fsync latency to tell disk stalls from control-plane CPU starvation.",
+            "link": "etcd.html"
+        })
+
+    # etcd disk stall check: the client-side latency above cannot separate
+    # disk from CPU, but the server-side WAL fsync p99 can. etcd's own
+    # guidance is p99 fsync < 10ms on suitable disks.
+    fsync_worst = None
+    for row in etcd_disk:
+        if row['source'] == 'etcd-main' and row['phase_name'].startswith('throughput') and row['fsync_n'] >= 50:
+            if fsync_worst is None or row['fsync_p99_ms'] > fsync_worst['fsync_p99_ms']:
+                fsync_worst = row
+
+    if fsync_worst and fsync_worst['fsync_p99_ms'] > 10.0:
+        w = fsync_worst
+        findings.append({
+            "severity": "critical" if w['fsync_p99_ms'] > 100.0 else "warning",
+            "title": f"etcd WAL fsync Latency ({w['fsync_p99_ms']:.1f}ms p99)",
+            "desc": f"During phase {w['phase_name']}, etcd's WAL fsync p99 reached {w['fsync_p99_ms']:.1f}ms (avg {w['fsync_avg_ms']:.2f}ms over {w['fsync_n']:,} fsyncs). etcd waits on every write for this, so the storage volume is the bottleneck: consider a faster or larger etcd disk. If client-observed etcd latency is elevated while this number stays flat, the time is going to control-plane CPU instead.",
             "link": "etcd.html"
         })
 
@@ -1108,6 +1193,7 @@ def main():
         "active_page": "etcd",
         "summary": summary,
         "etcd_ops": etcd_ops,
+        "etcd_disk": etcd_disk,
         "chart_data": etcd_chart_data,
         "phases": js_phases
     }

--- a/test/stress/generate-report/static/report.css
+++ b/test/stress/generate-report/static/report.css
@@ -139,6 +139,44 @@ body {
     font-family: var(--font-sans);
 }
 
+/* In-page section navigation: sticky under the top of the viewport so the
+   reader always sees what sections a page has and where they are. Built by
+   report.js from the card titles. */
+.section-nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 20px;
+    padding: 10px 0;
+    margin-bottom: 24px;
+    background-color: var(--bg-color);
+    border-bottom: 1px solid var(--border-color);
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+}
+
+.section-nav a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.section-nav a:hover {
+    color: var(--text-primary);
+}
+
+.section-nav a.active {
+    color: var(--accent-primary);
+    font-weight: 700;
+}
+
+/* Anchor jumps must clear the sticky section nav. */
+.card {
+    scroll-margin-top: 64px;
+}
+
 /* Cards and Layout Grid */
 .grid {
     display: grid;

--- a/test/stress/generate-report/static/report.js
+++ b/test/stress/generate-report/static/report.js
@@ -86,6 +86,65 @@ function renderTable(selector, columns, rows) {
     table.replaceChildren(thead, tbody);
 }
 
+// ---- Section navigation ----
+//
+// Pages are a stack of cards, and anything below the first screenful is
+// easy to miss (the etcd disk-latency table shipped effectively invisible).
+// Build a sticky in-page nav from the card titles: one link per card, with
+// the section currently in view highlighted. Runs automatically on every
+// page with more than one card; no per-page wiring.
+function buildSectionNav() {
+    const main = document.querySelector('.main-content');
+    if (!main) return;
+    // Sections are titled cards; KPI stat tiles (cards with a .card-value)
+    // are not sections, so they don't get nav entries.
+    const cards = [...main.querySelectorAll('.card')]
+        .filter(c => c.querySelector('.card-title') && !c.querySelector('.card-value'));
+    if (cards.length < 2) return;
+
+    const nav = document.createElement('nav');
+    nav.className = 'section-nav';
+    const seen = new Map();
+    const links = cards.map(card => {
+        // Card titles may carry badges (live stats); the nav wants only the
+        // title text.
+        const titleEl = card.querySelector('.card-title').cloneNode(true);
+        titleEl.querySelectorAll('.badge').forEach(badge => badge.remove());
+        const title = titleEl.textContent.trim().replace(/\s+/g, ' ');
+        if (!card.id) {
+            let id = 'section-' + title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+            const n = seen.get(id) || 0;
+            seen.set(id, n + 1);
+            card.id = n ? `${id}-${n + 1}` : id;
+        }
+        const link = document.createElement('a');
+        link.href = '#' + card.id;
+        link.textContent = title;
+        nav.appendChild(link);
+        return { link, card };
+    });
+    const header = main.querySelector('.header');
+    if (header) {
+        header.insertAdjacentElement('afterend', nav);
+    } else {
+        main.prepend(nav);
+    }
+
+    // Scrollspy: the active section is the last card whose top has scrolled
+    // past the sticky nav.
+    const update = () => {
+        const threshold = nav.getBoundingClientRect().bottom + 24;
+        let active = links[0];
+        for (const l of links) {
+            if (l.card.getBoundingClientRect().top <= threshold) active = l;
+        }
+        links.forEach(l => l.link.classList.toggle('active', l === active));
+    };
+    document.addEventListener('scroll', update, { passive: true });
+    update();
+}
+document.addEventListener('DOMContentLoaded', buildSectionNav);
+
 // ---- Chart helpers ----
 
 const CHART_COLORS = [

--- a/test/stress/generate-report/templates/etcd.html
+++ b/test/stress/generate-report/templates/etcd.html
@@ -37,6 +37,27 @@
     </div>
 </div>
 
+<div class="card">
+    <div class="card-title">etcd Disk Latency by Phase (server-side)</div>
+    {% if etcd_disk %}
+    <div class="card-desc">
+        The request latencies above are the apiserver's client-side view and cannot separate disk
+        from CPU. These are etcd's own numbers: WAL fsync is the disk wait on every write, backend
+        commit is the periodic boltdb flush. If client latency rises while fsync stays flat, the
+        control plane is CPU-starved, not I/O-bound. etcd's guidance: fsync p99 under 10ms.
+    </div>
+    <div class="table-container">
+        <table id="etcd-disk-table"></table>
+    </div>
+    {% else %}
+    <div class="card-desc">
+        No etcd server-side metrics in this run. They are captured when etcd serves its plain-HTTP
+        metrics listener (<code>etcdClusters[].manager.listenMetricsURLs</code> on kOps); older runs
+        predate this.
+    </div>
+    {% endif %}
+</div>
+
 <script>
     const etcdOps = {{ etcd_ops | tojson }};
     renderTable('#etcd-ops-table', [
@@ -47,6 +68,23 @@
         {key: 'avg_latency_ms', label: 'Average Latency', render: v =>
             badge(v > 20 ? 'danger' : v > 5 ? 'warning' : 'success', v.toFixed(2) + 'ms')}
     ], etcdOps);
+
+    const etcdDisk = {{ etcd_disk | tojson }};
+    if (etcdDisk.length) {
+        renderTable('#etcd-disk-table', [
+            {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+            {key: 'source', label: 'Cluster', render: v => `<code>${escapeHtml(v)}</code>`},
+            {key: 'fsync_n', label: 'WAL fsyncs'},
+            {key: 'fsync_avg_ms', label: 'fsync avg', render: v =>
+                badge(v > 10 ? 'danger' : v > 2 ? 'warning' : 'success', v.toFixed(2) + 'ms')},
+            {key: 'fsync_p99_ms', label: 'fsync p99', render: v =>
+                badge(v > 100 ? 'danger' : v > 10 ? 'warning' : 'success', v.toFixed(1) + 'ms')},
+            {key: 'commit_avg_ms', label: 'backend commit avg', render: v =>
+                badge(v > 25 ? 'danger' : v > 5 ? 'warning' : 'success', v.toFixed(2) + 'ms')},
+            {key: 'commit_p99_ms', label: 'backend commit p99', render: v =>
+                badge(v > 250 ? 'danger' : v > 25 ? 'warning' : 'success', v.toFixed(1) + 'ms')}
+        ], etcdDisk);
+    }
 
     const chartData = {{ chart_data | tojson }};
     const phases = {{ phases | tojson }};

--- a/test/stress/promscrape.go
+++ b/test/stress/promscrape.go
@@ -47,7 +47,7 @@ import (
 // same pattern).
 type metricSample struct {
 	TS       time.Time       `json:"ts"`
-	Source   string          `json:"source"`   // kube-apiserver | kube-controller-manager | kube-scheduler | agent-sandbox-controller | kubelet
+	Source   string          `json:"source"`   // kube-apiserver | kube-controller-manager | kube-scheduler | agent-sandbox-controller | kubelet | cilium-agent | etcd-main | etcd-events
 	Instance string          `json:"instance"` // pod or node name
 	Metric   string          `json:"metric"`   // family name (+ _bucket/_sum/_count for histograms and summaries)
 	Labels   json.RawMessage `json:"labels,omitempty"`
@@ -61,7 +61,8 @@ type metricSample struct {
 // resolve or scrape is logged and skipped, never fatal.
 //
 // Not scraped (deliberately): cadvisor (very large, container-level resource
-// data) and etcd (requires client certificates).
+// data). etcd is scraped via its dedicated plain-HTTP metrics listener when
+// the cluster enables one (the client port requires mTLS and is skipped).
 type promScraper struct {
 	kube *kubernetes.Clientset
 
@@ -162,6 +163,17 @@ func (s *promScraper) resolveSources(ctx context.Context) []promSource {
 	// cilium is absent or metrics are disabled, the scrape is logged and
 	// skipped.
 	forPods("kube-system", "cilium-agent", "http", 9090, "k8s-app=cilium")
+	// etcd main and events: etcd's client port needs mTLS, but its dedicated
+	// metrics listener (--listen-metrics-urls; enabled on the stress cluster
+	// via etcdClusters[].manager.listenMetricsURLs) serves /metrics over
+	// plain HTTP. Ports are 2391/2392 — both pods share the control-plane
+	// host network, and etcd's conventional 2381 is already etcd-events'
+	// PEER port on kOps (2380/2381/2382 = main/events/cilium peers).
+	// WAL fsync and backend-commit latency live here — the signal that
+	// separates etcd disk stalls from control-plane CPU starvation.
+	// Best-effort: clusters without the listener just skip it.
+	forPods("kube-system", "etcd-main", "http", 2391, "k8s-app=etcd-manager-main")
+	forPods("kube-system", "etcd-events", "http", 2392, "k8s-app=etcd-manager-events")
 
 	nodes, err := s.kube.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
We're seeing etcd update latency (about 14ms), and we want to
narrow down the cause (in particular, whether it's CPU or I/O).

Capture etcd's own metrics: enable etcd's dedicated plain-HTTP metrics
listener on the stress cluster (etcdClusters[].manager.listenMetricsURLs,
ports 2381 main / 2382 events since both pods share the control-plane
host network; unreachable from outside the deny-by-default VPC), and
scrape it through the apiserver pod proxy like every other component.
Best-effort as usual: clusters without the listener skip it.

Surface the two disk-health numbers on the etcd report page per phase:
WAL fsync latency (the disk wait on every write) and backend commit
latency, avg from the sum/count deltas and p99 interpolated from the
histogram bucket deltas. Add a finding when fsync p99 exceeds etcd's
own 10ms guidance (critical above 100ms), and reword the existing
client-side latency finding to point at the new signal instead of
assuming disk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side etcd disk latency metrics to benchmark reports, including WAL fsync and backend commit averages and p99 values by phase.
  * Added severity indicators and a dedicated disk-latency report section.
  * Added detection for elevated etcd WAL fsync latency with warning and critical findings.
  * Benchmark metric collection now captures metrics from the main and events etcd services over dedicated listeners.
* **Bug Fixes**
  * Reports now clearly indicate when server-side etcd metrics were unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->