### PR TITLE
agent-sandbox-rl: sandbox recycling (reset-and-reuse) + warm-pool over-creation mitigations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ hermes-sandbox-knowledge.md
 # KWOK simulated cluster test output
 .build-kwok/
 kwok-cl2-report/
+.DS_Store

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -14,15 +14,19 @@ Sandbox `v0.5.0rc1` (v1beta1).
   tasks** (÷ tasks-per-image) — the RL-rollout claim-churn lever. `GitRestoreReset`
   restores `/testbed` to a pristine tag (`git reset --hard` + `clean -xdff` + detach),
   sweeps processes + `/tmp`, disables git gc/maintenance (avoids shared-store
-  corruption), then **verifies** cleanliness: repo at pristine SHA, and — as tripwires,
-  not repairs — the Python env (`pip freeze` hash), git config/hooks hash, and process
-  count unchanged. Any drift → the sandbox is **quarantined** (released, fresh claim),
-  so contamination never silently biases rewards. The costlier reset tiers (env-dir
-  restore, overlay/checkpoint restart) are deliberately deferred — detected and
-  escalated to a fresh claim instead. `determinism_canary` runs a task twice in one
-  recycled sandbox and asserts byte-identical output (the correctness gate). New
-  `reset`/`quarantine`/`rotate` phases in the `RunReport`. Design + deep-research
-  hardening notes: `plans/sandbox-recycling.md`.
+  corruption), then **verifies** the repo is back at the pristine SHA and clean; drift
+  → the sandbox is **quarantined** (released, fresh claim) so contamination never
+  silently biases rewards. Reset is **git-only by default** (fast); the site-packages
+  (`pip freeze`) and git-config/hooks tripwires are opt-in (`check_env`/`check_config`,
+  bounded otherwise by `max_reuses` + the canary). Scales via a **persistent exec
+  session** (`SandboxSession`, `use_session=True`): one held-open `bash` stream per
+  sandbox → exec cost O(sandboxes) not O(tasks). Safe on mixed image sets: a non-git
+  `/testbed` falls back to fresh-claim-per-task; an exec failure mid-reset quarantines
+  rather than aborting. `determinism_canary` asserts byte-identical output across a
+  reset (correctness gate). New `reset`/`quarantine`/`rotate` phases in `RunReport`.
+  Measured (no-op, mc=100): RL shape 50×40 reuse 416s/81 claims/100% vs regular
+  944s/1,987/99.35%. Costlier reset tiers (env-dir restore, overlay/checkpoint) are
+  deferred. Design + deep-research hardening: `plans/sandbox-recycling.md`.
 - **`pipelined` strategy** (`strategies.py`, `async_fleet.py`): double-buffered
   sliding window — prefetch window N+1's pools (background thread / `asyncio.Task`)
   while window N's tasks run, so image pull overlaps execution. Footprint bounded

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -9,6 +9,20 @@ Initial implementation (design phases 1–7), live-verified on GKE against Agent
 Sandbox `v0.5.0rc1` (v1beta1).
 
 ### Added (performance & scale)
+- **Sandbox recycling — `reuse_git_restore_sandbox`** (`recycle.py`): reset-and-reuse
+  one claimed sandbox across same-image tasks so **claims scale with problems, not
+  tasks** (÷ tasks-per-image) — the RL-rollout claim-churn lever. `GitRestoreReset`
+  restores `/testbed` to a pristine tag (`git reset --hard` + `clean -xdff` + detach),
+  sweeps processes + `/tmp`, disables git gc/maintenance (avoids shared-store
+  corruption), then **verifies** cleanliness: repo at pristine SHA, and — as tripwires,
+  not repairs — the Python env (`pip freeze` hash), git config/hooks hash, and process
+  count unchanged. Any drift → the sandbox is **quarantined** (released, fresh claim),
+  so contamination never silently biases rewards. The costlier reset tiers (env-dir
+  restore, overlay/checkpoint restart) are deliberately deferred — detected and
+  escalated to a fresh claim instead. `determinism_canary` runs a task twice in one
+  recycled sandbox and asserts byte-identical output (the correctness gate). New
+  `reset`/`quarantine`/`rotate` phases in the `RunReport`. Design + deep-research
+  hardening notes: `plans/sandbox-recycling.md`.
 - **`pipelined` strategy** (`strategies.py`, `async_fleet.py`): double-buffered
   sliding window — prefetch window N+1's pools (background thread / `asyncio.Task`)
   while window N's tasks run, so image pull overlaps execution. Footprint bounded

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -77,6 +77,14 @@ Sandbox `v0.5.0rc1` (v1beta1).
   sandbox survives its pool being scaled to 0 / deleted (a `SandboxClaim` detaches it
   from warm-pool ownership). Non-recyclable (fresh-claim-per-task) images keep their
   pools. `scale_on_hold=False` restores resident pools.
+- **Async recycle (`reuse_git_restore_sandbox_async`)** (`recycle.py`): coroutine-per-group
+  twin of `reuse_git_restore_sandbox` for `AsyncSandboxFleet`. Blocking git/exec/claim calls
+  are offloaded to the fleet's bounded pool, so it **holds far more concurrent recycled
+  sandboxes than the sync thread-per-group executor** (one OS thread per held sandbox) —
+  lifting the driver-side concurrency ceiling. Effective *exec* concurrency is still bounded
+  by the pool + apiserver exec path (a native async I/O backend would lift that too). Same
+  semantics (reset / quarantine / rotate / `scale_on_hold`); `process_fn` may be sync or
+  async. (`AsyncSandboxFleet.start_warmpools` also gained the `create_budget` staging arg.)
 - **Node-aware disk window sizing** (`sizing.py`, `config.py`, `fleet.py`):
   `recommend_window_disk` / `recommend_window_pipelined` gained a `nodes` arg so the
   disk budget is the **whole pool's** usable disk (distinct images spread across nodes),

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -30,6 +30,17 @@ Sandbox `v0.5.0rc1` (v1beta1).
   refuses**: the customer owns their cluster. See `plans/sdk-runaway-safeguards.md` (notes).
 
 ### Added (performance & scale)
+- **`recycle=` flag on `run()`** (`fleet.py`, `async_fleet.py`, `strategies.py`):
+  recycling is now an **orthogonal modifier** on the managed runner —
+  `fleet.run(fn, strategy="naive", recycle=True, …)` (and the async twin) — not a
+  strategy value. The chosen warm-pool `strategy` still governs warming; `recycle`
+  swaps the task→sandbox binding to reset-and-reuse via
+  `reuse_git_restore_sandbox(_async)` (executor injection through the strategy
+  functions). Off by default (a no-op for 1:1 eval; only multi-task-per-image shapes
+  benefit, and not every RL/eval scenario resets cleanly). Recycle opts
+  (`reset`/`max_reuses`/`reset_timeout`/`use_session`/`scale_on_hold`; async also
+  `shards_per_image`/`claim_concurrency`) are forwarded and ignored when
+  `recycle=False`. The low-level executors remain public for use outside `run()`.
 - **Sandbox recycling — `reuse_git_restore_sandbox`** (`recycle.py`): reset-and-reuse
   one claimed sandbox across same-image tasks so **claims scale with problems, not
   tasks** (÷ tasks-per-image) — the RL-rollout claim-churn lever. `GitRestoreReset`

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -51,6 +51,32 @@ Sandbox `v0.5.0rc1` (v1beta1).
   parallel); `_run_windowed`/`_run_pipelined` use it instead of warming one image at a
   time. Measured at 500 images: `sliding` dropped **2556s → 279s (9.2×)**, making the
   windowed strategies competitive with `naive` (the async path was already concurrent).
+- **Staged warm fill (`warm_create_budget`)** (`config.py`, `fleet.py`):
+  `start_warmpools`/`setup` warm pools in **waves** of ≤ `warm_create_budget` sandbox
+  creates in flight (default **1000**), waiting for each wave to reach Ready before the
+  next. Bounds the controller's concurrent create burst (Σ pools×replicas) so a large
+  or deep warm can't trip the SandboxWarmPool over-creation race (upstream
+  [#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)) — the burst
+  that triggers it is `warm-pool-workers × replicas_per_pool`, and the wait between
+  waves lets the informer cache converge. `warm_create_budget=0` (or `create_budget=0`)
+  restores the old warm-all-at-once behavior; a warm ≤ the budget is a single wave
+  (no change). **Reduces but does not by itself eliminate** the controller-side race —
+  for large/deep *cold* warms it must be paired with a low
+  `--sandbox-warm-pool-concurrent-workers` (the churn is per-pool + lagging pod GC).
+  The robust fix is upstream (expectations pattern on warm-pool creates + counting
+  `Terminating` toward the target); the RL-safe path is to not deep-warm at all
+  (recycle → 1 replica/pool).
+- **Recycle scale-on-hold (`scale_on_hold`, default on)** (`recycle.py`): once
+  `reuse_git_restore_sandbox` claims and holds a recyclable sandbox for its group, it
+  drops that image's warm pool (`unwarm_image`) so the controller doesn't
+  **replenish** a replacement the reuse never claims — removing the *sustained*
+  idle-warm footprint (steady state ~1× the held count instead of ~2×) and the
+  ongoing claim-driven replenishment that feeds #1215 (the peak during the initial
+  concurrent-claim burst can still transiently ~2× until claims are staged too).
+  Quarantine/rotation re-claims JIT re-warm first. Verified safe by probe: a claimed
+  sandbox survives its pool being scaled to 0 / deleted (a `SandboxClaim` detaches it
+  from warm-pool ownership). Non-recyclable (fresh-claim-per-task) images keep their
+  pools. `scale_on_hold=False` restores resident pools.
 - **Node-aware disk window sizing** (`sizing.py`, `config.py`, `fleet.py`):
   `recommend_window_disk` / `recommend_window_pipelined` gained a `nodes` arg so the
   disk budget is the **whole pool's** usable disk (distinct images spread across nodes),

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -17,13 +17,13 @@ Sandbox `v0.5.0rc1` (v1beta1).
   regardless of source — in-SDK, unlike an external watchdog that goes blind when the
   apiserver 429s. Wired into `run()`. Config: `overcommit_factor` (1.5),
   `max_live_sandboxes` (None), `breaker_poll_s` (5.0).
-- **Guaranteed teardown + label reaper** (`fleet.py`, `reaper.py`, `constants.py`):
+- **Best-effort teardown + label reaper** (`fleet.py`, `reaper.py`, `constants.py`):
   every created resource is stamped with a per-run label (`RUN_ID_LABEL` = `fleet.run_id`);
-  `setup()` installs `atexit` + SIGINT/SIGTERM handlers that tear down on any exit path
-  (`install_teardown_hooks`, default on); and **`reap(run_id=…)`** / `python -m
-  agent_sandbox_rl.reaper` deletes a run's resources by label — the guaranteed sweep for
-  an **orphaned** driver that died without cleanup (the failure mode behind the worst
-  incident).
+  `setup()` installs `atexit` + SIGINT/SIGTERM handlers that tear down on **graceful**
+  exits (`install_teardown_hooks`, default on) — best-effort, they can't catch SIGKILL /
+  OOM / node loss. For those abrupt cases, **`reap(run_id=…)`** / `python -m
+  agent_sandbox_rl.reaper` deletes a run's resources by label — the recovery path for an
+  **orphaned** driver that died without cleanup (the failure mode behind the worst incident).
 - **Capacity/QPS advisory** (`fleet.py`): `plan()` attaches `plan.warnings` (+ logs) when
   the warm footprint or `max_concurrent` looks beyond what the control plane absorbs
   (Pending-pod risk, apiserver 429 risk, #1215 deep-warm risk). **Warn only — never

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -8,6 +8,27 @@ All notable changes to `agent-sandbox-rl`. Format loosely follows
 Initial implementation (design phases 1–7), live-verified on GKE against Agent
 Sandbox `v0.5.0rc1` (v1beta1).
 
+### Added (safety / runaway safeguards)
+- **Circuit breaker** (`config.py`, `fleet.py`): a background monitor
+  (`fleet.overcommit_guard`) samples the live Sandbox count this run owns (by run-id
+  label) and, if it exceeds `min(expected × overcommit_factor, max_live_sandboxes)`,
+  **tears the fleet down and raises `FleetOvercommitError`**. Keys off *intent*, so it
+  catches accidental over-creation (runaway / orphaned driver / warm-pool #1215)
+  regardless of source — in-SDK, unlike an external watchdog that goes blind when the
+  apiserver 429s. Wired into `run()`. Config: `overcommit_factor` (1.5),
+  `max_live_sandboxes` (None), `breaker_poll_s` (5.0).
+- **Guaranteed teardown + label reaper** (`fleet.py`, `reaper.py`, `constants.py`):
+  every created resource is stamped with a per-run label (`RUN_ID_LABEL` = `fleet.run_id`);
+  `setup()` installs `atexit` + SIGINT/SIGTERM handlers that tear down on any exit path
+  (`install_teardown_hooks`, default on); and **`reap(run_id=…)`** / `python -m
+  agent_sandbox_rl.reaper` deletes a run's resources by label — the guaranteed sweep for
+  an **orphaned** driver that died without cleanup (the failure mode behind the worst
+  incident).
+- **Capacity/QPS advisory** (`fleet.py`): `plan()` attaches `plan.warnings` (+ logs) when
+  the warm footprint or `max_concurrent` looks beyond what the control plane absorbs
+  (Pending-pod risk, apiserver 429 risk, #1215 deep-warm risk). **Warn only — never
+  refuses**: the customer owns their cluster. See `plans/sdk-runaway-safeguards.md` (notes).
+
 ### Added (performance & scale)
 - **Sandbox recycling — `reuse_git_restore_sandbox`** (`recycle.py`): reset-and-reuse
   one claimed sandbox across same-image tasks so **claims scale with problems, not

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -14,9 +14,11 @@ Sandbox `v0.5.0rc1` (v1beta1).
   label) and, if it exceeds `min(expected × overcommit_factor, max_live_sandboxes)`,
   **tears the fleet down and raises `FleetOvercommitError`**. Keys off *intent*, so it
   catches accidental over-creation (runaway / orphaned driver / warm-pool #1215)
-  regardless of source — in-SDK, unlike an external watchdog that goes blind when the
-  apiserver 429s. Wired into `run()`. Config: `overcommit_factor` (1.5),
-  `max_live_sandboxes` (None), `breaker_poll_s` (5.0).
+  regardless of source, and being in-SDK it acts in-process (aborts the run + tears
+  down) rather than needing an external watchdog. It samples via the apiserver, so on a
+  list error it fails **open** (under-counts, not a false trip) — it is not a substitute
+  for control-plane back-pressure during sustained 429s. Wired into `run()`. Config:
+  `overcommit_factor` (1.5), `max_live_sandboxes` (None), `breaker_poll_s` (5.0).
 - **Best-effort teardown + label reaper** (`fleet.py`, `reaper.py`, `constants.py`):
   every created resource is stamped with a per-run label (`RUN_ID_LABEL` = `fleet.run_id`);
   `setup()` installs `atexit` + SIGINT/SIGTERM handlers that tear down on **graceful**

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -350,6 +350,22 @@ the fleet builds a per-context client for each, distributes pools/claims, and ea
 `SandboxHandle` carries its owning cluster. Cross-cluster reachability is the
 caller's concern (see the integration guide).
 
+### Multiple clusters and multiple node pools
+
+Each `ClusterConfig` targets one placement domain via its `node_selector`, so plan
+a deployment as **one `ClusterConfig` per (cluster × node pool)** and let a
+`placement` strategy spread work across them. For pools *within the same cluster*,
+give each config the same `context` but a distinct `node_selector` — **and a
+distinct `namespace`**: SandboxTemplate/WarmPool names are keyed by image only
+(`r2e-img-<hash>`), so two same-namespace configs warming the same image would
+collide; separate namespaces keep them isolated. Prefer `capacity-weighted` or
+`least-loaded` placement when pools are heterogeneous (e.g. a 110-pod e2 pool
+alongside a 256-pod n2 pool) so the larger pool gets a proportional share, and set
+each config's capacity/weight accordingly. (To instead let the scheduler place
+across pools freely, use a single config with no `node_selector` and a node
+affinity in `TemplateSpec.extra_pod_spec` — simpler, but you lose control of the
+split across pools with different pod caps.)
+
 ## Configuration reference
 
 **FleetConfig:** `clusters`, `placement`, `max_concurrent` (1), `max_warmpool_size`

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -414,6 +414,16 @@ images fit disk; `cluster_nodes` makes that the *whole pool's* disk (distinct im
 spread across nodes) instead of a single node's (None = conservative single-node
 bound; the capacity planner sets it from the probed node count).
 
+**Runaway safeguards** (see `plans/sdk-runaway-safeguards.md`): `overcommit_factor`
+(1.5) + `max_live_sandboxes` (None) — the **circuit breaker**: if live sandboxes this
+run owns exceed `min(expected × factor, max_live_sandboxes)`, the fleet tears down and
+raises `FleetOvercommitError` (catches accidental over-creation; `factor=0` disables);
+`breaker_poll_s` (5.0). `install_teardown_hooks` (True) installs atexit/SIGINT/SIGTERM
+teardown so a killed driver still cleans up; every resource is labelled with
+`fleet.run_id`, and **`reap(run_id=…)`** / `python -m agent_sandbox_rl.reaper` sweeps an
+orphaned run by label. `plan()` also emits **advisory** `plan.warnings` (never fatal)
+for footprint/concurrency beyond what the control plane comfortably absorbs.
+
 **ClusterConfig:** `name`, `kubeconfig`, `context`, `in_cluster`, `namespace`,
 `node_selector`, `runtime_class`, `image_pull_secret`, `weight`, `max_replicas`.
 

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -339,7 +339,9 @@ fleet.run(rollout_fn, strategy="naive", keep_warm=True)       # reuse across ste
 ```
 
 The [load test](tests/loadtest.py) reproduces both: `--tasks-per-image 1` (eval) vs
-`--tasks-per-image G --warm-per-task --colocate` (RL).
+`--tasks-per-image G --warm-per-task --colocate` (RL). Add `reuse` to `--strategies`
+(e.g. `--strategies naive,pipelined,reuse`) to compare recycling against the warm-pool
+strategies in the same run (`--max-reuses`/`--reset-timeout`/`--check-env` tune it).
 
 ## Multi-cluster
 

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -284,12 +284,28 @@ fleet.teardown()
 ```
 
 The reset (`GitRestoreReset`) restores `/testbed` to a pristine git tag, sweeps
-processes + `/tmp`, then **verifies** cleanliness — repo at the pristine SHA, and (as
-tripwires) the Python env, git config/hooks, and process count unchanged. Any drift
-**quarantines** the sandbox (release + fresh claim) rather than risk contaminating the
-next rollout — because in RL a polluted sandbox silently biases rewards, which is worse
-than a crash. The env-restore and overlay/checkpoint reset tiers are deferred; drift in
-those surfaces escalates to a fresh claim.
+processes + `/tmp`, then **verifies** the repo is back at the pristine SHA and clean;
+any drift **quarantines** the sandbox (release + fresh claim) rather than risk
+contaminating the next rollout — in RL a polluted sandbox silently biases rewards,
+worse than a crash. By default the reset is **git-only** (fast); the expensive
+site-packages (`pip freeze`) and git-config/hooks tripwires are opt-in
+(`GitRestoreReset(check_env=True, check_config=True)`) since env drift is rare and
+already bounded by `max_reuses` + the canary. The env-restore and overlay/checkpoint
+tiers are deferred; drift there escalates to a fresh claim.
+
+Two things make this scale (both on by default):
+- **Persistent exec session** (`use_session=True`) — one held-open `bash` stream per
+  sandbox, so task + reset pipe over a single websocket instead of one apiserver
+  `exec` connect per command (exec cost O(sandboxes), not O(tasks)).
+- **Safe on mixed image sets** — a non-git `/testbed` (no pristine anchor) can't be
+  git-restored, so those images transparently fall back to a fresh claim per task; an
+  `exec` failure mid-reset quarantines rather than aborting the batch.
+
+Measured (barkland-brust, no-op, mc=100): at the RL shape (50 problems × 40 rollouts)
+reuse **beat** fresh-claim on wall (416s vs 944s), claims (81 vs 1,987, 24.5×), and
+success (100% vs 99.35%) — regular's shallow per-image warm pool saturates under
+same-image contention. At eval shape (many distinct images, 1:1) keep fresh-claim +
+`pipelined`; reuse only cuts claims there. See `plans/sandbox-recycling.md`.
 
 > ⚠️ **Verify before trusting it for training.** Run the determinism canary first — the
 > same seeded task twice in one recycled sandbox must produce byte-identical output:

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -419,9 +419,10 @@ bound; the capacity planner sets it from the probed node count).
 run owns exceed `min(expected × factor, max_live_sandboxes)`, the fleet tears down and
 raises `FleetOvercommitError` (catches accidental over-creation; `factor=0` disables);
 `breaker_poll_s` (5.0). `install_teardown_hooks` (True) installs atexit/SIGINT/SIGTERM
-teardown so a killed driver still cleans up; every resource is labelled with
-`fleet.run_id`, and **`reap(run_id=…)`** / `python -m agent_sandbox_rl.reaper` sweeps an
-orphaned run by label. `plan()` also emits **advisory** `plan.warnings` (never fatal)
+teardown on graceful exits (normal return, exceptions, `SIGINT`/`SIGTERM`) — these are
+**best-effort** and can't catch `SIGKILL` / OOM / node loss. For those abrupt cases,
+every resource is labelled with `fleet.run_id`, and **`reap(run_id=…)`** / `python -m
+agent_sandbox_rl.reaper` is the recovery path — sweeping an orphaned run by label. `plan()` also emits **advisory** `plan.warnings` (never fatal)
 for footprint/concurrency beyond what the control plane comfortably absorbs.
 
 **ClusterConfig:** `name`, `kubeconfig`, `context`, `in_cluster`, `namespace`,

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -165,6 +165,7 @@ python run_swebench_fleet.py
 | **SandboxHandle** | A claimed sandbox: `hostname`, `pod_name`, `pod_ip`, `endpoint(port)`, `exec(cmd)`, `release()`. |
 | **Placement** | Which cluster serves an image: `round-robin`, `least-loaded`, `capacity-weighted`, `image-affinity`. |
 | **Strategy** | *When* pools exist: `none`, `naive`, `sliding`, `pipelined`. |
+| **Recycling** | *Reuse* one sandbox across same-image tasks (reset between): `reuse_git_restore_sandbox` + `GitRestoreReset` (claims scale ÷ tasks-per-image). |
 | **Adapters** | Framework glue: `adapters.swebench` (dataset → tasks), `adapters.r2egym` (`make_fleet_repo_env` binds a warm pod into R2E-Gym/tunix `RepoEnv`). |
 
 ## Warm-pool strategies
@@ -263,6 +264,41 @@ fleet.run(process_fn, strategy="naive")          # warm everything, full depth, 
 > per-image replicas the pipelined window shrinks to keep its footprint bounded, which
 > serializes problems and underfills `max_concurrent` once rollouts do real work
 > (measured: pipelined wall 55 s → 97 s). `pipelined` is for the 1:1 eval case.
+
+### Sandbox recycling (reset-and-reuse) — experimental
+
+`warm_per_task` gives each rollout its own *fresh* sandbox; **recycling** instead keeps
+one claimed sandbox and *resets* it between rollouts on the same image, so **claims
+scale with problems, not tasks** (÷ *G*). At the RL shape (G rollouts/problem) that is
+G× fewer claims, controller reconciles, and API-server writes.
+
+```python
+from agent_sandbox_rl import reuse_git_restore_sandbox, determinism_canary
+
+fleet.setup()
+# reuse one sandbox per image; reset between same-image tasks, quarantine if dirty
+results = reuse_git_restore_sandbox(
+    fleet, fleet.tasks, process_fn, concurrency=40,
+    max_reuses=32, reset_timeout=5.0)
+fleet.teardown()
+```
+
+The reset (`GitRestoreReset`) restores `/testbed` to a pristine git tag, sweeps
+processes + `/tmp`, then **verifies** cleanliness — repo at the pristine SHA, and (as
+tripwires) the Python env, git config/hooks, and process count unchanged. Any drift
+**quarantines** the sandbox (release + fresh claim) rather than risk contaminating the
+next rollout — because in RL a polluted sandbox silently biases rewards, which is worse
+than a crash. The env-restore and overlay/checkpoint reset tiers are deferred; drift in
+those surfaces escalates to a fresh claim.
+
+> ⚠️ **Verify before trusting it for training.** Run the determinism canary first — the
+> same seeded task twice in one recycled sandbox must produce byte-identical output:
+> ```python
+> out = determinism_canary(fleet, task, process_fn)
+> assert out["identical"] and out["reset_clean"]
+> ```
+> Recycling is experimental; the design, hardening findings, and known limits are in
+> `plans/sandbox-recycling.md` (notes repo).
 
 ### Eval vs RL — recommended recipes
 

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -165,7 +165,7 @@ python run_swebench_fleet.py
 | **SandboxHandle** | A claimed sandbox: `hostname`, `pod_name`, `pod_ip`, `endpoint(port)`, `exec(cmd)`, `release()`. |
 | **Placement** | Which cluster serves an image: `round-robin`, `least-loaded`, `capacity-weighted`, `image-affinity`. |
 | **Strategy** | *When* pools exist: `none`, `naive`, `sliding`, `pipelined`. |
-| **Recycling** | *Reuse* one sandbox across same-image tasks (reset between): `reuse_git_restore_sandbox` + `GitRestoreReset` (claims scale ÷ tasks-per-image). |
+| **Recycling** | *Reuse* one sandbox across same-image tasks (reset between): `run(recycle=True)` — orthogonal to strategy — backed by `reuse_git_restore_sandbox` + `GitRestoreReset` (claims scale ÷ tasks-per-image). |
 | **Adapters** | Framework glue: `adapters.swebench` (dataset → tasks), `adapters.r2egym` (`make_fleet_repo_env` binds a warm pod into R2E-Gym/tunix `RepoEnv`). |
 
 ## Warm-pool strategies
@@ -302,15 +302,21 @@ one claimed sandbox and *resets* it between rollouts on the same image, so **cla
 scale with problems, not tasks** (÷ *G*). At the RL shape (G rollouts/problem) that is
 G× fewer claims, controller reconciles, and API-server writes.
 
