### PR TITLE
test/stress: sustained-rate (Poisson) phase, monotonic latency accounting, client connection calibration

### DIFF
--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -185,6 +185,13 @@ type Config struct {
 	// controller's worst-case refill latency (any replenishment delay + cold
 	// launch p99), or the pool runs dry and claims cold-start.
 	SustainedPoolHeadroom time.Duration `json:"sustainedPoolHeadroomNanos"`
+	// SustainedLifecycleBudget is the assumed per-claim ready+delete pipeline
+	// time (everything outside the dwell) used when estimating the phase's
+	// peak concurrent pods in checkClusterCapacity. If the cluster's
+	// Ready/delete path is slower than this under load, raise it so the
+	// capacity check demands enough headroom to keep queueing out of the
+	// latency measurement.
+	SustainedLifecycleBudget time.Duration `json:"sustainedLifecycleBudgetNanos"`
 
 	// ClientConnections shards the harness's own mutating requests across N
 	// HTTP/2 connections (1 = share the watches' single connection, the
@@ -250,6 +257,7 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.ClaimDwell, "claim-dwell", 5*time.Second, "How long each sustained claim is held after Ready before deletion")
 	flag.IntVar(&cfg.SustainedNamespaces, "sustained-namespaces", 1, "Spread the sustained phase's pools and claims across N pre-created namespaces (1 = run in the test namespace)")
 	flag.DurationVar(&cfg.SustainedPoolHeadroom, "sustained-pool-headroom", 10*time.Second, "Warm pool sizing for the sustained phase: each namespace's pool has ceil(rate/namespaces * headroom-seconds) replicas; must cover the controller's worst-case refill latency")
+	flag.DurationVar(&cfg.SustainedLifecycleBudget, "sustained-lifecycle-budget", 5*time.Second, "Assumed per-claim ready+delete pipeline time (beyond --claim-dwell) used to size the sustained phase's pod-capacity estimate; raise it if the cluster's Ready/delete path is slower under load")
 	flag.IntVar(&cfg.ClientConnections, "client-connections", 1, "Shard the harness's mutating API requests across N HTTP/2 connections; 1 = single connection shared with watches (historical behavior, subject to the apiserver's ~100-streams-per-connection cap)")
 	flag.BoolVar(&cfg.CollectMetrics, "collect-metrics", true, "Whether to scrape Prometheus metrics from the control plane, the sandbox controller, and kubelets to metrics.jsonl.gz")
 	flag.DurationVar(&cfg.MetricsInterval, "metrics-interval", 15*time.Second, "Interval between Prometheus metrics scrapes")
@@ -628,17 +636,24 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 				return test.runClaimsWarmPhase(ctx, number)
 			}})
 		case raw == string(PhaseClaimsWarmSustained):
