### PR TITLE
feat(sdk): single-watch wait_for_claim_ready + faster dev port-forward polling

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -337,6 +337,36 @@ sandbox = client.create_sandbox(
 
 The volume claim templates are validated against the warmpool template's policy and rules (e.g., whether custom volume claims are allowed or if overrides are permitted).
 
+### 9. Startup Latency: How the SDK Waits for Readiness
+
+`create_sandbox()` is fully **watch-based** — it never polls the Kubernetes
+API on an interval, so there is no poll-interval latency added on top of the
+controller's own claim-to-Ready time.
+
+The wait is a **single watch on the SandboxClaim**. The claim controller
+publishes the bound sandbox name (`status.sandbox.name`), the pod IPs
+(`status.sandbox.podIPs`) and the forwarded `Ready` condition in one status
+update when it adopts a warm-pool sandbox, so the first watch event that
+carries the sandbox name normally also carries `Ready=True` and
+`create_sandbox()` returns immediately. On a cold start (no warm sandbox
+available, or `env`/`volume_claim_templates` set, which force cold starts)
+the same watch simply keeps streaming claim updates until the forwarded
+`Ready` condition flips to `True`.
+
+Latency guidance:
+
+- **Do not poll** `Sandbox`/`SandboxClaim` objects with `get_*` calls in a
+  loop to detect readiness; a poll interval of `T` adds an average of `T/2`
+  (uniformly distributed 0..`T`) on top of the controller latency. Use
+  `create_sandbox()` / the claim `Ready` condition watch.
+- `sandbox_ready_timeout` (default 180s) bounds the whole wait; the watch
+  returns as soon as the claim is Ready, the timeout only caps the worst case.
+- The Kubernetes client reuses a single authenticated connection pool for
+  the watch, so no extra TLS handshakes occur on the ready path.
+- With the local-tunnel connection mode, the first request additionally pays
+  for the `kubectl port-forward` startup; the SDK probes the local port every
+  50ms while it comes up. Gateway/in-cluster modes do not have this step.
+
 ## Testing
 
 A test script is included to verify the full lifecycle (Creation -> Execution -> File I/O -> Cleanup).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/__init__.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/__init__.py
@@ -19,6 +19,7 @@ from .exceptions import (
     SandboxTemplateNotFoundError,
     SandboxWarmPoolNotFoundError,
     SandboxNotReadyError,
+    SandboxClaimFailedError,
     SandboxPortForwardError,
     SandboxRequestError,
 )

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -31,8 +31,9 @@ from .constants import (
     SANDBOX_API_VERSION,
     SANDBOX_PLURAL_NAME,
     CREATED_BY_LABEL,
+    TERMINAL_CLAIM_READY_REASONS,
 )
-from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
+from .exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
 from .utils import select_pod_ip, is_valid_ip, is_valid_gateway_hostname
 
 
@@ -171,6 +172,11 @@ class AsyncK8sHelper:
         await self._ensure_initialized()
 
         goal = "claim readiness" if require_ready else "sandbox name"
+        # Keep the legacy resolve-path message byte-identical to the original
+        # two-watch implementation (callers/tests may match on it).
+        deleted_msg = (f"SandboxClaim '{claim_name}' was deleted while waiting for claim readiness"
+                       if require_ready else
+                       f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
         deadline = time.monotonic() + timeout
         rv = resource_version or "0"
         logger.info(f"Watching claim '{claim_name}' for {goal} (from resourceVersion={rv})...")
@@ -197,7 +203,7 @@ class AsyncK8sHelper:
                         continue
                     if event["type"] == "DELETED":
                         raise SandboxMetadataError(
-                            f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name"
+                            deleted_msg
                         )
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         claim_object = event["object"]
@@ -221,6 +227,17 @@ class AsyncK8sHelper:
                             elif cond.get("reason") == "WarmPoolNotFound":
                                 raise SandboxWarmPoolNotFoundError(
                                     f"SandboxWarmPool requested does not exist: {cond.get('message', 'WarmPool not found')}"
+                                )
+                            elif (
+                                cond.get("type") == "Ready"
+                                and cond.get("status") == "False"
+                                and cond.get("reason") in TERMINAL_CLAIM_READY_REASONS
+                            ):
+                                # The controller reported a failure it will not
+                                # retry; waiting out the timeout cannot succeed.
+                                raise SandboxClaimFailedError(
+                                    f"SandboxClaim '{claim_name}' failed with terminal reason "
+                                    f"{cond.get('reason')}: {cond.get('message', '')}"
                                 )
                             if cond.get("type") == "Ready" and cond.get("status") == "True":
                                 ready = True

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -110,7 +110,7 @@ class AsyncK8sHelper:
         logger.info(
             f"Creating SandboxClaim '{name}' in namespace '{namespace}' using warm pool '{warmpool}'..."
         )
-        await self.custom_objects_api.create_namespaced_custom_object(
+        return await self.custom_objects_api.create_namespaced_custom_object(
             group=CLAIM_API_GROUP,
             version=CLAIM_API_VERSION,
             namespace=namespace,
@@ -118,21 +118,67 @@ class AsyncK8sHelper:
             body=manifest,
         )
 
-    async def resolve_sandbox_name(self, claim_name: str, namespace: str, timeout: int) -> str:
+    async def resolve_sandbox_name(self, claim_name: str, namespace: str, timeout: int, resource_version: str | None = None) -> str:
         """Resolves the actual Sandbox name from the SandboxClaim status.
         With warm pool adoption, the sandbox name may differ from the claim
         name. This method watches the SandboxClaim until the sandbox name
         appears in the claim's status, then returns it.
+
+        Args:
+            resource_version: Optional resourceVersion to start the watch
+                from (e.g. ``metadata.resourceVersion`` of the create
+                response). Defaults to ``"0"`` — see ``_watch_claim``.
+        """
+        return await self._watch_claim(claim_name, namespace, timeout, require_ready=False,
+                                       resource_version=resource_version)
+
+    async def wait_for_claim_ready(self, claim_name: str, namespace: str, timeout: int, resource_version: str | None = None) -> str:
+        """Watches the SandboxClaim until it is bound to a sandbox AND its
+        Ready condition is True, then returns the sandbox name.
+
+        This is the lowest-latency ready-wait: the claim controller writes
+        ``status.sandbox.name``, ``status.sandbox.podIPs`` and the forwarded
+        Ready condition in a single status update on warm-pool adoption, so a
+        single watch on the claim observes readiness without a second watch
+        on the Sandbox resource (the claim's Ready condition is a direct
+        forward of the Sandbox's Ready condition).
+
+        Args:
+            resource_version: Optional resourceVersion to start the watch
+                from (e.g. ``metadata.resourceVersion`` of the create
+                response). Defaults to ``"0"`` — see ``_watch_claim``.
+        """
+        return await self._watch_claim(claim_name, namespace, timeout, require_ready=True,
+                                       resource_version=resource_version)
+
+    async def _watch_claim(self, claim_name: str, namespace: str, timeout: int, require_ready: bool,
+                           resource_version: str | None = None) -> str:
+        """Shared SandboxClaim watch loop.
+
+        Returns the sandbox name once ``status.sandbox.name`` is populated;
+        when ``require_ready`` is set, additionally waits until the claim's
+        Ready condition is True.
+
+        The watch always starts from an explicit resourceVersion — the
+        claim's own (from the create response) when the caller has it, else
+        ``"0"`` — so the apiserver serves it from the watch cache. A watch
+        with UNSET resourceVersion forces a quorum etcd read to establish
+        initial state on every wait, which at high claim rates is pure
+        apiserver/etcd load on the latency path. If the supplied version has
+        been compacted away (410 Gone), the watch transparently restarts from
+        ``"0"`` (current state from the watch cache).
         """
         await self._ensure_initialized()
 
+        goal = "claim readiness" if require_ready else "sandbox name"
         deadline = time.monotonic() + timeout
-        logger.info(f"Resolving sandbox name from claim '{claim_name}'...")
+        rv = resource_version or "0"
+        logger.info(f"Watching claim '{claim_name}' for {goal} (from resourceVersion={rv})...")
         while True:
             remaining = int(deadline - time.monotonic())
             if remaining <= 0:
                 raise TimeoutError(
-                    f"Could not resolve sandbox name from claim "
+                    f"Could not resolve {goal} from claim "
                     f"'{claim_name}' within {timeout} seconds."
                 )
             w = watch.Watch()
@@ -144,6 +190,7 @@ class AsyncK8sHelper:
                     version=CLAIM_API_VERSION,
                     plural=CLAIM_PLURAL_NAME,
                     field_selector=f"metadata.name={claim_name}",
+                    resource_version=rv,
                     timeout_seconds=remaining,
                 ):
                     if event is None:
@@ -154,8 +201,14 @@ class AsyncK8sHelper:
                         )
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         claim_object = event["object"]
+                        # Track the last-seen resourceVersion so a stream
+                        # restart resumes instead of replaying history.
+                        seen_rv = (claim_object.get("metadata") or {}).get("resourceVersion")
+                        if seen_rv:
+                            rv = seen_rv
                         status = claim_object.get("status") or {}
-                        
+
+                        ready = False
                         for cond in status.get("conditions", []):
                             if (
                                 cond.get("type") == "Ready"
@@ -169,13 +222,29 @@ class AsyncK8sHelper:
                                 raise SandboxWarmPoolNotFoundError(
                                     f"SandboxWarmPool requested does not exist: {cond.get('message', 'WarmPool not found')}"
                                 )
+                            if cond.get("type") == "Ready" and cond.get("status") == "True":
+                                ready = True
 
                         sandbox_status = status.get("sandbox", {})
                         # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
                         name = sandbox_status.get("name", "") or sandbox_status.get("Name", "")
-                        if name:
-                            logger.info(f"Resolved sandbox name '{name}' from claim status")
+                        if name and (ready or not require_ready):
+                            logger.info(
+                                f"Resolved sandbox name '{name}' from claim status"
+                                + (" (claim Ready)" if ready else "")
+                            )
                             return name
+            except client.ApiException as e:
+                if e.status == 410:
+                    # The requested resourceVersion was compacted away:
+                    # restart from the watch cache's current state.
+                    logger.info(
+                        f"Watch on claim '{claim_name}' expired (410 Gone at resourceVersion={rv}); "
+                        "restarting from current state"
+                    )
+                    rv = "0"
+                    continue
+                raise
             finally:
                 await w.close()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -171,20 +171,19 @@ class AsyncK8sHelper:
         """
         await self._ensure_initialized()
 
-        goal = "claim readiness" if require_ready else "sandbox name"
-        # Keep the legacy resolve-path message byte-identical to the original
-        # two-watch implementation (callers/tests may match on it).
+        wait_target = "claim readiness" if require_ready else "sandbox name"
+        # Existing tests assert on the exact resolve-path message.
         deleted_msg = (f"SandboxClaim '{claim_name}' was deleted while waiting for claim readiness"
                        if require_ready else
                        f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
         deadline = time.monotonic() + timeout
         rv = resource_version or "0"
-        logger.info(f"Watching claim '{claim_name}' for {goal} (from resourceVersion={rv})...")
+        logger.info(f"Watching claim '{claim_name}' for {wait_target} (from resourceVersion={rv})...")
         while True:
             remaining = int(deadline - time.monotonic())
             if remaining <= 0:
                 raise TimeoutError(
-                    f"Could not resolve {goal} from claim "
+                    f"Could not resolve {wait_target} from claim "
                     f"'{claim_name}' within {timeout} seconds."
                 )
             w = watch.Watch()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -23,7 +23,6 @@ import atexit
 import asyncio
 import logging
 import sys
-import time
 import uuid
 from typing import Generic, TypeVar
 
@@ -191,7 +190,7 @@ class AsyncSandboxClient(Generic[T]):
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
 
         try:
-            await self._create_claim(
+            created_claim = await self._create_claim(
                 claim_name,
                 warmpool,
                 namespace,
@@ -200,15 +199,19 @@ class AsyncSandboxClient(Generic[T]):
                 volume_claim_templates=volume_claim_templates,
                 pod_metadata=pod_metadata
             )
-            start_time = time.monotonic()
-            sandbox_id = await self.k8s_helper.resolve_sandbox_name(
-                claim_name, namespace, sandbox_ready_timeout
+            # Wait for the claim to be bound and Ready in a single watch.
+            # The claim status carries the sandbox name (which differs from
+            # the claim name with warm pools) and the forwarded Ready
+            # condition in the same status update, so no second watch on the
+            # Sandbox resource is needed. The watch starts from the create
+            # response's resourceVersion so the apiserver serves it from the
+            # watch cache instead of a quorum etcd read per wait.
+            claim_rv = None
+            if isinstance(created_claim, dict):
+                claim_rv = (created_claim.get("metadata") or {}).get("resourceVersion")
+            sandbox_id = await self._wait_for_claim_ready(
+                claim_name, namespace, sandbox_ready_timeout, resource_version=claim_rv
             )
-            elapsed_time = time.monotonic() - start_time
-            remaining_timeout = max(0, int(sandbox_ready_timeout - elapsed_time))
-            if remaining_timeout <= 0:
-                raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
-            await self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
@@ -430,7 +433,7 @@ class AsyncSandboxClient(Generic[T]):
             if trace_context_str:
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
-        await self.k8s_helper.create_sandbox_claim(
+        return await self.k8s_helper.create_sandbox_claim(
             claim_name,
             warmpool_name,
             namespace,
@@ -441,8 +444,15 @@ class AsyncSandboxClient(Generic[T]):
             pod_metadata=pod_metadata
         )
 
+    @async_trace_span("wait_for_claim_ready")
+    async def _wait_for_claim_ready(self, claim_name: str, namespace: str, timeout: int, resource_version: str | None = None) -> str:
+        """Waits for the SandboxClaim to be bound and Ready, returning the sandbox name."""
+        return await self.k8s_helper.wait_for_claim_ready(claim_name, namespace, timeout, resource_version=resource_version)
+
     @async_trace_span("wait_for_sandbox_ready")
     async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
+        """Retained for API compatibility; ``create_sandbox`` now uses the
+        single-watch ``_wait_for_claim_ready`` path instead."""
         await self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @async_trace_span("delete_claim")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -451,8 +451,7 @@ class AsyncSandboxClient(Generic[T]):
 
     @async_trace_span("wait_for_sandbox_ready")
     async def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
-        """Retained for API compatibility; ``create_sandbox`` now uses the
-        single-watch ``_wait_for_claim_ready`` path instead."""
+        """Waits for the Sandbox custom resource to have a 'Ready' status."""
         await self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @async_trace_span("delete_claim")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -193,8 +193,11 @@ class LocalTunnelConnectionStrategy(ConnectionStrategy):
                     self.base_url = f"http://127.0.0.1:{local_port}"
                     logging.info(f"Tunnel ready at {self.base_url}")
                     return self.base_url
-                
-                time.sleep(0.5)
+
+                # Poll the local port at 50ms: this is a cheap localhost socket
+                # probe, and a coarser interval (e.g. 500ms) adds a uniform
+                # 0-500ms of avoidable latency to the first sandbox request.
+                time.sleep(0.05)
 
             self.close()
             raise TimeoutError("Failed to establish tunnel to Router Service.")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/constants.py
@@ -37,3 +37,17 @@ PODSNAPSHOT_PLURAL = "podsnapshots"
 PODSNAPSHOTMANUALTRIGGER_PLURAL = "podsnapshotmanualtriggers"
 PODSNAPSHOTMANUALTRIGGER_API_KIND = "PodSnapshotManualTrigger"
 PODSNAPSHOT_API_KIND = "PodSnapshot"
+
+# SandboxClaim Ready=False reasons the claim controller will not recover from
+# on its own (see computeReadyCondition in
+# extensions/controllers/sandboxclaim_controller.go). Watch-based ready-waits
+# fail fast on these instead of burning the full timeout. Transient reasons
+# (AdoptionPending, SandboxMissing, SandboxNotReady, ReconcilerError) are
+# intentionally absent: the controller retries those.
+TERMINAL_CLAIM_READY_REASONS = frozenset({
+    "InvalidMetadata",
+    "EnvVarsInjectionRejected",
+    "VolumeClaimTemplatesError",
+    "ClaimExpired",     # extensions ClaimExpiredReason
+    "SandboxExpired",   # core SandboxReasonExpired, forwarded to the claim
+})

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/exceptions.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/exceptions.py
@@ -65,3 +65,13 @@ class SandboxRequestError(SandboxError):
         super().__init__(message)
         self.status_code = status_code
         self.response = response
+
+
+class SandboxClaimFailedError(SandboxError):
+    """The SandboxClaim reported a terminal Ready=False reason.
+
+    The claim controller will not retry these (e.g. InvalidMetadata,
+    VolumeClaimTemplatesError, ClaimExpired); the claim will not become
+    ready without user action, so ready-waits raise instead of waiting
+    out the timeout.
+    """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -16,12 +16,13 @@ import logging
 import time
 from typing import List
 from kubernetes import client, config, watch
-from .exceptions import SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
+from .exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxNotFoundError, SandboxTemplateNotFoundError, SandboxWarmPoolNotFoundError
 from .utils import is_valid_ip, is_valid_gateway_hostname
 from .constants import (
     CLAIM_API_GROUP,
     CLAIM_API_VERSION,
     CLAIM_PLURAL_NAME,
+    TERMINAL_CLAIM_READY_REASONS,
     GATEWAY_API_GROUP,
     GATEWAY_API_VERSION,
     GATEWAY_PLURAL,
@@ -150,6 +151,11 @@ class K8sHelper:
         ``"0"`` (current state from the watch cache).
         """
         goal = "claim readiness" if require_ready else "sandbox name"
+        # Keep the legacy resolve-path message byte-identical to the original
+        # two-watch implementation (callers/tests may match on it).
+        deleted_msg = (f"SandboxClaim '{claim_name}' was deleted while waiting for claim readiness"
+                       if require_ready else
+                       f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
         deadline = time.monotonic() + timeout
         rv = resource_version or "0"
         logging.info(f"Watching claim '{claim_name}' for {goal} (from resourceVersion={rv})...")
@@ -176,8 +182,7 @@ class K8sHelper:
                         continue
                     if event["type"] == "DELETED":
                         w.stop()
-                        raise SandboxMetadataError(
-                            f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
+                        raise SandboxMetadataError(deleted_msg)
                     if event["type"] in ["ADDED", "MODIFIED"]:
                         claim_object = event['object']
                         # Track the last-seen resourceVersion so a stream
@@ -202,6 +207,18 @@ class K8sHelper:
                                 w.stop()
                                 raise SandboxWarmPoolNotFoundError(
                                     f"SandboxWarmPool requested does not exist: {cond.get('message', 'WarmPool not found')}"
+                                )
+                            elif (
+                                cond.get('type') == 'Ready'
+                                and cond.get('status') == 'False'
+                                and cond.get('reason') in TERMINAL_CLAIM_READY_REASONS
+                            ):
+                                # The controller reported a failure it will not
+                                # retry; waiting out the timeout cannot succeed.
+                                w.stop()
+                                raise SandboxClaimFailedError(
+                                    f"SandboxClaim '{claim_name}' failed with terminal reason "
+                                    f"{cond.get('reason')}: {cond.get('message', '')}"
                                 )
                             if cond.get('type') == 'Ready' and cond.get('status') == 'True':
                                 ready = True

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -91,72 +91,140 @@ class K8sHelper:
             "spec": spec,
         }
         logging.info(f"Creating SandboxClaim '{name}' in namespace '{namespace}' using warm pool '{warmpool}'...")
-        self.custom_objects_api.create_namespaced_custom_object(
+        return self.custom_objects_api.create_namespaced_custom_object(
             group=CLAIM_API_GROUP,
             version=CLAIM_API_VERSION,
             namespace=namespace,
             plural=CLAIM_PLURAL_NAME,
             body=manifest
         )
-    
-    def resolve_sandbox_name(self, claim_name: str, namespace: str, timeout: int) -> str:
+
+    def resolve_sandbox_name(self, claim_name: str, namespace: str, timeout: int, resource_version: str | None = None) -> str:
         """Resolves the actual Sandbox name from the SandboxClaim status.
         With warm pool adoption, the sandbox name may differ from the claim
         name. This method watches the SandboxClaim until the sandbox name
         appears in the claim's status, then returns it.
+
+        Args:
+            resource_version: Optional resourceVersion to start the watch
+                from (e.g. ``metadata.resourceVersion`` of the create
+                response). Defaults to ``"0"`` — see ``_watch_claim``.
         """
+        return self._watch_claim(claim_name, namespace, timeout, require_ready=False,
+                                 resource_version=resource_version)
+
+    def wait_for_claim_ready(self, claim_name: str, namespace: str, timeout: int, resource_version: str | None = None) -> str:
+        """Watches the SandboxClaim until it is bound to a sandbox AND its
+        Ready condition is True, then returns the sandbox name.
+
+        This is the lowest-latency ready-wait: the claim controller writes
+        ``status.sandbox.name``, ``status.sandbox.podIPs`` and the forwarded
+        Ready condition in a single status update on warm-pool adoption, so a
+        single watch on the claim observes readiness without a second watch
+        on the Sandbox resource (the claim's Ready condition is a direct
+        forward of the Sandbox's Ready condition).
+
+        Args:
+            resource_version: Optional resourceVersion to start the watch
+                from (e.g. ``metadata.resourceVersion`` of the create
+                response). Defaults to ``"0"`` — see ``_watch_claim``.
+        """
+        return self._watch_claim(claim_name, namespace, timeout, require_ready=True,
+                                 resource_version=resource_version)
+
+    def _watch_claim(self, claim_name: str, namespace: str, timeout: int, require_ready: bool,
+                     resource_version: str | None = None) -> str:
+        """Shared SandboxClaim watch loop.
+
+        Returns the sandbox name once ``status.sandbox.name`` is populated;
+        when ``require_ready`` is set, additionally waits until the claim's
+        Ready condition is True.
+
+        The watch always starts from an explicit resourceVersion — the
+        claim's own (from the create response) when the caller has it, else
+        ``"0"`` — so the apiserver serves it from the watch cache. A watch
+        with UNSET resourceVersion forces a quorum etcd read to establish
+        initial state on every wait, which at high claim rates is pure
+        apiserver/etcd load on the latency path. If the supplied version has
+        been compacted away (410 Gone), the watch transparently restarts from
+        ``"0"`` (current state from the watch cache).
+        """
+        goal = "claim readiness" if require_ready else "sandbox name"
         deadline = time.monotonic() + timeout
-        logging.info(f"Resolving sandbox name from claim '{claim_name}'...")
+        rv = resource_version or "0"
+        logging.info(f"Watching claim '{claim_name}' for {goal} (from resourceVersion={rv})...")
         while True:
             remaining = int(deadline - time.monotonic())
             if remaining <= 0:
                 raise TimeoutError(
-                    f"Could not resolve sandbox name from claim "
+                    f"Could not resolve {goal} from claim "
                     f"'{claim_name}' within {timeout} seconds.")
             w = watch.Watch()
-            for event in w.stream(
-                func=self.custom_objects_api.list_namespaced_custom_object,
-                namespace=namespace,
-                group=CLAIM_API_GROUP,
-                version=CLAIM_API_VERSION,
-                plural=CLAIM_PLURAL_NAME,
-                field_selector=f"metadata.name={claim_name}",
-                timeout_seconds=remaining
-            ):
-                if event is None:
-                    continue
-                if event["type"] == "DELETED":
-                    w.stop()
-                    raise SandboxMetadataError(
-                        f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
-                if event["type"] in ["ADDED", "MODIFIED"]:
-                    claim_object = event['object']
-                    status = claim_object.get('status') or {}
-                    
-                    for cond in status.get('conditions', []):
-                        if (
-                            cond.get('type') == 'Ready'
-                            and cond.get('status') == 'False'
-                            and cond.get('reason') == 'TemplateNotFound'
-                        ):
-                            w.stop()
-                            raise SandboxTemplateNotFoundError(
-                                f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
-                            )
-                        elif cond.get('reason') == 'WarmPoolNotFound':
-                            w.stop()
-                            raise SandboxWarmPoolNotFoundError(
-                                f"SandboxWarmPool requested does not exist: {cond.get('message', 'WarmPool not found')}"
-                            )
-
-                    sandbox_status = status.get('sandbox', {})
-                    # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
-                    name = sandbox_status.get('name', '') or sandbox_status.get('Name', '')
-                    if name:
-                        logging.info(
-                            f"Resolved sandbox name '{name}' from claim status")
+            try:
+                event_iter = w.stream(
+                    func=self.custom_objects_api.list_namespaced_custom_object,
+                    namespace=namespace,
+                    group=CLAIM_API_GROUP,
+                    version=CLAIM_API_VERSION,
+                    plural=CLAIM_PLURAL_NAME,
+                    field_selector=f"metadata.name={claim_name}",
+                    resource_version=rv,
+                    timeout_seconds=remaining
+                )
+                for event in event_iter:
+                    if event is None:
+                        continue
+                    if event["type"] == "DELETED":
                         w.stop()
-                        return name
+                        raise SandboxMetadataError(
+                            f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
+                    if event["type"] in ["ADDED", "MODIFIED"]:
+                        claim_object = event['object']
+                        # Track the last-seen resourceVersion so a stream
+                        # restart resumes instead of replaying history.
+                        seen_rv = (claim_object.get('metadata') or {}).get('resourceVersion')
+                        if seen_rv:
+                            rv = seen_rv
+                        status = claim_object.get('status') or {}
+
+                        ready = False
+                        for cond in status.get('conditions', []):
+                            if (
+                                cond.get('type') == 'Ready'
+                                and cond.get('status') == 'False'
+                                and cond.get('reason') == 'TemplateNotFound'
+                            ):
+                                w.stop()
+                                raise SandboxTemplateNotFoundError(
+                                    f"SandboxTemplate requested does not exist: {cond.get('message', 'Template not found')}"
+                                )
+                            elif cond.get('reason') == 'WarmPoolNotFound':
+                                w.stop()
+                                raise SandboxWarmPoolNotFoundError(
+                                    f"SandboxWarmPool requested does not exist: {cond.get('message', 'WarmPool not found')}"
+                                )
+                            if cond.get('type') == 'Ready' and cond.get('status') == 'True':
+                                ready = True
+
+                        sandbox_status = status.get('sandbox', {})
+                        # Support both 'name' (standard) and 'Name' (legacy, before CRD rename in #440)
+                        name = sandbox_status.get('name', '') or sandbox_status.get('Name', '')
+                        if name and (ready or not require_ready):
+                            logging.info(
+                                f"Resolved sandbox name '{name}' from claim status"
+                                + (" (claim Ready)" if ready else ""))
+                            w.stop()
+                            return name
+            except client.ApiException as e:
+                if e.status == 410:
+                    # The requested resourceVersion was compacted away:
+                    # restart from the watch cache's current state.
+                    logging.info(
+                        f"Watch on claim '{claim_name}' expired (410 Gone at resourceVersion={rv}); "
+                        "restarting from current state")
+                    rv = "0"
+                    continue
+                raise
 
     def wait_for_sandbox_ready(self, name: str, namespace: str, timeout: int) -> str | None:
         """Waits for the Sandbox custom resource to have a 'Ready' status.

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -150,20 +150,19 @@ class K8sHelper:
         been compacted away (410 Gone), the watch transparently restarts from
         ``"0"`` (current state from the watch cache).
         """
-        goal = "claim readiness" if require_ready else "sandbox name"
-        # Keep the legacy resolve-path message byte-identical to the original
-        # two-watch implementation (callers/tests may match on it).
+        wait_target = "claim readiness" if require_ready else "sandbox name"
+        # Existing tests assert on the exact resolve-path message.
         deleted_msg = (f"SandboxClaim '{claim_name}' was deleted while waiting for claim readiness"
                        if require_ready else
                        f"SandboxClaim '{claim_name}' was deleted while resolving sandbox name")
         deadline = time.monotonic() + timeout
         rv = resource_version or "0"
-        logging.info(f"Watching claim '{claim_name}' for {goal} (from resourceVersion={rv})...")
+        logging.info(f"Watching claim '{claim_name}' for {wait_target} (from resourceVersion={rv})...")
         while True:
             remaining = int(deadline - time.monotonic())
             if remaining <= 0:
                 raise TimeoutError(
-                    f"Could not resolve {goal} from claim "
+                    f"Could not resolve {wait_target} from claim "
                     f"'{claim_name}' within {timeout} seconds.")
             w = watch.Watch()
             try:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -20,7 +20,6 @@ file I/O) via the Sandbox resource handle.
 import uuid
 import atexit
 import sys
-import time
 import logging
 from typing import List, Dict, Tuple, TypeVar, Generic, Type
 
@@ -145,7 +144,7 @@ class SandboxClient(Generic[T]):
         claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
 
         try:
-            self._create_claim(
+            created_claim = self._create_claim(
                 claim_name,
                 warmpool,
                 namespace,
@@ -154,17 +153,19 @@ class SandboxClient(Generic[T]):
                 volume_claim_templates=volume_claim_templates,
                 pod_metadata=pod_metadata,
             )
-            # Resolve the sandbox id from the sandbox claim object.
-            # In case of warmpool, sandbox id is not the same as claim name.
-            start_time = time.monotonic()
-            sandbox_id = self.k8s_helper.resolve_sandbox_name(
-                claim_name, namespace, sandbox_ready_timeout
+            # Wait for the claim to be bound and Ready in a single watch.
+            # The claim status carries the sandbox name (which differs from
+            # the claim name with warm pools) and the forwarded Ready
+            # condition in the same status update, so no second watch on the
+            # Sandbox resource is needed. The watch starts from the create
+            # response's resourceVersion so the apiserver serves it from the
+            # watch cache instead of a quorum etcd read per wait.
+            claim_rv = None
+            if isinstance(created_claim, dict):
+                claim_rv = (created_claim.get("metadata") or {}).get("resourceVersion")
+            sandbox_id = self._wait_for_claim_ready(
+                claim_name, namespace, sandbox_ready_timeout, resource_version=claim_rv
             )
-            elapsed_time = time.monotonic() - start_time
-            remaining_timeout = max(0, int(sandbox_ready_timeout - elapsed_time))
-            if remaining_timeout <= 0:
-                raise TimeoutError("Sandbox resolution exceeded the ready timeout.")
-            self._wait_for_sandbox_ready(sandbox_id, namespace, remaining_timeout)
 
             sandbox = self.sandbox_class(
                 claim_name=claim_name,
@@ -340,7 +341,7 @@ class SandboxClient(Generic[T]):
             if trace_context_str:
                 annotations["opentelemetry.io/trace-context"] = trace_context_str
 
-        self.k8s_helper.create_sandbox_claim(
+        return self.k8s_helper.create_sandbox_claim(
             claim_name,
             warmpool_name,
             namespace,
@@ -351,9 +352,18 @@ class SandboxClient(Generic[T]):
             pod_metadata=pod_metadata,
         )
 
+    @trace_span("wait_for_claim_ready")
+    def _wait_for_claim_ready(self, claim_name: str, namespace: str, timeout: int, resource_version: str | None = None) -> str:
+        """Waits for the SandboxClaim to be bound and Ready, returning the sandbox name."""
+        return self.k8s_helper.wait_for_claim_ready(claim_name, namespace, timeout, resource_version=resource_version)
+
     @trace_span("wait_for_sandbox_ready")
     def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
-        """Waits for the Sandbox custom resource to have a 'Ready' status."""
+        """Waits for the Sandbox custom resource to have a 'Ready' status.
+
+        Retained for API compatibility; ``create_sandbox`` now uses the
+        single-watch ``_wait_for_claim_ready`` path instead.
+        """
         self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @trace_span("delete_claim")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -359,11 +359,7 @@ class SandboxClient(Generic[T]):
 
     @trace_span("wait_for_sandbox_ready")
     def _wait_for_sandbox_ready(self, sandbox_id: str, namespace: str, timeout: int):
-        """Waits for the Sandbox custom resource to have a 'Ready' status.
-
-        Retained for API compatibility; ``create_sandbox`` now uses the
-        single-watch ``_wait_for_claim_ready`` path instead.
-        """
+        """Waits for the Sandbox custom resource to have a 'Ready' status."""
         self.k8s_helper.wait_for_sandbox_ready(sandbox_id, namespace, timeout)
 
     @trace_span("delete_claim")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -19,6 +19,8 @@ import pytest
 
 pytest.importorskip("kubernetes_asyncio")
 
+from kubernetes_asyncio import client
+
 from k8s_agent_sandbox.async_k8s_helper import AsyncK8sHelper
 from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
 
@@ -167,6 +169,136 @@ class TestAsyncK8sHelperResolveSandboxName(unittest.IsolatedAsyncioTestCase):
             await self.helper.resolve_sandbox_name("test-claim", "default", timeout=5)
 
         self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
+    async def test_async_wait_for_claim_ready_single_event(self, mock_watch_class):
+        """Warm-pool fast path: name + Ready arrive in one claim status update."""
+        mock_watch = MagicMock()
+        mock_watch.close = AsyncMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "warm-sandbox-1", "podIPs": ["10.0.0.5"]},
+                },
+            },
+        }
+
+        async def mock_stream(*args, **kwargs):
+            yield mock_event
+
+        mock_watch.stream = mock_stream
+        mock_watch_class.return_value = mock_watch
+
+        name = await self.helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertEqual(name, "warm-sandbox-1")
+        self.assertEqual(mock_watch_class.call_count, 1)
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
+    async def test_async_wait_for_claim_ready_name_before_ready(self, mock_watch_class):
+        """Cold-start path: the name lands first, Ready arrives on a later event."""
+        mock_watch = MagicMock()
+        mock_watch.close = AsyncMock()
+        name_only_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "False", "reason": "SandboxNotReady"}],
+                    "sandbox": {"name": "cold-sandbox-1"},
+                },
+            },
+        }
+        ready_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "cold-sandbox-1", "podIPs": ["10.0.0.9"]},
+                },
+            },
+        }
+
+        async def mock_stream(*args, **kwargs):
+            yield name_only_event
+            yield ready_event
+
+        mock_watch.stream = mock_stream
+        mock_watch_class.return_value = mock_watch
+
+        name = await self.helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertEqual(name, "cold-sandbox-1")
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
+    async def test_async_watch_resource_version_passthrough(self, mock_watch_class):
+        """The ready-wait watch starts from the supplied resourceVersion
+        ("0" by default) so it never forces a quorum etcd read."""
+        mock_watch = MagicMock()
+        mock_watch.close = AsyncMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim", "resourceVersion": "7"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "warm-sandbox-1"},
+                },
+            },
+        }
+
+        seen_kwargs = {}
+
+        async def mock_stream(*args, **kwargs):
+            seen_kwargs.update(kwargs)
+            yield mock_event
+
+        mock_watch.stream = mock_stream
+        mock_watch_class.return_value = mock_watch
+
+        name = await self.helper.wait_for_claim_ready(
+            "test-claim", "default", timeout=5, resource_version="12345")
+        self.assertEqual(name, "warm-sandbox-1")
+        self.assertEqual(seen_kwargs["resource_version"], "12345")
+
+        seen_kwargs.clear()
+        name = await self.helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertEqual(seen_kwargs["resource_version"], "0")
+
+    @patch("k8s_agent_sandbox.async_k8s_helper.watch.Watch")
+    async def test_async_watch_410_gone_restarts_from_zero(self, mock_watch_class):
+        """A compacted-away resourceVersion (410 Gone) restarts the watch
+        from "0" instead of failing the wait."""
+        mock_watch = MagicMock()
+        mock_watch.close = AsyncMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim", "resourceVersion": "7"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "warm-sandbox-1"},
+                },
+            },
+        }
+
+        stream_rvs = []
+
+        async def mock_stream(*args, **kwargs):
+            stream_rvs.append(kwargs.get("resource_version"))
+            if len(stream_rvs) == 1:
+                raise client.ApiException(status=410)
+            yield mock_event
+
+        mock_watch.stream = mock_stream
+        mock_watch_class.return_value = mock_watch
+
+        name = await self.helper.wait_for_claim_ready(
+            "test-claim", "default", timeout=5, resource_version="12345")
+        self.assertEqual(name, "warm-sandbox-1")
+        self.assertEqual(stream_rvs, ["12345", "0"])
 
 
 class TestAsyncK8sHelperWaitForSandboxReady(unittest.IsolatedAsyncioTestCase):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -54,7 +54,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         self.client.sandbox_class = self.mock_sandbox_class
 
     async def test_create_sandbox_success(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="resolved-id")
         self.mock_k8s_helper.get_sandbox = AsyncMock(return_value={"metadata": {}})
 
         mock_sandbox_instance = MagicMock()