-```python
-from agent_sandbox_rl import reuse_git_restore_sandbox, determinism_canary
+Turn it on with the **`recycle=True`** flag on `fleet.run(...)` — an *orthogonal
+modifier*, not a strategy value: the chosen `strategy` still governs warming, `recycle`
+only swaps the task→sandbox binding to reset-and-reuse. It's off by default (a no-op for
+1:1 eval; it only helps multi-task-per-image shapes, and not every RL/eval scenario
+resets cleanly).
 
-fleet.setup()
-# reuse one sandbox per image; reset between same-image tasks, quarantine if dirty
-results = reuse_git_restore_sandbox(
-    fleet, fleet.tasks, process_fn, concurrency=40,
-    max_reuses=32, reset_timeout=5.0)
-fleet.teardown()
+```python
+from agent_sandbox_rl import determinism_canary
+
+# reuse one sandbox per image; reset between same-image tasks, quarantine if dirty.
+# strategy warms the pools; run() manages setup / RunReport / teardown.
+results = fleet.run(process_fn, strategy="naive", concurrency=40,
+                    recycle=True, max_reuses=32, reset_timeout=5.0)
+# async twin: await afleet.run(process_fn, strategy="naive", recycle=True, …)
+# low-level (full control outside run()): reuse_git_restore_sandbox(fleet, tasks, fn, conc)
 ```
 
 The reset (`GitRestoreReset`) restores `/testbed` to a pristine git tag, sweeps

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -177,10 +177,29 @@ python run_swebench_fleet.py
 | `pipelined` | Like `sliding`, but **prefetch** window N+1's pools while window N's tasks run, so image pull overlaps execution. | Bounded (≤ 2 windows; the window is halved so peak ≈ `max_concurrent`). | **Pull-bound eval sweeps** (many distinct images, 1 task each). |
 | `none` | One size-1 pool per image on demand, torn down after. | Lowest (cold-start per image). | Tiny runs / debugging. |
 
-`pipelined` is the throughput pick **when image pull dominates** — e.g. a 1:1
-**eval** sweep over hundreds of distinct images — because it hides each window's
-pull behind the previous window's execution. It is *not* the pick for RL rollouts
-that warm many replicas per image (see [Eval vs RL](#eval-vs-rl--recommended-recipes)).
+**How to choose — two questions: does the warm set fit on disk, and is pull the bottleneck?**
+
+1. **Does the whole warm set fit on the node/pool's disk?** `naive` warms *every* pool
+   at once, so all resident images must fit simultaneously. **If they fit**, `naive` is
+   the simplest and reaches steady state fastest. **If they don't fit** (large image
+   sets — the common case at hundreds+ of multi-GB images), you *must* bound what's
+   resident at any moment → use **`sliding`** or **`pipelined`**, whose window
+   auto-sizes to the disk budget (`avg_image_gb` / `node_ephemeral_gb` / `cluster_nodes`;
+   see [Disk-aware window](#configuration-reference)). This is the primary reason to
+   reach for a windowed strategy: **the images don't fit storage.**
+2. **Is image pull the bottleneck?** For a **1:1 eval sweep** (hundreds of distinct
+   images, one task each) pull dominates wall time → **`pipelined`** hides each window's
+   pull behind the previous window's execution. So use `pipelined` when *either* the set
+   doesn't fit disk *or* pull dominates (usually both, for eval).
+3. **RL rollouts (1:G)** — each image is claimed by G rollouts, so pools are deep. Use
+   **`naive`** or **`sliding`** with `warm_per_task` (+ `colocate_replicas`), **not
+   `pipelined`**: deep per-image replicas shrink the pipelined window and serialize
+   problems (measured wall 55 s → 97 s). See [Eval vs RL](#eval-vs-rl--recommended-recipes).
+
+**In short:** `naive` when everything fits and you want simplicity; **`pipelined`/`sliding`
+when the image set is too big for disk** (windowed = fits by construction), with
+`pipelined` adding pull/exec overlap for pull-bound eval; `naive`/`sliding` + `warm_per_task`
+for RL.
 For repeated passes over the same dataset (RL epochs), use **`epochs=N`** to keep
 pools resident between passes (re-pulls then hit the node layer cache — see
 [Strategies & tuning](docs/strategies.md)), or **`keep_warm=True`** to drive your
@@ -247,6 +266,17 @@ fleet.run(process_fn, strategy="naive")          # warm everything, full depth, 
   node's containerd layer cache (pairs with the default `image_pull_policy:
   IfNotPresent`). Soft, so it spills to other nodes instead of dead-locking when a
   node fills. Size the node for `replicas × cpu_request` (e.g. 50 × 250m ≈ 13 vCPU).
+- **Deep/large warms stage automatically** — `warm_per_task` across many images can
+  ask the controller to create tens of thousands of replicas at once. `start_warmpools`
+  fills in **waves** of ≤ `warm_create_budget` (default 1000) creates, waiting for each
+  wave to be Ready before the next. Set `warm_create_budget=0` to warm all at once.
+  > ⚠️ **Staging alone is not sufficient at scale.** Current Agent Sandbox releases
+  > (≤ v0.5.2) have a warm-pool over-creation *churn* bug
+  > ([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)) that
+  > staging only *slows*. For large/deep *cold* warms, also set the controller flag
+  > **`--sandbox-warm-pool-concurrent-workers` low (≤10)** (leave sandbox/claim workers
+  > high). The RL-safe path avoids the regime entirely — **recycle** one sandbox per
+  > problem (see **Sandbox recycling** below) instead of deep-warming.
 
 > **When does this help?** Only when an image carries **more than one task**. A 1:1
 > eval sweep (one image per task — see below) gets `min(1, …) = 1` replica, so
@@ -320,6 +350,9 @@ same-image contention. At eval shape (many distinct images, 1:1) keep fresh-clai
 
 The two workloads pull in opposite directions: **eval** is *pull-bound* (many distinct
 images, one task each), **RL** is *claim-bound* per problem (one image, many rollouts).
+(Eval uses `pipelined` because a large distinct-image set rarely fits disk *and* pull
+dominates; if your eval set is small enough to fit resident, plain `naive` also works
+and is simpler — see [How to choose](#warm-pool-strategies).)
 
 | Job | Image : task | Strategy | Sizing levers | Why |
 | :-- | :-- | :-- | :-- | :-- |
@@ -370,8 +403,11 @@ split across pools with different pod caps.)
 
 **FleetConfig:** `clusters`, `placement`, `max_concurrent` (1), `max_warmpool_size`
 (8), `warm_per_task` (False — one warm replica per task for instant claims),
-`window_size` (None=auto), `ready_timeout` (900), `template` (`TemplateSpec`),
-`template_name_prefix` (`r2e-img-`), `labels`. Disk-aware sizing (optional):
+`window_size` (None=auto), `ready_timeout` (900), `warm_create_budget` (1000 — stage
+the warm fill in waves of ≤ N sandbox creates in flight to curb the controller's
+over-creation race; pair with a low `--sandbox-warm-pool-concurrent-workers` for
+large/deep cold warms; `0` = warm all at once), `template`
+(`TemplateSpec`), `template_name_prefix` (`r2e-img-`), `labels`. Disk-aware sizing (optional):
 `avg_image_gb`, `node_ephemeral_gb`, `disk_headroom` (0.25), `cluster_nodes`
 (None) — when set, the auto window for `sliding`/`pipelined` is capped so resident
 images fit disk; `cluster_nodes` makes that the *whole pool's* disk (distinct images
@@ -553,7 +589,7 @@ the controller Deployment's container args, namespace `agent-sandbox-system`):
 | `--kube-api-burst` | `10` | n/a | **Moot while `qps=-1`** (burst is only consulted when QPS > 0). Only raise if you set a positive QPS. |
 | `--sandbox-concurrent-workers` | `100` | **`1000`** | Sandbox reconciles (claim binding → Ready) are the main serializer; match your peak concurrent sandboxes. |
 | `--sandbox-claim-concurrent-workers` | `50` | **`1000`** | Concurrent `SandboxClaim` reconciles; match peak in-flight claims. |
-| `--sandbox-warm-pool-concurrent-workers` | `1` | **`1000`** | Parallel warm-pool reconciles (one per image pool); raise so many pools warm at once. |
+| `--sandbox-warm-pool-concurrent-workers` | `1` | **`≤10`** ⚠️ | **Do _not_ raise to 1000.** High values trigger the warm-pool over-creation *churn* bug ([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)): parallel reconciles race a stale informer cache and over-create → delete → re-create sandboxes; with lagging pod GC the pod count balloons (observed ~17K pods for an 8K target). Keep it **low (≤10; `1` fully serializes)** until #1215 is fixed upstream. Warm-pool provisioning is a one-time setup cost, so low concurrency here barely affects steady-state throughput. |
 | `--sandbox-template-concurrent-workers` | `1` | **`1000`** | Parallel template reconciles. |
 | `--sandbox-warm-pool-max-batch-size` | `300` | **`1000`** | Parallel pod create/delete *within* one warm-pool reconcile. |
 
@@ -562,7 +598,10 @@ controller's API client is already uncapped at `qps=-1`. The **worker concurrenc
 flags are what unblock high-scale claims. Size them to your `max_concurrent`. Also
 size this package's client pool (`build_api_client` defaults the urllib3
 `connection_pool_maxsize` to 1000) to match — otherwise the driver throttles before
-the controller does.
+the controller does. **One exception:** `--sandbox-warm-pool-concurrent-workers` — keep
+it **low (≤10)**, not 1000 (see the ⚠️ row above): warm-pool provisioning is a one-time
+setup cost, and high concurrency there triggers the #1215 over-creation churn. Pair with
+this package's staged warm fill (`FleetConfig.warm_create_budget`, default 1000).
 
 Example patch:
 
@@ -570,7 +609,7 @@ Example patch:
 kubectl -n agent-sandbox-system patch deploy agent-sandbox-controller --type=json -p '[
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-concurrent-workers=1000"},
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-claim-concurrent-workers=1000"},
-  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-warm-pool-concurrent-workers=1000"},
+  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-warm-pool-concurrent-workers=10"},
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-template-concurrent-workers=1000"},
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-warm-pool-max-batch-size=1000"}
 ]'

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
@@ -57,6 +57,7 @@ from .recycle import (
     ResetOutcome,
     determinism_canary,
     reuse_git_restore_sandbox,
+    reuse_git_restore_sandbox_async,
 )
 from .placement import (
     CapacityWeighted,
@@ -135,6 +136,7 @@ __all__ = [
     "ResetBaseline",
     "ResetOutcome",
     "reuse_git_restore_sandbox",
+    "reuse_git_restore_sandbox_async",
     "determinism_canary",
     # observability
     "Observer",

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
@@ -49,7 +49,7 @@ from .exceptions import (
 )
 from .async_fleet import AsyncSandboxFleet
 from .fleet import FleetPlan, PlanEntry, SandboxFleet
-from .handles import SandboxHandle
+from .handles import SandboxHandle, SandboxSession
 from .observability import Observer, RunReport, repo_family, serve_metrics
 from .recycle import (
     GitRestoreReset,
@@ -126,6 +126,7 @@ __all__ = [
     "FleetPlan",
     "PlanEntry",
     "SandboxHandle",
+    "SandboxSession",
     # strategies
     "STRATEGIES",
     "process_parallel",

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
@@ -51,6 +51,13 @@ from .async_fleet import AsyncSandboxFleet
 from .fleet import FleetPlan, PlanEntry, SandboxFleet
 from .handles import SandboxHandle
 from .observability import Observer, RunReport, repo_family, serve_metrics
+from .recycle import (
+    GitRestoreReset,
+    ResetBaseline,
+    ResetOutcome,
+    determinism_canary,
+    reuse_git_restore_sandbox,
+)
 from .placement import (
     CapacityWeighted,
     ImageAffinity,
@@ -122,6 +129,12 @@ __all__ = [
     # strategies
     "STRATEGIES",
     "process_parallel",
+    # recycling (reset-and-reuse)
+    "GitRestoreReset",
+    "ResetBaseline",
+    "ResetOutcome",
+    "reuse_git_restore_sandbox",
+    "determinism_canary",
     # observability
     "Observer",
     "RunReport",

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
@@ -44,11 +44,13 @@ from .config import (
 from .exceptions import (
     CapacityError,
     FleetError,
+    FleetOvercommitError,
     NoClusterAvailableError,
     PreflightError,
 )
 from .async_fleet import AsyncSandboxFleet
 from .fleet import FleetPlan, PlanEntry, SandboxFleet
+from .reaper import reap
 from .handles import SandboxHandle, SandboxSession
 from .observability import Observer, RunReport, repo_family, serve_metrics
 from .recycle import (
@@ -156,6 +158,8 @@ __all__ = [
     "PreflightError",
     "CapacityError",
     "NoClusterAvailableError",
+    "FleetOvercommitError",
+    "reap",
 ]
 
 __version__ = "0.1.0.dev0"

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
@@ -235,7 +235,8 @@ class AsyncSandboxFleet:
     return results
 
   async def _run_windowed(self, process_fn, concurrency, window,
-                          replicas_override=None, *, teardown=True):
+                          replicas_override=None, *, teardown=True, executor=None):
+    executor = executor or self._process_parallel
     await self.preflight()
     await self.plan()
     images = list(self.image_counts().keys())
@@ -256,7 +257,7 @@ class AsyncSandboxFleet:
                               replicas_override=replicas_override, wait=True)
         batch_pairs = [(i, t) for img in batch for (i, t) in by_image[img]]
         batch_tasks = [t for _i, t in batch_pairs]
-        batch_results = await self._process_parallel(batch_tasks, process_fn, concurrency)
+        batch_results = await executor(batch_tasks, process_fn, concurrency)
         for (i, _t), r in zip(batch_pairs, batch_results, strict=True):
           results[i] = r
         for img in batch:
@@ -267,11 +268,12 @@ class AsyncSandboxFleet:
     return results
 
   async def _run_pipelined(self, process_fn, concurrency, window,
-                           replicas_override=None, *, teardown=True):
+                           replicas_override=None, *, teardown=True, executor=None):
     """Async double-buffered sliding window: prefetch window N+1's pools (an
     ``asyncio.Task``) while window N's tasks run. Footprint ≤ 2 windows — the
     current window is unwarmed before awaiting the next prefetch, and only one
     prefetch task is ever in flight."""
+    executor = executor or self._process_parallel
     await self.preflight()
     await self.plan()
     images = list(self.image_counts().keys())
@@ -299,7 +301,7 @@ class AsyncSandboxFleet:
                    if n + 1 < len(batches) else None)
         batch_pairs = [(i, t) for img in batch for (i, t) in by_image[img]]
         batch_tasks = [t for _i, t in batch_pairs]
-        batch_results = await self._process_parallel(batch_tasks, process_fn, concurrency)
+        batch_results = await executor(batch_tasks, process_fn, concurrency)
         for (i, _t), r in zip(batch_pairs, batch_results, strict=True):
           results[i] = r
         for img in batch:
@@ -318,40 +320,67 @@ class AsyncSandboxFleet:
         await self.teardown()
     return results
 
-  async def _run_once(self, strategy, process_fn, conc, *, teardown):
+  async def _run_once(self, strategy, process_fn, conc, *, teardown, executor=None):
+    executor = executor or self._process_parallel
     if strategy == "naive":
       try:
         await self.setup()
-        return await self._process_parallel(self.tasks, process_fn, conc)
+        return await executor(self.tasks, process_fn, conc)
       finally:
         if teardown:
           await self.teardown()
     if strategy == "sliding":
       return await self._run_windowed(
-          process_fn, conc, self._fleet.recommended_window(), teardown=teardown)
+          process_fn, conc, self._fleet.recommended_window(), teardown=teardown,
+          executor=executor)
     if strategy == "pipelined":
       return await self._run_pipelined(
           process_fn, conc, self._fleet.recommended_window(pipelined=True),
-          teardown=teardown)
+          teardown=teardown, executor=executor)
     if strategy == "none":
       return await self._run_windowed(
-          process_fn, conc, 1, replicas_override=1, teardown=teardown)
+          process_fn, conc, 1, replicas_override=1, teardown=teardown,
+          executor=executor)
     raise ValueError(f"unknown strategy '{strategy}'")
 
   async def run(self, process_fn: Callable[[Task, SandboxHandle], object | Awaitable],
                 strategy: str = "naive", concurrency: int | None = None,
-                *, epochs: int = 1, keep_warm: bool = False) -> list:
+                *, epochs: int = 1, keep_warm: bool = False,
+                recycle: bool = False, reset=None, max_reuses: int = 32,
+                reset_timeout: float = 5.0, use_session: bool = True,
+                scale_on_hold: bool = True, shards_per_image: int = 1,
+                claim_concurrency: int = 0) -> list:
     """Run all loaded tasks under ``strategy`` with up to ``concurrency``
     concurrent claim+exec. ``process_fn`` may be sync or a coroutine function.
 
     ``epochs``/``keep_warm`` mirror `SandboxFleet.run`: ``epochs>1`` runs N passes
     keeping pools resident between them (returns ``list[list]``); ``keep_warm=True``
     skips the final teardown for caller-driven reuse.
+
+    ``recycle`` is an **orthogonal** modifier (not a strategy): the chosen
+    ``strategy`` still governs warm-pool sizing/timing, but same-image tasks reuse
+    one claimed sandbox (git-restore reset between them) via
+    `recycle.reuse_git_restore_sandbox_async` instead of a fresh claim per task. It
+    applies to multi-task-per-image workloads (RL rollouts) and is a no-op for 1:1
+    eval, so it is off by default. ``reset``/``max_reuses``/``reset_timeout``/
+    ``use_session``/``scale_on_hold``/``shards_per_image``/``claim_concurrency`` are
+    forwarded to the async recycle executor and ignored when ``recycle=False``.
     """
     if epochs < 1:
       raise ValueError("epochs must be >= 1")
     conc = concurrency or self.config.max_concurrent
     obs = self._fleet._obs
+    executor = None
+    if recycle:                                # swap task→sandbox binding, keep warming
+      from .recycle import GitRestoreReset, reuse_git_restore_sandbox_async
+      _reset = reset or GitRestoreReset()
+
+      async def executor(tasks, process_fn, concurrency):  # noqa: E306
+        return await reuse_git_restore_sandbox_async(
+            self, tasks, process_fn, concurrency, reset=_reset,
+            max_reuses=max_reuses, reset_timeout=reset_timeout,
+            use_session=use_session, scale_on_hold=scale_on_hold,
+            shards_per_image=shards_per_image, claim_concurrency=claim_concurrency)
     if self._fleet.plan_ is None:              # give the circuit breaker a footprint
       await self.plan()
     expected = self._fleet.plan_.total_replicas if self._fleet.plan_ else None
@@ -363,7 +392,7 @@ class AsyncSandboxFleet:
         logger.debug("could not collect environment", exc_info=True)
       if epochs == 1:
         results = await self._run_once(strategy, process_fn, conc,
-                                       teardown=not keep_warm)
+                                       teardown=not keep_warm, executor=executor)
       else:
         results = []
         for e in range(epochs):
@@ -371,7 +400,8 @@ class AsyncSandboxFleet:
           logger.info("epoch %d/%d", e + 1, epochs)
           try:
             results.append(await self._run_once(
-                strategy, process_fn, conc, teardown=last and not keep_warm))
+                strategy, process_fn, conc, teardown=last and not keep_warm,
+                executor=executor))
           except BaseException:               # a mid-run epoch never tore down
             if not keep_warm and not last:
               await self.teardown()

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
@@ -150,8 +150,10 @@ class AsyncSandboxFleet:
   async def ensure_templates(self):
     return await self._to_thread(self._fleet.ensure_templates)
 
-  async def start_warmpools(self, wait: bool = True):
-    return await self._to_thread(self._fleet.start_warmpools, wait)
+  async def start_warmpools(self, wait: bool = True,
+                            create_budget: int | None = None):
+    return await self._to_thread(self._fleet.start_warmpools, wait,
+                                 create_budget=create_budget)
 
   async def prepull(self, wait: bool = True):
     return await self._to_thread(self._fleet.prepull, wait)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
@@ -352,7 +352,10 @@ class AsyncSandboxFleet:
       raise ValueError("epochs must be >= 1")
     conc = concurrency or self.config.max_concurrent
     obs = self._fleet._obs
-    with obs.run(strategy) as report:
+    if self._fleet.plan_ is None:              # give the circuit breaker a footprint
+      await self.plan()
+    expected = self._fleet.plan_.total_replicas if self._fleet.plan_ else None
+    with self._fleet.overcommit_guard(expected), obs.run(strategy) as report:
       self._fleet.report = report
       try:
         report.environment = await self._to_thread(self._fleet.describe_environment)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
@@ -134,6 +134,11 @@ class FleetConfig(BaseModel):
   overcommit_factor: float = 1.5
   max_live_sandboxes: int | None = None      # optional absolute hard ceiling
   breaker_poll_s: float = 5.0
+  # Trip only after the ceiling is breached for this many *consecutive* polls, so a
+  # transient spike (a claim briefly double-warms before scale-down; Terminating-pod
+  # GC lag) can't tear down a healthy run on a single sample. One healthy poll resets
+  # the counter. Sustained breach = breaker_trip_polls × breaker_poll_s.
+  breaker_trip_polls: int = 3
   # Guaranteed teardown (#4): install atexit + SIGINT/SIGTERM handlers that tear
   # the fleet down on any exit path (orphan defense; pairs with the run-id label +
   # reaper). Set False if the host owns signal handling.

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
@@ -126,6 +126,18 @@ class FleetConfig(BaseModel):
   # behavior). The safe value scales inversely with controller warm-pool worker
   # concurrency; 1000 is calibrated for a high-worker controller.
   warm_create_budget: int = 1000
+  # --- runaway safeguards (see plans/sdk-runaway-safeguards.md) ------------- #
+  # Circuit breaker (#1, fail-safe): abort + teardown if live sandboxes this run
+  # owns exceed the safe ceiling — min(expected × overcommit_factor,
+  # max_live_sandboxes). Keys off *intent*, so it catches accidental over-creation
+  # (runaway/orphan/#1215) not a large-but-intended run. 0/None on factor disables.
+  overcommit_factor: float = 1.5
+  max_live_sandboxes: int | None = None      # optional absolute hard ceiling
+  breaker_poll_s: float = 5.0
+  # Guaranteed teardown (#4): install atexit + SIGINT/SIGTERM handlers that tear
+  # the fleet down on any exit path (orphan defense; pairs with the run-id label +
+  # reaper). Set False if the host owns signal handling.
+  install_teardown_hooks: bool = True
   template: TemplateSpec = Field(default_factory=TemplateSpec)
   template_name_prefix: str = "r2e-img-"
   labels: dict[str, str] = Field(default_factory=lambda: dict(constants.DEFAULT_LABELS))

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
@@ -119,6 +119,13 @@ class FleetConfig(BaseModel):
   warm_per_task: bool = False
   window_size: int | None = None            # sliding: None = auto from max_concurrent
   ready_timeout: int = 900
+  # Stage the warm fill in waves of <= this many sandbox creates in flight,
+  # waiting for each wave to reach Ready before the next. Bounds the controller's
+  # concurrent create burst (Σ pools×replicas) so a large/deep warm can't trip the
+  # SandboxWarmPool over-creation race (#1215). 0 = warm everything at once (old
+  # behavior). The safe value scales inversely with controller warm-pool worker
+  # concurrency; 1000 is calibrated for a high-worker controller.
+  warm_create_budget: int = 1000
   template: TemplateSpec = Field(default_factory=TemplateSpec)
   template_name_prefix: str = "r2e-img-"
   labels: dict[str, str] = Field(default_factory=lambda: dict(constants.DEFAULT_LABELS))

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/constants.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/constants.py
@@ -44,3 +44,6 @@ KEEPALIVE_COMMAND = ["sleep", "infinity"]
 MANAGED_BY_LABEL = "app"
 MANAGED_BY_VALUE = "agent-sandbox-rl"
 DEFAULT_LABELS = {MANAGED_BY_LABEL: MANAGED_BY_VALUE}
+# Per-run label stamped on every resource a fleet creates, so an orphaned run's
+# resources can always be swept by the reaper (`reap(run_id=…)`).
+RUN_ID_LABEL = "agents.x-k8s.io/asrl-run-id"

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/exceptions.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/exceptions.py
@@ -29,3 +29,9 @@ class CapacityError(FleetError):
 
 class NoClusterAvailableError(FleetError):
   """Placement could not select a cluster for a task."""
+
+
+class FleetOvercommitError(FleetError):
+  """The in-SDK circuit breaker tripped: live sandboxes exceeded the safe ceiling
+  (``overcommit_factor`` × expected, or ``max_live_sandboxes``), signalling a
+  runaway/over-creation. The fleet is torn down before this is raised."""

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -378,9 +378,49 @@ class SandboxFleet:
       if err is not None:
         raise err
 
-  def start_warmpools(self, wait: bool = True) -> None:
-    """Warm every planned pool, concurrently (bounded by ``max_concurrent``)."""
-    self._warm_entries((self.plan_ or self.plan()).entries, wait)
+  def start_warmpools(self, wait: bool = True,
+                      create_budget: int | None = None) -> None:
+    """Warm every planned pool, concurrently (bounded by ``max_concurrent``).
+
+    The budget (``create_budget`` if given, else ``config.warm_create_budget``)
+    caps how many sandbox creates are in flight per wave; pools are warmed in
+    **waves** whose summed replicas stay under it, waiting for each wave to reach
+    Ready before the next starts. This bounds the controller's concurrent
+    sandbox-create burst (Σ pools×replicas in flight), which avoids the
+    SandboxWarmPool over-creation race (#1215) at large/deep warm targets — the
+    burst that trips it is ``workers × replicas_per_pool``, and waiting between
+    waves lets the informer cache converge. Budget ``0`` warms all at once;
+    ``create_budget=None`` falls back to the config default.
+
+    Note: when staging is active (budget > 0), intermediate waves always block on
+    readiness regardless of ``wait`` — waiting between waves is what makes staging
+    work; only the final wave honors ``wait``. So ``wait=False`` is not fully
+    non-blocking under staging; pass ``create_budget=0`` for the old all-at-once,
+    ``wait``-honoring behavior."""
+    # None = fall back to the configured default; 0 = explicitly warm all at once.
+    budget = self.config.warm_create_budget if create_budget is None else create_budget
+    entries = (self.plan_ or self.plan()).entries
+    if not budget or budget <= 0:
+      self._warm_entries(entries, wait)
+      return
+    wave: list = []
+    wave_creates = 0
+    n_waves = 0
+    for e in entries:
+      # A pool is atomic: if one entry alone exceeds the budget, it warms solo.
+      if wave and wave_creates + e.replicas > budget:
+        n_waves += 1
+        logger.info("staged warm: wave %d — %d pools / %d creates (budget %d)",
+                    n_waves, len(wave), wave_creates, budget)
+        self._warm_entries(wave, wait=True)   # wait so the cache converges first
+        wave, wave_creates = [], 0
+      wave.append(e)
+      wave_creates += e.replicas
+    if wave:
+      n_waves += 1
+      logger.info("staged warm: wave %d — %d pools / %d creates (budget %d)",
+                  n_waves, len(wave), wave_creates, budget)
+      self._warm_entries(wave, wait=wait)
 
   def warm_images(self, images, *, replicas_override: int | None = None,
                   wait: bool = True) -> None:
@@ -437,13 +477,17 @@ class SandboxFleet:
     for c in self.registry:
       _pp.prepull_delete(c)
 
-  def setup(self, prepull: bool = False) -> "SandboxFleet":
-    """preflight → plan → (optional pre-pull) → start (and wait for) warm pools."""
+  def setup(self, prepull: bool = False,
+            create_budget: int | None = None) -> "SandboxFleet":
+    """preflight → plan → (optional pre-pull) → start (and wait for) warm pools.
+
+    ``create_budget`` (if set) stages the warm fill in waves to bound the
+    controller's concurrent create burst — see ``start_warmpools``."""
     self.preflight()
     self.plan()
     if prepull:
       self.prepull(wait=True)
-    self.start_warmpools(wait=True)
+    self.start_warmpools(wait=True, create_budget=create_budget)
     return self
 
   # --- claims ------------------------------------------------------------ #

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -126,6 +126,15 @@ class SandboxFleet:
     # fall back when no registry was given at all.
     self.registry = (registry if registry is not None
                      else self._default_registry(self.config))
+    # A caller-supplied registry was built before the run-id was stamped above, so
+    # its clusters' Resources.labels lack it — the pods it creates would then carry
+    # no run-id and be invisible to the breaker/reaper. Ensure every cluster
+    # (default or supplied) carries this run's labels. Idempotent for the default.
+    for _c in self.registry:
+      try:
+        _c.resources.labels.update(self.config.labels)
+      except Exception:  # noqa: BLE001 — a non-standard registry may differ; best-effort
+        pass
     self.placement = get_placement(self.config.placement)
     self.tasks: list[Task] = []
     self.plan_: FleetPlan | None = None
@@ -198,18 +207,29 @@ class SandboxFleet:
     stop = threading.Event()
     tripped = {"n": 0}
 
+    need = max(1, self.config.breaker_trip_polls)
+
     def _loop():
+      breaches = 0
       while not stop.wait(self.config.breaker_poll_s):
         n = self.live_owned_count()
         if n > ceiling:
-          logger.error("circuit breaker TRIPPED: %d live sandboxes > ceiling %d "
-                       "(expected %d) — aborting run + tearing down", n, ceiling, expected)
+          breaches += 1
+          logger.warning("circuit breaker: %d live pods > ceiling %d (breach %d/%d "
+                         "consecutive; expected %d)", n, ceiling, breaches, need, expected)
+          if breaches < need:
+            continue                          # transient spike — wait for a sustained breach
+          logger.error("circuit breaker TRIPPED: %d live pods > ceiling %d for %d "
+                       "consecutive polls (expected %d) — aborting run + tearing down",
+                       n, ceiling, breaches, expected)
           tripped["n"] = n
           try:
             self.teardown()
           except Exception:  # noqa: BLE001
             logger.warning("teardown during breaker trip failed", exc_info=True)
           return
+        else:
+          breaches = 0                        # healthy poll resets; only SUSTAINED breach trips
 
     th = threading.Thread(target=_loop, name="asrl-breaker", daemon=True)
     th.start()

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -161,12 +161,16 @@ class SandboxFleet:
     return f"{constants.RUN_ID_LABEL}={self.run_id}"
 
   def live_owned_count(self) -> int:
-    """Live Sandbox CRs this run owns (by run-id label), across clusters."""
+    """Live sandbox **pods** this run owns (by run-id label), across clusters.
+
+    The Sandbox controller does not copy the run-id label onto Sandbox CRs, so we
+    count pods instead — the pod template carries the fleet labels (incl. run-id),
+    so this reflects the actual live footprint, including #1215 over-creation."""
     sel = self.run_selector()
     n = 0
     for c in self.registry:
       try:
-        n += len(c.resources.list_sandboxes(label_selector=sel))
+        n += c.resources.count_pods(label_selector=sel)
       except Exception:  # noqa: BLE001 — a transient list error must not crash the breaker
         pass
     return n
@@ -235,8 +239,13 @@ class SandboxFleet:
         self._prev_handlers.pop(sig, None)
 
   def _on_signal(self, signum, frame):
-    logger.warning("signal %d → tearing down fleet run %s", signum, self.run_id)
-    self._safe_teardown()
+    # Do NOT tear down inline: this handler can fire while the main thread holds
+    # self._lock, and teardown → release_all → release re-acquires it → deadlock.
+    # Instead unwind (raise), which releases any held lock, and let the atexit hook
+    # (_safe_teardown, registered in _install_teardown_hooks) run teardown outside
+    # the signal context.
+    logger.warning("signal %d → aborting fleet run %s (teardown via atexit)",
+                   signum, self.run_id)
     prev = self._prev_handlers.get(signum)
     if callable(prev) and prev not in (signal.SIG_DFL, signal.SIG_IGN):
       prev(signum, frame)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -850,7 +850,10 @@ class SandboxFleet:
   # --- managed runner ---------------------------------------------------- #
   def run(self, process_fn: Callable[[Task, SandboxHandle], object],
           strategy: str = "naive", concurrency: int | None = None,
-          *, epochs: int = 1, keep_warm: bool = False) -> list:
+          *, epochs: int = 1, keep_warm: bool = False,
+          recycle: bool = False, reset=None, max_reuses: int = 32,
+          reset_timeout: float = 5.0, use_session: bool = True,
+          scale_on_hold: bool = True) -> list:
     """Run all loaded tasks under ``strategy`` (none|naive|sliding|pipelined) with
     up to ``concurrency`` parallel claim+exec (defaults to ``config.max_concurrent``).
 
@@ -860,14 +863,34 @@ class SandboxFleet:
     returns the flat ``list`` (a per-task exception is captured, not raised).
     ``keep_warm=True`` skips the final teardown so a caller's own loop can reuse the
     warm pools; call ``fleet.teardown()`` when done.
+
+    ``recycle`` is an **orthogonal** modifier, not a strategy: with ``recycle=True``
+    the chosen ``strategy`` still governs warm-pool sizing/timing, but tasks sharing
+    an image reuse one claimed sandbox (git-restore reset between them) instead of a
+    fresh claim per task — see `recycle.reuse_git_restore_sandbox`. It only applies
+    to workloads with a resettable ``/testbed`` (multiple tasks per image, e.g. RL
+    rollouts); for 1:1 eval it is a no-op, so it is off by default. ``reset`` (a
+    ``GitRestoreReset``), ``max_reuses``, ``reset_timeout``, ``use_session`` and
+    ``scale_on_hold`` are forwarded to the recycle executor and ignored when
+    ``recycle=False``.
     """
-    from .strategies import STRATEGIES
+    from .strategies import STRATEGIES, process_parallel
     if strategy not in STRATEGIES:
       raise ValueError(f"unknown strategy '{strategy}'; choose from {sorted(STRATEGIES)}")
     if epochs < 1:
       raise ValueError("epochs must be >= 1")
     conc = concurrency or self.config.max_concurrent
     fn = STRATEGIES[strategy]
+    executor = process_parallel
+    if recycle:                               # swap task→sandbox binding, keep warming
+      from .recycle import GitRestoreReset, reuse_git_restore_sandbox
+      _reset = reset or GitRestoreReset()
+
+      def executor(fleet, tasks, process_fn, concurrency):  # noqa: E306
+        return reuse_git_restore_sandbox(
+            fleet, tasks, process_fn, concurrency, reset=_reset,
+            max_reuses=max_reuses, reset_timeout=reset_timeout,
+            use_session=use_session, scale_on_hold=scale_on_hold)
     if self.plan_ is None:
       self.plan()                             # give the circuit breaker a footprint
     expected = self.plan_.total_replicas if self.plan_ else None
@@ -878,7 +901,8 @@ class SandboxFleet:
       except Exception:  # noqa: BLE001 — environment is best-effort
         logger.debug("could not collect environment", exc_info=True)
       if epochs == 1:
-        results = fn(self, process_fn, conc, teardown=not keep_warm)
+        results = fn(self, process_fn, conc, teardown=not keep_warm,
+                     executor=executor)
       else:
         results = []
         for e in range(epochs):
@@ -886,7 +910,7 @@ class SandboxFleet:
           logger.info("epoch %d/%d", e + 1, epochs)
           try:
             results.append(fn(self, process_fn, conc,
-                              teardown=last and not keep_warm))
+                              teardown=last and not keep_warm, executor=executor))
           except BaseException:               # a mid-run epoch never tore down
             if not keep_warm and not last:
               self.teardown()

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -23,20 +23,24 @@ release → teardown. Use the primitives directly from an RL loop, or the manage
 
 from __future__ import annotations
 
+import atexit
 import collections
+import contextlib
 import logging
 import math
+import signal
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Callable, Optional
 
 from kubernetes import client
 
-from . import sizing
+from . import constants, sizing
 from .cluster import Cluster, ClusterRegistry
 from .config import ClusterConfig, FleetConfig
-from .exceptions import FleetError, PreflightError
+from .exceptions import FleetError, FleetOvercommitError, PreflightError
 from .handles import SandboxHandle
 from .observability import Observer, repo_family
 from .placement import get_placement
@@ -81,6 +85,7 @@ class FleetPlan:
   def __init__(self, entries: list[PlanEntry]):
     self.entries = entries
     self._by_image = {e.image: e for e in entries}
+    self.warnings: list[str] = []            # (#5) advisory notes, never fatal
 
   def for_image(self, image: str) -> Optional[PlanEntry]:
     return self._by_image.get(image)
@@ -101,7 +106,20 @@ class SandboxFleet:
 
   def __init__(self, config: FleetConfig | None = None,
                registry: ClusterRegistry | None = None):
-    self.config = config or FleetConfig()
+    # Copy the caller's config so we don't mutate their object when stamping the
+    # run-id label below.
+    src = config or FleetConfig()
+    self.config = (src.model_copy(deep=True) if hasattr(src, "model_copy")
+                   else src.copy(deep=True))
+    # Stamp a per-run label on everything this fleet creates so an orphaned run
+    # can always be swept by the reaper (#4). Set before the registry is built so
+    # it flows into every create call's labels.
+    self.run_id = uuid.uuid4().hex[:12]
+    self.config.labels = {**self.config.labels, constants.RUN_ID_LABEL: self.run_id}
+    self._prev_handlers: dict = {}           # signum -> previous handler (to restore)
+    self._atexit_registered = False
+    self._torndown = False
+    self._teardown_lock = threading.Lock()   # makes _teardown idempotent/reentrant
     # Honor an explicitly-passed registry even when empty — `ClusterRegistry`
     # defines `__len__`, so `registry or …` would treat `ClusterRegistry([])` as
     # falsy and build a default ambient Cluster (which loads kube-config). Only
@@ -136,6 +154,119 @@ class SandboxFleet:
   @property
   def observer(self):
     return self._obs
+
+  # --- runaway safeguards (plans/sdk-runaway-safeguards.md) --------------- #
+  def run_selector(self) -> str:
+    """Label selector for resources this run owns (the reaper key)."""
+    return f"{constants.RUN_ID_LABEL}={self.run_id}"
+
+  def live_owned_count(self) -> int:
+    """Live Sandbox CRs this run owns (by run-id label), across clusters."""
+    sel = self.run_selector()
+    n = 0
+    for c in self.registry:
+      try:
+        n += len(c.resources.list_sandboxes(label_selector=sel))
+      except Exception:  # noqa: BLE001 — a transient list error must not crash the breaker
+        pass
+    return n
+
+  @contextlib.contextmanager
+  def overcommit_guard(self, expected: int | None = None):
+    """Circuit breaker (#1): a background thread samples ``live_owned_count`` and, if
+    it exceeds ``min(expected × overcommit_factor, max_live_sandboxes)``, tears the
+    fleet down and raises `FleetOvercommitError` on exit. Keys off *intent* so it
+    trips on accidental over-creation (runaway / orphan / #1215), not a large-but-
+    intended run. Disabled when both knobs are off."""
+    factor = self.config.overcommit_factor
+    hard = self.config.max_live_sandboxes
+    if expected is None:
+      expected = self.plan_.total_replicas if self.plan_ else 0
+    ceilings = []
+    if factor and factor > 0 and expected > 0:
+      ceilings.append(int(expected * factor))
+    if hard:
+      ceilings.append(int(hard))
+    ceiling = min(ceilings) if ceilings else None
+    if ceiling is None:
+      yield
+      return
+    stop = threading.Event()
+    tripped = {"n": 0}
+
+    def _loop():
+      while not stop.wait(self.config.breaker_poll_s):
+        n = self.live_owned_count()
+        if n > ceiling:
+          logger.error("circuit breaker TRIPPED: %d live sandboxes > ceiling %d "
+                       "(expected %d) — aborting run + tearing down", n, ceiling, expected)
+          tripped["n"] = n
+          try:
+            self.teardown()
+          except Exception:  # noqa: BLE001
+            logger.warning("teardown during breaker trip failed", exc_info=True)
+          return
+
+    th = threading.Thread(target=_loop, name="asrl-breaker", daemon=True)
+    th.start()
+    try:
+      yield
+    finally:
+      stop.set()
+      th.join(timeout=2)
+    if tripped["n"]:
+      raise FleetOvercommitError(
+          f"live sandboxes {tripped['n']} exceeded ceiling {ceiling} (expected "
+          f"{expected}, factor {factor}) — run aborted, fleet torn down")
+
+  def _install_teardown_hooks(self) -> None:
+    """(#4) atexit + SIGINT/SIGTERM → teardown so a killed/crashing driver still
+    cleans up. Signal install is a no-op off the main thread; atexit always set."""
+    if not self._atexit_registered:
+      atexit.register(self._safe_teardown)
+      self._atexit_registered = True
+    for sig in (signal.SIGINT, signal.SIGTERM):
+      if sig in self._prev_handlers:
+        continue
+      try:
+        self._prev_handlers[sig] = signal.getsignal(sig)
+        signal.signal(sig, self._on_signal)
+      except (ValueError, OSError):        # not main thread / unsupported
+        self._prev_handlers.pop(sig, None)
+
+  def _on_signal(self, signum, frame):
+    logger.warning("signal %d → tearing down fleet run %s", signum, self.run_id)
+    self._safe_teardown()
+    prev = self._prev_handlers.get(signum)
+    if callable(prev) and prev not in (signal.SIG_DFL, signal.SIG_IGN):
+      prev(signum, frame)
+    elif signum == signal.SIGINT:
+      raise KeyboardInterrupt
+    else:
+      raise SystemExit(128 + signum)
+
+  def _safe_teardown(self) -> None:
+    if self._torndown:
+      return
+    try:
+      self.teardown()
+    except Exception:  # noqa: BLE001
+      logger.warning("teardown hook failed", exc_info=True)
+
+  def _remove_teardown_hooks(self) -> None:
+    if self._atexit_registered:
+      with contextlib.suppress(Exception):
+        atexit.unregister(self._safe_teardown)
+      self._atexit_registered = False
+    # signal.signal only works on the main thread — when teardown runs from the
+    # breaker thread we can't restore here; leave the (idempotent) handlers in
+    # place rather than silently failing. They're cleared on the next main-thread
+    # teardown / process exit.
+    if threading.current_thread() is threading.main_thread():
+      for sig, prev in list(self._prev_handlers.items()):
+        with contextlib.suppress(ValueError, OSError):
+          signal.signal(sig, prev)
+      self._prev_handlers.clear()
 
   @staticmethod
   def _default_registry(config: FleetConfig) -> ClusterRegistry:
@@ -290,10 +421,36 @@ class SandboxFleet:
           cluster=c.name, image=image, template=template,
           pool=f"pool-{template}", replicas=replicas, tasks=counts[image]))
     self.plan_ = FleetPlan(entries)
+    self._advise(self.plan_)                   # (#5) warn-only capacity/QPS advisory
     logger.info("Plan: %d images across %d cluster(s), %d total warm replicas",
                 len(entries), len(self.plan_.by_cluster()),
                 self.plan_.total_replicas)
     return self.plan_
+
+  def _advise(self, plan: "FleetPlan") -> None:
+    """(#5) Warn — never refuse — when the plan's footprint or claim concurrency
+    looks beyond what the control plane comfortably absorbs. The customer owns
+    their cluster; this is a sign, not a gate."""
+    total = plan.total_replicas
+    nodes = self.config.cluster_nodes
+    if nodes:
+      slots = nodes * 200                      # rough usable pod slots/node
+      if total > slots:
+        plan.warnings.append(
+            f"warm footprint {total} exceeds ~{slots} schedulable slots "
+            f"({nodes} nodes × ~200) — expect Pending pods / capacity churn.")
+    if self.config.max_concurrent > 2000:
+      plan.warnings.append(
+          f"max_concurrent {self.config.max_concurrent} exceeds ~2000 the apiserver "
+          f"typically sustains for concurrent claims — expect 429s and possible "
+          f"over-creation; consider staging claims or a lower cap.")
+    if total > 20000:
+      plan.warnings.append(
+          f"warm footprint {total} is very large; deep warm can trip the warm-pool "
+          f"over-creation race (#1215) — keep the controller's "
+          f"--sandbox-warm-pool-concurrent-workers low and stage the fill.")
+    for msg in plan.warnings:
+      logger.warning("plan advisory: %s", msg)
 
   # --- provisioning ------------------------------------------------------ #
   def _ensure_pool(self, cluster: Cluster, image: str, replicas: int) -> str:
@@ -459,6 +616,28 @@ class SandboxFleet:
     c.release_replicas(reps)
     self._obs.warm_remove(entry.cluster, reps)
 
+  def set_pool_replicas(self, image: str, replicas: int) -> None:
+    """Patch an image's warm pool to ``replicas`` (scale up or down) without
+    deleting it. Used by **sharded** recycle to cancel the controller's
+    replenishment as held shards claim: keeping ``desired = K − held`` means
+    ``held + warm == K`` per image throughout, so 18K claims never over-provision
+    (unlike ``unwarm_image``, which drops the whole pool). Best-effort on the warm
+    capacity counter — the delta is reconciled at ``teardown`` (reset_counts)."""
+    entry = (self.plan_ or self.plan()).for_image(image)
+    if entry is None:
+      return
+    replicas = max(0, replicas)
+    c = self.registry.get(entry.cluster)
+    c.resources.create_warmpool(entry.pool, entry.template, replicas, reconcile=True)
+    with self._lock:
+      prev = self._warmed.get(image, entry.replicas)
+      self._warmed[image] = replicas
+    delta = replicas - prev
+    if delta > 0:
+      c.reserve_replicas(delta)
+    elif delta < 0:
+      c.release_replicas(-delta)
+
   def prepull(self, wait: bool = True) -> None:
     """Pre-pull each cluster's planned images via a DaemonSet (optional)."""
     from . import prepull as _pp
@@ -483,6 +662,9 @@ class SandboxFleet:
 
     ``create_budget`` (if set) stages the warm fill in waves to bound the
     controller's concurrent create burst — see ``start_warmpools``."""
+    if self.config.install_teardown_hooks:
+      self._install_teardown_hooks()          # (#4) clean up even on kill/crash
+    self._torndown = False
     self.preflight()
     self.plan()
     if prepull:
@@ -598,6 +780,14 @@ class SandboxFleet:
       self._teardown(delete_namespace)
 
   def _teardown(self, delete_namespace: bool) -> None:
+    # Idempotent/reentrant: the breaker thread, a strategy's teardown, __exit__,
+    # and signal handlers can all call this — only the first pass this cycle runs
+    # (setup() resets the flag). Deletes are 404-tolerant, but this avoids the
+    # redundant sweeps + the registry/handle race of concurrent teardowns.
+    with self._teardown_lock:
+      if self._torndown:
+        return
+      self._torndown = True
     self.release_all()
     for c in self.registry:
       sel = c.resources.managed_selector()
@@ -620,6 +810,7 @@ class SandboxFleet:
       self._warmed.clear()
       self._ondemand.clear()
     self.plan_ = None
+    self._remove_teardown_hooks()
 
   def __enter__(self) -> "SandboxFleet":
     return self.setup()
@@ -648,7 +839,10 @@ class SandboxFleet:
       raise ValueError("epochs must be >= 1")
     conc = concurrency or self.config.max_concurrent
     fn = STRATEGIES[strategy]
-    with self._obs.run(strategy) as report:
+    if self.plan_ is None:
+      self.plan()                             # give the circuit breaker a footprint
+    expected = self.plan_.total_replicas if self.plan_ else None
+    with self.overcommit_guard(expected), self._obs.run(strategy) as report:
       self.report = report
       try:
         report.environment = self.describe_environment()

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -282,15 +282,19 @@ class SandboxFleet:
     # Instead unwind (raise), which releases any held lock, and let the atexit hook
     # (_safe_teardown, registered in _install_teardown_hooks) run teardown outside
     # the signal context.
+    prev = self._prev_handlers.get(signum)
+    if prev == signal.SIG_IGN:
+      logger.debug("signal %d ignored (previous handler was SIG_IGN)", signum)
+      return                                   # honor an explicit ignore — don't turn it into an abort
     logger.warning("signal %d → aborting fleet run %s (teardown via atexit)",
                    signum, self.run_id)
-    prev = self._prev_handlers.get(signum)
-    if callable(prev) and prev not in (signal.SIG_DFL, signal.SIG_IGN):
-      prev(signum, frame)
-    elif signum == signal.SIGINT:
+    if callable(prev) and prev != signal.SIG_DFL:
+      prev(signum, frame)                      # chain to a custom handler first
+    # Always unwind after chaining (a prior callable that returns normally must not
+    # silently resume the run when we've logged "aborting"); SIG_DFL falls through here too.
+    if signum == signal.SIGINT:
       raise KeyboardInterrupt
-    else:
-      raise SystemExit(128 + signum)
+    raise SystemExit(128 + signum)
 
   def _safe_teardown(self) -> None:
     if self._torndown:

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -182,8 +182,11 @@ class SandboxFleet:
     for c in self.registry:
       try:
         n += c.resources.count_pods(label_selector=sel)
-      except Exception:  # noqa: BLE001 — a transient list error must not crash the breaker
-        pass
+      except Exception as e:  # noqa: BLE001 — a transient list error must not crash the breaker
+        # Fail open (don't crash the poll) but surface it: the breaker under-counts
+        # this poll, so operators can see when it's blind (e.g. apiserver 429s).
+        logger.warning("live_owned_count: pod count failed on cluster %s (%s); "
+                       "breaker under-counts this poll", c.name, e)
     return n
 
   @contextlib.contextmanager

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -142,6 +142,8 @@ class SandboxFleet:
     self._warmed: dict[str, int] = {}        # image -> replicas currently warmed
     self._ondemand: set[tuple[str, str]] = set()   # (cluster, image) pools made via acquire()
     self._lock = threading.Lock()            # guards bookkeeping under parallel run
+    self._guard_active = False                # re-entrancy flag for overcommit_guard
+    self._guard_lock = threading.Lock()      # guards _guard_active
     self._obs = Observer(self.config.observability)
     self.report = None                       # set by run()/the Observer
     if self.config.observability.enable_tracing:
@@ -204,6 +206,20 @@ class SandboxFleet:
     if ceiling is None:
       yield
       return
+    # Re-entrancy: `run(recycle=True)` opens this guard around the strategy/executor,
+    # and the recycle executor opens it again — nesting on the same fleet. Run only
+    # the outer monitor: a second thread would double the pod-list load per poll (a
+    # full filtered list under a selector) and race into teardown on a trip. Direct
+    # executor callers (no surrounding run) still get their own guard.
+    with self._guard_lock:
+      if self._guard_active:
+        reentrant = True
+      else:
+        self._guard_active = True
+        reentrant = False
+    if reentrant:
+      yield
+      return
     stop = threading.Event()
     tripped = {"n": 0}
 
@@ -238,6 +254,8 @@ class SandboxFleet:
     finally:
       stop.set()
       th.join(timeout=2)
+      with self._guard_lock:
+        self._guard_active = False
     if tripped["n"]:
       raise FleetOvercommitError(
           f"live sandboxes {tripped['n']} exceeded ceiling {ceiling} (expected "
@@ -633,15 +651,23 @@ class SandboxFleet:
     self._warm_entry(entry, wait, replicas_override=replicas_override)
 
   def unwarm_image(self, image: str) -> None:
-    """Tear down one image's pool + template."""
+    """Tear down one image's pool + template. **Idempotent**: a no-op if the image
+    isn't currently warmed. Two callers can legitimately unwarm the same image —
+    `scale_on_hold` recycling drops a held sandbox's pool, and a windowed strategy
+    sweeps its window at the end — so releasing capacity / counting `warm_remove`
+    must happen exactly once. (`release_replicas` is not idempotent: a second call
+    would double-decrement `active_replicas`, freeing capacity that isn't free and
+    over-admitting later windows.)"""
     entry = (self.plan_ or self.plan()).for_image(image)
     if entry is None:
-      return
+      return                                   # locate the pool before mutating state
+    with self._lock:
+      if image not in self._warmed:
+        return                                 # already unwarmed — don't double-release
+      reps = self._warmed.pop(image)
     c = self.registry.get(entry.cluster)
     c.resources.delete_warmpool(entry.pool)
     c.resources.delete_template(entry.template)
-    with self._lock:
-      reps = self._warmed.pop(image, entry.replicas)
     c.release_replicas(reps)
     self._obs.warm_remove(entry.cluster, reps)
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -182,8 +182,11 @@ class SandboxHandle:
   def exec(self, command, timeout: float | None = None) -> str:
     """Run a command inside the sandbox (router-free, via the pod's exec API).
 
-    ``timeout`` (seconds) bounds the wait; ``None`` waits until the command
-    finishes (the default for both paths — a session never silently caps a command).
+    ``timeout`` (seconds) bounds the wait on the **session** path; ``None`` (default)
+    waits until the command finishes. The one-shot path always runs to completion
+    (``_preload_content=True`` blocks), so a finite ``timeout`` takes effect only when
+    a session is attached — the point being that attaching a session no longer
+    silently caps a command (the previous 120s default).
 
     If a persistent `SandboxSession` is attached (``open_session()``), the command
     is piped over that single held-open stream — no per-command websocket connect

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -84,6 +84,9 @@ class SandboxSession:
     deadline = time.monotonic() + open_timeout
     while time.monotonic() < deadline and not self._resp.is_open():
       self._resp.update(timeout=1)
+    if not self.is_open:                        # honor open_timeout explicitly
+      raise TimeoutError(
+          f"session websocket did not open within {open_timeout}s on {pod}")
     self.run("stty -echo 2>/dev/null; true")   # quiet the pty echo where supported
 
   @property

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
@@ -40,6 +41,90 @@ def exec_in_pod(core_api, pod: str, namespace: str, command) -> str:
       pod, namespace, command=command,
       stderr=True, stdin=False, stdout=True, tty=False,
       _preload_content=True)
+
+
+def _as_script(command) -> str:
+  """Normalize an exec `command` (str or argv) to a shell script string for a
+  persistent session. ``["bash","-lc",script]`` → ``script``; other argv joined."""
+  if isinstance(command, str):
+    return command
+  if len(command) >= 3 and command[0] in ("bash", "sh") and command[1] == "-lc":
+    return command[2]
+  return " ".join(command)
+
+
+class SandboxSession:
+  """One long-lived `bash` exec stream per sandbox — commands are piped over a
+  single held-open websocket instead of a fresh `connect...pod_exec` per call.
+
+  This is the control-plane lever for recycling: with a session, a sandbox's
+  task + reset commands cost **one** apiserver exec connection for its whole
+  life (O(sandboxes)) instead of one per command (O(tasks)) — which is what
+  saturates the exec path at high concurrency.
+
+  ``run(command)`` returns combined stdout (like `exec_in_pod`). Framing: a
+  sentinel is emitted after each command; the sentinel's assembled form never
+  appears in the echoed input (built by shell concatenation), so it matches only
+  real output. A pty (`tty=True`) keeps bash line-buffered so small outputs flush
+  promptly. Not thread-safe — one session is driven by one worker.
+  """
+
+  def __init__(self, core_api, pod: str, namespace: str, *,
+               open_timeout: float = 30.0):
+    self.pod = pod
+    self._seq = 0
+    self._resp = stream(
+        core_api.connect_get_namespaced_pod_exec, pod, namespace,
+        command=["bash"], stderr=True, stdin=True, stdout=True, tty=True,
+        _preload_content=False)
+    # Let the shell come up and drain the initial prompt/banner.
+    deadline = time.monotonic() + open_timeout
+    while time.monotonic() < deadline and not self._resp.is_open():
+      self._resp.update(timeout=1)
+    self.run("stty -echo 2>/dev/null; true")   # quiet the pty echo where supported
+
+  @property
+  def is_open(self) -> bool:
+    try:
+      return bool(self._resp.is_open())
+    except Exception:  # noqa: BLE001
+      return False
+
+  def run(self, command, timeout: float = 120.0) -> str:
+    self._seq += 1
+    # Assemble the marker at runtime ("__A""B" -> "AB") so the literal never
+    # appears in the pty-echoed command line — only in the command's output.
+    tok = f"ASRLDONE{self._seq}X"
+    head, tail = tok[:6], tok[6:]
+    script = _as_script(command)
+    self._resp.write_stdin(script + "\n")
+    self._resp.write_stdin(f'printf "%s%s\\n" "{head}" "{tail}"\n')
+    marker = tok
+    buf = []
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+      self._resp.update(timeout=1)
+      if self._resp.peek_stdout():
+        buf.append(self._resp.read_stdout())
+        text = "".join(buf)
+        if marker in text:
+          out = text.split(marker, 1)[0]
+          return out.replace("\r\n", "\n")
+      if self._resp.peek_stderr():
+        self._resp.read_stderr()               # drain to avoid backpressure
+      if not self.is_open:
+        break
+    raise TimeoutError(f"session.run timed out/closed on {self.pod}")
+
+  def close(self) -> None:
+    try:
+      self._resp.write_stdin("exit\n")
+    except Exception:  # noqa: BLE001
+      pass
+    try:
+      self._resp.close()
+    except Exception:  # noqa: BLE001
+      pass
 
 
 @dataclass
@@ -67,18 +152,36 @@ class SandboxHandle:
   pod_ip: Optional[str] = None
   sandbox: object = None
   _cluster: "Cluster" = field(default=None, repr=False)
+  _session: Optional["SandboxSession"] = field(default=None, repr=False)
 
   def exec(self, command) -> str:
     """Run a command inside the sandbox (router-free, via the pod's exec API).
 
-    Uses a **thread-local** ``CoreV1Api`` (``Cluster.exec_core_api``): the
-    kubernetes ``stream()`` (websocket) exec is not thread-safe across a shared
-    client, so parallel execs stay isolated per thread — but the client is cached
-    per thread rather than rebuilt per call, avoiding a leaked connection/thread
-    pool on every exec.
+    If a persistent `SandboxSession` is attached (``open_session()``), the command
+    is piped over that single held-open stream — no per-command websocket connect
+    (the recycling control-plane lever). Otherwise a fresh one-shot exec is used,
+    via a **thread-local** ``CoreV1Api`` (``Cluster.exec_core_api``): the
+    kubernetes ``stream()`` websocket exec is not thread-safe across a shared
+    client, so parallel one-shot execs stay isolated per thread while the client
+    is cached per thread rather than rebuilt per call.
     """
+    if self._session is not None and self._session.is_open:
+      return self._session.run(command)
     core = self._cluster.exec_core_api()
     return exec_in_pod(core, self.pod_name, self._cluster.namespace, command)
+
+  def open_session(self) -> "SandboxSession":
+    """Open (once) a persistent exec session so subsequent ``exec()`` calls reuse
+    a single websocket instead of connecting per command. Returns it."""
+    if self._session is None or not self._session.is_open:
+      self._session = SandboxSession(
+          self._cluster.exec_core_api(), self.pod_name, self._cluster.namespace)
+    return self._session
+
+  def close_session(self) -> None:
+    if self._session is not None:
+      self._session.close()
+      self._session = None
 
   def endpoint(self, port: int = 8888) -> str:
     """In-cluster endpoint (``<hostname>.<namespace>:<port>``) for callers that
@@ -92,6 +195,7 @@ class SandboxHandle:
     it also updates the fleet's claim/replica bookkeeping under its lock. Calling
     this directly just frees the remote resources.
     """
+    self.close_session()                       # drop the persistent stream, if any
     if self.sandbox is not None:
       self.sandbox.terminate()
     else:

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -110,14 +110,14 @@ class SandboxSession:
       if remaining <= 0:
         break
       self._resp.update(timeout=min(1.0, remaining))   # honor small timeouts
+      if self._resp.peek_stderr():
+        buf.append(self._resp.read_stderr())   # combine stderr (exec() returns both)
       if self._resp.peek_stdout():
         buf.append(self._resp.read_stdout())
         text = "".join(buf)
         if marker in text:
           out = text.split(marker, 1)[0]
           return out.replace("\r\n", "\n")
-      if self._resp.peek_stderr():
-        self._resp.read_stderr()               # drain to avoid backpressure
       if not self.is_open:
         break
     raise TimeoutError(f"session.run timed out/closed on {self.pod}")

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -78,7 +78,7 @@ class SandboxSession:
     self._seq = 0
     self._resp = stream(
         core_api.connect_get_namespaced_pod_exec, pod, namespace,
-        command=["bash"], stderr=True, stdin=True, stdout=True, tty=True,
+        command=["bash", "-l"], stderr=True, stdin=True, stdout=True, tty=True,
         _preload_content=False)
     # Let the shell come up and drain the initial prompt/banner.
     deadline = time.monotonic() + open_timeout
@@ -87,7 +87,12 @@ class SandboxSession:
     if not self.is_open:                        # honor open_timeout explicitly
       raise TimeoutError(
           f"session websocket did not open within {open_timeout}s on {pod}")
-    self.run("stty -echo 2>/dev/null; true")   # quiet the pty echo where supported
+    # `bash -l` matches the one-shot `bash -lc` path (sources /etc/profile* where
+    # conda activation lives) so a session and a fallback one-shot share the env.
+    # Quiet the pty echo and clear PS1/PROMPT_COMMAND so no prompt/banner leaks
+    # into command output.
+    self.run("stty -echo 2>/dev/null; PS1=''; PROMPT_COMMAND=''; true",
+             timeout=open_timeout)
 
   @property
   def is_open(self) -> bool:
@@ -96,7 +101,13 @@ class SandboxSession:
     except Exception:  # noqa: BLE001
       return False
 
-  def run(self, command, timeout: float = 120.0) -> str:
+  def run(self, command, timeout: float | None = None) -> str:
+    """Run ``command`` over the session, returning combined stdout/stderr.
+
+    ``timeout=None`` waits indefinitely (parity with the one-shot exec path, whose
+    ``_preload_content=True`` blocks until the command finishes) — so attaching a
+    session never silently caps a command. On timeout or a closed socket the session
+    is closed before raising, so its stale buffer can't bleed into the next call."""
     self._seq += 1
     # Assemble the marker at runtime ("__A""B" -> "AB") so the literal never
     # appears in the pty-echoed command line — only in the command's output.
@@ -107,12 +118,16 @@ class SandboxSession:
     self._resp.write_stdin(f'printf "%s%s\\n" "{head}" "{tail}"\n')
     marker = tok
     buf = []
-    deadline = time.monotonic() + timeout
+    deadline = None if timeout is None else time.monotonic() + timeout
     while True:
-      remaining = deadline - time.monotonic()
-      if remaining <= 0:
-        break
-      self._resp.update(timeout=min(1.0, remaining))   # honor small timeouts
+      if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+          break
+        upd = min(1.0, remaining)
+      else:
+        upd = 1.0
+      self._resp.update(timeout=upd)             # honor small timeouts
       if self._resp.peek_stderr():
         buf.append(self._resp.read_stderr())   # combine stderr (exec() returns both)
       if self._resp.peek_stdout():
@@ -123,6 +138,7 @@ class SandboxSession:
           return out.replace("\r\n", "\n")
       if not self.is_open:
         break
+    self.close()                                 # drop stale state; never reuse a timed-out session
     raise TimeoutError(f"session.run timed out/closed on {self.pod}")
 
   def close(self) -> None:
@@ -163,8 +179,11 @@ class SandboxHandle:
   _cluster: "Cluster" = field(default=None, repr=False)
   _session: Optional["SandboxSession"] = field(default=None, repr=False)
 
-  def exec(self, command) -> str:
+  def exec(self, command, timeout: float | None = None) -> str:
     """Run a command inside the sandbox (router-free, via the pod's exec API).
+
+    ``timeout`` (seconds) bounds the wait; ``None`` waits until the command
+    finishes (the default for both paths — a session never silently caps a command).
 
     If a persistent `SandboxSession` is attached (``open_session()``), the command
     is piped over that single held-open stream — no per-command websocket connect
@@ -175,7 +194,7 @@ class SandboxHandle:
     is cached per thread rather than rebuilt per call.
     """
     if self._session is not None and self._session.is_open:
-      return self._session.run(command)
+      return self._session.run(command, timeout=timeout)
     core = self._cluster.exec_core_api()
     return exec_in_pod(core, self.pod_name, self._cluster.namespace, command)
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import shlex
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
@@ -50,7 +51,9 @@ def _as_script(command) -> str:
     return command
   if len(command) >= 3 and command[0] in ("bash", "sh") and command[1] == "-lc":
     return command[2]
-  return " ".join(command)
+  # shell-quote each arg so argv round-trips through the bash session intact
+  # (e.g. ['sh','-c','echo $(hostname)'] -> "sh -c 'echo $(hostname)'").
+  return shlex.join(command)
 
 
 class SandboxSession:
@@ -102,8 +105,11 @@ class SandboxSession:
     marker = tok
     buf = []
     deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-      self._resp.update(timeout=1)
+    while True:
+      remaining = deadline - time.monotonic()
+      if remaining <= 0:
+        break
+      self._resp.update(timeout=min(1.0, remaining))   # honor small timeouts
       if self._resp.peek_stdout():
         buf.append(self._resp.read_stdout())
         text = "".join(buf)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/observability.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/observability.py
@@ -145,7 +145,8 @@ class RunReport:
   environment: dict = field(default_factory=dict)   # per-cluster details
 
   _ORDER = ("preflight", "plan", "prepull", "create_warmpool", "wait_pool_ready",
-            "prefetch", "claim", "process", "release", "teardown")
+            "prefetch", "claim", "process", "reset", "quarantine", "rotate",
+            "release", "teardown")
 
   def add_phase(self, name: str, dur: float) -> None:
     c = self.phases.setdefault(name, [0, 0.0, 0.0])

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/reaper.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/reaper.py
@@ -16,10 +16,11 @@
 sweep for an **orphaned** run whose driver died without tearing down.
 
     from agent_sandbox_rl import reap
-    reap(run_id="ab12cd34ef56", context="my-ctx", namespace="rl")   # one run
-    reap(context="my-ctx", namespace="rl")                          # all asrl-managed
+    reap(run_id="ab12cd34ef56", context="my-ctx", namespace="rl")   # one run (recommended)
+    reap(all_managed=True, context="my-ctx", namespace="rl")        # EVERY run (opt-in)
 
     python -m agent_sandbox_rl.reaper --run-id ab12cd34ef56 --context my-ctx --namespace rl
+    python -m agent_sandbox_rl.reaper --all --namespace rl          # every run (opt-in)
 
 Deletes claims → warmpools → sandboxes → templates (order matters: claims first so
 they stop holding sandboxes; warmpools next so the controller stops replenishing),
@@ -44,10 +45,20 @@ logger = logging.getLogger("agent_sandbox_rl.reap")
 
 def reap(run_id: str | None = None, *, context: str | None = None,
          namespace: str = "default", kubeconfig: str | None = None,
-         in_cluster: bool = False, delete_pods: bool = True) -> dict:
-  """Delete resources matching a run-id (or all asrl-managed if ``run_id`` is None).
+         in_cluster: bool = False, delete_pods: bool = True,
+         all_managed: bool = False) -> dict:
+  """Delete resources for a single run (``run_id``), or — only when
+  ``all_managed=True`` — **every** agent-sandbox-rl run in the namespace.
 
-  Returns a dict of per-kind deletion counts. Safe to run repeatedly (idempotent)."""
+  The all-managed sweep is opt-in on purpose: it force-deletes (grace 0) pods of
+  *healthy concurrent runs* too, so it must never be the accidental default of a
+  "clean up my killed run" invocation. Returns per-kind deletion counts;
+  idempotent."""
+  if run_id is None and not all_managed:
+    raise ValueError(
+        "reap requires a run_id; to sweep EVERY agent-sandbox-rl run in the "
+        "namespace (including healthy concurrent ones) pass all_managed=True "
+        "(CLI: --all)")
   selector = (f"{constants.RUN_ID_LABEL}={run_id}" if run_id
               else f"{constants.MANAGED_BY_LABEL}={constants.MANAGED_BY_VALUE}")
   cluster = Cluster(
@@ -86,7 +97,10 @@ def reap(run_id: str | None = None, *, context: str | None = None,
 
 def main(argv=None) -> None:
   p = argparse.ArgumentParser(description="Reap agent-sandbox-rl resources by label.")
-  p.add_argument("--run-id", default=None, help="reap one run; omit to reap all asrl-managed")
+  p.add_argument("--run-id", default=None, help="reap one run by id (recommended)")
+  p.add_argument("--all", action="store_true",
+                 help="sweep ALL agent-sandbox-rl runs in the namespace, incl. healthy "
+                      "concurrent ones (required when --run-id is omitted)")
   p.add_argument("--context", default=None)
   p.add_argument("--namespace", default="default")
   p.add_argument("--kubeconfig", default=None)
@@ -94,9 +108,12 @@ def main(argv=None) -> None:
   p.add_argument("--keep-pods", action="store_true", help="don't force-delete pods")
   a = p.parse_args(argv)
   logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-  counts = reap(a.run_id, context=a.context, namespace=a.namespace,
-                kubeconfig=a.kubeconfig, in_cluster=a.in_cluster,
-                delete_pods=not a.keep_pods)
+  try:
+    counts = reap(a.run_id, context=a.context, namespace=a.namespace,
+                  kubeconfig=a.kubeconfig, in_cluster=a.in_cluster,
+                  delete_pods=not a.keep_pods, all_managed=a.all)
+  except ValueError as e:
+    p.error(str(e))
   print(counts)
 
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/reaper.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/reaper.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reaper (#4): delete everything a fleet run created, by label — the guaranteed
+sweep for an **orphaned** run whose driver died without tearing down.
+
+    from agent_sandbox_rl import reap
+    reap(run_id="ab12cd34ef56", context="my-ctx", namespace="rl")   # one run
+    reap(context="my-ctx", namespace="rl")                          # all asrl-managed
+
+    python -m agent_sandbox_rl.reaper --run-id ab12cd34ef56 --context my-ctx --namespace rl
+
+Deletes claims → warmpools → sandboxes → templates (order matters: claims first so
+they stop holding sandboxes; warmpools next so the controller stops replenishing),
+then force-deletes any pods carrying the label. Deleting the CRs also cascades their
+pods via owner refs; the explicit pod delete is a belt-and-suspenders sweep.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from kubernetes import client
+
+from . import constants
+from .cluster import Cluster
+from .config import ClusterConfig
+
+logger = logging.getLogger("agent_sandbox_rl.reap")
+
+
+def reap(run_id: str | None = None, *, context: str | None = None,
+         namespace: str = "default", kubeconfig: str | None = None,
+         in_cluster: bool = False, delete_pods: bool = True) -> dict:
+  """Delete resources matching a run-id (or all asrl-managed if ``run_id`` is None).
+
+  Returns a dict of per-kind deletion counts. Safe to run repeatedly (idempotent)."""
+  selector = (f"{constants.RUN_ID_LABEL}={run_id}" if run_id
+              else f"{constants.MANAGED_BY_LABEL}={constants.MANAGED_BY_VALUE}")
+  cluster = Cluster(
+      ClusterConfig(context=context, namespace=namespace, kubeconfig=kubeconfig,
+                    in_cluster=in_cluster),
+      labels=constants.DEFAULT_LABELS)
+  r = cluster.resources
+  counts: dict[str, int] = {}
+
+  def _sweep(kind, lister, deleter):
+    names = lister(label_selector=selector)
+    for n in names:
+      try:
+        deleter(n)
+      except Exception:  # noqa: BLE001 — best-effort; keep going
+        logger.warning("reap: failed to delete %s %s", kind, n, exc_info=True)
+    counts[kind] = len(names)
+
+  _sweep("claims", r.list_claims, r.delete_claim)
+  _sweep("warmpools", r.list_warmpools, r.delete_warmpool)
+  _sweep("sandboxes", r.list_sandboxes, r.delete_sandbox)
+  _sweep("templates", r.list_templates, r.delete_template)
+
+  if delete_pods:
+    try:
+      cluster.core_api.delete_collection_namespaced_pod(
+          namespace=namespace, label_selector=selector,
+          grace_period_seconds=0, propagation_policy="Background")
+      counts["pods"] = "requested (force)"
+    except Exception:  # noqa: BLE001
+      logger.warning("reap: pod delete-collection failed", exc_info=True)
+
+  logger.info("reap(%s): %s", run_id or "all-managed", counts)
+  return counts
+
+
+def main(argv=None) -> None:
+  p = argparse.ArgumentParser(description="Reap agent-sandbox-rl resources by label.")
+  p.add_argument("--run-id", default=None, help="reap one run; omit to reap all asrl-managed")
+  p.add_argument("--context", default=None)
+  p.add_argument("--namespace", default="default")
+  p.add_argument("--kubeconfig", default=None)
+  p.add_argument("--in-cluster", action="store_true")
+  p.add_argument("--keep-pods", action="store_true", help="don't force-delete pods")
+  a = p.parse_args(argv)
+  logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+  counts = reap(a.run_id, context=a.context, namespace=a.namespace,
+                kubeconfig=a.kubeconfig, in_cluster=a.in_cluster,
+                delete_pods=not a.keep_pods)
+  print(counts)
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/reaper.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/reaper.py
@@ -23,15 +23,17 @@ sweep for an **orphaned** run whose driver died without tearing down.
 
 Deletes claims → warmpools → sandboxes → templates (order matters: claims first so
 they stop holding sandboxes; warmpools next so the controller stops replenishing),
-then force-deletes any pods carrying the label. Deleting the CRs also cascades their
-pods via owner refs; the explicit pod delete is a belt-and-suspenders sweep.
+then force-deletes any pods carrying the run-id label. Claims/warmpools/templates
+carry the run-id label directly. Deleting claims + warmpools **cascades the Sandbox
+CRs** via owner refs — Sandbox CRs themselves don't carry the run-id label (the
+controller doesn't copy it), so the sandbox pass is a best-effort no-op unless a
+future controller propagates it. Sandbox **pods** do carry the label (via the pod
+template), so the pod delete-collection is a real, direct sweep.
 """
 from __future__ import annotations
 
 import argparse
 import logging
-
-from kubernetes import client
 
 from . import constants
 from .cluster import Cluster
@@ -53,7 +55,7 @@ def reap(run_id: str | None = None, *, context: str | None = None,
                     in_cluster=in_cluster),
       labels=constants.DEFAULT_LABELS)
   r = cluster.resources
-  counts: dict[str, int] = {}
+  counts: dict[str, int | str] = {}
 
   def _sweep(kind, lister, deleter):
     names = lister(label_selector=selector)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -339,14 +339,18 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
       if handle is not None:
         fleet.release(handle)
 
-  if concurrency <= 1:
-    for g in groups:
-      _run_group(g)
-    return results
-  with ThreadPoolExecutor(max_workers=concurrency) as ex:
-    futs = [ex.submit(_run_group, g) for g in groups]
-    for fut in as_completed(futs):
-      fut.result()                            # surface executor-level errors
+  # Circuit breaker (#1): abort + teardown if live sandboxes run away (the recycle
+  # path is exactly where over-creation bit us, so it must be guarded too).
+  expected = fleet.plan_.total_replicas if getattr(fleet, "plan_", None) else len(groups)
+  with fleet.overcommit_guard(expected):
+    if concurrency <= 1:
+      for g in groups:
+        _run_group(g)
+    else:
+      with ThreadPoolExecutor(max_workers=concurrency) as ex:
+        futs = [ex.submit(_run_group, g) for g in groups]
+        for fut in as_completed(futs):
+          fut.result()                          # surface executor-level errors
   return results
 
 
@@ -355,28 +359,52 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
                                           max_reuses: int = 32,
                                           reset_timeout: float = 5.0,
                                           use_session: bool = True,
-                                          scale_on_hold: bool = True):
+                                          scale_on_hold: bool = True,
+                                          shards_per_image: int = 1):
   """Async twin of `reuse_git_restore_sandbox` for `AsyncSandboxFleet`.
 
-  Same semantics — group by image, reset-and-reuse one held sandbox per group,
-  quarantine/rotate, `scale_on_hold` — but each group is an **asyncio coroutine**
-  instead of a thread. Blocking git/exec/claim calls are offloaded to the fleet's
-  bounded pool (`afleet._to_thread`), so coroutines let you **hold far more
-  concurrent groups than OS threads allow** (the sync executor is one thread per
-  held sandbox). Effective *exec* concurrency is still bounded by that pool and the
-  apiserver exec path — coroutines lift the driver-side ceiling, not the exec-plane
-  one (a native async I/O backend would lift that too). ``process_fn`` may be sync
-  or async. Returns one result per task in ``tasks`` order (per-task exceptions are
-  captured, not raised)."""
+  Same semantics — reset-and-reuse a held sandbox, quarantine/rotate, scale_on_hold
+  — but each group is an **asyncio coroutine** rather than a thread, so it holds far
+  more concurrent sandboxes than OS threads allow (blocking git/exec/claim calls are
+  offloaded to the fleet's bounded pool). Effective *exec* concurrency is still
+  bounded by that pool + the apiserver exec path — coroutines lift the driver-side
+  ceiling, not the exec-plane one.
+
+  **``shards_per_image`` (default 1):** run K sandboxes **per image** in parallel
+  (each shard recycles a slice of that image's tasks) — how you saturate a pool from
+  a small image set. Requires the image's warm pool to have K replicas (warm with
+  ``warm_per_task`` + ``max_warmpool_size=K``). With ``scale_on_hold``, the pool is
+  ref-counted to ``desired = active_shards − held`` so ``held + warm == active`` per
+  image throughout: K claims never trigger the replenishment storm, and no dangling
+  warm is left when shards finish. ``process_fn`` may be sync or async; results are
+  returned in ``tasks`` order (per-task exceptions captured, not raised)."""
   reset = reset or GitRestoreReset()
   results: list = [None] * len(tasks)
   by_image: dict[str, list[tuple[int, Task]]] = {}
   for i, t in enumerate(tasks):
     by_image.setdefault(t.image, []).append((i, t))
-  groups = list(by_image.values())
+  K = max(1, shards_per_image)
+  groups: list[tuple[str, list]] = []           # (image, [(idx, task), …])
+  for img, items in by_image.items():
+    if K <= 1:
+      groups.append((img, items))
+    else:                                       # round-robin split → K balanced shards
+      for s in range(K):
+        shard = items[s::K]
+        if shard:
+          groups.append((img, shard))
   sync = afleet._fleet                          # the wrapped SandboxFleet
   obs = sync._obs
   sem = asyncio.Semaphore(max(1, concurrency))
+  # per-image ref-count for scale_on_hold: desired replicas = active − held
+  active: dict[str, int] = {}
+  for img, _g in groups:
+    active[img] = active.get(img, 0) + 1
+  held: dict[str, int] = {img: 0 for img in active}
+  locks: dict[str, asyncio.Lock] = {img: asyncio.Lock() for img in active}
+
+  async def _rescale(img):                       # hold locks[img] around this
+    await afleet._to_thread(sync.set_pool_replicas, img, active[img] - held[img])
 
   async def _process(handle, i, t):
     fam = repo_family(t)
@@ -392,7 +420,7 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
     finally:
       obs.task_done(handle.cluster_name, fam, status, time.monotonic() - t0)
 
-  async def _run_group(group):
+  async def _run_group(img, group):
     async with sem:
       handle = None
       baseline = None
@@ -401,9 +429,6 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
       try:
         for pos, (i, t) in enumerate(group):
           if handle is None:
-            if scale_on_hold and recyclable:     # re-claim: pool was dropped, JIT re-warm
-              await afleet._to_thread(sync.warm_image, t.image,
-                                      replicas_override=1, wait=True)
             handle = await afleet.acquire(t)
             if use_session:
               try:
@@ -418,8 +443,10 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
                 logger.info("image %s not git-recyclable — fresh claim per task", t.image)
             elif recyclable:
               baseline = await afleet._to_thread(reset.prime, handle)
-            if scale_on_hold and recyclable:     # holding → stop the pool replenishing
-              await afleet._to_thread(sync.unwarm_image, t.image)
+            if scale_on_hold and recyclable:     # holding → cancel this claim's replenish
+              async with locks[img]:
+                held[img] += 1
+                await _rescale(img)
             uses = 0
           await _process(handle, i, t)
           if pos == len(group) - 1:
@@ -430,6 +457,10 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
           if uses >= max_reuses:                  # planned rotation (drift bound)
             with obs.phase("rotate", cluster=handle.cluster_name):
               await afleet.release(handle)
+            if scale_on_hold and recyclable:      # released → make a warm for re-claim
+              async with locks[img]:
+                held[img] -= 1
+                await _rescale(img)
             handle = None; continue
           with obs.phase("reset", cluster=handle.cluster_name):
             outcome = await afleet._to_thread(reset.reset, handle, baseline,
@@ -439,12 +470,29 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
                            handle.pod_name, outcome.reason)
             with obs.phase("quarantine", cluster=handle.cluster_name):
               await afleet.release(handle)
+            if scale_on_hold and recyclable:
+              async with locks[img]:
+                held[img] -= 1
+                await _rescale(img)
             handle = None
       finally:
-        if handle is not None:
+        holding = handle is not None
+        if holding:
           await afleet.release(handle)
+        if scale_on_hold and recyclable:          # shard done: active−1 (+ held−1 if it
+          async with locks[img]:                  # was holding) leaves desired unchanged
+            if holding:                           # → no dangling warm at end of run
+              held[img] -= 1
+            active[img] -= 1
+            await _rescale(img)
 
-  await asyncio.gather(*(_run_group(g) for g in groups))
+  # Circuit breaker (#1) around the whole fan-out — the sync guard's monitor thread
+  # runs independently of the loop; on trip it tears down (failing in-flight claims,
+  # captured per task) and raises FleetOvercommitError here.
+  expected = (afleet._fleet.plan_.total_replicas
+              if afleet._fleet.plan_ else len(groups))
+  with afleet._fleet.overcommit_guard(expected):
+    await asyncio.gather(*(_run_group(img, g) for img, g in groups))
   return results
 
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -114,6 +114,13 @@ class GitRestoreReset:
         d[k.strip()] = v.strip()
     return d
 
+  @staticmethod
+  def recyclable(baseline: ResetBaseline) -> bool:
+    """Can this sandbox be git-restored? False when `/testbed` has no git repo
+    (or `git` is absent / `git tag` failed) — the caller should then process the
+    image's tasks with fresh claims instead of quarantining every reset."""
+    return bool(baseline.pristine_sha)
+
   # -- prime: once per sandbox at first claim ----------------------------- #
   def prime(self, handle: SandboxHandle) -> ResetBaseline:
     tb = self.testbed
@@ -128,7 +135,12 @@ class GitRestoreReset:
         f'git -C {tb} config gc.pruneExpire never; '
         f'git -C {tb} checkout -q --detach pristine >/dev/null 2>&1; '
         + self._fingerprint_sh())
-    d = self._parse(handle.exec(["bash", "-lc", script]))
+    try:
+      d = self._parse(handle.exec(["bash", "-lc", script]))
+    except Exception as e:  # noqa: BLE001 — dead pod / no bash → not recyclable
+      logger.warning("prime failed on %s (%s); image treated as non-recyclable",
+                     getattr(handle, "pod_name", "?"), e)
+      return ResetBaseline()          # empty → recyclable() False → fresh path
     return ResetBaseline(
         pristine_sha=d.get("PRISTINE", "") or d.get("HEAD", ""),
         env_hash=d.get("ENV", ""),
@@ -161,7 +173,12 @@ class GitRestoreReset:
         + f'rm -rf {wipe} >/dev/null 2>&1; '
         + self._fingerprint_sh())
     t0 = time.monotonic()
-    d = self._parse(handle.exec(["bash", "-lc", script]))
+    try:
+      d = self._parse(handle.exec(["bash", "-lc", script]))
+    except Exception as e:  # noqa: BLE001 — exec failed (dead pod / no bash):
+      # never raise into the batch; report dirty so the caller quarantines.
+      return ResetOutcome(clean=False, seconds=round(time.monotonic() - t0, 3),
+                          reason="exec_error", detail={"error": str(e)})
     elapsed = time.monotonic() - t0
 
     reason = self._first_failure(d, baseline, elapsed, timeout)
@@ -211,6 +228,13 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
 
   Records ``reset`` / ``quarantine`` / ``rotate`` phases in the RunReport so the
   claim-economics win is measurable next to the baseline strategies.
+
+  **Non-git images are handled transparently:** if an image has no git repo at
+  ``/testbed`` (no pristine anchor at prime), it can't be git-restored, so that
+  image's tasks fall back to a **fresh claim per task** (no reset attempts, no
+  quarantine churn) — safe to point this at a mixed image set. A reset whose
+  ``exec`` fails (dead pod / no bash) is reported dirty and quarantined, never
+  raised into the batch.
   """
   reset = reset or GitRestoreReset()
   results = [None] * len(tasks)
@@ -237,15 +261,27 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
     handle = None
     baseline = None
     uses = 0
+    recyclable = None                         # None = undetermined; decided at 1st prime
     try:
       for pos, (i, t) in enumerate(group):
-        if handle is None:                    # first task, or after a quarantine
+        if handle is None:                    # first task, or after release
           handle = fleet.acquire(t)
-          baseline = reset.prime(handle)
+          if recyclable is None:              # first claim for this image: prime + decide
+            baseline = reset.prime(handle)
+            recyclable = reset.recyclable(baseline)
+            if not recyclable:
+              logger.info("image %s not git-recyclable (%s) — fresh claim per task",
+                          t.image, baseline and "no pristine anchor")
+          elif recyclable:                    # recyclable image, fresh sandbox after
+            baseline = reset.prime(handle)    # rotate/quarantine → re-anchor pristine
           uses = 0
         _process(handle, i, t)
         if pos == len(group) - 1:
-          break                               # nothing to reset for
+          break                               # last task in group: nothing to reset for
+        if not recyclable:                    # can't reset → fresh claim, no reset/quarantine
+          fleet.release(handle)
+          handle = None
+          continue
         uses += 1
         if uses >= max_reuses:                # planned rotation (drift bound)
           with fleet._obs.phase("rotate", cluster=handle.cluster_name):

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -47,6 +47,11 @@ logger = logging.getLogger("agent_sandbox_rl.recycle")
 
 _DEFAULT_WIPE = ("/tmp/*", "/var/tmp/*", "$HOME/.cache/*")
 
+# Sentinel for "task not processed yet" in the results list, so a group's infra
+# error only overwrites genuinely-unprocessed slots — not a task that legitimately
+# returned None (which `is None` would clobber).
+_UNSET = object()
+
 
 @dataclass
 class ResetBaseline:
@@ -211,10 +216,16 @@ class GitRestoreReset:
       return "head_mismatch"
     if (d.get("DIRTY", "0") or "0") != "0":
       return "worktree_dirty"
-    if self.check_env and base.env_hash and d.get("ENV", "") != base.env_hash:
-      return "env_drift"                     # site-packages tripwire (the big hole)
-    if self.check_config and base.config_hash and d.get("CFG", "") != base.config_hash:
-      return "config_or_hooks_drift"         # booby-trap tripwire
+    if self.check_env:                       # site-packages tripwire (the big hole)
+      if not base.env_hash:
+        return "env_baseline_missing"        # requested but no baseline → can't verify, quarantine
+      if d.get("ENV", "") != base.env_hash:
+        return "env_drift"
+    if self.check_config:                    # booby-trap tripwire
+      if not base.config_hash:
+        return "config_baseline_missing"
+      if d.get("CFG", "") != base.config_hash:
+        return "config_or_hooks_drift"
     # process-count backstop: allow a little slack for transient exec children
     try:
       if base.proc_count and int(d.get("PROCS", "0")) > base.proc_count + 2:
@@ -266,7 +277,7 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
   images keep their pools. Set False to keep pools resident (old behavior).
   """
   reset = reset or GitRestoreReset()
-  results = [None] * len(tasks)
+  results = [_UNSET] * len(tasks)
   by_image: dict[str, list[tuple[int, Task]]] = {}
   for i, t in enumerate(tasks):
     by_image.setdefault(t.image, []).append((i, t))
@@ -341,7 +352,7 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
       logger.error("recycle group failed on %s: %s",
                    group[0][1].image if group else "?", e)
       for gi, _gt in group:
-        if results[gi] is None:
+        if results[gi] is _UNSET:
           results[gi] = e
     finally:
       if handle is not None:
@@ -365,7 +376,7 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
             fut.result()                        # _run_group captures per-group; this is a backstop
           except Exception:  # noqa: BLE001 — never let one group abort the batch
             logger.error("recycle group raised past its own handler", exc_info=True)
-  return results
+  return [None if r is _UNSET else r for r in results]   # unprocessed → None
 
 
 async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency, *,
@@ -394,7 +405,7 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
   warm is left when shards finish. ``process_fn`` may be sync or async; results are
   returned in ``tasks`` order (per-task exceptions captured, not raised)."""
   reset = reset or GitRestoreReset()
-  results: list = [None] * len(tasks)
+  results: list = [_UNSET] * len(tasks)
   by_image: dict[str, list[tuple[int, Task]]] = {}
   for i, t in enumerate(tasks):
     by_image.setdefault(t.image, []).append((i, t))
@@ -503,7 +514,7 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
         # (KeyboardInterrupt/SystemExit still propagate).
         logger.error("recycle group failed on %s: %s", img, e)
         for gi, _gt in group:
-          if results[gi] is None:
+          if results[gi] is _UNSET:
             results[gi] = e
       finally:
         holding = handle is not None
@@ -529,7 +540,7 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
     # so one group's infra error can't discard the whole batch's results.
     await asyncio.gather(*(_run_group(img, g) for img, g in groups),
                          return_exceptions=True)
-  return results
+  return [None if r is _UNSET else r for r in results]   # unprocessed → None
 
 
 def determinism_canary(fleet, task, process_fn, *,

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -374,7 +374,8 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
                                           reset_timeout: float = 5.0,
                                           use_session: bool = True,
                                           scale_on_hold: bool = True,
-                                          shards_per_image: int = 1):
+                                          shards_per_image: int = 1,
+                                          claim_concurrency: int = 0):
   """Async twin of `reuse_git_restore_sandbox` for `AsyncSandboxFleet`.
 
   Same semantics — reset-and-reuse a held sandbox, quarantine/rotate, scale_on_hold
@@ -410,6 +411,13 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
   sync = afleet._fleet                          # the wrapped SandboxFleet
   obs = sync._obs
   sem = asyncio.Semaphore(max(1, concurrency))
+  # Staged claims (E11.4): bound how many groups CLAIM (+ scale-down patch) at once,
+  # so reaching a large held count doesn't fire a simultaneous claim burst that
+  # 429-saturates the apiserver. 0 = unlimited (all groups claim at once). Groups
+  # still *hold* up to `concurrency`; only the acquire+prime+scale phase is throttled.
+  claim_sem = asyncio.Semaphore(
+      claim_concurrency if (claim_concurrency and claim_concurrency > 0)
+      else max(1, len(groups)))
   # per-image ref-count for scale_on_hold: desired replicas = active − held
   active: dict[str, int] = {}
   for img, _g in groups:
@@ -443,24 +451,25 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
       try:
         for pos, (i, t) in enumerate(group):
           if handle is None:
-            handle = await afleet.acquire(t)
-            if use_session:
-              try:
-                await afleet._to_thread(handle.open_session)
-              except Exception as e:             # noqa: BLE001 — fall back to one-shot exec
-                logger.warning("session open failed on %s (%s); one-shot exec",
-                               handle.pod_name, e)
-            if recyclable is None:               # first claim: prime + decide
-              baseline = await afleet._to_thread(reset.prime, handle)
-              recyclable = reset.recyclable(baseline)
-              if not recyclable:
-                logger.info("image %s not git-recyclable — fresh claim per task", t.image)
-            elif recyclable:
-              baseline = await afleet._to_thread(reset.prime, handle)
-            if scale_on_hold and recyclable:     # holding → cancel this claim's replenish
-              async with locks[img]:
-                held[img] += 1
-                await _rescale(img)
+            async with claim_sem:                # staged claims: bound in-flight acquires
+              handle = await afleet.acquire(t)
+              if use_session:
+                try:
+                  await afleet._to_thread(handle.open_session)
+                except Exception as e:           # noqa: BLE001 — fall back to one-shot exec
+                  logger.warning("session open failed on %s (%s); one-shot exec",
+                                 handle.pod_name, e)
+              if recyclable is None:             # first claim: prime + decide
+                baseline = await afleet._to_thread(reset.prime, handle)
+                recyclable = reset.recyclable(baseline)
+                if not recyclable:
+                  logger.info("image %s not git-recyclable — fresh claim per task", t.image)
+              elif recyclable:
+                baseline = await afleet._to_thread(reset.prime, handle)
+              if scale_on_hold and recyclable:   # holding → cancel this claim's replenish
+                async with locks[img]:
+                  held[img] += 1
+                  await _rescale(img)
             uses = 0
           await _process(handle, i, t)
           if pos == len(group) - 1:

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -279,7 +279,7 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
     try:
       with fleet._obs.phase("process", cluster=handle.cluster_name, family=fam):
         results[i] = process_fn(t, handle)
-    except BaseException as e:                # noqa: BLE001 — capture, keep batch alive
+    except Exception as e:                    # noqa: BLE001 — capture (let KeyboardInterrupt/SystemExit propagate)
       status = "error"
       results[i] = e
       logger.error("task %s failed: %s", t.id, e)
@@ -335,9 +335,20 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
           with fleet._obs.phase("quarantine", cluster=handle.cluster_name):
             fleet.release(handle)
           handle = None
+    except Exception as e:                    # noqa: BLE001 — infra error (claim/reset/
+      # release/warm): capture for this group's unprocessed tasks so one group's
+      # failure can't abort the whole batch (KeyboardInterrupt/SystemExit still propagate).
+      logger.error("recycle group failed on %s: %s",
+                   group[0][1].image if group else "?", e)
+      for gi, _gt in group:
+        if results[gi] is None:
+          results[gi] = e
     finally:
       if handle is not None:
-        fleet.release(handle)
+        try:
+          fleet.release(handle)
+        except Exception:  # noqa: BLE001
+          logger.warning("release failed during group cleanup", exc_info=True)
 
   # Circuit breaker (#1): abort + teardown if live sandboxes run away (the recycle
   # path is exactly where over-creation bit us, so it must be guarded too).
@@ -350,7 +361,10 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
       with ThreadPoolExecutor(max_workers=concurrency) as ex:
         futs = [ex.submit(_run_group, g) for g in groups]
         for fut in as_completed(futs):
-          fut.result()                          # surface executor-level errors
+          try:
+            fut.result()                        # _run_group captures per-group; this is a backstop
+          except Exception:  # noqa: BLE001 — never let one group abort the batch
+            logger.error("recycle group raised past its own handler", exc_info=True)
   return results
 
 
@@ -413,7 +427,7 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
     try:
       with obs.phase("process", cluster=handle.cluster_name, family=fam):
         results[i] = await afleet._call(process_fn, t, handle)
-    except BaseException as e:                   # noqa: BLE001 — capture, keep batch alive
+    except Exception as e:                       # noqa: BLE001 — capture (let KeyboardInterrupt/SystemExit propagate)
       status = "error"
       results[i] = e
       logger.error("task %s failed: %s", t.id, e)
@@ -475,10 +489,20 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
                 held[img] -= 1
                 await _rescale(img)
             handle = None
+      except Exception as e:                      # noqa: BLE001 — infra error: capture for
+        # this group's unprocessed tasks so it can't abort the whole gather
+        # (KeyboardInterrupt/SystemExit still propagate).
+        logger.error("recycle group failed on %s: %s", img, e)
+        for gi, _gt in group:
+          if results[gi] is None:
+            results[gi] = e
       finally:
         holding = handle is not None
         if holding:
-          await afleet.release(handle)
+          try:
+            await afleet.release(handle)
+          except Exception:  # noqa: BLE001
+            logger.warning("release failed during group cleanup", exc_info=True)
         if scale_on_hold and recyclable:          # shard done: active−1 (+ held−1 if it
           async with locks[img]:                  # was holding) leaves desired unchanged
             if holding:                           # → no dangling warm at end of run
@@ -492,7 +516,10 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
   expected = (afleet._fleet.plan_.total_replicas
               if afleet._fleet.plan_ else len(groups))
   with afleet._fleet.overcommit_guard(expected):
-    await asyncio.gather(*(_run_group(img, g) for img, g in groups))
+    # return_exceptions=True is a backstop — _run_group already captures per-group,
+    # so one group's infra error can't discard the whole batch's results.
+    await asyncio.gather(*(_run_group(img, g) for img, g in groups),
+                         return_exceptions=True)
   return results
 
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -1,0 +1,299 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sandbox recycling — reset-and-reuse a claimed sandbox across same-image tasks.
+
+For G rollouts on one image, claiming→deleting→re-claiming per rollout makes claims
+scale with *tasks*; recycling makes them scale with *problems* (÷G). The crux is the
+**pollution problem**: a reused sandbox must look byte-identical to a fresh one, or it
+silently biases RL rewards. See `plans/sandbox-recycling.md` for the full design and
+the v2 deep-research findings this implements.
+
+This module ships the **git-restore** reset tier (the cheapest safe mechanism):
+restore the `/testbed` working tree to a pristine tag, sweep processes + `/tmp`, then
+**verify** cleanliness — repo clean at the pristine SHA, and (tripwires, not fixes) the
+Python env, git config, and hooks unchanged. Drift in a surface we don't actively
+restore → the reset returns False → the executor **quarantines** the sandbox (releases
+it and claims a fresh one). It deliberately does NOT restore the conda/site-packages
+env or overlay-restart (the costlier tiers): those are detected and escalated to a
+fresh claim instead. `determinism_canary` is the ground-truth check that a reset
+actually produced identical outputs.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+
+from .handles import SandboxHandle
+from .observability import repo_family
+from .sources import Task
+
+logger = logging.getLogger("agent_sandbox_rl.recycle")
+
+_DEFAULT_WIPE = ("/tmp/*", "/var/tmp/*", "$HOME/.cache/*")
+
+
+@dataclass
+class ResetBaseline:
+  """Pristine fingerprint captured at first claim; compared on every reset."""
+
+  pristine_sha: str = ""
+  env_hash: str = ""
+  config_hash: str = ""
+  proc_count: int = 0
+
+
+@dataclass
+class ResetOutcome:
+  """Result of one reset attempt. ``clean`` False → caller must quarantine."""
+
+  clean: bool
+  seconds: float
+  reason: str = ""            # first failing probe (empty when clean)
+  detail: dict = field(default_factory=dict)
+
+
+class GitRestoreReset:
+  """Restore a sandbox to its pristine baseline via git + a cleanliness verify.
+
+  ``check_env`` / ``check_config`` toggle the site-packages and git-config/hooks
+  **tripwires** (drift → quarantine, since this tier does not restore them).
+  ``testbed`` is the editable-installed repo dir whose realpath must stay stable.
+  All work is one ``exec`` round-trip per phase (prime / reset) to keep the reset
+  off the critical path budget.
+  """
+
+  def __init__(self, testbed: str = "/testbed", *, check_env: bool = True,
+               check_config: bool = True, wipe=_DEFAULT_WIPE,
+               kill_new_procs: bool = True):
+    self.testbed = testbed
+    self.check_env = check_env
+    self.check_config = check_config
+    self.wipe = tuple(wipe)
+    self.kill_new_procs = kill_new_procs
+
+  # -- shared shell fragments --------------------------------------------- #
+  def _fingerprint_sh(self) -> str:
+    tb = self.testbed
+    # KEY=VALUE lines, parsed by _parse. pip freeze is the site-packages tripwire;
+    # config+hooks listing is the booby-trap tripwire (v2: agent `git config`
+    # writes land in shared .git/config even with worktreeConfig).
+    return (
+        f'echo "PRISTINE=$(git -C {tb} rev-parse pristine 2>/dev/null)"; '
+        f'echo "HEAD=$(git -C {tb} rev-parse HEAD 2>/dev/null)"; '
+        f'echo "DIRTY=$(git -C {tb} status --porcelain 2>/dev/null | wc -l | tr -d " ")"; '
+        f'echo "ENV=$(pip freeze 2>/dev/null | sha256sum | cut -d" " -f1)"; '
+        f'echo "CFG=$( (git -C {tb} config --list; ls -la {tb}/.git/hooks 2>/dev/null) '
+        f'| sha256sum | cut -d" " -f1)"; '
+        f'echo "PROCS=$(ps -eo pid= 2>/dev/null | wc -l | tr -d " ")"')
+
+  @staticmethod
+  def _parse(out: str) -> dict:
+    d = {}
+    for line in out.splitlines():
+      if "=" in line:
+        k, _, v = line.partition("=")
+        d[k.strip()] = v.strip()
+    return d
+
+  # -- prime: once per sandbox at first claim ----------------------------- #
+  def prime(self, handle: SandboxHandle) -> ResetBaseline:
+    tb = self.testbed
+    script = (
+        "set +e; "
+        # anchor a pristine ref that survives agent branching, and kill all
+        # implicit maintenance so the (shared, for worktrees) object store is
+        # never gc'd concurrently — v2 findings.
+        f'git -C {tb} tag -f pristine >/dev/null 2>&1; '
+        f'git -C {tb} config gc.auto 0; '
+        f'git -C {tb} config maintenance.auto false; '
+        f'git -C {tb} config gc.pruneExpire never; '
+        f'git -C {tb} checkout -q --detach pristine >/dev/null 2>&1; '
+        + self._fingerprint_sh())
+    d = self._parse(handle.exec(["bash", "-lc", script]))
+    return ResetBaseline(
+        pristine_sha=d.get("PRISTINE", "") or d.get("HEAD", ""),
+        env_hash=d.get("ENV", ""),
+        config_hash=d.get("CFG", ""),
+        proc_count=int(d.get("PROCS", "0") or 0))
+
+  # -- reset: between rollouts -------------------------------------------- #
+  def reset(self, handle: SandboxHandle, baseline: ResetBaseline,
+            *, timeout: float = 5.0) -> ResetOutcome:
+    tb = self.testbed
+    wipe = " ".join(self.wipe)
+    kill = ""
+    if self.kill_new_procs:
+      # Clean-slate: kill every process except init (pid1 = the keepalive) and
+      # our own reset shell/parent. Not a baseline diff — SWE-bench images run
+      # nothing but pid1 + exec transients, so a full sweep is the safe reset;
+      # for images with legitimate long-lived daemons, set kill_new_procs=False.
+      # Process hygiene across k8s exec is unverified (research sub-Q4); the PROCS
+      # tripwire below is the backstop.
+      kill = (
+          'for p in $(ps -eo pid= 2>/dev/null | tr -d " "); do '
+          '[ "$p" = "1" ] || [ "$p" = "$$" ] || [ "$p" = "$PPID" ] || '
+          'kill -9 "$p" 2>/dev/null; done; ')
+    script = (
+        "set +e; "
+        + kill
+        + f'git -C {tb} reset -q --hard pristine >/dev/null 2>&1; '
+        + f'git -C {tb} clean -qxdff >/dev/null 2>&1; '
+        + f'git -C {tb} checkout -q --detach pristine >/dev/null 2>&1; '
+        + f'rm -rf {wipe} >/dev/null 2>&1; '
+        + self._fingerprint_sh())
+    t0 = time.monotonic()
+    d = self._parse(handle.exec(["bash", "-lc", script]))
+    elapsed = time.monotonic() - t0
+
+    reason = self._first_failure(d, baseline, elapsed, timeout)
+    return ResetOutcome(clean=(reason == ""), seconds=round(elapsed, 3),
+                        reason=reason, detail=d)
+
+  def _first_failure(self, d: dict, base: ResetBaseline, elapsed: float,
+                     timeout: float) -> str:
+    # No pristine anchor (non-git /testbed, or `git tag` failed at prime) means
+    # the git-restore reset is a no-op we cannot verify — never claim clean.
+    if not base.pristine_sha:
+      return "no_pristine_anchor"
+    if elapsed > timeout:
+      return "timeout"                       # advisory: measured, not kill-enforced
+    if d.get("HEAD", "") != base.pristine_sha:
+      return "head_mismatch"
+    if (d.get("DIRTY", "0") or "0") != "0":
+      return "worktree_dirty"
+    if self.check_env and base.env_hash and d.get("ENV", "") != base.env_hash:
+      return "env_drift"                     # site-packages tripwire (the big hole)
+    if self.check_config and base.config_hash and d.get("CFG", "") != base.config_hash:
+      return "config_or_hooks_drift"         # booby-trap tripwire
+    # process-count backstop: allow a little slack for transient exec children
+    try:
+      if base.proc_count and int(d.get("PROCS", "0")) > base.proc_count + 2:
+        return "process_leak"
+    except ValueError:
+      pass
+    return ""
+
+
+def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
+                              reset: GitRestoreReset | None = None,
+                              max_reuses: int = 32,
+                              reset_timeout: float = 5.0):
+  """Execute ``tasks`` reusing one sandbox per image (claims scale ÷ tasks-per-image).
+
+  Tasks are grouped by image; each group runs sequentially inside a single claimed
+  sandbox, git-restore-reset between rollouts. Groups run in parallel up to
+  ``concurrency`` (= the concurrent-sandbox budget). ``max_reuses`` bounds how many
+  tasks one sandbox serves before a **rotation** (release + fresh claim) to cap drift.
+  A reset that fails cleanliness verification or exceeds ``reset_timeout`` triggers a
+  **quarantine** (also release + fresh claim). ``reset_timeout`` is advisory — it flags
+  a *slow* reset after the fact; it does not interrupt a *hung* ``exec`` (that blocks
+  the group's worker thread). Returns one result per task in ``tasks`` order (a per-task
+  exception is captured, not raised) — matching ``strategies.process_parallel``.
+
+  Records ``reset`` / ``quarantine`` / ``rotate`` phases in the RunReport so the
+  claim-economics win is measurable next to the baseline strategies.
+  """
+  reset = reset or GitRestoreReset()
+  results = [None] * len(tasks)
+  by_image: dict[str, list[tuple[int, Task]]] = {}
+  for i, t in enumerate(tasks):
+    by_image.setdefault(t.image, []).append((i, t))
+  groups = list(by_image.values())
+
+  def _process(handle, i, t):
+    fam = repo_family(t)
+    t0 = time.monotonic()
+    status = "ok"
+    try:
+      with fleet._obs.phase("process", cluster=handle.cluster_name, family=fam):
+        results[i] = process_fn(t, handle)
+    except BaseException as e:                # noqa: BLE001 — capture, keep batch alive
+      status = "error"
+      results[i] = e
+      logger.error("task %s failed: %s", t.id, e)
+    finally:
+      fleet._obs.task_done(handle.cluster_name, fam, status, time.monotonic() - t0)
+
+  def _run_group(group):
+    handle = None
+    baseline = None
+    uses = 0
+    try:
+      for pos, (i, t) in enumerate(group):
+        if handle is None:                    # first task, or after a quarantine
+          handle = fleet.acquire(t)
+          baseline = reset.prime(handle)
+          uses = 0
+        _process(handle, i, t)
+        if pos == len(group) - 1:
+          break                               # nothing to reset for
+        uses += 1
+        if uses >= max_reuses:                # planned rotation (drift bound)
+          with fleet._obs.phase("rotate", cluster=handle.cluster_name):
+            fleet.release(handle)
+          handle = None
+          continue
+        with fleet._obs.phase("reset", cluster=handle.cluster_name):
+          outcome = reset.reset(handle, baseline, timeout=reset_timeout)
+        if not outcome.clean:                 # dirty → quarantine, fresh claim next
+          logger.warning("quarantine sandbox %s after reset: %s",
+                         handle.pod_name, outcome.reason)
+          with fleet._obs.phase("quarantine", cluster=handle.cluster_name):
+            fleet.release(handle)
+          handle = None
+    finally:
+      if handle is not None:
+        fleet.release(handle)
+
+  if concurrency <= 1:
+    for g in groups:
+      _run_group(g)
+    return results
+  with ThreadPoolExecutor(max_workers=concurrency) as ex:
+    futs = [ex.submit(_run_group, g) for g in groups]
+    for fut in as_completed(futs):
+      fut.result()                            # surface executor-level errors
+  return results
+
+
+def determinism_canary(fleet, task, process_fn, *,
+                       reset: GitRestoreReset | None = None):
+  """Run ``task`` twice in ONE recycled sandbox with a reset between; report whether
+  the two outputs are byte-identical (any difference == contamination by definition).
+
+  This is the ground-truth verification gate from the design doc — run it before
+  trusting recycling for training. Returns a dict with ``identical`` / ``reset_clean``
+  / the two results / the reset outcome. Releases the sandbox on exit.
+  """
+  reset = reset or GitRestoreReset()
+  handle = fleet.acquire(task)
+  try:
+    baseline = reset.prime(handle)
+    first = process_fn(task, handle)
+    outcome = reset.reset(handle, baseline)
+    second = process_fn(task, handle)
+    return {
+        "identical": first == second,
+        "reset_clean": outcome.clean,
+        "reset_reason": outcome.reason,
+        "reset_seconds": outcome.seconds,
+        "first": first,
+        "second": second,
+    }
+  finally:
+    fleet.release(handle)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -33,6 +33,7 @@ actually produced identical outputs.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -346,6 +347,104 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
     futs = [ex.submit(_run_group, g) for g in groups]
     for fut in as_completed(futs):
       fut.result()                            # surface executor-level errors
+  return results
+
+
+async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency, *,
+                                          reset: GitRestoreReset | None = None,
+                                          max_reuses: int = 32,
+                                          reset_timeout: float = 5.0,
+                                          use_session: bool = True,
+                                          scale_on_hold: bool = True):
+  """Async twin of `reuse_git_restore_sandbox` for `AsyncSandboxFleet`.
+
+  Same semantics — group by image, reset-and-reuse one held sandbox per group,
+  quarantine/rotate, `scale_on_hold` — but each group is an **asyncio coroutine**
+  instead of a thread. Blocking git/exec/claim calls are offloaded to the fleet's
+  bounded pool (`afleet._to_thread`), so coroutines let you **hold far more
+  concurrent groups than OS threads allow** (the sync executor is one thread per
+  held sandbox). Effective *exec* concurrency is still bounded by that pool and the
+  apiserver exec path — coroutines lift the driver-side ceiling, not the exec-plane
+  one (a native async I/O backend would lift that too). ``process_fn`` may be sync
+  or async. Returns one result per task in ``tasks`` order (per-task exceptions are
+  captured, not raised)."""
+  reset = reset or GitRestoreReset()
+  results: list = [None] * len(tasks)
+  by_image: dict[str, list[tuple[int, Task]]] = {}
+  for i, t in enumerate(tasks):
+    by_image.setdefault(t.image, []).append((i, t))
+  groups = list(by_image.values())
+  sync = afleet._fleet                          # the wrapped SandboxFleet
+  obs = sync._obs
+  sem = asyncio.Semaphore(max(1, concurrency))
+
+  async def _process(handle, i, t):
+    fam = repo_family(t)
+    t0 = time.monotonic()
+    status = "ok"
+    try:
+      with obs.phase("process", cluster=handle.cluster_name, family=fam):
+        results[i] = await afleet._call(process_fn, t, handle)
+    except BaseException as e:                   # noqa: BLE001 — capture, keep batch alive
+      status = "error"
+      results[i] = e
+      logger.error("task %s failed: %s", t.id, e)
+    finally:
+      obs.task_done(handle.cluster_name, fam, status, time.monotonic() - t0)
+
+  async def _run_group(group):
+    async with sem:
+      handle = None
+      baseline = None
+      uses = 0
+      recyclable = None
+      try:
+        for pos, (i, t) in enumerate(group):
+          if handle is None:
+            if scale_on_hold and recyclable:     # re-claim: pool was dropped, JIT re-warm
+              await afleet._to_thread(sync.warm_image, t.image,
+                                      replicas_override=1, wait=True)
+            handle = await afleet.acquire(t)
+            if use_session:
+              try:
+                await afleet._to_thread(handle.open_session)
+              except Exception as e:             # noqa: BLE001 — fall back to one-shot exec
+                logger.warning("session open failed on %s (%s); one-shot exec",
+                               handle.pod_name, e)
+            if recyclable is None:               # first claim: prime + decide
+              baseline = await afleet._to_thread(reset.prime, handle)
+              recyclable = reset.recyclable(baseline)
+              if not recyclable:
+                logger.info("image %s not git-recyclable — fresh claim per task", t.image)
+            elif recyclable:
+              baseline = await afleet._to_thread(reset.prime, handle)
+            if scale_on_hold and recyclable:     # holding → stop the pool replenishing
+              await afleet._to_thread(sync.unwarm_image, t.image)
+            uses = 0
+          await _process(handle, i, t)
+          if pos == len(group) - 1:
+            break
+          if not recyclable:                      # can't reset → fresh claim per task
+            await afleet.release(handle); handle = None; continue
+          uses += 1
+          if uses >= max_reuses:                  # planned rotation (drift bound)
+            with obs.phase("rotate", cluster=handle.cluster_name):
+              await afleet.release(handle)
+            handle = None; continue
+          with obs.phase("reset", cluster=handle.cluster_name):
+            outcome = await afleet._to_thread(reset.reset, handle, baseline,
+                                              timeout=reset_timeout)
+          if not outcome.clean:                   # dirty → quarantine, fresh claim next
+            logger.warning("quarantine sandbox %s after reset: %s",
+                           handle.pod_name, outcome.reason)
+            with obs.phase("quarantine", cluster=handle.cluster_name):
+              await afleet.release(handle)
+            handle = None
+      finally:
+        if handle is not None:
+          await afleet.release(handle)
+
+  await asyncio.gather(*(_run_group(g) for g in groups))
   return results
 
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -224,7 +224,8 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
                               reset: GitRestoreReset | None = None,
                               max_reuses: int = 32,
                               reset_timeout: float = 5.0,
-                              use_session: bool = True):
+                              use_session: bool = True,
+                              scale_on_hold: bool = True):
   """Execute ``tasks`` reusing one sandbox per image (claims scale ÷ tasks-per-image).
 
   Tasks are grouped by image; each group runs sequentially inside a single claimed
@@ -246,6 +247,19 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
   quarantine churn) — safe to point this at a mixed image set. A reset whose
   ``exec`` fails (dead pod / no bash) is reported dirty and quarantined, never
   raised into the batch.
+
+  **``scale_on_hold`` (default True):** once a recyclable sandbox is claimed and
+  held for its whole group, its warm pool is dropped (`unwarm_image`) so the
+  controller does not **replenish** a replacement the reuse never claims. This
+  removes the *sustained* idle-warm footprint (steady state ~1× the held count
+  instead of ~2×) and the ongoing claim-driven replenishment that feeds the
+  warm-pool over-creation bug (#1215). Note the *peak* during the initial
+  concurrent-claim burst can still transiently reach ~2× (each claim briefly
+  replenishes before its `unwarm` lands); stage the claims to cut that too. A
+  quarantine/rotation re-claim JIT re-warms the pool first. Verified safe: a
+  claimed sandbox survives its pool being scaled/deleted (a `SandboxClaim`
+  detaches it from warm-pool ownership). Non-recyclable (fresh-claim-per-task)
+  images keep their pools. Set False to keep pools resident (old behavior).
   """
   reset = reset or GitRestoreReset()
   results = [None] * len(tasks)
@@ -276,6 +290,8 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
     try:
       for pos, (i, t) in enumerate(group):
         if handle is None:                    # first task, or after release
+          if scale_on_hold and recyclable:    # re-claim: pool was dropped, JIT re-warm
+            fleet.warm_image(t.image, replicas_override=1, wait=True)
           handle = fleet.acquire(t)
           if use_session:                     # one held-open exec stream per sandbox
             try:
@@ -291,6 +307,8 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
                           t.image, baseline and "no pristine anchor")
           elif recyclable:                    # recyclable image, fresh sandbox after
             baseline = reset.prime(handle)    # rotate/quarantine → re-anchor pristine
+          if scale_on_hold and recyclable:    # holding it → stop the pool replenishing
+            fleet.unwarm_image(t.image)
           uses = 0
         _process(handle, i, t)
         if pos == len(group) - 1:

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -152,7 +152,10 @@ class GitRestoreReset:
                      getattr(handle, "pod_name", "?"), e)
       return ResetBaseline()          # empty → recyclable() False → fresh path
     return ResetBaseline(
-        pristine_sha=d.get("PRISTINE", "") or d.get("HEAD", ""),
+        # Only trust the `pristine` tag we set; do NOT fall back to HEAD. If
+        # `git tag -f pristine` failed, PRISTINE is empty → recyclable() is False
+        # → fresh-claim path (never reuse without a verifiable pristine anchor).
+        pristine_sha=d.get("PRISTINE", ""),
         env_hash=d.get("ENV", ""),
         config_hash=d.get("CFG", ""),
         proc_count=int(d.get("PROCS", "0") or 0))

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -71,14 +71,18 @@ class GitRestoreReset:
   """Restore a sandbox to its pristine baseline via git + a cleanliness verify.
 
   ``check_env`` / ``check_config`` toggle the site-packages and git-config/hooks
-  **tripwires** (drift → quarantine, since this tier does not restore them).
-  ``testbed`` is the editable-installed repo dir whose realpath must stay stable.
-  All work is one ``exec`` round-trip per phase (prime / reset) to keep the reset
-  off the critical path budget.
+  **tripwires** (drift → quarantine, since this tier does not restore them). Both
+  default **off**: they cost a per-reset `pip freeze` / config scan that dominates
+  reset time and is Python/git-specific, while env/config drift is rare and already
+  bounded by ``max_reuses`` + the determinism canary. Turn ``check_env`` on for
+  workloads whose agents mutate site-packages (and accept the cost). ``testbed`` is
+  the editable-installed repo dir whose realpath must stay stable. Each phase
+  (prime / reset) is one ``exec`` — routed through a persistent `SandboxSession`
+  when the handle has one, so resets don't re-connect per command.
   """
 
-  def __init__(self, testbed: str = "/testbed", *, check_env: bool = True,
-               check_config: bool = True, wipe=_DEFAULT_WIPE,
+  def __init__(self, testbed: str = "/testbed", *, check_env: bool = False,
+               check_config: bool = False, wipe=_DEFAULT_WIPE,
                kill_new_procs: bool = True):
     self.testbed = testbed
     self.check_env = check_env
@@ -89,21 +93,27 @@ class GitRestoreReset:
   # -- shared shell fragments --------------------------------------------- #
   def _fingerprint_sh(self) -> str:
     tb = self.testbed
-    # KEY=VALUE lines, parsed by _parse. pip freeze is the site-packages tripwire;
-    # config+hooks listing is the booby-trap tripwire (v2: agent `git config`
-    # writes land in shared .git/config even with worktreeConfig).
-    return (
-        f'echo "PRISTINE=$(git -C {tb} rev-parse pristine 2>/dev/null)"; '
-        f'echo "HEAD=$(git -C {tb} rev-parse HEAD 2>/dev/null)"; '
-        f'echo "DIRTY=$(git -C {tb} status --porcelain 2>/dev/null | wc -l | tr -d " ")"; '
-        f'echo "ENV=$(pip freeze 2>/dev/null | sha256sum | cut -d" " -f1)"; '
-        # config + hook *content* (names + bodies), mtime-free and order-stable —
-        # `ls -la` would hash mtimes and false-positive on every reset.
-        f'echo "CFG=$( (git -C {tb} config --list --local 2>/dev/null | sort; '
-        f'for f in {tb}/.git/hooks/*; do [ -f "$f" ] && '
-        f'echo "H:$(basename "$f")" && cat "$f"; done 2>/dev/null) '
-        f'| sha256sum | cut -d" " -f1)"; '
-        f'echo "PROCS=$(ps -eo pid= 2>/dev/null | wc -l | tr -d " ")"')
+    # KEY=VALUE lines, parsed by _parse. Only compute what we actually verify —
+    # `pip freeze` (the env tripwire) is the expensive part, so it's skipped
+    # unless check_env is on (git-only reset is the fast default path).
+    parts = [
+        f'echo "PRISTINE=$(git -C {tb} rev-parse pristine 2>/dev/null)"',
+        f'echo "HEAD=$(git -C {tb} rev-parse HEAD 2>/dev/null)"',
+        f'echo "DIRTY=$(git -C {tb} status --porcelain 2>/dev/null | wc -l | tr -d " ")"',
+    ]
+    if self.check_env:
+      parts.append('echo "ENV=$(pip freeze 2>/dev/null | sha256sum | cut -d" " -f1)"')
+    if self.check_config:
+      # config + hook *content* (names + bodies), mtime-free and order-stable —
+      # `ls -la` would hash mtimes and false-positive on every reset.
+      parts.append(
+          f'echo "CFG=$( (git -C {tb} config --list --local 2>/dev/null | sort; '
+          f'for f in {tb}/.git/hooks/*; do [ -f "$f" ] && '
+          f'echo "H:$(basename "$f")" && cat "$f"; done 2>/dev/null) '
+          f'| sha256sum | cut -d" " -f1)"')
+    if self.kill_new_procs:
+      parts.append('echo "PROCS=$(ps -eo pid= 2>/dev/null | wc -l | tr -d " ")"')
+    return "; ".join(parts)
 
   @staticmethod
   def _parse(out: str) -> dict:
@@ -213,7 +223,8 @@ class GitRestoreReset:
 def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
                               reset: GitRestoreReset | None = None,
                               max_reuses: int = 32,
-                              reset_timeout: float = 5.0):
+                              reset_timeout: float = 5.0,
+                              use_session: bool = True):
   """Execute ``tasks`` reusing one sandbox per image (claims scale ÷ tasks-per-image).
 
   Tasks are grouped by image; each group runs sequentially inside a single claimed
@@ -266,6 +277,12 @@ def reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *,
       for pos, (i, t) in enumerate(group):
         if handle is None:                    # first task, or after release
           handle = fleet.acquire(t)
+          if use_session:                     # one held-open exec stream per sandbox
+            try:
+              handle.open_session()
+            except Exception as e:            # noqa: BLE001 — fall back to one-shot exec
+              logger.warning("session open failed on %s (%s); one-shot exec",
+                             handle.pod_name, e)
           if recyclable is None:              # first claim for this image: prime + decide
             baseline = reset.prime(handle)
             recyclable = reset.recyclable(baseline)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -97,7 +97,11 @@ class GitRestoreReset:
         f'echo "HEAD=$(git -C {tb} rev-parse HEAD 2>/dev/null)"; '
         f'echo "DIRTY=$(git -C {tb} status --porcelain 2>/dev/null | wc -l | tr -d " ")"; '
         f'echo "ENV=$(pip freeze 2>/dev/null | sha256sum | cut -d" " -f1)"; '
-        f'echo "CFG=$( (git -C {tb} config --list; ls -la {tb}/.git/hooks 2>/dev/null) '
+        # config + hook *content* (names + bodies), mtime-free and order-stable —
+        # `ls -la` would hash mtimes and false-positive on every reset.
+        f'echo "CFG=$( (git -C {tb} config --list --local 2>/dev/null | sort; '
+        f'for f in {tb}/.git/hooks/*; do [ -f "$f" ] && '
+        f'echo "H:$(basename "$f")" && cat "$f"; done 2>/dev/null) '
         f'| sha256sum | cut -d" " -f1)"; '
         f'echo "PROCS=$(ps -eo pid= 2>/dev/null | wc -l | tr -d " ")"')
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/recycle.py
@@ -523,11 +523,17 @@ async def reuse_git_restore_sandbox_async(afleet, tasks, process_fn, concurrency
             await afleet.release(handle)
           except Exception:  # noqa: BLE001
             logger.warning("release failed during group cleanup", exc_info=True)
-        if scale_on_hold and recyclable:          # shard done: active−1 (+ held−1 if it
-          async with locks[img]:                  # was holding) leaves desired unchanged
-            if holding:                           # → no dangling warm at end of run
+        # Decrement active UNCONDITIONALLY (every shard counted itself in `active`
+        # up front). A shard that died before its first prime (recyclable still
+        # None, e.g. acquire raised) must still drop out, or recyclable siblings
+        # compute desired = active − held with the dead shard still counted and
+        # leave a dangling warm replica. Only the held−1 / rescale are gated on
+        # scale_on_hold + recyclable (they only ran on that path).
+        async with locks[img]:
+          active[img] -= 1
+          if scale_on_hold and recyclable:        # active−1 (+ held−1 if holding)
+            if holding:                           # → desired unchanged, no dangling warm
               held[img] -= 1
-            active[img] -= 1
             await _rescale(img)
 
   # Circuit breaker (#1) around the whole fan-out — the sync guard's monitor thread

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -55,11 +55,18 @@ class Resources:
     against the CRD schema but not persisted.
     """
     try:
-      self.custom_api.get_namespaced_custom_object(
+      existing = self.custom_api.get_namespaced_custom_object(
           group=constants.GROUP, version=constants.VERSION,
           namespace=self.namespace, plural=constants.TEMPLATES_PLURAL,
           name=template_name)
       logger.info("SandboxTemplate '%s' already exists.", template_name)
+      # Template names are deterministic per image (r2e-img-<md5>), so a template
+      # left over from a previous/other run is reused as-is — and its pod-template
+      # labels would carry the OLD run-id, making this run's pods invisible to the
+      # circuit breaker and mis-targeted by the reaper (the #1215 safeguards).
+      # Reconcile the run/managed labels so pods this run spawns are attributed to
+      # this run.
+      self._reconcile_template_labels(template_name, existing)
       return False
     except client.ApiException as e:
       if e.status != 404:
@@ -150,6 +157,34 @@ class Resources:
             }
         },
     }
+
+  def _reconcile_template_labels(self, template_name: str, existing: dict) -> None:
+    """Patch a pre-existing template's metadata + pod-template labels up to this
+    run's labels when they differ, so a reused/leftover template doesn't attribute
+    this run's pods to a stale run-id (breaker/reaper correctness, #1215). Only
+    patches on mismatch; failures warn (the safeguards degrade, not the run)."""
+    desired_meta = dict(self.labels)
+    desired_pod = {**self.labels, "sandbox": template_name}
+    cur_meta = ((existing.get("metadata") or {}).get("labels")) or {}
+    cur_pod = ((((existing.get("spec") or {}).get("podTemplate") or {})
+                .get("metadata") or {}).get("labels")) or {}
+    stale = (any(cur_meta.get(k) != v for k, v in desired_meta.items())
+             or any(cur_pod.get(k) != v for k, v in desired_pod.items()))
+    if not stale:
+      return
+    try:
+      self.custom_api.patch_namespaced_custom_object(
+          group=constants.GROUP, version=constants.VERSION,
+          namespace=self.namespace, plural=constants.TEMPLATES_PLURAL,
+          name=template_name,
+          body={"metadata": {"labels": desired_meta},
+                "spec": {"podTemplate": {"metadata": {"labels": desired_pod}}}})
+      logger.info("Reconciled labels on pre-existing SandboxTemplate '%s' "
+                  "(run-id refresh)", template_name)
+    except client.ApiException:
+      logger.warning("Failed to reconcile labels on SandboxTemplate '%s'; the "
+                     "circuit breaker/reaper may under-count this run's pods for "
+                     "its image", template_name, exc_info=True)
 
   def delete_template(self, template_name: str) -> None:
     self._delete(constants.TEMPLATES_PLURAL, template_name, "SandboxTemplate")

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -307,8 +307,14 @@ class Resources:
   def list_claims(self, label_selector: str | None = None) -> list[str]:
     return self._list(constants.CLAIMS_PLURAL, label_selector)
 
+  def list_sandboxes(self, label_selector: str | None = None) -> list[str]:
+    return self._list(constants.SANDBOXES_PLURAL, label_selector)
+
   def delete_claim(self, name: str) -> None:
     self._delete(constants.CLAIMS_PLURAL, name, "SandboxClaim")
+
+  def delete_sandbox(self, name: str) -> None:
+    self._delete(constants.SANDBOXES_PLURAL, name, "Sandbox")
 
   def managed_selector(self) -> str:
     return f"{constants.MANAGED_BY_LABEL}={constants.MANAGED_BY_VALUE}"

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -139,7 +139,13 @@ class Resources:
         },
         "spec": {
             "podTemplate": {
-                "metadata": {"labels": {"sandbox": template_name}},
+                # Propagate the fleet labels (incl. the per-run RUN_ID_LABEL) onto
+                # the pod template so every sandbox POD carries them — the Sandbox
+                # controller does not copy the claim/pool run-id label onto Sandbox
+                # CRs, so pods are how a run attributes its live footprint (circuit
+                # breaker count + reaper pod sweep). `sandbox=<template>` is kept for
+                # the colocation affinity above.
+                "metadata": {"labels": {**self.labels, "sandbox": template_name}},
                 "spec": pod_spec,
             }
         },
@@ -308,28 +314,40 @@ class Resources:
     return self._list(constants.CLAIMS_PLURAL, label_selector)
 
   def list_sandboxes(self, label_selector: str | None = None) -> list[str]:
-    return self._list(constants.SANDBOXES_PLURAL, label_selector)
+    # Sandbox is in the CORE group, not extensions — pass it explicitly.
+    return self._list(constants.SANDBOXES_PLURAL, label_selector,
+                      group=constants.SANDBOX_GROUP, version=constants.SANDBOX_VERSION)
+
+  def count_pods(self, label_selector: str | None = None) -> int:
+    """Number of pods matching ``label_selector`` in this namespace (the actual
+    live footprint — sandbox pods carry the fleet labels via the pod template)."""
+    kwargs = {"label_selector": label_selector} if label_selector else {}
+    pods = self.core_api.list_namespaced_pod(namespace=self.namespace, **kwargs)
+    return len(pods.items)
 
   def delete_claim(self, name: str) -> None:
     self._delete(constants.CLAIMS_PLURAL, name, "SandboxClaim")
 
   def delete_sandbox(self, name: str) -> None:
-    self._delete(constants.SANDBOXES_PLURAL, name, "Sandbox")
+    self._delete(constants.SANDBOXES_PLURAL, name, "Sandbox",
+                 group=constants.SANDBOX_GROUP, version=constants.SANDBOX_VERSION)
 
   def managed_selector(self) -> str:
     return f"{constants.MANAGED_BY_LABEL}={constants.MANAGED_BY_VALUE}"
 
-  def _list(self, plural: str, label_selector: str | None) -> list[str]:
+  def _list(self, plural: str, label_selector: str | None, *,
+            group: str = constants.GROUP, version: str = constants.VERSION) -> list[str]:
     kwargs = {"label_selector": label_selector} if label_selector else {}
     objs = self.custom_api.list_namespaced_custom_object(
-        group=constants.GROUP, version=constants.VERSION,
+        group=group, version=version,
         namespace=self.namespace, plural=plural, **kwargs)
     return [o["metadata"]["name"] for o in objs.get("items", [])]
 
-  def _delete(self, plural: str, name: str, kind: str) -> None:
+  def _delete(self, plural: str, name: str, kind: str, *,
+              group: str = constants.GROUP, version: str = constants.VERSION) -> None:
     try:
       self.custom_api.delete_namespaced_custom_object(
-          group=constants.GROUP, version=constants.VERSION,
+          group=group, version=version,
           namespace=self.namespace, plural=plural, name=name,
           body=client.V1DeleteOptions(grace_period_seconds=0))
       logger.info("Deleted %s '%s'", kind, name)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -354,11 +354,24 @@ class Resources:
                       group=constants.SANDBOX_GROUP, version=constants.SANDBOX_VERSION)
 
   def count_pods(self, label_selector: str | None = None) -> int:
-    """Number of pods matching ``label_selector`` in this namespace (the actual
-    live footprint — sandbox pods carry the fleet labels via the pod template)."""
+    """Count pods matching ``label_selector`` in this namespace (the run's live
+    footprint) **without transferring the full pod list** — the circuit breaker
+    polls this repeatedly and the target scale is tens of thousands of pods.
+
+    Uses a ``limit=1`` list + ``metadata.remainingItemCount`` (a server-provided
+    hint) to get the total cheaply; falls back to a full list only when the server
+    omits the hint yet more pages exist."""
     kwargs = {"label_selector": label_selector} if label_selector else {}
-    pods = self.core_api.list_namespaced_pod(namespace=self.namespace, **kwargs)
-    return len(pods.items)
+    resp = self.core_api.list_namespaced_pod(namespace=self.namespace, limit=1, **kwargs)
+    meta = resp.metadata
+    remaining = getattr(meta, "remaining_item_count", None)
+    if remaining is not None:
+      return len(resp.items) + remaining
+    if not getattr(meta, "_continue", None):
+      return len(resp.items)                 # single page holds the whole set
+    # more pages exist but no count hint: fall back to a full (unpaged) list.
+    resp = self.core_api.list_namespaced_pod(namespace=self.namespace, **kwargs)
+    return len(resp.items)
 
   def delete_claim(self, name: str) -> None:
     self._delete(constants.CLAIMS_PLURAL, name, "SandboxClaim")

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -173,6 +173,11 @@ class Resources:
     if not stale:
       return
     try:
+      # patch_namespaced_custom_object sends a JSON Merge Patch (RFC 7386;
+      # the client's only content-type for CRD patch is merge-patch+json), which
+      # merges nested objects — so this UPSERTS the managed label keys and leaves
+      # any pre-existing/operator labels on the template + podTemplate intact. It
+      # does not replace the label maps.
       self.custom_api.patch_namespaced_custom_object(
           group=constants.GROUP, version=constants.VERSION,
           namespace=self.namespace, plural=constants.TEMPLATES_PLURAL,

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -359,19 +359,29 @@ class Resources:
     polls this repeatedly and the target scale is tens of thousands of pods.
 
     Uses a ``limit=1`` list + ``metadata.remainingItemCount`` (a server-provided
-    hint) to get the total cheaply; falls back to a full list only when the server
-    omits the hint yet more pages exist."""
+    hint) to get the total cheaply. That hint is only populated for **selector-less**
+    lists — the apiserver deliberately returns nil for any label/field predicate
+    (``PrepareContinueToken``) — and the breaker always polls with a run-id selector,
+    so beyond one page we page through in bounded chunks counting ``len(items)`` only
+    (never transferring the whole list in a single response)."""
     kwargs = {"label_selector": label_selector} if label_selector else {}
     resp = self.core_api.list_namespaced_pod(namespace=self.namespace, limit=1, **kwargs)
     meta = resp.metadata
     remaining = getattr(meta, "remaining_item_count", None)
     if remaining is not None:
-      return len(resp.items) + remaining
-    if not getattr(meta, "_continue", None):
+      return len(resp.items) + remaining     # selector-less fast path
+    cont = getattr(meta, "_continue", None)
+    if not cont:
       return len(resp.items)                 # single page holds the whole set
-    # more pages exist but no count hint: fall back to a full (unpaged) list.
-    resp = self.core_api.list_namespaced_pod(namespace=self.namespace, **kwargs)
-    return len(resp.items)
+    # Selector query with >1 page (no count hint): paginate. Bounds per-request
+    # payload + client memory at scale instead of one giant filtered list.
+    total = len(resp.items)
+    while cont:
+      resp = self.core_api.list_namespaced_pod(
+          namespace=self.namespace, limit=500, _continue=cont, **kwargs)
+      total += len(resp.items)
+      cont = getattr(resp.metadata, "_continue", None)
+    return total
 
   def delete_claim(self, name: str) -> None:
     self._delete(constants.CLAIMS_PLURAL, name, "SandboxClaim")

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/resources.py
@@ -162,7 +162,12 @@ class Resources:
     """Patch a pre-existing template's metadata + pod-template labels up to this
     run's labels when they differ, so a reused/leftover template doesn't attribute
     this run's pods to a stale run-id (breaker/reaper correctness, #1215). Only
-    patches on mismatch; failures warn (the safeguards degrade, not the run)."""
+    patches on mismatch; failures warn (the safeguards degrade, not the run).
+
+    Two concurrent runs sharing an image (same deterministic template name) take
+    turns re-labeling this template — pod attribution between their breakers/reapers
+    is last-writer-wins. Both directions are safe: a breaker under-counts and fails
+    open, and a per-run reap misses the other run's pods rather than deleting them."""
     desired_meta = dict(self.labels)
     desired_pod = {**self.labels, "sandbox": template_name}
     cur_meta = ((existing.get("metadata") or {}).get("labels")) or {}

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/strategies.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/strategies.py
@@ -79,18 +79,26 @@ def process_parallel(fleet, tasks, process_fn, concurrency):
   return results
 
 
-def run_naive(fleet, process_fn, concurrency, *, teardown=True):
-  """Pre-warm every image up front, process all tasks in parallel, tear down."""
+def run_naive(fleet, process_fn, concurrency, *, teardown=True,
+              executor=process_parallel):
+  """Pre-warm every image up front, process all tasks in parallel, tear down.
+
+  ``executor`` is the per-batch execution primitive (``(fleet, tasks, process_fn,
+  concurrency) -> results``); it defaults to ``process_parallel`` (fresh
+  claim+release per task) and is swapped for the recycle executor when
+  ``fleet.run(recycle=True)`` — the strategy still governs *warming*, ``executor``
+  governs the task→sandbox binding.
+  """
   try:
     fleet.setup()              # inside try: a setup failure still triggers teardown
-    return process_parallel(fleet, fleet.tasks, process_fn, concurrency)
+    return executor(fleet, fleet.tasks, process_fn, concurrency)
   finally:
     if teardown:
       fleet.teardown()
 
 
 def _run_windowed(fleet, process_fn, concurrency, window, replicas_override=None,
-                  *, teardown=True):
+                  *, teardown=True, executor=process_parallel):
   """Process unique images in batches of ``window``: warm the batch, process its
   tasks in parallel, tear the batch down, then advance."""
   fleet.preflight()
@@ -112,7 +120,7 @@ def _run_windowed(fleet, process_fn, concurrency, window, replicas_override=None
       batch_tasks = [t for _i, t in batch_pairs]
       logger.info("window [%d..%d): %d image(s), %d task(s)",
                   start, start + len(batch), len(batch), len(batch_tasks))
-      batch_results = process_parallel(fleet, batch_tasks, process_fn, concurrency)
+      batch_results = executor(fleet, batch_tasks, process_fn, concurrency)
       for (i, _t), r in zip(batch_pairs, batch_results, strict=True):
         results[i] = r
       for img in batch:
@@ -123,14 +131,17 @@ def _run_windowed(fleet, process_fn, concurrency, window, replicas_override=None
   return results
 
 
-def run_sliding(fleet, process_fn, concurrency, *, teardown=True):
+def run_sliding(fleet, process_fn, concurrency, *, teardown=True,
+                executor=process_parallel):
   """Keep only a window of image pools warm at a time (footprint-bounded)."""
   return _run_windowed(fleet, process_fn, concurrency,
-                       fleet.recommended_window(), teardown=teardown)
+                       fleet.recommended_window(), teardown=teardown,
+                       executor=executor)
 
 
 def _run_pipelined(fleet, process_fn, concurrency, window,
-                   replicas_override=None, *, teardown=True):
+                   replicas_override=None, *, teardown=True,
+                   executor=process_parallel):
   """Double-buffered sliding window: while window N's tasks run, prefetch window
   N+1's pools in the background so image pull overlaps execution.
 
@@ -163,7 +174,7 @@ def _run_pipelined(fleet, process_fn, concurrency, window,
       batch_tasks = [t for _i, t in batch_pairs]
       logger.info("pipelined window [%d/%d]: %d image(s), %d task(s)",
                   n + 1, len(batches), len(batch), len(batch_tasks))
-      batch_results = process_parallel(fleet, batch_tasks, process_fn, concurrency)
+      batch_results = executor(fleet, batch_tasks, process_fn, concurrency)
       for (i, _t), r in zip(batch_pairs, batch_results, strict=True):
         results[i] = r
       for img in batch:
@@ -177,16 +188,19 @@ def _run_pipelined(fleet, process_fn, concurrency, window,
   return results
 
 
-def run_pipelined(fleet, process_fn, concurrency, *, teardown=True):
+def run_pipelined(fleet, process_fn, concurrency, *, teardown=True,
+                  executor=process_parallel):
   """Pipelined sliding window (see `_run_pipelined`)."""
   return _run_pipelined(fleet, process_fn, concurrency,
-                        fleet.recommended_window(pipelined=True), teardown=teardown)
+                        fleet.recommended_window(pipelined=True),
+                        teardown=teardown, executor=executor)
 
 
-def run_none(fleet, process_fn, concurrency, *, teardown=True):
+def run_none(fleet, process_fn, concurrency, *, teardown=True,
+             executor=process_parallel):
   """No pre-warming: one size-1 pool per image, on demand, torn down after."""
   return _run_windowed(fleet, process_fn, concurrency, window=1,
-                       replicas_override=1, teardown=teardown)
+                       replicas_override=1, teardown=teardown, executor=executor)
 
 
 STRATEGIES = {

--- a/examples/agent-sandbox-rl/docs/design.md
+++ b/examples/agent-sandbox-rl/docs/design.md
@@ -146,14 +146,18 @@ so the simple case stays simple.
 | start claims | `acquire(task) -> SandboxHandle`, `acquire_batch(tasks) -> [SandboxHandle]` (placement-routed) |
 | return hostname list | `handles()`, `hostnames()`, `endpoints()` (cluster-qualified) |
 | teardown / delete | `release(handle)`, `release_all()`, `teardown(delete_namespace=False)` (routes to owning cluster) |
-| managed batch | `run(process_fn, strategy=None) -> [Result]` |
-| recycle (reset-and-reuse) | `reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *, reset, max_reuses, reset_timeout, use_session)`; `GitRestoreReset.prime/reset/recyclable`; `SandboxHandle.open_session()` (`SandboxSession`); `determinism_canary(...)` |
+| managed batch | `run(process_fn, strategy="naive", *, recycle=False, …) -> [Result]` |
+| recycle (reset-and-reuse) | `run(..., recycle=True, reset=, max_reuses=, reset_timeout=, use_session=, scale_on_hold=)` (flag, orthogonal to strategy) → `reuse_git_restore_sandbox(_async)`; `GitRestoreReset.prime/reset/recyclable`; `SandboxHandle.open_session()` (`SandboxSession`); `determinism_canary(...)` |
 | ergonomics | context manager `__enter__/__exit__` → `setup()`/`teardown()` |
 
-**Sandbox recycling** (`recycle.py`, experimental) is a third execution mode beside
-primitives and the managed runner: reuse one claimed sandbox across same-image tasks,
-resetting between them, so claims scale with *problems* (÷ tasks-per-image) instead of
-tasks. The shipped tier is **git-restore** (`GitRestoreReset`: `git reset --hard
+**Sandbox recycling** (`recycle.py`, experimental) is an **orthogonal modifier on the
+managed runner** — `run(..., recycle=True)` — not a separate execution mode or strategy
+value: the chosen warm-pool `strategy` still governs warming, while `recycle` swaps the
+task→sandbox binding to reuse one claimed sandbox across same-image tasks, resetting
+between them, so claims scale with *problems* (÷ tasks-per-image) instead of tasks. It is
+off by default (a no-op for 1:1 eval; only multi-task-per-image shapes benefit). The
+executors (`reuse_git_restore_sandbox` / `_async`) remain callable directly for control
+outside `run()`. The shipped tier is **git-restore** (`GitRestoreReset`: `git reset --hard
 pristine` + `clean -xdff` + process/`/tmp` sweep, then verify the repo is at the
 pristine SHA and clean); dirty resets **quarantine** to a fresh claim. Reset is
 **git-only by default** — the `pip freeze` env and git-config/hooks tripwires are opt-in