-			if test.cfg.SustainedRate <= 0 {
-				return nil, fmt.Errorf("phase %q requires --sustained-rate > 0", raw)
+			// Finite checks: flag.Float64Var accepts "NaN" and "+Inf" (NaN
+			// even passes a <= 0 test), and non-finite values would flow
+			// into pool sizing and the capacity estimate where float->int
+			// conversion is implementation-defined.
+			if test.cfg.SustainedRate <= 0 || math.IsNaN(test.cfg.SustainedRate) || math.IsInf(test.cfg.SustainedRate, 0) {
+				return nil, fmt.Errorf("phase %q requires a finite --sustained-rate > 0", raw)
 			}
-			if test.cfg.SustainedSeconds <= 0 {
-				return nil, fmt.Errorf("phase %q requires --sustained-seconds > 0", raw)
+			if test.cfg.SustainedSeconds <= 0 || math.IsNaN(test.cfg.SustainedSeconds) || math.IsInf(test.cfg.SustainedSeconds, 0) {
+				return nil, fmt.Errorf("phase %q requires a finite --sustained-seconds > 0", raw)
 			}
 			if test.cfg.SustainedNamespaces < 1 {
 				return nil, fmt.Errorf("phase %q requires --sustained-namespaces >= 1", raw)
 			}
 			if test.cfg.SustainedPoolHeadroom <= 0 {
 				return nil, fmt.Errorf("phase %q requires --sustained-pool-headroom > 0", raw)
+			}
+			if test.cfg.SustainedLifecycleBudget <= 0 {
+				return nil, fmt.Errorf("phase %q requires --sustained-lifecycle-budget > 0", raw)
 			}
 			runs = append(runs, phaseRun{number, PhaseClaimsWarmSustained, func(ctx context.Context) error {
 				return test.runClaimsWarmSustainedPhase(ctx, number)
@@ -724,9 +739,10 @@ func checkClusterCapacity(cfg Config, info *ClusterInfo) error {
 		// Steady state: the pools stay full (refill replaces adopted
 		// sandboxes) while adopted sandboxes live for roughly the ready
 		// latency + dwell + deletion pipeline before their pods go away;
-		// budget ~5s of pipeline on top of the dwell.
+		// --sustained-lifecycle-budget bounds the pipeline part on top of
+		// the dwell.
 		poolTotal := sustainedPoolReplicasPerNamespace(cfg) * cfg.SustainedNamespaces
-		inFlight := int(math.Ceil(cfg.SustainedRate * (cfg.ClaimDwell.Seconds() + 5)))
+		inFlight := int(math.Ceil(cfg.SustainedRate * (cfg.ClaimDwell.Seconds() + cfg.SustainedLifecycleBudget.Seconds())))
 		if n := poolTotal + inFlight; n > extra {
 			extra = n
 		}

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -44,6 +44,7 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -109,6 +110,11 @@ type PhaseSummary struct {
 	// Per-worker-node rates, alongside the raw aggregates above.
 	CreateThroughputPerNode *PerNodeRates `json:"createThroughputPerNode,omitempty"`
 	ReadyThroughputPerNode  *PerNodeRates `json:"readyThroughputPerNode,omitempty"`
+
+	// SustainedWindows holds the claims-warm-sustained phase's rolling
+	// per-10s-window create->Ready stats (arrival-time bucketed): the
+	// "latency holds over time" evidence. Set only for that phase.
+	SustainedWindows []WindowedLatency `json:"sustainedWindows,omitempty"`
 }
 
 // Summary is written to summary.json at the end of the test.
@@ -162,6 +168,24 @@ type Config struct {
 	// and up to ~2x transiently while the pool replenishes claimed sandboxes.
 	ClaimsWarmCount int `json:"claimsWarmCount"`
 
+	// claims-warm-sustained parameters (see sustained.go for the full model).
+	// SustainedRate is the target claim arrival rate in claims/s (Poisson).
+	SustainedRate float64 `json:"sustainedRate"`
+	// SustainedSeconds is the duration of the arrival window in seconds.
+	SustainedSeconds float64 `json:"sustainedSeconds"`
+	// ClaimDwell is how long each sustained claim is held after Ready before
+	// it is deleted (steady-state churn realism: adoption + refill + teardown
+	// all run concurrently).
+	ClaimDwell time.Duration `json:"claimDwellNanos"`
+	// SustainedNamespaces spreads the sustained phase's pools and claims
+	// round-robin across N pre-created namespaces (shard testing).
+	SustainedNamespaces int `json:"sustainedNamespaces"`
+	// SustainedPoolHeadroom sizes each namespace's warm pool:
+	// replicas = ceil(rate/namespaces * headroom-seconds). It must cover the
+	// controller's worst-case refill latency (any replenishment delay + cold
+	// launch p99), or the pool runs dry and claims cold-start.
+	SustainedPoolHeadroom time.Duration `json:"sustainedPoolHeadroomNanos"`
+
 	// ClientConnections shards the harness's own mutating requests across N
 	// HTTP/2 connections (1 = share the watches' single connection, the
 	// historical behavior). The apiserver caps ~100 concurrent streams per
@@ -213,7 +237,7 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.Timeout, "timeout", 30*time.Minute, "Timeout for the entire test run")
 	flag.DurationVar(&cfg.PerSandboxTimeout, "per-sandbox-timeout", 5*time.Minute, "Timeout for a single sandbox to become ready / be deleted")
 	flag.IntVar(&cfg.CreateConcurrency, "create-concurrency", 20, "Number of concurrent workers creating Sandboxes (fill and throughput phases)")
-	phasesFlag := flag.String("phases", "probe,throughput-mif50", "Comma-separated phase names to run in order (fill, probe, claims-warm, throughput-mifN). Structured forms like throughput{maxInFlight:N} may be added later")
+	phasesFlag := flag.String("phases", "probe,throughput-mif50", "Comma-separated phase names to run in order (fill, probe, claims-warm, claims-warm-sustained, throughput-mifN). Structured forms like throughput{maxInFlight:N} may be added later")
 	flag.IntVar(&cfg.FillPerNode, "fill-per-node", 10, "Number of long-running background Sandboxes per worker node for the fill phase")
 	flag.IntVar(&cfg.ProbeCount, "probe-count", 20, "Number of latency probe Sandboxes for the probe phase")
 	flag.IntVar(&cfg.ProbeConcurrency, "probe-concurrency", 1, "Number of concurrent latency probes; keep low for clean latency numbers")
@@ -221,6 +245,11 @@ func run(ctx context.Context) error {
 	flag.IntVar(&cfg.ThroughputCount, "throughput-count", 200, "Number of Sandboxes to churn per throughput phase (before --throughput-min-seconds)")
 	flag.Float64Var(&cfg.ThroughputMinSeconds, "throughput-min-seconds", 45, "Minimum duration of each throughput phase; levels churn beyond -throughput-count until this much time has elapsed (0 = count-based only)")
 	flag.IntVar(&cfg.ClaimsWarmCount, "claims-warm-count", 300, "Warm pool size and number of simultaneous SandboxClaims for the claims-warm phase (requires the extensions controller)")
+	flag.Float64Var(&cfg.SustainedRate, "sustained-rate", 300, "Target SandboxClaim arrival rate in claims/s (Poisson-jittered) for the claims-warm-sustained phase (requires the extensions controller)")
+	flag.Float64Var(&cfg.SustainedSeconds, "sustained-seconds", 60, "Duration of the claims-warm-sustained arrival window in seconds")
+	flag.DurationVar(&cfg.ClaimDwell, "claim-dwell", 5*time.Second, "How long each sustained claim is held after Ready before deletion")
+	flag.IntVar(&cfg.SustainedNamespaces, "sustained-namespaces", 1, "Spread the sustained phase's pools and claims across N pre-created namespaces (1 = run in the test namespace)")
+	flag.DurationVar(&cfg.SustainedPoolHeadroom, "sustained-pool-headroom", 10*time.Second, "Warm pool sizing for the sustained phase: each namespace's pool has ceil(rate/namespaces * headroom-seconds) replicas; must cover the controller's worst-case refill latency")
 	flag.IntVar(&cfg.ClientConnections, "client-connections", 1, "Shard the harness's mutating API requests across N HTTP/2 connections; 1 = single connection shared with watches (historical behavior, subject to the apiserver's ~100-streams-per-connection cap)")
 	flag.BoolVar(&cfg.CollectMetrics, "collect-metrics", true, "Whether to scrape Prometheus metrics from the control plane, the sandbox controller, and kubelets to metrics.jsonl.gz")
 	flag.DurationVar(&cfg.MetricsInterval, "metrics-interval", 15*time.Second, "Interval between Prometheus metrics scrapes")
@@ -246,6 +275,9 @@ func run(ctx context.Context) error {
 	}
 	if cfg.ClientConnections < 1 {
 		return fmt.Errorf("--client-connections must be >= 1, got %d", cfg.ClientConnections)
+	}
+	if cfg.ClaimDwell < 0 {
+		return fmt.Errorf("--claim-dwell must be >= 0, got %v", cfg.ClaimDwell)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
@@ -479,6 +511,7 @@ func run(ctx context.Context) error {
 		profiler:       profiler,
 		ctrlProfiler:   ctrlProfiler,
 		mutateClient:   mutateClient,
+		nsClient:       mutateClient.Resource(gvrNamespaces),
 		sandboxClient:  mutateClient.Resource(gvrSandboxes).Namespace(cfg.Namespace),
 		templateClient: mutateClient.Resource(gvrSandboxTemplates).Namespace(cfg.Namespace),
 		warmPoolClient: mutateClient.Resource(gvrSandboxWarmPools).Namespace(cfg.Namespace),
@@ -594,10 +627,26 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 			runs = append(runs, phaseRun{number, PhaseClaimsWarm, func(ctx context.Context) error {
 				return test.runClaimsWarmPhase(ctx, number)
 			}})
+		case raw == string(PhaseClaimsWarmSustained):
+			if test.cfg.SustainedRate <= 0 {
+				return nil, fmt.Errorf("phase %q requires --sustained-rate > 0", raw)
+			}
+			if test.cfg.SustainedSeconds <= 0 {
+				return nil, fmt.Errorf("phase %q requires --sustained-seconds > 0", raw)
+			}
+			if test.cfg.SustainedNamespaces < 1 {
+				return nil, fmt.Errorf("phase %q requires --sustained-namespaces >= 1", raw)
+			}
+			if test.cfg.SustainedPoolHeadroom <= 0 {
+				return nil, fmt.Errorf("phase %q requires --sustained-pool-headroom > 0", raw)
+			}
+			runs = append(runs, phaseRun{number, PhaseClaimsWarmSustained, func(ctx context.Context) error {
+				return test.runClaimsWarmSustainedPhase(ctx, number)
+			}})
 		default:
 			maxInFlight, ok := throughputMaxInFlight(raw)
 			if !ok {
-				return nil, fmt.Errorf("unknown phase %q (want fill, probe, claims-warm, or throughput-mifN)", raw)
+				return nil, fmt.Errorf("unknown phase %q (want fill, probe, claims-warm, claims-warm-sustained, or throughput-mifN)", raw)
 			}
 			if test.cfg.ThroughputCount <= 0 {
 				return nil, fmt.Errorf("phase %q requires --throughput-count > 0", raw)
@@ -624,9 +673,12 @@ func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
 }
 
 // hasClaimsPhase reports whether any phase needs the SandboxClaim machinery
-// (claim watch, extensions CRDs, controller profiler).
+// (claim watch, extensions CRDs, controller profiler). The claim watch is
+// cluster-wide, so it also covers the sustained phase's extra <ns>-s1..sN
+// shard namespaces.
 func hasClaimsPhase(phases []string) bool {
-	return slices.Contains(phases, string(PhaseClaimsWarm))
+	return slices.Contains(phases, string(PhaseClaimsWarm)) ||
+		slices.Contains(phases, string(PhaseClaimsWarmSustained))
 }
 
 // throughputMaxInFlight parses throughput / throughput-mifN phase names.
@@ -656,7 +708,9 @@ func throughputMaxInFlight(name string) (int, bool) {
 // of that the warm pool controller replenishes claimed sandboxes, so the
 // phase can transiently reach ~2x its count — that overshoot is warned about
 // rather than required, because replenishment pods only queue (they do not
-// delay the claims being measured) and cleanup removes them.
+// delay the claims being measured) and cleanup removes them. The
+// claims-warm-sustained budget covers its warm pools (kept full by refill)
+// plus the adopted-but-not-yet-deleted sandboxes.
 func checkClusterCapacity(cfg Config, info *ClusterInfo) error {
 	extra := 0
 	if slices.Contains(cfg.Phases, string(PhaseProbe)) && cfg.ProbeConcurrency > extra {
@@ -665,6 +719,17 @@ func checkClusterCapacity(cfg Config, info *ClusterInfo) error {
 	claimsWarm := slices.Contains(cfg.Phases, string(PhaseClaimsWarm))
 	if claimsWarm && cfg.ClaimsWarmCount > extra {
 		extra = cfg.ClaimsWarmCount
+	}
+	if slices.Contains(cfg.Phases, string(PhaseClaimsWarmSustained)) {
+		// Steady state: the pools stay full (refill replaces adopted
+		// sandboxes) while adopted sandboxes live for roughly the ready
+		// latency + dwell + deletion pipeline before their pods go away;
+		// budget ~5s of pipeline on top of the dwell.
+		poolTotal := sustainedPoolReplicasPerNamespace(cfg) * cfg.SustainedNamespaces
+		inFlight := int(math.Ceil(cfg.SustainedRate * (cfg.ClaimDwell.Seconds() + 5)))
+		if n := poolTotal + inFlight; n > extra {
+			extra = n
+		}
 	}
 	for _, name := range cfg.Phases {
 		if maxInFlight, ok := throughputMaxInFlight(name); ok && maxInFlight > extra {
@@ -772,6 +837,9 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 			return cfg.ProbeCount
 		case PhaseClaimsWarm:
 			return cfg.ClaimsWarmCount
+		case PhaseClaimsWarmSustained:
+			// Expected arrivals; the Poisson process varies the actual count.
+			return sustainedExpectedClaims(cfg)
 		default:
 			// Throughput phases (one per throughput-mifN entry).
 			return cfg.ThroughputCount
@@ -824,6 +892,9 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 		}
 		ps.CreateThroughput = computeThroughputStats(createTimes)
 		ps.ReadyThroughput = computeThroughputStats(readyTimes)
+		if result.name == PhaseClaimsWarmSustained {
+			ps.SustainedWindows = computeWindowedLatencies(phaseRecords, sustainedWindow)
+		}
 		if clusterInfo != nil {
 			ps.CreateThroughputPerNode = ps.CreateThroughput.perNode(clusterInfo.Nodes)
 			ps.ReadyThroughputPerNode = ps.ReadyThroughput.perNode(clusterInfo.Nodes)
@@ -977,6 +1048,31 @@ func printReport(summary *Summary, clusterInfo *ClusterInfo) {
 				fmt.Printf("  time until ALL claims Ready:     n/a (not all claims became Ready)\n")
 			}
 			fmt.Printf("  claim ready throughput:          %s\n", formatThroughput(ps.ReadyThroughput))
+		case PhaseClaimsWarmSustained:
+			// Like claims-warm, only claim-level intervals are meaningful; the
+			// headline evidence is the per-window trend, not one aggregate.
+			cfg := summary.Config
+			fmt.Printf("  target arrivals:                 %.1f/s (Poisson) for %.0fs across %d namespace(s); pool %d/ns (headroom %s), dwell %s\n",
+				cfg.SustainedRate, cfg.SustainedSeconds, cfg.SustainedNamespaces,
+				sustainedPoolReplicasPerNamespace(cfg), cfg.SustainedPoolHeadroom, cfg.ClaimDwell)
+			fmt.Printf("  claim create throughput:         %s\n", formatThroughput(ps.CreateThroughput))
+			fmt.Printf("  claim create ack (apiserver):    %s\n", formatLatency(ps.Latency.CreateAck))
+			fmt.Printf("  claim create -> claim Ready:     %s\n", formatLatency(ps.Latency.EndToEndReady))
+			fmt.Printf("  claim ready throughput:          %s\n", formatThroughput(ps.ReadyThroughput))
+			fmt.Printf("  rolling %.0fs windows by arrival time (create -> Ready):\n", sustainedWindow.Seconds())
+			for _, w := range ps.SustainedWindows {
+				if w.Arrivals == 0 {
+					fmt.Printf("    [%4.0fs-%4.0fs) arrivals=0\n", w.StartOffsetSeconds, w.EndOffsetSeconds)
+					continue
+				}
+				lat := "no readies"
+				if w.Latency != nil {
+					lat = fmt.Sprintf("p50=%-8s p90=%-8s p99=%-8s max=%s",
+						formatMs(w.Latency.P50Ms), formatMs(w.Latency.P90Ms), formatMs(w.Latency.P99Ms), formatMs(w.Latency.MaxMs))
+				}
+				fmt.Printf("    [%4.0fs-%4.0fs) arrivals=%-5d ready=%-5d %s\n",
+					w.StartOffsetSeconds, w.EndOffsetSeconds, w.Arrivals, w.Ready, lat)
+			}
 		default:
 			fmt.Printf("  end-to-end ready latency:        %s\n", formatLatency(ps.Latency.EndToEndReady))
 			fmt.Printf("  create throughput:               %s\n", formatThroughput(ps.CreateThroughput))

--- a/test/stress/phases.go
+++ b/test/stress/phases.go
@@ -39,7 +39,10 @@ type stressTest struct {
 	// are sharded over N dedicated connections so create bursts neither
 	// queue on the ~100-stream per-connection cap nor congest the watches
 	// (see clientconns.go).
-	mutateClient  dynamic.Interface
+	mutateClient dynamic.Interface
+	// nsClient creates/deletes the extra namespaces of the multi-namespace
+	// sustained phase (cluster-scoped).
+	nsClient      dynamic.ResourceInterface
 	sandboxClient dynamic.ResourceInterface
 	// Extensions clients (extensions.agents.x-k8s.io/v1beta1), used by the
 	// claims-warm phases. The extensions controller must be deployed

--- a/test/stress/stats.go
+++ b/test/stress/stats.go
@@ -152,6 +152,75 @@ func computeTimeToAllReady(records []SandboxRecord) *float64 {
 	return &seconds
 }
 
+// WindowedLatency aggregates create->Ready latency over one fixed window of
+// ARRIVALS: records are bucketed by CreateCalled, so each window reflects the
+// experience of the claims that arrived during it. In a sustained-rate phase,
+// latency degradation over time shows up as later windows getting slower.
+type WindowedLatency struct {
+	// StartOffsetSeconds/EndOffsetSeconds bound the window [start, end)
+	// relative to the earliest CreateCalled among the records.
+	StartOffsetSeconds float64 `json:"startOffsetSeconds"`
+	EndOffsetSeconds   float64 `json:"endOffsetSeconds"`
+	// Arrivals counts records whose CreateCalled fell in this window;
+	// Ready counts how many of those were observed Ready (ever, not
+	// necessarily within the window).
+	Arrivals int `json:"arrivals"`
+	Ready    int `json:"ready"`
+	// Latency summarizes create->Ready for the Ready arrivals; nil when none.
+	Latency *LatencyStats `json:"latency,omitempty"`
+}
+
+// computeWindowedLatencies buckets records into contiguous windows of the
+// given size by CreateCalled and summarizes create->Ready latency per window.
+// Records without a CreateCalled are skipped; empty interior windows are
+// retained (Arrivals=0) so the timeline stays contiguous.
+func computeWindowedLatencies(records []SandboxRecord, window time.Duration) []WindowedLatency {
+	if window <= 0 {
+		return nil
+	}
+	var base, last time.Time
+	for i := range records {
+		t := records[i].CreateCalled
+		if t.IsZero() {
+			continue
+		}
+		if base.IsZero() || t.Before(base) {
+			base = t
+		}
+		if t.After(last) {
+			last = t
+		}
+	}
+	if base.IsZero() {
+		return nil
+	}
+
+	numWindows := int(last.Sub(base)/window) + 1
+	out := make([]WindowedLatency, numWindows)
+	durations := make([][]time.Duration, numWindows)
+	for i := range out {
+		out[i].StartOffsetSeconds = (time.Duration(i) * window).Seconds()
+		out[i].EndOffsetSeconds = (time.Duration(i+1) * window).Seconds()
+	}
+	for i := range records {
+		rec := &records[i]
+		if rec.CreateCalled.IsZero() {
+			continue
+		}
+		idx := int(rec.CreateCalled.Sub(base) / window)
+		out[idx].Arrivals++
+		if rec.SandboxReady.IsZero() {
+			continue
+		}
+		out[idx].Ready++
+		durations[idx] = append(durations[idx], rec.SandboxReady.Sub(rec.CreateCalled))
+	}
+	for i := range out {
+		out[i].Latency = computeLatencyStats(durations[i])
+	}
+	return out
+}
+
 // ThroughputStats summarizes the rate at which a set of events occurred.
 type ThroughputStats struct {
 	Count           int     `json:"count"`

--- a/test/stress/stats_test.go
+++ b/test/stress/stats_test.go
@@ -180,6 +180,113 @@ func TestComputeLatencyStatsPercentiles(t *testing.T) {
 	}
 }
 
+func TestComputeWindowedLatencies(t *testing.T) {
+	base := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	window := 10 * time.Second
+
+	records := []SandboxRecord{
+		// Window 0 ([0s,10s)): two arrivals, both ready, 100ms and 300ms.
+		rec(base, 0, 100*time.Millisecond),
+		rec(base, 9*time.Second, 9*time.Second+300*time.Millisecond),
+		// Window 1 ([10s,20s)): one arrival, never ready.
+		rec(base, 12*time.Second, -1),
+		// Window 2 ([20s,30s)): empty (no arrivals) — must be retained.
+		// Window 3 ([30s,40s)): one arrival, ready AFTER the window ends
+		// (2s latency); it still counts in its ARRIVAL window.
+		rec(base, 39*time.Second, 41*time.Second),
+		// A record without CreateCalled must be skipped entirely.
+		rec(base, -1, 5*time.Second),
+	}
+
+	windows := computeWindowedLatencies(records, window)
+	if len(windows) != 4 {
+		t.Fatalf("got %d windows, want 4: %+v", len(windows), windows)
+	}
+
+	w0 := windows[0]
+	if w0.StartOffsetSeconds != 0 || w0.EndOffsetSeconds != 10 {
+		t.Errorf("window 0 bounds = [%v,%v), want [0,10)", w0.StartOffsetSeconds, w0.EndOffsetSeconds)
+	}
+	if w0.Arrivals != 2 || w0.Ready != 2 {
+		t.Errorf("window 0 arrivals/ready = %d/%d, want 2/2", w0.Arrivals, w0.Ready)
+	}
+	if w0.Latency == nil || w0.Latency.Count != 2 {
+		t.Fatalf("window 0 latency = %+v, want count 2", w0.Latency)
+	}
+	if got, want := w0.Latency.MinMs, 100.0; math.Abs(got-want) > 1e-6 {
+		t.Errorf("window 0 MinMs = %v, want %v", got, want)
+	}
+	if got, want := w0.Latency.MaxMs, 300.0; math.Abs(got-want) > 1e-6 {
+		t.Errorf("window 0 MaxMs = %v, want %v", got, want)
+	}
+
+	w1 := windows[1]
+	if w1.Arrivals != 1 || w1.Ready != 0 || w1.Latency != nil {
+		t.Errorf("window 1 = %+v, want arrivals=1 ready=0 latency=nil", w1)
+	}
+
+	w2 := windows[2]
+	if w2.Arrivals != 0 || w2.Ready != 0 || w2.Latency != nil {
+		t.Errorf("window 2 = %+v, want empty interior window retained", w2)
+	}
+
+	w3 := windows[3]
+	if w3.Arrivals != 1 || w3.Ready != 1 {
+		t.Errorf("window 3 arrivals/ready = %d/%d, want 1/1", w3.Arrivals, w3.Ready)
+	}
+	if w3.Latency == nil || math.Abs(w3.Latency.P50Ms-2000.0) > 1e-6 {
+		t.Errorf("window 3 latency = %+v, want p50 2000ms (bucketed by arrival, not readiness)", w3.Latency)
+	}
+}
+
+// TestComputeWindowedLatenciesShowsDegradation is the phase's reason to
+// exist: a workload whose latency worsens over time must produce
+// monotonically increasing window percentiles rather than one flat aggregate.
+func TestComputeWindowedLatenciesShowsDegradation(t *testing.T) {
+	base := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	window := 10 * time.Second
+
+	// 3 windows x 100 arrivals; latency = 100ms in window 0, 200ms in 1, 400ms in 2.
+	var records []SandboxRecord
+	for w := range 3 {
+		latency := time.Duration(100*(1<<w)) * time.Millisecond
+		for i := range 100 {
+			offset := time.Duration(w)*window + time.Duration(i)*window/100
+			records = append(records, rec(base, offset, offset+latency))
+		}
+	}
+
+	windows := computeWindowedLatencies(records, window)
+	if len(windows) != 3 {
+		t.Fatalf("got %d windows, want 3", len(windows))
+	}
+	for w, wantMs := range []float64{100, 200, 400} {
+		got := windows[w]
+		if got.Arrivals != 100 || got.Ready != 100 || got.Latency == nil {
+			t.Fatalf("window %d = %+v, want 100 arrivals/ready with latency", w, got)
+		}
+		for name, ms := range map[string]float64{"p50": got.Latency.P50Ms, "p90": got.Latency.P90Ms, "p99": got.Latency.P99Ms} {
+			if math.Abs(ms-wantMs) > 1e-6 {
+				t.Errorf("window %d %s = %vms, want %vms", w, name, ms, wantMs)
+			}
+		}
+	}
+}
+
+func TestComputeWindowedLatenciesEdgeCases(t *testing.T) {
+	base := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	if got := computeWindowedLatencies(nil, 10*time.Second); got != nil {
+		t.Errorf("no records: got %+v, want nil", got)
+	}
+	if got := computeWindowedLatencies([]SandboxRecord{rec(base, 0, time.Second)}, 0); got != nil {
+		t.Errorf("zero window: got %+v, want nil", got)
+	}
+	// Only records without CreateCalled -> no windows.
+	if got := computeWindowedLatencies([]SandboxRecord{rec(base, -1, time.Second)}, 10*time.Second); got != nil {
+		t.Errorf("no create timestamps: got %+v, want nil", got)
+	}
+}
+
 func fmtPtr(f *float64) any {
 	if f == nil {
 		return "<nil>"

--- a/test/stress/sustained.go
+++ b/test/stress/sustained.go
@@ -1,0 +1,463 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// claims-warm-sustained: an open-loop, sustained-rate SandboxClaim phase.
+//
+// Where the other phases either launch cold sandboxes or fire requests as an
+// all-at-once burst, this phase models steady-state arrivals: SandboxClaims
+// arrive as a Poisson process at --sustained-rate claims/s for
+// --sustained-seconds, each claim is deleted --claim-dwell after it becomes
+// Ready, and the warm pool controller refills continuously in the
+// background. The question it answers is the one a burst cannot: do
+// create->Ready latencies HOLD over time, or do they degrade as adoption,
+// refill, and teardown churn compound? Degradation shows up directly in the
+// rolling per-10s-window p50/p90/p99 (summary.json sustainedWindows, also
+// printed in the report).
+//
+// Pool sizing (per namespace): replicas = ceil(rate/namespaces x
+// --sustained-pool-headroom seconds). The pool drains at the arrival rate and
+// each consumed sandbox is replaced only after the controller's replenishment
+// latency, so the steady-state inventory deficit is rate x refill-latency.
+// The headroom must therefore cover the controller's WORST-CASE refill
+// latency: any delay the controller applies before replenishing consumed
+// sandboxes, plus the cold sandbox launch p99 on the cluster under test. The
+// 10s default assumes prompt replenishment; raise it if the controller defers
+// refill, or the pool runs dry and claims cold-start (visible as
+// window-latency cliffs — a real degradation signal, but of the pool sizing,
+// not the adoption path).
+//
+// Cluster capacity: peak concurrent pods ~= pool total (kept full by refill)
+// + rate x (ready-latency + dwell + deletion pipeline) adopted-but-not-yet-
+// deleted sandboxes; checkClusterCapacity budgets this.
+//
+// --sustained-namespaces=N pre-creates N namespaces (<run-ns>-s1..sN), each
+// with its own template + pool, and spreads arrivals round-robin across them.
+// Namespaces are a natural sharding key, so this makes the phase usable for
+// controller sharding experiments: a sharded controller needs arrivals spread
+// over multiple namespaces before shards share the load. With N=1 the phase
+// runs entirely in the main test namespace.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+)
+
+// sustainedWindow is the fixed aggregation window for the phase's rolling
+// create->Ready latency stats (summary sustainedWindows + live progress logs).
+const sustainedWindow = 10 * time.Second
+
+// poissonSchedule yields successive arrival offsets of a homogeneous Poisson
+// process with the given rate (events/second): inter-arrival gaps are
+// exponentially distributed with mean 1/rate. Offsets are absolute from the
+// schedule origin, so a pacing loop that sleeps until start+offset never
+// accumulates drift (a late arrival does not delay subsequent ones).
+type poissonSchedule struct {
+	rate float64
+	rng  *rand.Rand
+	next time.Duration
+}
+
+// newPoissonSchedule returns a schedule for rate events/second (must be > 0).
+func newPoissonSchedule(rate float64, rng *rand.Rand) *poissonSchedule {
+	return &poissonSchedule{rate: rate, rng: rng}
+}
+
+// Next returns the offset of the next arrival from the schedule origin.
+// Offsets are strictly increasing.
+func (p *poissonSchedule) Next() time.Duration {
+	gap := time.Duration(p.rng.ExpFloat64() / p.rate * float64(time.Second))
+	// ExpFloat64 can (rarely) round to a zero duration at high rates; keep
+	// offsets strictly increasing so arrivals stay ordered.
+	if gap <= 0 {
+		gap = time.Nanosecond
+	}
+	p.next += gap
+	return p.next
+}
+
+// sustainedPoolReplicasPerNamespace returns the SandboxWarmPool replica count
+// created in EACH of the phase's namespaces:
+// ceil(rate/namespaces x headroom-seconds). See the package comment for the
+// sizing rationale.
+func sustainedPoolReplicasPerNamespace(cfg Config) int {
+	if cfg.SustainedNamespaces < 1 || cfg.SustainedRate <= 0 {
+		return 0
+	}
+	perNS := cfg.SustainedRate / float64(cfg.SustainedNamespaces)
+	return int(math.Ceil(perNS * cfg.SustainedPoolHeadroom.Seconds()))
+}
+
+// sustainedExpectedClaims is the expected arrival count (rate x duration);
+// the Poisson process makes the actual count vary around it.
+func sustainedExpectedClaims(cfg Config) int {
+	return int(math.Round(cfg.SustainedRate * cfg.SustainedSeconds))
+}
+
+// sustainedNamespaceClients bundles the per-namespace resource clients used
+// by the sustained phase. Mutating clients come from the (optionally
+// sharded) mutate client; see configureCreateConnections.
+type sustainedNamespaceClients struct {
+	name     string
+	template dynamic.ResourceInterface
+	pool     dynamic.ResourceInterface
+	claim    dynamic.ResourceInterface
+}
+
+func (s *stressTest) sustainedClientsFor(namespace string) sustainedNamespaceClients {
+	return sustainedNamespaceClients{
+		name:     namespace,
+		template: s.mutateClient.Resource(gvrSandboxTemplates).Namespace(namespace),
+		pool:     s.mutateClient.Resource(gvrSandboxWarmPools).Namespace(namespace),
+		claim:    s.mutateClient.Resource(gvrSandboxClaims).Namespace(namespace),
+	}
+}
+
+// runClaimsWarmSustainedPhase drives the sustained-rate claim workload
+// described in the package comment.
+func (s *stressTest) runClaimsWarmSustainedPhase(ctx context.Context, number PhaseNumber) error {
+	phase := PhaseClaimsWarmSustained
+	rate := s.cfg.SustainedRate
+	duration := time.Duration(s.cfg.SustainedSeconds * float64(time.Second))
+	nsCount := s.cfg.SustainedNamespaces
+	poolReplicas := sustainedPoolReplicasPerNamespace(s.cfg)
+	expected := sustainedExpectedClaims(s.cfg)
+
+	templateName := fmt.Sprintf("p%d-stemplate", number)
+	poolName := fmt.Sprintf("p%d-spool", number)
+
+	// Clean up claims, pools, templates, and extra namespaces even when the
+	// phase fails partway (including mid-namespace-creation): later phases
+	// assume spare capacity is back. The closure sees the final slice.
+	namespaces := make([]sustainedNamespaceClients, 0, nsCount)
+	defer func() { s.cleanupSustained(ctx, number, namespaces, poolName, templateName) }()
+
+	// Resolve and (for N>1) pre-create the namespaces.
+	if nsCount == 1 {
+		namespaces = append(namespaces, s.sustainedClientsFor(s.namespace))
+	} else {
+		for i := 1; i <= nsCount; i++ {
+			name := fmt.Sprintf("%s-s%d", s.namespace, i)
+			if err := s.createNamespace(ctx, name); err != nil {
+				return fmt.Errorf("[%s#%d] failed to create namespace %s: %w", phase, number, name, err)
+			}
+			namespaces = append(namespaces, s.sustainedClientsFor(name))
+		}
+		log.Printf("[%s#%d] pre-created %d namespaces (%s-s1..s%d)", phase, number, nsCount, s.namespace, nsCount)
+	}
+
+	// Provision one template + pool per namespace, then wait for every pool
+	// to be fully ready: pool provisioning is setup, not measurement.
+	log.Printf("[%s#%d] provisioning %d warm pool(s) of %d replicas (rate %.1f/s, headroom %s)",
+		phase, number, nsCount, poolReplicas, rate, s.cfg.SustainedPoolHeadroom)
+	for _, nsc := range namespaces {
+		templateID := types.NamespacedName{Name: templateName, Namespace: nsc.name}
+		poolID := types.NamespacedName{Name: poolName, Namespace: nsc.name}
+		if _, err := nsc.template.Create(ctx, buildTemplateObject(templateID, s.cfg.Image), metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("[%s#%d] failed to create sandbox template in %s: %w", phase, number, nsc.name, err)
+		}
+		if _, err := nsc.pool.Create(ctx, buildWarmPoolObject(poolID, templateName, poolReplicas), metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("[%s#%d] failed to create warm pool in %s: %w", phase, number, nsc.name, err)
+		}
+	}
+	nsIndices := make([]int, len(namespaces))
+	for i := range nsIndices {
+		nsIndices[i] = i
+	}
+	if _, err := ForkJoin(ctx, nsIndices, nsCount, func(i int) (struct{}, error) {
+		return struct{}{}, s.waitWarmPoolReady(ctx, namespaces[i].pool, phase, poolName, poolReplicas, number)
+	}); err != nil {
+		return err
+	}
+
+	// Profile a mid-run slice: by 10s in, arrivals + refill + teardown all
+	// overlap, which is the steady state this phase exists to measure. The
+	// controller profile (when enabled) covers the same window so server- and
+	// controller-side cost correlate.
+	if s.profiler != nil {
+		go s.profiler.CaptureCPUProfile(ctx, phase, 10*time.Second, 30*time.Second)
+	}
+	if s.ctrlProfiler != nil {
+		go s.ctrlProfiler.CaptureCPUProfile(ctx, phase, 10*time.Second, 30*time.Second)
+	}
+
+	log.Printf("[%s#%d] arrivals: %.1f/s Poisson for %s (~%d claims) across %d namespace(s), dwell %s after Ready",
+		phase, number, rate, duration, expected, nsCount, s.cfg.ClaimDwell)
+
+	// Live per-window progress, so degradation is visible while running.
+	windowLogCtx, stopWindowLog := context.WithCancel(ctx)
+	defer stopWindowLog()
+	go s.logSustainedWindows(windowLogCtx, number)
+
+	// Open-loop arrival pacing: sleep until start+offset for each scheduled
+	// arrival. Arrivals are never gated on earlier claims completing — that
+	// is the difference between measuring a target rate and a closed loop.
+	sched := newPoissonSchedule(rate, rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())))
+	start := time.Now()
+	launched := 0
+	var wg sync.WaitGroup
+	for {
+		offset := sched.Next()
+		if offset > duration {
+			break
+		}
+		if wait := time.Until(start.Add(offset)); wait > 0 {
+			select {
+			case <-ctx.Done():
+				wg.Wait()
+				return ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+		nsc := namespaces[launched%len(namespaces)]
+		id := types.NamespacedName{Name: fmt.Sprintf("p%d-sclaim-%d", number, launched), Namespace: nsc.name}
+		launched++
+		wg.Go(func() {
+			s.runSustainedClaimLifecycle(ctx, nsc.claim, id, poolName, number)
+		})
+	}
+
+	elapsed := time.Since(start)
+	log.Printf("[%s#%d] arrival window done: %d claims launched over %s (%.1f/s achieved vs %.1f/s target); draining in-flight lifecycles",
+		phase, number, launched, elapsed.Round(time.Millisecond), float64(launched)/elapsed.Seconds(), rate)
+
+	// Drain: every lifecycle is bounded (WaitReady/WaitGone timeouts + dwell).
+	wg.Wait()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	counts := s.tracker.Snapshot()[number]
+	if counts.Created == 0 {
+		return fmt.Errorf("[%s#%d] all %d claim creations failed", phase, number, counts.Failed)
+	}
+	log.Printf("[%s#%d] done: %d created, %d ready, %d deleted, %d failed",
+		phase, number, counts.Created, counts.Ready, counts.Deleted, counts.Failed)
+	return nil
+}
+
+// runSustainedClaimLifecycle is one claim's full arc: create -> observed
+// Ready -> dwell -> delete -> observed gone. Failures are recorded on the
+// record (they surface as Failed in the summary), never aborting the phase.
+func (s *stressTest) runSustainedClaimLifecycle(ctx context.Context, claimClient dynamic.ResourceInterface, id types.NamespacedName, poolName string, number PhaseNumber) {
+	if err := s.createClaim(ctx, claimClient, id, poolName, PhaseClaimsWarmSustained, number); err != nil {
+		return
+	}
+
+	if err := s.tracker.WaitReady(ctx, id, s.cfg.PerSandboxTimeout); err != nil && ctx.Err() == nil {
+		s.tracker.MarkError(id, err.Error())
+		log.Printf("[%s#%d] %s: %v", PhaseClaimsWarmSustained, number, id.Name, err)
+		// Fall through: delete the claim regardless, to keep churn realistic.
+	}
+
+	// Dwell: hold the claim after Ready so adopted sandboxes occupy capacity
+	// like real workloads do, then release it (delete -> refill continues).
+	if s.cfg.ClaimDwell > 0 {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(s.cfg.ClaimDwell):
+		}
+	}
+	if ctx.Err() != nil {
+		// Shutting down; cleanup/namespace deletion removes the claim.
+		return
+	}
+
+	s.tracker.MarkDeleteCalled(id)
+	if err := claimClient.Delete(ctx, id.Name, metav1.DeleteOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			s.tracker.MarkGone(id)
+			return
+		}
+		s.tracker.MarkError(id, fmt.Sprintf("delete failed: %v", err))
+		log.Printf("[%s#%d] failed to delete claim %s: %v", PhaseClaimsWarmSustained, number, id.Name, err)
+		return
+	}
+	if err := s.tracker.WaitGone(ctx, id, s.cfg.PerSandboxTimeout); err != nil && ctx.Err() == nil {
+		s.tracker.MarkError(id, err.Error())
+		log.Printf("[%s#%d] %s: %v", PhaseClaimsWarmSustained, number, id.Name, err)
+	}
+}
+
+// logSustainedWindows logs the most recent COMPLETE rolling window's
+// create->Ready percentiles every sustainedWindow, so latency degradation is
+// visible live rather than only in the post-run summary.
+func (s *stressTest) logSustainedWindows(ctx context.Context, number PhaseNumber) {
+	ticker := time.NewTicker(sustainedWindow)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		var recs []SandboxRecord
+		for _, rec := range s.tracker.Records() {
+			if rec.PhaseNumber == number {
+				recs = append(recs, rec)
+			}
+		}
+		windows := computeWindowedLatencies(recs, sustainedWindow)
+		if len(windows) < 2 {
+			continue
+		}
+		// The last window is still filling; report the one before it.
+		w := windows[len(windows)-2]
+		if w.Arrivals == 0 {
+			continue
+		}
+		line := "no readies yet"
+		if w.Latency != nil {
+			line = fmt.Sprintf("p50=%s p90=%s p99=%s", formatMs(w.Latency.P50Ms), formatMs(w.Latency.P90Ms), formatMs(w.Latency.P99Ms))
+		}
+		log.Printf("[%s#%d] window [%3.0fs-%3.0fs): arrivals=%d ready=%d create->Ready %s",
+			PhaseClaimsWarmSustained, number, w.StartOffsetSeconds, w.EndOffsetSeconds, w.Arrivals, w.Ready, line)
+	}
+}
+
+// createNamespace creates the named namespace, tolerating AlreadyExists.
+func (s *stressTest) createNamespace(ctx context.Context, name string) error {
+	nsObj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]any{
+				"name": name,
+			},
+		},
+	}
+	_, err := s.nsClient.Create(ctx, nsObj, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+// cleanupSustained removes everything the phase created: leftover claims
+// (most were already deleted after their dwell), the pools and templates,
+// and — for multi-namespace runs — the extra namespaces themselves. Like the
+// probe/throughput deletes, failures are logged rather than returned so
+// cleanup problems do not mask the phase's measurement, and the end-of-run
+// namespace deletion is the backstop for the main namespace.
+func (s *stressTest) cleanupSustained(ctx context.Context, number PhaseNumber, namespaces []sustainedNamespaceClients, poolName, templateName string) {
+	if ctx.Err() != nil || len(namespaces) == 0 {
+		// Shutting down (namespace cleanup removes remaining objects), or
+		// the phase failed before any namespace was resolved.
+		return
+	}
+	phase := PhaseClaimsWarmSustained
+
+	// Delete claims that never made it to their own delete (failed, timed
+	// out, or the phase aborted mid-dwell).
+	var leftovers []types.NamespacedName
+	for _, rec := range s.tracker.Records() {
+		if rec.PhaseNumber == number && !rec.CreateReturned.IsZero() && rec.SandboxDeleted.IsZero() && rec.DeleteCalled.IsZero() {
+			leftovers = append(leftovers, types.NamespacedName{Name: rec.Name, Namespace: rec.Namespace})
+		}
+	}
+	log.Printf("[%s#%d] cleaning up: %d leftover claims, %d pool(s)/template(s)", phase, number, len(leftovers), len(namespaces))
+	_, _ = ForkJoin(ctx, leftovers, max(s.cfg.CreateConcurrency, 1), func(id types.NamespacedName) (struct{}, error) {
+		claimClient := s.mutateClient.Resource(gvrSandboxClaims).Namespace(id.Namespace)
+		if err := claimClient.Delete(ctx, id.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("[%s#%d] failed to delete claim %s/%s: %v", phase, number, id.Namespace, id.Name, err)
+		}
+		return struct{}{}, nil
+	})
+
+	for _, nsc := range namespaces {
+		if err := nsc.pool.Delete(ctx, poolName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("[%s#%d] failed to delete warm pool %s/%s: %v", phase, number, nsc.name, poolName, err)
+		}
+		if err := nsc.template.Delete(ctx, templateName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("[%s#%d] failed to delete template %s/%s: %v", phase, number, nsc.name, templateName, err)
+		}
+	}
+
+	// Multi-namespace runs: delete the extra namespaces (cascades sandboxes,
+	// pods, and anything the claim deletes missed), then wait for them to go
+	// so later phases see restored capacity. Best-effort with a stall bound.
+	if len(namespaces) > 1 || namespaces[0].name != s.namespace {
+		for _, nsc := range namespaces {
+			if err := s.nsClient.Delete(ctx, nsc.name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				log.Printf("[%s#%d] failed to delete namespace %s: %v", phase, number, nsc.name, err)
+			}
+		}
+		s.waitSustainedGone(ctx, number, func() (int, error) {
+			remaining := 0
+			for _, nsc := range namespaces {
+				if _, err := s.nsClient.Get(ctx, nsc.name, metav1.GetOptions{}); err == nil {
+					remaining++
+				} else if !apierrors.IsNotFound(err) {
+					return 0, err
+				}
+			}
+			return remaining, nil
+		}, "namespaces")
+		return
+	}
+
+	// Single-namespace runs: wait for pool/claim-owned sandboxes in the main
+	// namespace to disappear so their pods stop occupying capacity that a
+	// later phase counts on.
+	s.waitSustainedGone(ctx, number, func() (int, error) {
+		return s.countOwnedSandboxes(ctx)
+	}, "pool/claim-owned sandboxes")
+}
+
+// waitSustainedGone polls count() until it reaches zero, with the same
+// progress-stall bound the other cleanup paths use. Best-effort: stalls and
+// list errors are logged, not returned.
+func (s *stressTest) waitSustainedGone(ctx context.Context, number PhaseNumber, count func() (int, error), what string) {
+	phase := PhaseClaimsWarmSustained
+	lastRemaining := -1
+	lastProgress := time.Now()
+	for {
+		remaining, err := count()
+		if err != nil {
+			log.Printf("[%s#%d] cleanup progress check failed: %v", phase, number, err)
+			return
+		}
+		if remaining == 0 {
+			log.Printf("[%s#%d] cleanup complete", phase, number)
+			return
+		}
+		if remaining != lastRemaining {
+			lastRemaining = remaining
+			lastProgress = time.Now()
+		}
+		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
+			log.Printf("[%s#%d] WARNING: %d %s still present after %v; later phases may see reduced spare capacity",
+				phase, number, remaining, what, s.cfg.PerSandboxTimeout)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}

--- a/test/stress/sustained.go
+++ b/test/stress/sustained.go
@@ -362,14 +362,32 @@ func (s *stressTest) createNamespace(ctx context.Context, name string) error {
 // and — for multi-namespace runs — the extra namespaces themselves. Like the
 // probe/throughput deletes, failures are logged rather than returned so
 // cleanup problems do not mask the phase's measurement, and the end-of-run
-// namespace deletion is the backstop for the main namespace.
+// namespace deletion is the backstop for the main namespace. That backstop
+// only covers the main namespace, so when the phase context was cancelled
+// (timeout or shutdown) and extra namespaces exist, cleanup still runs — on
+// a context detached from the cancelled one — or the -sN namespaces would
+// leak.
 func (s *stressTest) cleanupSustained(ctx context.Context, number PhaseNumber, namespaces []sustainedNamespaceClients, poolName, templateName string) {
-	if ctx.Err() != nil || len(namespaces) == 0 {
-		// Shutting down (namespace cleanup removes remaining objects), or
-		// the phase failed before any namespace was resolved.
+	if len(namespaces) == 0 {
+		// The phase failed before any namespace was resolved.
 		return
 	}
 	phase := PhaseClaimsWarmSustained
+	if ctx.Err() != nil {
+		if len(namespaces) == 1 && namespaces[0].name == s.namespace {
+			// Shutting down, and everything lives in the main test
+			// namespace: the end-of-run namespace deletion removes it.
+			return
+		}
+		// Shutting down with extra namespaces created outside the main test
+		// namespace: no backstop removes those, so clean up anyway on a
+		// detached context, bounded like the end-of-run cleanup so a wedged
+		// cluster cannot hang shutdown.
+		log.Printf("[%s#%d] phase context cancelled; cleaning up extra namespaces on a detached context", phase, number)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		defer cancel()
+	}
 
 	// Delete every created claim that was never OBSERVED deleted — including
 	// ones whose delete was attempted but failed (or whose DELETED event the

--- a/test/stress/sustained.go
+++ b/test/stress/sustained.go
@@ -371,11 +371,13 @@ func (s *stressTest) cleanupSustained(ctx context.Context, number PhaseNumber, n
 	}
 	phase := PhaseClaimsWarmSustained
 
-	// Delete claims that never made it to their own delete (failed, timed
-	// out, or the phase aborted mid-dwell).
+	// Delete every created claim that was never OBSERVED deleted — including
+	// ones whose delete was attempted but failed (or whose DELETED event the
+	// watch missed), so a failed delete can't leak a claim into later phases.
+	// Re-deleting an already-gone claim is just a cheap NotFound.
 	var leftovers []types.NamespacedName
 	for _, rec := range s.tracker.Records() {
-		if rec.PhaseNumber == number && !rec.CreateReturned.IsZero() && rec.SandboxDeleted.IsZero() && rec.DeleteCalled.IsZero() {
+		if rec.PhaseNumber == number && !rec.CreateReturned.IsZero() && rec.SandboxDeleted.IsZero() {
 			leftovers = append(leftovers, types.NamespacedName{Name: rec.Name, Namespace: rec.Namespace})
 		}
 	}

--- a/test/stress/sustained_test.go
+++ b/test/stress/sustained_test.go
@@ -134,3 +134,32 @@ func TestSustainedExpectedClaims(t *testing.T) {
 		t.Errorf("sustainedExpectedClaims = %d, want 18000", got)
 	}
 }
+
+func TestCheckClusterCapacitySustained(t *testing.T) {
+	base := Config{
+		Phases:                   []string{string(PhaseClaimsWarmSustained)},
+		SustainedRate:            100,
+		SustainedNamespaces:      1,
+		SustainedPoolHeadroom:    10 * time.Second,
+		ClaimDwell:               5 * time.Second,
+		SustainedLifecycleBudget: 5 * time.Second,
+	}
+	// pool = ceil(100*10) = 1000, inFlight = ceil(100*(5+5)) = 1000 => 2000.
+	if err := checkClusterCapacity(base, &ClusterInfo{PodCapacity: 2000}); err != nil {
+		t.Errorf("capacity 2000 should fit needed 2000: %v", err)
+	}
+	if err := checkClusterCapacity(base, &ClusterInfo{PodCapacity: 1999}); err == nil {
+		t.Error("capacity 1999 should fail for needed 2000")
+	}
+
+	// A slower assumed ready+delete pipeline must raise the requirement:
+	// budget 15s => inFlight = ceil(100*(5+15)) = 2000 => needed 3000.
+	slow := base
+	slow.SustainedLifecycleBudget = 15 * time.Second
+	if err := checkClusterCapacity(slow, &ClusterInfo{PodCapacity: 2000}); err == nil {
+		t.Error("capacity 2000 should fail once the lifecycle budget raises needed to 3000")
+	}
+	if err := checkClusterCapacity(slow, &ClusterInfo{PodCapacity: 3000}); err != nil {
+		t.Errorf("capacity 3000 should fit needed 3000: %v", err)
+	}
+}

--- a/test/stress/sustained_test.go
+++ b/test/stress/sustained_test.go
@@ -1,0 +1,136 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"math"
+	"math/rand/v2"
+	"testing"
+	"time"
+)
+
+func fixedRng() *rand.Rand {
+	return rand.New(rand.NewPCG(0xA5A5A5A5, 0x5A5A5A5A))
+}
+
+func TestPoissonScheduleStrictlyIncreasing(t *testing.T) {
+	sched := newPoissonSchedule(1000, fixedRng())
+	prev := time.Duration(-1)
+	for i := range 10000 {
+		next := sched.Next()
+		if next <= prev {
+			t.Fatalf("arrival %d: offset %v not strictly greater than previous %v", i, next, prev)
+		}
+		prev = next
+	}
+}
+
+// TestPoissonScheduleRate verifies the process realizes the target rate: the
+// mean inter-arrival gap approximates 1/rate, and the number of arrivals in
+// a window of T seconds approximates rate*T.
+func TestPoissonScheduleRate(t *testing.T) {
+	for _, rate := range []float64{5, 300, 2000} {
+		sched := newPoissonSchedule(rate, fixedRng())
+		const n = 200000
+		var last time.Duration
+		for range n {
+			last = sched.Next()
+		}
+		gotMean := last.Seconds() / n
+		wantMean := 1 / rate
+		if math.Abs(gotMean-wantMean)/wantMean > 0.02 {
+			t.Errorf("rate %.0f: mean inter-arrival %.6fs, want %.6fs (+/-2%%)", rate, gotMean, wantMean)
+		}
+	}
+
+	// Arrival count within a fixed window, as the phase's pacing loop uses it.
+	const rate, seconds = 300.0, 60.0
+	sched := newPoissonSchedule(rate, fixedRng())
+	duration := time.Duration(seconds * float64(time.Second))
+	count := 0
+	for sched.Next() <= duration {
+		count++
+	}
+	expected := rate * seconds
+	if math.Abs(float64(count)-expected)/expected > 0.05 {
+		t.Errorf("arrivals in %vs = %d, want ~%.0f (+/-5%%)", seconds, count, expected)
+	}
+}
+
+// TestPoissonScheduleIsExponential checks the jitter really is Poisson and
+// not, say, uniform: exponential inter-arrival gaps have a coefficient of
+// variation of 1 (uniform jitter would give ~0.58).
+func TestPoissonScheduleIsExponential(t *testing.T) {
+	const rate = 100.0
+	const n = 100000
+	sched := newPoissonSchedule(rate, fixedRng())
+	gaps := make([]float64, n)
+	prev := time.Duration(0)
+	var sum float64
+	for i := range gaps {
+		next := sched.Next()
+		gaps[i] = (next - prev).Seconds()
+		sum += gaps[i]
+		prev = next
+	}
+	mean := sum / n
+	var variance float64
+	for _, g := range gaps {
+		variance += (g - mean) * (g - mean)
+	}
+	variance /= n
+	cv := math.Sqrt(variance) / mean
+	if math.Abs(cv-1) > 0.05 {
+		t.Errorf("coefficient of variation = %.3f, want ~1.0 (exponential inter-arrivals)", cv)
+	}
+}
+
+func TestSustainedPoolReplicasPerNamespace(t *testing.T) {
+	tests := []struct {
+		name       string
+		rate       float64
+		namespaces int
+		headroom   time.Duration
+		want       int
+	}{
+		{"default sizing", 300, 1, 10 * time.Second, 3000},
+		{"split across namespaces", 300, 4, 10 * time.Second, 750},
+		{"rounds up", 100, 3, 10 * time.Second, 334}, // 100/3*10 = 333.33...
+		{"small rate", 0.5, 1, 10 * time.Second, 5},
+		{"sub-replica rounds to one", 0.05, 1, 10 * time.Second, 1},
+		{"zero rate", 0, 1, 10 * time.Second, 0},
+		{"invalid namespaces", 300, 0, 10 * time.Second, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				SustainedRate:         tc.rate,
+				SustainedNamespaces:   tc.namespaces,
+				SustainedPoolHeadroom: tc.headroom,
+			}
+			if got := sustainedPoolReplicasPerNamespace(cfg); got != tc.want {
+				t.Errorf("sustainedPoolReplicasPerNamespace(rate=%v ns=%d headroom=%v) = %d, want %d",
+					tc.rate, tc.namespaces, tc.headroom, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSustainedExpectedClaims(t *testing.T) {
+	cfg := Config{SustainedRate: 300, SustainedSeconds: 60}
+	if got := sustainedExpectedClaims(cfg); got != 18000 {
+		t.Errorf("sustainedExpectedClaims = %d, want 18000", got)
+	}
+}

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -41,6 +41,10 @@ const (
 	// PhaseClaimsWarm fires SandboxClaims simultaneously against a fully
 	// provisioned SandboxWarmPool, measuring claim-create -> claim-Ready latency.
 	PhaseClaimsWarm Phase = "claims-warm"
+	// PhaseClaimsWarmSustained streams SandboxClaims at a target rate with
+	// Poisson jitter against continuously replenished warm pools, measuring
+	// whether create -> Ready latency holds over time (see sustained.go).
+	PhaseClaimsWarmSustained Phase = "claims-warm-sustained"
 )
 
 // PhaseNumber is a 1-based index into the run's phase list (Config.Phases /


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds three harness improvements to the stress tool, all found while benchmarking SandboxClaim adoption against warm pools with a 300-claim workload. No controller behavior changes; test harness only.

**1. `claims-warm-sustained` phase: open-loop, sustained-rate SandboxClaim arrivals (`sustained.go`).**
The existing phases either launch cold sandboxes or fire everything at once, which is an adversarial burst shape. This phase models steady-state arrivals instead: claims arrive as a Poisson process at `--sustained-rate` claims/s for `--sustained-seconds`, each is deleted `--claim-dwell` after Ready, and the warm pool controller refills continuously, so adoption, refill, and teardown churn compound like they would in production. Arrivals are open-loop (paced by absolute schedule offsets, never gated on earlier claims completing), so the phase measures a target rate rather than degrading into a closed loop. The headline output is rolling per-10s-window create->Ready percentiles bucketed by arrival time (`sustainedWindows` in summary.json, also printed live), which makes "does latency hold over time?" directly visible. `--sustained-namespaces=N` optionally spreads pools and claims round-robin over N pre-created namespaces (namespaces are a natural shard key for controller sharding experiments), and `--sustained-pool-headroom` sizes each pool as ceil(rate/namespaces x headroom-seconds) so pool sizing covers the controller's worst-case refill latency. Unit tests verify the Poisson schedule is strictly increasing, realizes the target rate, and is genuinely exponential (CV ~= 1), plus pool sizing and windowed-latency math (including that degradation over time produces increasing window percentiles).

**2. Monotonic, client-side latency accounting for claim records (`tracker.go`, `stats.go`).**
While validating the benchmark we found two ways to silently corrupt latency numbers, and this PR bakes the defenses into the harness: (a) durations must never be derived from server-side `metadata.creationTimestamp` / condition `lastTransitionTime`, which are truncated to whole seconds — in a 300-claim warm-adoption benchmark, timestamp-truncation math inflated reported queue-wait about 30x (reported p50 1025ms vs 33ms measured client-side; see #781 for the same class of bug); and (b) per-record timing must come from unconditional client-side observation (watch-event receipt, `time.Now()`), never from sampled/rate-limited log lines, which drop the slow cohort and bias every derived quantile. The claim tracker therefore stamps all milestones with client monotonic-clock timestamps at watch-event receipt, records the server-side timestamps separately as a cross-check only, and the new `computeTimeToAllReady`/`computeWindowedLatencies` aggregations (with tests) operate purely on the client-observed milestones.

**3. `--client-connections=N`: shard the harness's mutating requests over N HTTP/2 connections (`clientconns.go`).**
client-go multiplexes everything built from one `rest.Config` onto a single HTTP/2 connection, and the apiserver caps ~100 concurrent streams per connection. Historically the stress tool put all traffic (creates, deletes, watches, scrapes) on that one connection, so a create burst wider than ~100 queued inside the harness waiting for a stream: in the same 300-claim benchmark this inflated reported create-ack latency roughly 2-3x with client-side queueing that says nothing about the apiserver or the controller. With N>1, mutating requests round-robin over N dedicated connections (per-shard `Dial` functions, so client-go's transport cache builds distinct transports, using only supported client-go API) while the watches keep their own untouched connection that create bursts cannot congest. The default N=1 preserves today's single-connection behavior exactly, and the harness warns when `--client-connections < ceil(create-concurrency/100)` so runs that measure the congested shape do so knowingly. Tests assert exactly N TCP dials, HTTP/2 on every shard, deterministic round-robin distribution, and that the watch client's connection stays distinct from every create shard.

Also includes a minimal `generate_report.py` fix required by the new phase: the watch-stream scan now pins the envelope schema and keeps `object` as raw JSON instead of `read_json_auto`, because sandboxclaims watch events (whose `status.sandbox` key is absent from the sampled pod/sandbox shapes) made DuckDB's inferred-STRUCT scan fail with `unknown key` and killed the whole report.

**Why there is no latency A/B table on this PR:** behavior-affecting PRs in this series each carry a BASE-vs-change A/B benchmark run; this PR changes only the test harness, so a controller A/B table would measure the same controller twice. The quantitative evidence here is about measurement honesty, with numbers above: ~30x inflation of reported queue-wait from 1s-truncated server timestamps (reported p50 1025ms vs 33ms measured client-side) and ~2-3x inflation of reported create-ack latency from single-connection client-side stream queueing — both measured in a 300-claim warm-adoption benchmark and cross-checked against the client watch stream.

#### Which issue(s) this PR is related to:

Ref #403, Ref #624 (benchmark/scale-testing umbrellas: this extends the stress harness with a steady-state workload shape and removes two measurement artifacts that misattributed client-side effects to the control plane). Ref #781 (the 1s-truncated-timestamp measurement hazard; this PR keeps the harness immune to it on the claim path). Happy to rebase this onto PR #1148's harness split whenever it lands.

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `claims-warm-sustained` sustained-rate warm-pool stress phase (now in the default phase list).
  * Introduced configurable sustained workload parameters (arrival rate/duration, claim dwell, multi-namespace sharding, pool headroom, lifecycle budget).
  * Added rolling windowed analytics and a dedicated report section with arrival vs ready counts and create→ack/create→Ready latency percentiles.
  * Extended cluster capacity checks for sustained steady-state warm pools and in-flight claims; added `--claim-dwell >= 0` validation.

* **Tests**
  * Added unit tests covering Poisson scheduling, sustained scaling/capacity calculations, and windowed latency analytics (including edge cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->