### PR TITLE
stress-test: add claims-warm phase measuring warm-pool SandboxClaim adoption

### DIFF
--- a/dev/ci/periodics/benchmarks-kops-gcp-claims
+++ b/dev/ci/periodics/benchmarks-kops-gcp-claims
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Periodic variant of the warm-pool claim-adoption benchmark: same test, run
+# on a schedule against main so we get a continuous adoption-latency baseline.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+exec "${REPO_ROOT}/dev/ci/presubmits/benchmarks-kops-gcp-claims"

--- a/dev/ci/presubmits/benchmarks-kops-gcp-claims
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-claims
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the warm-pool SandboxClaim adoption benchmark on a kOps GCP cluster
+# (see test/benchmarks/scenarios/benchmarks-kops-gcp-claims). The claim path
+# is CNI-insensitive (pool pods are Running before the burst), so only a
+# cilium variant exists.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+export CNI=cilium
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# benchmarks-kops-gcp-claims measures warm-pool SandboxClaim adoption:
+# a burst of STRESS_CLAIMS_WARM simultaneous claims against a fully
+# provisioned SandboxWarmPool, reporting per-claim create->Ready latency
+# and time until ALL claims are Ready (see test/stress claims-warm).
+#
+# This is a dedicated scenario (rather than a phase appended to the main
+# benchmarks-kops-gcp run) so claim-adoption changes get their own presubmit
+# signal: the claim path is controller/control-plane bound, not node bound,
+# and its numbers should not share a job with the multi-level sandbox churn
+# phases whose runtime and cluster sizing are driven by node throughput.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# The adoption burst never cold-starts pods: the pool's pods are Running
+# before the first claim is created, so node count only has to fit the pool
+# (plus its transient replenishment overshoot, up to ~2x the pool). 6 worker
+# nodes give ~630 spare pod slots, which fits the 300-replica pool and its
+# replenishment without the pool provisioning step dominating the job's
+# wall-clock the way the 20-node churn scenario's sizing would suggest.
+export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-6}"
+
+# claims-warm only: pool provisioning is setup (untimed), the burst is the
+# measurement. Sharding the harness's creates over 4 HTTP/2 connections keeps
+# the load generator's own connection cap (~100 concurrent streams) from
+# queueing a 300-wide burst and inflating measured create-ack.
+export STRESS_PHASES="${STRESS_PHASES:-claims-warm}"
+export STRESS_CLAIMS_WARM="${STRESS_CLAIMS_WARM:-300}"
+export STRESS_EXTRA_ARGS="${STRESS_EXTRA_ARGS:---client-connections=4}"
+
+# Serve the controller's pprof endpoints so the stress tool's
+# --profile-controller (on by default for claims phases) can capture CPU and
+# heap profiles bracketing the burst; heap lives behind the debug set.
+export CONTROLLER_ARGS="${CONTROLLER_ARGS:---enable-pprof-debug}"
+
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -250,9 +250,12 @@ if [[ "${CNI}" == "cilium" ]]; then
   kops validate cluster --wait 5m
 fi
 
-# Deploy to cluster
+# Deploy to cluster. CONTROLLER_ARGS optionally appends controller flags
+# (e.g. "--enable-pprof-debug" so the stress tool's --profile-controller can
+# actually fetch CPU/heap profiles; see benchmarks-kops-gcp-claims).
 echo "Deploying to cluster..."
-dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" --extensions
+dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" --extensions \
+  ${CONTROLLER_ARGS:+--controller-args "${CONTROLLER_ARGS}"}
 
 # Wait for controller to be ready
 echo "Waiting for controller to be ready..."
@@ -270,6 +273,7 @@ echo "Benchmark completed successfully."
 #   fill              long-running background sandboxes (scale)
 #   probe             low-concurrency launch latency
 #   throughput-mifN   closed-loop churn capped at N in-flight
+#   claims-warm       SandboxClaim burst against a provisioned warm pool
 #
 # Keep fill (fill-per-node * nodes) + max(mifN) below spare pod capacity
 # (roughly 3 * 110 minus system pods on the default cluster); the test
@@ -291,6 +295,10 @@ echo "Running stress test"
 # kube-scheduler, the sandbox controller, and kubelets are collected by the
 # stress tool itself (metrics.jsonl.gz; see --collect-metrics).
 set +o errexit
+# STRESS_EXTRA_ARGS appends verbatim extra flags (word-split on purpose) so
+# scenarios can pass tool flags without this script growing an env knob for
+# each one (e.g. --client-connections=4 in benchmarks-kops-gcp-claims).
+# shellcheck disable=SC2086
 go run ./test/stress \
   --phases="${STRESS_PHASES:-fill,probe,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
   --fill-per-node="${STRESS_FILL_PER_NODE:-10}" \
@@ -298,8 +306,10 @@ go run ./test/stress \
   --throughput-count="${STRESS_THROUGHPUT_COUNT:-500}" \
   --throughput-min-seconds="${STRESS_THROUGHPUT_MIN_SECONDS:-45}" \
   --create-concurrency="${STRESS_CREATE_CONCURRENCY:-50}" \
+  --claims-warm-count="${STRESS_CLAIMS_WARM:-300}" \
   --timeout="${STRESS_TIMEOUT:-30m}" \
-  --output-dir="${STRESS_OUTPUT_DIR}"
+  --output-dir="${STRESS_OUTPUT_DIR}" \
+  ${STRESS_EXTRA_ARGS:-}
 stress_status=$?
 set -o errexit
 capture_stress_diagnostics

--- a/test/stress/apfcheck.go
+++ b/test/stress/apfcheck.go
@@ -1,0 +1,182 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// APF priority-level preflight.
+//
+// The claims phases' create-ack numbers assume the harness's claim POSTs
+// ride the APF *exempt* priority level (admin kubeconfig -> system:masters
+// -> the built-in "exempt" FlowSchema). A mis-provisioned kubeconfig
+// silently shifts every create onto a queued priority level and poisons
+// the run's create-ack numbers without any visible error.
+//
+// The apiserver reports the APF classification of EVERY request in the
+// X-Kubernetes-PF-FlowSchema-UID / X-Kubernetes-PF-PriorityLevel-UID
+// response headers, so the check is one server-side DRY-RUN SandboxClaim
+// create through a header-capturing transport (classification happens in
+// the filter chain, well before validation/storage — the dry-run never
+// persists anything and the result is valid even if the create itself is
+// rejected). UIDs are resolved to names via the flowcontrol API and the
+// result lands in summary.json (Summary.APFVerification) and the run log.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	pfFlowSchemaHeader    = "X-Kubernetes-PF-FlowSchema-UID"
+	pfPriorityLevelHeader = "X-Kubernetes-PF-PriorityLevel-UID"
+	// exemptPriorityLevelName is the built-in APF priority level that
+	// bypasses queuing entirely; the bench contract is that harness claim
+	// POSTs classify here (admin kubeconfig -> system:masters).
+	exemptPriorityLevelName = "exempt"
+)
+
+var (
+	gvrFlowSchemas = schema.GroupVersionResource{
+		Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Resource: "flowschemas"}
+	gvrPriorityLevels = schema.GroupVersionResource{
+		Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Resource: "prioritylevelconfigurations"}
+)
+
+// APFVerification is the recorded result of the preflight (summary.json).
+type APFVerification struct {
+	// FlowSchema / PriorityLevel are the resolved object NAMES; the UIDs are
+	// kept alongside in case name resolution failed mid-run.
+	FlowSchema       string `json:"flowSchema,omitempty"`
+	FlowSchemaUID    string `json:"flowSchemaUID,omitempty"`
+	PriorityLevel    string `json:"priorityLevel,omitempty"`
+	PriorityLevelUID string `json:"priorityLevelUID,omitempty"`
+	// Exempt reports whether the claim POST classified into the exempt
+	// priority level — the bench-calibration contract.
+	Exempt bool `json:"exempt"`
+	// Error records a non-fatal preflight failure (the run proceeds and is
+	// annotated as unverified rather than aborted).
+	Error string `json:"error,omitempty"`
+}
+
+// pfHeaderCapture records the APF classification headers of the last
+// response that carried them.
+type pfHeaderCapture struct {
+	base http.RoundTripper
+
+	mu    sync.Mutex
+	fsUID string
+	plUID string
+}
+
+func (h *pfHeaderCapture) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := h.base.RoundTrip(req)
+	if resp != nil {
+		if fs := resp.Header.Get(pfFlowSchemaHeader); fs != "" {
+			h.mu.Lock()
+			h.fsUID = fs
+			h.plUID = resp.Header.Get(pfPriorityLevelHeader)
+			h.mu.Unlock()
+		}
+	}
+	return resp, err
+}
+
+func (h *pfHeaderCapture) uids() (string, string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.fsUID, h.plUID
+}
+
+// verifyClaimPostPriorityLevel dry-run-creates one SandboxClaim in the given
+// (existing) namespace through a header-capturing copy of the harness's rest
+// config and resolves the APF classification. It never fails the run: any
+// error is recorded in the returned struct.
+func verifyClaimPostPriorityLevel(ctx context.Context, baseConfig *rest.Config, namespace string) *APFVerification {
+	result := &APFVerification{}
+
+	capture := &pfHeaderCapture{}
+	cfg := rest.CopyConfig(baseConfig)
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		capture.base = rt
+		return capture
+	})
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		result.Error = fmt.Sprintf("build preflight client: %v", err)
+		return result
+	}
+
+	claim := buildClaimObject(
+		types.NamespacedName{Namespace: namespace, Name: "apf-preflight"},
+		"apf-preflight-pool")
+	// Server-side dry run: full authn/authz/APF/admission traversal, nothing
+	// persisted. The PF headers are set regardless of the create's outcome,
+	// so a rejection (e.g. future CRD validation) does not void the check.
+	_, createErr := client.Resource(gvrSandboxClaims).Namespace(namespace).
+		Create(ctx, claim, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+
+	fsUID, plUID := capture.uids()
+	if fsUID == "" {
+		if createErr != nil {
+			result.Error = fmt.Sprintf("dry-run claim create returned no APF headers (err: %v)", createErr)
+		} else {
+			result.Error = "dry-run claim create returned no APF headers (APF disabled?)"
+		}
+		return result
+	}
+	result.FlowSchemaUID, result.PriorityLevelUID = fsUID, plUID
+
+	result.FlowSchema = resolveUIDToName(ctx, client, gvrFlowSchemas, fsUID)
+	result.PriorityLevel = resolveUIDToName(ctx, client, gvrPriorityLevels, plUID)
+	result.Exempt = result.PriorityLevel == exemptPriorityLevelName
+	return result
+}
+
+// resolveUIDToName lists the given cluster-scoped resource and returns the
+// name of the object with the given UID ("" if not found / list failed).
+func resolveUIDToName(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, uid string) string {
+	list, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return ""
+	}
+	for _, item := range list.Items {
+		if string(item.GetUID()) == uid {
+			return item.GetName()
+		}
+	}
+	return ""
+}
+
+// logAPFVerification prints the preflight verdict in run-log-greppable form.
+func logAPFVerification(v *APFVerification) {
+	switch {
+	case v.Error != "":
+		log.Printf("APF preflight: UNVERIFIED (%s) — create-ack numbers may include priority-level queueing", v.Error)
+	case v.Exempt:
+		log.Printf("APF preflight: claim POSTs ride flowSchema=%q priorityLevel=%q (exempt: no APF queueing on the create path)",
+			v.FlowSchema, v.PriorityLevel)
+	default:
+		log.Printf("APF preflight WARNING: claim POSTs classify into flowSchema=%q priorityLevel=%q (uid %s), NOT the exempt level — "+
+			"create-ack measurements will include APF seat contention; check the kubeconfig user (expected system:masters)",
+			v.FlowSchema, v.PriorityLevel, v.PriorityLevelUID)
+	}
+}

