### PR TITLE
perf(sandboxclaim): stop fanning pool status churn out to every claim

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1795,11 +1795,16 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 // and still depend on warm-pool state.
 //
 // Claims that are already bound to a sandbox (status.sandboxStatus.name set) are
-// skipped: once bound, a claim's reconciliation is driven by its own events and by
-// the Owns(&Sandbox{}) watch, and nothing in the bound path consults the pool in a
-// way that a pool event must trigger. If the bound sandbox is later deleted, the
-// sandbox delete event (Owns watch) re-reconciles the claim and clears
-// status.sandboxStatus.name, after which the claim receives pool events again.
+// skipped: pool events exist to wake claims that are still WAITING on the pool
+// (binding/adoption), and a bound claim's reconciliation is driven by its own
+// events and by the Owns(&Sandbox{}) watch. Note the bound path does still read
+// the pool/template on reconcile (reconcileActive fetches them for metadata and
+// NetworkPolicy reconciliation) — the deliberate trade-off here is that pool or
+// template spec changes no longer proactively re-enqueue every bound claim;
+// bound claims pick such changes up on their next reconcile from any other
+// trigger. If the bound sandbox is later deleted, the sandbox delete event
+// (Owns watch) re-reconciles the claim and clears status.sandboxStatus.name,
+// after which the claim receives pool events again.
 // Claims being deleted are likewise skipped since Reconcile returns immediately
 // for them. Unbound claims are always enqueued: they may be waiting for the pool
 // to appear (ErrWarmPoolNotFound requeue path) or for a usable pool spec.

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1791,7 +1791,18 @@ func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 	}
 }
 
-// mapWarmPoolToClaims maps a SandboxWarmPool to a list of SandboxClaims that reference it.
+// mapWarmPoolToClaims maps a SandboxWarmPool to the SandboxClaims that reference it
+// and still depend on warm-pool state.
+//
+// Claims that are already bound to a sandbox (status.sandboxStatus.name set) are
+// skipped: once bound, a claim's reconciliation is driven by its own events and by
+// the Owns(&Sandbox{}) watch, and nothing in the bound path consults the pool in a
+// way that a pool event must trigger. If the bound sandbox is later deleted, the
+// sandbox delete event (Owns watch) re-reconciles the claim and clears
+// status.sandboxStatus.name, after which the claim receives pool events again.
+// Claims being deleted are likewise skipped since Reconcile returns immediately
+// for them. Unbound claims are always enqueued: they may be waiting for the pool
+// to appear (ErrWarmPoolNotFound requeue path) or for a usable pool spec.
 func (r *SandboxClaimReconciler) mapWarmPoolToClaims(ctx context.Context, obj client.Object) []ctrl.Request {
 	warmPool, ok := obj.(*extensionsv1beta1.SandboxWarmPool)
 	if !ok {
@@ -1806,6 +1817,9 @@ func (r *SandboxClaimReconciler) mapWarmPoolToClaims(ctx context.Context, obj cl
 	requests := make([]ctrl.Request, 0, len(claims.Items))
 	for i := range claims.Items {
 		claim := &claims.Items[i]
+		if claim.Status.SandboxStatus.Name != "" || !claim.DeletionTimestamp.IsZero() {
+			continue
+		}
 		requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: claim.Namespace, Name: claim.Name}})
 	}
 	return requests
@@ -1836,7 +1850,18 @@ func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWo
 		Watches(
 			&extensionsv1beta1.SandboxWarmPool{},
 			handler.EnqueueRequestsFromMapFunc(r.mapWarmPoolToClaims),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+			// GenerationChangedPredicate (instead of ResourceVersionChangedPredicate)
+			// drops pool STATUS-only updates, which churn on every adoption /
+			// replenishment and previously fanned out to every claim referencing
+			// the pool (O(pool status writes x claims) no-op reconciles during
+			// bursts). Claims never wait on pool status: newly adoptable warm
+			// sandboxes reach claims through the Sandbox watch feeding the
+			// in-memory WarmSandboxQueue, and a claim that finds the queue empty
+			// falls through to cold-start in the same reconcile rather than
+			// blocking on pool capacity. Pool create/delete events and spec
+			// (generation) changes still pass, covering claims requeueing on
+			// ErrWarmPoolNotFound / ErrTemplateNotFound.
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
 		// TODO: Keep a lightweight SandboxTemplate -> claims map watch to promptly reconcile
 		// claims when a missing template is created, instead of relying on the 1-minute fallback.

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -4363,6 +4363,25 @@ func TestMapWarmPoolToClaims(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "claim-other", Namespace: "default"},
 		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "other-warmpool"}},
 	}
