### PR TITLE
stress-test report: capture node-level CPU and iowait, add Node Resources page

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/node-exporter.yaml
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/node-exporter.yaml
@@ -1,0 +1,94 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# node-exporter for the stress test: node-level CPU (including iowait),
+# memory and disk stats, which nothing else exposes (kubelet metrics only
+# describe the kubelet process; cadvisor is deliberately not scraped).
+# The stress tool scrapes :9100 through the apiserver pod proxy
+# (see test/stress/promscrape.go), so the port needs no external exposure.
+#
+# Runs on every node INCLUDING the control plane (tolerations: Exists) --
+# control-plane CPU starvation is precisely the condition this exists to
+# measure, so it must survive there: system-node-critical priority and a
+# small dedicated CPU request keep it scheduled and running on a saturated
+# node. Collectors are restricted to the cheap /proc + /sys ones we chart.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+    spec:
+      hostNetwork: true
+      hostPID: true
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.8.2
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --web.listen-address=:9100
+            - --collector.disable-defaults
+            - --collector.cpu
+            - --collector.meminfo
+            - --collector.diskstats
+            - --collector.loadavg
+          ports:
+            - name: metrics
+              containerPort: 9100
+              hostPort: 9100
+          resources:
+            requests:
+              cpu: 50m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          # The enabled collectors only read world-readable /proc and /sys
+          # files, so run unprivileged (matching the upstream helm chart's
+          # defaults).
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -270,6 +270,14 @@ if [[ "${CNI}" == "cilium" ]]; then
   kops validate cluster --wait 5m
 fi
 
+# node-exporter: node-level CPU (incl. iowait), memory and disk stats for
+# every node including the control plane; the stress tool scrapes it via the
+# apiserver pod proxy (see promscrape.go). Without it the report cannot tell
+# control-plane CPU saturation from disk stalls at the node level.
+echo "Deploying node-exporter..."
+kubectl apply -f test/benchmarks/scenarios/benchmarks-kops-gcp/node-exporter.yaml
+kubectl --namespace kube-system rollout status daemonset/node-exporter --timeout=3m
+
 # Deploy to cluster. CONTROLLER_ARGS optionally appends controller flags
 # (e.g. "--enable-pprof-debug" so the stress tool's --profile-controller can
 # actually fetch CPU/heap profiles; see benchmarks-kops-gcp-claims).

--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -875,8 +875,116 @@ def main():
                 "limit": pod_capacity
             })
 