@@ -82,7 +82,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(len(active), 1)
 
     async def test_create_sandbox_failure_cleanup(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(
             side_effect=Exception("Timeout")
         )
 
@@ -97,7 +97,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
 
     async def test_create_sandbox_cancellation_cleanup(self):
         """CancelledError (BaseException) should still trigger claim cleanup."""
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(
             side_effect=asyncio.CancelledError()
         )
 
@@ -277,7 +277,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             await self.client.create_sandbox("t", labels={"": "v"})
 
     async def test_create_sandbox_with_pod_metadata(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="resolved-id")
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
@@ -305,7 +305,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             await self.client.create_sandbox("t", pod_labels={"bad key!": "v"})
 
     async def test_create_sandbox_with_shutdown_after_seconds(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="resolved-id")
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
@@ -325,7 +325,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             self.assertIn("shutdownTime", lifecycle)
 
     async def test_create_sandbox_with_volume_claim_templates(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="resolved-id")
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
@@ -377,7 +377,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         )
 
     async def test_create_sandbox_without_shutdown_after_seconds(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="resolved-id")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="resolved-id")
         mock_sandbox_instance = MagicMock()
         mock_sandbox_instance.terminate = AsyncMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
@@ -483,7 +483,7 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         config = SandboxInClusterConnectionConfig()
         client = AsyncSandboxClient(connection_config=config, cleanup=False)
         mock_k8s_helper = client.k8s_helper
