### PR TITLE
fix(controller): release leader lease on graceful shutdown

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -300,14 +300,7 @@ func main() {
 		}
 	}
 
-	mgrOpts := ctrl.Options{
-		Scheme:                  scheme,
-		Metrics:                 metricsOpts,
-		HealthProbeBindAddress:  probeAddr,
-		LeaderElection:          enableLeaderElection,
-		LeaderElectionNamespace: leaderElectionNamespace,
-		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
-	}
+	mgrOpts := buildManagerOptions(scheme, metricsOpts, probeAddr, enableLeaderElection, leaderElectionNamespace)
 	// managedFields stripping, the Pod spec diet, and (optionally) the
 	// tracking-label scoping; see buildCacheOptions for the rationale.
 	cacheOpts, err := buildCacheOptions(cacheLabelSelectors)

--- a/cmd/agent-sandbox-controller/manageroptions.go
+++ b/cmd/agent-sandbox-controller/manageroptions.go
@@ -38,7 +38,9 @@ func buildManagerOptions(scheme *runtime.Scheme, metricsOpts metricsserver.Optio
 		// deploy. Crash failover still pays lease expiry by design
 		// (split-brain safety); only clean exits release early. Safe here:
 		// controller-runtime requires the binary to exit promptly once the
-		// manager stops, and main() returns right after mgr.Start.
+		// manager stops; mgr.Start is the last explicit statement in main(),
+		// and any deferred shutdown work (e.g. tracing cleanup) must stay
+		// bounded so the process still exits promptly.
 		LeaderElectionReleaseOnCancel: true,
 	}
 }

--- a/cmd/agent-sandbox-controller/manageroptions.go
+++ b/cmd/agent-sandbox-controller/manageroptions.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// buildManagerOptions constructs the controller manager options used by
+// main(). The webhook server option is applied separately in main() when the
+// webhook subsystem is enabled.
+func buildManagerOptions(scheme *runtime.Scheme, metricsOpts metricsserver.Options, probeAddr string, enableLeaderElection bool, leaderElectionNamespace string) ctrl.Options {
+	return ctrl.Options{
+		Scheme:                  scheme,
+		Metrics:                 metricsOpts,
+		HealthProbeBindAddress:  probeAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionNamespace: leaderElectionNamespace,
+		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
+		// Release the leader Lease on graceful shutdown so a rolling update
+		// hands over leadership in ~0-2s instead of waiting out the full 15s
+		// LeaseDuration with no active controller — at a sustained 500
+		// claims/s that gap is ~7,500 claims queueing during a routine
+		// deploy. Crash failover still pays lease expiry by design
+		// (split-brain safety); only clean exits release early. Safe here:
+		// controller-runtime requires the binary to exit promptly once the
+		// manager stops, and main() returns right after mgr.Start.
+		LeaderElectionReleaseOnCancel: true,
+	}
+}