+    # Node-level CPU from node-exporter (source 'node'; captured when the
+    # scenario deploys the DaemonSet). node_cpu_seconds_total is a counter
+    # per cpu per mode; summing per-scrape deltas over cpus per node gives
+    # cpu-seconds by mode, so busy% = 1 - (idle + iowait) / total. iowait is
+    # carried separately: it is the waiting-on-disk share, the node-level
+    # number that distinguishes I/O starvation from CPU starvation.
+    def node_role(instance):
+        return "control-plane" if ("control-plane" in instance or "master" in instance) else "worker"
+
+    def cpu_shares(modes):
+        total = sum(modes.values())
+        if total <= 0:
+            return None
+        idle = modes.get("idle", 0.0)
+        iowait = modes.get("iowait", 0.0)
+        return ((total - idle - iowait) / total * 100, iowait / total * 100)
+
+    print("Querying node CPU by phase...")
+    node_cpu_raw = metrics_by_phase(
+        conn, metrics_path_str,
+        metrics=["node_cpu_seconds_total"],
+        labels={"mode": "mode", "cpu": "cpu"},
+        group_by=["instance", "mode"],
+        where="source = 'node'")
+
+    node_mode_seconds = {}
+    for phase_name, instance, mode, seconds in node_cpu_raw:
+        node_mode_seconds.setdefault((phase_name, instance), {})[mode] = seconds
+
+    # Per phase: one row for the control plane, one aggregated over workers.
+    node_cpu_summary = []
+    nodes_per_phase = {}
+    for (phase_name, instance), modes in node_mode_seconds.items():
+        shares = cpu_shares(modes)
+        if shares is not None:
+            nodes_per_phase.setdefault(phase_name, {}).setdefault(node_role(instance), []).append(shares)
+    for phase_name, roles in nodes_per_phase.items():
+        for role, shares in roles.items():
+            busy = [s[0] for s in shares]
+            iowait = [s[1] for s in shares]
+            node_cpu_summary.append({
+                "phase_name": phase_name,
+                "role": role,
+                "nodes": len(shares),
+                "busy_avg_pct": sum(busy) / len(busy),
+                "busy_max_pct": max(busy),
+                "iowait_avg_pct": sum(iowait) / len(iowait),
+                "iowait_max_pct": max(iowait),
+            })
+    node_cpu_summary.sort(key=lambda r: (phase_order_map_early.get(r["phase_name"], 99), r["role"]))
+
+    print("Querying node CPU timeseries...")
+    node_cpu_ts_raw = metrics_timeseries(
+        conn, metrics_path_str,
+        metrics=["node_cpu_seconds_total"],
+        labels={"mode": "mode", "cpu": "cpu"},
+        group_by=["instance", "mode"],
+        where="source = 'node'")
+
+    ts_modes = {}
+    for ts, instance, mode, seconds in node_cpu_ts_raw:
+        ts_modes.setdefault((ts, instance), {})[mode] = seconds
+    ts_roles = {}
+    for (ts, instance), modes in ts_modes.items():
+        shares = cpu_shares(modes)
+        if shares is not None:
+            ts_roles.setdefault(ts, {}).setdefault(node_role(instance), []).append(shares)
+    node_chart_data = []
+    for ts in sorted(ts_roles):
+        row = {"ts": ts}
+        for role, shares in ts_roles[ts].items():
+            prefix = "cp" if role == "control-plane" else "worker"
+            row[prefix + "_busy"] = sum(s[0] for s in shares) / len(shares)
+            row[prefix + "_iowait"] = sum(s[1] for s in shares) / len(shares)
+        node_chart_data.append(row)
+
     # 4. Analyzer rules to identify findings
     findings = []
+
+    # Node CPU / iowait checks: a saturated control-plane node slows every
+    # component on it (etcd, apiserver, KCM, scheduler), while iowait points
+    # at the disk instead.
+    cp_worst = None
+    io_worst = None
+    for row in node_cpu_summary:
+        if not row['phase_name'].startswith('throughput'):
+            continue
+        # Gate on the busiest node, not the role average: on an HA control
+        # plane one saturated node (e.g. the etcd leader) must not be
+        # averaged away by idle peers.
+        if row['role'] == 'control-plane' and (cp_worst is None or row['busy_max_pct'] > cp_worst['busy_max_pct']):
+            cp_worst = row
+        if io_worst is None or row['iowait_max_pct'] > io_worst['iowait_max_pct']:
+            io_worst = row
+
+    if cp_worst and cp_worst['busy_max_pct'] > 75.0:
+        findings.append({
+            "severity": "critical" if cp_worst['busy_max_pct'] > 90.0 else "warning",
+            "title": f"Control Plane CPU Saturation ({cp_worst['busy_max_pct']:.0f}% busy)",
+            "desc": f"During phase {cp_worst['phase_name']} the busiest control-plane node ran at {cp_worst['busy_max_pct']:.0f}% CPU busy (iowait {cp_worst['iowait_max_pct']:.1f}%). etcd, the apiserver, kube-controller-manager and the scheduler share these cores, so every control-plane latency — including client-observed etcd latency — inflates under this. Consider a larger control-plane machine type.",
+            "link": "nodes.html"
+        })
+
+    if io_worst and io_worst['iowait_max_pct'] > 10.0:
+        findings.append({
+            "severity": "critical" if io_worst['iowait_max_pct'] > 25.0 else "warning",
+            "title": f"Node I/O Wait ({io_worst['iowait_max_pct']:.1f}% iowait)",
+            "desc": f"During phase {io_worst['phase_name']}, a {io_worst['role']} node spent up to {io_worst['iowait_max_pct']:.1f}% of CPU time waiting on I/O. The disk, not the CPU, is pacing that node.",
+            "link": "nodes.html"
+        })
 
     # CRI check
     cri_run_pod_latency_max = 0.0