-        mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="my-sandbox")
+        mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="my-sandbox")
 
         mock_sandbox_class = MagicMock()
         mock_sandbox_class.return_value = MagicMock()
@@ -915,7 +915,7 @@ class TestAsyncSandboxClientInClusterConnectionConfig(unittest.IsolatedAsyncioTe
         self.client.sandbox_class = self.mock_sandbox_class
 
     async def test_create_sandbox_passes_connection_config(self):
-        self.mock_k8s_helper.resolve_sandbox_name = AsyncMock(return_value="sandbox-123")
+        self.mock_k8s_helper.wait_for_claim_ready = AsyncMock(return_value="sandbox-123")
         self.mock_k8s_helper.wait_for_sandbox_ready = AsyncMock(return_value="10.244.0.5")
 
         mock_sandbox = MagicMock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -183,8 +183,110 @@ class TestK8sHelperResolveSandboxName(unittest.TestCase):
         
         with self.assertRaises(SandboxMetadataError) as context:
             helper.resolve_sandbox_name("test-claim", "default", timeout=5)
-            
+
         self.assertIn("SandboxClaim 'test-claim' was deleted while resolving sandbox name", str(context.exception))
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_claim_ready_single_event(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        """Warm-pool fast path: name + Ready arrive in one claim status update."""
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "warm-sandbox-1", "podIPs": ["10.0.0.5"]},
+                },
+            },
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+
+        self.assertEqual(name, "warm-sandbox-1")
+        # Only the claim is watched; no call against the Sandbox resource.
+        self.assertEqual(mock_watch_class.call_count, 1)
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_claim_ready_name_before_ready(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        """Cold-start path: the name lands first, Ready arrives on a later event."""
+        mock_watch = MagicMock()
+        name_only_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "False", "reason": "SandboxNotReady"}],
+                    "sandbox": {"name": "cold-sandbox-1"},
+                },
+            },
+        }
+        ready_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "cold-sandbox-1", "podIPs": ["10.0.0.9"]},
+                },
+            },
+        }
+        mock_watch.stream.return_value = [name_only_event, ready_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertEqual(name, "cold-sandbox-1")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_claim_ready_template_not_found(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "False",
+                            "reason": "TemplateNotFound",
+                            "message": "Template 'non-existent-template' not found",
+                        }
+                    ]
+                },
+            },
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        with self.assertRaises(SandboxTemplateNotFoundError):
+            helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_resolve_sandbox_name_returns_before_ready(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        """resolve_sandbox_name keeps its legacy semantics: name alone suffices."""
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "False", "reason": "SandboxNotReady"}],
+                    "sandbox": {"name": "pending-sandbox"},
+                },
+            },
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.resolve_sandbox_name("test-claim", "default", timeout=5)
+        self.assertEqual(name, "pending-sandbox")
 
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
@@ -577,6 +679,94 @@ class TestK8sHelperWaitForGatewayIP(unittest.TestCase):
         helper = K8sHelper()
         ip = helper.wait_for_gateway_ip("test-gateway", "default", timeout=5)
         self.assertEqual(ip, "192.168.1.1")
