### PR TITLE
stress-test report: show better CPU totals on the flame graph

### DIFF
--- a/test/stress/generate-report/static/flamegraph.js
+++ b/test/stress/generate-report/static/flamegraph.js
@@ -228,6 +228,24 @@ function buildFlameTree(profile, valueIndex) {
     return root;
 }
 
+// searchSelfTime sums the self ("flat" in pprof terms) time of matched
+// frames: each frame's value minus its children's, over every matched
+// occurrence including nested and recursive ones. Complements the
+// inclusive total that d3-flame-graph's search handler reports, which
+// counts each matched subtree once (frames under an already-matched
+// ancestor are excluded there to avoid double counting).
+function searchSelfTime(nodes) {
+    let self = 0;
+    for (const node of nodes) {
+        let childSum = 0;
+        for (const child of node.children || []) {
+            childSum += child.value;
+        }
+        self += node.value - childSum;
+    }
+    return self;
+}
+
 // loadPprof fetches a pprof file, gunzips it if needed (pprof files are
 // gzip-compressed by convention), and parses it.
 async function loadPprof(url) {

--- a/test/stress/generate-report/static/report.css
+++ b/test/stress/generate-report/static/report.css
@@ -251,6 +251,10 @@ code {
 .badge-warning { background-color: #fffbeb; color: var(--accent-warning); border-color: #fde68a; }
 .badge-danger { background-color: #fef2f2; color: var(--accent-danger); border-color: #fecaca; }
 .badge-info { background-color: #eff6ff; color: var(--accent-primary); border-color: #bfdbfe; }
+/* Search/filter summaries (e.g. the pprof page's filtered-CPU stat) */
+.badge-search { background-color: #f5f3ff; color: #7c3aed; border-color: #ddd6fe; }
+/* Zoom-state summaries (e.g. the pprof page's showing-X-cpu-s stat) */
+.badge-zoom { background-color: #f0fdfa; color: #0d9488; border-color: #99f6e4; }
 
 /* Threshold-colored numeric cells */
 .num-good { color: var(--accent-success); }

--- a/test/stress/generate-report/templates/pprof.html
+++ b/test/stress/generate-report/templates/pprof.html
@@ -26,7 +26,11 @@
 <div class="card">
     <div class="card-title">
         <span>kube-apiserver CPU profile</span>
-        <span class="badge badge-info" id="profile-info"></span>
+        <span>
+            <span class="badge badge-search" id="profile-search-info" hidden></span>
+            <span class="badge badge-zoom" id="profile-zoom-info" hidden></span>
+            <span class="badge badge-info" id="profile-info"></span>
+        </span>
     </div>
     <div class="profile-controls">
         <label for="profile-select">Profile:</label>
@@ -54,6 +58,10 @@
     const container = document.getElementById('flamegraph');
     const select = document.getElementById('profile-select');
     const info = document.getElementById('profile-info');
+    const searchInfo = document.getElementById('profile-search-info');
+    const searchInput = document.getElementById('profile-search');
+    const zoomInfo = document.getElementById('profile-zoom-info');
+    let profileTotal = 0; // current profile's total value, for zoom percentages
 
     const chart = flamegraph()
         .width(Math.max(container.clientWidth, 600))
@@ -61,6 +69,34 @@
         .minFrameSize(2)
         .transitionDuration(250)
         .sort(true);
+
+    // Summarize the filtered CPU: `sum` is d3-flame-graph's inclusive total
+    // (each matched subtree counted once, so recursion and nested matches
+    // don't double count); self time is the matched frames' own samples,
+    // pprof's "flat".
+    chart.setSearchHandler((results, sum, totalValue) => {
+        if (!results.length || !searchInput.value) {
+            searchInfo.hidden = true;
+            return;
+        }
+        const pct = totalValue > 0 ? (sum / totalValue * 100).toFixed(1) : '0.0';
+        searchInfo.textContent = `filter: ${(sum / 1e9).toFixed(1)} cpu-s incl. sub-calls (${pct}%), ` +
+            `${(searchSelfTime(results) / 1e9).toFixed(1)} cpu-s self`;
+        searchInfo.hidden = false;
+    });
+
+    // d3-flame-graph invokes onClick after zooming to the clicked frame (and
+    // resetZoom routes through the same path with the root), so this is the
+    // one place that always knows the current zoom target.
+    chart.onClick(d => {
+        if (!d || !d.parent) {
+            zoomInfo.hidden = true;
+            return;
+        }
+        const pct = profileTotal > 0 ? (d.value / profileTotal * 100).toFixed(1) : '0.0';
+        zoomInfo.textContent = `showing: ${(d.value / 1e9).toFixed(1)} cpu-s (${pct}%)`;
+        zoomInfo.hidden = false;
+    });
 
     async function show(file) {
         info.textContent = 'loading…';
@@ -72,7 +108,17 @@
             d3.select(container).datum(tree).call(chart);
             const seconds = profile.durationNanos / 1e9;
             const cores = profile.durationNanos > 0 ? tree.value / profile.durationNanos : 0;
-            info.textContent = `${pick.label}: ${(tree.value / 1e9).toFixed(1)} cpu-s over ${seconds.toFixed(0)}s (${cores.toFixed(1)} cores)`;
+            profileTotal = tree.value;
+            zoomInfo.hidden = true;
+            info.textContent = `total: ${(tree.value / 1e9).toFixed(1)} cpu-s over ${seconds.toFixed(0)}s (${cores.toFixed(1)} cores)`;
+            info.title = pick.label; // sample type, e.g. cpu/nanoseconds
+            // Carry the active filter (and its summary badge) over to the
+            // newly selected profile.
+            if (searchInput.value) {
+                chart.search(searchInput.value);
+            } else {
+                searchInfo.hidden = true;
+            }
         } catch (err) {
             info.textContent = 'load failed';
             container.innerHTML = `<div class="card-desc">Failed to load <code>${escapeHtml(file)}</code>: ${escapeHtml(err.message)}.<br>` +
@@ -82,8 +128,13 @@
     }
 
     select.addEventListener('change', () => show(select.value));
-    document.getElementById('profile-search').addEventListener('input', e => {
-        if (e.target.value) { chart.search(e.target.value); } else { chart.clear(); }
+    searchInput.addEventListener('input', e => {
+        if (e.target.value) {
+            chart.search(e.target.value);
+        } else {
+            chart.clear();
+            searchInfo.hidden = true;
+        }
     });
     document.getElementById('profile-reset').addEventListener('click', () => chart.resetZoom());
     show(select.value);


### PR DESCRIPTION
When filtering the pprof flame graph, show what the filter adds up to:
a second badge (purple, next to the blue profile total) with the
matched frames' total CPU both inclusive of sub-calls and self-only
(pprof's cum and flat).

Rename the profile badge from the sample-type jargon
('cpu/nanoseconds: ...') to 'total: 109.3 cpu-s over 20s (5.4 cores)';
the sample type moves to the badge's tooltip.

Add a teal 'showing: 20.1 cpu-s (16.6%)' badge while zoomed into a
frame. d3-flame-graph invokes onClick after zooming to the clicked
frame, and resetZoom routes through the same path with the root, so
one handler tracks every way the zoom can change; the badge hides at
full zoom-out and on profile switch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search summaries to CPU profile flame graphs, showing matched inclusive time, percentage of total, and self time.
  * Search filters now remain active when switching between profiles.
  * Search result badges update automatically and hide when the search is cleared.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->