### PR TITLE
feat(metrics): REST client latency histograms

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -183,6 +183,12 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	// Install client-go REST latency hooks before any client issues requests.
+	// Explicit (not package init) so binaries that import internal/metrics but
+	// don't serve the controller-runtime registry (e.g. sandbox-router) don't
+	// record observations that are never exposed.
+	asmetrics.RegisterRESTClientLatencyMetrics()
+
 	// Initialize Tracing Provider
 	var instrumenter = asmetrics.NewNoOp()
 	if enableTracing {

--- a/internal/metrics/restclient.go
+++ b/internal/metrics/restclient.go
@@ -17,6 +17,7 @@ package metrics
 import (
 	"context"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -68,18 +69,28 @@ var (
 	)
 )
 
-func init() {
-	metrics.Registry.MustRegister(requestLatency, rateLimiterLatency)
+var registerRESTClientOnce sync.Once
 
-	// client-go's clientmetrics.Register is guarded by a sync.Once that
-	// controller-runtime's pkg/metrics init() already consumes (wiring only
-	// RequestResult), so a second Register call would be a silent no-op.
-	// Assign the exported hook variables directly instead. This happens at
-	// package init, before the manager (or any client) issues requests, and
-	// Register never overwrites hooks whose RegisterOpts field is nil, so the
-	// assignment is safe regardless of package init order.
-	clientmetrics.RequestLatency = &latencyAdapter{metric: requestLatency}
-	clientmetrics.RateLimiterLatency = &latencyAdapter{metric: rateLimiterLatency}
+// RegisterRESTClientLatencyMetrics registers the latency histograms with
+// controller-runtime's global registry and installs the client-go latency
+// hooks. It is called explicitly by the controller binary (not in init()) so
+// that other binaries importing this package — e.g. sandbox-router, which
+// serves a private Prometheus registry — don't pay for observations that are
+// never exposed. Call it before any client issues requests; it is idempotent.
+func RegisterRESTClientLatencyMetrics() {
+	registerRESTClientOnce.Do(func() {
+		metrics.Registry.MustRegister(requestLatency, rateLimiterLatency)
+
+		// client-go's clientmetrics.Register is guarded by a sync.Once that
+		// controller-runtime's pkg/metrics init() already consumes (wiring
+		// only RequestResult), so a second Register call would be a silent
+		// no-op. Instead, unconditionally overwrite the exported
+		// RequestLatency/RateLimiterLatency hook variables — controller-runtime
+		// leaves both at their no-op defaults, so nothing is lost, and doing
+		// it before any client sends a request means no observation is missed.
+		clientmetrics.RequestLatency = &latencyAdapter{metric: requestLatency}
+		clientmetrics.RateLimiterLatency = &latencyAdapter{metric: rateLimiterLatency}
+	})
 }
 
 type latencyAdapter struct {

--- a/internal/metrics/restclient.go
+++ b/internal/metrics/restclient.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// controller-runtime's pkg/metrics only wires client-go's RequestResult hook
+// (rest_client_requests_total): request COUNTS are exported but request
+// LATENCY is not, so per-verb API round-trip time is invisible on the
+// controller's /metrics endpoint. This file adds the two latency hooks,
+// using the same metric names as k8s.io/component-base so standard
+// dashboards and queries apply.
+
+var (
+	// restClientLatencyBuckets spans sub-ms cache hits through multi-second
+	// throttled/contended calls (matches component-base's upper range while
+	// adding finer low-end resolution for small, fast writes).
+	restClientLatencyBuckets = []float64{
+		0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+		1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0,
+	}
+
+	// requestLatency is the client-observed latency of Kubernetes API
+	// requests, per verb and host. The URL path is deliberately dropped to
+	// bound cardinality; resource-level splits come from the apiserver's own
+	// apiserver_request_duration_seconds, and the delta between the two is
+	// the network+client overhead this metric exists to expose.
+	requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rest_client_request_duration_seconds",
+			Help:    "Request latency in seconds. Broken down by verb and host.",
+			Buckets: restClientLatencyBuckets,
+		},
+		[]string{"verb", "host"},
+	)
+
+	// rateLimiterLatency is the time requests spend waiting on the client-side
+	// rate limiter before being sent, per verb and host. Non-zero values under
+	// burst load mean --kube-api-qps/--kube-api-burst are the bottleneck, not
+	// the apiserver.
+	rateLimiterLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rest_client_rate_limiter_duration_seconds",
+			Help:    "Client side rate limiter latency in seconds. Broken down by verb and host.",
+			Buckets: restClientLatencyBuckets,
+		},
+		[]string{"verb", "host"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(requestLatency, rateLimiterLatency)
+
+	// client-go's clientmetrics.Register is guarded by a sync.Once that
+	// controller-runtime's pkg/metrics init() already consumes (wiring only
+	// RequestResult), so a second Register call would be a silent no-op.
+	// Assign the exported hook variables directly instead. This happens at
+	// package init, before the manager (or any client) issues requests, and
+	// Register never overwrites hooks whose RegisterOpts field is nil, so the
+	// assignment is safe regardless of package init order.
+	clientmetrics.RequestLatency = &latencyAdapter{metric: requestLatency}
+	clientmetrics.RateLimiterLatency = &latencyAdapter{metric: rateLimiterLatency}
+}
+
+type latencyAdapter struct {
+	metric *prometheus.HistogramVec
+}
+
+func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
+	l.metric.WithLabelValues(verb, u.Host).Observe(latency.Seconds())
+}