+
+
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperWatchResourceVersion(unittest.TestCase):
+    """The claim ready-wait watch must always carry an explicit
+    resourceVersion (the created claim's, or "0") so the apiserver serves it
+    from the watch cache — an unset resourceVersion forces a quorum etcd read
+    to establish initial state on every wait."""
+
+    @staticmethod
+    def _ready_event(rv="7"):
+        return {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim", "resourceVersion": rv},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "warm-sandbox-1"},
+                },
+            },
+        }
+
+    def test_create_sandbox_claim_returns_api_response(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+        mock_api.create_namespaced_custom_object.return_value = {
+            "metadata": {"name": "test-claim", "resourceVersion": "42"}
+        }
+
+        helper = K8sHelper()
+        resp = helper.create_sandbox_claim("test-claim", "test-warmpool", "test-namespace")
+        self.assertEqual(resp["metadata"]["resourceVersion"], "42")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_watch_defaults_to_resource_version_zero(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_watch.stream.return_value = [self._ready_event()]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+
+        self.assertEqual(name, "warm-sandbox-1")
+        self.assertEqual(mock_watch.stream.call_args.kwargs["resource_version"], "0")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_watch_starts_from_created_claim_resource_version(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_watch.stream.return_value = [self._ready_event()]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.wait_for_claim_ready("test-claim", "default", timeout=5, resource_version="12345")
+
+        self.assertEqual(name, "warm-sandbox-1")
+        self.assertEqual(mock_watch.stream.call_args.kwargs["resource_version"], "12345")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_watch_410_gone_restarts_from_zero(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        """A compacted-away resourceVersion (410 Gone) restarts the watch
+        from "0" instead of failing the wait."""
+        mock_watch = MagicMock()
+        mock_watch.stream.side_effect = [
+            client.ApiException(status=410),
+            [self._ready_event()],
+        ]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.wait_for_claim_ready("test-claim", "default", timeout=5, resource_version="12345")
+
+        self.assertEqual(name, "warm-sandbox-1")
+        first, second = mock_watch.stream.call_args_list
+        self.assertEqual(first.kwargs["resource_version"], "12345")
+        self.assertEqual(second.kwargs["resource_version"], "0")
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_watch_non_410_api_exception_reraises(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        mock_watch = MagicMock()
+        mock_watch.stream.side_effect = client.ApiException(status=403)
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        with self.assertRaises(client.ApiException) as ctx:
+            helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertEqual(ctx.exception.status, 403)
 
 
 if __name__ == '__main__':

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 from kubernetes import client
 from k8s_agent_sandbox.k8s_helper import K8sHelper
-from k8s_agent_sandbox.exceptions import SandboxMetadataError, SandboxTemplateNotFoundError
+from k8s_agent_sandbox.exceptions import SandboxClaimFailedError, SandboxMetadataError, SandboxTemplateNotFoundError
 
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
@@ -266,6 +266,65 @@ class TestK8sHelperResolveSandboxName(unittest.TestCase):
         helper = K8sHelper()
         with self.assertRaises(SandboxTemplateNotFoundError):
             helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_claim_ready_terminal_reason_fails_fast(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        """A terminal Ready=False reason raises immediately instead of waiting out the timeout."""
+        mock_watch = MagicMock()
+        mock_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [
+                        {
+                            "type": "Ready",
+                            "status": "False",
+                            "reason": "VolumeClaimTemplatesError",
+                            "message": "volumeClaimTemplates overrides are not allowed",
+                        }
+                    ]
+                },
+            },
+        }
+        mock_watch.stream.return_value = [mock_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        with self.assertRaises(SandboxClaimFailedError) as context:
+            helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertIn("VolumeClaimTemplatesError", str(context.exception))
+
+    @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
+    def test_wait_for_claim_ready_transient_reason_keeps_waiting(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):
+        """Transient Ready=False reasons (controller retries) do not abort the wait."""
+        mock_watch = MagicMock()
+        transient_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "False", "reason": "ReconcilerError",
+                                    "message": "Error seen: transient conflict"}],
+                },
+            },
+        }
+        ready_event = {
+            "type": "MODIFIED",
+            "object": {
+                "metadata": {"name": "test-claim"},
+                "status": {
+                    "conditions": [{"type": "Ready", "status": "True"}],
+                    "sandbox": {"name": "recovered-sandbox-1"},
+                },
+            },
+        }
+        mock_watch.stream.return_value = [transient_event, ready_event]
+        mock_watch_class.return_value = mock_watch
+
+        helper = K8sHelper()
+        name = helper.wait_for_claim_ready("test-claim", "default", timeout=5)
+        self.assertEqual(name, "recovered-sandbox-1")
 
     @patch("k8s_agent_sandbox.k8s_helper.watch.Watch")
     def test_resolve_sandbox_name_returns_before_ready(self, mock_watch_class, mock_config, mock_api_cls, mock_core_cls):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_lifecycle_integration.py