--- a/test/stress/apfcheck_test.go
+++ b/test/stress/apfcheck_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+type stubRoundTripper struct {
+	responses []*http.Response
+	i         int
+}
+
+func (s *stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	resp := s.responses[s.i%len(s.responses)]
+	s.i++
+	return resp, nil
+}
+
+func respWithPF(fsUID, plUID string) *http.Response {
+	h := http.Header{}
+	if fsUID != "" {
+		h.Set(pfFlowSchemaHeader, fsUID)
+		h.Set(pfPriorityLevelHeader, plUID)
+	}
+	return &http.Response{StatusCode: 200, Header: h}
+}
+
+// TestPFHeaderCaptureRecordsClassification pins the two properties the
+// preflight relies on: header names match what kube-apiserver emits
+// (case-insensitive Get), and responses without APF headers (e.g. the
+// discovery calls the dynamic client makes before the dry-run POST) never
+// clobber a captured classification.
+func TestPFHeaderCaptureRecordsClassification(t *testing.T) {
+	capture := &pfHeaderCapture{base: &stubRoundTripper{responses: []*http.Response{
+		respWithPF("", ""),                 // discovery: no APF headers
+		respWithPF("fs-uid-1", "pl-uid-1"), // the dry-run create
+		respWithPF("", ""),                 // trailing header-less response
+	}}}
+
+	req := &http.Request{}
+	for range 3 {
+		if _, err := capture.RoundTrip(req); err != nil {
+			t.Fatalf("RoundTrip: %v", err)
+		}
+	}
+	fs, pl := capture.uids()
+	if fs != "fs-uid-1" || pl != "pl-uid-1" {
+		t.Errorf("captured (%q, %q), want (fs-uid-1, pl-uid-1)", fs, pl)
+	}
+}