--- a/examples/agent-sandbox-rl/docs/design.md
+++ b/examples/agent-sandbox-rl/docs/design.md
@@ -146,18 +146,24 @@ so the simple case stays simple.
 | return hostname list | `handles()`, `hostnames()`, `endpoints()` (cluster-qualified) |
 | teardown / delete | `release(handle)`, `release_all()`, `teardown(delete_namespace=False)` (routes to owning cluster) |
 | managed batch | `run(process_fn, strategy=None) -> [Result]` |
-| recycle (reset-and-reuse) | `reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *, reset, max_reuses, reset_timeout)`; `GitRestoreReset.prime/reset`; `determinism_canary(...)` |
+| recycle (reset-and-reuse) | `reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *, reset, max_reuses, reset_timeout, use_session)`; `GitRestoreReset.prime/reset/recyclable`; `SandboxHandle.open_session()` (`SandboxSession`); `determinism_canary(...)` |
 | ergonomics | context manager `__enter__/__exit__` → `setup()`/`teardown()` |
 
 **Sandbox recycling** (`recycle.py`, experimental) is a third execution mode beside
 primitives and the managed runner: reuse one claimed sandbox across same-image tasks,
 resetting between them, so claims scale with *problems* (÷ tasks-per-image) instead of
 tasks. The shipped tier is **git-restore** (`GitRestoreReset`: `git reset --hard
-pristine` + `clean -xdff` + process/`/tmp` sweep, then a cleanliness verify with
-env / config-hooks / process-count tripwires); dirty resets **quarantine** to a fresh
-claim. Costlier tiers (env-dir restore, overlay/checkpoint restart) are deferred. Full
-design, hardening (deep-research verified), and open questions live in the companion
-notes repo `plans/sandbox-recycling.md`; `determinism_canary` is the correctness gate.
+pristine` + `clean -xdff` + process/`/tmp` sweep, then verify the repo is at the
+pristine SHA and clean); dirty resets **quarantine** to a fresh claim. Reset is
+**git-only by default** — the `pip freeze` env and git-config/hooks tripwires are opt-in
+(`check_env`/`check_config`), bounded otherwise by `max_reuses` + the canary. It scales
+via a **persistent exec session** (`SandboxSession`, `use_session=True`): one held-open
+`bash` stream per sandbox so task+reset cost O(sandboxes) apiserver exec connections, not
+O(tasks) — `SandboxHandle.exec()` routes through it transparently. Non-git images fall
+back to fresh-claim-per-task; exec failures quarantine rather than abort. Costlier tiers
+(env-dir restore, overlay/checkpoint restart) are deferred. `determinism_canary` is the
+correctness gate. Full design + deep-research hardening + A/B findings: notes repo
+`plans/sandbox-recycling.md`.
 
 **Two modes (both shipped):** (1) **primitives** an RL loop drives itself
 (`acquire` → use `handle.hostname/endpoint` → `release`); (2) **managed runner**

--- a/examples/agent-sandbox-rl/docs/design.md
+++ b/examples/agent-sandbox-rl/docs/design.md
@@ -146,7 +146,18 @@ so the simple case stays simple.
 | return hostname list | `handles()`, `hostnames()`, `endpoints()` (cluster-qualified) |
 | teardown / delete | `release(handle)`, `release_all()`, `teardown(delete_namespace=False)` (routes to owning cluster) |
 | managed batch | `run(process_fn, strategy=None) -> [Result]` |
+| recycle (reset-and-reuse) | `reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *, reset, max_reuses, reset_timeout)`; `GitRestoreReset.prime/reset`; `determinism_canary(...)` |
 | ergonomics | context manager `__enter__/__exit__` → `setup()`/`teardown()` |
+
+**Sandbox recycling** (`recycle.py`, experimental) is a third execution mode beside
+primitives and the managed runner: reuse one claimed sandbox across same-image tasks,
+resetting between them, so claims scale with *problems* (÷ tasks-per-image) instead of
+tasks. The shipped tier is **git-restore** (`GitRestoreReset`: `git reset --hard
+pristine` + `clean -xdff` + process/`/tmp` sweep, then a cleanliness verify with
+env / config-hooks / process-count tripwires); dirty resets **quarantine** to a fresh
+claim. Costlier tiers (env-dir restore, overlay/checkpoint restart) are deferred. Full
+design, hardening (deep-research verified), and open questions live in the companion
+notes repo `plans/sandbox-recycling.md`; `determinism_canary` is the correctness gate.
 
 **Two modes (both shipped):** (1) **primitives** an RL loop drives itself
 (`acquire` → use `handle.hostname/endpoint` → `release`); (2) **managed runner**

--- a/examples/agent-sandbox-rl/docs/design.md
+++ b/examples/agent-sandbox-rl/docs/design.md
@@ -123,7 +123,8 @@ so the simple case stays simple.
   `JsonlSource`; `SweBenchSource` (HF) in `adapters/swebench.py` (`swebench` extra).
 - **`FleetConfig`** (pydantic): `clusters: list[ClusterConfig]`, `placement`,
   `max_concurrent`, `max_warmpool_size`, `window_size` (None=auto),
-  `ready_timeout`, `template` (`TemplateSpec`), `template_name_fn`
+  `ready_timeout`, `warm_create_budget` (1000 — stage the warm fill in waves of ≤ N
+  in-flight creates; 0 = all at once), `template` (`TemplateSpec`), `template_name_fn`
   (default `r2e-img-<md5[:12]>`), `labels`.
 - **`SandboxHandle`** (`handles.py`): per claim — `task`, **`cluster`** (name +
   connection), `claim_name`, `sandbox_id`, **`hostname`** (stable in-cluster DNS),
@@ -139,7 +140,7 @@ so the simple case stays simple.
 | preflight checks | `preflight() -> dict[cluster, PreflightReport]` (raises on hard failures) |
 | compute replicas | `plan() -> FleetPlan` (per-cluster, per-image replicas + window) |
 | set templates | `ensure_templates()` (across selected clusters) |
-| pools / start warmpools | `start_warmpools(wait=True)` (distributes pools across clusters per placement+sizing) |
+| pools / start warmpools | `start_warmpools(wait=True, create_budget=None)` (distributes pools across clusters per placement+sizing; staged in ≤`warm_create_budget` in-flight-create waves) |
 | (optional) pre-pull | `prepull(wait=True)` / `prepull_delete()` (per cluster) |
 | setup | `setup()` — preflight → plan → (optional prepull) → start warm pools |
 | start claims | `acquire(task) -> SandboxHandle`, `acquire_batch(tasks) -> [SandboxHandle]` (placement-routed) |

--- a/examples/agent-sandbox-rl/docs/strategies.md
+++ b/examples/agent-sandbox-rl/docs/strategies.md
@@ -149,19 +149,30 @@ claim per group.
 
 The shipped reset tier is **git-restore** (`GitRestoreReset`): `git reset --hard
 pristine` + `clean -xdff` + detach + process/`/tmp` sweep, then a **cleanliness verify**
-— repo at the pristine SHA and, as tripwires (detect, don't repair), the Python env
-(`pip freeze` hash), git config/hooks hash, and process count unchanged. Drift, a reset
-over `reset_timeout`, or hitting `max_reuses` → **quarantine** (release + fresh claim).
-Rationale: in RL a polluted sandbox silently biases rewards, so *detect-and-escalate*
-beats a cheap-but-unverified wipe. The env-restore and overlay/checkpoint tiers are
-deferred (drift there escalates to a fresh claim).
+that the repo is back at the pristine SHA and clean. **Git-only by default** (fast); the
+site-packages (`pip freeze`) and git-config/hooks tripwires are opt-in
+(`check_env`/`check_config`) — env drift is rare and bounded by `max_reuses` + the
+canary, and `pip freeze` per reset was the dominant cost. Drift, a reset over
+`reset_timeout`, or hitting `max_reuses` → **quarantine** (release + fresh claim).
+Rationale: a polluted sandbox silently biases RL rewards, so *detect-and-escalate* beats
+a cheap-but-unverified wipe. Env-restore and overlay/checkpoint tiers are deferred.
 
+- **Scales via a persistent exec session** (`use_session=True`, default): one held-open
+  `bash` stream per sandbox, so task + reset pipe over a single websocket rather than a
+  fresh apiserver `exec` connect per command — exec cost O(sandboxes), not O(tasks).
+  This is what makes reuse viable at high concurrency (per-command exec saturated the
+  apiserver in an earlier run).
+- **Safe on mixed image sets:** a non-git `/testbed` (no pristine anchor) transparently
+  falls back to fresh-claim-per-task; an exec failure mid-reset quarantines rather than
+  aborting the batch.
 - **Verify first:** `determinism_canary(fleet, task, process_fn)` runs a task twice in
-  one recycled sandbox; `identical` must be True before trusting recycled runs for
-  training.
-- **Cost model:** recycling pays off only when reset time ≪ claim time (~2–5 s) and an
-  image carries many tasks (RL, not 1:1 eval). New `reset`/`quarantine`/`rotate` phases
-  in the `RunReport` make the trade measurable.
+  one recycled sandbox; `identical` must be True before trusting recycled runs.
+- **When it wins:** at the **RL shape** (few problems, many rollouts each) reuse beats
+  fresh-claim on wall, claims, *and* reliability — regular's shallow per-image warm pool
+  saturates under same-image contention (measured 50×40 no-op: reuse 416s/81 claims/100%
+  vs regular 944s/1,987/99.35%). At **1:1 eval** (many distinct images) keep fresh-claim
+  + `pipelined`; reuse only cuts claims there and costs wall. `reset`/`quarantine`/
+  `rotate` phases in the `RunReport` make the trade measurable.
 - Full design + deep-research hardening (git shared-store gc hazards, `/testbed`
   realpath stability, the site-packages hole) and open questions: notes repo
   `plans/sandbox-recycling.md`.

--- a/examples/agent-sandbox-rl/docs/strategies.md
+++ b/examples/agent-sandbox-rl/docs/strategies.md
@@ -32,7 +32,7 @@ The two workloads pull in opposite directions:
 | Workload | Strategy | Sizing flags | Caching levers | Why |
 | :--- | :--- | :--- | :--- | :--- |
 | **Eval (1:1 sweep)** | **`pipelined`** | default (concurrency-aware) | `epochs`/`keep_warm` + `IfNotPresent` + in-region mirror; `prepull` if it fits disk | Pull dominates → overlap window N+1's pull with N's run, and reuse the node cache across passes. `warm_per_task`/`colocate` are no-ops (1 task/image). |
-| **RL (1:G rollouts)** | **`naive`** or **`sliding`** | `warm_per_task=True` (+ `max_warmpool_size ≥ G`), `colocate_replicas=True` | `keep_warm=True` across steps + `IfNotPresent` | Every rollout claims its own ready replica → lowest straggler tail. **Avoid `pipelined`** — deep replicas shrink its window and serialize problems. |
+| **RL (1:G rollouts)** | **`naive`** or **`sliding`** | `warm_per_task=True` (+ `max_warmpool_size ≥ G`), `colocate_replicas=True` — *or* `recycle=True` (reuse one sandbox ÷G) | `keep_warm=True` across steps + `IfNotPresent` | Every rollout claims its own ready replica → lowest straggler tail. **Avoid `pipelined`** — deep replicas shrink its window and serialize problems. Add `recycle=True` when claims (not latency) are the bottleneck — see [§3 Recycling](#recycling-reset-and-reuse--experimental-orthogonal-to-strategy--sizing). |
 | **Tiny run / debug** | `none` | default | — | Lowest footprint (one size-1 pool per image, on demand); inherently sequential. |
 | **Batch may exceed pool capacity** | `pipelined` or `sliding` | default | — | Bounded footprint survives over-subscription where `naive` drops tasks (see [§6](#6-capacity--over-subscription)). |
 
@@ -143,10 +143,26 @@ What they do and don't buy:
 Instant-claim gives each rollout a *fresh* sandbox; **recycling** reuses *one* sandbox
 across a problem's G rollouts, resetting between them — so claims scale with **problems**
 (÷G), not tasks. Where instant-claim cuts claim *latency*, recycling cuts claim *count*
-(and the controller reconciles / API-server writes that scale with it). Use it via
-`reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *, max_reuses,
-reset_timeout)` instead of `fleet.run(...)`; it groups tasks by image and reuses one
-claim per group.
+(and the controller reconciles / API-server writes that scale with it).
+
+Turn it on with the **`recycle=True`** flag on `fleet.run(...)` — an *orthogonal
+modifier*, not a strategy value. The chosen `strategy` still governs warming (pool
+sizing/timing); `recycle` only changes the task→sandbox binding to reset-and-reuse:
+
+```python
+# RL rollouts: warm naive, reuse one sandbox per problem across its G rollouts
+fleet.run(rollout_fn, strategy="naive", recycle=True, max_reuses=G, keep_warm=True)
+await afleet.run(rollout_fn, strategy="naive", recycle=True)   # async twin
+```
+
+It is **off by default** because it only applies to workloads with a resettable
+`/testbed` and multiple tasks per image — for a 1:1 eval sweep it is a no-op, and it
+can be limiting (not every RL/eval shape resets cleanly). `reset` (a `GitRestoreReset`),
+`max_reuses`, `reset_timeout`, `use_session` and `scale_on_hold` are forwarded to the
+recycle executor (async also takes `shards_per_image` / `claim_concurrency`); all are
+ignored when `recycle=False`. Under the hood it groups tasks by image and reuses one
+claim per group via `recycle.reuse_git_restore_sandbox(_async)` — which you can still
+call directly for full control outside `run()`.
 
 The shipped reset tier is **git-restore** (`GitRestoreReset`): `git reset --hard
 pristine` + `clean -xdff` + detach + process/`/tmp` sweep, then a **cleanliness verify**

--- a/examples/agent-sandbox-rl/docs/strategies.md
+++ b/examples/agent-sandbox-rl/docs/strategies.md
@@ -54,7 +54,7 @@ fleet.run(rollout_fn, strategy="naive", keep_warm=True)       # reuse across ste
 | **Warm-pool strategy** | when pools exist & footprint | `run(strategy=…)`: `naive` / `sliding` / `pipelined` / `none` | `pipelined` eval; `naive`/`sliding` RL |
 | **Concurrency-aware sizing** (default) | pool depth = image's share of the budget | `max_concurrent`, `max_warmpool_size` | eval (1:1), minimal footprint |
 | **Instant-claim (pre-warm)** | one warm replica **per task** | `FleetConfig.warm_per_task=True` | RL (G rollouts share an image) |
-| **Staged warm fill** | warm in waves to bound the controller's create burst | `FleetConfig.warm_create_budget` (1000; `0`=all at once) | large/deep warms — avoids the #1215 over-creation race |
+| **Staged warm fill** | warm in waves to bound the controller's create burst | `FleetConfig.warm_create_budget` (1000; `0`=all at once) | large/deep warms — mitigates the #1215 over-creation race (bounds the burst) |
 | **Replica co-location** | pack a pool's replicas on one node → 1 pull/node | `TemplateSpec.colocate_replicas=True` | deep pools (RL), cache reuse |
 | **Cross-epoch reuse** | keep pools resident across passes | `run(epochs=N)` / `keep_warm=True` | repeated passes (RL epochs) |
 | **Node layer cache** | re-use already-pulled layers | `TemplateSpec.image_pull_policy=IfNotPresent` (default) | every repeated run |

--- a/examples/agent-sandbox-rl/docs/strategies.md
+++ b/examples/agent-sandbox-rl/docs/strategies.md
@@ -54,6 +54,7 @@ fleet.run(rollout_fn, strategy="naive", keep_warm=True)       # reuse across ste
 | **Warm-pool strategy** | when pools exist & footprint | `run(strategy=…)`: `naive` / `sliding` / `pipelined` / `none` | `pipelined` eval; `naive`/`sliding` RL |
 | **Concurrency-aware sizing** (default) | pool depth = image's share of the budget | `max_concurrent`, `max_warmpool_size` | eval (1:1), minimal footprint |
 | **Instant-claim (pre-warm)** | one warm replica **per task** | `FleetConfig.warm_per_task=True` | RL (G rollouts share an image) |
+| **Staged warm fill** | warm in waves to bound the controller's create burst | `FleetConfig.warm_create_budget` (1000; `0`=all at once) | large/deep warms — avoids the #1215 over-creation race |
 | **Replica co-location** | pack a pool's replicas on one node → 1 pull/node | `TemplateSpec.colocate_replicas=True` | deep pools (RL), cache reuse |
 | **Cross-epoch reuse** | keep pools resident across passes | `run(epochs=N)` / `keep_warm=True` | repeated passes (RL epochs) |
 | **Node layer cache** | re-use already-pulled layers | `TemplateSpec.image_pull_policy=IfNotPresent` (default) | every repeated run |

--- a/examples/agent-sandbox-rl/docs/strategies.md
+++ b/examples/agent-sandbox-rl/docs/strategies.md
@@ -137,6 +137,35 @@ What they do and don't buy:
   the pipelined window to keep its footprint bounded, which serializes problems and
   underfills `max_concurrent` once rollouts do real work.
 
+### Recycling (reset-and-reuse) — experimental, orthogonal to strategy & sizing
+
+Instant-claim gives each rollout a *fresh* sandbox; **recycling** reuses *one* sandbox
+across a problem's G rollouts, resetting between them — so claims scale with **problems**
+(÷G), not tasks. Where instant-claim cuts claim *latency*, recycling cuts claim *count*
+(and the controller reconciles / API-server writes that scale with it). Use it via
+`reuse_git_restore_sandbox(fleet, tasks, process_fn, concurrency, *, max_reuses,
+reset_timeout)` instead of `fleet.run(...)`; it groups tasks by image and reuses one
+claim per group.
+
+The shipped reset tier is **git-restore** (`GitRestoreReset`): `git reset --hard
+pristine` + `clean -xdff` + detach + process/`/tmp` sweep, then a **cleanliness verify**
+— repo at the pristine SHA and, as tripwires (detect, don't repair), the Python env
+(`pip freeze` hash), git config/hooks hash, and process count unchanged. Drift, a reset
+over `reset_timeout`, or hitting `max_reuses` → **quarantine** (release + fresh claim).
+Rationale: in RL a polluted sandbox silently biases rewards, so *detect-and-escalate*
+beats a cheap-but-unverified wipe. The env-restore and overlay/checkpoint tiers are
+deferred (drift there escalates to a fresh claim).
+
+- **Verify first:** `determinism_canary(fleet, task, process_fn)` runs a task twice in
+  one recycled sandbox; `identical` must be True before trusting recycled runs for
+  training.
+- **Cost model:** recycling pays off only when reset time ≪ claim time (~2–5 s) and an
+  image carries many tasks (RL, not 1:1 eval). New `reset`/`quarantine`/`rotate` phases
+  in the `RunReport` make the trade measurable.
+- Full design + deep-research hardening (git shared-store gc hazards, `/testbed`
+  realpath stability, the site-packages hole) and open questions: notes repo
+  `plans/sandbox-recycling.md`.
+
 ---
 
 ## 4. Caching & amortization levers (avoid the pull)

--- a/examples/agent-sandbox-rl/examples/rl_integration.md
+++ b/examples/agent-sandbox-rl/examples/rl_integration.md
@@ -36,6 +36,67 @@ slowest of G rollouts, so a stray queued claim delays the whole step. Use `naive
 `keep_warm=True` to reuse pools across training steps. Full rationale and measurements:
 [eval vs RL](../README.md#eval-vs-rl--recommended-recipes).
 
+## Recycling — reuse one sandbox across a problem's G rollouts
+
+Instant-claim (above) gives each rollout its *own* fresh sandbox. **Recycling** instead
+holds **one** sandbox per problem and git-restore-resets it between rollouts, so **claims
+scale with problems, not tasks** (÷G) — cutting claim latency and control-plane load at
+RL scale. It's the recommended path for high G, and it's a wall-clock + reliability win
+when a shallow warm pool would otherwise saturate under same-image claims.
+
+```python
+from agent_sandbox_rl import (SandboxFleet, FleetConfig, ClusterConfig, TemplateSpec,
+                              ResourceSpec, SweBenchSource, Task, swebench_probe,
+                              reuse_git_restore_sandbox, determinism_canary)
+from agent_sandbox_rl.sources import to_tasks
+
+# SHALLOW warm: recycle holds ~1 sandbox per problem, so 1 replica/pool is enough.
+# Do NOT deep-warm (warm_per_task) for recycling — that stresses the warm-pool controller.
+fleet = SandboxFleet(FleetConfig(
+    clusters=[ClusterConfig(name="c1", namespace="rl")],
+    max_concurrent=500,                                    # concurrent problems held
+    template=TemplateSpec(resources=ResourceSpec(cpu="250m", memory="512Mi"))))
+
+G = 16
+problems = to_tasks(SweBenchSource(limit=500))
+tasks = [Task(id=f"p{i:04d}-r{g}", image=t.image)         # P problems × G rollouts
+         for i, t in enumerate(problems) for g in range(G)]
+fleet.load_tasks(tasks)
+fleet.setup()                                             # shallow warm (staged by default)
+
+# Correctness gate FIRST — same task twice in one recycled sandbox must be byte-identical:
+c = determinism_canary(fleet, problems[0], swebench_probe)
+assert c["identical"] and c["reset_clean"], "reset leaks state — recycling is unsafe here"
+
+# One claim per problem; git-restore reset between its G rollouts:
+results = reuse_git_restore_sandbox(fleet, fleet.tasks, rollout_fn, concurrency=500)
+fleet.teardown()
+```
+
+- **Claims ≈ P, not P·G** — the headline. Reset is git-only by default (`git reset --hard`
+  + `clean -xdff` + verify the pristine SHA); a dirty reset **quarantines** the sandbox
+  (fresh claim) so contamination can never silently bias rewards. A non-git `/testbed`
+  transparently falls back to fresh-claim-per-task.
+- **`determinism_canary`** is the ground-truth check — run it before trusting recycling
+  for training.
+- **Async** (Ray / SkyRL / tunix loops): `reuse_git_restore_sandbox_async(afleet, …)` —
+  a coroutine per group. `shards_per_image=K` runs K sandboxes/image in parallel (saturate
+  a small image set); `claim_concurrency=N` staged-claims to stay under the apiserver.
+
+### Safeguards at scale (on by default)
+Large/deep warm pools can stress the warm-pool controller
+([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)); the SDK is
+fail-safe by default:
+- **Circuit breaker** — `FleetConfig.overcommit_factor` (1.5) / `max_live_sandboxes`: if
+  live sandboxes exceed the ceiling, the fleet tears down and raises `FleetOvercommitError`
+  (catches accidental over-creation — runaway / orphan).
+- **Guaranteed teardown + reaper** — every resource is labelled with `fleet.run_id`;
+  `atexit`/SIGINT/SIGTERM tear down on graceful exit, and **`reap(run_id=…)`** /
+  `python -m agent_sandbox_rl.reaper` sweeps an **orphaned** run (SIGKILL / OOM / node loss).
+- **Staged fill/claims** — `warm_create_budget` (staged warm) + `claim_concurrency` bound
+  concurrent apiserver ops; for large deep warms also keep the controller's
+  `--sandbox-warm-pool-concurrent-workers` low (≤10).
+
 ## Generic env wrapper (primitives)
 
 ```python

--- a/examples/agent-sandbox-rl/examples/rl_integration.md
+++ b/examples/agent-sandbox-rl/examples/rl_integration.md
@@ -47,7 +47,7 @@ when a shallow warm pool would otherwise saturate under same-image claims.
 ```python
 from agent_sandbox_rl import (SandboxFleet, FleetConfig, ClusterConfig, TemplateSpec,
                               ResourceSpec, SweBenchSource, Task, swebench_probe,
-                              reuse_git_restore_sandbox, determinism_canary)
+                              determinism_canary)
 from agent_sandbox_rl.sources import to_tasks
 
 # SHALLOW warm: recycle holds ~1 sandbox per problem, so 1 replica/pool is enough.
