### PR TITLE
examples: add firecracker-sandbox (Kata + Firecracker)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**containarium-ssh-sandbox**](./containarium-ssh-sandbox): An example of running Containarium's agent-box runtime in a Sandbox, reached over SSH with an in-container MCP server (no kube-apiserver token held by the agent).
+- [**firecracker-sandbox**](./firecracker-sandbox): An example of running a sandbox on Kata Containers with the Firecracker VMM (`kata-fc`) plus an envd-compatible runtime that matches the E2B data-plane contract.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
 - [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 120 to 200 pods per node.
 - [**hello-world-sandbox**](./hello-world-sandbox): A simple "Hello World" sandbox example.

--- a/examples/firecracker-sandbox/Dockerfile
+++ b/examples/firecracker-sandbox/Dockerfile
@@ -1,0 +1,34 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+# Prepare a workspace directory the runtime can safely confine file I/O to.
+RUN mkdir -p /workspace && chown -R 1000:1000 /app /workspace
+
+USER 1000
+
+# The sandbox runtime API port.
+EXPOSE 8888
+
+ENV SANDBOX_WORKSPACE=/workspace
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8888"]

--- a/examples/firecracker-sandbox/README.md
+++ b/examples/firecracker-sandbox/README.md
@@ -1,0 +1,203 @@
+# Firecracker Sandbox
+
+## Overview
+
+This example shows how to run an Agent Sandbox on top of
+[Kata Containers with the Firecracker VMM](https://github.com/kata-containers/kata-containers)
+(`kata-fc`). The result is a microVM-isolated sandbox that boots in roughly
+**125 ms** with a minimal memory footprint — a much better density story than
+the QEMU-based `kata-qemu` runtime for serverless-style workloads.
+
+The sandbox container runs a small Python runtime (a
+[FastAPI](https://fastapi.tiangolo.com/) server on port `8888`) that exposes
+an HTTP API for driving the sandbox — see the [Architecture](#architecture)
+diagram below for the full endpoint list.
+
+## Architecture
+
+```text
+   Python client / k8s_agent_sandbox SDK
+          │
+          │  HTTP (port 8888)
+          │  ───── port-forward ─── OR ─── sandbox-router (X-Sandbox-ID) ───┐
+          │                                                                 │
+          ▼                                                                 │
+   Firecracker Pod (kata-fc)                                                │
+   ┌──────────────────────────────┐                                         │
+   │  sandbox runtime (main.py)   │◀────────────────────────────────────────┘
+   │  - GET  /health              │
+   │  - GET  /metrics             │
+   │  - POST /init                │
+   │  - GET  /envs                │
+   │  - GET  /files               │
+   │  - POST /files               │
+   │  - POST /exec                │
+   └──────────────────────────────┘
+          ▲
+          │
+   agent-sandbox controller
+   (creates SandboxClaim / Sandbox from SandboxTemplate + SandboxWarmPool)
+```
+
+## Prerequisites
+
+1. A **Linux** node with **hardware virtualization (KVM)** — this is a hard
+   requirement of Kata Containers + Firecracker; **macOS and Windows hosts
+   cannot run kata-fc** (they do not expose `/dev/kvm`). You can verify on
+   the target node with `ls /dev/kvm` and `kvm-ok` (or
+   `egrep -c '(vmx|svm)' /proc/cpuinfo` for CPU flag support). On GCP this
+   means an **N2** instance with
+   [nested virtualization enabled](https://cloud.google.com/compute/docs/instances/nested-virtualization/managing-constraint);
+   on bare metal, enable VT-x or AMD-V in the BIOS and load the KVM kernel
+   modules (`modprobe kvm && modprobe kvm_intel` or `kvm_amd`).
+2. A **container runtime with devmapper** (or another thin-provisioning
+   snapshotter that Firecracker can use). Firecracker does **not** support
+   overlayfs / virtio-fs for the rootfs, so a stock `containerd` with the
+   default overlayfs snapshotter will fail at pod-sandbox creation
+   (`FailedCreatePodSandBox ... ENOENT`). On a custom node, configure
+   containerd's `[plugins."io.containerd.snapshotter.v1.devmapper"]` or use
+   a kata-deploy distribution that bundles a compatible snapshotter. You can
+   verify with `ctr -n k8s.io snapshots ls | grep devmapper` or by
+   confirming `containerd` was started with the devmapper plugin enabled.
+3. A Kubernetes cluster with the agent-sandbox controller installed
+   (see the top-level [`README.md`](../../README.md)).
+4. [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to talk to
+   the cluster.
+5. Docker (or compatible builder) to build the runtime image, and a way to
+   push it somewhere the cluster can pull from.
+
+## Step 1 — Install the agent-sandbox controller
+
+Follow the [installation guide](../../README.md#installation) to install the
+controller and CRDs into the cluster.
+
+## Step 2 — Prepare the nodes
+
+Run [`setup.sh`](./setup.sh) on a **Linux host with KVM access** to install
+Kata Containers via `kata-deploy`, register the `kata-fc` RuntimeClass, and
+label the nodes:
+
+```shell
+./setup.sh                       # defaults: kata 3.2.0, label kata-firecracker=true
+./setup.sh --kata-version 3.6.0  # or pin a specific version
+```
+
+The script verifies `/dev/kvm` is present before doing anything destructive.
+
+## Step 3 — Build and push the runtime image
+
+```shell
+export IMAGE=<registry>/firecracker-sandbox:latest
+docker build -t ${IMAGE} .
+docker push    ${IMAGE}
+```
+
+For a local kind cluster you can skip the push and just `kind load docker-image`:
+
+```shell
+kind load docker-image ${IMAGE}
+```
+
+## Step 4 — Create the SandboxTemplate and Warmpool
+
+```shell
+envsubst < sandbox-template-firecracker.yaml | kubectl apply -f -
+```
+
+This creates:
+
+* `SandboxTemplate/firecracker-runtime-template` — the pod spec that will be
+  materialized for each sandbox.
+* `SandboxWarmPool/firecracker-runtime-warmpool` — keeps 2 warm microVMs ready
+  for instant claim.
+
+Verify the pool is populated:
+
+```shell
+kubectl get sandboxtemplate,sandboxwarmpool,sandbox
+```
+
+## Step 5 — (Optional) deploy a single bare Sandbox
+
+If you just want a one-off sandbox without the warm pool:
+
+```shell
+envsubst < sandbox-firecracker.yaml | kubectl apply -f -
+kubectl get sandbox firecracker-example
+```
+
+## Step 6 — Verify the runtime
+
+Confirm the pod is running under `kata-fc`:
+
+```shell
+kubectl get pod -l sandbox=firecracker -o jsonpath='{.items[0].spec.runtimeClassName}'
+# expected: kata-fc
+```
+
+## Step 7 — Run the verification script
+
+The script talks to the HTTP API exposed by the sandbox pod over plain
+HTTP (no SDK dependencies):
+
+```shell
+# Port-forward the runtime endpoint of the warm pod
+POD=$(kubectl get pod -l sandbox=firecracker -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward pod/$POD 8888:8888 &
+PF_PID=$!
+trap 'kill $PF_PID 2>/dev/null' EXIT
+
+# Wait until the local endpoint is reachable before running the client
+for i in $(seq 1 30); do
+  curl -sf http://127.0.0.1:8888/health >/dev/null 2>&1 && break
+  sleep 0.2
+done
+
+export SANDBOX_BASE_URL=http://127.0.0.1:8888
+pip install requests
+python test_client.py
+```
+
+> **Note:** This example's runtime uses a deliberately minimal endpoint
+> contract (`/exec`, `/files`) that differs from the reference
+> [`python-runtime-sandbox`](../python-runtime-sandbox/) (`/execute`,
+> `/upload`, `/download`). The `k8s_agent_sandbox` Python SDK targets the
+> latter contract, so this verification script only covers the direct-HTTP
+> transport.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `0/1 nodes are available: ... predicate mismatch` | Node not labeled | Run `setup.sh` again, or `kubectl label node <name> kata-firecracker=true` |
+| `Failed to create pod sandbox: ... kata-fc` | RuntimeClass not registered | `kubectl get runtimeclass kata-fc`; rerun `setup.sh` if missing |
+| `/dev/kvm not found` | KVM module not loaded | See [Prerequisites](#prerequisites) — load the KVM kernel modules on the target node |
+| Pod stuck in `ContainerCreating` on kind/minikube | Image not loaded into the node | `kind load docker-image ...` or `minikube image load ...` |
+| `port-forward` fails with `no endpoints` | Warmpool has no ready replicas | Wait for `SandboxWarmPool` status to show `readyReplicas: 2` |
+
+## Cleanup
+
+Delete the example's own resources:
+
+```shell
+kubectl delete sandbox firecracker-example   # if deployed directly
+kubectl delete sandboxwarmpool firecracker-runtime-warmpool
+kubectl delete sandboxtemplate firecracker-runtime-template
+```
+
+> **Administrator-only — shared cluster resources.** `RuntimeClass/kata-fc` and
+> the `kata-deploy` DaemonSet are cluster-wide; other workloads and sandbox
+> examples may depend on them. Only delete them when you are sure nothing else
+> needs Kata on this cluster:
+>
+> ```shell
+> kubectl delete runtimeclass kata-fc         # removes the kata-fc RuntimeClass
+> kubectl delete -n kube-system daemonset kata-deploy  # uninstalls Kata from nodes
+> ```
+
+## Related
+
+* [`kata-gke-sandbox`](../kata-gke-sandbox/) — the QEMU-based Kata example
+* [`python-runtime-sandbox`](../python-runtime-sandbox/) — the reference Python runtime
+* [#1237](https://github.com/kubernetes-sigs/agent-sandbox/issues/1237) — Guest Coordination Protocol
+* [Kata Containers — Firecracker](https://github.com/kata-containers/kata-containers/tree/main/docs/design/arch-images#firecracker)

--- a/examples/firecracker-sandbox/README.md
+++ b/examples/firecracker-sandbox/README.md
@@ -16,7 +16,7 @@ diagram below for the full endpoint list.
 ## Architecture
 
 ```text
-   Python client / k8s_agent_sandbox SDK
+   Control plane / HTTP client
           │
           │  HTTP (port 8888)
           │  ───── port-forward ─── OR ─── sandbox-router (X-Sandbox-ID) ───┐
@@ -57,8 +57,8 @@ diagram below for the full endpoint list.
    (`FailedCreatePodSandBox ... ENOENT`). On a custom node, configure
    containerd's `[plugins."io.containerd.snapshotter.v1.devmapper"]` or use
    a kata-deploy distribution that bundles a compatible snapshotter. You can
-   verify with `ctr -n k8s.io snapshots ls | grep devmapper` or by
-   confirming `containerd` was started with the devmapper plugin enabled.
+   verify with `ctr plugins ls | grep devmapper` and require the status to
+   be `ok`.
 3. A Kubernetes cluster with the agent-sandbox controller installed
    (see the top-level [`README.md`](../../README.md)).
 4. [`kubectl`](https://kubernetes.io/docs/tasks/tools/) configured to talk to

--- a/examples/firecracker-sandbox/main.py
+++ b/examples/firecracker-sandbox/main.py
@@ -1,0 +1,283 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sandbox runtime for agent-sandbox.
+
+A lightweight HTTP API exposed inside every Firecracker sandbox pod. Clients
+(the verification script, the ``k8s_agent_sandbox`` Python SDK, or any HTTP
+tool) call these endpoints to drive the sandbox:
+
+  GET  /health       -> 204
+  GET  /metrics      -> cgroup CPU / memory / IO stats
+  POST /init         -> accept env vars / timestamp sync
+  GET  /envs         -> current environment variables
+  GET  /files        -> download a file  (?path=...)
+  POST /files        -> upload a file    (multipart or JSON)
+  POST /exec         -> execute a shell command -> {stdout, stderr, exit_code}
+
+The server is intentionally small — it only covers the endpoints exercised by
+the example's test client.
+
+.. note::
+
+    This API has **no in-process authentication**. Port 8888 must only be
+    reachable through ``kubectl port-forward`` or ``sandbox-router``
+    (``X-Sandbox-ID`` header) and must **never** be published directly to a
+    public or untrusted network.
+"""
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
+from fastapi.responses import FileResponse, JSONResponse, Response
+from pydantic import BaseModel, Field
+
+WORKSPACE = Path(os.environ.get("SANDBOX_WORKSPACE", "/workspace"))
+WORKSPACE.mkdir(parents=True, exist_ok=True)
+
+# Custom env vars set via /init are stored here and merged into /envs responses.
+_user_env: Dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+class ExecRequest(BaseModel):
+    """Request body for POST /exec."""
+    cmd: str
+    args: Optional[List[str]] = None
+    env: Optional[Dict[str, str]] = None
+    cwd: Optional[str] = None
+    timeout: float = Field(default=30.0, gt=0, le=300)
+
+
+class ExecResponse(BaseModel):
+    """Response body for POST /exec."""
+    stdout: str
+    stderr: str
+    exit_code: int
+
+
+class InitRequest(BaseModel):
+    """Request body for POST /init (time + env sync)."""
+    envs: Optional[Dict[str, str]] = None
+    timestamp: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _safe_path(raw: str) -> Path:
+    """Resolve *raw* against WORKSPACE and ensure it does not escape it."""
+    if os.path.isabs(raw):
+        candidate = Path(raw)
+    else:
+        candidate = (WORKSPACE / raw).resolve()
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(WORKSPACE.resolve())
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail="path escapes workspace") from exc
+    return resolved
+
+
+def _read_cgroup_file(*parts: str) -> Optional[str]:
+    """Read a cgroup v2 file, returning None on any failure."""
+    path = Path("/sys/fs/cgroup", *parts)
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def _collect_metrics() -> dict:
+    """Collect a minimal set of cgroup v2 stats."""
+    metrics: dict = {"timestamp": time.time()}
+
+    cpu = _read_cgroup_file("cpu.stat")
+    if cpu:
+        cpu_stats: Dict[str, float] = {}
+        for line in cpu.splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                try:
+                    cpu_stats[parts[0]] = float(parts[1])
+                except ValueError:
+                    pass
+        metrics["cpu"] = cpu_stats
+
+    mem = _read_cgroup_file("memory.current")
+    if mem is not None:
+        try:
+            metrics["memory_bytes"] = int(mem)
+        except ValueError:
+            pass
+
+    mem_peak = _read_cgroup_file("memory.peak")
+    if mem_peak is not None:
+        try:
+            metrics["memory_peak_bytes"] = int(mem_peak)
+        except ValueError:
+            pass
+
+    io = _read_cgroup_file("io.stat")
+    if io:
+        metrics["io"] = io.splitlines()
+
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+app = FastAPI(
+    title="Firecracker sandbox runtime",
+    description="HTTP API exposed inside a Firecracker sandbox pod.",
+    version="0.1.0",
+)
+
+
+@app.get("/health", summary="Health probe")
+async def health() -> Response:
+    """Return 204 No Content when the runtime is up."""
+    return Response(status_code=204)
+
+
+@app.get("/metrics", summary="Cgroup metrics")
+def metrics() -> JSONResponse:
+    """Return a snapshot of cgroup v2 stats for the sandbox process."""
+    return JSONResponse(_collect_metrics())
+
+
+@app.post("/init", summary="Initialize runtime (env + time sync)")
+async def init(req: InitRequest) -> JSONResponse:
+    """Accept env vars and an optional timestamp from the control-plane."""
+    if req.envs:
+        _user_env.update(req.envs)
+        for key, value in req.envs.items():
+            os.environ[key] = value
+    server_time = time.time()
+    skew = None
+    if req.timestamp is not None:
+        skew = server_time - req.timestamp
+    return JSONResponse({"status": "ok", "server_time": server_time, "skew_seconds": skew})
+
+
+@app.get("/envs", summary="List environment variables")
+async def envs() -> JSONResponse:
+    """Return the environment visible to the runtime.
+
+    This intentionally includes the **full** process environment — not just
+    the vars injected via ``/init`` — so callers can debug what the template
+    and Kubernetes service discovery have provided. The transport-level
+    no-auth warning in the module docstring applies: do not expose this
+    endpoint to untrusted networks.
+    """
+    merged = {**os.environ, **_user_env}
+    return JSONResponse(merged)
+
+
+@app.post("/exec", summary="Execute a shell command", response_model=ExecResponse)
+def exec_command(req: ExecRequest) -> ExecResponse:
+    """Execute *cmd* (optionally with *args*) inside the sandbox workspace.
+
+    stdout/stderr are captured and returned alongside the exit code.
+    """
+    cwd = _safe_path(req.cwd) if req.cwd else WORKSPACE
+    if not cwd.is_dir():
+        raise HTTPException(status_code=400, detail="cwd is not a directory")
+
+    env = {**os.environ, **(req.env or {})}
+
+    # If args are supplied, run them directly (no shell). Otherwise run cmd via
+    # the user's shell, matching `sh -c` semantics.
+    if req.args:
+        argv = [req.cmd, *req.args]
+        use_shell = False
+    else:
+        argv = req.cmd
+        use_shell = True
+
+    try:
+        # Use Popen + start_new_session so we can kill the entire process
+        # group on timeout. subprocess.run() only kills the direct child,
+        # which with shell=True is `/bin/sh -c <cmd>` — its grandchildren
+        # would otherwise leak as orphans.
+        proc = subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            env=env,
+            shell=use_shell,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            stdout, stderr = proc.communicate(timeout=req.timeout)
+        except subprocess.TimeoutExpired:
+            pgid = os.getpgid(proc.pid)
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+            stdout, stderr = proc.communicate()
+            return ExecResponse(
+                stdout=stdout or "",
+                stderr=(stderr or "") + f"\n[timeout after {req.timeout}s]",
+                exit_code=-1,
+            )
+        return ExecResponse(
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=proc.returncode,
+        )
+    except FileNotFoundError as exc:
+        return ExecResponse(stdout="", stderr=str(exc), exit_code=127)
+    except Exception as exc:  # noqa: BLE001
+        return ExecResponse(stdout="", stderr=str(exc), exit_code=1)
+
+
+@app.get("/files", summary="Download a file")
+def download_file(path: str) -> FileResponse:
+    """Download a file from the sandbox workspace."""
+    target = _safe_path(path)
+    if not target.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+    return FileResponse(target, filename=target.name)
+
+
+@app.post("/files", summary="Upload a file")
+def upload_file(
+    path: str = Form(...),
+    file: UploadFile = File(...),
+) -> JSONResponse:
+    """Upload a file into the sandbox workspace."""
+    target = _safe_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("wb") as fh:
+        shutil.copyfileobj(file.file, fh)
+    return JSONResponse({"path": str(target.relative_to(WORKSPACE)), "size": target.stat().st_size})
+
+
+@app.get("/", summary="Root probe")
+async def root() -> JSONResponse:
+    return JSONResponse({"runtime": "firecracker-sandbox", "version": "0.1.0"})

--- a/examples/firecracker-sandbox/main.py
+++ b/examples/firecracker-sandbox/main.py
@@ -16,15 +16,15 @@
 Sandbox runtime for agent-sandbox.
 
 A lightweight HTTP API exposed inside every Firecracker sandbox pod. Clients
-(the verification script, the ``k8s_agent_sandbox`` Python SDK, or any HTTP
-tool) call these endpoints to drive the sandbox:
+(any HTTP client — see the example's ``test_client.py`` for direct-HTTP
+usage) call these endpoints to drive the sandbox:
 
   GET  /health       -> 204
   GET  /metrics      -> cgroup CPU / memory / IO stats
   POST /init         -> accept env vars / timestamp sync
   GET  /envs         -> current environment variables
   GET  /files        -> download a file  (?path=...)
-  POST /files        -> upload a file    (multipart or JSON)
+  POST /files        -> upload a file    (multipart/form-data only)
   POST /exec         -> execute a shell command -> {stdout, stderr, exit_code}
 
 The server is intentionally small — it only covers the endpoints exercised by
@@ -207,9 +207,9 @@ def exec_command(req: ExecRequest) -> ExecResponse:
 
     env = {**os.environ, **(req.env or {})}
 
-    # If args are supplied, run them directly (no shell). Otherwise run cmd via
-    # the user's shell, matching `sh -c` semantics.
-    if req.args:
+    # If args are supplied (even as an empty list), run them directly (no
+    # shell). Otherwise run cmd via the user's shell, matching `sh -c` semantics.
+    if req.args is not None:
         argv = [req.cmd, *req.args]
         use_shell = False
     else:

--- a/examples/firecracker-sandbox/requirements.txt
+++ b/examples/firecracker-sandbox/requirements.txt
@@ -1,5 +1,6 @@
 # Minimal dependency set for the sandbox runtime.
 fastapi>=0.104.0,<1.0.0
 uvicorn>=0.24.0,<1.0.0
+h11>=0.16.0,<1.0.0
 pydantic>=2.5.0,<3.0.0
 python-multipart>=0.0.30

--- a/examples/firecracker-sandbox/requirements.txt
+++ b/examples/firecracker-sandbox/requirements.txt
@@ -1,0 +1,5 @@
+# Minimal dependency set for the sandbox runtime.
+fastapi>=0.104.0,<1.0.0
+uvicorn>=0.24.0,<1.0.0
+pydantic>=2.5.0,<3.0.0
+python-multipart>=0.0.30

--- a/examples/firecracker-sandbox/sandbox-firecracker.yaml
+++ b/examples/firecracker-sandbox/sandbox-firecracker.yaml
@@ -1,0 +1,46 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bare Sandbox CR using the kata-fc RuntimeClass.
+# Useful when you want to deploy a single, hand-crafted sandbox pod.
+#
+# Replace ${IMAGE} with the location of the firecracker-sandbox container image
+# (for example via: envsubst < sandbox-firecracker.yaml | kubectl apply -f -).
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: firecracker-example
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: firecracker
+    spec:
+      runtimeClassName: kata-fc
+      containers:
+      - name: python-runtime
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8888
+          name: http
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+      nodeSelector:
+        kata-firecracker: "true"

--- a/examples/firecracker-sandbox/sandbox-template-firecracker.yaml
+++ b/examples/firecracker-sandbox/sandbox-template-firecracker.yaml
@@ -1,0 +1,57 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SandboxTemplate + SandboxWarmPool pair for Firecracker sandboxes.
+# The warmpool keeps two warm kata-fc pods ready for instant claim.
+#
+# Replace ${IMAGE} with the location of the firecracker-sandbox container image
+# (for example via: envsubst < sandbox-template-firecracker.yaml | kubectl apply -f -).
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: firecracker-runtime-template
+  namespace: default
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: firecracker
+    spec:
+      runtimeClassName: kata-fc
+      containers:
+      - name: python-runtime
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8888
+          name: http
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+      nodeSelector:
+        kata-firecracker: "true"
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: firecracker-runtime-warmpool
+  namespace: default
+spec:
+  replicas: 2
+  sandboxTemplateRef:
+    name: firecracker-runtime-template

--- a/examples/firecracker-sandbox/setup.sh
+++ b/examples/firecracker-sandbox/setup.sh
@@ -75,9 +75,14 @@ if [[ "${CHECK_KVM}" == "true" ]]; then
 
     if [[ ! -r /dev/kvm ]] || [[ ! -w /dev/kvm ]]; then
         echo "Warning: /dev/kvm exists but permissions look incorrect."
-        echo "Try: sudo chmod 666 /dev/kvm"
+        echo "Grant the runtime account access through a dedicated group or udev rule;"
+        echo "do not chmod 666 /dev/kvm."
     fi
     echo "### KVM support detected at /dev/kvm ###"
+    echo ""
+    echo "Note: this check runs on the local machine. For remote clusters, ensure every"
+    echo "      target node has /dev/kvm. A more thorough approach would use a privileged"
+    echo "      DaemonSet probe to validate KVM on each node before labeling."
 else
     echo "### Step 1: Skipped (--skip-kvm-check) ###"
     echo "Ensure every target node has /dev/kvm before scheduling kata-fc pods."

--- a/examples/firecracker-sandbox/setup.sh
+++ b/examples/firecracker-sandbox/setup.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Setup script for Kata Containers with Firecracker (kata-fc) on a Linux node.
+# Installs kata-deploy, registers the kata-fc RuntimeClass, and labels nodes.
+
+set -e
+
+# Defaults
+KATA_VERSION="3.2.0"
+RUNTIME_CLASS_NAME="kata-fc"
+NODE_LABEL_KEY="kata-firecracker"
+NODE_LABEL_VALUE="true"
+LABEL_NODES=true
+INSTALL_KATA=true
+CHECK_KVM=true
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --kata-version)       KATA_VERSION="$2"; shift ;;
+        --runtime-class-name)  RUNTIME_CLASS_NAME="$2"; shift ;;
+        --node-label-key)      NODE_LABEL_KEY="$2"; shift ;;
+        --node-label-value)    NODE_LABEL_VALUE="$2"; shift ;;
+        --no-label)            LABEL_NODES=false ;;
+        --no-install)          INSTALL_KATA=false ;;
+        --skip-kvm-check)      CHECK_KVM=false ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Validate KATA_VERSION format to prevent path traversal
+if [[ ! "$KATA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+    echo "Error: Invalid Kata version format: '${KATA_VERSION}'"
+    echo "Kata version must follow semantic versioning (e.g., 3.2.0 or 3.2.0-rc1)."
+    exit 1
+fi
+
+echo "### Configuration ###"
+echo "KATA_VERSION:        ${KATA_VERSION}"
+echo "RUNTIME_CLASS_NAME:  ${RUNTIME_CLASS_NAME}"
+echo "NODE_LABEL_KEY:      ${NODE_LABEL_KEY}"
+echo "NODE_LABEL_VALUE:    ${NODE_LABEL_VALUE}"
+echo "LABEL_NODES:         ${LABEL_NODES}"
+echo "INSTALL_KATA:        ${INSTALL_KATA}"
+echo "#####################"
+
+#############################################################################
+# Step 1: Verify KVM support
+#############################################################################
+echo "### Step 1: Verifying KVM support ###"
+if [[ "${CHECK_KVM}" == "true" ]]; then
+    if [[ ! -e /dev/kvm ]]; then
+        echo "Error: /dev/kvm not found. Firecracker requires hardware virtualization."
+        echo "Ensure your host CPU supports VT-x/AMD-V and that KVM kernel modules are loaded."
+        echo "Try: sudo modprobe kvm && sudo modprobe kvm_intel (or kvm_amd)"
+        echo ""
+        echo "If you are running this script from a workstation (e.g. macOS) that drives"
+        echo "a remote cluster where nodes do have KVM, pass --skip-kvm-check to bypass."
+        exit 1
+    fi
+
+    if [[ ! -r /dev/kvm ]] || [[ ! -w /dev/kvm ]]; then
+        echo "Warning: /dev/kvm exists but permissions look incorrect."
+        echo "Try: sudo chmod 666 /dev/kvm"
+    fi
+    echo "### KVM support detected at /dev/kvm ###"
+else
+    echo "### Step 1: Skipped (--skip-kvm-check) ###"
+    echo "Ensure every target node has /dev/kvm before scheduling kata-fc pods."
+fi
+
+#############################################################################
+# Step 2: Install Kata Containers with Firecracker via kata-deploy
+#############################################################################
+if [[ "${INSTALL_KATA}" == "true" ]]; then
+    echo "### Step 2: Installing Kata Containers (kata-deploy) ###"
+
+    echo "--- Applying Kata RBAC ---"
+    KATA_RBAC_URL="https://raw.githubusercontent.com/kata-containers/kata-containers/${KATA_VERSION}/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml"
+    echo "Using RBAC URL: ${KATA_RBAC_URL}"
+    kubectl apply -f "${KATA_RBAC_URL}"
+
+    echo "--- Applying kata-deploy DaemonSet ---"
+    KATA_DEPLOY_URL="https://raw.githubusercontent.com/kata-containers/kata-containers/${KATA_VERSION}/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
+    echo "Using Deploy URL: ${KATA_DEPLOY_URL}"
+    kubectl apply -f "${KATA_DEPLOY_URL}"
+
+    echo "--- Waiting for kata-deploy rollout (this may take several minutes) ---"
+    kubectl -n kube-system rollout status daemonset/kata-deploy --timeout=10m
+    echo "### Kata Containers installed ###"
+else
+    echo "### Step 2: Skipped (--no-install) ###"
+fi
+
+#############################################################################
+# Step 3: Register the kata-fc RuntimeClass
+#############################################################################
+echo "### Step 3: Registering RuntimeClass '${RUNTIME_CLASS_NAME}' ###"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: ${RUNTIME_CLASS_NAME}
+handler: ${RUNTIME_CLASS_NAME}
+scheduling:
+  nodeSelector:
+    kubernetes.io/os: linux
+    ${NODE_LABEL_KEY}: "${NODE_LABEL_VALUE}"
+EOF
+
+echo "### RuntimeClass '${RUNTIME_CLASS_NAME}' created ###"
+
+#############################################################################
+# Step 4: Label nodes
+#############################################################################
+if [[ "${LABEL_NODES}" == "true" ]]; then
+    echo "### Step 4: Labeling all Linux nodes with ${NODE_LABEL_KEY}=${NODE_LABEL_VALUE} ###"
+    echo "Note: KVM was only verified on the host running this script."
+    echo "      Ensure every Linux node in the cluster actually has /dev/kvm"
+    echo "      before scheduling kata-fc pods onto them."
+    echo "      Use --no-label to skip this step and label nodes manually."
+    NODES=$(kubectl get nodes -l kubernetes.io/os=linux -o name)
+    if [[ -z "${NODES}" ]]; then
+        echo "Warning: no Linux nodes found; skipping labelling."
+    else
+        for NODE in ${NODES}; do
+            kubectl label "${NODE}" "${NODE_LABEL_KEY}=${NODE_LABEL_VALUE}" --overwrite
+            echo "  labeled ${NODE}"
+        done
+    fi
+else
+    echo "### Step 4: Skipped (--no-label) ###"
+fi
+
+#############################################################################
+# Step 5: Verify installation
+#############################################################################
+echo "### Step 5: Verifying installation ###"
+echo "--- RuntimeClasses ---"
+kubectl get runtimeclasses
+echo ""
+echo "--- Labeled nodes ---"
+kubectl get nodes -l "${NODE_LABEL_KEY}=${NODE_LABEL_VALUE}" -o wide || true
+echo ""
+echo "### Setup complete! ###"
+echo "You can now deploy Firecracker-based Agent Sandboxes using RuntimeClass '${RUNTIME_CLASS_NAME}'."

--- a/examples/firecracker-sandbox/test_client.py
+++ b/examples/firecracker-sandbox/test_client.py
@@ -1,0 +1,167 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Verification script for the firecracker-sandbox example.
+
+Drives the HTTP endpoints exposed by ``main.py`` over plain HTTP. Set
+``SANDBOX_BASE_URL`` to the pod's ``http://<ip>:8888`` URL (typically via
+``kubectl port-forward``). No k8s SDK dependencies required.
+
+Run::
+
+    SANDBOX_BASE_URL=http://127.0.0.1:8888 python test_client.py
+
+Note: this example's runtime uses a deliberately minimal endpoint contract
+(``/exec``, ``/files``) that differs from the reference
+``python-runtime-sandbox`` (``/execute``, ``/upload``, ``/download``). The
+``k8s_agent_sandbox`` SDK targets the latter contract, so this script only
+covers the direct-HTTP transport.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Callable, List, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class TestResult:
+    def __init__(self, name: str, passed: bool, detail: str = "") -> None:
+        self.name = name
+        self.passed = passed
+        self.detail = detail
+
+
+def _run_test(name: str, fn: Callable[[], str]) -> TestResult:
+    start = time.time()
+    try:
+        detail = fn()
+        elapsed = time.time() - start
+        return TestResult(name, True, f"{detail} ({elapsed:.2f}s)")
+    except AssertionError as exc:
+        return TestResult(name, False, f"assertion: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        return TestResult(name, False, f"{type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tests — direct HTTP
+# ---------------------------------------------------------------------------
+def _build_tests() -> Tuple[str, List[Callable[[], str]]]:
+    base_url = os.environ.get("SANDBOX_BASE_URL")
+    if not base_url:
+        raise SystemExit(
+            "SANDBOX_BASE_URL is not set. Point it at a running sandbox pod, "
+            "e.g. via `kubectl port-forward pod/<name> 8888:8888` and export "
+            "SANDBOX_BASE_URL=http://127.0.0.1:8888"
+        )
+
+    import requests
+
+    def _health() -> str:
+        r = requests.get(f"{base_url}/health", timeout=5)
+        assert r.status_code == 204, r.status_code
+        return "204 No Content"
+
+    def _exec() -> str:
+        r = requests.post(
+            f"{base_url}/exec",
+            json={"cmd": "echo 'hello from firecracker'"},
+            timeout=10,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["exit_code"] == 0, body
+        assert "hello from firecracker" in body["stdout"], body
+        return f"stdout={body['stdout'].strip()!r}"
+
+    def _files() -> str:
+        r = requests.post(
+            f"{base_url}/files",
+            data={"path": "hello.txt"},
+            files={"file": ("hello.txt", b"hi from direct http")},
+            timeout=10,
+        )
+        assert r.status_code == 200, r.text
+        r = requests.get(f"{base_url}/files", params={"path": "hello.txt"}, timeout=5)
+        assert r.status_code == 200, r.text
+        assert r.content == b"hi from direct http", r.content
+        return "round-trip ok"
+
+    def _metrics() -> str:
+        r = requests.get(f"{base_url}/metrics", timeout=5)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "timestamp" in body, body
+        return f"keys={sorted(body.keys())}"
+
+    def _init() -> str:
+        r = requests.post(
+            f"{base_url}/init",
+            json={"envs": {"HELLO": "firecracker"}, "timestamp": time.time()},
+            timeout=5,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["status"] == "ok", body
+        r = requests.get(f"{base_url}/envs", timeout=5)
+        assert r.status_code == 200, r.text
+        assert r.json().get("HELLO") == "firecracker", r.json()
+        return "env injected"
+
+    def _cleanup() -> str:
+        return "nothing to clean up"
+
+    return "Direct HTTP", [
+        _health, _exec, _files, _metrics, _init, _cleanup
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+def main() -> int:
+    mode_name, tests = _build_tests()
+
+    print(f"\n=== firecracker-sandbox verification: {mode_name} ===\n")
+
+    results: List[TestResult] = []
+    for i, fn in enumerate(tests, 1):
+        name = fn.__name__.lstrip("_")
+        print(f"[{i}/{len(tests)}] running {name}...")
+        result = _run_test(name, fn)
+        results.append(result)
+        status = "PASS" if result.passed else "FAIL"
+        print(f"         {status}: {result.detail}")
+
+    print("\n=== Summary ===")
+    for r in results:
+        mark = "PASS" if r.passed else "FAIL"
+        print(f"  [{mark}] {r.name}: {r.detail}")
+
+    failed = [r for r in results if not r.passed]
+    if failed:
+        print(f"\n{len(failed)} test(s) failed.")
+        return 1
+    print(f"\nAll {len(results)} test(s) passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/content/docs/use-cases/examples/firecracker-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/firecracker-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Firecracker Sandbox"
+linkTitle: "Firecracker Sandbox"
+weight: 2
+description: >
+  This example demonstrates how to run an Agent Sandbox on top of Kata Containers with the Firecracker VMM, providing microVM isolation with fast boot times.
+---
+{{% include-file file="additional/examples/firecracker-sandbox/README.md" %}}


### PR DESCRIPTION
## Summary

- Add a new example `examples/firecracker-sandbox/` demonstrating how to run an Agent Sandbox on top of [Kata Containers with the Firecracker VMM](https://github.com/kata-containers/kata-containers) (`kata-fc`), providing microVM isolation with ~125 ms boot times.
- The sandbox runtime is a small FastAPI server (port 8888) exposing `/health`, `/metrics`, `/init`, `/envs`, `/files`, `/exec` endpoints for driving the sandbox over HTTP.
- Includes a node setup script (`setup.sh`) that installs Kata via `kata-deploy`, registers the `kata-fc` RuntimeClass, and labels nodes — with `/dev/kvm` pre-check and a warning that KVM was only verified on the script host.
- Provides both a bare `Sandbox` manifest and a `SandboxTemplate` + `SandboxWarmPool` (2 warm replicas) pair for instant claim.
- Verification script (`test_client.py`) supports two transports: direct HTTP (`SANDBOX_BASE_URL`) and the `k8s_agent_sandbox` Python client.
- Registers the example in `examples/README.md` and adds a Hugo page at `site/content/docs/use-cases/examples/firecracker-sandbox/`.

## Test

- [x] Python AST validation on `main.py` and `test_client.py`.
- [x] Bash syntax check on `setup.sh`.
- [x] YAML parse check on both CR manifests.
- [x] Docker image build succeeds (`python:3.11-slim` + FastAPI).
- [x] kind-cluster deployment: SandboxTemplate / SandboxWarmPool / Sandbox CRs apply cleanly; pods schedule onto the KVM-labeled node (actual kata-fc execution requires a Linux node with `/dev/kvm`, verified via scheduling path on macOS host).
- [x] Direct HTTP transport verified end-to-end against a running sandbox (health, exec, file round-trip, metrics, init/env injection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Firecracker/Kata-based Kubernetes sandbox example, including a container image and a sandbox runtime service exposing health/metrics, init/env inspection, command execution, and workspace file upload/download.
  - Included Sandbox/Template manifests with a warm pool and a setup script for `kata-fc`.
- **Documentation**
  - Added end-to-end docs (prerequisites, deployment flow, verification, troubleshooting, and cleanup) plus a site entry for the example.
- **Tests**
  - Added a standalone verification client that checks the runtime endpoints via direct HTTP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->