--- a/test/stress/clientconns.go
+++ b/test/stress/clientconns.go
@@ -1,0 +1,145 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
+)
+
+// dialFunc matches rest.Config.Dial / net.Dialer.DialContext.
+type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// configureCreateConnections optionally shards the harness's MUTATING API
+// traffic (claim/sandbox/pool creates and deletes) across `connections`
+// independent TCP+TLS+HTTP/2 connections.
+//
+// Why: the kube-apiserver advertises SETTINGS_MAX_CONCURRENT_STREAMS=100 by
+// default, and client-go multiplexes every request built from one rest.Config
+// onto a single HTTP/2 connection. Historically the stress tool put ALL of
+// its traffic — e.g. 300 simultaneous claim creates during the claims-warm
+// burst, PLUS the five resource watches, PLUS metrics scrapes — on that one
+// connection. Under a 300-wide create burst, creates queue in the harness
+// waiting for one of ~100 streams, which inflates the measured create-ack
+// (and therefore create→Ready) with client-side queueing that says nothing
+// about the controller or the apiserver. This is the exact ceiling the
+// controller hit and fixed in cmd/agent-sandbox-controller/transport.go; this
+// file mirrors that approach for the load generator.
+//
+// How: identical mechanism to the controller's configureAPIConnections — for
+// each shard, copy the rest.Config and set a distinct Dial function.
+// client-go's TLS transport cache keys on the resulting DialHolder pointer,
+// so every shard gets its own *http.Transport and its own TCP/HTTP2
+// connection, using only supported client-go API. A round-robin RoundTripper
+// over the shards is installed via cfg.WrapTransport.
+//
+// Callers apply this to a COPY of the base rest.Config and build the
+// mutating dynamic client from it; the watch/scrape clients keep the
+// untouched base config. Because the base config has no custom Dial, its
+// transport cache entry is distinct from every shard's, so with
+// connections > 1 the watch streams always ride a connection that create
+// bursts cannot congest.
+//
+// connections == 1 leaves cfg completely untouched: one connection shared by
+// creates, watches, and scrapes — the historical stress-tool behavior.
+func configureCreateConnections(cfg *rest.Config, connections int) error {
+	return configureCreateConnectionsWithDialer(cfg, connections, nil)
+}
+
+// configureCreateConnectionsWithDialer is configureCreateConnections with an
+// injectable base dialer so tests can count/observe the underlying TCP
+// connections. A nil baseDial uses a per-shard net.Dialer identical to
+// client-go's default (30s timeout, 30s keep-alive).
+func configureCreateConnectionsWithDialer(cfg *rest.Config, connections int, baseDial dialFunc) error {
+	if connections < 1 {
+		return fmt.Errorf("client-connections must be >= 1, got %d", connections)
+	}
+	if connections == 1 {
+		// Default: preserve historical single-connection behavior exactly.
+		return nil
+	}
+	if cfg.Dial != nil || cfg.Transport != nil {
+		return fmt.Errorf("client-connections > 1 is incompatible with a custom Dial/Transport on the rest.Config")
+	}
+
+	shards := make([]http.RoundTripper, 0, connections)
+	for i := range connections {
+		shardCfg := rest.CopyConfig(cfg)
+		// The shard transports live *below* the WrapTransport slot of the
+		// outer config; never inherit an outer wrapper (recursion guard).
+		shardCfg.WrapTransport = nil
+		dial := baseDial
+		if dial == nil {
+			// Mirrors the default dialer client-go's transport cache uses.
+			dial = (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext
+		}
+		// Setting Dial forces a distinct transport cache entry per shard
+		// (fresh DialHolder pointer per TransportFor call).
+		shardCfg.Dial = dial
+		rt, err := rest.TransportFor(shardCfg)
+		if err != nil {
+			return fmt.Errorf("building create-path connection shard %d/%d: %w", i+1, connections, err)
+		}
+		shards = append(shards, rt)
+	}
+
+	sharded := &shardedRoundTripper{shards: shards}
+	cfg.WrapTransport = func(http.RoundTripper) http.RoundTripper {
+		return sharded
+	}
+	return nil
+}
+
+// shardedRoundTripper distributes requests round-robin over a fixed set of
+// independent transports (one HTTP/2 connection each).
+type shardedRoundTripper struct {
+	shards []http.RoundTripper
+	next   atomic.Uint64
+}
+
+func (s *shardedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := s.next.Add(1) % uint64(len(s.shards))
+	return s.shards[idx].RoundTrip(req)
+}
+
+// CloseIdleConnections lets http.Client.CloseIdleConnections reach the
+// per-shard transports (net/http checks for this interface).
+func (s *shardedRoundTripper) CloseIdleConnections() {
+	type closeIdler interface{ CloseIdleConnections() }
+	for _, shard := range s.shards {
+		rt := shard
+		for rt != nil {
+			if ci, ok := rt.(closeIdler); ok {
+				ci.CloseIdleConnections()
+				break
+			}
+			wrapper, ok := rt.(utilnet.RoundTripperWrapper)
+			if !ok {
+				break
+			}
+			rt = wrapper.WrappedRoundTripper()
+		}
+	}
+}

--- a/test/stress/clientconns_test.go
+++ b/test/stress/clientconns_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"maps"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// connTrackingServer is an HTTP/2-enabled TLS test server that records which
+// client connection (RemoteAddr) served each request. Mirrors the test rig
+// for the controller's transport sharding (cmd/agent-sandbox-controller).
+type connTrackingServer struct {
+	srv *httptest.Server
+
+	mu          sync.Mutex
+	reqsPerConn map[string]int
+}
+
+func newConnTrackingServer(t *testing.T) *connTrackingServer {
+	t.Helper()
+	cts := &connTrackingServer{reqsPerConn: map[string]int{}}
+	cts.srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cts.mu.Lock()
+		cts.reqsPerConn[r.RemoteAddr]++
+		cts.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	cts.srv.EnableHTTP2 = true
+	cts.srv.StartTLS()
+	t.Cleanup(cts.srv.Close)
+	return cts
+}
+
+func (c *connTrackingServer) restConfig() *rest.Config {
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.srv.Certificate().Raw})
+	return &rest.Config{
+		Host:            c.srv.URL,
+		TLSClientConfig: rest.TLSClientConfig{CAData: caPEM},
+	}
+}
+
+func (c *connTrackingServer) snapshot() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int, len(c.reqsPerConn))
+	maps.Copy(out, c.reqsPerConn)
+	return out
+}
+
+// countingDialer wraps the standard dialer and counts TCP dials.
+func countingDialer(dials *atomic.Int64) dialFunc {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		dials.Add(1)
+		return (&net.Dialer{}).DialContext(ctx, network, address)
+	}
+}
+
+func TestConfigureCreateConnectionsDefaultIsNoop(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.invalid"}
+	if err := configureCreateConnections(cfg, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.WrapTransport != nil {
+		t.Error("connections=1 must not install a WrapTransport (historical single-connection behavior must be preserved)")
+	}
+	if cfg.Dial != nil {
+		t.Error("connections=1 must not set a custom dialer")
+	}
+}
+
+func TestConfigureCreateConnectionsRejectsInvalid(t *testing.T) {
+	for _, n := range []int{0, -1} {
+		if err := configureCreateConnections(&rest.Config{Host: "https://example.invalid"}, n); err == nil {
+			t.Errorf("connections=%d: expected error, got nil", n)
+		}
+	}
+}
+
+func TestConfigureCreateConnectionsRejectsCustomDialOrTransport(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.invalid"}
+	cfg.Dial = (&net.Dialer{}).DialContext
+	if err := configureCreateConnections(cfg, 2); err == nil {
+		t.Error("expected error for config with custom Dial")
+	}
+	cfg2 := &rest.Config{Host: "https://example.invalid", Transport: http.DefaultTransport}
+	if err := configureCreateConnections(cfg2, 2); err == nil {
+		t.Error("expected error for config with custom Transport")
+	}
+}
+
+// TestCreateShardingDistinctConnections verifies the core claim: with
+// --client-connections=N, exactly N distinct TCP connections are dialed, all
+// speak HTTP/2, and requests are distributed round-robin across them.
+func TestCreateShardingDistinctConnections(t *testing.T) {
+	const shardCount = 4
+	const requests = 32
+
+	server := newConnTrackingServer(t)
+	cfg := server.restConfig()
+
+	var dials atomic.Int64
+	if err := configureCreateConnectionsWithDialer(cfg, shardCount, countingDialer(&dials)); err != nil {
+		t.Fatalf("configureCreateConnectionsWithDialer: %v", err)
+	}
+	if cfg.Dial != nil {
+		t.Fatal("sharding must not set Dial on the original config (only on shard copies)")
+	}
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor: %v", err)
+	}
+
+	// Sequential requests: round-robin is deterministic and a shard never
+	// dials twice (its connection is established by the prior request).
+	for i := range requests {
+		resp, err := httpClient.Get(fmt.Sprintf("%s/probe/%d", server.srv.URL, i))
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.ProtoMajor != 2 {
+			t.Fatalf("request %d: expected HTTP/2, got %s", i, resp.Proto)
+		}
+	}
+
+	if got := dials.Load(); got != shardCount {
+		t.Errorf("expected exactly %d TCP dials (one per shard), got %d", shardCount, got)
+	}
+	perConn := server.snapshot()
+	if len(perConn) != shardCount {
+		t.Errorf("expected %d distinct client connections at the server, got %d: %v", shardCount, len(perConn), perConn)
+	}
+	for addr, n := range perConn {
+		if n != requests/shardCount {
+			t.Errorf("connection %s served %d requests, expected exactly %d (round-robin)", addr, n, requests/shardCount)
+		}
+	}
+}
+
+// TestWatchClientKeepsOwnConnection verifies the create/watch split the
+// harness relies on: a client built from the UNTOUCHED base config (the
+// watch client) uses a connection distinct from every create shard, so
+// create bursts cannot congest watch event delivery.
+func TestWatchClientKeepsOwnConnection(t *testing.T) {
+	const shardCount = 2
+
+	server := newConnTrackingServer(t)
+	baseCfg := server.restConfig()
+
+	// Mirrors run(): the mutate config is a copy of the base; the base
+	// config itself is never modified.
+	mutateCfg := rest.CopyConfig(baseCfg)
+	var shardDials atomic.Int64
+	if err := configureCreateConnectionsWithDialer(mutateCfg, shardCount, countingDialer(&shardDials)); err != nil {
+		t.Fatalf("configureCreateConnectionsWithDialer: %v", err)
+	}
+	mutateClient, err := rest.HTTPClientFor(mutateCfg)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor(mutate): %v", err)
+	}
+
+	for i := range 2 * shardCount {
+		resp, err := mutateClient.Get(server.srv.URL + "/create")
+		if err != nil {
+			t.Fatalf("mutate request %d: %v", i, err)
+		}
+		resp.Body.Close()
+	}
+	createConns := server.snapshot()
+	if len(createConns) != shardCount {
+		t.Fatalf("expected %d create-shard connections, got %d: %v", shardCount, len(createConns), createConns)
+	}
+
+	watchClient, err := rest.HTTPClientFor(baseCfg)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor(base): %v", err)
+	}
+	for i := range 3 {
+		resp, err := watchClient.Get(server.srv.URL + "/watch")
+		if err != nil {
+			t.Fatalf("watch request %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.ProtoMajor != 2 {
+			t.Fatalf("watch request %d: expected HTTP/2, got %s", i, resp.Proto)
+		}
+	}
+
+	allConns := server.snapshot()
+	if len(allConns) != shardCount+1 {
+		t.Errorf("expected %d total connections (create shards + dedicated watch), got %d: %v", shardCount+1, len(allConns), allConns)
+	}
+	watchConns := 0
+	for addr := range allConns {
+		if _, usedByCreates := createConns[addr]; !usedByCreates {
+			watchConns++
+		}
+	}
+	if watchConns != 1 {
+		t.Errorf("expected exactly 1 connection exclusive to the watch client, got %d", watchConns)
+	}
+}

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -98,6 +98,11 @@ type PhaseSummary struct {
 
 	Latency LatencyBreakdown `json:"latency"`
 
+	// TimeToAllReadySeconds is first Create call -> last observed Ready, set
+	// only when every record in the phase became Ready. It is the headline
+	// metric for the claims-warm burst (how long until ALL claims are Ready).
+	TimeToAllReadySeconds *float64 `json:"timeToAllReadySeconds,omitempty"`
+
 	CreateThroughput *ThroughputStats `json:"createThroughput,omitempty"`
 	ReadyThroughput  *ThroughputStats `json:"readyThroughput,omitempty"`
 
@@ -114,6 +119,10 @@ type Summary struct {
 	Config    Config          `json:"config"`
 	Cluster   *ClusterInfo    `json:"cluster,omitempty"`
 	Phases    []*PhaseSummary `json:"phases"` // ordered by run sequence
+	// APFVerification records which APF flow schema / priority level the
+	// harness's claim POSTs classified into (preflight dry-run; claims
+	// phases only). The create-ack calibration contract is Exempt=true.
+	APFVerification *APFVerification `json:"apfVerification,omitempty"`
 }
 
 // Config holds the test parameters.
@@ -147,13 +156,41 @@ type Config struct {
 	// elapsed (0 = count-based only).
 	ThroughputMinSeconds float64 `json:"throughputMinSeconds"`
 
+	// ClaimsWarmCount sizes the claims-warm phase: the SandboxWarmPool replica
+	// count and the number of SandboxClaims fired simultaneously against it.
+	// The cluster needs ClaimsWarmCount spare pod slots for the pool itself,
+	// and up to ~2x transiently while the pool replenishes claimed sandboxes.
+	ClaimsWarmCount int `json:"claimsWarmCount"`
+
+	// ClientConnections shards the harness's own mutating requests across N
+	// HTTP/2 connections (1 = share the watches' single connection, the
+	// historical behavior). The apiserver caps ~100 concurrent streams per
+	// connection, so wide create bursts on one connection queue inside the
+	// harness and inflate measured create-ack; see clientconns.go.
+	ClientConnections int `json:"clientConnections"`
+
 	CollectMetrics  bool          `json:"collectMetrics"`
 	MetricsInterval time.Duration `json:"metricsIntervalNanos"`
 
 	// ProfileAPIServer captures a kube-apiserver CPU profile during each
 	// throughput level (pprof-apiserver-<phase>.pprof).
 	ProfileAPIServer bool `json:"profileAPIServer"`
+
+	// ProfileController captures agent-sandbox-controller CPU and heap
+	// profiles DURING the claims-warm burst (pprof-controller-*.pprof);
+	// requires the controller to run with --enable-pprof / --enable-pprof-debug.
+	ProfileController bool `json:"profileController"`
 }
+
+// GVRs shared by the watchers and the claims-warm phase (the extension GVRs
+// exist only when the extensions controller is deployed; see hasClaimsPhase).
+var (
+	gvrNamespaces       = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	gvrSandboxes        = schema.GroupVersionResource{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"}
+	gvrSandboxTemplates = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxtemplates"}
+	gvrSandboxWarmPools = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxwarmpools"}
+	gvrSandboxClaims    = schema.GroupVersionResource{Group: "extensions.agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxclaims"}
+)
 
 func main() {
 	// Setup context that cancels on timeout or signal
@@ -176,16 +213,19 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.Timeout, "timeout", 30*time.Minute, "Timeout for the entire test run")
 	flag.DurationVar(&cfg.PerSandboxTimeout, "per-sandbox-timeout", 5*time.Minute, "Timeout for a single sandbox to become ready / be deleted")
 	flag.IntVar(&cfg.CreateConcurrency, "create-concurrency", 20, "Number of concurrent workers creating Sandboxes (fill and throughput phases)")
-	phasesFlag := flag.String("phases", "probe,throughput-mif50", "Comma-separated phase names to run in order (fill, probe, throughput-mifN). Structured forms like throughput{maxInFlight:N} may be added later")
+	phasesFlag := flag.String("phases", "probe,throughput-mif50", "Comma-separated phase names to run in order (fill, probe, claims-warm, throughput-mifN). Structured forms like throughput{maxInFlight:N} may be added later")
 	flag.IntVar(&cfg.FillPerNode, "fill-per-node", 10, "Number of long-running background Sandboxes per worker node for the fill phase")
 	flag.IntVar(&cfg.ProbeCount, "probe-count", 20, "Number of latency probe Sandboxes for the probe phase")
 	flag.IntVar(&cfg.ProbeConcurrency, "probe-concurrency", 1, "Number of concurrent latency probes; keep low for clean latency numbers")
 	flag.DurationVar(&cfg.ProbeInterval, "probe-interval", 0, "Delay between latency probes")
 	flag.IntVar(&cfg.ThroughputCount, "throughput-count", 200, "Number of Sandboxes to churn per throughput phase (before --throughput-min-seconds)")
 	flag.Float64Var(&cfg.ThroughputMinSeconds, "throughput-min-seconds", 45, "Minimum duration of each throughput phase; levels churn beyond -throughput-count until this much time has elapsed (0 = count-based only)")
+	flag.IntVar(&cfg.ClaimsWarmCount, "claims-warm-count", 300, "Warm pool size and number of simultaneous SandboxClaims for the claims-warm phase (requires the extensions controller)")
+	flag.IntVar(&cfg.ClientConnections, "client-connections", 1, "Shard the harness's mutating API requests across N HTTP/2 connections; 1 = single connection shared with watches (historical behavior, subject to the apiserver's ~100-streams-per-connection cap)")
 	flag.BoolVar(&cfg.CollectMetrics, "collect-metrics", true, "Whether to scrape Prometheus metrics from the control plane, the sandbox controller, and kubelets to metrics.jsonl.gz")
 	flag.DurationVar(&cfg.MetricsInterval, "metrics-interval", 15*time.Second, "Interval between Prometheus metrics scrapes")
 	flag.BoolVar(&cfg.ProfileAPIServer, "profile-apiserver", true, "Capture a kube-apiserver CPU profile during each throughput level (pprof-apiserver-<phase>.pprof)")
+	flag.BoolVar(&cfg.ProfileController, "profile-controller", true, "Capture agent-sandbox-controller CPU+heap profiles during the claims-warm burst (best-effort; the controller must run with --enable-pprof / --enable-pprof-debug)")
 	flag.Parse()
 
 	for part := range strings.SplitSeq(*phasesFlag, ",") {
@@ -201,8 +241,11 @@ func run(ctx context.Context) error {
 	if cfg.Timeout <= 0 || cfg.PerSandboxTimeout <= 0 {
 		return fmt.Errorf("timeouts must be > 0: timeout=%v per-sandbox-timeout=%v", cfg.Timeout, cfg.PerSandboxTimeout)
 	}
-	if cfg.FillPerNode < 0 || cfg.ProbeCount < 0 || cfg.ThroughputCount < 0 {
-		return fmt.Errorf("counts must be >= 0: fill-per-node=%d probe=%d throughput=%d", cfg.FillPerNode, cfg.ProbeCount, cfg.ThroughputCount)
+	if cfg.FillPerNode < 0 || cfg.ProbeCount < 0 || cfg.ThroughputCount < 0 || cfg.ClaimsWarmCount < 0 {
+		return fmt.Errorf("counts must be >= 0: fill-per-node=%d probe=%d throughput=%d claims-warm=%d", cfg.FillPerNode, cfg.ProbeCount, cfg.ThroughputCount, cfg.ClaimsWarmCount)
+	}
+	if cfg.ClientConnections < 1 {
+		return fmt.Errorf("--client-connections must be >= 1, got %d", cfg.ClientConnections)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
@@ -232,6 +275,39 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("failed to build dynamic client: %w", err)
 	}
 
+	// Mutating requests (creates/deletes) optionally get their own sharded
+	// connections so wide create bursts neither queue on the apiserver's
+	// ~100-streams-per-connection HTTP/2 cap nor congest the watch streams
+	// that timestamp Ready. --client-connections=1 keeps the historical
+	// single shared connection (mutateClient == dynamicClient).
+	mutateClient := dynamicClient
+	if cfg.ClientConnections > 1 {
+		mutateConfig := rest.CopyConfig(restConfig)
+		if err := configureCreateConnections(mutateConfig, cfg.ClientConnections); err != nil {
+			return fmt.Errorf("failed to configure create-path connections: %w", err)
+		}
+		mutateClient, err = dynamic.NewForConfig(mutateConfig)
+		if err != nil {
+			return fmt.Errorf("failed to build sharded mutate client: %w", err)
+		}
+		log.Printf("Mutating requests sharded across %d dedicated HTTP/2 connections (watches keep their own connection)", cfg.ClientConnections)
+	}
+	// Connection calibration: the apiserver caps each HTTP/2 connection at
+	// ~100 concurrent streams, so a create burst wider than 100*connections
+	// queues on the client's own transport and inflates the measured
+	// create-ack without touching the server. The widest burst is
+	// create-concurrency for the sandbox phases, and the full claim count
+	// for claims-warm (all claims fire at once, not concurrency-capped).
+	// Warn instead of failing: a run may deliberately probe that shape.
+	burstWidth := cfg.CreateConcurrency
+	if hasClaimsPhase(cfg.Phases) && cfg.ClaimsWarmCount > burstWidth {
+		burstWidth = cfg.ClaimsWarmCount
+	}
+	if minConns := (burstWidth + 99) / 100; cfg.ClientConnections < minConns {
+		log.Printf("WARNING: --client-connections=%d < ceil(max create burst %d / 100)=%d — create-ack latency will include client-side HTTP/2 stream queueing",
+			cfg.ClientConnections, burstWidth, minConns)
+	}
+
 	clusterInfo, err := inspectCluster(ctx, restConfig, dynamicClient)
 	if err != nil {
 		return fmt.Errorf("failed to inspect cluster: %w", err)
@@ -247,7 +323,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Create namespace
-	nsClient := dynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"})
+	nsClient := dynamicClient.Resource(gvrNamespaces)
 	nsObj := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -274,6 +350,15 @@ func run(ctx context.Context) error {
 		}()
 	}
 
+	// APF preflight (claims phases only): verify the harness's claim POSTs
+	// classify into the exempt priority level before any latency-bearing
+	// phase runs; the verdict is logged and recorded in summary.json.
+	var apfVerification *APFVerification
+	if hasClaimsPhase(cfg.Phases) {
+		apfVerification = verifyClaimPostPriorityLevel(ctx, restConfig, cfg.Namespace)
+		logAPFVerification(apfVerification)
+	}
+
 	tracker := NewTracker()
 	taskRunner := NewTaskRunner(cancel)
 
@@ -293,27 +378,37 @@ func run(ctx context.Context) error {
 		{Group: "", Version: "v1", Resource: "events"},
 		{Group: "agents.x-k8s.io", Version: "v1beta1", Resource: "sandboxes"},
 	}
+	// Only watch SandboxClaims when a claims phase runs: the extensions
+	// CRDs may not be installed otherwise, and a missing CRD would make the
+	// watcher retry-loop for the whole run.
+	if hasClaimsPhase(cfg.Phases) {
+		gvrList = append(gvrList, gvrSandboxClaims)
+	}
+
+	// recordEvent builds the shared watch callback: milestone tracking first
+	// (cheap and time-sensitive), then the watch log write.
+	recordEvent := func(gvr schema.GroupVersionResource) func(event WatchEventRecord) error {
+		return func(event WatchEventRecord) error {
+			if u, ok := event.Object.(*unstructured.Unstructured); ok {
+				tracker.HandleWatchEvent(gvr.Resource, event.Type, u)
+			} else if event.Object != nil {
+				return fmt.Errorf("unhandled type in event %T", event.Object)
+			}
+
+			if writeToFileChannel != nil {
+				select {
+				case writeToFileChannel <- event:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		}
+	}
 
 	for _, gvr := range gvrList {
 		taskRunner.RunAsync(ctx, func(ctx context.Context) error {
-			return watchResource(ctx, dynamicClient, gvr, func(event WatchEventRecord) error {
-				// Update milestone tracking first: it is cheap and time-sensitive,
-				// while the file write may block briefly on the writer.
-				if u, ok := event.Object.(*unstructured.Unstructured); ok {
-					tracker.HandleWatchEvent(gvr.Resource, event.Type, u)
-				} else if event.Object != nil {
-					return fmt.Errorf("unhandled type in event %T", event.Object)
-				}
-
-				if writeToFileChannel != nil {
-					select {
-					case writeToFileChannel <- event:
-					case <-ctx.Done():
-						return ctx.Err()
-					}
-				}
-				return nil
-			})
+			return watchResource(ctx, dynamicClient, gvr, recordEvent(gvr))
 		})
 	}
 
@@ -365,16 +460,29 @@ func run(ctx context.Context) error {
 		}
 	}
 
+	// CPU/heap-profile the sandbox controller during the claims phases
+	// (the controller is the suspected bottleneck of the adoption path).
+	var ctrlProfiler *controllerProfiler
+	if cfg.ProfileController && hasClaimsPhase(cfg.Phases) {
+		ctrlProfiler, err = newControllerProfiler(restConfig, cfg.OutputDir)
+		if err != nil {
+			return fmt.Errorf("failed to build controller profiler: %w", err)
+		}
+	}
+
+	// All mutating clients are built from mutateClient (sharded when
+	// --client-connections > 1); the watches above stay on dynamicClient.
 	test := &stressTest{
-		cfg:       cfg,
-		tracker:   tracker,
-		namespace: cfg.Namespace,
-		profiler:  profiler,
-		sandboxClient: dynamicClient.Resource(schema.GroupVersionResource{
-			Group:    "agents.x-k8s.io",
-			Version:  "v1beta1",
-			Resource: "sandboxes",
-		}).Namespace(cfg.Namespace),
+		cfg:            cfg,
+		tracker:        tracker,
+		namespace:      cfg.Namespace,
+		profiler:       profiler,
+		ctrlProfiler:   ctrlProfiler,
+		mutateClient:   mutateClient,
+		sandboxClient:  mutateClient.Resource(gvrSandboxes).Namespace(cfg.Namespace),
+		templateClient: mutateClient.Resource(gvrSandboxTemplates).Namespace(cfg.Namespace),
+		warmPoolClient: mutateClient.Resource(gvrSandboxWarmPools).Namespace(cfg.Namespace),
+		claimClient:    mutateClient.Resource(gvrSandboxClaims).Namespace(cfg.Namespace),
 	}
 
 	phaseRuns, err := buildPhaseRuns(test)
@@ -414,6 +522,7 @@ func run(ctx context.Context) error {
 
 	// Write outputs even if a phase failed: partial data is still useful.
 	summary := buildSummary(runID, testStartTime, cfg, clusterInfo, tracker, phaseResults)
+	summary.APFVerification = apfVerification
 	if err := writeOutputs(cfg.OutputDir, summary, tracker); err != nil {
 		if phaseErr == nil {
 			phaseErr = err
@@ -478,10 +587,17 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 			runs = append(runs, phaseRun{number, PhaseProbe, func(ctx context.Context) error {
 				return test.runProbePhase(ctx, number)
 			}})
+		case raw == string(PhaseClaimsWarm):
+			if test.cfg.ClaimsWarmCount <= 0 {
+				return nil, fmt.Errorf("phase %q requires --claims-warm-count > 0", raw)
+			}
+			runs = append(runs, phaseRun{number, PhaseClaimsWarm, func(ctx context.Context) error {
+				return test.runClaimsWarmPhase(ctx, number)
+			}})
 		default:
 			maxInFlight, ok := throughputMaxInFlight(raw)
 			if !ok {
-				return nil, fmt.Errorf("unknown phase %q (want fill, probe, or throughput-mifN)", raw)
+				return nil, fmt.Errorf("unknown phase %q (want fill, probe, claims-warm, or throughput-mifN)", raw)
 			}
 			if test.cfg.ThroughputCount <= 0 {
 				return nil, fmt.Errorf("phase %q requires --throughput-count > 0", raw)
@@ -507,6 +623,12 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 	return runs, nil
 }
 
+// hasClaimsPhase reports whether any phase needs the SandboxClaim machinery
+// (claim watch, extensions CRDs, controller profiler).
+func hasClaimsPhase(phases []string) bool {
+	return slices.Contains(phases, string(PhaseClaimsWarm))
+}
+
 // throughputMaxInFlight parses throughput / throughput-mifN phase names.
 func throughputMaxInFlight(name string) (int, bool) {
 	if name == string(PhaseThroughput) {
@@ -529,11 +651,20 @@ func throughputMaxInFlight(name string) (int, bool) {
 // pipeline, so the run would not test what it claims to test.
 //
 // Phases run sequentially, so peak concurrent test pods is fill plus the
-// larger of the probe/throughput in-flight caps (fill sandboxes stay up).
+// largest of the probe/claims-warm/throughput in-flight caps (fill sandboxes
+// stay up). The claims-warm pool needs its full replica count in pods; on top
+// of that the warm pool controller replenishes claimed sandboxes, so the
+// phase can transiently reach ~2x its count — that overshoot is warned about
+// rather than required, because replenishment pods only queue (they do not
+// delay the claims being measured) and cleanup removes them.
 func checkClusterCapacity(cfg Config, info *ClusterInfo) error {
 	extra := 0
 	if slices.Contains(cfg.Phases, string(PhaseProbe)) && cfg.ProbeConcurrency > extra {
 		extra = cfg.ProbeConcurrency
+	}
+	claimsWarm := slices.Contains(cfg.Phases, string(PhaseClaimsWarm))
+	if claimsWarm && cfg.ClaimsWarmCount > extra {
+		extra = cfg.ClaimsWarmCount
 	}
 	for _, name := range cfg.Phases {
 		if maxInFlight, ok := throughputMaxInFlight(name); ok && maxInFlight > extra {
@@ -551,9 +682,12 @@ func checkClusterCapacity(cfg Config, info *ClusterInfo) error {
 	}
 	switch {
 	case needed > spare:
-		return fmt.Errorf("test needs up to %d concurrent pods but the cluster only has %d spare pod slots; results would measure capacity queueing, not launch performance. Reduce --fill-per-node / throughput-mifN or add nodes", needed, spare)
+		return fmt.Errorf("test needs up to %d concurrent pods but the cluster only has %d spare pod slots; results would measure capacity queueing, not launch performance. Reduce --fill-per-node / --claims-warm-count / throughput-mifN or add nodes", needed, spare)
 	case spare > 0 && needed > spare*9/10:
 		log.Printf("WARNING: test needs up to %d concurrent pods, over 90%% of the %d spare pod slots; scheduling may interfere with measurements.", needed, spare)
+	}
+	if claimsWarm && 2*cfg.ClaimsWarmCount > spare {
+		log.Printf("WARNING: claims-warm pool replenishment can transiently need up to %d pods (2x --claims-warm-count) but only %d spare pod slots exist; replenishment pods will queue on capacity. Add nodes or reduce --claims-warm-count.", 2*cfg.ClaimsWarmCount, spare)
 	}
 	return nil
 }
@@ -636,6 +770,8 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 			return cfg.FillCount
 		case PhaseProbe:
 			return cfg.ProbeCount
+		case PhaseClaimsWarm:
+			return cfg.ClaimsWarmCount
 		default:
 			// Throughput phases (one per throughput-mifN entry).
 			return cfg.ThroughputCount
@@ -663,12 +799,13 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 		// real request.
 		req := max(requested(result.name), len(phaseRecords))
 		ps := &PhaseSummary{
-			Number:             result.number,
-			Name:               string(result.name),
-			Requested:          req,
-			DurationSeconds:    result.duration.Seconds(),
-			StartOffsetSeconds: result.offset.Seconds(),
-			Latency:            computeLatencyBreakdown(phaseRecords),
+			Number:                result.number,
+			Name:                  string(result.name),
+			Requested:             req,
+			DurationSeconds:       result.duration.Seconds(),
+			StartOffsetSeconds:    result.offset.Seconds(),
+			Latency:               computeLatencyBreakdown(phaseRecords),
+			TimeToAllReadySeconds: computeTimeToAllReady(phaseRecords),
 		}
 		var createTimes, readyTimes []time.Time
 		for i := range phaseRecords {
@@ -827,6 +964,19 @@ func printReport(summary *Summary, clusterInfo *ClusterInfo) {
 		case PhaseProbe:
 			fmt.Println("  Launch latency breakdown:")
 			printBreakdown(ps.Latency)
+		case PhaseClaimsWarm:
+			// Claim records have no pod milestones (the pods were pre-warmed),
+			// so only the claim-level intervals are meaningful. CreateAck
+			// isolates the client's Create call from controller binding
+			// latency (both are also in sandboxes.jsonl per claim).
+			fmt.Printf("  claim create ack (apiserver):    %s\n", formatLatency(ps.Latency.CreateAck))
+			fmt.Printf("  claim create -> claim Ready:     %s\n", formatLatency(ps.Latency.EndToEndReady))
+			if ps.TimeToAllReadySeconds != nil {
+				fmt.Printf("  time until ALL claims Ready:     %.2fs\n", *ps.TimeToAllReadySeconds)
+			} else {
+				fmt.Printf("  time until ALL claims Ready:     n/a (not all claims became Ready)\n")
+			}
+			fmt.Printf("  claim ready throughput:          %s\n", formatThroughput(ps.ReadyThroughput))
 		default:
 			fmt.Printf("  end-to-end ready latency:        %s\n", formatLatency(ps.Latency.EndToEndReady))
 			fmt.Printf("  create throughput:               %s\n", formatThroughput(ps.CreateThroughput))
@@ -861,6 +1011,7 @@ func getRestConfig() (*rest.Config, error) {
 // watchResource will watch the given resource until the context is cancelled, or the callback function returns an error.
 func watchResource(ctx context.Context, dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, callback func(event WatchEventRecord) error) error {
 	var resourceVersion string
+	iface := dynamicClient.Resource(gvr)
 
 	for {
 		select {
@@ -874,7 +1025,7 @@ func watchResource(ctx context.Context, dynamicClient dynamic.Interface, gvr sch
 			ResourceVersion: resourceVersion,
 		}
 
-		watcher, err := dynamicClient.Resource(gvr).Watch(ctx, listOptions)
+		watcher, err := iface.Watch(ctx, listOptions)
 		if err != nil {
 			select {
 			case <-ctx.Done():

--- a/test/stress/phases.go
+++ b/test/stress/phases.go
@@ -31,13 +31,30 @@ import (
 
 // stressTest bundles the shared state used by the test phases.
 type stressTest struct {
-	cfg           Config
-	tracker       *Tracker
+	cfg     Config
+	tracker *Tracker
+	// mutateClient issues all of the harness's mutating requests (creates
+	// and deletes). With --client-connections=1 it shares the watch client's
+	// single HTTP/2 connection (historical behavior); with N>1 its requests
+	// are sharded over N dedicated connections so create bursts neither
+	// queue on the ~100-stream per-connection cap nor congest the watches
+	// (see clientconns.go).
+	mutateClient  dynamic.Interface
 	sandboxClient dynamic.ResourceInterface
-	namespace     string
+	// Extensions clients (extensions.agents.x-k8s.io/v1beta1), used by the
+	// claims-warm phases. The extensions controller must be deployed
+	// (deploy-to-kube --extensions) for those phases to work.
+	templateClient dynamic.ResourceInterface
+	warmPoolClient dynamic.ResourceInterface
+	claimClient    dynamic.ResourceInterface
+	namespace      string
 	// profiler captures apiserver CPU profiles during throughput levels
 	// (nil when --profile-apiserver is false).
 	profiler *apiserverProfiler
+	// ctrlProfiler captures controller CPU/heap profiles during the
+	// claims-warm burst (nil when --profile-controller is false or the
+	// phase does not run).
+	ctrlProfiler *controllerProfiler
 }
 
 // buildSandboxObject returns a minimal long-running Sandbox.
@@ -297,4 +314,330 @@ func (s *stressTest) runThroughputLevel(ctx context.Context, name Phase, number 
 	counts := s.tracker.Snapshot()[number]
 	log.Printf("[%s#%d] done: %d created, %d ready, %d failed", name, number, counts.Created, counts.Ready, counts.Failed)
 	return nil
+}
+
+// extensionsGroupVersion is the API group/version of the SandboxTemplate,
+// SandboxWarmPool, and SandboxClaim extension resources.
+const extensionsGroupVersion = "extensions.agents.x-k8s.io/v1beta1"
+
+// buildTemplateObject returns a minimal SandboxTemplate wrapping the same
+// long-running pod spec used by the raw-sandbox phases (see buildSandboxObject
+// for why the command traps SIGTERM and the token mount is disabled).
+func buildTemplateObject(id types.NamespacedName, image string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": extensionsGroupVersion,
+			"kind":       "SandboxTemplate",
+			"metadata": map[string]any{
+				"name":      id.Name,
+				"namespace": id.Namespace,
+			},
+			"spec": map[string]any{
+				// Explicitly service-free: no per-sandbox headless Service,
+				// so pool churn costs no Service/EndpointSlice writes. This
+				// pins the current default (unset spec.service also skips
+				// creation) so the benchmark stays service-free even if the
+				// field's defaulting ever changes.
+				"service": false,
+				"podTemplate": map[string]any{
+					"spec": map[string]any{
+						"restartPolicy":                 "Never",
+						"terminationGracePeriodSeconds": int64(1),
+						"automountServiceAccountToken":  false,
+						"containers": []any{
+							map[string]any{
+								"name":            "main",
+								"image":           image,
+								"imagePullPolicy": "IfNotPresent",
+								"command":         []string{"sh", "-c", "trap 'exit 0' TERM INT; sleep infinity & wait"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildWarmPoolObject returns a SandboxWarmPool of the given size backed by
+// the given SandboxTemplate.
+func buildWarmPoolObject(id types.NamespacedName, templateName string, replicas int) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": extensionsGroupVersion,
+			"kind":       "SandboxWarmPool",
+			"metadata": map[string]any{
+				"name":      id.Name,
+				"namespace": id.Namespace,
+			},
+			"spec": map[string]any{
+				"replicas": int64(replicas),
+				"sandboxTemplateRef": map[string]any{
+					"name": templateName,
+				},
+			},
+		},
+	}
+}
+
+// buildClaimObject returns a SandboxClaim against the given warm pool.
+func buildClaimObject(id types.NamespacedName, poolName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": extensionsGroupVersion,
+			"kind":       "SandboxClaim",
+			"metadata": map[string]any{
+				"name":      id.Name,
+				"namespace": id.Namespace,
+			},
+			"spec": map[string]any{
+				"warmPoolRef": map[string]any{
+					"name": poolName,
+				},
+			},
+		},
+	}
+}
+
+// createClaim registers a record and issues the SandboxClaim Create call via
+// the given (namespace-bound) client. Like createSandbox, Create errors are
+// recorded on the record rather than aborting the phase.
+func (s *stressTest) createClaim(ctx context.Context, claimClient dynamic.ResourceInterface, id types.NamespacedName, poolName string, phase Phase, number PhaseNumber) error {
+	claim := buildClaimObject(id, poolName)
+	s.tracker.RegisterClaim(id, phase, number)
+	_, err := claimClient.Create(ctx, claim, metav1.CreateOptions{})
+	s.tracker.MarkCreateReturned(id, err)
+	if err != nil {
+		log.Printf("[%s] failed to create claim %s: %v", phase, id.Name, err)
+	}
+	return err
+}
+
+// waitWarmPoolReady polls the pool (via the given namespace-bound client)
+// until status.readyReplicas >= want, so the claim phases measure binding
+// latency against a fully provisioned pool rather than sandbox launch
+// latency. Progress-stall detection mirrors the fill phase: if readyReplicas
+// stops advancing for PerSandboxTimeout, fail.
+func (s *stressTest) waitWarmPoolReady(ctx context.Context, poolClient dynamic.ResourceInterface, phase Phase, poolName string, want int, number PhaseNumber) error {
+	lastReady := int64(-1)
+	lastProgress := time.Now()
+	for {
+		pool, err := poolClient.Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("[%s#%d] failed to get warm pool %s: %w", phase, number, poolName, err)
+		}
+		ready, _, err := unstructured.NestedInt64(pool.Object, "status", "readyReplicas")
+		if err != nil {
+			return fmt.Errorf("[%s#%d] failed to read warm pool status: %w", phase, number, err)
+		}
+		if ready >= int64(want) {
+			log.Printf("[%s#%d] warm pool %s ready: %d/%d replicas", phase, number, poolName, ready, want)
+			return nil
+		}
+		if ready != lastReady {
+			lastReady = ready
+			lastProgress = time.Now()
+		}
+		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
+			return fmt.Errorf("[%s#%d] warm pool stalled: %d/%d replicas ready with no progress for %v", phase, number, ready, want, s.cfg.PerSandboxTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// runClaimsWarmPhase measures SandboxClaim -> Ready latency against a fully
+// provisioned warm pool: it creates a SandboxTemplate and a SandboxWarmPool of
+// ClaimsWarmCount replicas, waits for every replica to be Ready (pool
+// provisioning is setup, not measurement), then fires ClaimsWarmCount claims
+// as simultaneously as possible (one goroutine per claim, released together)
+// and waits for every claim to be observed Ready.
+//
+// Metrics: the summary's CreateAck stats isolate the claim Create call
+// (apiserver write path) from EndToEndReady (create -> claim Ready=True by
+// watch); TimeToAllReadySeconds is first-create -> last-ready. Each record
+// also carries the claim Ready condition's lastTransitionTime
+// (serverSandboxReady in sandboxes.jsonl) as a server-side cross-check.
+//
+// Capacity: the pool itself needs ClaimsWarmCount pod slots, and the pool
+// controller replenishes claimed sandboxes, so up to ~2x ClaimsWarmCount pods
+// can transiently exist during and after the burst. Size the cluster with
+// headroom (see checkClusterCapacity's warning) or throttle replenishment via
+// --sandbox-warm-pool-concurrent-workers.
+func (s *stressTest) runClaimsWarmPhase(ctx context.Context, number PhaseNumber) error {
+	count := s.cfg.ClaimsWarmCount
+	if count == 0 {
+		return nil
+	}
+
+	templateID := types.NamespacedName{Name: fmt.Sprintf("p%d-claims-template", number), Namespace: s.namespace}
+	poolID := types.NamespacedName{Name: fmt.Sprintf("p%d-claims-pool", number), Namespace: s.namespace}
+
+	log.Printf("[%s#%d] provisioning warm pool %s with %d replicas", PhaseClaimsWarm, number, poolID.Name, count)
+	if _, err := s.templateClient.Create(ctx, buildTemplateObject(templateID, s.cfg.Image), metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("[%s#%d] failed to create sandbox template: %w", PhaseClaimsWarm, number, err)
+	}
+	if _, err := s.warmPoolClient.Create(ctx, buildWarmPoolObject(poolID, templateID.Name, count), metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("[%s#%d] failed to create warm pool: %w", PhaseClaimsWarm, number, err)
+	}
+
+	ids := make([]types.NamespacedName, 0, count)
+	for i := range count {
+		ids = append(ids, types.NamespacedName{Name: fmt.Sprintf("p%d-claim-%d", number, i), Namespace: s.namespace})
+	}
+
+	// Clean up the claims, the pool, and the template even when the phase
+	// fails partway: later phases assume the cluster's spare capacity is back.
+	defer s.cleanupClaimsWarm(ctx, number, ids, poolID, templateID)
+
+	if err := s.waitWarmPoolReady(ctx, s.warmPoolClient, PhaseClaimsWarm, poolID.Name, count, number); err != nil {
+		return err
+	}
+
+	// Fire all claims at once: one goroutine per claim, all released by a
+	// single channel close so the creates hit the apiserver as close to
+	// simultaneously as the client allows (rate limiting is disabled).
+	log.Printf("[%s#%d] firing %d claims simultaneously", PhaseClaimsWarm, number, count)
+
+	// Profile the burst itself, not the aftermath: the controller CPU
+	// profile window opens right as claim creation begins (the adoption
+	// transaction is over within the first seconds), with heap snapshots
+	// bracketing the burst. The apiserver profile runs over the same window
+	// to correlate server-side cost. All best-effort. The phase can finish
+	// well inside the 15s profile window (that is the goal), so the deferred
+	// Wait keeps the process alive until the profiles are written.
+	var profileWG sync.WaitGroup
+	defer profileWG.Wait()
+	if s.ctrlProfiler != nil {
+		profileWG.Go(func() { s.ctrlProfiler.CaptureCPUProfile(ctx, PhaseClaimsWarm, 0, 15*time.Second) })
+		profileWG.Go(func() { s.ctrlProfiler.CaptureHeapProfile(ctx, PhaseClaimsWarm, "burst-start") })
+	}
+	if s.profiler != nil {
+		profileWG.Go(func() { s.profiler.CaptureCPUProfile(ctx, PhaseClaimsWarm, 0, 15*time.Second) })
+	}
+
+	release := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		wg.Go(func() {
+			<-release
+			// Errors are recorded per-claim; do not abort the phase.
+			_ = s.createClaim(ctx, s.claimClient, id, poolID.Name, PhaseClaimsWarm, number)
+		})
+	}
+	close(release)
+	wg.Wait()
+
+	// Wait for all successfully-created claims to be observed Ready, with
+	// the same progress-stall detection as the fill phase.
+	lastReady := -1
+	lastProgress := time.Now()
+	for {
+		counts := s.tracker.Snapshot()[number]
+		if counts.Created == 0 {
+			return fmt.Errorf("[%s#%d] all %d claim creations failed", PhaseClaimsWarm, number, counts.Failed)
+		}
+		if counts.Ready >= counts.Created {
+			log.Printf("[%s#%d] all %d created claims are Ready (%d failed to create)",
+				PhaseClaimsWarm, number, counts.Created, counts.Failed)
+			if s.ctrlProfiler != nil {
+				// Post-burst heap snapshot: diff against burst-start to see
+				// what the adoption path allocated/retained.
+				s.ctrlProfiler.CaptureHeapProfile(ctx, PhaseClaimsWarm, "burst-end")
+			}
+			return nil
+		}
+		if counts.Ready != lastReady {
+			lastReady = counts.Ready
+			lastProgress = time.Now()
+		}
+		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
+			return fmt.Errorf("[%s#%d] stalled: %d/%d claims Ready with no progress for %v", PhaseClaimsWarm, number, counts.Ready, counts.Created, s.cfg.PerSandboxTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// cleanupClaimsWarm deletes the claims, the pool, and the template, then
+// waits (best-effort) for the pool- and claim-owned sandboxes to go away so
+// later phases start from the same spare capacity. Failures are logged, not
+// returned: like probe/throughput deletes, cleanup problems should not mask
+// the phase's measurement, and namespace deletion is the backstop.
+func (s *stressTest) cleanupClaimsWarm(ctx context.Context, number PhaseNumber, ids []types.NamespacedName, poolID, templateID types.NamespacedName) {
+	if ctx.Err() != nil {
+		// Shutting down; namespace cleanup will remove remaining objects.
+		return
+	}
+	log.Printf("[%s#%d] cleaning up %d claims, pool %s, template %s", PhaseClaimsWarm, number, len(ids), poolID.Name, templateID.Name)
+
+	_, _ = ForkJoin(ctx, ids, max(s.cfg.CreateConcurrency, 1), func(id types.NamespacedName) (struct{}, error) {
+		if err := s.claimClient.Delete(ctx, id.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("[%s#%d] failed to delete claim %s: %v", PhaseClaimsWarm, number, id.Name, err)
+		}
+		return struct{}{}, nil
+	})
+
+	if err := s.warmPoolClient.Delete(ctx, poolID.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		log.Printf("[%s#%d] failed to delete warm pool %s: %v", PhaseClaimsWarm, number, poolID.Name, err)
+	}
+	if err := s.templateClient.Delete(ctx, templateID.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		log.Printf("[%s#%d] failed to delete template %s: %v", PhaseClaimsWarm, number, templateID.Name, err)
+	}
+
+	// Wait for the sandboxes owned by the pool or the claims to be deleted,
+	// so their pods stop occupying capacity that a later phase counts on.
+	// Best-effort: on timeout we log and move on.
+	lastRemaining := -1
+	lastProgress := time.Now()
+	for {
+		remaining, err := s.countOwnedSandboxes(ctx)
+		if err != nil {
+			log.Printf("[%s#%d] failed to list sandboxes during cleanup: %v", PhaseClaimsWarm, number, err)
+			return
+		}
+		if remaining == 0 {
+			log.Printf("[%s#%d] cleanup complete", PhaseClaimsWarm, number)
+			return
+		}
+		if remaining != lastRemaining {
+			lastRemaining = remaining
+			lastProgress = time.Now()
+		}
+		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
+			log.Printf("[%s#%d] WARNING: %d pool/claim-owned sandboxes still present after %v; later phases may see reduced spare capacity", PhaseClaimsWarm, number, remaining, s.cfg.PerSandboxTimeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+// countOwnedSandboxes counts sandboxes in the test namespace owned by a
+// SandboxWarmPool or SandboxClaim. Fill-phase sandboxes have no owner and are
+// excluded: they are supposed to stay up.
+func (s *stressTest) countOwnedSandboxes(ctx context.Context) (int, error) {
+	list, err := s.sandboxClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for i := range list.Items {
+		for _, ref := range list.Items[i].GetOwnerReferences() {
+			if ref.Kind == "SandboxWarmPool" || ref.Kind == "SandboxClaim" {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
 }

--- a/test/stress/pprof.go
+++ b/test/stress/pprof.go
@@ -21,8 +21,10 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -81,4 +83,110 @@ func (p *apiserverProfiler) CaptureCPUProfile(ctx context.Context, phase Phase, 
 		return
 	}
 	log.Printf("[pprof] captured apiserver CPU profile for %s (%d bytes)", phase, len(raw))
+}
+
+// controllerProfiler captures CPU and heap profiles from the agent-sandbox
+// controller's pprof endpoints, which live on the metrics port (:8080) when
+// the controller runs with --enable-pprof (CPU) / --enable-pprof-debug
+// (heap and the other debug profiles). Endpoints are reached through the
+// apiserver pod proxy, so no direct pod network path is needed and the same
+// admin kubeconfig used for everything else suffices.
+//
+// All captures are best-effort: a controller deployed without the pprof
+// flags just yields a logged 404 and the run continues.
+type controllerProfiler struct {
+	kube      *kubernetes.Clientset
+	outputDir string
+}
+
+const (
+	controllerNamespace   = "agent-sandbox-system"
+	controllerPodSelector = "app=agent-sandbox-controller"
+	controllerMetricsPort = 8080
+)
+
+func newControllerProfiler(restConfig *rest.Config, outputDir string) (*controllerProfiler, error) {
+	kube, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("building kubernetes client: %w", err)
+	}
+	return &controllerProfiler{kube: kube, outputDir: outputDir}, nil
+}
+
+// podNames lists the current controller pods. With leader election only one
+// does the work, but profiling every replica is cheap and avoids guessing
+// the leader.
+func (p *controllerProfiler) podNames(ctx context.Context) []string {
+	pods, err := p.kube.CoreV1().Pods(controllerNamespace).List(ctx, metav1.ListOptions{LabelSelector: controllerPodSelector})
+	if err != nil {
+		log.Printf("[pprof] listing controller pods: %v", err)
+		return nil
+	}
+	names := make([]string, 0, len(pods.Items))
+	for i := range pods.Items {
+		names = append(names, pods.Items[i].Name)
+	}
+	return names
+}
+
+func (p *controllerProfiler) capture(ctx context.Context, pod, endpoint, outFile string, params map[string]string) {
+	req := p.kube.CoreV1().RESTClient().Get().
+		AbsPath(fmt.Sprintf("/api/v1/namespaces/%s/pods/http:%s:%d/proxy/debug/pprof/%s",
+			controllerNamespace, pod, controllerMetricsPort, endpoint))
+	for k, v := range params {
+		req = req.Param(k, v)
+	}
+	raw, err := req.DoRaw(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("[pprof] controller %s profile from %s failed: %v", endpoint, pod, err)
+		}
+		return
+	}
+	path := filepath.Join(p.outputDir, outFile)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		log.Printf("[pprof] writing %s: %v", path, err)
+		return
+	}
+	log.Printf("[pprof] captured controller %s profile from %s (%d bytes)", endpoint, pod, len(raw))
+}
+
+// CaptureCPUProfile records one CPU profile of the given duration from every
+// controller pod, starting after delay. Synchronous; run in a goroutine
+// alongside the phase so the profile window covers the load being measured
+// (e.g. delay=0 started right as the claims burst fires).
+// Analyze with: go tool pprof -top pprof-controller-<phase>-<pod>.pprof.
+func (p *controllerProfiler) CaptureCPUProfile(ctx context.Context, phase Phase, delay, duration time.Duration) {
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, duration+30*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, pod := range p.podNames(ctx) {
+		wg.Go(func() {
+			p.capture(ctx, pod, "profile",
+				fmt.Sprintf("pprof-controller-%s-%s.pprof", phase, pod),
+				map[string]string{"seconds": strconv.Itoa(int(duration.Seconds()))})
+		})
+	}
+	wg.Wait()
+}
+
+// CaptureHeapProfile snapshots the heap profile of every controller pod
+// (requires --enable-pprof-debug). label distinguishes multiple snapshots
+// within one phase (e.g. burst-start vs burst-end).
+// Analyze with: go tool pprof -top -sample_index=inuse_space <file>.
+func (p *controllerProfiler) CaptureHeapProfile(ctx context.Context, phase Phase, label string) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	for _, pod := range p.podNames(ctx) {
+		p.capture(ctx, pod, "heap",
+			fmt.Sprintf("pprof-controller-heap-%s-%s-%s.pprof", phase, label, pod), nil)
+	}
 }

--- a/test/stress/stats.go
+++ b/test/stress/stats.go
@@ -123,6 +123,35 @@ func computeLatencyBreakdown(records []SandboxRecord) LatencyBreakdown {
 	}
 }
 
+// computeTimeToAllReady returns the seconds from the first Create call to the
+// last observed Ready across the given records: how long until every request
+// in the batch was Ready. It returns nil when there are no records or when
+// any record failed to reach Ready (the batch never became "all ready").
+//
+// This is the headline metric for burst phases like claims-warm, where all
+// creates are issued at once and the question is when the last claim became
+// Ready, not just the per-claim percentiles.
+func computeTimeToAllReady(records []SandboxRecord) *float64 {
+	if len(records) == 0 {
+		return nil
+	}
+	var firstCreate, lastReady time.Time
+	for i := range records {
+		rec := &records[i]
+		if rec.CreateCalled.IsZero() || rec.SandboxReady.IsZero() {
+			return nil
+		}
+		if firstCreate.IsZero() || rec.CreateCalled.Before(firstCreate) {
+			firstCreate = rec.CreateCalled
+		}
+		if rec.SandboxReady.After(lastReady) {
+			lastReady = rec.SandboxReady
+		}
+	}
+	seconds := lastReady.Sub(firstCreate).Seconds()
+	return &seconds
+}
+
 // ThroughputStats summarizes the rate at which a set of events occurred.
 type ThroughputStats struct {
 	Count           int     `json:"count"`

--- a/test/stress/stats_test.go
+++ b/test/stress/stats_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// rec builds a SandboxRecord with CreateCalled/SandboxReady at the given
+// offsets from base (negative offset = field left zero).
+func rec(base time.Time, createOffset, readyOffset time.Duration) SandboxRecord {
+	r := SandboxRecord{}
+	if createOffset >= 0 {
+		r.CreateCalled = base.Add(createOffset)
+	}
+	if readyOffset >= 0 {
+		r.SandboxReady = base.Add(readyOffset)
+	}
+	return r
+}
+
+func TestComputeTimeToAllReady(t *testing.T) {
+	base := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		records []SandboxRecord
+		want    *float64 // nil means "expect nil"
+	}{
+		{
+			name:    "no records",
+			records: nil,
+			want:    nil,
+		},
+		{
+			name: "single record",
+			records: []SandboxRecord{
+				rec(base, 0, 1500*time.Millisecond),
+			},
+			want: new(1.5),
+		},
+		{
+			name: "spans first create to last ready",
+			records: []SandboxRecord{
+				rec(base, 100*time.Millisecond, 2*time.Second),
+				rec(base, 0, 5*time.Second), // earliest create, latest ready
+				rec(base, 200*time.Millisecond, 3*time.Second),
+			},
+			want: new(5.0),
+		},
+		{
+			name: "last ready not on last created",
+			records: []SandboxRecord{
+				rec(base, 0, 10*time.Second),
+				rec(base, time.Second, 2*time.Second),
+			},
+			want: new(10.0),
+		},
+		{
+			name: "one record never ready",
+			records: []SandboxRecord{
+				rec(base, 0, 2*time.Second),
+				rec(base, 0, -1), // ready never observed
+			},
+			want: nil,
+		},
+		{
+			name: "record without create call",
+			records: []SandboxRecord{
+				rec(base, -1, 2*time.Second),
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeTimeToAllReady(tc.records)
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("computeTimeToAllReady() = %v, want %v", fmtPtr(got), fmtPtr(tc.want))
+			}
+			if got != nil && math.Abs(*got-*tc.want) > 1e-9 {
+				t.Errorf("computeTimeToAllReady() = %v, want %v", *got, *tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeLatencyBreakdownClaimRecords(t *testing.T) {
+	// Claim records only have CreateCalled/CreateReturned/SandboxReady set
+	// (no pod milestones); the breakdown must expose CreateAck and
+	// EndToEndReady and leave the pod-stage intervals nil.
+	base := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	records := []SandboxRecord{
+		{
+			CreateCalled:   base,
+			CreateReturned: base.Add(50 * time.Millisecond),
+			SandboxReady:   base.Add(2 * time.Second),
+		},
+		{
+			CreateCalled:   base.Add(10 * time.Millisecond),
+			CreateReturned: base.Add(40 * time.Millisecond),
+			SandboxReady:   base.Add(4*time.Second + 10*time.Millisecond),
+		},
+	}
+
+	b := computeLatencyBreakdown(records)
+
+	if b.CreateAck == nil || b.CreateAck.Count != 2 {
+		t.Fatalf("CreateAck = %+v, want count 2", b.CreateAck)
+	}
+	if got, want := b.CreateAck.MaxMs, 50.0; math.Abs(got-want) > 1e-6 {
+		t.Errorf("CreateAck.MaxMs = %v, want %v", got, want)
+	}
+	if b.EndToEndReady == nil || b.EndToEndReady.Count != 2 {
+		t.Fatalf("EndToEndReady = %+v, want count 2", b.EndToEndReady)
+	}
+	if got, want := b.EndToEndReady.MaxMs, 4000.0; math.Abs(got-want) > 1e-6 {
+		t.Errorf("EndToEndReady.MaxMs = %v, want %v", got, want)
+	}
+	for name, stats := range map[string]*LatencyStats{
+		"CreateToPodCreated":     b.CreateToPodCreated,
+		"PodCreatedToScheduled":  b.PodCreatedToScheduled,
+		"ScheduledToPodRunning":  b.ScheduledToPodRunning,
+		"PodRunningToPodReady":   b.PodRunningToPodReady,
+		"PodReadyToSandboxReady": b.PodReadyToSandboxReady,
+	} {
+		if stats != nil {
+			t.Errorf("%s = %+v, want nil (claim records have no pod milestones)", name, stats)
+		}
+	}
+}
+
+func TestComputeLatencyStatsPercentiles(t *testing.T) {
+	// 1..100 ms: nearest-rank percentiles are exact.
+	var durations []time.Duration
+	for i := 1; i <= 100; i++ {
+		durations = append(durations, time.Duration(i)*time.Millisecond)
+	}
+
+	stats := computeLatencyStats(durations)
+	if stats == nil {
+		t.Fatal("computeLatencyStats() = nil, want stats")
+	}
+	checks := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"Count", float64(stats.Count), 100},
+		{"MinMs", stats.MinMs, 1},
+		{"MeanMs", stats.MeanMs, 50.5},
+		{"P50Ms", stats.P50Ms, 50},
+		{"P90Ms", stats.P90Ms, 90},
+		{"P99Ms", stats.P99Ms, 99},
+		{"MaxMs", stats.MaxMs, 100},
+	}
+	for _, c := range checks {
+		if math.Abs(c.got-c.want) > 1e-6 {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+
+	if got := computeLatencyStats(nil); got != nil {
+		t.Errorf("computeLatencyStats(nil) = %+v, want nil", got)
+	}
+}
+
+func fmtPtr(f *float64) any {
+	if f == nil {
+		return "<nil>"
+	}
+	return *f
+}

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -38,6 +38,9 @@ const (
 	PhaseProbe Phase = "probe"
 	// PhaseThroughput sandboxes are churned (create -> ready -> delete) to measure sustained throughput.
 	PhaseThroughput Phase = "throughput"
+	// PhaseClaimsWarm fires SandboxClaims simultaneously against a fully
+	// provisioned SandboxWarmPool, measuring claim-create -> claim-Ready latency.
+	PhaseClaimsWarm Phase = "claims-warm"
 )
 
 // PhaseNumber is a 1-based index into the run's phase list (Config.Phases /
@@ -105,7 +108,20 @@ type SandboxRecord struct {
 	NodeName    string `json:"nodeName,omitempty"`
 	ContainerID string `json:"containerID,omitempty"`
 
+	// BoundSandbox is set for claims-warm records only: the name of the warm
+	// Sandbox the SandboxClaim was bound to (status.sandbox.name), for joining
+	// against the sandboxes/pods watch streams offline. The pool names its
+	// sandboxes itself, so claim records never correlate with pod milestones
+	// by name the way raw-sandbox records do.
+	BoundSandbox string `json:"boundSandbox,omitempty"`
+
 	// Client-observed milestones.
+	//
+	// For claims-warm records the tracked object is a SandboxClaim rather
+	// than a Sandbox: CreateCalled/CreateReturned bracket the claim Create
+	// call, SandboxReady is the claim observed with condition Ready=True,
+	// and SandboxDeleted is the claim's watch DELETED event. Pod milestones
+	// stay zero (the backing pod belongs to a pool-named Sandbox).
 	CreateCalled    time.Time `json:"createCalled,omitzero"`    // just before the Create API call
 	CreateReturned  time.Time `json:"createReturned,omitzero"`  // Create API call returned successfully
 	PodCreated      time.Time `json:"podCreated,omitzero"`      // first watch event for the backing Pod
@@ -127,6 +143,14 @@ type SandboxRecord struct {
 	ServerSandboxReady   time.Time `json:"serverSandboxReady,omitzero"`   // sandbox Ready condition lastTransitionTime
 
 	Error string `json:"error,omitempty"`
+
+	// isClaim marks records whose tracked object is a SandboxClaim. The claim
+	// controller's cold-start fallback creates a Sandbox (and thus a Pod)
+	// named after the claim, so without this marker a cold-started claim's
+	// sandbox/pod watch events would stamp sandbox milestones onto the claim
+	// record and under-report adoption latency (the Sandbox turns Ready
+	// before the claim does).
+	isClaim bool
 
 	ready *Future[bool]
 	gone  *Future[bool]
@@ -161,6 +185,16 @@ func (t *Tracker) Register(id types.NamespacedName, name Phase, number PhaseNumb
 	rec.gone = newFuture[bool]()
 	t.mu.Lock()
 	t.records[id] = rec
+	t.mu.Unlock()
+	return rec
+}
+
+// RegisterClaim is Register for a SandboxClaim: the record's milestones are
+// driven by the sandboxclaims watch only (see SandboxRecord.isClaim).
+func (t *Tracker) RegisterClaim(id types.NamespacedName, name Phase, number PhaseNumber) *SandboxRecord {
+	rec := t.Register(id, name, number)
+	t.mu.Lock()
+	rec.isClaim = true
 	t.mu.Unlock()
 	return rec
 }
@@ -319,6 +353,55 @@ func (t *Tracker) HandleWatchEvent(resource string, eventType watch.EventType, u
 		t.handleSandboxEvent(eventType, u)
 	case "pods":
 		t.handlePodEvent(eventType, u)
+	case "sandboxclaims":
+		t.handleClaimEvent(eventType, u)
+	}
+}
+
+// handleClaimEvent updates claims-warm records from SandboxClaim watch events.
+// Claim milestones are stored in the shared SandboxRecord fields (see the
+// field comments): the claim's Ready condition marks SandboxReady, so the
+// existing summary/report pipeline treats claim readiness like sandbox
+// readiness. Records share one map across resources; the isClaim marker
+// keeps claim records and sandbox/pod records from cross-talking when names
+// collide (the cold-start fallback names its Sandbox after the claim).
+func (t *Tracker) handleClaimEvent(eventType watch.EventType, u *unstructured.Unstructured) {
+	id := types.NamespacedName{Name: u.GetName(), Namespace: u.GetNamespace()}
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	rec, ok := t.records[id]
+	if !ok || !rec.isClaim {
+		return
+	}
+
+	if eventType == watch.Deleted {
+		if rec.SandboxDeleted.IsZero() {
+			rec.SandboxDeleted = now
+		}
+		// Claims never share a name with a tracked pod, so the claim's
+		// deletion is the last event we will see for this record.
+		rec.gone.Done(true)
+		return
+	}
+
+	if rec.ServerSandboxCreated.IsZero() {
+		rec.ServerSandboxCreated = u.GetCreationTimestamp().Time
+	}
+
+	if rec.BoundSandbox == "" {
+		if name, _, _ := unstructured.NestedString(u.Object, "status", "sandbox", "name"); name != "" {
+			rec.BoundSandbox = name
+		}
+	}
+
+	if ready, ltt := conditionTrue(u, "Ready"); ready && rec.SandboxReady.IsZero() {
+		rec.SandboxReady = now
+		// Server-side cross-check: the claim Ready condition's
+		// lastTransitionTime (1s granularity, controller clock).
+		rec.ServerSandboxReady = ltt
+		rec.ready.Done(true)
 	}
 }
 
@@ -329,7 +412,9 @@ func (t *Tracker) handleSandboxEvent(eventType watch.EventType, u *unstructured.
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	rec, ok := t.records[id]
-	if !ok {
+	if !ok || rec.isClaim {
+		// A same-named Sandbox next to a claim record means the claim
+		// cold-started; its milestones must come from the claim itself.
 		return
 	}
 
@@ -368,7 +453,9 @@ func (t *Tracker) handlePodEvent(eventType watch.EventType, u *unstructured.Unst
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	rec, ok := t.records[id]
-	if !ok {
+	if !ok || rec.isClaim {
+		// Claim records take no pod milestones, even from a same-named
+		// cold-start pod (see handleSandboxEvent).
 		return
 	}
 


### PR DESCRIPTION
## What this PR does

Adds a **`claims-warm` phase** to the stress harness (`test/stress`) plus a **dedicated benchmark scenario/CI wiring** for it, so changes to the SandboxClaim / warm-pool adoption path get their own latency signal on PRs.

There is significant in-flight optimization work on the claim adoption path (see the warm-adoption performance investigation on the aditya-shantanu fork, `perf-investigation-master`, where this phase originates and was exercised at 300-claim bursts). The goal here is to land the **measuring instrument first**, so that work can be split into reviewable PRs whose impact each shows up as a before/after in this benchmark.

### The phase

`claims-warm` measures warm-pool adoption, not sandbox launch:

1. Create a SandboxTemplate + SandboxWarmPool of `--claims-warm-count` (default 300) replicas and wait for every replica Ready — **setup, untimed**.
2. Fire `--claims-warm-count` SandboxClaims simultaneously (one goroutine per claim, released together).
3. Report per-claim **create-ack** and **create → claim-Ready** percentiles, plus **time until ALL claims are Ready** (`timeToAllReadySeconds`, the headline burst metric). Each record carries `boundSandbox` (`status.sandbox.name`) for offline joins against the sandbox/pod watch streams.

### Measurement-honesty pieces that ride along

- `--client-connections=N`: shards the harness's own mutating requests across N HTTP/2 connections. The apiserver caps ~100 concurrent streams per connection, so a 300-wide burst on one connection queues in the load generator and inflates measured create-ack. Watches keep their own connection. Default 1 = exact historical behavior.
- **APF preflight**: one server-side dry-run claim create through a header-capturing transport records which FlowSchema/PriorityLevel harness POSTs classify into (`summary.apfVerification`). The calibration contract is the exempt level; a queued PL would silently poison create-ack numbers. Never fails the run.
- `--profile-controller` (claims phases only, best-effort): controller CPU profile over the burst window + heap snapshots bracketing it.
- Claim records are tagged internally so a cold-started claim (whose fallback Sandbox/Pod share the claim's name) cannot have sandbox/pod watch events mis-stamp its milestones and under-report adoption latency.

### Scenario + CI wiring

- `test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run`: claims-warm only, 6 worker nodes (the adoption burst never cold-starts pods, so it is controller/control-plane bound, not node bound), `--client-connections=4`, controller deployed with `--enable-pprof-debug`.
- `dev/ci/presubmits/benchmarks-kops-gcp-claims` + periodic alias, following the existing `benchmarks-kops-gcp-cilium` pattern. Prow job entries in kubernetes/test-infra are a follow-up PR.
- Shared `benchmarks-kops-gcp/run` gains `STRESS_CLAIMS_WARM`, `STRESS_EXTRA_ARGS`, and `CONTROLLER_ARGS` passthroughs (all default to prior behavior).

### Non-goals / follow-ups

- The sustained-rate variant (`claims-warm-sustained`, Poisson arrivals with rolling-window percentiles) is deliberately excluded to keep this reviewable; it is the natural follow-up once the burst phase lands.
- No changes to existing phases: with claims-warm absent from `--phases`, flag defaults keep the SandboxClaim watch off and the client construction byte-identical, so current benchmark numbers are unaffected. `generate_report.py` needs no changes (its schema-pinned scans already tolerate claim watch events).

### Testing

- `go build` / `go vet` / `go test ./test/stress/` green (new unit tests for the stats, APF header capture, and connection sharding).
- Existing-phase behavior verified unchanged against the pre-PR tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `claims-warm` benchmark phase for burst testing sandbox claims and warm pools.
  - Added `--claims-warm-count` and `--client-connections` controls to tune workload size and sharding.
  - Added APF preflight verification for claim POST priority classification.
  - Added optional controller CPU/heap profiling during claims runs.
  - Added “time to all ready” reporting for claims warmup.
- **Bug Fixes**
  - Improved tracking, watch recording, and cleanup for claim-based benchmark lifecycle.
- **Tests**
  - Added automated coverage for connection sharding, APF header capture, and claims readiness/latency metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->