@@ -64,6 +64,7 @@ class TestLifecycleIntegration(unittest.TestCase):
         sandbox_client.sandbox_class = MagicMock()
 
         real_helper.resolve_sandbox_name = MagicMock(return_value="sandbox-abc")
+        real_helper.wait_for_claim_ready = MagicMock(return_value="sandbox-abc")
         real_helper.wait_for_sandbox_ready = MagicMock()
 
         before = datetime.now(timezone.utc)
@@ -110,6 +111,7 @@ class TestLifecycleIntegration(unittest.TestCase):
         sandbox_client.sandbox_class = MagicMock()
 
         real_helper.resolve_sandbox_name = MagicMock(return_value="sandbox-abc")
+        real_helper.wait_for_claim_ready = MagicMock(return_value="sandbox-abc")
         real_helper.wait_for_sandbox_ready = MagicMock()
 
         sandbox_client.create_sandbox("my-warmpool", "default")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -53,19 +53,21 @@ class TestSandboxClient(unittest.TestCase):
     @patch('uuid.uuid4')
     def test_create_sandbox_success(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'
-        self.mock_k8s_helper.resolve_sandbox_name.return_value = "resolved-id"
+        self.mock_k8s_helper.wait_for_claim_ready.return_value = "resolved-id"
         self.mock_k8s_helper.get_sandbox.return_value = {
             "metadata": {"annotations": {POD_NAME_ANNOTATION: "custom-pod-name"}}
         }
-        
+
         mock_sandbox_instance = MagicMock()
         self.mock_sandbox_class.return_value = mock_sandbox_instance
-        
-        with patch.object(self.client, '_create_claim') as mock_create_claim, \
-             patch.object(self.client, '_wait_for_sandbox_ready') as mock_wait:
-            
+
+        with patch.object(self.client, '_create_claim') as mock_create_claim:
+            # The create response's resourceVersion seeds the ready-wait
+            # watch so it is served from the apiserver watch cache.
+            mock_create_claim.return_value = {"metadata": {"resourceVersion": "12345"}}
+
             sandbox = self.client.create_sandbox("test-warmpool", "test-namespace")
-            
+
             mock_create_claim.assert_called_once_with(
                 "sandbox-claim-1234abcd",
                 "test-warmpool",
@@ -76,8 +78,12 @@ class TestSandboxClient(unittest.TestCase):
                 pod_metadata=None,
             )
 
-            self.mock_k8s_helper.resolve_sandbox_name.assert_called_once_with("sandbox-claim-1234abcd", "test-namespace", 180)
-            mock_wait.assert_called_once_with("resolved-id", "test-namespace", ANY)
+            # A single claim watch resolves the sandbox name AND readiness;
+            # no separate wait on the Sandbox resource. The watch starts at
+            # the created claim's resourceVersion.
+            self.mock_k8s_helper.wait_for_claim_ready.assert_called_once_with(
+                "sandbox-claim-1234abcd", "test-namespace", 180, resource_version="12345")
+            self.mock_k8s_helper.wait_for_sandbox_ready.assert_not_called()
             self.assertEqual(sandbox, mock_sandbox_instance)
             
             # Verify the new sandbox is tracked in the registry
@@ -87,8 +93,8 @@ class TestSandboxClient(unittest.TestCase):
     @patch('uuid.uuid4')
     def test_create_sandbox_failure_cleanup(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'
-        self.mock_k8s_helper.resolve_sandbox_name.side_effect = Exception("Timeout Error")
-        
+        self.mock_k8s_helper.wait_for_claim_ready.side_effect = Exception("Timeout Error")
+
         with patch.object(self.client, '_create_claim') as mock_create_claim:
             with self.assertRaises(Exception) as context:
                 self.client.create_sandbox("test-warmpool", "test-namespace")


### PR DESCRIPTION
#### What this PR does / why we need it

Waiting for a SandboxClaim to become ready in the Python SDK currently runs **two sequential watches**: one on the claim (to learn the bound sandbox name), then a second on the sandbox (to wait for Ready). But the claim's own status already carries both the bound sandbox name and the forwarded Ready condition, so the second watch is a full watch setup/teardown of pure overhead on every claim.

Per-change summary:

- **`wait_for_claim_ready()` (sync and async):** a single watch on the claim itself that resolves on the claim's own status, anchored to the create/read `resourceVersion` so no event between the initial read and the watch start can be missed (with a 410-Gone restart path). The legacy two-watch methods are kept unchanged, so existing callers are fully compatible.
- **Dev port-forward readiness polling 500ms → 50ms:** the fixed 500ms poll dominated connect times in dev/port-forward mode; with fast-starting sandboxes it added up to ~0.5s of pure waiting per connection.
- **README latency guidance** documenting the single-watch wait and the port-forward polling behavior.

#### Performance (A/B, this change alone)

Measured 2026-07-21 on kops GCP (Kubernetes v1.35.6): 6× e2-standard-8 workers + e2-standard-16 control plane, tuned control plane/nodes, **stock upstream-main controller image** deployed (server side identical for both modes), warm pool of 60, client on an in-region VM. 50 sequential claim create → ready-wait cycles per mode; pool availability is re-checked between iterations so every cycle is a warm adoption. Legacy mode ran the upstream-main SDK; single mode ran this branch.

| claim create → ready-wait return (n=50) | legacy two-watch | single-watch (this PR) | delta |
|---|---|---|---|
| mean | 68.4ms | 54.9ms | **−13.5ms (−20%)** |
| p50 | 67.0ms | 53.5ms | −20% |
| p90 | 83.7ms | 66.0ms | −21% |
| max | 110.5ms | 82.8ms | −25% |

50/50 successes in both modes, zero failures. The saved ~13-18ms is the second watch's setup/teardown round trip — a constant client-side cost that becomes a significant share of observed ready latency exactly when the server side is fast (the same cluster's uncontended create→Ready is ~60-90ms).

Unit tests cover the new single-watch wait (ready, resourceVersion anchoring, 410/permission failure paths) for both the sync and async clients; the full package suite passes (298 tests).

#### Which issue(s) this PR fixes

Related to #574, #286

```release-note
Python SDK: new single-watch `wait_for_claim_ready()` waits for a SandboxClaim using one watch on the claim itself (previously two sequential watches); dev port-forward readiness polling interval reduced from 500ms to 50ms.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced sandbox startup latency by switching `create_sandbox` to a single, watch-based claim readiness flow.
  * Improved local-tunnel readiness detection by polling every 50ms.

* **Reliability**
  * Enhanced claim readiness handling to resume from the last seen event, recover from Kubernetes watch compaction (HTTP 410), and correctly handle warm vs cold readiness timing.
  * Added `SandboxClaimFailedError` for terminal claim failures.

* **Documentation**
  * Added a new Python client section explaining startup latency, warm/cold behavior, timeouts, and local-tunnel overhead.

* **Tests**
  * Expanded unit coverage for readiness edge cases and watch restart/410 recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->