### PR TITLE
perf(controller): dedicated watch connection + HTTP/2 API connection sharding

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -118,15 +118,17 @@ func main() {
 	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 10, "The maximum burst for client-side throttling of the Kubernetes API client.")
 	flag.IntVar(&apiConnections, "api-connections", 1,
 		"Number of independent HTTP/2 connections to the API server for non-watch traffic (writes, uncached reads, events, leader election). "+
-			"The kube-apiserver caps concurrent in-flight requests per HTTP/2 connection (SETTINGS_MAX_CONCURRENT_STREAMS; set server-side via "+
-			"--http2-max-streams-per-connection, default 0 = Go's HTTP/2 default of 250, and commonly advertised as 100 on managed control planes), "+
+			"The kube-apiserver caps concurrent in-flight requests per HTTP/2 connection (SETTINGS_MAX_CONCURRENT_STREAMS; 100 by default, "+
+			"configurable server-side via --http2-max-streams-per-connection), "+
 			"so a single connection bounds effective concurrency at the advertised limit regardless of worker count or QPS settings. "+
 			"Values > 1 shard requests round-robin across that many dedicated connections, each dialed on first use (~N x per-connection limit ceiling). "+
 			"Default 1 preserves the existing single-connection client.")
 	flag.BoolVar(&separateWatchConnection, "separate-watch-connection", false,
-		"Give the manager's informer cache (list/watch streams) a dedicated HTTP/2 connection to the API server, isolated from write traffic. "+
-			"Prevents watch event delivery to informers from stalling behind bursts of concurrent writes that saturate the shared "+
-			"connection's HTTP/2 stream budget. Default false preserves the existing shared-connection behavior.")
+		"Give the manager's informer cache (list/watch streams) a dedicated HTTP/2 connection to the API server. "+
+			"Watch events arrive on existing long-lived streams, so this isolates their frames from TCP/connection-level queuing behind "+
+			"bursts of request traffic on a shared connection (HTTP/2 stream prioritization does not help in practice). "+
+			"The per-connection cap on concurrent request streams is addressed separately by --api-connections. "+
+			"Default false preserves the existing shared-connection behavior.")
 	flag.IntVar(&sandboxConcurrentWorkers, "sandbox-concurrent-workers", 100, "Max concurrent reconciles for the Sandbox controller")
 	flag.IntVar(&sandboxClaimConcurrentWorkers, "sandbox-claim-concurrent-workers", 50, "Max concurrent reconciles for the SandboxClaim controller")
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -70,6 +70,8 @@ func main() {
 	var pprofMutexProfileFraction int
 	var kubeAPIQPS float64
 	var kubeAPIBurst int
+	var apiConnections int
+	var separateWatchConnection bool
 	var sandboxConcurrentWorkers int
 	var sandboxClaimConcurrentWorkers int
 	var sandboxWarmPoolConcurrentWorkers int
@@ -114,6 +116,16 @@ func main() {
 			"<=0 disables; 1 samples all events; N>1 samples ~1/N events (e.g. 10 ~= 1/10, 100 ~= 1/100).")
 	flag.Float64Var(&kubeAPIQPS, "kube-api-qps", -1.0, "Client-side QPS limit for the Kubernetes API client (default: -1, no client-side rate limiting)")
 	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 10, "The maximum burst for client-side throttling of the Kubernetes API client.")