+	// Bound claim: already has a sandbox recorded in status, so pool events must
+	// not re-enqueue it (its reconciles are driven by the claim/sandbox watches).
+	claimBound := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim-bound", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPoolName}},
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			SandboxStatus: extensionsv1beta1.SandboxStatus{Name: "adopted-sandbox"},
+		},
+	}
+	// Deleting claim: Reconcile returns immediately for it, so it is skipped too.
+	claimDeleting := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "claim-deleting",
+			Namespace:         "default",
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPoolName}},
+	}
 
 	warmPool := &extensionsv1beta1.SandboxWarmPool{
 		ObjectMeta: metav1.ObjectMeta{Name: warmPoolName, Namespace: "default"},
@@ -4375,7 +4394,7 @@ func TestMapWarmPoolToClaims(t *testing.T) {
 	// Let's use the WithIndex option on the fake client builder to support the matchingFields query!
 	fakeClientWithIndex := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(claim1, claim2, claimOther, warmPool).
+		WithObjects(claim1, claim2, claimOther, claimBound, claimDeleting, warmPool).
 		WithIndex(&extensionsv1beta1.SandboxClaim{}, extensionsv1beta1.WarmPoolRefField, func(obj client.Object) []string {
 			c := obj.(*extensionsv1beta1.SandboxClaim)
 			if c.Spec.WarmPoolRef.Name == "" {
@@ -4393,7 +4412,7 @@ func TestMapWarmPoolToClaims(t *testing.T) {
 	requests := reconciler.mapWarmPoolToClaims(context.Background(), warmPool)
 
 	if len(requests) != 2 {
-		t.Fatalf("expected 2 requests, got %d", len(requests))
+		t.Fatalf("expected 2 requests (unbound claims only), got %d: %v", len(requests), requests)
 	}
 
 	expectedNames := map[string]bool{"claim-1": true, "claim-2": true}
@@ -4404,6 +4423,42 @@ func TestMapWarmPoolToClaims(t *testing.T) {
 		if req.Namespace != "default" {
 			t.Errorf("expected namespace 'default', got %s", req.Namespace)
 		}
+	}
+}
+
+// TestWarmPoolMapWatchPredicate pins the event classes the pool->claims map watch
+// reacts to: status-only pool updates (generation unchanged) must be filtered out,
+// while spec changes (generation bump) still pass so unbound claims wake up.
+func TestWarmPoolMapWatchPredicate(t *testing.T) {
+	pred := predicate.GenerationChangedPredicate{}
+
+	oldPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-warmpool",
+			Namespace:       "default",
+			Generation:      1,
+			ResourceVersion: "100",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{Replicas: new(int32(5))},
+	}
+
+	// Status-only update: resourceVersion moves, generation does not.
+	statusOnlyPool := oldPool.DeepCopy()
+	statusOnlyPool.ResourceVersion = "101"
+	statusOnlyPool.Status.ReadyReplicas = 3
+
+	if pred.Update(event.UpdateEvent{ObjectOld: oldPool, ObjectNew: statusOnlyPool}) {
+		t.Errorf("expected status-only pool update (generation unchanged) to be filtered out")
+	}
+
+	// Spec update: the API server bumps metadata.generation.
+	specChangedPool := oldPool.DeepCopy()
+	specChangedPool.ResourceVersion = "102"
+	specChangedPool.Generation = 2
+	specChangedPool.Spec.Replicas = new(int32(10))
+
+	if !pred.Update(event.UpdateEvent{ObjectOld: oldPool, ObjectNew: specChangedPool}) {
+		t.Errorf("expected spec (generation) pool update to pass the predicate")
 	}
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it

The SandboxClaim controller watches SandboxWarmPool and maps every pool event to **every claim referencing that pool**. Pool *status* churns continuously while claims are being bound (replicas/readyReplicas counters move on each adoption and replenishment), so every status write re-enqueues all N claims referencing the pool — O(N²) no-op reconciles arriving exactly when the controller is busiest (one component of the reconcile storm described in #527).

Two changes:

- The pool→claims map watch now uses `GenerationChangedPredicate` instead of `ResourceVersionChangedPredicate`: pool status-only updates no longer fan out. Pool create/delete events and spec (generation) changes still map, so claims waiting on a missing or changed pool still wake up promptly.
- `mapWarmPoolToClaims` skips claims that are already bound (`status.sandboxStatus.name` set) or being deleted: a bound claim's reconciliation is driven by its own events and the `Owns(&Sandbox{})` watch, and if its sandbox is later deleted, that delete event re-reconciles the claim and clears the binding — after which it receives pool events again.

No adoption wakeup is lost: newly adoptable warm sandboxes reach waiting claims through the Sandbox watch feeding the warm-sandbox queue, not through the pool fan-out.

#### Performance (A/B, this change alone)

Measured 2026-07-21 on kops GCP (Kubernetes v1.35.6): 6× e2-standard-8 workers + e2-standard-16 control plane, tuned control plane/nodes, webhook enabled, stress client on an in-region VM (4 calibrated HTTP/2 connections). **Same cluster within each comparison**; each leg = 20-claim smoke gate + 300 SandboxClaims fired simultaneously against a fully-warm 300-replica pool. BASE = upstream main (9a4b3a0); P3 = this branch. All four legs: 300/300 Ready, 0 failed.

The fan-out scales with worker throughput (the workqueue dedups adds while claims are still queued), so it was measured at two worker configurations:

**At stock defaults (50 claim workers):** SandboxClaim reconciles over the burst drop 1,883 → 1,527 (**−19%**); claim-ready latency was indistinguishable within run-to-run variance (BASE p50/p90 1142/2048ms vs P3 1526/2977ms on this pair, while BASE legs across three same-day clusters of identical shape spanned p50 861-1328ms / p90 1916-2684ms — the single-burst spread exceeds any per-leg delta at this config).

**At 400 sandbox + 400 claim workers (identical on both legs) — the configuration where the storm actually bites:**

| | BASE | this PR | delta |
|---|---|---|---|
| SandboxClaim reconciles (300-claim burst) | 9,207 | 5,259 | **−43%** (~3,950 no-op passes removed) |
| Sandbox reconciles | 18,802 | 12,503 | −34% |
| SandboxWarmPool reconciles | 1,266 | 812 | −36% |
| claim create ack p90 | 72ms | 47ms | −35% |
| claim create → Ready p50 | 816ms | 726ms | −11% |
| claim create → Ready p90 | 1427ms | 985ms | **−31%** |
| time to ALL 300 Ready | 8.39s | 6.42s | −23% |

Tail caveat, for honesty: p99/max in both runs are dominated by a handful of stragglers (BASE max 8.39s, P3 max 6.41s; p99 3.25s vs 6.36s) — single-run tails at that depth are not resolvable in this environment, while the reconcile counters and the p50/p90/all-ready improvements are consistent with the mechanism (removed queue pressure).

Unit tests pin the mapper's skip behavior (bound / deleting / unbound — `TestMapWarmPoolToClaims`) and the event classes the predicate passes (`TestWarmPoolMapWatchPredicate`: status-only update filtered, generation change passes).

#### Which issue(s) this PR fixes

Related to #527

```release-note
SandboxWarmPool status-only updates no longer re-enqueue every SandboxClaim referencing the pool, and already-bound or deleting claims are skipped by the pool-to-claim watch mapping.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warm-pool-to-claim reconciliation to skip claims that are already bound to a sandbox or are currently being deleted.
  * Updated warm-pool event handling so status-only updates no longer trigger claim reconciliations; only generation/spec changes do.
* **Tests**
  * Extended warm-pool mapping tests to cover bound and deleting claims, ensuring only eligible claims are re-queued.
  * Added coverage to verify warm-pool watch behavior correctly filters out status-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->