@@ -62,26 +62,32 @@ problems = to_tasks(SweBenchSource(limit=500))
 tasks = [Task(id=f"p{i:04d}-r{g}", image=t.image)         # P problems × G rollouts
          for i, t in enumerate(problems) for g in range(G)]
 fleet.load_tasks(tasks)
-fleet.setup()                                             # shallow warm (staged by default)
 
-# Correctness gate FIRST — same task twice in one recycled sandbox must be byte-identical:
+# Correctness gate FIRST — same task twice in one recycled sandbox must be byte-identical
+# (on-demand claim; no warm pool needed yet):
 c = determinism_canary(fleet, problems[0], swebench_probe)
 assert c["identical"] and c["reset_clean"], "reset leaks state — recycling is unsafe here"
 
-# One claim per problem; git-restore reset between its G rollouts:
-results = reuse_git_restore_sandbox(fleet, fleet.tasks, rollout_fn, concurrency=500)
-fleet.teardown()
+# recycle=True is an ORTHOGONAL flag on run(): strategy="naive" shallow-warms the pools,
+# recycle reuses one claim per problem across its G rollouts (git-restore reset between).
+# run() manages setup / RunReport / teardown.
+results = fleet.run(rollout_fn, strategy="naive", concurrency=500,
+                    recycle=True, max_reuses=G)
 ```
 
 - **Claims ≈ P, not P·G** — the headline. Reset is git-only by default (`git reset --hard`
   + `clean -xdff` + verify the pristine SHA); a dirty reset **quarantines** the sandbox
   (fresh claim) so contamination can never silently bias rewards. A non-git `/testbed`
   transparently falls back to fresh-claim-per-task.
+- **`recycle` is a flag, not a strategy** — it composes with any warm-pool strategy and is
+  off by default (a no-op for 1:1 eval; it only helps multi-task-per-image shapes). For
+  full control outside `run()`, call `reuse_git_restore_sandbox(fleet, tasks, fn, conc)`
+  directly.
 - **`determinism_canary`** is the ground-truth check — run it before trusting recycling
   for training.
-- **Async** (Ray / SkyRL / tunix loops): `reuse_git_restore_sandbox_async(afleet, …)` —
-  a coroutine per group. `shards_per_image=K` runs K sandboxes/image in parallel (saturate
-  a small image set); `claim_concurrency=N` staged-claims to stay under the apiserver.
+- **Async** (Ray / SkyRL / tunix loops): `await afleet.run(fn, recycle=True, …)` — the
+  async twin. `shards_per_image=K` runs K sandboxes/image in parallel (saturate a small
+  image set); `claim_concurrency=N` staged-claims to stay under the apiserver.
 
 ### Safeguards at scale (on by default)
 Large/deep warm pools can stress the warm-pool controller

--- a/examples/agent-sandbox-rl/examples/rl_integration.md
+++ b/examples/agent-sandbox-rl/examples/rl_integration.md
@@ -176,6 +176,44 @@ fleet then replaces `eval_deepswe.py`'s inline warm-pool management.
 Requires R2E-Gym, which isn't on PyPI — install it from its checkout
 (`pip install -e path/to/R2E-Gym`). There is no `r2egym` extra.
 
+### Training loop (agentic GRPO): warm + recycle env
+
+tunix's agentic GRPO learner owns the episode loop — it builds one env per rollout
+via `env_class(single_example, group_id=…, pair_index=…, **env_kwargs)` and calls
+`reset`/`step`/`close`. To run those episodes on **warm, recycled** pods instead of
+cold-created ones, subclass the SWE env so it checks a pod out of a shared pool
+(git-restore-reset between episodes) rather than creating one:
+
+```python
+from examples.deepswe.swe_env import SWEEnv                 # tunix reference env
+from agent_sandbox_rl import Task, GitRestoreReset
+from agent_sandbox_rl.adapters.r2egym import make_fleet_repo_env, r2egym_command_files
+
+class FleetSWEEnv(SWEEnv):
+    def __init__(self, entry, *, pool, **kw):               # pool via env_kwargs
+        super().__init__(entry, **kw)                       # entry, group_id, pair_index…
+        self._pool = pool
+    def _task(self):
+        return Task(id=self.entry["instance_id"], image=self.entry["docker_image"],
+                    metadata={"ds": self.entry})            # keep_row → R2E-Gym grading
+    def _initial_observation(self):
+        self._handle, self._baseline = self._pool.checkout(self._task())
+        self.env = make_fleet_repo_env(self._handle, command_files=r2egym_command_files())
+        return self.env.get_task_instruction()
+    def close(self):                                        # return for reuse, don't delete
+        self._pool.checkin(self._task(), self._handle, self._baseline)
+```
+
+where `pool.checkout` reuses an idle warm sandbox for the image (running
+`GitRestoreReset.reset` first, quarantining on a dirty reset) or claims a fresh one,
+and `checkin` returns it. Build the fleet once and inject the pool via
+`GRPOLearner(env_class=FleetSWEEnv, env_kwargs={"pool": pool}, …)`. Run
+`determinism_canary` before training — a dirty reset silently biases rewards. A
+group's `G` rollouts run concurrently (each holds its own pod while active), so the
+win is **pod _creates_ scale with peak concurrency, not total episodes** — warm pods
+are reused across episodes/steps rather than created per rollout. Size
+`max_concurrent` to the peak concurrent episodes, not the number of problems.
+
 ## TorchRL / SkyRL
 
 Wrap `acquire`/`release` around an episode in your `EnvBase`/env:

--- a/examples/agent-sandbox-rl/examples/run_swebench_recycle.py
+++ b/examples/agent-sandbox-rl/examples/run_swebench_recycle.py
@@ -25,7 +25,9 @@ recycle counterpart of `run_swebench_fleet.py`. Env-configured:
   RUNTIME_CLASS=gvisor python run_swebench_recycle.py
 
 Safeguards are on by default (circuit breaker + run-id label + staged warm); if a
-run is killed abruptly, sweep it with `python -m agent_sandbox_rl.reaper --namespace rl`.
+run is killed abruptly, sweep just that run with its id (printed at startup):
+`python -m agent_sandbox_rl.reaper --run-id <id> --namespace rl`. (Reaping *every*
+run in the namespace needs an explicit `--all` — it also deletes healthy runs.)
 """
 
 import json

--- a/examples/agent-sandbox-rl/examples/run_swebench_recycle.py
+++ b/examples/agent-sandbox-rl/examples/run_swebench_recycle.py
@@ -16,8 +16,10 @@
 
 Builds P problems x G rollouts, warms **shallow** (recycling holds ~1 sandbox per
 problem — do NOT deep-warm), runs a **determinism gate**, then
-`reuse_git_restore_sandbox` so claims scale with problems, not tasks (/G). The
-recycle counterpart of `run_swebench_fleet.py`. Env-configured:
+`fleet.run(..., recycle=True)` so claims scale with problems, not tasks (/G).
+`recycle` is an orthogonal flag: the `strategy` ("naive" here) still governs
+warming; `recycle` swaps the task→sandbox binding to reset-and-reuse. The recycle
+counterpart of `run_swebench_fleet.py`. Env-configured:
 
   PROBLEMS=500 ROLLOUTS=16 MAX_CONCURRENT=500 CPU=250m MEMORY=512Mi \
   DETERMINISM=5 NAMESPACE=rl \
@@ -37,7 +39,7 @@ import time
 
 from agent_sandbox_rl import (ClusterConfig, FleetConfig, ResourceSpec, SandboxFleet,
                               SweBenchSource, Task, TemplateSpec, determinism_canary,
-                              reuse_git_restore_sandbox, swebench_probe)
+                              swebench_probe)
 from agent_sandbox_rl.sources import to_tasks
 
 logging.basicConfig(
@@ -82,9 +84,10 @@ def main():
   print(f"recycle: {len(images)} problems x {rollouts} rollouts = {len(tasks)} tasks; "
         f"mc={max_concurrent}", flush=True)
 
-  fleet.setup()                                        # shallow warm (staged by default)
-
-  # Correctness gate: same task twice in one recycled sandbox must be byte-identical.
+  # Correctness gate FIRST (on-demand claims — no pool needed yet): the same task
+  # run twice in one recycled sandbox must be byte-identical, or the reset leaks
+  # state and recycling is unsafe. Tear down the canary's on-demand pools before
+  # the measured run so it starts from a clean plan.
   determ = []
   for img in images[:determinism]:
     out = determinism_canary(fleet, Task(id=f"canary-{img[-12:]}", image=img), swebench_probe)
@@ -92,15 +95,20 @@ def main():
     print(f"  determinism {'OK ' if determ[-1] else 'FAIL'} {img.split('/')[-1]}", flush=True)
   if determ and not all(determ):
     raise SystemExit("determinism gate FAILED — reset leaks state; recycling is unsafe")
+  if determinism:
+    fleet.teardown()                                   # drop canary on-demand pools
 
   def rollout(task, handle):                           # no-op probe by default
     return swebench_probe(task, handle)
 
+  # Recycle via the run() flag: strategy="naive" shallow-warms the pools, recycle
+  # reuses one sandbox per problem across its G rollouts (max_reuses=G bounds drift
+  # before a rotation). run() manages setup / RunReport / teardown.
   t0 = time.monotonic()
-  with fleet.observer.run("reuse") as rep:
-    reuse_git_restore_sandbox(fleet, fleet.tasks, rollout, max_concurrent)
-    rep.total_s = time.monotonic() - t0
-  fleet.teardown()
+  fleet.run(rollout, strategy="naive", concurrency=max_concurrent,
+            recycle=True, max_reuses=rollouts)
+  rep = fleet.report
+  rep.total_s = time.monotonic() - t0
 
   d = rep.to_dict()
   claims = d.get("claims", 0)

--- a/examples/agent-sandbox-rl/examples/run_swebench_recycle.py
+++ b/examples/agent-sandbox-rl/examples/run_swebench_recycle.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RL-shape recycling: reuse one sandbox across a problem's G rollouts.
+
+Builds P problems x G rollouts, warms **shallow** (recycling holds ~1 sandbox per
+problem — do NOT deep-warm), runs a **determinism gate**, then
+`reuse_git_restore_sandbox` so claims scale with problems, not tasks (/G). The
+recycle counterpart of `run_swebench_fleet.py`. Env-configured:
+
+  PROBLEMS=500 ROLLOUTS=16 MAX_CONCURRENT=500 CPU=250m MEMORY=512Mi \
+  DETERMINISM=5 NAMESPACE=rl \
+  NODE_SELECTOR_KEY=cloud.google.com/gke-nodepool NODE_SELECTOR_VAL=gvisor-pool \
+  RUNTIME_CLASS=gvisor python run_swebench_recycle.py
+
+Safeguards are on by default (circuit breaker + run-id label + staged warm); if a
+run is killed abruptly, sweep it with `python -m agent_sandbox_rl.reaper --namespace rl`.
+"""
+
+import json
+import logging
+import os
+import time
+
+from agent_sandbox_rl import (ClusterConfig, FleetConfig, ResourceSpec, SandboxFleet,
+                              SweBenchSource, Task, TemplateSpec, determinism_canary,
+                              reuse_git_restore_sandbox, swebench_probe)
+from agent_sandbox_rl.sources import to_tasks
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+
+def _env(name, default):
+  return os.getenv(name, default)
+
+
+def main():
+  problems = int(_env("PROBLEMS", "50"))
+  rollouts = int(_env("ROLLOUTS", "16"))              # G per problem
+  max_concurrent = int(_env("MAX_CONCURRENT", "500"))  # concurrent problems held
+  determinism = int(_env("DETERMINISM", "5"))          # canary on first N images (0 = skip)
+  namespace = _env("NAMESPACE", "default")
+  ready_timeout = int(_env("SANDBOX_READY_TIMEOUT", "900"))
+  cpu, memory = _env("CPU", "250m"), _env("MEMORY", "512Mi")
+
+  node_selector = None
+  if _env("NODE_SELECTOR_KEY", "") and _env("NODE_SELECTOR_VAL", ""):
+    node_selector = {os.environ["NODE_SELECTOR_KEY"]: os.environ["NODE_SELECTOR_VAL"]}
+  template = TemplateSpec(
+      runtime_class=_env("RUNTIME_CLASS", "") or None, node_selector=node_selector,
+      image_pull_secret=_env("IMAGE_PULL_SECRET", "") or None,
+      resources=ResourceSpec(cpu=cpu, memory=memory))
+
+  contexts = [c for c in _env("KUBE_CONTEXTS", "").split(",") if c]
+  clusters = ([ClusterConfig(name=c, context=c, namespace=namespace) for c in contexts]
+              if contexts else [ClusterConfig(name="default", namespace=namespace)])
+
+  # Shallow warm: no warm_per_task — recycle needs ~1 replica/pool, not G.
+  fleet = SandboxFleet(FleetConfig(
+      clusters=clusters, max_concurrent=max_concurrent,
+      ready_timeout=ready_timeout, template=template))
+
+  base = to_tasks(SweBenchSource(limit=problems))
+  images = [t.image for t in base]
+  tasks = [Task(id=f"p{i:04d}-r{g}", image=img)
+           for i, img in enumerate(images) for g in range(rollouts)]
+  fleet.load_tasks(tasks)
+  print(f"recycle: {len(images)} problems x {rollouts} rollouts = {len(tasks)} tasks; "
+        f"mc={max_concurrent}", flush=True)
+
+  fleet.setup()                                        # shallow warm (staged by default)
+
+  # Correctness gate: same task twice in one recycled sandbox must be byte-identical.
+  determ = []
+  for img in images[:determinism]:
+    out = determinism_canary(fleet, Task(id=f"canary-{img[-12:]}", image=img), swebench_probe)
+    determ.append(out["identical"] and out["reset_clean"])
+    print(f"  determinism {'OK ' if determ[-1] else 'FAIL'} {img.split('/')[-1]}", flush=True)
+  if determ and not all(determ):
+    raise SystemExit("determinism gate FAILED — reset leaks state; recycling is unsafe")
+
+  def rollout(task, handle):                           # no-op probe by default
+    return swebench_probe(task, handle)
+
+  t0 = time.monotonic()
+  with fleet.observer.run("reuse") as rep:
+    reuse_git_restore_sandbox(fleet, fleet.tasks, rollout, max_concurrent)
+    rep.total_s = time.monotonic() - t0
+  fleet.teardown()
+
+  d = rep.to_dict()
+  claims = d.get("claims", 0)
+  print(json.dumps({
+      "problems": len(images), "rollouts": rollouts, "tasks": len(tasks),
+      "claims": claims,
+      "claims_per_task": round(claims / max(1, len(tasks)), 4),
+      "tasks_ok": d.get("tasks_ok", 0), "tasks_err": d.get("tasks_err", 0),
+      "wall_s": round(d.get("total_s", 0.0), 1),
+      "determinism_clean": f"{sum(determ)}/{len(determ)}",
+  }, indent=2))
+  print(f"\n{rep.summary()}")
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/agent-sandbox-rl/performance_reports/.gitignore
+++ b/examples/agent-sandbox-rl/performance_reports/.gitignore
@@ -8,3 +8,5 @@
 # Redacted sample report (environment scrubbed) — the one checked-in example.
 !sample_rl_rollout.md
 !sample_rl_rollout.json
+# Report template (no live data — the blank skeleton report generators fill in).
+!REPORT_TEMPLATE.md

--- a/examples/agent-sandbox-rl/performance_reports/REPORT_TEMPLATE.md
+++ b/examples/agent-sandbox-rl/performance_reports/REPORT_TEMPLATE.md
@@ -1,0 +1,148 @@
+# <TITLE — e.g. "SWE-bench load test" or "Full SWE-bench benchmark">
+
+> **Run completed:** <YYYY-MM-DD HH:MM TZ> — cluster `<cluster>`, pool `<pool>` (<N>× <machine-type>, <disk>), <cache state: cold nodes / warm node caches / flushed before each strategy>.
+
+<!--
+Template distilled from swebench500_all_strats_gvisor1000_warm.md (the
+tests/loadtest.py `format_report` output). Sections marked (auto) are emitted
+by the harness — don't hand-edit them in generated reports; fill them manually
+only for ad-hoc write-ups. Sections marked (manual) are for the author.
+-->
+
+## Performance progress at a glance (worst → best)  <!-- (manual) -->
+
+<!-- ASCII bar chart of wall-clock per strategy, worst → best, bars proportional
+     (≈46 chars for the slowest; scale the rest). One trailing annotation per bar;
+     mark the winner with "◀ <X>× vs <worst>". Follow with 1 short paragraph of
+     cross-run context: same batch on prior pools/reports, and what this run isolates. -->
+
+```
+<worst-strategy>   ██████████████████████████████████████████████  <t>s   <annotation — the floor>
+<strategy>         ██████████                                      <t>s   <annotation>
+<best-strategy>    █████                                           <t>s   <annotation>   ◀ <X>× vs <worst>
+```
+
+<Cross-run context: cold vs warm on this pool, same batch on prior pools — cite the
+source reports so the descent is traceable.>
+
+## Parameters  <!-- (auto) -->
+
+- **images**: `<N>`
+- **tasks_per_image**: `<K — 1 = eval shape, >1 = RL rollout shape>`
+- **total_tasks**: `<N*K>`
+- **strategies**: `<naive,sliding,pipelined,none — order matters if caches are shared>`
+- **max_concurrent**: `<mc>`
+- **max_warmpool_size**: `<cap>`
+- **warm_per_task**: `<True|False>`
+- **colocate_replicas**: `<True|False>`
+- **window_size**: `<None = planner-chosen>`
+- **task_duration_s**: `<0.0 = no-op probe, isolates infra latency>`
+- **image_template**: `<image set + environment note, e.g. "(real SWE-bench 500 from AR mirror; <pool spec>; <cache footing>)">`
+
+## Methodology  <!-- (auto; verify the cache-footing sentence matches reality) -->
+
+Each strategy runs the **same** batch — **<N>** distinct container images, **<K>** task(s) per image (**<N*K>** tasks total) — end to end against the live cluster, then tears its pools down before the next strategy starts (so strategies never share warm state).
+
+Per task the harness: (1) ensures a `SandboxTemplate` + `SandboxWarmPool` exist for the task's image — *when/how many* pools are pre-warmed is what the **strategy** decides; (2) **claims** a ready sandbox; (3) runs `process_fn`; (4) releases the sandbox.
+
+Wall-clock is the true end-to-end batch time under `max_concurrent=<mc>`. Per-phase totals are summed across concurrent workers, so they exceed wall-clock — divide by the phase count (`n`) for the average a single task saw. **Efficiency** = fastest strategy's wall ÷ this strategy's wall.
+
+> ⚠️ **Cache footing (state it explicitly):** node containerd caches persist across pool teardown. Say whether this run was cold (fresh/flushed nodes), first-strategy-cold (prior methodology), or all-warm — cross-report comparisons are meaningless without it.
+
+Strategies compared:
+- **naive** — all pools warmed up front (peak = #images) — fastest claims, largest footprint.
+- **sliding** — a rolling window of warm pools tracks the concurrency frontier.
+- **pipelined** — double-buffered sliding window — prefetch window N+1 while window N runs, so image pulls overlap execution; footprint bounded to ≤2 windows.
+- **none** — no pre-warming; one pool on demand at a time (window=1, serial) — worst-case baseline.
+
+## Cluster & nodes  <!-- (auto) -->
+
+- `<fleet-name>`: **context**=<kube-context>  **namespace**=<ns>  **k8s_version**=<ver>  **nodes**=<n>  **node_pools**=[<pools>]  **instance_types**=[<types>]  **region**=<region>
+
+### Cluster & node configuration  <!-- (manual — the detail the auto line lacks) -->
+
+`<cluster>` GKE cluster (<ownership/purpose>, project `<project>`, region **<region>**)<, recent changes worth noting — upgrades, repools>.
+
+- **k8s**: `<version>`  ·  **agent-sandbox controller**: `<image tag>` (<registry>)
+- **runtime**: <gVisor/runc> (`runtimeClass=<rc>`)  ·  **<image streaming on/off>**
+- **image source**: <registry + path> (`imagePullPolicy: <policy>`)
+- **per-sandbox resources** (`TemplateSpec.resources`): **cpu `<req>`**, **memory `<req>`** —
+  requests only, no limits. CPU budget = <pool vCPU> ÷ <cpu req> = **<n>** pods; kubelet pod
+  cap **<n>** (<per-node> − ~<system pods> system ≈ **<usable>** usable) — state which one binds.
+
+| pool | machine | nodes | per-node (allocatable) | role |
+|---|---|---:|---|---|
+| **`<sandbox-pool>`** | <machine-type> | <n> (<zone spread>) | **~<x> vCPU** · **~<x> GiB** mem · **~<x> GiB** ephemeral (<disk type/size>) · **<x>** pods · taint `<taint>` | sandbox workload |
+| `<system-pool>` | <machine-type> | <n> | <allocatable> · runc (untainted) | controller + system |
+
+**Pool totals (<sandbox-pool>, probed):** **<x> vCPU** · **~<x> GiB** ephemeral ·
+**<x>** pod cap — the three numbers the capacity planner reads. <Optional: ratio vs the
+previous pool for cross-report context.>
+
+## Warm-pool plan (<N> pools)  <!-- (auto; truncated at ~60 rows) -->
+
+| image | pool | replicas | cluster |
+|---|---|---:|---|
+| `<image-ref>` | `<pool-name>` | <r> | <fleet-name> |
+| … | … | … | (+<remainder> more) |
+
+## Results — per stage, per strategy  <!-- (auto) -->
+
+> **wall** is the true end-to-end time for the whole batch. Per-phase columns are **summed across concurrency**, so they exceed the wall-clock — the `avg` figures are the per-task experience. **claim avg/max** is the *time-to-sandbox* (request → ready, claimed sandbox); **efficiency** = fastest strategy's wall ÷ this strategy's wall.
+
+| strategy | wall | prep (create+wait) | pool-ready avg/max | claim avg/max | claims | net task Σ/avg | warm pools (peak/total/created) | ok | efficiency |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| **<strategy>** | <w>s | <p>s | <a>/<m>s | <a>/<m>s | <n> | <Σ>/<avg>s | <peak>/<total>/<created> | <ok>/<total> | <e>% |
+
+## Key findings  <!-- (manual — the part only a human/Claude adds) -->
+
+1. **<Headline: which strategy won and by how much.>**
+2. **<Cross-run comparison: against which prior report, what changed (pool, cache footing, code), and what that isolates.>**
+3. **<Bottleneck read: which phase dominates wall (pull? orchestration floor? claim tail?) and what lever that suggests next.>**
+
+Caveats: <cache footing, strategy order effects, anything non-apples-to-apples>.
+
+## Metric glossary  <!-- (auto, static) -->
+
+Each line in a strategy's RunReport reads `phase  total_s  (n=count, max=slowest)`:
+
+| field | meaning |
+|---|---|
+| `total_s` | wall-time **summed across all concurrent workers** spent in this phase |
+| `n` | how many times the phase ran (one per pool, or one per task) |
+| `max` | the slowest single occurrence — the tail latency for that phase |
+
+| phase | what it measures |
+|---|---|
+| `preflight` | one-time cluster checks (API reachable, namespace, CRDs) before any work |
+| `plan` | compute the image→warm-pool plan (in-memory; ~0s) |
+| `create_warmpool` | issue the `SandboxWarmPool` create calls (n = pools created) |
+| `wait_pool_ready` | block until a pool replica is Ready — the **image pull + pod start** cost |
+| `prefetch` | *(pipelined only)* background warm of the next window, overlapped with execution |
+| `claim` | request a sandbox → have a claimed, ready one — **time-to-sandbox** |
+| `process` | time inside `process_fn` (the task itself) |
+| `release` | return the sandbox / claim to the pool |
+| `teardown` | delete pools + templates at the end of the run |
+
+## Full RunReport per strategy  <!-- (auto) -->
+
+### <strategy>
+```
+  preflight        <t>s  (n=1, max=<t>s)
+  plan             <t>s  (n=1, max=<t>s)
+  create_warmpool  <t>s  (n=<pools>, max=<t>s)
+  wait_pool_ready  <t>s  (n=<pools>, max=<t>s)
+  claim            <t>s  (n=<tasks>, max=<t>s)
+  process          <t>s  (n=<tasks>, max=<t>s)
+  release          <t>s  (n=<tasks>, max=<t>s)
+  teardown         <t>s  (n=1, max=<t>s)
+  TOTAL wall       <t>s
+  claims=<n>  tasks=<ok>ok/<err>err  warm peak=<p>
+```
+
+## Image list  <!-- (auto; first 80 + count) -->
+
+```
+<image refs…>
+... (+<remainder> more)
+```

--- a/examples/agent-sandbox-rl/tests/loadtest.py
+++ b/examples/agent-sandbox-rl/tests/loadtest.py
@@ -39,9 +39,15 @@ import os
 import time
 
 from agent_sandbox_rl import (AsyncSandboxFleet, ClusterConfig, FleetConfig,
-                              ListSource, STRATEGIES, Task, TemplateSpec)
+                              GitRestoreReset, ListSource, SandboxFleet,
+                              STRATEGIES, Task, TemplateSpec,
+                              reuse_git_restore_sandbox)
 
 ALL_STRATEGIES = ["none", "naive", "sliding", "pipelined"]
+# "reuse" is an execution MODE, not a warm-pool strategy — recognized in an
+# explicit --strategies list (not in "all"); it warms all pools then recycles
+# one sandbox per image instead of claiming per task.
+_REUSE = "reuse"
 
 
 # --------------------------------------------------------------------------- #
@@ -81,9 +87,11 @@ def resolve_strategies(spec: str) -> list[str]:
     if spec == "all":
         return list(ALL_STRATEGIES)
     out = [s.strip() for s in spec.split(",") if s.strip()]
-    bad = [s for s in out if s not in STRATEGIES]
+    allowed = set(STRATEGIES) | {_REUSE}
+    bad = [s for s in out if s not in allowed]
     if bad:
-        raise ValueError(f"unknown strategies {bad}; choose from {sorted(STRATEGIES)}")
+        raise ValueError(f"unknown strategies {bad}; choose from "
+                         f"{sorted(allowed)}")
     return out
 
 
@@ -326,7 +334,62 @@ def _make_fleet(args) -> AsyncSandboxFleet:
     return AsyncSandboxFleet(cfg)
 
 
+def _run_reuse(args, tasks):
+    """Reuse mode (sync fleet + recycling): warm all pools, then reuse one sandbox
+    per image (git-restore reset between same-image tasks) instead of a fresh claim
+    per task. Runs in a worker thread from the async loop (see _run_strategy)."""
+    dur = args.task_duration
+
+    def probe(task, handle):
+        if dur > 0:
+            time.sleep(dur)
+        return handle.pod_name
+
+    cluster = ClusterConfig(name="loadtest", context=args.context,
+                            namespace=args.namespace,
+                            node_selector=parse_node_selector(args.node_selector),
+                            runtime_class=args.runtime_class)
+    cfg = FleetConfig(clusters=[cluster], max_concurrent=args.max_concurrent,
+                      max_warmpool_size=args.max_warmpool_size,
+                      warm_per_task=args.warm_per_task,
+                      ready_timeout=args.ready_timeout,
+                      template=TemplateSpec(runtime_class=args.runtime_class,
+                                            colocate_replicas=args.colocate))
+    fleet = SandboxFleet(cfg)
+    reset = GitRestoreReset(check_env=args.check_env, check_config=args.check_env)
+    entries = []
+    t0 = time.monotonic()
+    try:
+        fleet.load_tasks(ListSource(tasks))
+        plan = fleet.plan()
+        entries = [{"image": e.image, "pool": e.pool, "replicas": e.replicas,
+                    "cluster": e.cluster} for e in plan.entries]
+        fleet.setup()
+        with fleet.observer.run(_REUSE) as report:
+            fleet.report = report
+            t0 = time.monotonic()
+            res = reuse_git_restore_sandbox(
+                fleet, tasks, probe, args.max_concurrent, reset=reset,
+                max_reuses=args.max_reuses, reset_timeout=args.reset_timeout,
+                use_session=args.use_session)
+            report.total_s = time.monotonic() - t0
+        wall = report.total_s
+        ok = sum(1 for r in res if not isinstance(r, Exception))
+        rep = report.to_dict()
+    except Exception as e:                  # noqa: BLE001
+        wall = time.monotonic() - t0
+        ok, rep = 0, (fleet.report.to_dict() if fleet.report else {"phases": {}})
+        rep["error"] = f"{type(e).__name__}: {e}"
+    finally:
+        fleet.teardown()
+    return ({"strategy": _REUSE, "wall_s": round(wall, 2), "ok": ok,
+             "total": len(tasks), "report": rep}, entries)
+
+
 async def _run_strategy(args, tasks, strategy):
+    if strategy == _REUSE:
+        return await asyncio.to_thread(_run_reuse, args, tasks)
+
     dur = args.task_duration
 
     async def probe(task, handle):
@@ -412,6 +475,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--colocate", action="store_true",
                    help="prefer co-locating a pool's replicas on one node (cache reuse)")
     p.add_argument("--window-size", type=int, default=None)
+    # recycling (only used by the `reuse` pseudo-strategy)
+    p.add_argument("--max-reuses", type=int, default=100000,
+                   help="[reuse] max tasks per sandbox before rotating to a fresh one")
+    p.add_argument("--reset-timeout", type=float, default=10.0,
+                   help="[reuse] advisory per-reset budget (s); slower → quarantine")
+    p.add_argument("--check-env", action="store_true",
+                   help="[reuse] enable the pip-freeze/config drift tripwires (default: git-only)")
+    p.add_argument("--no-session", dest="use_session", action="store_false",
+                   help="[reuse] one-shot exec per command instead of a persistent session")
+    p.set_defaults(use_session=True)
     p.add_argument("--ready-timeout", type=int, default=1800)
     p.add_argument("--task-duration", type=float, default=0.0,
                    help="seconds to sleep in process_fn (simulate task work)")

--- a/examples/agent-sandbox-rl/tests/loadtest.py
+++ b/examples/agent-sandbox-rl/tests/loadtest.py
@@ -369,7 +369,7 @@ def _run_reuse(args, tasks):
             fleet.report = report
             t0 = time.monotonic()
             res = reuse_git_restore_sandbox(
-                fleet, tasks, probe, args.max_concurrent, reset=reset,
+                fleet, fleet.tasks, probe, args.max_concurrent, reset=reset,
                 max_reuses=args.max_reuses, reset_timeout=args.reset_timeout,
                 use_session=args.use_session)
             report.total_s = time.monotonic() - t0

--- a/examples/agent-sandbox-rl/tests/test_fleet.py
+++ b/examples/agent-sandbox-rl/tests/test_fleet.py
@@ -457,3 +457,62 @@ def test_plan_budget_no_overshoot_three_clusters(make_cluster):
   plan = f.plan()
   assert plan.total_replicas == 8
   assert plan.total_replicas <= 8       # would have been 9 with round()
+
+
+# --- runaway safeguards --------------------------------------------------- #
+def test_run_id_label_stamped(make_cluster):
+  from agent_sandbox_rl.constants import RUN_ID_LABEL
+  f = _fleet(ClusterRegistry([make_cluster("solo")]))
+  assert len(f.run_id) == 12
+  assert f.config.labels[RUN_ID_LABEL] == f.run_id      # flows onto every create
+  assert f.run_selector() == f"{RUN_ID_LABEL}={f.run_id}"
+
+
+def test_circuit_breaker_trips_and_tears_down(make_cluster, monkeypatch):
+  import time
+  import unittest.mock as m
+  from agent_sandbox_rl import FleetOvercommitError
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4,
+             overcommit_factor=1.5, breaker_poll_s=0.02)
+  f.load_tasks(["i1", "i2"]); f.plan()
+  monkeypatch.setattr(f, "live_owned_count", lambda: 999)   # simulate runaway
+  td = m.MagicMock(wraps=f.teardown); monkeypatch.setattr(f, "teardown", td)
+  with pytest.raises(FleetOvercommitError):
+    with f.overcommit_guard(expected=2):                    # ceiling = 3
+      time.sleep(0.2)                                       # let the breaker poll
+  assert td.called                                          # tore down on trip
+
+
+def test_circuit_breaker_disabled_when_factor_zero(make_cluster, monkeypatch):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), overcommit_factor=0, max_live_sandboxes=None)
+  monkeypatch.setattr(f, "live_owned_count", lambda: 10**9)
+  with f.overcommit_guard(expected=2):                      # no ceiling → never trips
+    pass
+
+
+def test_plan_advisory_warns_but_never_raises(make_cluster):
+  f = _fleet(ClusterRegistry([make_cluster("solo")]), max_concurrent=5000)
+  f.load_tasks(["i1", "i2"])
+  plan = f.plan()                                           # must NOT raise
+  assert any("max_concurrent" in w for w in plan.warnings)  # warned, proceeded
+
+
+def test_reap_deletes_by_run_id_selector(monkeypatch):
+  import unittest.mock as m
+  import agent_sandbox_rl.reaper as reap_mod
+  from agent_sandbox_rl.constants import RUN_ID_LABEL
+  res = m.MagicMock()
+  res.list_claims.return_value = ["cl1"]
+  res.list_warmpools.return_value = ["wp1"]
+  res.list_sandboxes.return_value = ["sb1", "sb2"]
+  res.list_templates.return_value = []
+  fake = m.MagicMock(); fake.resources = res
+  monkeypatch.setattr(reap_mod, "Cluster", lambda *a, **k: fake)
+  counts = reap_mod.reap(run_id="abc123", context="x", namespace="ns")
+  sel = f"{RUN_ID_LABEL}=abc123"
+  res.list_sandboxes.assert_called_with(label_selector=sel)
+  res.delete_sandbox.assert_any_call("sb1")
+  res.delete_warmpool.assert_any_call("wp1")
+  assert counts["sandboxes"] == 2 and counts["claims"] == 1

--- a/examples/agent-sandbox-rl/tests/test_fleet.py
+++ b/examples/agent-sandbox-rl/tests/test_fleet.py
@@ -249,6 +249,64 @@ def test_start_warmpools_provisions_each_entry(two_cluster_registry):
     assert c.active_replicas >= 1
 
 
+def _spy_waves(monkeypatch, f):
+  """Record how many pools each ``_warm_entries`` call warms (= one wave)."""
+  waves = []
+  orig = f._warm_entries
+  def spy(entries, wait, replicas_override=None):
+    waves.append(len(entries))
+    return orig(entries, wait, replicas_override=replicas_override)
+  monkeypatch.setattr(f, "_warm_entries", spy)
+  return waves
+
+
+def _ten_pools_of_four(c):
+  """A solo-cluster fleet whose plan is 10 pools × 4 replicas (40 creates)."""
+  f = _fleet(ClusterRegistry([c]), max_concurrent=10,
+             warm_per_task=True, max_warmpool_size=4)
+  imgs = [f"img{i}" for i in range(10)]
+  f.load_tasks([img for img in imgs for _ in range(4)])   # 4 tasks/image → 4 replicas
+  assert {e.replicas for e in f.plan().entries} == {4}
+  return f
+
+
+def test_start_warmpools_stages_by_create_budget(make_cluster, monkeypatch):
+  f = _ten_pools_of_four(make_cluster("solo"))
+  waves = _spy_waves(monkeypatch, f)
+  f.start_warmpools(wait=True, create_budget=4)        # 4 replicas → 1 pool/wave
+  assert waves == [1] * 10                              # 10 pools, 10 waves
+
+
+def test_start_warmpools_entry_over_budget_warms_solo(make_cluster, monkeypatch):
+  # a single pool whose replicas exceed the budget can't be split -> it warms solo
+  c = make_cluster("solo")
+  f = _ten_pools_of_four(c)                     # 10 pools × 4 replicas
+  waves = _spy_waves(monkeypatch, f)
+  f.start_warmpools(wait=True, create_budget=2) # 2 < 4 -> every pool is oversized
+  assert waves == [1] * 10                      # each warms alone, none dropped
+  assert c.resources.create_warmpool.call_count == 10
+
+
+def test_start_warmpools_budget_zero_warms_all_at_once(make_cluster, monkeypatch):
+  c = make_cluster("solo")
+  f = _ten_pools_of_four(c)
+  waves = _spy_waves(monkeypatch, f)
+  f.start_warmpools(wait=True, create_budget=0)         # explicit opt-out → single wave
+  assert waves == [10]
+  assert c.resources.create_warmpool.call_count == 10
+
+
+def test_start_warmpools_uses_config_budget_default(make_cluster, monkeypatch):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=10, warm_per_task=True,
+             max_warmpool_size=4, warm_create_budget=8)  # no create_budget arg below
+  imgs = [f"img{i}" for i in range(10)]
+  f.load_tasks([img for img in imgs for _ in range(4)])
+  waves = _spy_waves(monkeypatch, f)
+  f.start_warmpools(wait=True)                          # falls back to config budget 8 → 2/wave
+  assert waves == [2, 2, 2, 2, 2]
+
+
 def test_acquire_returns_handle_on_right_cluster(two_cluster_registry):
   f = _fleet(two_cluster_registry, placement="image-affinity")
   tasks = f.load_tasks(["imgA", "imgB"])

--- a/examples/agent-sandbox-rl/tests/test_loadtest.py
+++ b/examples/agent-sandbox-rl/tests/test_loadtest.py
@@ -84,6 +84,23 @@ def test_resolve_strategies():
     loadtest.resolve_strategies("bogus")
 
 
+def test_resolve_strategies_accepts_reuse_but_not_in_all():
+  # `reuse` is a recognized execution mode in an explicit list...
+  assert loadtest.resolve_strategies("naive, reuse") == ["naive", "reuse"]
+  # ...but "all" stays the four warm-pool strategies (reuse is opt-in).
+  assert "reuse" not in loadtest.resolve_strategies("all")
+
+
+def test_parser_exposes_reuse_flags():
+  a = loadtest.build_parser().parse_args(
+      ["--images", "1", "--image-template", "img{i}", "--strategies", "reuse",
+       "--max-reuses", "8", "--check-env"])
+  assert a.max_reuses == 8 and a.check_env is True and a.use_session is True
+  a2 = loadtest.build_parser().parse_args(
+      ["--images", "1", "--image-template", "img{i}", "--no-session"])
+  assert a2.use_session is False
+
+
 def _fake_result(strategy, wall, ok=10, total=10):
   return {
       "strategy": strategy, "wall_s": wall, "ok": ok, "total": total,

--- a/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
+++ b/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
@@ -1,0 +1,191 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the PR #1232 review fixes:
+- Sandbox list/delete use the CORE API group/version (not extensions).
+- The run-id / managed labels propagate to the pod template (so pods carry them).
+- Resources.count_pods; the circuit breaker counts pods (run-id label lives there).
+- Drift tripwire quarantines instead of silently skipping on a missing baseline.
+- SandboxSession: login shell, unbounded default timeout, close-on-timeout.
+"""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+from kubernetes import client
+
+import agent_sandbox_rl.handles as handles
+from agent_sandbox_rl import (ClusterRegistry, FleetConfig, GitRestoreReset,
+                              SandboxFleet, constants)
+from agent_sandbox_rl.config import TemplateSpec
+from agent_sandbox_rl.handles import SandboxSession
+from agent_sandbox_rl.resources import Resources
+
+IMG = "reg/swebench-verified@sha256:deadbeef"
+TNAME = "r2e-img-abc123"
+
+
+def _res(labels=None):
+  return Resources(MagicMock(), MagicMock(), "ns", labels=labels)
+
+
+# --- #3: Sandbox is in the CORE group, not extensions --------------------- #
+def test_list_sandboxes_uses_core_group():
+  r = _res()
+  r.custom_api.list_namespaced_custom_object.return_value = {"items": []}
+  r.list_sandboxes(label_selector="x=y")
+  _, kw = r.custom_api.list_namespaced_custom_object.call_args
+  assert kw["group"] == constants.SANDBOX_GROUP
+  assert kw["version"] == constants.SANDBOX_VERSION
+  assert kw["plural"] == constants.SANDBOXES_PLURAL
+
+
+def test_delete_sandbox_uses_core_group():
+  r = _res()
+  r.delete_sandbox("sb-1")
+  _, kw = r.custom_api.delete_namespaced_custom_object.call_args
+  assert kw["group"] == constants.SANDBOX_GROUP
+  assert kw["version"] == constants.SANDBOX_VERSION
+
+
+def test_extensions_resources_still_use_extensions_group():
+  r = _res()
+  r.custom_api.list_namespaced_custom_object.return_value = {"items": []}
+  r.list_warmpools()
+  _, kw = r.custom_api.list_namespaced_custom_object.call_args
+  assert kw["group"] == constants.GROUP  # unchanged for warmpools/templates/claims
+
+
+# --- #1/#2: run-id label propagates to the pod template (pods carry it) ---- #
+def test_pod_template_carries_run_and_managed_labels():
+  r = _res(labels={constants.RUN_ID_LABEL: "run123"})
+  r.custom_api.get_namespaced_custom_object.side_effect = client.ApiException(status=404)
+  r.ensure_template(IMG, TNAME, TemplateSpec())
+  _, kw = r.custom_api.create_namespaced_custom_object.call_args
+  labels = kw["body"]["spec"]["podTemplate"]["metadata"]["labels"]
+  assert labels["sandbox"] == TNAME                                   # colocation label kept
+  assert labels[constants.RUN_ID_LABEL] == "run123"                   # so pods are run-scoped
+  assert labels[constants.MANAGED_BY_LABEL] == constants.MANAGED_BY_VALUE
+
+
+# --- #1: count_pods + breaker counts pods --------------------------------- #
+def test_count_pods():
+  r = _res()
+  r.core_api.list_namespaced_pod.return_value = MagicMock(items=[1, 2, 3])
+  assert r.count_pods(label_selector="run=x") == 3
+  _, kw = r.core_api.list_namespaced_pod.call_args
+  assert kw["label_selector"] == "run=x"
+
+
+def test_live_owned_count_counts_pods_by_run_id(make_cluster):
+  c = make_cluster("solo")
+  c.resources.count_pods.return_value = 7
+  f = SandboxFleet(FleetConfig(), registry=ClusterRegistry([c]))
+  assert f.live_owned_count() == 7
+  _, kw = c.resources.count_pods.call_args
+  assert kw["label_selector"] == f.run_selector()   # keyed off run-id, which pods carry
+
+
+# --- #9: enabled tripwire with a missing baseline quarantines (not skip) --- #
+class _FakeHandle:
+  def __init__(self, fps):
+    self.cluster_name = "c"; self.pod_name = "p"; self._fps = list(fps); self.calls = []
+
+  def exec(self, command):
+    self.calls.append(command)
+    return self._fps.pop(0)
+
+
+@pytest.mark.parametrize("fp,reason", [
+    ("PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=\nCFG=g1\nPROCS=5", "env_baseline_missing"),
+    ("PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e1\nCFG=\nPROCS=5", "config_baseline_missing"),
+])
+def test_missing_baseline_hash_quarantines(fp, reason):
+  h = _FakeHandle([fp, fp])                      # prime, then reset (nothing drifts)
+  r = GitRestoreReset(check_env=True, check_config=True)
+  base = r.prime(h)
+  out = r.reset(h, base)
+  assert not out.clean and out.reason == reason  # can't verify → not "clean"
+
+
+# --- #5/#6/#8: SandboxSession shell + timeout semantics ------------------- #
+class _FakeWS:
+  def __init__(self, outputs=None, emit_marker=True):
+    self.outputs = outputs or {}; self._pending = ""; self._open = True
+    self.emit_marker = emit_marker
+
+  def is_open(self):
+    return self._open
+
+  def update(self, timeout=1):
+    pass
+
+  def write_stdin(self, s):
+    if not self._open:
+      return
+    m = re.search(r'printf "%s%s\\n" "([^"]+)" "([^"]+)"', s)
+    if m:
+      if self.emit_marker:
+        self._pending += m.group(1) + m.group(2) + "\n"
+      return
+    for k, o in self.outputs.items():
+      if k in s:
+        self._pending += o
+        break
+
+  def peek_stdout(self):
+    return len(self._pending)
+
+  def read_stdout(self):
+    p, self._pending = self._pending, ""
+    return p
+
+  def peek_stderr(self):
+    return 0
+
+  def read_stderr(self):
+    return ""
+
+  def close(self):
+    self._open = False
+
+
+def test_session_uses_login_shell(monkeypatch):
+  captured = {}
+
+  def fake_stream(*a, command=None, **k):
+    captured["command"] = command
+    return _FakeWS()
+
+  monkeypatch.setattr(handles, "stream", fake_stream)
+  SandboxSession(MagicMock(), "pod", "ns")
+  assert captured["command"] == ["bash", "-l"]   # matches one-shot `bash -lc` env
+
+
+def test_session_run_unbounded_default_returns(monkeypatch):
+  ws = _FakeWS(outputs={"echo hi": "hi\n"})
+  monkeypatch.setattr(handles, "stream", lambda *a, **k: ws)
+  s = SandboxSession(MagicMock(), "pod", "ns")
+  assert s.run("echo hi").strip() == "hi"        # timeout=None default, no silent cap
+
+
+def test_session_run_timeout_closes_session(monkeypatch):
+  ws = _FakeWS(outputs={"echo hi": "hi\n"})
+  monkeypatch.setattr(handles, "stream", lambda *a, **k: ws)
+  s = SandboxSession(MagicMock(), "pod", "ns")    # init completes (marker on)
+  ws.emit_marker = False                          # next command never completes
+  with pytest.raises(TimeoutError):
+    s.run("sleep 999", timeout=0.05)
+  assert not s.is_open                            # timed-out session is dropped, not reused

--- a/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
+++ b/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
@@ -81,12 +81,33 @@ def test_pod_template_carries_run_and_managed_labels():
 
 
 # --- #1: count_pods + breaker counts pods --------------------------------- #
-def test_count_pods():
+def test_count_pods_uses_remaining_item_count():
   r = _res()
-  r.core_api.list_namespaced_pod.return_value = MagicMock(items=[1, 2, 3])
-  assert r.count_pods(label_selector="run=x") == 3
+  resp = MagicMock(items=[object()])            # only 1 object transferred
+  resp.metadata.remaining_item_count = 41
+  r.core_api.list_namespaced_pod.return_value = resp
+  assert r.count_pods(label_selector="run=x") == 42   # 1 + 41, no full list
   _, kw = r.core_api.list_namespaced_pod.call_args
-  assert kw["label_selector"] == "run=x"
+  assert kw["label_selector"] == "run=x" and kw["limit"] == 1
+
+
+def test_count_pods_small_set_single_page():
+  r = _res()
+  resp = MagicMock(items=[object()])
+  resp.metadata.remaining_item_count = None
+  resp.metadata._continue = None                # whole set fit in the first page
+  r.core_api.list_namespaced_pod.return_value = resp
+  assert r.count_pods() == 1
+
+
+def test_count_pods_fallback_full_list_when_no_hint():
+  r = _res()
+  page = MagicMock(items=[object()])
+  page.metadata.remaining_item_count = None
+  page.metadata._continue = "tok"               # more pages, but server gave no count hint
+  full = MagicMock(items=[object(), object(), object()])
+  r.core_api.list_namespaced_pod.side_effect = [page, full]
+  assert r.count_pods() == 3
 
 
 def test_live_owned_count_counts_pods_by_run_id(make_cluster):

--- a/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
+++ b/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
@@ -264,3 +264,37 @@ def test_unwarm_image_idempotent_preserves_capacity(make_cluster):
   assert c.active_replicas == 3                     # i2's reservation preserved (not phantom-freed)
   assert c.resources.delete_warmpool.call_count == 1
   assert c.resources.delete_template.call_count == 1
+
+
+# --- review round 5: _on_signal honors SIG_IGN + always unwinds ----------- #
+import signal as _signal
+
+
+def _fleet_no_hooks(make_cluster):
+  # constructing a fleet does NOT install real signal handlers (that's setup()),
+  # so we can drive _on_signal directly with a hand-set _prev_handlers map.
+  return SandboxFleet(FleetConfig(), registry=ClusterRegistry([make_cluster("solo")]))
+
+
+def test_on_signal_honors_sig_ign(make_cluster):
+  f = _fleet_no_hooks(make_cluster)
+  f._prev_handlers = {_signal.SIGINT: _signal.SIG_IGN}
+  assert f._on_signal(_signal.SIGINT, None) is None   # SIG_IGN → do NOT turn ignore into abort
+
+
+def test_on_signal_chains_prev_then_unwinds(make_cluster):
+  f = _fleet_no_hooks(make_cluster)
+  seen = {"n": 0}
+  def prev(signum, frame):
+    seen["n"] += 1                                    # a custom handler that returns normally
+  f._prev_handlers = {_signal.SIGINT: prev}
+  with pytest.raises(KeyboardInterrupt):              # must still unwind so atexit teardown runs
+    f._on_signal(_signal.SIGINT, None)
+  assert seen["n"] == 1                               # prior handler was invoked (chained)
+
+
+def test_on_signal_default_unwinds(make_cluster):
+  f = _fleet_no_hooks(make_cluster)
+  f._prev_handlers = {_signal.SIGTERM: _signal.SIG_DFL}
+  with pytest.raises(SystemExit):                     # SIG_DFL falls through to the unwind
+    f._on_signal(_signal.SIGTERM, None)

--- a/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
+++ b/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
@@ -21,6 +21,7 @@
 """
 
 import re
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -100,14 +101,27 @@ def test_count_pods_small_set_single_page():
   assert r.count_pods() == 1
 
 
-def test_count_pods_fallback_full_list_when_no_hint():
+def test_count_pods_paginates_when_no_hint():
+  # remainingItemCount is nil for selector queries (the breaker's case), so beyond
+  # one page count_pods must PAGE (bounded chunks), never pull one unpaged full list.
   r = _res()
-  page = MagicMock(items=[object()])
-  page.metadata.remaining_item_count = None
-  page.metadata._continue = "tok"               # more pages, but server gave no count hint
-  full = MagicMock(items=[object(), object(), object()])
-  r.core_api.list_namespaced_pod.side_effect = [page, full]
-  assert r.count_pods() == 3
+  p0 = MagicMock(items=[object()])              # limit=1 probe
+  p0.metadata.remaining_item_count = None
+  p0.metadata._continue = "tok1"               # more pages, no count hint
+  p1 = MagicMock(items=[object(), object()])
+  p1.metadata.remaining_item_count = None
+  p1.metadata._continue = "tok2"
+  p2 = MagicMock(items=[object()])
+  p2.metadata.remaining_item_count = None
+  p2.metadata._continue = None                 # last page
+  r.core_api.list_namespaced_pod.side_effect = [p0, p1, p2]
+  assert r.count_pods(label_selector="run=x") == 4      # 1 + 2 + 1
+  calls = r.core_api.list_namespaced_pod.call_args_list
+  assert len(calls) == 3
+  assert all("limit" in c.kwargs for c in calls)        # never an unpaged full list
+  assert calls[1].kwargs["_continue"] == "tok1" and calls[1].kwargs["limit"] == 500
+  assert calls[2].kwargs["_continue"] == "tok2"
+  assert all(c.kwargs["label_selector"] == "run=x" for c in calls)
 
 
 def test_live_owned_count_counts_pods_by_run_id(make_cluster):
@@ -210,3 +224,43 @@ def test_session_run_timeout_closes_session(monkeypatch):
   with pytest.raises(TimeoutError):
     s.run("sleep 999", timeout=0.05)
   assert not s.is_open                            # timed-out session is dropped, not reused
+
+
+# --- review round 4: overcommit_guard re-entrancy ------------------------- #
+def test_overcommit_guard_is_reentrant(make_cluster):
+  # run(recycle=True) opens the guard, then the recycle executor opens it again on
+  # the same fleet. Only the OUTER monitor should run — a second breaker thread would
+  # double the pod-list load per poll and both would race into teardown on a trip.
+  c = make_cluster("solo")
+  c.resources.count_pods.return_value = 0
+  f = SandboxFleet(FleetConfig(max_live_sandboxes=10),
+                   registry=ClusterRegistry([c]))
+  n = lambda: sum(1 for t in threading.enumerate() if t.name == "asrl-breaker")
+  assert n() == 0
+  with f.overcommit_guard(expected=5):
+    assert n() == 1 and f._guard_active
+    with f.overcommit_guard(expected=5):          # nested (executor inside run)
+      assert n() == 1                              # inner reused the outer — no 2nd thread
+    assert f._guard_active                          # inner exit didn't clear the outer flag
+  assert not f._guard_active                         # outer exit clears it
+  assert n() == 0                                    # monitor stopped
+
+
+# --- review round 4: unwarm_image idempotency ----------------------------- #
+def test_unwarm_image_idempotent_preserves_capacity(make_cluster):
+  # Two callers legitimately unwarm the same image (scale_on_hold + a windowed
+  # strategy's window-end sweep). The 2nd call must NOT release replicas again —
+  # pre-fix it defaulted reps to entry.replicas and double-decremented active_replicas,
+  # clamping at 0 and freeing OTHER images' still-reserved capacity.
+  c = make_cluster("solo")
+  f = SandboxFleet(FleetConfig(max_concurrent=8), registry=ClusterRegistry([c]))
+  f.load_tasks(["i1", "i2"])
+  f.warm_image("i1", replicas_override=3)
+  f.warm_image("i2", replicas_override=3)
+  assert c.active_replicas == 6
+  f.unwarm_image("i1")
+  assert c.active_replicas == 3 and "i1" not in f._warmed
+  f.unwarm_image("i1")                              # double unwarm — must be a no-op
+  assert c.active_replicas == 3                     # i2's reservation preserved (not phantom-freed)
+  assert c.resources.delete_warmpool.call_count == 1
+  assert c.resources.delete_template.call_count == 1

--- a/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
+++ b/examples/agent-sandbox-rl/tests/test_pr1232_fixes.py
@@ -298,3 +298,15 @@ def test_on_signal_default_unwinds(make_cluster):
   f._prev_handlers = {_signal.SIGTERM: _signal.SIG_DFL}
   with pytest.raises(SystemExit):                     # SIG_DFL falls through to the unwind
     f._on_signal(_signal.SIGTERM, None)
+
+
+# --- review round 5: live_owned_count fails open but logs ----------------- #
+def test_live_owned_count_fails_open_and_logs(make_cluster, caplog):
+  import logging
+  good = make_cluster("good"); good.resources.count_pods.return_value = 5
+  bad = make_cluster("bad"); bad.resources.count_pods.side_effect = RuntimeError("429")
+  f = SandboxFleet(FleetConfig(), registry=ClusterRegistry([good, bad]))
+  with caplog.at_level(logging.WARNING):
+    n = f.live_owned_count()
+  assert n == 5                                        # fails open: good cluster counted, no raise
+  assert "under-counts" in caplog.text and "bad" in caplog.text   # but the blind poll is surfaced

--- a/examples/agent-sandbox-rl/tests/test_pr1232_review2.py
+++ b/examples/agent-sandbox-rl/tests/test_pr1232_review2.py
@@ -1,0 +1,122 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the second PR #1232 review round:
+- a pre-existing (stale-run) template has its labels reconciled to this run;
+- a caller-supplied registry still gets the run-id on its cluster labels;
+- the circuit breaker trips only after N *consecutive* over-ceiling polls;
+- reap() refuses the all-managed sweep unless it's opt-in.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import agent_sandbox_rl.reaper as reaper
+from agent_sandbox_rl import (ClusterRegistry, FleetConfig, SandboxFleet, constants)
+from agent_sandbox_rl.config import TemplateSpec
+from agent_sandbox_rl.exceptions import FleetOvercommitError
+from agent_sandbox_rl.resources import Resources
+
+IMG = "reg/swebench-verified@sha256:deadbeef"
+TNAME = "r2e-img-abc123"
+RID = constants.RUN_ID_LABEL
+
+
+# --- template label reconciliation (blocking) ----------------------------- #
+def test_ensure_template_reconciles_stale_run_label():
+  r = Resources(MagicMock(), MagicMock(), "ns", labels={RID: "new"})
+  # a leftover template from a prior run carries the OLD run-id
+  r.custom_api.get_namespaced_custom_object.return_value = {
+      "metadata": {"labels": {constants.MANAGED_BY_LABEL: constants.MANAGED_BY_VALUE, RID: "old"}},
+      "spec": {"podTemplate": {"metadata": {"labels": {"sandbox": TNAME, RID: "old"}}}},
+  }
+  created = r.ensure_template(IMG, TNAME, TemplateSpec())
+  assert created is False
+  r.custom_api.patch_namespaced_custom_object.assert_called_once()
+  body = r.custom_api.patch_namespaced_custom_object.call_args.kwargs["body"]
+  assert body["metadata"]["labels"][RID] == "new"
+  assert body["spec"]["podTemplate"]["metadata"]["labels"][RID] == "new"
+  assert body["spec"]["podTemplate"]["metadata"]["labels"]["sandbox"] == TNAME
+
+
+def test_ensure_template_no_patch_when_labels_current():
+  r = Resources(MagicMock(), MagicMock(), "ns", labels={RID: "same"})
+  r.custom_api.get_namespaced_custom_object.return_value = {
+      "metadata": {"labels": dict(r.labels)},
+      "spec": {"podTemplate": {"metadata": {"labels": {**r.labels, "sandbox": TNAME}}}},
+  }
+  r.ensure_template(IMG, TNAME, TemplateSpec())
+  r.custom_api.patch_namespaced_custom_object.assert_not_called()
+
+
+# --- caller-supplied registry gets the run-id (blocking, related gap) ------ #
+def test_supplied_registry_clusters_get_run_id(make_cluster):
+  c = make_cluster("solo")
+  c.resources.labels = {constants.MANAGED_BY_LABEL: constants.MANAGED_BY_VALUE}  # built pre-run-id
+  f = SandboxFleet(FleetConfig(install_teardown_hooks=False),
+                   registry=ClusterRegistry([c]))
+  assert c.resources.labels.get(RID) == f.run_id   # stamped onto the supplied registry
+
+
+# --- breaker: sustained vs transient breach ------------------------------- #
+def _breaker_fleet(make_cluster, pods, trip_polls):
+  c = make_cluster("solo")
+  if callable(pods):
+    c.resources.count_pods.side_effect = lambda **k: pods()
+  else:
+    c.resources.count_pods.return_value = pods
+  f = SandboxFleet(FleetConfig(overcommit_factor=1.0, breaker_poll_s=0.02,
+                               breaker_trip_polls=trip_polls, install_teardown_hooks=False),
+                   registry=ClusterRegistry([c]))
+  f.teardown = lambda *a, **k: None   # no-op (avoid touching the fake registry)
+  return f
+
+
+def test_breaker_trips_on_sustained_breach(make_cluster):
+  f = _breaker_fleet(make_cluster, pods=100, trip_polls=2)   # 100 >> ceiling(=1)
+  with pytest.raises(FleetOvercommitError):
+    with f.overcommit_guard(expected=1):
+      time.sleep(0.25)                                       # ~12 polls → ≥2 consecutive → trip
+
+
+def test_breaker_ignores_single_transient_spike(make_cluster):
+  seq = iter([100])                                          # one breach, then healthy forever
+  f = _breaker_fleet(make_cluster, pods=lambda: next(seq, 0), trip_polls=3)
+  with f.overcommit_guard(expected=1):                      # 1 breach resets → never 3 consecutive
+    time.sleep(0.2)
+  # no FleetOvercommitError == pass
+
+
+def test_breaker_trip_polls_default():
+  assert FleetConfig().breaker_trip_polls == 3
+
+
+# --- reaper all-managed is opt-in ----------------------------------------- #
+def test_reap_refuses_all_managed_without_opt_in():
+  with pytest.raises(ValueError):
+    reaper.reap(run_id=None)                                 # no run_id, no all_managed → error
+
+
+def test_reap_all_managed_opt_in_passes_guard(monkeypatch):
+  # all_managed=True must get past the guard (we stub the cluster so no real k8s).
+  fake_cluster = MagicMock()
+  fake_cluster.resources.list_claims.return_value = []
+  fake_cluster.resources.list_warmpools.return_value = []
+  fake_cluster.resources.list_sandboxes.return_value = []
+  fake_cluster.resources.list_templates.return_value = []
+  monkeypatch.setattr(reaper, "Cluster", lambda *a, **k: fake_cluster)
+  counts = reaper.reap(all_managed=True, delete_pods=False)  # must NOT raise
+  assert isinstance(counts, dict)

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -413,3 +413,24 @@ def test_reuse_guarded_by_circuit_breaker(make_cluster, monkeypatch):
     return 1
   with pytest.raises(FleetOvercommitError):
     reuse_git_restore_sandbox(f, f.tasks, slow, concurrency=1, use_session=False)
+
+
+def test_reuse_infra_error_isolated_to_group(make_cluster, monkeypatch):
+  # an acquire/reset/release error in one image's group must NOT abort the batch —
+  # that group's tasks get the error; other groups still succeed.
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["good", "good", "bad"])          # 2 images (good×2, bad×1)
+  f.setup()
+  real_acquire = f.acquire
+  def flaky_acquire(task):
+    if task.image == "bad":
+      raise RuntimeError("claim boom")
+    return real_acquire(task)
+  monkeypatch.setattr(f, "acquire", flaky_acquire)
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: "ok",
+                                  concurrency=2, use_session=False)
+  assert res[0] == "ok" and res[1] == "ok"       # good group unaffected
+  assert isinstance(res[2], Exception)           # bad group captured, batch survived
+  f.teardown()

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -1,0 +1,179 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recycling / git-restore reset — unit tests (no cluster; fake exec)."""
+
+import pytest
+
+from agent_sandbox_rl import (ClusterRegistry, FleetConfig, GitRestoreReset,
+                              SandboxFleet, determinism_canary,
+                              reuse_git_restore_sandbox)
+from agent_sandbox_rl.handles import SandboxHandle
+from agent_sandbox_rl.preflight import PreflightReport
+
+
+@pytest.fixture(autouse=True)
+def _stub_preflight(monkeypatch):
+  def ok(cluster, **kw):
+    r = PreflightReport(cluster.name)
+    r.add("stub", True)
+    return r
+  monkeypatch.setattr("agent_sandbox_rl.preflight.preflight_cluster", ok)
+
+
+# --- GitRestoreReset against a scripted fake handle ----------------------- #
+class FakeHandle:
+  """Records exec() calls and replays canned fingerprint lines per call."""
+
+  def __init__(self, fingerprints):
+    self.cluster_name = "c"
+    self.pod_name = "pod-x"
+    self._fps = list(fingerprints)
+    self.calls = []
+
+  def exec(self, command):
+    self.calls.append(command)
+    return self._fps.pop(0)
+
+
+_CLEAN = ("PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5")
+
+
+def test_prime_captures_baseline_and_disables_gc():
+  h = FakeHandle([_CLEAN])
+  base = GitRestoreReset().prime(h)
+  assert base.pristine_sha == "abc"
+  assert base.env_hash == "e1"
+  assert base.config_hash == "g1"
+  assert base.proc_count == 5
+  script = h.calls[0][2]
+  assert "gc.auto 0" in script
+  assert "maintenance.auto false" in script
+  assert "gc.pruneExpire never" in script
+  assert "tag -f pristine" in script
+
+
+def test_reset_clean_when_fingerprint_matches():
+  h = FakeHandle([_CLEAN, _CLEAN])       # prime, then reset
+  r = GitRestoreReset()
+  base = r.prime(h)
+  out = r.reset(h, base)
+  assert out.clean and out.reason == ""
+  script = h.calls[1][2]
+  assert "reset -q --hard pristine" in script
+  assert "clean -qxdff" in script
+
+
+@pytest.mark.parametrize("fp,reason", [
+    ("PRISTINE=abc\nHEAD=xyz\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5", "head_mismatch"),
+    ("PRISTINE=abc\nHEAD=abc\nDIRTY=3\nENV=e1\nCFG=g1\nPROCS=5", "worktree_dirty"),
+    ("PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e2\nCFG=g1\nPROCS=5", "env_drift"),
+    ("PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e1\nCFG=g2\nPROCS=5", "config_or_hooks_drift"),
+    ("PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=99", "process_leak"),
+])
+def test_reset_detects_each_pollution_vector(fp, reason):
+  h = FakeHandle([_CLEAN, fp])
+  r = GitRestoreReset()
+  base = r.prime(h)
+  out = r.reset(h, base)
+  assert not out.clean
+  assert out.reason == reason
+
+
+def test_no_pristine_anchor_is_never_clean():
+  # non-git /testbed (or `git tag` failed): prime yields empty PRISTINE/HEAD ->
+  # reset must refuse to claim clean, so the sandbox is quarantined not reused.
+  empty = "PRISTINE=\nHEAD=\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5"
+  h = FakeHandle([empty, empty])
+  r = GitRestoreReset()
+  base = r.prime(h)
+  out = r.reset(h, base)
+  assert not out.clean
+  assert out.reason == "no_pristine_anchor"
+
+
+def test_env_check_can_be_disabled():
+  drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e2\nCFG=g1\nPROCS=5"
+  h = FakeHandle([_CLEAN, drift])
+  r = GitRestoreReset(check_env=False)
+  base = r.prime(h)
+  assert r.reset(h, base).clean          # env drift ignored when check_env=False
+
+
+# --- executor against the FakeCluster fleet ------------------------------- #
+def _fleet(registry, **cfg):
+  return SandboxFleet(FleetConfig(**cfg), registry=registry)
+
+
+def _patch_clean_exec(monkeypatch):
+  """Make every SandboxHandle.exec return a clean fingerprint (reset always OK)."""
+  monkeypatch.setattr(SandboxHandle, "exec", lambda self, cmd: _CLEAN)
+
+
+def test_reuse_one_claim_per_image(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img", "img", "img", "img"])   # 4 tasks, 1 image
+  f.setup()
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: h.pod_name, concurrency=4)
+  assert len(res) == 4 and all(isinstance(x, str) for x in res)
+  # one image -> one claim reused across all 4 tasks (÷G economics)
+  assert c.sandbox_client.create_sandbox.call_count == 1
+  f.teardown()
+
+
+def test_reset_failure_triggers_quarantine(make_cluster, monkeypatch):
+  # prime returns clean; every reset returns env drift -> quarantine each time
+  drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=DRIFT\nCFG=g1\nPROCS=5"
+  seq = {"n": 0}
+
+  def fake_exec(self, cmd):
+    seq["n"] += 1
+    # odd calls are prime (after each fresh claim), even are resets
+    return _CLEAN if "tag -f pristine" in cmd[2] else drift
+  monkeypatch.setattr(SandboxHandle, "exec", fake_exec)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img", "img", "img"])          # 3 tasks, 1 image
+  f.setup()
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: h.pod_name, concurrency=1)
+  assert len(res) == 3
+  # every reset dirty -> a fresh claim per task = 3 claims (no successful reuse)
+  assert c.sandbox_client.create_sandbox.call_count == 3
+  f.teardown()
+
+
+def test_max_reuses_rotates_sandbox(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)               # resets always clean
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img"] * 5)                     # 5 tasks, 1 image
+  f.setup()
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1, max_reuses=2)
+  # rotate after every 2 reuses: claims at task 1, 3, 5 -> 3 claims
+  assert c.sandbox_client.create_sandbox.call_count == 3
+  f.teardown()
+
+
+def test_determinism_canary_identical(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img"])
+  f.setup()
+  out = determinism_canary(f, f.tasks[0], lambda t, h: "same-output")
+  assert out["identical"] is True
+  assert out["reset_clean"] is True
+  f.teardown()

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -167,6 +167,55 @@ def test_max_reuses_rotates_sandbox(make_cluster, monkeypatch):
   f.teardown()
 
 
+def test_recyclable_helper():
+  r = GitRestoreReset()
+  from agent_sandbox_rl import ResetBaseline
+  assert r.recyclable(ResetBaseline(pristine_sha="abc")) is True
+  assert r.recyclable(ResetBaseline(pristine_sha="")) is False
+
+
+def test_prime_exec_error_is_non_recyclable():
+  class Boom:
+    cluster_name = "c"
+    pod_name = "p"
+    def exec(self, cmd):
+      raise RuntimeError("no bash")
+  base = GitRestoreReset().prime(Boom())
+  assert base.pristine_sha == ""            # empty -> recyclable() False
+
+
+def test_reset_exec_error_quarantines_not_raises():
+  class Boom:
+    cluster_name = "c"
+    pod_name = "p"
+    calls = 0
+    def exec(self, cmd):
+      Boom.calls += 1
+      if Boom.calls == 1:
+        return _CLEAN                        # prime ok
+      raise RuntimeError("pod died")         # reset exec fails
+  h = Boom()
+  r = GitRestoreReset()
+  base = r.prime(h)
+  out = r.reset(h, base)                     # must NOT raise
+  assert not out.clean and out.reason == "exec_error"
+
+
+def test_non_git_image_falls_back_to_fresh_per_task(make_cluster, monkeypatch):
+  # empty pristine -> not recyclable -> fresh claim per task, no reset attempts
+  empty = "PRISTINE=\nHEAD=\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5"
+  monkeypatch.setattr(SandboxHandle, "exec", lambda self, cmd: empty)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img", "img", "img"])          # 3 tasks, 1 non-git image
+  f.setup()
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1)
+  assert res == [1, 1, 1]
+  # non-recyclable -> a fresh claim per task = 3 claims (degrades to the regular path)
+  assert c.sandbox_client.create_sandbox.call_count == 3
+  f.teardown()
+
+
 def test_determinism_canary_identical(make_cluster, monkeypatch):
   _patch_clean_exec(monkeypatch)
   c = make_cluster("solo")

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -358,7 +358,7 @@ async def test_reuse_async_one_claim_per_image(make_cluster, monkeypatch):
   af.close()
 
 
-async def test_reuse_async_scale_on_hold_drops_pool(make_cluster, monkeypatch):
+async def test_reuse_async_scale_on_hold_refcounts_pool(make_cluster, monkeypatch):
   import unittest.mock as m
   from agent_sandbox_rl import AsyncSandboxFleet
   from agent_sandbox_rl.recycle import reuse_git_restore_sandbox_async
@@ -367,10 +367,49 @@ async def test_reuse_async_scale_on_hold_drops_pool(make_cluster, monkeypatch):
   af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
   af.load_tasks(["img", "img", "img", "img"])
   await af.setup()
-  uw = m.MagicMock(wraps=af._fleet.unwarm_image)
-  monkeypatch.setattr(af._fleet, "unwarm_image", uw)
+  spr = m.MagicMock(wraps=af._fleet.set_pool_replicas)
+  monkeypatch.setattr(af._fleet, "set_pool_replicas", spr)
   await reuse_git_restore_sandbox_async(
       af, af.tasks, lambda t, h: 1, concurrency=1, use_session=False, scale_on_hold=True)
-  assert uw.call_count == 1                       # held sandbox drops its pool
+  # K=1: holding drives desired to 0 (active 1 − held 1) — cancels replenishment
+  assert spr.call_count >= 1
+  assert any(call.args[1] == 0 for call in spr.call_args_list)
   await af.teardown()
   af.close()
+
+
+async def test_reuse_async_sharded_runs_k_sandboxes_per_image(make_cluster, monkeypatch):
+  from agent_sandbox_rl import AsyncSandboxFleet
+  from agent_sandbox_rl.recycle import reuse_git_restore_sandbox_async
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=8, max_warmpool_size=3),
+                         registry=ClusterRegistry([c]))
+  af.load_tasks(["img"] * 6)                       # 1 image, 6 tasks
+  await af.setup()
+  res = await reuse_git_restore_sandbox_async(
+      af, af.tasks, lambda t, h: h.pod_name, concurrency=8,
+      use_session=False, shards_per_image=3)
+  assert len(res) == 6 and all(isinstance(x, str) for x in res)
+  # 3 shards → 3 concurrent sandboxes for the one image (each recycles 2 tasks)
+  assert c.sandbox_client.create_sandbox.call_count == 3
+  await af.teardown()
+  af.close()
+
+
+def test_reuse_guarded_by_circuit_breaker(make_cluster, monkeypatch):
+  # the recycle path must be guarded too (that's where over-creation bit us)
+  import time
+  from agent_sandbox_rl import FleetOvercommitError
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=2,
+             overcommit_factor=1.5, breaker_poll_s=0.02)
+  f.load_tasks(["img"] * 4)
+  f.setup()
+  monkeypatch.setattr(f, "live_owned_count", lambda: 999)   # simulate runaway
+  def slow(t, h):
+    time.sleep(0.15)                                        # let the breaker poll
+    return 1
+  with pytest.raises(FleetOvercommitError):
+    reuse_git_restore_sandbox(f, f.tasks, slow, concurrency=1, use_session=False)

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -185,6 +185,90 @@ def test_max_reuses_rotates_sandbox(make_cluster, monkeypatch):
   f.teardown()
 
 
+def _spy_warm(f, monkeypatch):
+  import unittest.mock as m
+  uw = m.MagicMock(wraps=f.unwarm_image)
+  w = m.MagicMock(wraps=f.warm_image)
+  monkeypatch.setattr(f, "unwarm_image", uw)
+  monkeypatch.setattr(f, "warm_image", w)
+  return uw, w
+
+
+def test_scale_on_hold_drops_pool_after_claim(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)               # resets always clean → held, no re-claim
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img"] * 4)
+  f.setup()
+  uw, w = _spy_warm(f, monkeypatch)
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1,
+                            use_session=False, scale_on_hold=True)
+  assert c.sandbox_client.create_sandbox.call_count == 1   # one claim reused
+  assert uw.call_count == 1                                 # pool dropped once (holding)
+  assert w.call_count == 0                                  # no re-claim → no JIT re-warm
+  f.teardown()
+
+
+def test_scale_on_hold_rewarms_on_rotation(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img"] * 5)                     # rotate after every 2 reuses
+  f.setup()
+  uw, w = _spy_warm(f, monkeypatch)
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1,
+                            max_reuses=2, use_session=False, scale_on_hold=True)
+  assert c.sandbox_client.create_sandbox.call_count == 3   # claims at task 1,3,5
+  assert uw.call_count == 3                                 # drop pool on each hold
+  assert w.call_count == 2                                  # JIT re-warm before re-claims (3,5)
+  f.teardown()
+
+
+def test_scale_on_hold_rewarms_on_quarantine(make_cluster, monkeypatch):
+  # prime clean (recyclable) but every reset dirty -> quarantine -> re-claim each time
+  drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=7\nENV=e1\nCFG=g1\nPROCS=5"
+  monkeypatch.setattr(SandboxHandle, "exec",
+                      lambda self, cmd: _CLEAN if "tag -f pristine" in cmd[2] else drift)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img"] * 3)
+  f.setup()
+  uw, w = _spy_warm(f, monkeypatch)
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1,
+                            use_session=False, scale_on_hold=True)
+  assert c.sandbox_client.create_sandbox.call_count == 3   # dirty reset -> fresh claim each task
+  assert uw.call_count == 3                                 # each held claim drops its pool
+  assert w.call_count == 2                                  # JIT re-warm before the 2 re-claims
+
+
+def test_scale_on_hold_skips_non_recyclable(make_cluster, monkeypatch):
+  # no pristine anchor -> not recyclable -> fresh-claim-per-task path keeps the pool
+  empty = "PRISTINE=\nHEAD=\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5"
+  monkeypatch.setattr(SandboxHandle, "exec", lambda self, cmd: empty)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=1)
+  f.load_tasks(["img"] * 3)
+  f.setup()
+  uw, w = _spy_warm(f, monkeypatch)
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1,
+                            use_session=False, scale_on_hold=True)
+  # non-recyclable never holds -> pool must stay (no unwarm) and no JIT re-warm
+  assert uw.call_count == 0 and w.call_count == 0
+
+
+def test_scale_on_hold_false_keeps_pool(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img"] * 4)
+  f.setup()
+  uw, w = _spy_warm(f, monkeypatch)
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1,
+                            use_session=False, scale_on_hold=False)
+  assert uw.call_count == 0 and w.call_count == 0          # pools left resident
+  f.teardown()
+
+
 def test_recyclable_helper():
   r = GitRestoreReset()
   from agent_sandbox_rl import ResetBaseline

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -84,11 +84,30 @@ def test_reset_clean_when_fingerprint_matches():
 ])
 def test_reset_detects_each_pollution_vector(fp, reason):
   h = FakeHandle([_CLEAN, fp])
-  r = GitRestoreReset()
+  # enable every tripwire (defaults are off = git-only fast path)
+  r = GitRestoreReset(check_env=True, check_config=True)
   base = r.prime(h)
   out = r.reset(h, base)
   assert not out.clean
   assert out.reason == reason
+
+
+def test_git_only_default_ignores_env_and_config_drift():
+  # defaults check_env/check_config off: only git state is verified
+  drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e2\nCFG=g2\nPROCS=5"
+  h = FakeHandle([_CLEAN, drift])
+  r = GitRestoreReset()
+  base = r.prime(h)
+  assert r.reset(h, base).clean            # env+config drift ignored by default
+
+
+def test_git_only_fingerprint_omits_pip_freeze():
+  # the expensive pip freeze must not be in the default (git-only) reset script
+  h = FakeHandle([_CLEAN, _CLEAN])
+  r = GitRestoreReset()
+  base = r.prime(h)
+  r.reset(h, base)
+  assert all("pip freeze" not in c[2] for c in h.calls)
 
 
 def test_no_pristine_anchor_is_never_clean():
@@ -127,7 +146,7 @@ def test_reuse_one_claim_per_image(make_cluster, monkeypatch):
   f = _fleet(ClusterRegistry([c]), max_concurrent=4)
   f.load_tasks(["img", "img", "img", "img"])   # 4 tasks, 1 image
   f.setup()
-  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: h.pod_name, concurrency=4)
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: h.pod_name, concurrency=4, use_session=False)
   assert len(res) == 4 and all(isinstance(x, str) for x in res)
   # one image -> one claim reused across all 4 tasks (÷G economics)
   assert c.sandbox_client.create_sandbox.call_count == 1
@@ -135,20 +154,19 @@ def test_reuse_one_claim_per_image(make_cluster, monkeypatch):
 
 
 def test_reset_failure_triggers_quarantine(make_cluster, monkeypatch):
-  # prime returns clean; every reset returns env drift -> quarantine each time
-  drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=DRIFT\nCFG=g1\nPROCS=5"
-  seq = {"n": 0}
+  # prime returns clean; every reset returns a DIRTY worktree (git-only catches
+  # it regardless of env/config checks) -> quarantine each time
+  drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=7\nENV=e1\nCFG=g1\nPROCS=5"
 
   def fake_exec(self, cmd):
-    seq["n"] += 1
-    # odd calls are prime (after each fresh claim), even are resets
+    # prime issues `git tag -f pristine`; resets don't
     return _CLEAN if "tag -f pristine" in cmd[2] else drift
   monkeypatch.setattr(SandboxHandle, "exec", fake_exec)
   c = make_cluster("solo")
   f = _fleet(ClusterRegistry([c]), max_concurrent=1)
   f.load_tasks(["img", "img", "img"])          # 3 tasks, 1 image
   f.setup()
-  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: h.pod_name, concurrency=1)
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: h.pod_name, concurrency=1, use_session=False)
   assert len(res) == 3
   # every reset dirty -> a fresh claim per task = 3 claims (no successful reuse)
   assert c.sandbox_client.create_sandbox.call_count == 3
@@ -161,7 +179,7 @@ def test_max_reuses_rotates_sandbox(make_cluster, monkeypatch):
   f = _fleet(ClusterRegistry([c]), max_concurrent=1)
   f.load_tasks(["img"] * 5)                     # 5 tasks, 1 image
   f.setup()
-  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1, max_reuses=2)
+  reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1, max_reuses=2, use_session=False)
   # rotate after every 2 reuses: claims at task 1, 3, 5 -> 3 claims
   assert c.sandbox_client.create_sandbox.call_count == 3
   f.teardown()
@@ -209,7 +227,7 @@ def test_non_git_image_falls_back_to_fresh_per_task(make_cluster, monkeypatch):
   f = _fleet(ClusterRegistry([c]), max_concurrent=1)
   f.load_tasks(["img", "img", "img"])          # 3 tasks, 1 non-git image
   f.setup()
-  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1)
+  res = reuse_git_restore_sandbox(f, f.tasks, lambda t, h: 1, concurrency=1, use_session=False)
   assert res == [1, 1, 1]
   # non-recyclable -> a fresh claim per task = 3 claims (degrades to the regular path)
   assert c.sandbox_client.create_sandbox.call_count == 3

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -122,6 +122,17 @@ def test_no_pristine_anchor_is_never_clean():
   assert out.reason == "no_pristine_anchor"
 
 
+def test_pristine_tag_failed_is_non_recyclable_no_head_fallback():
+  # HEAD exists but `git tag -f pristine` failed → empty PRISTINE. prime must NOT
+  # fall back to HEAD (that would reuse without a verifiable pristine anchor).
+  fp = "PRISTINE=\nHEAD=abc123\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5"
+  h = FakeHandle([fp])
+  r = GitRestoreReset()
+  base = r.prime(h)
+  assert base.pristine_sha == ""            # no HEAD fallback
+  assert r.recyclable(base) is False        # → fresh-claim path
+
+
 def test_env_check_can_be_disabled():
   drift = "PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e2\nCFG=g1\nPROCS=5"
   h = FakeHandle([_CLEAN, drift])

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -434,3 +434,32 @@ def test_reuse_infra_error_isolated_to_group(make_cluster, monkeypatch):
   assert res[0] == "ok" and res[1] == "ok"       # good group unaffected
   assert isinstance(res[2], Exception)           # bad group captured, batch survived
   f.teardown()
+
+
+async def test_reuse_async_claim_concurrency_throttles(make_cluster, monkeypatch):
+  # staged claims: with shards=3 (3 concurrent groups) but claim_concurrency=1,
+  # acquires must be serialized (peak in-flight acquire == 1).
+  import asyncio
+  from agent_sandbox_rl import AsyncSandboxFleet
+  from agent_sandbox_rl.recycle import reuse_git_restore_sandbox_async
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=8, max_warmpool_size=3),
+                         registry=ClusterRegistry([c]))
+  af.load_tasks(["img"] * 6)
+  await af.setup()
+  state = {"cur": 0, "peak": 0}
+  real = af.acquire
+  async def tracked_acquire(task):
+    state["cur"] += 1; state["peak"] = max(state["peak"], state["cur"])
+    try:
+      await asyncio.sleep(0.02)
+      return await real(task)
+    finally:
+      state["cur"] -= 1
+  monkeypatch.setattr(af, "acquire", tracked_acquire)
+  await reuse_git_restore_sandbox_async(
+      af, af.tasks, lambda t, h: 1, concurrency=8, use_session=False,
+      shards_per_image=3, claim_concurrency=1)
+  assert state["peak"] == 1                       # claims serialized by the admission sem
+  await af.teardown(); af.close()

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -339,3 +339,38 @@ def test_determinism_canary_identical(make_cluster, monkeypatch):
   assert out["identical"] is True
   assert out["reset_clean"] is True
   f.teardown()
+
+
+# --- async executor (AsyncSandboxFleet) ----------------------------------- #
+async def test_reuse_async_one_claim_per_image(make_cluster, monkeypatch):
+  from agent_sandbox_rl import AsyncSandboxFleet
+  from agent_sandbox_rl.recycle import reuse_git_restore_sandbox_async
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
+  af.load_tasks(["img", "img", "img", "img"])   # 4 tasks, 1 image
+  await af.setup()
+  res = await reuse_git_restore_sandbox_async(
+      af, af.tasks, lambda t, h: h.pod_name, concurrency=4, use_session=False)
+  assert len(res) == 4 and all(isinstance(x, str) for x in res)
+  assert c.sandbox_client.create_sandbox.call_count == 1   # one claim reused (÷G)
+  await af.teardown()
+  af.close()
+
+
+async def test_reuse_async_scale_on_hold_drops_pool(make_cluster, monkeypatch):
+  import unittest.mock as m
+  from agent_sandbox_rl import AsyncSandboxFleet
+  from agent_sandbox_rl.recycle import reuse_git_restore_sandbox_async
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
+  af.load_tasks(["img", "img", "img", "img"])
+  await af.setup()
+  uw = m.MagicMock(wraps=af._fleet.unwarm_image)
+  monkeypatch.setattr(af._fleet, "unwarm_image", uw)
+  await reuse_git_restore_sandbox_async(
+      af, af.tasks, lambda t, h: 1, concurrency=1, use_session=False, scale_on_hold=True)
+  assert uw.call_count == 1                       # held sandbox drops its pool
+  await af.teardown()
+  af.close()

--- a/examples/agent-sandbox-rl/tests/test_recycle.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle.py
@@ -397,6 +397,39 @@ async def test_reuse_async_sharded_runs_k_sandboxes_per_image(make_cluster, monk
   af.close()
 
 
+async def test_reuse_async_shard_death_before_prime_no_dangling_warm(make_cluster, monkeypatch):
+  # A shard that dies BEFORE its first prime (recyclable still None, e.g. acquire raised)
+  # must still drop out of `active`; otherwise recyclable sibling shards compute
+  # desired = active − held with the dead shard still counted and leave a dangling warm
+  # replica (desired never reaches 0).
+  import unittest.mock as m
+  from agent_sandbox_rl import AsyncSandboxFleet
+  from agent_sandbox_rl.recycle import reuse_git_restore_sandbox_async
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4, max_warmpool_size=2),
+                         registry=ClusterRegistry([c]))
+  af.load_tasks(["img"] * 4)                          # 1 image → 2 shards of 2 tasks
+  await af.setup()
+  spr = m.MagicMock(wraps=af._fleet.set_pool_replicas)
+  monkeypatch.setattr(af._fleet, "set_pool_replicas", spr)
+  real_acquire = af.acquire
+  calls = {"n": 0}
+  async def flaky(task):
+    calls["n"] += 1
+    if calls["n"] == 1:                               # first shard dies before prime
+      raise RuntimeError("acquire boom")
+    return await real_acquire(task)
+  monkeypatch.setattr(af, "acquire", flaky)
+  await reuse_git_restore_sandbox_async(
+      af, af.tasks, lambda t, h: 1, concurrency=4,
+      use_session=False, scale_on_hold=True, shards_per_image=2)
+  # post-fix: the dead shard still decremented `active`, so desired drains to 0 (no leftover warm)
+  assert any(call.args[1] == 0 for call in spr.call_args_list), spr.call_args_list
+  await af.teardown()
+  af.close()
+
+
 def test_reuse_guarded_by_circuit_breaker(make_cluster, monkeypatch):
   # the recycle path must be guarded too (that's where over-creation bit us)
   import time

--- a/examples/agent-sandbox-rl/tests/test_recycle_run_flag.py
+++ b/examples/agent-sandbox-rl/tests/test_recycle_run_flag.py
@@ -1,0 +1,183 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`recycle=` flag on fleet.run / async_fleet.run — an orthogonal modifier that
+swaps the task→sandbox binding (reset-and-reuse) while the chosen *strategy* still
+governs warming. These tests verify the routing (executor injection), opt
+plumbing, and that recycle composes with every strategy — the reset/quarantine
+mechanics themselves live in test_recycle.py."""
+
+import unittest.mock as m
+
+import pytest
+
+import agent_sandbox_rl.recycle as recycle_mod
+from agent_sandbox_rl import (AsyncSandboxFleet, ClusterRegistry, FleetConfig,
+                              SandboxFleet)
+from agent_sandbox_rl.handles import SandboxHandle
+from agent_sandbox_rl.preflight import PreflightReport
+
+_CLEAN = "PRISTINE=abc\nHEAD=abc\nDIRTY=0\nENV=e1\nCFG=g1\nPROCS=5"
+
+
+@pytest.fixture(autouse=True)
+def _stub_preflight(monkeypatch):
+  def ok(cluster, **kw):
+    r = PreflightReport(cluster.name)
+    r.add("stub", True)
+    return r
+  monkeypatch.setattr("agent_sandbox_rl.preflight.preflight_cluster", ok)
+
+
+def _fleet(registry, **cfg):
+  return SandboxFleet(FleetConfig(**cfg), registry=registry)
+
+
+def _patch_clean_exec(monkeypatch):
+  monkeypatch.setattr(SandboxHandle, "exec", lambda self, cmd: _CLEAN)
+
+
+def _spy_reuse(monkeypatch):
+  """Replace the sync recycle executor with a spy that returns one result per
+  task (so run() bookkeeping stays happy) and records how it was called."""
+  spy = m.MagicMock(side_effect=lambda fleet, tasks, pf, conc, **kw: [pf(t, None) for t in tasks])
+  monkeypatch.setattr(recycle_mod, "reuse_git_restore_sandbox", spy)
+  return spy
+
+
+def _spy_reuse_async(monkeypatch):
+  async def _fake(afleet, tasks, pf, conc, **kw):
+    return [await afleet._call(pf, t, None) for t in tasks]
+  spy = m.MagicMock(side_effect=_fake)
+  monkeypatch.setattr(recycle_mod, "reuse_git_restore_sandbox_async", spy)
+  return spy
+
+
+# --- routing: recycle flag selects the executor --------------------------- #
+def test_run_recycle_true_routes_to_reuse_executor(make_cluster, monkeypatch):
+  spy = _spy_reuse(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img", "img", "img"])
+  res = f.run(lambda t, h: "ok", strategy="naive", recycle=True)
+  assert res == ["ok", "ok", "ok"]
+  assert spy.call_count == 1                    # naive → one executor call over all tasks
+
+
+def test_run_recycle_false_does_not_call_reuse(make_cluster, monkeypatch):
+  spy = _spy_reuse(monkeypatch)
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img", "img", "img"])
+  f.run(lambda t, h: "ok", strategy="naive", recycle=False)
+  spy.assert_not_called()                        # default path = process_parallel
+
+
+def test_run_recycle_forwards_opts(make_cluster, monkeypatch):
+  spy = _spy_reuse(monkeypatch)
+  reset = recycle_mod.GitRestoreReset(testbed="/repo")
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=2)
+  f.load_tasks(["img", "img"])
+  f.run(lambda t, h: 1, strategy="naive", recycle=True, reset=reset,
+        max_reuses=7, reset_timeout=9.0, use_session=False, scale_on_hold=False)
+  _fleet_arg, _tasks, _pf, _conc = spy.call_args.args
+  kw = spy.call_args.kwargs
+  assert kw["reset"] is reset and kw["max_reuses"] == 7
+  assert kw["reset_timeout"] == 9.0 and kw["use_session"] is False
+  assert kw["scale_on_hold"] is False
+
+
+def test_run_recycle_composes_with_windowed_strategy(make_cluster, monkeypatch):
+  # recycle must layer under a warming strategy, not only naive: the executor is
+  # invoked once per window (here 'none' = window of 1 image).
+  spy = _spy_reuse(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=2)
+  f.load_tasks(["a", "a", "b", "b"])             # 2 images
+  f.run(lambda t, h: t.image, strategy="none", recycle=True)
+  assert spy.call_count == 2                      # one executor call per window/image
+
+
+# --- end-to-end claim economics (real executor, fake exec) ---------------- #
+def test_run_recycle_reuses_one_claim_per_image(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img"] * 4)                       # 1 image, 4 tasks
+  res = f.run(lambda t, h: h.pod_name, strategy="naive", recycle=True,
+              use_session=False)
+  assert len(res) == 4 and all(isinstance(x, str) for x in res)
+  assert c.sandbox_client.create_sandbox.call_count == 1   # reused across all 4 (÷G)
+
+
+def test_run_without_recycle_claims_per_task(make_cluster, monkeypatch):
+  # contrast: the default path re-claims, so it creates strictly more sandboxes
+  # than the recycled run for the same multi-task-per-image workload.
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]), max_concurrent=4)
+  f.load_tasks(["img"] * 4)
+  f.run(lambda t, h: h.pod_name, strategy="naive", recycle=False)
+  assert c.sandbox_client.create_sandbox.call_count > 1
+
+
+# --- async twin ----------------------------------------------------------- #
+async def test_async_run_recycle_true_routes_to_async_reuse(make_cluster, monkeypatch):
+  spy = _spy_reuse_async(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
+  af.load_tasks(["img", "img", "img"])
+  res = await af.run(lambda t, h: "ok", strategy="naive", recycle=True)
+  assert res == ["ok", "ok", "ok"]
+  assert spy.call_count == 1
+  af.close()
+
+
+async def test_async_run_recycle_forwards_async_opts(make_cluster, monkeypatch):
+  spy = _spy_reuse_async(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
+  af.load_tasks(["img", "img"])
+  await af.run(lambda t, h: 1, strategy="naive", recycle=True,
+               max_reuses=5, shards_per_image=3, claim_concurrency=2)
+  kw = spy.call_args.kwargs
+  assert kw["max_reuses"] == 5 and kw["shards_per_image"] == 3
+  assert kw["claim_concurrency"] == 2
+  af.close()
+
+
+async def test_async_run_recycle_false_does_not_call_reuse(make_cluster, monkeypatch):
+  spy = _spy_reuse_async(monkeypatch)
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
+  af.load_tasks(["img", "img"])
+  await af.run(lambda t, h: "ok", strategy="naive", recycle=False)
+  spy.assert_not_called()
+  af.close()
+
+
+async def test_async_run_recycle_reuses_one_claim_per_image(make_cluster, monkeypatch):
+  _patch_clean_exec(monkeypatch)
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(max_concurrent=4), registry=ClusterRegistry([c]))
+  af.load_tasks(["img"] * 4)
+  res = await af.run(lambda t, h: h.pod_name, strategy="naive", recycle=True,
+                     use_session=False)
+  assert len(res) == 4 and all(isinstance(x, str) for x in res)
+  assert c.sandbox_client.create_sandbox.call_count == 1
+  await af.teardown()
+  af.close()

--- a/examples/agent-sandbox-rl/tests/test_session.py
+++ b/examples/agent-sandbox-rl/tests/test_session.py
@@ -130,3 +130,11 @@ def test_handle_exec_routes_through_session(monkeypatch):
   h._session = sess
   assert h.exec(["bash", "-lc", "echo hi"]) == "via-session"
   sess.run.assert_called_once()
+
+
+def test_as_script_shell_quotes_argv():
+  # bash -lc payload passes through; other argv is shell-quoted so it round-trips
+  # through the session (the sh -c script stays a single argument).
+  assert handles._as_script("echo hi") == "echo hi"
+  assert handles._as_script(["bash", "-lc", "echo hi"]) == "echo hi"
+  assert handles._as_script(["sh", "-c", "echo $(hostname)"]) == "sh -c 'echo $(hostname)'"

--- a/examples/agent-sandbox-rl/tests/test_session.py
+++ b/examples/agent-sandbox-rl/tests/test_session.py
@@ -1,0 +1,132 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SandboxSession framing — unit tests with a fake websocket (no cluster)."""
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+import agent_sandbox_rl.handles as handles
+from agent_sandbox_rl.handles import SandboxSession
+
+
+class FakeWS:
+  """Simulates a pod's bash-over-websocket: echoes the run() marker and replays
+  programmed per-command output. ``outputs`` maps a command substring -> stdout."""
+
+  def __init__(self, outputs=None):
+    self.outputs = outputs or {}
+    self._pending = ""
+    self._open = True
+    self.stdin = []
+
+  def is_open(self):
+    return self._open
+
+  def update(self, timeout=1):
+    pass
+
+  def write_stdin(self, s):
+    self.stdin.append(s)
+    if not self._open:                        # closed stream: nothing echoes back
+      return
+    m = re.search(r'printf "%s%s\\n" "([^"]+)" "([^"]+)"', s)
+    if m:                                    # the sentinel line -> emit assembled marker
+      self._pending += m.group(1) + m.group(2) + "\n"
+      return
+    for key, out in self.outputs.items():   # a real command -> emit its programmed output
+      if key in s:
+        self._pending += out
+        break
+
+  def peek_stdout(self):
+    return len(self._pending)
+
+  def read_stdout(self):
+    p, self._pending = self._pending, ""
+    return p
+
+  def peek_stderr(self):
+    return 0
+
+  def read_stderr(self):
+    return ""
+
+  def close(self):
+    self._open = False
+
+
+@pytest.fixture
+def patch_stream(monkeypatch):
+  holder = {}
+  def _factory(outputs=None):
+    ws = FakeWS(outputs)
+    holder["ws"] = ws
+    monkeypatch.setattr(handles, "stream", lambda *a, **k: ws)
+    return ws
+  return _factory
+
+
+def test_session_run_returns_command_output(patch_stream):
+  patch_stream({"git rev-parse": "abc123\n"})
+  s = SandboxSession(MagicMock(), "pod", "ns")
+  out = s.run("git rev-parse HEAD")
+  assert out == "abc123\n"
+
+
+def test_session_strips_crlf(patch_stream):
+  patch_stream({"echo": "line1\r\nline2\r\n"})
+  s = SandboxSession(MagicMock(), "pod", "ns")
+  assert s.run("echo x") == "line1\nline2\n"
+
+
+def test_session_marker_not_matched_in_echoed_input(patch_stream):
+  # even if the pod echoes the command line back, the assembled marker only
+  # appears in real output -> run() returns just the output, not the echo.
+  ws = patch_stream({"mycmd": "RESULT\n"})
+  s = SandboxSession(MagicMock(), "pod", "ns")
+  out = s.run("mycmd")
+  assert out == "RESULT\n"
+
+
+def test_session_run_raises_when_stream_closed(patch_stream):
+  ws = patch_stream({})
+  s = SandboxSession(MagicMock(), "pod", "ns")
+  ws._open = False
+  ws._pending = ""                           # no marker will ever arrive
+  with pytest.raises(TimeoutError):
+    s.run("whatever", timeout=0.2)
+
+
+def test_session_close_marks_closed(patch_stream):
+  ws = patch_stream({})
+  s = SandboxSession(MagicMock(), "pod", "ns")
+  assert s.is_open
+  s.close()
+  assert not s.is_open
+
+
+def test_handle_exec_routes_through_session(monkeypatch):
+  from agent_sandbox_rl.handles import SandboxHandle
+  from agent_sandbox_rl.sources import Task
+  sess = MagicMock()
+  sess.is_open = True
+  sess.run.return_value = "via-session"
+  h = SandboxHandle(task=Task(id="t", image="i"), cluster_name="c",
+                    claim_name="cl", sandbox_id="s", pod_name="p", hostname="s")
+  h._session = sess
+  assert h.exec(["bash", "-lc", "echo hi"]) == "via-session"
+  sess.run.assert_called_once()


### PR DESCRIPTION
Adds **sandbox recycling** for RL rollouts and the **warm-pool safety mitigations** it needs at scale, in the `examples/agent-sandbox-rl` SDK.

## Sandbox recycling (`reuse_git_restore_sandbox`)
Reuse one claimed sandbox across a problem's G rollouts, git-restore-resetting between them, so **claims scale with problems, not tasks** (÷G) — cutting claim latency and controller/API load for the RL-rollout shape.
- Contamination-guarded: `determinism_canary` (byte-identical output across a reset) + quarantine on any dirty reset, so contamination can't silently bias rewards.
- Git-only reset by default (`git reset --hard` + `clean -xdff` + detach, verify pristine SHA); persistent exec session (exec cost O(sandboxes), not O(tasks)).
- Safe on mixed/non-git image sets (falls back to fresh-claim-per-task) and on exec failures (quarantine, never raises).

## Warm-pool over-creation mitigations (#1215)
High warm-pool worker concurrency + a deep/cold warm triggers a SandboxWarmPool create/delete **churn** (over-create off a stale informer cache, then delete excess), which lagging pod GC turns into a pod-count runaway.
- **Staged warm fill** (`FleetConfig.warm_create_budget`, default 1000): `start_warmpools` fills in waves of ≤ N in-flight creates, waiting for Ready between waves so the informer cache converges — bounding the concurrent create burst. `0` = warm all at once. Also on `AsyncSandboxFleet`.
- **Recycle scale-on-hold** (`scale_on_hold=True`): once a recyclable sandbox is claimed and held, its warm pool is dropped so the controller doesn't replenish a replacement the reuse never claims; quarantine/rotation re-claims JIT re-warm. (Verified a claimed sandbox survives its pool being scaled/deleted — a `SandboxClaim` detaches ownership.)
- Docs: the "Setting your controller to high scale" guide now warns to keep `--sandbox-warm-pool-concurrent-workers` **low (≤10)**, not 1000; warm-pool strategy selection rewritten around the disk-fit decision.

## Validation
Canonical SWE-bench 500 (500 problems × 16 rollouts = 8,000 rollouts): **500 claims** (~16× fewer than fresh-claim), **8,000/8,000 ok**, **15/15 determinism-clean**, pods 1:1 with sandboxes (no churn). Full test suite: **256 passing**.

## Notes
The underlying #1215 churn is an upstream controller issue these SDK-side levers *mitigate* (staged fill + scale-on-hold + the tuning-guide fix); the robust fix is the expectations pattern on warm-pool creates + counting `Terminating` toward the target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental sandbox recycling (reset-and-reuse) with drift/cleanliness verification, quarantine on failures, max-reuse rotation, and fresh-claim fallback.
  * Added persistent exec sessions for faster repeated commands.
  * Added staged warm-pool creation controls (`warm_create_budget` / per-run `create_budget`).
  * Added runaway safeguards (overcommit circuit breaker + automatic teardown) and a `reap` cleanup utility with run-id labeling.
* **Documentation**
  * Expanded recycling and warm-pool strategy guidance, plus performance report and orchestration instructions.
* **Tests**
  * Added coverage for recycling, warm staging waves, exec-session framing/quoting, and safeguard/reaper behavior.
* **Chores**
  * Updated macOS ignore rules and added a performance report template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->