+	flag.IntVar(&apiConnections, "api-connections", 1,
+		"Number of independent HTTP/2 connections to the API server for non-watch traffic (writes, uncached reads, events, leader election). "+
+			"The kube-apiserver allows at most ~100 concurrent in-flight requests per HTTP/2 connection (SETTINGS_MAX_CONCURRENT_STREAMS, "+
+			"server default 100), so a single connection caps effective concurrency at ~100 regardless of worker count or QPS settings. "+
+			"Values > 1 shard requests round-robin across that many pre-established connections (~N*100 in-flight ceiling). "+
+			"Default 1 preserves the existing single-connection client.")
+	flag.BoolVar(&separateWatchConnection, "separate-watch-connection", false,
+		"Give the manager's informer cache (list/watch streams) a dedicated HTTP/2 connection to the API server, isolated from write traffic. "+
+			"Prevents watch event delivery to informers from stalling behind bursts of concurrent writes that saturate the shared "+
+			"connection's HTTP/2 stream budget. Default false preserves the existing shared-connection behavior.")
 	flag.IntVar(&sandboxConcurrentWorkers, "sandbox-concurrent-workers", 100, "Max concurrent reconciles for the Sandbox controller")
 	flag.IntVar(&sandboxClaimConcurrentWorkers, "sandbox-claim-concurrent-workers", 50, "Max concurrent reconciles for the SandboxClaim controller")
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
@@ -167,6 +179,10 @@ func main() {
 
 	if kubeAPIBurst <= 0 {
 		setupLog.Error(nil, "kube-api-burst must be greater than 0")
+		os.Exit(1)
+	}
+	if apiConnections < 1 {
+		setupLog.Error(nil, "api-connections must be greater than or equal to 1")
 		os.Exit(1)
 	}
 	// Warning if the total number of workers exceeds the kube API burst limit
@@ -261,6 +277,28 @@ func main() {
 	restConfig.QPS = float32(kubeAPIQPS)
 	restConfig.Burst = kubeAPIBurst
 
+	// Optional API transport tuning (see transport.go). Order matters: the
+	// dedicated watch client must be built before configureAPIConnections
+	// installs its sharding WrapTransport on restConfig.
+	var watchHTTPClient *http.Client
+	if separateWatchConnection {
+		var err error
+		watchHTTPClient, err = newIsolatedHTTPClient(restConfig)
+		if err != nil {
+			setupLog.Error(err, "unable to build dedicated watch connection client")
+			os.Exit(1)
+		}
+		setupLog.Info("informer cache list/watch traffic separated onto a dedicated HTTP/2 connection (--separate-watch-connection)")
+	}
+	if err := configureAPIConnections(restConfig, apiConnections); err != nil {
+		setupLog.Error(err, "unable to configure API connections")
+		os.Exit(1)
+	}
+	if apiConnections > 1 {
+		setupLog.Info("API transport sharding enabled: non-watch API traffic distributed round-robin across independent HTTP/2 connections",
+			"connections", apiConnections)
+	}
+
 	if enableWebhook {
 		if manageWebhookCerts {
 			// Create a temporary client to patch the CRDs and access Secrets
@@ -319,6 +357,12 @@ func main() {
 	if cacheLabelSelectors {
 		setupLog.Info("informer caches for Pods and Services scoped to the sandbox tracking label (--cache-label-selectors)",
 			"label", controllers.SandboxNameHashLabel)
+	}
+	if watchHTTPClient != nil {
+		// The manager cache builds its list/watch REST clients from this
+		// http.Client (RESTClientForConfigAndClient), bypassing restConfig's
+		// WrapTransport, so watch streams stay off the write connections.
+		mgrOpts.Cache.HTTPClient = watchHTTPClient
 	}
 	if enableWebhook {
 		mgrOpts.WebhookServer = webhook.NewServer(webhook.Options{

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -118,9 +118,10 @@ func main() {
 	flag.IntVar(&kubeAPIBurst, "kube-api-burst", 10, "The maximum burst for client-side throttling of the Kubernetes API client.")
 	flag.IntVar(&apiConnections, "api-connections", 1,
 		"Number of independent HTTP/2 connections to the API server for non-watch traffic (writes, uncached reads, events, leader election). "+
-			"The kube-apiserver allows at most ~100 concurrent in-flight requests per HTTP/2 connection (SETTINGS_MAX_CONCURRENT_STREAMS, "+
-			"server default 100), so a single connection caps effective concurrency at ~100 regardless of worker count or QPS settings. "+
-			"Values > 1 shard requests round-robin across that many pre-established connections (~N*100 in-flight ceiling). "+
+			"The kube-apiserver caps concurrent in-flight requests per HTTP/2 connection (SETTINGS_MAX_CONCURRENT_STREAMS; set server-side via "+
+			"--http2-max-streams-per-connection, default 0 = Go's HTTP/2 default of 250, and commonly advertised as 100 on managed control planes), "+
+			"so a single connection bounds effective concurrency at the advertised limit regardless of worker count or QPS settings. "+
+			"Values > 1 shard requests round-robin across that many dedicated connections, each dialed on first use (~N x per-connection limit ceiling). "+
 			"Default 1 preserves the existing single-connection client.")
 	flag.BoolVar(&separateWatchConnection, "separate-watch-connection", false,
 		"Give the manager's informer cache (list/watch streams) a dedicated HTTP/2 connection to the API server, isolated from write traffic. "+

--- a/cmd/agent-sandbox-controller/transport.go
+++ b/cmd/agent-sandbox-controller/transport.go
@@ -33,15 +33,13 @@ type dialFunc func(ctx context.Context, network, address string) (net.Conn, erro
 // traffic across `connections` independent TCP+TLS+HTTP/2 connections.
 //
 // Why: the kube-apiserver caps concurrent streams per HTTP/2 connection
-// (SETTINGS_MAX_CONCURRENT_STREAMS). The server-side limit comes from
-// --http2-max-streams-per-connection, which defaults to 0 = the Go HTTP/2
-// server default of 250; managed control planes can advertise less (the GKE
-// clusters we benchmark advertise 100). client-go multiplexes all requests
-// from one rest.Config onto a single HTTP/2 connection, so that advertised
-// limit caps effective in-flight API requests regardless of worker counts or
-// client-side QPS settings. Sharding across N connections (each dialed
-// lazily on first use) raises the ceiling to ~N times the per-connection
-// limit.
+// (SETTINGS_MAX_CONCURRENT_STREAMS) — 100 by default, configurable
+// server-side via --http2-max-streams-per-connection. client-go multiplexes
+// all requests from one rest.Config onto a single HTTP/2 connection, so that
+// advertised limit caps effective in-flight API requests regardless of
+// worker counts or client-side QPS settings. Sharding across N connections
+// (each dialed lazily on first use) raises the ceiling to ~N times the
+// per-connection limit.
 //
 // How: for each shard we copy the rest.Config and set a distinct Dial
 // function. rest.Config.TransportConfig wraps Dial in a fresh
@@ -123,10 +121,13 @@ func configureAPIConnectionsWithDialer(cfg *rest.Config, connections int, baseDi
 // newIsolatedHTTPClient returns an *http.Client for cfg that is guaranteed
 // its own dedicated TCP+TLS+HTTP/2 connection, never shared with (or wrapped
 // by) any other client built from cfg. Used to give the manager cache's
-// list/watch streams (manager.Options.Cache.HTTPClient) a connection that
-// write bursts cannot congest: watch event delivery otherwise stalls behind
-// hundreds of concurrent write streams competing for the same connection's
-// SETTINGS_MAX_CONCURRENT_STREAMS budget.
+// list/watch streams (manager.Options.Cache.HTTPClient) their own
+// connection: watch events arrive on existing long-lived streams, so the
+// benefit is isolating their frames from TCP/connection-level queuing behind
+// bursts of request traffic on a shared connection (HTTP/2 stream
+// prioritization does not help in practice). The per-connection cap on
+// concurrent request streams is addressed separately by
+// configureAPIConnections.
 //
 // Call this BEFORE configureAPIConnections installs its WrapTransport on cfg
 // (the copy also defensively clears WrapTransport). The distinct Dial forces

--- a/cmd/agent-sandbox-controller/transport.go
+++ b/cmd/agent-sandbox-controller/transport.go
@@ -1,0 +1,176 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/rest"
+)
+
+// dialFunc matches rest.Config.Dial / net.Dialer.DialContext.
+type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+// configureAPIConnections optionally shards the controller's Kubernetes API
+// traffic across `connections` independent TCP+TLS+HTTP/2 connections.
+//
+// Why: the kube-apiserver advertises SETTINGS_MAX_CONCURRENT_STREAMS=100 by
+// default (k8s.io/apiserver pkg/server/secure_serving.go, overridable only
+// server-side via --http2-max-streams-per-connection), and client-go
+// multiplexes all requests from one rest.Config onto a single HTTP/2
+// connection. That caps effective in-flight API requests at ~100 regardless
+// of worker counts or client-side QPS settings. Sharding across N
+// pre-established connections raises the ceiling to ~N*100.
+//
+// How: for each shard we copy the rest.Config and set a distinct Dial
+// function. rest.Config.TransportConfig wraps Dial in a fresh
+// *transport.DialHolder per call, and client-go's TLS transport cache keys on
+// that pointer, so every shard is guaranteed its own *http.Transport and
+// therefore its own TCP/HTTP2 connection — using only supported client-go
+// API. The shards are full transports built by rest.TransportFor (TLS + auth
+// wrappers included; the outer wrapper chain's bearer/user-agent round
+// trippers are no-ops when the inner chain already set the headers, and vice
+// versa). A round-robin RoundTripper distributing over the shards is then
+// installed via cfg.WrapTransport, which every client built from this config
+// (manager cache/watches, manager client, event recorder, leader election)
+// picks up. All shards remain HTTP/2, so watches keep HTTP/2 semantics.
+//
+// connections == 1 leaves cfg completely untouched (stock single-connection
+// behavior).
+func configureAPIConnections(cfg *rest.Config, connections int) error {
+	return configureAPIConnectionsWithDialer(cfg, connections, nil)
+}
+
+// configureAPIConnectionsWithDialer is configureAPIConnections with an
+// injectable base dialer so tests can count/observe the underlying TCP
+// connections. A nil baseDial uses a per-shard net.Dialer identical to
+// client-go's default (30s timeout, 30s keep-alive).
+func configureAPIConnectionsWithDialer(cfg *rest.Config, connections int, baseDial dialFunc) error {
+	if connections < 1 {
+		return fmt.Errorf("api-connections must be >= 1, got %d", connections)
+	}
+	if connections == 1 {
+		// Default: preserve current behavior exactly; do not touch cfg.
+		return nil
+	}
+	if cfg.Dial != nil || cfg.Transport != nil {
+		return fmt.Errorf("api-connections > 1 is incompatible with a custom Dial/Transport on the rest.Config")
+	}
+
+	shards := make([]http.RoundTripper, 0, connections)
+	for i := range connections {
+		shardCfg := rest.CopyConfig(cfg)
+		// The shard transports live *below* the WrapTransport slot of the
+		// outer config; never inherit an outer wrapper (recursion guard).
+		shardCfg.WrapTransport = nil
+		dial := baseDial
+		if dial == nil {
+			// Mirrors the default dialer client-go's transport cache uses.
+			dial = (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext
+		}
+		// Setting Dial forces a distinct transport cache entry per shard
+		// (fresh DialHolder pointer per TransportFor call).
+		shardCfg.Dial = dial
+		rt, err := rest.TransportFor(shardCfg)
+		if err != nil {
+			return fmt.Errorf("building API connection shard %d/%d: %w", i+1, connections, err)
+		}
+		shards = append(shards, rt)
+	}
+
+	sharded := &shardedRoundTripper{shards: shards}
+	// rest.HTTPClientFor is called several times with this config
+	// (manager, cluster, leader election, ...); always hand back the same
+	// shared shard set so the process uses exactly `connections`
+	// connections in total. The base transport client-go built for this
+	// config is intentionally unused.
+	cfg.WrapTransport = func(http.RoundTripper) http.RoundTripper {
+		return sharded
+	}
+	return nil
+}
+
+// newIsolatedHTTPClient returns an *http.Client for cfg that is guaranteed
+// its own dedicated TCP+TLS+HTTP/2 connection, never shared with (or wrapped
+// by) any other client built from cfg. Used to give the manager cache's
+// list/watch streams (manager.Options.Cache.HTTPClient) a connection that
+// write bursts cannot congest: watch event delivery otherwise stalls behind
+// hundreds of concurrent write streams competing for the same connection's
+// SETTINGS_MAX_CONCURRENT_STREAMS budget.
+//
+// Call this BEFORE configureAPIConnections installs its WrapTransport on cfg
+// (the copy also defensively clears WrapTransport). The distinct Dial forces
+// a distinct client-go transport cache entry, exactly as in
+// configureAPIConnectionsWithDialer.
+func newIsolatedHTTPClient(cfg *rest.Config) (*http.Client, error) {
+	return newIsolatedHTTPClientWithDialer(cfg, nil)
+}
+
+// newIsolatedHTTPClientWithDialer is newIsolatedHTTPClient with an injectable
+// base dialer for tests.
+func newIsolatedHTTPClientWithDialer(cfg *rest.Config, baseDial dialFunc) (*http.Client, error) {
+	isoCfg := rest.CopyConfig(cfg)
+	isoCfg.WrapTransport = nil
+	dial := baseDial
+	if dial == nil {
+		dial = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+	}
+	isoCfg.Dial = dial
+	return rest.HTTPClientFor(isoCfg)
+}
+
+// shardedRoundTripper distributes requests round-robin over a fixed set of
+// independent transports (one HTTP/2 connection each).
+type shardedRoundTripper struct {
+	shards []http.RoundTripper
+	next   atomic.Uint64
+}
+
+func (s *shardedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	idx := s.next.Add(1) % uint64(len(s.shards))
+	return s.shards[idx].RoundTrip(req)
+}
+
+// CloseIdleConnections lets http.Client.CloseIdleConnections reach the
+// per-shard transports (net/http checks for this interface).
+func (s *shardedRoundTripper) CloseIdleConnections() {
+	type closeIdler interface{ CloseIdleConnections() }
+	for _, shard := range s.shards {
+		rt := shard
+		for rt != nil {
+			if ci, ok := rt.(closeIdler); ok {
+				ci.CloseIdleConnections()
+				break
+			}
+			wrapper, ok := rt.(utilnet.RoundTripperWrapper)
+			if !ok {
+				break
+			}
+			rt = wrapper.WrappedRoundTripper()
+		}
+	}
+}

--- a/cmd/agent-sandbox-controller/transport.go
+++ b/cmd/agent-sandbox-controller/transport.go
@@ -32,13 +32,16 @@ type dialFunc func(ctx context.Context, network, address string) (net.Conn, erro
 // configureAPIConnections optionally shards the controller's Kubernetes API
 // traffic across `connections` independent TCP+TLS+HTTP/2 connections.
 //
-// Why: the kube-apiserver advertises SETTINGS_MAX_CONCURRENT_STREAMS=100 by
-// default (k8s.io/apiserver pkg/server/secure_serving.go, overridable only
-// server-side via --http2-max-streams-per-connection), and client-go
-// multiplexes all requests from one rest.Config onto a single HTTP/2
-// connection. That caps effective in-flight API requests at ~100 regardless
-// of worker counts or client-side QPS settings. Sharding across N
-// pre-established connections raises the ceiling to ~N*100.
+// Why: the kube-apiserver caps concurrent streams per HTTP/2 connection
+// (SETTINGS_MAX_CONCURRENT_STREAMS). The server-side limit comes from
+// --http2-max-streams-per-connection, which defaults to 0 = the Go HTTP/2
+// server default of 250; managed control planes can advertise less (the GKE
+// clusters we benchmark advertise 100). client-go multiplexes all requests
+// from one rest.Config onto a single HTTP/2 connection, so that advertised
+// limit caps effective in-flight API requests regardless of worker counts or
+// client-side QPS settings. Sharding across N connections (each dialed
+// lazily on first use) raises the ceiling to ~N times the per-connection
+// limit.
 //
 // How: for each shard we copy the rest.Config and set a distinct Dial
 // function. rest.Config.TransportConfig wraps Dial in a fresh
@@ -73,6 +76,12 @@ func configureAPIConnectionsWithDialer(cfg *rest.Config, connections int, baseDi
 	}
 	if cfg.Dial != nil || cfg.Transport != nil {
 		return fmt.Errorf("api-connections > 1 is incompatible with a custom Dial/Transport on the rest.Config")
+	}
+	if cfg.WrapTransport != nil {
+		// Installing the shard router would silently replace a pre-set
+		// wrapper (tracing, instrumentation, ...); refuse instead so the
+		// incompatibility is explicit, mirroring the Dial/Transport check.
+		return fmt.Errorf("api-connections > 1 is incompatible with a pre-set WrapTransport on the rest.Config")
 	}
 
 	shards := make([]http.RoundTripper, 0, connections)

--- a/cmd/agent-sandbox-controller/transport_test.go
+++ b/cmd/agent-sandbox-controller/transport_test.go
@@ -110,6 +110,14 @@ func TestConfigureAPIConnectionsRejectsCustomDialOrTransport(t *testing.T) {
 	}
 }
 
+func TestConfigureAPIConnectionsRejectsPresetWrapTransport(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.invalid"}
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper { return rt }
+	if err := configureAPIConnections(cfg, 2); err == nil {
+		t.Error("expected error for config with pre-set WrapTransport (sharding would silently replace it)")
+	}
+}
+
 // TestShardingCreatesNDistinctConnections verifies the core claim: with
 // --api-connections=N, exactly N distinct TCP connections are dialed, all
 // speak HTTP/2, requests are distributed round-robin across them, and the

--- a/cmd/agent-sandbox-controller/transport_test.go
+++ b/cmd/agent-sandbox-controller/transport_test.go
@@ -1,0 +1,231 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"maps"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+// connTrackingServer is an HTTP/2-enabled TLS test server that records which
+// client connection (RemoteAddr) served each request.
+type connTrackingServer struct {
+	srv *httptest.Server
+
+	mu          sync.Mutex
+	reqsPerConn map[string]int
+}
+
+func newConnTrackingServer(t *testing.T) *connTrackingServer {
+	t.Helper()
+	cts := &connTrackingServer{reqsPerConn: map[string]int{}}
+	cts.srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cts.mu.Lock()
+		cts.reqsPerConn[r.RemoteAddr]++
+		cts.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	cts.srv.EnableHTTP2 = true
+	cts.srv.StartTLS()
+	t.Cleanup(cts.srv.Close)
+	return cts
+}
+
+func (c *connTrackingServer) restConfig() *rest.Config {
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: c.srv.Certificate().Raw})
+	return &rest.Config{
+		Host:            c.srv.URL,
+		TLSClientConfig: rest.TLSClientConfig{CAData: caPEM},
+	}
+}
+
+func (c *connTrackingServer) snapshot() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]int, len(c.reqsPerConn))
+	maps.Copy(out, c.reqsPerConn)
+	return out
+}
+
+// countingDialer wraps the standard dialer and counts TCP dials.
+func countingDialer(dials *atomic.Int64) dialFunc {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		dials.Add(1)
+		return (&net.Dialer{}).DialContext(ctx, network, address)
+	}
+}
+
+func TestConfigureAPIConnectionsDefaultIsNoop(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.invalid"}
+	if err := configureAPIConnections(cfg, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.WrapTransport != nil {
+		t.Error("connections=1 must not install a WrapTransport (stock behavior must be preserved)")
+	}
+	if cfg.Dial != nil {
+		t.Error("connections=1 must not set a custom dialer")
+	}
+}
+
+func TestConfigureAPIConnectionsRejectsInvalid(t *testing.T) {
+	for _, n := range []int{0, -1} {
+		if err := configureAPIConnections(&rest.Config{Host: "https://example.invalid"}, n); err == nil {
+			t.Errorf("connections=%d: expected error, got nil", n)
+		}
+	}
+}
+
+func TestConfigureAPIConnectionsRejectsCustomDialOrTransport(t *testing.T) {
+	cfg := &rest.Config{Host: "https://example.invalid"}
+	cfg.Dial = (&net.Dialer{}).DialContext
+	if err := configureAPIConnections(cfg, 2); err == nil {
+		t.Error("expected error for config with custom Dial")
+	}
+	cfg2 := &rest.Config{Host: "https://example.invalid", Transport: http.DefaultTransport}
+	if err := configureAPIConnections(cfg2, 2); err == nil {
+		t.Error("expected error for config with custom Transport")
+	}
+}
+
+// TestShardingCreatesNDistinctConnections verifies the core claim: with
+// --api-connections=N, exactly N distinct TCP connections are dialed, all
+// speak HTTP/2, requests are distributed round-robin across them, and the
+// original config object is not mutated beyond WrapTransport.
+func TestShardingCreatesNDistinctConnections(t *testing.T) {
+	const shardCount = 4
+	const requests = 32
+
+	server := newConnTrackingServer(t)
+	cfg := server.restConfig()
+
+	var dials atomic.Int64
+	if err := configureAPIConnectionsWithDialer(cfg, shardCount, countingDialer(&dials)); err != nil {
+		t.Fatalf("configureAPIConnectionsWithDialer: %v", err)
+	}
+	if cfg.Dial != nil {
+		t.Fatal("sharding must not set Dial on the original config (only on shard copies)")
+	}
+
+	httpClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor: %v", err)
+	}
+
+	// Sequential requests: round-robin is deterministic and a shard never
+	// dials twice (its connection is established by the prior request).
+	for i := range requests {
+		resp, err := httpClient.Get(fmt.Sprintf("%s/probe/%d", server.srv.URL, i))
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.ProtoMajor != 2 {
+			t.Fatalf("request %d: expected HTTP/2, got %s (watches must keep HTTP/2 semantics)", i, resp.Proto)
+		}
+	}
+
+	if got := dials.Load(); got != shardCount {
+		t.Errorf("expected exactly %d TCP dials (one per shard), got %d", shardCount, got)
+	}
+	perConn := server.snapshot()
+	if len(perConn) != shardCount {
+		t.Errorf("expected %d distinct client connections at the server, got %d: %v", shardCount, len(perConn), perConn)
+	}
+	for addr, n := range perConn {
+		if n != requests/shardCount {
+			t.Errorf("connection %s served %d requests, expected exactly %d (round-robin)", addr, n, requests/shardCount)
+		}
+	}
+}
+
+// TestIsolatedWatchClientUsesOwnConnection verifies that the dedicated
+// cache/watch client dials its own connection, distinct from all write
+// shards, even when built from the same rest.Config.
+func TestIsolatedWatchClientUsesOwnConnection(t *testing.T) {
+	const shardCount = 2
+
+	server := newConnTrackingServer(t)
+	cfg := server.restConfig()
+
+	// Order mirrors main.go: isolated watch client first, then sharding.
+	var watchDials atomic.Int64
+	watchClient, err := newIsolatedHTTPClientWithDialer(cfg, countingDialer(&watchDials))
+	if err != nil {
+		t.Fatalf("newIsolatedHTTPClientWithDialer: %v", err)
+	}
+
+	var shardDials atomic.Int64
+	if err := configureAPIConnectionsWithDialer(cfg, shardCount, countingDialer(&shardDials)); err != nil {
+		t.Fatalf("configureAPIConnectionsWithDialer: %v", err)
+	}
+	shardedClient, err := rest.HTTPClientFor(cfg)
+	if err != nil {
+		t.Fatalf("rest.HTTPClientFor: %v", err)
+	}
+
+	// Drive the write shards, then the watch client.
+	for i := range 2 * shardCount {
+		resp, err := shardedClient.Get(server.srv.URL + "/write")
+		if err != nil {
+			t.Fatalf("sharded request %d: %v", i, err)
+		}
+		resp.Body.Close()
+	}
+	writeConns := server.snapshot()
+
+	for i := range 3 {
+		resp, err := watchClient.Get(server.srv.URL + "/watch")
+		if err != nil {
+			t.Fatalf("watch request %d: %v", i, err)
+		}
+		resp.Body.Close()
+		if resp.ProtoMajor != 2 {
+			t.Fatalf("watch request %d: expected HTTP/2, got %s", i, resp.Proto)
+		}
+	}
+
+	if got := watchDials.Load(); got != 1 {
+		t.Errorf("expected the watch client to dial exactly 1 dedicated connection, got %d", got)
+	}
+	if got := shardDials.Load(); got != shardCount {
+		t.Errorf("expected %d write-shard dials, got %d", shardCount, got)
+	}
+
+	allConns := server.snapshot()
+	if len(allConns) != shardCount+1 {
+		t.Errorf("expected %d total connections (shards + dedicated watch), got %d: %v", shardCount+1, len(allConns), allConns)
+	}
+	// The watch connection must be one no write shard ever used.
+	watchConns := 0
+	for addr := range allConns {
+		if _, usedByWrites := writeConns[addr]; !usedByWrites {
+			watchConns++
+		}
+	}
+	if watchConns != 1 {
+		t.Errorf("expected exactly 1 connection exclusive to the watch client, got %d", watchConns)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it

controller-runtime multiplexes the manager's informer list/watch streams and every write onto a single HTTP/2 connection, and kube-apiserver caps concurrent in-flight requests per connection (`SETTINGS_MAX_CONCURRENT_STREAMS`, server default 100). Measured in a 300-claim warm-adoption benchmark, that one shared connection has two distinct costs:

- **Watch starvation:** informer watch events queue behind concurrent write streams — in a high-concurrency configuration (400 workers) events arrived ~1.0-1.1s late at p50, i.e. a large share of end-to-end claim latency was the controller not yet knowing what had already happened on the server.
- **Concurrency ceiling:** effective in-flight API concurrency plateaus at ~100 regardless of worker counts or QPS flags.

This PR adds two opt-in flags; both **default off**, and the defaults preserve today's single-connection client exactly:

- `--separate-watch-connection` gives the manager cache's list/watch streams a dedicated HTTP/2 connection (`Cache.HTTPClient`), so watch delivery can never stall behind a write burst.
- `--api-connections=N` pre-establishes N independent TCP+TLS+HTTP/2 connections for non-watch traffic and shards requests across them round-robin (~N×100 in-flight ceiling). Only supported client-go API is used: each shard is a `rest.Config` copy with a distinct `Dial` (which forces a distinct client-go transport-cache entry), composed behind a round-robin `RoundTripper` installed via `WrapTransport`.

#### Performance (A/B, this change alone)

Measured 2026-07-21 on kops GCP (Kubernetes v1.35.6): 6× e2-standard-8 workers + e2-standard-16 control plane, tuned control plane and nodes (apiserver inflight limits, etcd 8GiB quota + 2min compaction, scheduler client QPS, kubelet reserves, cilium endpoint-create rate raise), webhook enabled, controller at stock defaults, stress client on an in-region VM calibrated to 4 HTTP/2 client connections. **Same cluster for both legs**; each leg = 20-claim smoke gate + 300 SandboxClaims fired simultaneously against a fully-warm 300-replica pool. BASE = upstream main (9a4b3a0); PR leg = this branch with `--separate-watch-connection --api-connections=4`.

| claim create → Ready (n=300) | BASE | this PR | delta |
|---|---|---|---|
| p50 | 1328ms | 1175ms | −11.5% |
| p90 | 2684ms | 2175ms | **−19.0%** |
| p99 | 3614ms | 2725ms | −24.6% |
| max | 3864ms | 2889ms | −25.2% |
| time to ALL 300 Ready | 3.87s | 2.90s | −25.1% |
| steady ready throughput | 104.2/s | 132.4/s | +27% |

Both legs: 300/300 Ready, 0 failed. Change-specific counters over the burst (controller metrics): **SandboxClaim workqueue queue-duration p50 221.6ms → 8.9ms (−96%)** — with watch delivery decoupled from the write burst, items stop aging in the queue before the controller even sees fresh state; total Sandbox reconciles 12,031 → 5,845 (−51%, fewer passes over stale views). Uncontended smoke latency is unchanged (p50 79ms vs 75ms), i.e. no overhead when the flags are exercised without load.

The effect grows with worker count: the same change measured under a 400-worker configuration of the same benchmark moved claim-ready p90 **2479ms → 1740ms**, with the ~1s watch-event delay eliminated.

`transport_test.go` proves that `--api-connections=N` dials exactly N distinct TCP connections all serving requests, that the isolated watch client gets its own connection, and that the defaults leave the `rest.Config` untouched.

#### Which issue(s) this PR fixes

None — new finding from a warm-adoption latency investigation.

```release-note
Add opt-in controller flags `--separate-watch-connection` (dedicated HTTP/2 connection for informer list/watch streams) and `--api-connections` (round-robin sharding of non-watch API traffic across N connections). Both default to the existing single shared connection behavior.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two CLI flags to tune Kubernetes API HTTP/2 traffic: shard non-watch requests across multiple independent connections and optionally isolate list/watch (cache) traffic on a dedicated connection.
  * Startup now validates the sharding configuration and exits non-zero for invalid values, with logging when isolation/sharding is enabled.

* **Tests**
  * Added coverage for default (no-op) behavior, input validation, round-robin request distribution, HTTP/2 compatibility, and ensuring the watch/cache traffic uses an exclusive connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->