--- a/cmd/agent-sandbox-controller/manageroptions_test.go
+++ b/cmd/agent-sandbox-controller/manageroptions_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+// TestBuildManagerOptionsReleasesLeaseOnCancel pins the graceful-shutdown
+// behavior: the manager must release its leader-election Lease when it stops
+// cleanly, so a rolling update hands leadership over immediately instead of
+// waiting out the LeaseDuration.
+func TestBuildManagerOptionsReleasesLeaseOnCancel(t *testing.T) {
+	opts := buildManagerOptions(runtime.NewScheme(), metricsserver.Options{}, ":8081", true, "agent-sandbox-system")
+	assert.True(t, opts.LeaderElectionReleaseOnCancel,
+		"LeaderElectionReleaseOnCancel must stay true so graceful shutdowns hand over leadership without waiting out the LeaseDuration")
+}
+
+// TestBuildManagerOptionsLeaderElectionID pins the leader-election lock name;
+// changing it would let two controller versions run as leaders concurrently
+// during an upgrade.
+func TestBuildManagerOptionsLeaderElectionID(t *testing.T) {
+	opts := buildManagerOptions(runtime.NewScheme(), metricsserver.Options{}, ":8081", true, "")
+	assert.Equal(t, "a3317529.agent-sandbox.x-k8s.io", opts.LeaderElectionID)
+}
+
+// TestBuildManagerOptionsPassThrough verifies the flag-derived inputs are
+// forwarded unchanged into the manager options.
+func TestBuildManagerOptionsPassThrough(t *testing.T) {
+	scheme := runtime.NewScheme()
+	metricsOpts := metricsserver.Options{BindAddress: ":8080"}
+
+	for _, enableLeaderElection := range []bool{true, false} {
+		for _, namespace := range []string{"", "agent-sandbox-system"} {
+			opts := buildManagerOptions(scheme, metricsOpts, ":8081", enableLeaderElection, namespace)
+			assert.Equal(t, enableLeaderElection, opts.LeaderElection,
+				"LeaderElection must pass through --leader-elect")
+			assert.Equal(t, namespace, opts.LeaderElectionNamespace,
+				"LeaderElectionNamespace must pass through --leader-election-namespace")
+			assert.Same(t, scheme, opts.Scheme)
+			assert.Equal(t, ":8081", opts.HealthProbeBindAddress)
+			assert.Equal(t, ":8080", opts.Metrics.BindAddress)
+		}
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it

`LeaderElectionReleaseOnCancel` is unset today, so on every rolling update the outgoing controller leaves its Lease to expire and the incoming replica waits out the full **15s LeaseDuration with no active controller**.

Changes:

- Set `LeaderElectionReleaseOnCancel: true` in the manager options. controller-runtime documents the precondition — the binary must terminate immediately once the manager stops — and it holds here: `mgr.Start(ctx)` is the last statement of `main()`. **Crash failover is unchanged by design:** only clean exits release the lease early; lease expiry still protects against split brain.
- Extract the manager-options construction into `buildManagerOptions` (behavior-preserving refactor) and add unit tests pinning `LeaderElectionReleaseOnCancel`, the leader-election ID, and the enable/namespace pass-through, so the setting cannot silently regress.

#### Performance (A/B, this change alone)

Method, stated plainly: a kind cluster; the real `agent-sandbox-controller` binary built from upstream main (BASE) vs this branch; two instances with `--leader-elect=true` (controller-runtime defaults: LeaseDuration 15s, RetryPeriod 2s); SIGTERM the leader (the graceful-shutdown path); leaderless window measured as SIGTERM → the standby holds the Lease (100ms Lease polling). Three trials per variant (measured 2026-07-21):

| trial | BASE handover | this PR |
|---|---|---|
| 1 | 18.83s | 1.49s |
| 2 | 14.79s | 1.65s |
| 3 | 18.92s | 0.70s |
| **mean** | **17.5s** | **1.28s** |

BASE is bounded below by LeaseDuration (15s) plus the standby's retry cadence; releasing the Lease on clean shutdown cuts handover to the standby's next retry (~0.7-1.7s), a **~13× shorter leaderless window**. For scale context: at a sustained 500 claims/s, a ~17s leaderless window is ≈8,500 claims arriving with no active controller during a routine deploy.

#### Which issue(s) this PR fixes

None.

#### Special notes for your reviewer

The refactor moves the existing `ctrl.Options` literal verbatim into `buildManagerOptions`; the webhook server option is still applied afterwards in `main()` exactly as before.

```release-note
The controller manager now releases its leader-election Lease on graceful shutdown, cutting rolling-update handover from ~15-19s (LeaseDuration expiry) to ~0.7-1.7s. Crash failover semantics are unchanged.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller shutdown behavior by releasing leadership promptly instead of waiting for the full lease duration.

* **Refactor**
  * Centralized controller manager configuration via a shared options builder, preserving existing leader-election, metrics, health probe, and namespace behavior.

* **Tests**
  * Added unit tests validating leadership release on cancel, leader-election lock ID behavior, and correct pass-through of key configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->