@@ -1233,6 +1341,16 @@ def main():
         "phases": js_phases
     }
     render_page("capacity.html", "capacity.html", capacity_ctx)
+
+    # Node resources context
+    nodes_ctx = {
+        "active_page": "nodes",
+        "summary": summary,
+        "node_cpu_summary": node_cpu_summary,
+        "chart_data": node_chart_data,
+        "phases": js_phases
+    }
+    render_page("nodes.html", "nodes.html", nodes_ctx)
 
     # CPU profiles context
     pprof_ctx = {

--- a/test/stress/generate-report/templates/base.html
+++ b/test/stress/generate-report/templates/base.html
@@ -59,6 +59,9 @@
             <li class="sidebar-item {% if active_page == 'capacity' %}active{% endif %}">
                 <a href="capacity.html">Cluster Capacity</a>
             </li>
+            <li class="sidebar-item {% if active_page == 'nodes' %}active{% endif %}">
+                <a href="nodes.html">Node Resources</a>
+            </li>
             <li class="sidebar-item {% if active_page == 'pprof' %}active{% endif %}">
                 <a href="pprof.html">CPU Profiles</a>
             </li>

--- a/test/stress/generate-report/templates/nodes.html
+++ b/test/stress/generate-report/templates/nodes.html
@@ -1,0 +1,98 @@
+<!--
+ Copyright 2026 The Kubernetes Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+{% extends "base.html" %}
+
+{% block title %}Node Resources - Sandbox Stress Test Report{% endblock %}
+
+{% block header_title %}Node CPU & I/O Wait{% endblock %}
+
+{% block content %}
+{% if node_cpu_summary %}
+<div class="grid">
+    <div class="card chart-card">
+        <div class="card-title">Node CPU Utilization Over Time</div>
+        <div class="chart-container">
+            <canvas id="nodeCpuChart"></canvas>
+        </div>
+        <div class="card-desc" style="margin-top: 12px;">
+            Busy is all non-idle, non-iowait CPU time; iowait is CPU time stalled waiting on disk.
+            High control-plane busy% slows etcd, the apiserver, KCM and the scheduler together —
+            client-observed etcd latency inflates without etcd's disk being the cause. High iowait
+            with spare CPU points at the disk instead. Workers are averaged across all worker nodes.
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-title">Node CPU by Phase</div>
+    <div class="table-container">
+        <table id="node-cpu-table"></table>
+    </div>
+</div>
+
+<script>
+    const nodeCpuSummary = {{ node_cpu_summary | tojson }};
+    renderTable('#node-cpu-table', [
+        {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+        {key: 'role', label: 'Role', render: v => `<code>${escapeHtml(v)}</code>`},
+        {key: 'nodes', label: 'Nodes'},
+        {key: 'busy_avg_pct', label: 'Busy (avg)', render: v =>
+            badge(v > 90 ? 'danger' : v > 75 ? 'warning' : 'success', v.toFixed(1) + '%')},
+        {key: 'busy_max_pct', label: 'Busy (max node)', render: v =>
+            badge(v > 90 ? 'danger' : v > 75 ? 'warning' : 'success', v.toFixed(1) + '%')},
+        {key: 'iowait_avg_pct', label: 'I/O wait (avg)', render: v =>
+            badge(v > 25 ? 'danger' : v > 10 ? 'warning' : 'success', v.toFixed(1) + '%')},
+        {key: 'iowait_max_pct', label: 'I/O wait (max node)', render: v =>
+            badge(v > 25 ? 'danger' : v > 10 ? 'warning' : 'success', v.toFixed(1) + '%')}
+    ], nodeCpuSummary);
+
+    const chartData = {{ chart_data | tojson }};
+    const phases = {{ phases | tojson }};
+
+    const timestamps = chartData.map(d => d.ts);
+    const formattedLabels = timeLabels(timestamps);
+    const pointTimes = timestamps.map(ts => new Date(ts).getTime());
+
+    const series = [
+        ['cp_busy', 'control-plane busy %'],
+        ['worker_busy', 'workers busy % (avg)'],
+        ['cp_iowait', 'control-plane iowait %'],
+        ['worker_iowait', 'workers iowait % (avg)'],
+    ];
+    const datasets = series.map(([key, label], idx) =>
+        lineDataset(label, chartData.map(d => d[key] ?? null), idx));
+
+    new Chart(document.getElementById('nodeCpuChart').getContext('2d'), {
+        type: 'line',
+        data: { labels: formattedLabels, datasets: datasets },
+        options: lineChartOptions('% of node CPU'),
+        plugins: [phaseBands(phases, pointTimes, formattedLabels)]
+    });
+</script>
+{% else %}
+<div class="card">
+    <div class="card-title">No node-level metrics in this run</div>
+    <div class="card-desc">
+        Node CPU and iowait are captured from a <code>node-exporter</code> DaemonSet
+        (deployed by the kOps stress scenario; see
+        <code>test/benchmarks/scenarios/benchmarks-kops-gcp/node-exporter.yaml</code>).
+        This run has no <code>source: node</code> samples — an older run, or a scenario
+        that does not deploy node-exporter.
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/test/stress/promscrape.go
+++ b/test/stress/promscrape.go
@@ -47,7 +47,7 @@ import (
 // same pattern).
 type metricSample struct {
 	TS       time.Time       `json:"ts"`
-	Source   string          `json:"source"`   // kube-apiserver | kube-controller-manager | kube-scheduler | agent-sandbox-controller | kubelet | cilium-agent | etcd-main | etcd-events
+	Source   string          `json:"source"`   // kube-apiserver | kube-controller-manager | kube-scheduler | agent-sandbox-controller | kubelet | cilium-agent | etcd-main | etcd-events | node
 	Instance string          `json:"instance"` // pod or node name
 	Metric   string          `json:"metric"`   // family name (+ _bucket/_sum/_count for histograms and summaries)
 	Labels   json.RawMessage `json:"labels,omitempty"`
@@ -174,6 +174,28 @@ func (s *promScraper) resolveSources(ctx context.Context) []promSource {
 	// Best-effort: clusters without the listener just skip it.
 	forPods("kube-system", "etcd-main", "http", 2391, "k8s-app=etcd-manager-main")
 	forPods("kube-system", "etcd-events", "http", 2392, "k8s-app=etcd-manager-events")
+
+	// node-exporter (deployed by the stress scenarios, e.g.
+	// benchmarks-kops-gcp/node-exporter.yaml): node-level CPU incl. iowait,
+	// memory and disk stats — the kubelet source above only describes the
+	// kubelet process itself. Unlike forPods, the instance is the NODE name,
+	// so report pages can group by node role. Best-effort: clusters without
+	// the DaemonSet skip it.
+	if pods, err := s.kube.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{LabelSelector: "app.kubernetes.io/name=node-exporter"}); err != nil {
+		log.Printf("[metrics] listing node-exporter pods: %v", err)
+	} else {
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Spec.NodeName == "" {
+				continue
+			}
+			sources = append(sources, promSource{
+				source:   "node",
+				instance: pod.Spec.NodeName,
+				path:     fmt.Sprintf("/api/v1/namespaces/kube-system/pods/http:%s:9100/proxy/metrics", pod.Name),
+			})
+		}
+	}
 
 	nodes, err := s.kube.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
We're seeing signs in the stress test that the control-plane node is
saturating CPU and/or disk, which is inflating latency for all
control-plane operations. This commit adds a minimal node-exporter
DaemonSet to capture CPU and iowait metrics, and adds a Node Resources
report page to visualize these metrics over time and per-phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added node-level CPU and I/O monitoring to stress-test runs.
  * Added a new Node Resources report page with charts and phase breakdowns.
  * Added etcd server-side disk latency metrics, including WAL fsync and backend commit analysis.
  * Expanded metrics collection to include etcd, node-exporter, and Cilium sources.
* **Bug Fixes**
  * Improved stress reports by identifying node CPU saturation and etcd storage stalls.
* **Enhancements**
  * Enabled node-exporter deployment and dedicated etcd metrics endpoints in benchmark environments.
  * Added severity indicators for etcd disk latency findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->