--- a/internal/metrics/restclient_test.go
+++ b/internal/metrics/restclient_test.go
@@ -46,11 +46,13 @@ func findHistogram(t *testing.T, name string) *dto.Metric {
 }
 
 func TestRESTClientLatencyMetrics(t *testing.T) {
+	// Idempotent: safe even if another test already registered.
+	RegisterRESTClientLatencyMetrics()
 	requestLatency.Reset()
 	rateLimiterLatency.Reset()
 
 	u := url.URL{Scheme: "https", Host: "apiserver.example:6443", Path: "/api/v1/namespaces/default/pods"}
-	// Observe through the client-go hooks to verify init() wired them up.
+	// Observe through the client-go hooks to verify registration wired them up.
 	clientmetrics.RequestLatency.Observe(context.Background(), "GET", u, 250*time.Millisecond)
 	clientmetrics.RateLimiterLatency.Observe(context.Background(), "GET", u, 5*time.Millisecond)
 

--- a/internal/metrics/restclient_test.go
+++ b/internal/metrics/restclient_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	clientmetrics "k8s.io/client-go/tools/metrics"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// findHistogram returns the single histogram series for the named metric
+// family in the controller-runtime registry, or nil if absent.
+func findHistogram(t *testing.T, name string) *dto.Metric {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() failed: %v", err)
+	}
+	for _, mf := range families {
+		if mf.GetName() != name {
+			continue
+		}
+		if len(mf.GetMetric()) != 1 {
+			t.Fatalf("expected 1 series for %s, got %d", name, len(mf.GetMetric()))
+		}
+		return mf.GetMetric()[0]
+	}
+	return nil
+}
+
+func TestRESTClientLatencyMetrics(t *testing.T) {
+	requestLatency.Reset()
+	rateLimiterLatency.Reset()
+
+	u := url.URL{Scheme: "https", Host: "apiserver.example:6443", Path: "/api/v1/namespaces/default/pods"}
+	// Observe through the client-go hooks to verify init() wired them up.
+	clientmetrics.RequestLatency.Observe(context.Background(), "GET", u, 250*time.Millisecond)
+	clientmetrics.RateLimiterLatency.Observe(context.Background(), "GET", u, 5*time.Millisecond)
+
+	for _, name := range []string{
+		"rest_client_request_duration_seconds",
+		"rest_client_rate_limiter_duration_seconds",
+	} {
+		m := findHistogram(t, name)
+		if m == nil {
+			t.Fatalf("metric %s not registered in controller-runtime registry", name)
+		}
+		if got := m.GetHistogram().GetSampleCount(); got != 1 {
+			t.Errorf("%s: expected 1 observation, got %d", name, got)
+		}
+		labels := map[string]string{}
+		for _, lp := range m.GetLabel() {
+			labels[lp.GetName()] = lp.GetValue()
+		}
+		if labels["verb"] != "GET" || labels["host"] != "apiserver.example:6443" {
+			t.Errorf("%s: unexpected labels %v, want verb=GET host=apiserver.example:6443", name, labels)
+		}
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

The controller currently exposes no visibility into apiserver round-trip latency as seen by the client: controller-runtime's `pkg/metrics` wires only client-go's `RequestResult` hook (`rest_client_requests_total`), so request counts are exported but request latency is not.

This PR adds a small `k8s.io/client-go/tools/metrics` adapter (`internal/metrics/restclient.go`) that registers two histograms into the controller-runtime Prometheus registry, using the same metric names as `k8s.io/component-base` so standard dashboards and queries apply:

- `rest_client_request_duration_seconds{verb, host}` — client-observed latency of Kubernetes API requests. The URL path is deliberately dropped to bound cardinality; the delta against the apiserver's own `apiserver_request_duration_seconds` exposes network+client overhead.
- `rest_client_rate_limiter_duration_seconds{verb, host}` — time requests wait on the client-side rate limiter before being sent. Non-zero values under burst load indicate `--kube-api-qps`/`--kube-api-burst` are the bottleneck rather than the apiserver.

Together these make write RTTs, watch re-establishment, and client-side queueing visible on the `/metrics` endpoint. We used these histograms to attribute latency while diagnosing warm-adoption performance in a 300-claim warm-adoption benchmark.

The hooks are self-registering at package init (the `internal/metrics` package is already imported by the controller binary), there is no behavior change, and the overhead is a single histogram observation per REST request — negligible.

Includes a unit test verifying observations made through the client-go hooks land in the registered histograms with the expected `verb`/`host` labels.

**Why there is no latency A/B table on this PR:** behavior-affecting PRs in this series each carry a BASE-vs-change A/B benchmark run on a dedicated tuned cluster; for this change a latency A/B is not meaningful, because it is observe-only — no request, cache, or reconcile path is altered, and the added cost is one histogram observation per REST request (nanoseconds against millisecond RTTs). What the PR adds is the attribution capability itself: with these histograms we could separate client-observed RTT from `apiserver_request_duration_seconds` and expose client-side rate-limiter waits while diagnosing warm-adoption latency in a 300-claim warm-adoption benchmark.

#### Which issue(s) this PR is related to:

Ref #245 (observability umbrella)

#### Release Note

```release-note
The controller now exposes REST client latency metrics: `rest_client_request_duration_seconds` and `rest_client_rate_limiter_duration_seconds` histograms (labeled by `verb` and `host`) on the metrics endpoint.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics to track Kubernetes REST client request latency.
  * Added Prometheus metrics to track time spent waiting on client-side rate limiting.
  * Metrics are labeled by HTTP method and server host for clearer observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->