### PR TITLE
feat(warmpool): replenish-delay and max-refill-rate refill shaping

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -180,6 +181,14 @@ func main() {
 	// Validation checks for sandboxWarmPoolMaxBatchSize (maximum batch size for sandbox creation and deletion in SandboxWarmPool controller)
 	if sandboxWarmPoolMaxBatchSize <= 0 {
 		setupLog.Error(nil, "sandbox-warm-pool-max-batch-size must be greater than 0")
+		os.Exit(1)
+	}
+	// Fail fast on nonsensical refill rates: flag parsing accepts "NaN" and
+	// "+Inf", and a negative rate would silently disable pacing (the
+	// controller treats <= 0 as unpaced), which is confusing to debug.
+	if math.IsNaN(sandboxWarmPoolMaxRefillRate) || math.IsInf(sandboxWarmPoolMaxRefillRate, 0) || sandboxWarmPoolMaxRefillRate < 0 {
+		setupLog.Error(nil, "sandbox-warm-pool-max-refill-rate must be a finite value >= 0 (0 disables pacing)",
+			"value", sandboxWarmPoolMaxRefillRate)
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -74,6 +74,8 @@ func main() {
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
 	var sandboxWarmPoolMaxBatchSize int
+	var sandboxWarmPoolReplenishDelay time.Duration
+	var sandboxWarmPoolMaxRefillRate float64
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -122,6 +124,15 @@ func main() {
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300. Creates advance one observed batch per watch round-trip (the expectations gate waits for a batch's add events before issuing the next), so a large pool fills in about ceil(replicas/batchSize) round-trips; raising this trades round-trips for burst size and is safe at any value under the gate.")
+	flag.DurationVar(&sandboxWarmPoolReplenishDelay, "sandbox-warm-pool-replenish-delay", 0,
+		"How long the SandboxWarmPool controller defers creating replacement sandboxes after pool members drop out of the pool "+
+			"(e.g. a burst of SandboxClaims adopting warm sandboxes), so the burst gets API server priority. "+
+			"The hold re-arms while members keep dropping. 0 (default) replenishes immediately.")
+	flag.Float64Var(&sandboxWarmPoolMaxRefillRate, "sandbox-warm-pool-max-refill-rate", 0,
+		"Max rate (sandboxes/second, per pool) at which the SandboxWarmPool controller creates replacement sandboxes, "+
+			"pacing refill into a smooth stream instead of full-deficit bursts that flood the write path and compete with claim adoption. "+
+			"Composes with --sandbox-warm-pool-replenish-delay: the delay defers the start of refill, the rate shapes its flow. "+
+			"0 (default) leaves refill unpaced (whole deficit per reconcile).")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
 	flag.BoolVar(&cacheLabelSelectors, "cache-label-selectors", false,
 		"Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label ("+
@@ -431,6 +442,8 @@ func main() {
 			MaxBatchSize:           sandboxWarmPoolMaxBatchSize,
 			EnableWarmPoolEviction: enableWarmPoolEviction,
 			Recorder:               mgr.GetEventRecorder("sandboxwarmpool-controller"),
+			ReplenishDelay:         sandboxWarmPoolReplenishDelay,
+			MaxRefillRate:          sandboxWarmPoolMaxRefillRate,
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")
 			os.Exit(1)

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -592,14 +592,25 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		// whether issuing them against the current cache is safe.
 		sandboxesToCreate, tokenWait := r.takeRefillTokens(poolKey, deficit, now)
 		if sandboxesToCreate < deficit {
-			// Token bucket exhausted for this pass: create what was granted
-			// now and requeue for the remainder when the next token accrues,
-			// keeping refill a smooth stream instead of a deficit burst.
 			logger.Info("Pacing pool replenishment",
 				"deficit", deficit,
 				"granted", sandboxesToCreate,
-				"requeueAfter", tokenWait)
-			requeueAfter = minNonZeroDuration(requeueAfter, tokenWait)
+				"tokenWait", tokenWait)
+			if sandboxesToCreate == 0 {
+				// Token bucket empty: nothing will be created this pass,
+				// so no Sandbox watch event will trigger the next
+				// reconcile — requeue for when the next token accrues.
+				requeueAfter = minNonZeroDuration(requeueAfter, tokenWait)
+			}
+			// When a partial batch IS granted, rely on the Owns(&Sandbox)
+			// watch instead: each create's informer event first lowers the
+			// creation expectation and then schedules a reconcile, so the
+			// next pass runs against a cache that already contains the new
+			// Sandbox. Requeueing on tokenWait as well would race that
+			// delivery and burn the pass on an unsatisfied expectations
+			// gate (a stale currentReplicas can no longer duplicate
+			// creates — the gate blocks that — but the futile wakeup and
+			// its 30s fallback would stall the paced stream).
 		}
 		if sandboxesToCreate > 0 {
 			sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash, currentSandboxBlueprintHash)

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -119,6 +120,224 @@ type SandboxWarmPoolReconciler struct {
 
 	// now is a test hook for the reconciler's clock; nil means time.Now.
 	now func() time.Time
+
+	// ReplenishDelay defers creation of replacement sandboxes after pool
+	// members drop out of the pool (e.g. a burst of SandboxClaims adopting
+	// warm sandboxes). Deferring lets the claim burst consume the API server
+	// budget first instead of racing it with replacement creates. Zero (the
+	// default) disables deferral and preserves the immediate-refill behavior.
+	//
+	// Caveat for SUSTAINED arrivals (measured in a 300-claim warm-adoption
+	// benchmark): the hold re-arms on every observed member drop, so while
+	// claims keep arriving the hold re-arms indefinitely, refill never
+	// starts, and the pool drains to zero. For sustained load prefer
+	// MaxRefillRate — a paced refill stream that coexists with adoption —
+	// combined with a small or zero delay.
+	ReplenishDelay time.Duration
+
+	// MaxRefillRate, when > 0, caps the rate (sandbox creates per second,
+	// PER POOL) at which replacement sandboxes are created, via a per-pool
+	// token bucket. It turns deficit-burst refill (one reconcile firing the
+	// whole deficit through slowStartBatch) into a smooth stream, so at
+	// sustained claim rates refill does not periodically flood the write
+	// path and compete with claim adoption. Zero (the default) leaves refill
+	// unshaped — the full-deficit slowStartBatch behavior.
+	//
+	// Semantics vs ReplenishDelay: the delay defers the START of refill;
+	// the rate shapes its FLOW once started. The bucket holds at most one
+	// second of creates (capacity = max(1, rate)), so refill resumes from a
+	// hold or an idle period with at most a 1×rate initial burst.
+	//
+	// Semantics vs the expectations gate: shaping decides how many creates
+	// this pass may ISSUE; the gate then decides whether issuing anything is
+	// safe against the cache. Tokens taken for a pass the gate refuses are
+	// refunded (no write was issued, so no API budget was spent).
+	//
+	// Sizing guidance (measured in a 300-claim warm-adoption benchmark:
+	// 300-deficit fill through a single reconcile's slowStartBatch):
+	//   - sandbox CREATE stage: ~85/s with API Priority and Fairness
+	//     queueing creates (~50ms mean queue wait), ~240/s burst without
+	//     APF shaping;
+	//   - pod scheduling: ~70/s (kube-scheduler default --kube-api-qps=50);
+	//   - pod start (cached image): ~2.5-3.5s, fully pipelined;
+	//   - net: a 300-member pool went 0 -> 300 Ready in ~6.4s.
+	// One pool's deficit is processed serially under its single reconcile
+	// key, so per-pool refill throughput tops out at
+	//   min(create ~85/s, scheduler share, MaxRefillRate).
+	// For a sustained claim arrival rate R/s aggregate refill must be >= R:
+	//   pools needed  >= ceil(R / per_pool_rate)
+	//   pool replicas >= R × (refill_p99 + replenish hold)   (shock absorber)
+	// e.g. 500 claims/s at ~70/s per pool => >= 8 pools of ~1-2k replicas.
+	// Run --sandbox-warm-pool-concurrent-workers >= pool count so distinct
+	// pools refill in parallel (parallelism across pools is free; a per-pool
+	// create-parallelism knob is NOT needed — slowStartBatch already reaches
+	// 128+-way parallelism inside a batch and the measured limiter is write
+	// RTT and the scheduler, not batch width).
+	MaxRefillRate float64
+
+	// replenishMu guards replenishState and refillState. Distinct pools may
+	// reconcile concurrently when MaxConcurrentReconciles > 1.
+	replenishMu sync.Mutex
+	// replenishState tracks, per pool, the last observed member count and any
+	// active replenish hold. Only used when ReplenishDelay > 0.
+	replenishState map[types.NamespacedName]*replenishDeferState
+	// refillState tracks, per pool, the token bucket that paces replacement
+	// creates. Only used when MaxRefillRate > 0.
+	refillState map[types.NamespacedName]*refillBucket
+}
+
+// refillBucket is the per-pool token bucket behind MaxRefillRate. Tokens
+// accrue at MaxRefillRate per second up to a capacity of max(1, rate) — one
+// second of creates — so a long-idle pool cannot bank a large burst.
+type refillBucket struct {
+	// tokens currently available; one token = one replacement create.
+	tokens float64
+	// last is when tokens were last accrued.
+	last time.Time
+}
+
+// replenishDeferState is the per-pool bookkeeping behind ReplenishDelay.
+type replenishDeferState struct {
+	// lastMembers is the active member count at the previous observation,
+	// plus any replacements created in that reconcile that may not be visible
+	// in the informer cache yet. A subsequent observation below this value
+	// means members were consumed (adopted/claimed/GC'd/deleted), not that
+	// our own creates are still propagating.
+	lastMembers int32
+	// deferUntil suppresses replacement creation while in the future. It is
+	// re-armed on every observed drop, so replenishment starts only after the
+	// burst that is draining the pool has settled for a full ReplenishDelay.
+	deferUntil time.Time
+}
+
+// observeMembersForReplenish records the pool's current active member count
+// and returns how long replacement creation should be deferred (zero means
+// create immediately). It must be called exactly once per reconcile so the
+// baseline stays fresh.
+func (r *SandboxWarmPoolReconciler) observeMembersForReplenish(key types.NamespacedName, currentReplicas, desiredReplicas int32, now time.Time) time.Duration {
+	if r.ReplenishDelay <= 0 {
+		return 0
+	}
+
+	r.replenishMu.Lock()
+	defer r.replenishMu.Unlock()
+
+	st, ok := r.replenishState[key]
+	if !ok {
+		// First observation of this pool (new pool or controller restart):
+		// there is no baseline to detect a drop against, so replenish
+		// immediately. Initial pool fill and scale-ups are never deferred.
+		if r.replenishState == nil {
+			r.replenishState = make(map[types.NamespacedName]*replenishDeferState)
+		}
+		r.replenishState[key] = &replenishDeferState{lastMembers: currentReplicas}
+		return 0
+	}
+
+	dropped := currentReplicas < st.lastMembers
+	st.lastMembers = currentReplicas
+
+	if currentReplicas >= desiredReplicas {
+		// Pool is full (or over-provisioned): nothing to defer.
+		st.deferUntil = time.Time{}
+		return 0
+	}
+	if dropped {
+		// Re-arm on every drop: while an adoption burst is still draining the
+		// pool, keep replacement creates out of its window.
+		st.deferUntil = now.Add(r.ReplenishDelay)
+	}
+	if remaining := st.deferUntil.Sub(now); remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+
+// noteReplenishCreates raises the pool's member baseline by the number of
+// replacements just created. Until the informer cache catches up, subsequent
+// reconciles may not see these creates; counting them in the baseline keeps
+// drop detection accurate — a stale low count registers as a drop (deferring
+// briefly) instead of re-arming nothing. (Duplicate creates off the stale
+// count are separately prevented by the expectations gate.)
+func (r *SandboxWarmPoolReconciler) noteReplenishCreates(key types.NamespacedName, created int32) {
+	if r.ReplenishDelay <= 0 || created <= 0 {
+		return
+	}
+	r.replenishMu.Lock()
+	defer r.replenishMu.Unlock()
+	if st, ok := r.replenishState[key]; ok {
+		st.lastMembers += created
+	}
+}
+
+// forgetReplenishState drops the per-pool replenish and refill bookkeeping
+// for a deleted pool.
+func (r *SandboxWarmPoolReconciler) forgetReplenishState(key types.NamespacedName) {
+	r.replenishMu.Lock()
+	defer r.replenishMu.Unlock()
+	delete(r.replenishState, key)
+	delete(r.refillState, key)
+}
+
+// takeRefillTokens grants up to want replacement creates from the pool's
+// token bucket and returns how many were granted plus, when the grant fell
+// short, how long until the next whole token accrues (the requeue interval
+// that keeps the paced stream flowing without relying on watch events).
+//
+// Tokens are consumed for every granted create up front; failed creates are
+// deliberately NOT refunded — a failed POST spends the same API-server budget
+// the rate exists to protect, and the controller's error backoff already
+// paces retries. (Creates the expectations gate refuses to issue are the one
+// exception: no POST happens, so the caller refunds via refundRefillTokens.)
+// When MaxRefillRate is zero the bucket is bypassed entirely and behavior is
+// byte-identical to the unshaped path.
+func (r *SandboxWarmPoolReconciler) takeRefillTokens(key types.NamespacedName, want int32, now time.Time) (int32, time.Duration) {
+	if r.MaxRefillRate <= 0 || want <= 0 {
+		return want, 0
+	}
+	capacity := math.Max(1, r.MaxRefillRate)
+
+	r.replenishMu.Lock()
+	defer r.replenishMu.Unlock()
+
+	b, ok := r.refillState[key]
+	if !ok {
+		if r.refillState == nil {
+			r.refillState = make(map[types.NamespacedName]*refillBucket)
+		}
+		// First observation of this pool (new pool or controller restart):
+		// start with a full bucket so small deficits are served immediately;
+		// anything beyond one second's worth is paced from the start.
+		b = &refillBucket{tokens: capacity, last: now}
+		r.refillState[key] = b
+	} else if elapsed := now.Sub(b.last); elapsed > 0 {
+		b.tokens = math.Min(capacity, b.tokens+r.MaxRefillRate*elapsed.Seconds())
+		b.last = now
+	}
+
+	granted := min(want, int32(b.tokens))
+	b.tokens -= float64(granted)
+	if granted >= want {
+		return granted, 0
+	}
+	// Ceil so the requeue never lands a hair before the token exists.
+	wait := time.Duration(math.Ceil((1 - b.tokens) / r.MaxRefillRate * float64(time.Second)))
+	return granted, wait
+}
+
+// refundRefillTokens returns tokens that were taken for creates which were
+// never issued (the expectations gate refused the pass). No POST happened, so
+// none of the API-server budget the rate protects was spent — unlike failed
+// creates, which are deliberately not refunded.
+func (r *SandboxWarmPoolReconciler) refundRefillTokens(key types.NamespacedName, n int32) {
+	if r.MaxRefillRate <= 0 || n <= 0 {
+		return
+	}
+	r.replenishMu.Lock()
+	defer r.replenishMu.Unlock()
+	if b, ok := r.refillState[key]; ok {
+		b.tokens = math.Min(math.Max(1, r.MaxRefillRate), b.tokens+float64(n))
+	}
 }
 
 // clockNow returns the reconciler's current time (time.Now unless a test
@@ -199,13 +418,14 @@ func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
-// forgetPool drops per-pool bookkeeping (expectations, not-progressing state)
-// once a pool is gone or terminating.
+// forgetPool drops per-pool bookkeeping (expectations, not-progressing state,
+// replenish/refill shaping state) once a pool is gone or terminating.
 func (r *SandboxWarmPoolReconciler) forgetPool(key types.NamespacedName) {
 	r.exp().Forget(key)
 	r.notProgressingMu.Lock()
 	delete(r.notProgressing, key)
 	r.notProgressingMu.Unlock()
+	r.forgetReplenishState(key)
 }
 
 // reconcilePool ensures the correct number of pre-allocated sandboxes exist in the pool.
@@ -338,46 +558,87 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 
 	maxBatchSize := int32(r.MaxBatchSize)
 
+	// Record the observed member count and check whether replacement creation
+	// should yield to a recent member drop (claim adoption burst). No-op when
+	// ReplenishDelay is zero.
+	replenishHold := r.observeMembersForReplenish(poolKey, currentReplicas, desiredReplicas, now)
+
 	// Create new sandboxes if we need more.
 	// Hard invariant: never create while the existing population (active,
 	// including non-Ready, plus terminating-still-present) already covers
 	// spec.replicas.
-	if totalReplicas < desiredReplicas && tmplErr == nil {
-		sandboxesToCreate := min(desiredReplicas-totalReplicas, maxBatchSize)
-
-		sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash, currentSandboxBlueprintHash)
-		switch {
-		case err != nil:
-			logger.Error(err, "Failed to build sandbox CR blueprint")
-			allErrors = errors.Join(allErrors, err)
-		// TryExpectCreations atomically checks that every create and delete
-		// this controller previously issued for the pool has been observed by
-		// the informer cache, and records the new in-flight creates. If prior
-		// writes are still unobserved the cached list above is stale and
-		// creating against it would overshoot the target (the #1215 runaway),
-		// so we skip and let the watch (or a fallback requeue) retrigger us.
-		case !r.exp().TryExpectCreations(poolKey, int(sandboxesToCreate)):
-			logger.Info("Skipping sandbox creation: waiting for in-flight creates/deletes to be observed",
-				"poolName", warmPool.Name)
-			requeueAfter = minNonZeroDuration(requeueAfter, expectationsPendingRequeueDelay)
-		default:
-			logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
-			// Parallel sandbox creation with adaptive slow-start batching (starts with 1 and doubles on success)
-			successes, createErr := slowStartBatch(ctx, int(sandboxesToCreate), 1, func(_ int) error {
-				return r.createPoolSandbox(ctx, warmPool, sandboxCR)
-			})
-			// Creates that never happened will never produce a watch event;
-			// lower their expectations immediately so the pool is not blocked
-			// until the expectations timeout. lower cannot be negative
-			// (slowStartBatch reports at most the requested count of
-			// successes); the > 0 guard only skips a no-op tracker call on
-			// the everything-succeeded path.
-			if lower := int(sandboxesToCreate) - successes; lower > 0 {
-				r.exp().LowerCreations(poolKey, lower)
-			}
-			if createErr != nil {
-				logger.Error(createErr, "Failed to create pool sandboxes")
-				allErrors = errors.Join(allErrors, createErr)
+	//
+	// The hold branch is keyed on the ACTIVE deficit (currentReplicas), not
+	// the population deficit (totalReplicas): a drop that is still draining
+	// as terminating members must keep the hold's wake-up armed, so that once
+	// the deletions are observed the remaining hold window (not a watch-event
+	// race) decides when refill starts.
+	if replenishHold > 0 && currentReplicas < desiredReplicas && tmplErr == nil {
+		// Members recently dropped out of the pool (e.g. adopted by a burst
+		// of claims). Defer replacement creation so the burst gets the API
+		// server budget first; status above still reflects actual counts.
+		// The refill token bucket is untouched during the hold (its
+		// capacity caps carryover at one second of creates), so when the
+		// hold expires the paced stream starts fresh: delay defers the
+		// START of refill, MaxRefillRate shapes its FLOW.
+		logger.Info("Deferring pool replenishment after recent member drop",
+			"deficit", desiredReplicas-currentReplicas,
+			"requeueAfter", replenishHold)
+		requeueAfter = minNonZeroDuration(requeueAfter, replenishHold)
+	} else if totalReplicas < desiredReplicas && tmplErr == nil {
+		deficit := min(desiredReplicas-totalReplicas, maxBatchSize)
+		// Shape first, then gate: the token bucket decides how many creates
+		// this pass may issue, and the expectations gate below decides
+		// whether issuing them against the current cache is safe.
+		sandboxesToCreate, tokenWait := r.takeRefillTokens(poolKey, deficit, now)
+		if sandboxesToCreate < deficit {
+			// Token bucket exhausted for this pass: create what was granted
+			// now and requeue for the remainder when the next token accrues,
+			// keeping refill a smooth stream instead of a deficit burst.
+			logger.Info("Pacing pool replenishment",
+				"deficit", deficit,
+				"granted", sandboxesToCreate,
+				"requeueAfter", tokenWait)
+			requeueAfter = minNonZeroDuration(requeueAfter, tokenWait)
+		}
+		if sandboxesToCreate > 0 {
+			sandboxCR, err := r.buildSandboxCR(warmPool, poolNameHash, template, currentPodTemplateHash, currentSandboxBlueprintHash)
+			switch {
+			case err != nil:
+				logger.Error(err, "Failed to build sandbox CR blueprint")
+				allErrors = errors.Join(allErrors, err)
+			// TryExpectCreations atomically checks that every create and delete
+			// this controller previously issued for the pool has been observed by
+			// the informer cache, and records the new in-flight creates. If prior
+			// writes are still unobserved the cached list above is stale and
+			// creating against it would overshoot the target (the #1215 runaway),
+			// so we skip and let the watch (or a fallback requeue) retrigger us.
+			// The granted tokens are refunded: no POST was issued for them.
+			case !r.exp().TryExpectCreations(poolKey, int(sandboxesToCreate)):
+				logger.Info("Skipping sandbox creation: waiting for in-flight creates/deletes to be observed",
+					"poolName", warmPool.Name)
+				r.refundRefillTokens(poolKey, sandboxesToCreate)
+				requeueAfter = minNonZeroDuration(requeueAfter, expectationsPendingRequeueDelay)
+			default:
+				logger.Info("Creating new pool sandboxes", "count", sandboxesToCreate)
+				// Parallel sandbox creation with adaptive slow-start batching (starts with 1 and doubles on success)
+				successes, createErr := slowStartBatch(ctx, int(sandboxesToCreate), 1, func(_ int) error {
+					return r.createPoolSandbox(ctx, warmPool, sandboxCR)
+				})
+				// Creates that never happened will never produce a watch event;
+				// lower their expectations immediately so the pool is not blocked
+				// until the expectations timeout. lower cannot be negative
+				// (slowStartBatch reports at most the requested count of
+				// successes); the > 0 guard only skips a no-op tracker call on
+				// the everything-succeeded path.
+				if lower := int(sandboxesToCreate) - successes; lower > 0 {
+					r.exp().LowerCreations(poolKey, lower)
+				}
+				r.noteReplenishCreates(poolKey, int32(successes))
+				if createErr != nil {
+					logger.Error(createErr, "Failed to create pool sandboxes")
+					allErrors = errors.Join(allErrors, createErr)
+				}
 			}
 		}
 	}

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -581,7 +581,10 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		// capacity caps carryover at one second of creates), so when the
 		// hold expires the paced stream starts fresh: delay defers the
 		// START of refill, MaxRefillRate shapes its FLOW.
-		logger.Info("Deferring pool replenishment after recent member drop",
+		// V(4): fires on every reconcile while the hold re-arms (one per
+		// adoption during a claim burst) — routine pacing, not a
+		// lifecycle event.
+		logger.V(4).Info("Deferring pool replenishment after recent member drop",
 			"deficit", desiredReplicas-currentReplicas,
 			"requeueAfter", replenishHold)
 		requeueAfter = minNonZeroDuration(requeueAfter, replenishHold)
@@ -592,7 +595,10 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		// whether issuing them against the current cache is safe.
 		sandboxesToCreate, tokenWait := r.takeRefillTokens(poolKey, deficit, now)
 		if sandboxesToCreate < deficit {
-			logger.Info("Pacing pool replenishment",
+			// V(4): fires on every paced pass (a 300-deficit refill is
+			// ~rate*seconds of them) — routine pacing, not a lifecycle
+			// event.
+			logger.V(4).Info("Pacing pool replenishment",
 				"deficit", deficit,
 				"granted", sandboxesToCreate,
 				"tokenWait", tokenWait)

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -315,7 +315,20 @@ func (r *SandboxWarmPoolReconciler) takeRefillTokens(key types.NamespacedName, w
 		b.last = now
 	}
 
-	granted := min(want, int32(b.tokens))
+	// Only narrow the float64 token count to int32 when the bucket holds
+	// fewer tokens than the request: then 0 <= b.tokens < float64(want) <=
+	// MaxInt32 and the conversion is exact. Converting unconditionally is
+	// implementation-defined for capacities above MaxInt32 (a huge-but-finite
+	// MaxRefillRate passes the flag validation, which only rejects
+	// NaN/Inf/negative): amd64 wraps to MinInt32, turning the grant negative
+	// — no creates issued AND no pacing requeue armed, wedging the pool
+	// (arm64 happens to saturate to MaxInt32). Guarding here (rather than
+	// clamping the flag) keeps the behavior defined on every platform and
+	// also covers programmatically constructed reconcilers.
+	granted := want
+	if b.tokens < float64(want) {
+		granted = int32(b.tokens)
+	}
 	b.tokens -= float64(granted)
 	if granted >= want {
 		return granted, 0

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -2708,9 +2708,12 @@ func TestReconcilePoolMaxRefillRate(t *testing.T) {
 		r := newReconciler(2, 0, &now, createTemplate(poolNamespace))
 
 		// Pass 1: full bucket grants one second of creates, remainder paced.
+		// A partial grant emits Sandbox watch events, so the next reconcile
+		// is watch-driven rather than a timed requeue that would race the
+		// cache and risk duplicate creates.
 		requeue, err := r.reconcilePool(ctx, warmPool)
 		require.NoError(t, err)
-		require.Equal(t, 500*time.Millisecond, requeue, "requeue must land on the next token")
+		require.Zero(t, requeue, "partial grant relies on the Sandbox watch, not a timed requeue")
 		require.Equal(t, 2, countOwned(t, r, warmPool))
 		syncPoolExpectations(r, warmPool)
 
@@ -2720,11 +2723,12 @@ func TestReconcilePoolMaxRefillRate(t *testing.T) {
 		require.Equal(t, 500*time.Millisecond, requeue)
 		require.Equal(t, 2, countOwned(t, r, warmPool), "no creates may happen with an empty bucket")
 
-		// Pass 3, +500ms: exactly one token accrued.
+		// Pass 3, +500ms: exactly one token accrued. Partial grant again, so
+		// the watch (not a timer) drives the next reconcile.
 		now = now.Add(500 * time.Millisecond)
 		requeue, err = r.reconcilePool(ctx, warmPool)
 		require.NoError(t, err)
-		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Zero(t, requeue)
 		require.Equal(t, 3, countOwned(t, r, warmPool))
 		syncPoolExpectations(r, warmPool)
 
@@ -2755,16 +2759,16 @@ func TestReconcilePoolMaxRefillRate(t *testing.T) {
 
 		requeue, err := r.reconcilePool(ctx, warmPool)
 		require.NoError(t, err)
-		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Zero(t, requeue, "partial grant relies on the Sandbox watch, not a timed requeue")
 		require.Equal(t, 2, countOwned(t, r, warmPool))
 
 		// Tokens have accrued, but the two creates are still unobserved: the
-		// gate refuses the pass (the 500ms token requeue composes below the
-		// 30s expectations fallback via minNonZeroDuration).
+		// gate refuses the granted pass and schedules the expectations
+		// fallback instead.
 		now = now.Add(time.Second)
 		requeue, err = r.reconcilePool(ctx, warmPool)
 		require.NoError(t, err)
-		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Equal(t, expectationsPendingRequeueDelay, requeue)
 		require.Equal(t, 2, countOwned(t, r, warmPool), "no creates may be issued while prior creates are unobserved")
 
 		// Once the watch catches up, the refunded tokens are spent at once —
@@ -2772,7 +2776,7 @@ func TestReconcilePoolMaxRefillRate(t *testing.T) {
 		syncPoolExpectations(r, warmPool)
 		requeue, err = r.reconcilePool(ctx, warmPool)
 		require.NoError(t, err)
-		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Zero(t, requeue, "partial grant relies on the Sandbox watch, not a timed requeue")
 		require.Equal(t, 4, countOwned(t, r, warmPool))
 	})
 
@@ -2837,11 +2841,12 @@ func TestReconcilePoolMaxRefillRate(t *testing.T) {
 		require.Equal(t, 1, countOwned(t, r, warmPool))
 
 		// Hold expired: the rate now shapes the FLOW — one create per second,
-		// starting with at most one second's worth (capacity 1).
+		// starting with at most one second's worth (capacity 1). The partial
+		// grant's own watch event drives the next reconcile (no timer).
 		now = now.Add(3500 * time.Millisecond)
 		requeue, err = r.reconcilePool(ctx, warmPool)
 		require.NoError(t, err)
-		require.Equal(t, time.Second, requeue, "remainder paced at 1/rate")
+		require.Zero(t, requeue, "partial grant relies on the Sandbox watch, not a timed requeue")
 		require.Equal(t, 2, countOwned(t, r, warmPool))
 		syncPoolExpectations(r, warmPool)
 

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -2631,6 +2631,24 @@ func TestTakeRefillTokens(t *testing.T) {
 		require.Equal(t, 2*time.Second, wait, "next token at 1/rate")
 	})
 
+	t.Run("rates beyond int32 range cannot wrap the grant negative", func(t *testing.T) {
+		// A finite rate above MaxInt32 passes the flag validation (which only
+		// rejects NaN/Inf/negative); the bucket capacity then exceeds what an
+		// int32 can hold, and an unconditional float64->int32 narrowing is
+		// implementation-defined — on amd64 it wraps the grant to MinInt32:
+		// no creates and no pacing requeue (arm64 happens to saturate). The
+		// grant must clamp to the request instead, on every platform.
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 1e18}
+		granted, wait := r.takeRefillTokens(key, 300, base)
+		require.Equal(t, int32(300), granted, "the whole request fits in the bucket")
+		require.Zero(t, wait)
+
+		// And again with a drained-then-huge accrual, for the accrue path.
+		granted, wait = r.takeRefillTokens(key, 250, base.Add(time.Hour))
+		require.Equal(t, int32(250), granted)
+		require.Zero(t, wait)
+	})
+
 	t.Run("refund returns unspent tokens up to capacity", func(t *testing.T) {
 		r := &SandboxWarmPoolReconciler{MaxRefillRate: 2}
 		granted, _ := r.takeRefillTokens(key, 2, base) // drain the initial 2

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -2276,4 +2277,628 @@ func TestSandboxBlueprintFieldsAreCompared(t *testing.T) {
 		"SandboxBlueprint fields have changed. Update compareSandboxBlueprint() in "+
 			"sandboxwarmpool_controller.go to compare the new field for staleness detection, then update the "+
 			"expected field list in this test to include it.")
+}
+
+// adoptSandboxByClaim simulates a SandboxClaim adopting a warm sandbox by
+// replacing its controller reference.
+func adoptSandboxByClaim(ctx context.Context, t *testing.T, c client.Client, sb *sandboxv1beta1.Sandbox, claimUID string) {
+	t.Helper()
+	sb.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+			Kind:       "SandboxClaim",
+			Name:       "claim-" + claimUID,
+			UID:        types.UID(claimUID),
+			Controller: new(true),
+		},
+	}
+	require.NoError(t, c.Update(ctx, sb))
+}
+
+// countPoolOwnedSandboxes returns how many sandboxes carry the pool label and
+// are controlled by the given warm pool.
+func countPoolOwnedSandboxes(ctx context.Context, t *testing.T, c client.Client, namespace, poolNameHash string, poolUID types.UID) int {
+	t.Helper()
+	list := &sandboxv1beta1.SandboxList{}
+	require.NoError(t, c.List(ctx, list, &client.ListOptions{Namespace: namespace}))
+	count := 0
+	for i := range list.Items {
+		sb := &list.Items[i]
+		if sb.Labels[warmPoolSandboxLabel] != poolNameHash {
+			continue
+		}
+		if ref := metav1.GetControllerOf(sb); ref != nil && ref.UID == poolUID {
+			count++
+		}
+	}
+	return count
+}
+
+func newReplenishTestPool(replicas int32) *extensionsv1beta1.SandboxWarmPool {
+	return &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pool",
+			Namespace: "default",
+			UID:       "warmpool-uid-replenish",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas: &replicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{
+				Name: "test-template",
+			},
+		},
+	}
+}
+
+func TestReconcilePoolReplenishDelay(t *testing.T) {
+	poolNamespace := "default"
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	replicas := int32(3)
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	newReconciler := func(delay time.Duration, now *time.Time, initialObjs ...runtime.Object) *SandboxWarmPoolReconciler {
+		return &SandboxWarmPoolReconciler{
+			Client:         newFakeClient(scheme, initialObjs...),
+			Scheme:         scheme,
+			MaxBatchSize:   sandboxCreateDeleteMaxBatchSize,
+			ReplenishDelay: delay,
+			now:            func() time.Time { return *now },
+		}
+	}
+
+	// fillPool reconciles until the pool is at the desired size and asserts no requeue is requested.
+	fillPool := func(t *testing.T, r *SandboxWarmPoolReconciler, warmPool *extensionsv1beta1.SandboxWarmPool) {
+		t.Helper()
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue, "initial pool fill must not be deferred")
+		syncPoolExpectations(r, warmPool)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		syncPoolExpectations(r, warmPool)
+		require.Equal(t, int(replicas), countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+	}
+
+	// adoptN simulates a claim burst adopting n pool-owned sandboxes.
+	adoptN := func(t *testing.T, r *SandboxWarmPoolReconciler, warmPool *extensionsv1beta1.SandboxWarmPool, n int) {
+		t.Helper()
+		list := &sandboxv1beta1.SandboxList{}
+		require.NoError(t, r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace}))
+		adopted := 0
+		for i := range list.Items {
+			if adopted == n {
+				break
+			}
+			sb := &list.Items[i]
+			if sb.Labels[warmPoolSandboxLabel] != poolNameHash {
+				continue
+			}
+			if ref := metav1.GetControllerOf(sb); ref == nil || ref.UID != warmPool.UID {
+				continue
+			}
+			adoptSandboxByClaim(ctx, t, r.Client, sb, fmt.Sprintf("claim-uid-%d", adopted))
+			adopted++
+		}
+		require.Equal(t, n, adopted, "expected to adopt %d sandboxes", n)
+	}
+
+	t.Run("zero delay (default) replaces adopted members immediately", func(t *testing.T) {
+		now := time.Now()
+		warmPool := newReplenishTestPool(replicas)
+		r := newReconciler(0, &now, createTemplate(poolNamespace))
+		fillPool(t, r, warmPool)
+
+		adoptN(t, r, warmPool, 2)
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue, "no requeue expected when delay is disabled")
+		require.Equal(t, int(replicas), countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID),
+			"replacements must be created in the same reconcile when delay is disabled")
+	})
+
+	t.Run("delay defers replacement creation until the window elapses", func(t *testing.T) {
+		const delay = 5 * time.Second
+		now := time.Now()
+		warmPool := newReplenishTestPool(replicas)
+		r := newReconciler(delay, &now, createTemplate(poolNamespace))
+		fillPool(t, r, warmPool)
+
+		adoptN(t, r, warmPool, 2)
+
+		// Drop detected: no creates, requeue after the full delay.
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, delay, requeue)
+		require.Equal(t, 1, countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID),
+			"no replacements may be created inside the deferral window")
+		require.Equal(t, int32(1), warmPool.Status.Replicas, "status must stay truthful while deferring")
+
+		// Mid-window reconcile: still deferred, requeue for the remainder.
+		now = now.Add(2 * time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 3*time.Second, requeue)
+		require.Equal(t, 1, countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+
+		// After the window: replacements are created in one batch.
+		now = now.Add(4 * time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, int(replicas), countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+		syncPoolExpectations(r, warmPool)
+
+		// Steady state afterwards: full pool, no requeue.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, replicas, warmPool.Status.Replicas)
+	})
+
+	t.Run("further drops re-arm the hold", func(t *testing.T) {
+		const delay = 5 * time.Second
+		now := time.Now()
+		warmPool := newReplenishTestPool(replicas)
+		r := newReconciler(delay, &now, createTemplate(poolNamespace))
+		fillPool(t, r, warmPool)
+
+		adoptN(t, r, warmPool, 1)
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, delay, requeue)
+
+		// A second adoption 3s into the window re-arms the hold for a full delay.
+		now = now.Add(3 * time.Second)
+		adoptN(t, r, warmPool, 1)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, delay, requeue, "hold must re-arm on a further drop")
+		require.Equal(t, 1, countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+
+		// Only after the re-armed window elapses do replacements get created.
+		now = now.Add(delay + time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, int(replicas), countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+	})
+
+	t.Run("GC still deletes stuck sandboxes while replacement is deferred", func(t *testing.T) {
+		const delay = 5 * time.Second
+		now := time.Now()
+		warmPool := newReplenishTestPool(replicas)
+		template := createTemplate(poolNamespace)
+
+		// Start with a full pool of ready, old sandboxes so GC age checks apply.
+		makeSandbox := func(suffix string) *sandboxv1beta1.Sandbox {
+			sb := createPoolSandbox("test-pool", poolNamespace, poolNameHash, template, suffix)
+			sb.CreationTimestamp = metav1.Time{Time: now.Add(-time.Hour)}
+			sb.Status.Conditions = []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+			}}
+			return sb
+		}
+		r := newReconciler(delay, &now, template,
+			makeSandbox("-aaa"), makeSandbox("-bbb"), makeSandbox("-ccc"))
+
+		// Baseline observation: pool is full, nothing created or deferred.
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, replicas, warmPool.Status.Replicas)
+
+		// One member becomes stuck (not ready, far past the readiness grace period).
+		stuck := &sandboxv1beta1.Sandbox{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: "test-pool-aaa"}, stuck))
+		stuck.Status.Conditions = []metav1.Condition{{
+			Type:   string(sandboxv1beta1.SandboxConditionReady),
+			Status: metav1.ConditionFalse,
+		}}
+		require.NoError(t, r.Update(ctx, stuck))
+
+		// GC must delete the stuck sandbox even though its replacement is
+		// deferred. The just-deleted member still occupies capacity as
+		// terminating this pass, so the hold's wake-up (not a create) is what
+		// this reconcile schedules.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, delay, requeue, "replacement of the GC'd sandbox should be deferred")
+		err = r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: "test-pool-aaa"}, &sandboxv1beta1.Sandbox{})
+		require.True(t, k8serrors.IsNotFound(err), "stuck sandbox must be GC'd despite the deferral")
+		require.Equal(t, 2, countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+		require.Equal(t, int32(2), warmPool.Status.Replicas)
+		require.Equal(t, int32(2), warmPool.Status.ReadyReplicas)
+
+		// After the window the replacement is created.
+		now = now.Add(delay + time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, int(replicas), countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID))
+	})
+}
+
+func TestObserveMembersForReplenish(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "test-pool"}
+	base := time.Now()
+
+	t.Run("disabled delay never defers and keeps no state", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{}
+		require.Zero(t, r.observeMembersForReplenish(key, 3, 5, base))
+		require.Zero(t, r.observeMembersForReplenish(key, 0, 5, base))
+		require.Nil(t, r.replenishState)
+	})
+
+	t.Run("state machine", func(t *testing.T) {
+		const delay = 10 * time.Second
+		r := &SandboxWarmPoolReconciler{ReplenishDelay: delay}
+
+		// First observation: deficit but no baseline -> immediate.
+		require.Zero(t, r.observeMembersForReplenish(key, 0, 5, base))
+
+		// Creates recorded -> baseline rises to 5; a stale read of 3 counts as a
+		// drop and defers instead of duplicating creates.
+		r.noteReplenishCreates(key, 5)
+		require.Equal(t, delay, r.observeMembersForReplenish(key, 3, 5, base))
+
+		// Mid-window with no further drop: remaining time, not a fresh window.
+		require.Equal(t, 6*time.Second, r.observeMembersForReplenish(key, 3, 5, base.Add(4*time.Second)))
+
+		// Further drop re-arms the full window.
+		require.Equal(t, delay, r.observeMembersForReplenish(key, 1, 5, base.Add(6*time.Second)))
+
+		// Window elapsed -> create immediately.
+		require.Zero(t, r.observeMembersForReplenish(key, 1, 5, base.Add(17*time.Second)))
+
+		// Full pool clears any hold even if a drop is observed simultaneously.
+		require.Equal(t, delay, r.observeMembersForReplenish(key, 0, 5, base.Add(18*time.Second)))
+		require.Zero(t, r.observeMembersForReplenish(key, 5, 5, base.Add(19*time.Second)))
+		// A drop observed after the full-pool reset arms a fresh hold.
+		require.Equal(t, delay, r.observeMembersForReplenish(key, 4, 5, base.Add(19*time.Second)))
+
+		// Forget removes the baseline: next observation is immediate again.
+		r.forgetReplenishState(key)
+		require.Zero(t, r.observeMembersForReplenish(key, 0, 5, base.Add(30*time.Second)))
+	})
+
+	t.Run("noteReplenishCreates ignores unknown pools and disabled delay", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{}
+		r.noteReplenishCreates(key, 3) // no-op, delay disabled
+		require.Nil(t, r.replenishState)
+
+		r = &SandboxWarmPoolReconciler{ReplenishDelay: time.Second}
+		r.noteReplenishCreates(key, 3) // no-op, pool never observed
+		require.Nil(t, r.replenishState[key])
+	})
+}
+
+func TestTakeRefillTokens(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "test-pool"}
+	base := time.Now()
+
+	t.Run("rate zero bypasses the bucket and keeps no state", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{}
+		granted, wait := r.takeRefillTokens(key, 300, base)
+		require.Equal(t, int32(300), granted)
+		require.Zero(t, wait)
+		require.Nil(t, r.refillState)
+	})
+
+	t.Run("non-positive want is a passthrough", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 5}
+		granted, wait := r.takeRefillTokens(key, 0, base)
+		require.Equal(t, int32(0), granted)
+		require.Zero(t, wait)
+		require.Nil(t, r.refillState, "no bucket may be allocated for a zero-deficit pool")
+	})
+
+	t.Run("new bucket starts full and grants at most capacity", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 4}
+		granted, wait := r.takeRefillTokens(key, 10, base)
+		require.Equal(t, int32(4), granted, "capacity is one second of creates")
+		require.Equal(t, 250*time.Millisecond, wait, "next token accrues in 1/rate")
+	})
+
+	t.Run("tokens accrue with elapsed time and cap at one second of creates", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 2}
+		granted, _ := r.takeRefillTokens(key, 5, base) // drain the initial 2
+		require.Equal(t, int32(2), granted)
+
+		// No time passed: nothing accrued.
+		granted, wait := r.takeRefillTokens(key, 3, base)
+		require.Equal(t, int32(0), granted)
+		require.Equal(t, 500*time.Millisecond, wait)
+
+		// Half a second: exactly one token.
+		granted, wait = r.takeRefillTokens(key, 3, base.Add(500*time.Millisecond))
+		require.Equal(t, int32(1), granted)
+		require.Equal(t, 500*time.Millisecond, wait)
+
+		// A long idle period accrues only up to capacity (no banked burst).
+		granted, wait = r.takeRefillTokens(key, 5, base.Add(time.Hour))
+		require.Equal(t, int32(2), granted)
+		require.Equal(t, 500*time.Millisecond, wait)
+	})
+
+	t.Run("fractional rate paces below one create per second", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 0.5}
+		granted, wait := r.takeRefillTokens(key, 2, base)
+		require.Equal(t, int32(1), granted, "capacity floor is one token")
+		require.Equal(t, 2*time.Second, wait, "next token at 1/rate")
+	})
+
+	t.Run("refund returns unspent tokens up to capacity", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 2}
+		granted, _ := r.takeRefillTokens(key, 2, base) // drain the initial 2
+		require.Equal(t, int32(2), granted)
+
+		// Refunding what was taken restores the full grant for the same instant.
+		r.refundRefillTokens(key, 2)
+		granted, _ = r.takeRefillTokens(key, 5, base)
+		require.Equal(t, int32(2), granted)
+
+		// Refunds cannot bank beyond capacity.
+		r.refundRefillTokens(key, 100)
+		granted, _ = r.takeRefillTokens(key, 5, base)
+		require.Equal(t, int32(2), granted)
+
+		// Refunds for pools without a bucket (or with pacing disabled) are no-ops.
+		r.refundRefillTokens(types.NamespacedName{Namespace: "default", Name: "other"}, 3)
+		require.Nil(t, r.refillState[types.NamespacedName{Namespace: "default", Name: "other"}])
+		rOff := &SandboxWarmPoolReconciler{}
+		rOff.refundRefillTokens(key, 3)
+		require.Nil(t, rOff.refillState)
+	})
+
+	t.Run("forgetReplenishState clears the bucket", func(t *testing.T) {
+		r := &SandboxWarmPoolReconciler{MaxRefillRate: 2}
+		granted, _ := r.takeRefillTokens(key, 5, base)
+		require.Equal(t, int32(2), granted)
+		r.forgetReplenishState(key)
+		require.Nil(t, r.refillState[key])
+		// Re-observation starts with a fresh full bucket.
+		granted, _ = r.takeRefillTokens(key, 5, base)
+		require.Equal(t, int32(2), granted)
+	})
+}
+
+func TestReconcilePoolMaxRefillRate(t *testing.T) {
+	poolNamespace := "default"
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	newReconciler := func(rate float64, delay time.Duration, now *time.Time, initialObjs ...runtime.Object) *SandboxWarmPoolReconciler {
+		return &SandboxWarmPoolReconciler{
+			Client:         newFakeClient(scheme, initialObjs...),
+			Scheme:         scheme,
+			MaxBatchSize:   sandboxCreateDeleteMaxBatchSize,
+			ReplenishDelay: delay,
+			MaxRefillRate:  rate,
+			now:            func() time.Time { return *now },
+		}
+	}
+
+	countOwned := func(t *testing.T, r *SandboxWarmPoolReconciler, warmPool *extensionsv1beta1.SandboxWarmPool) int {
+		t.Helper()
+		return countPoolOwnedSandboxes(ctx, t, r.Client, poolNamespace, poolNameHash, warmPool.UID)
+	}
+
+	t.Run("rate zero fills the whole deficit in one reconcile and keeps no bucket state", func(t *testing.T) {
+		now := time.Now()
+		warmPool := newReplenishTestPool(3)
+		r := newReconciler(0, 0, &now, createTemplate(poolNamespace))
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, 3, countOwned(t, r, warmPool))
+		require.Nil(t, r.refillState, "unshaped path must not allocate refill state")
+	})
+
+	t.Run("rate paces creates across reconciles with token-timed requeues", func(t *testing.T) {
+		// replicas=5, rate=2/s (bucket capacity 2): expect 2, 0, 1, 2 creates
+		// as the clock advances, with 500ms token waits in between.
+		now := time.Now()
+		warmPool := newReplenishTestPool(5)
+		r := newReconciler(2, 0, &now, createTemplate(poolNamespace))
+
+		// Pass 1: full bucket grants one second of creates, remainder paced.
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 500*time.Millisecond, requeue, "requeue must land on the next token")
+		require.Equal(t, 2, countOwned(t, r, warmPool))
+		syncPoolExpectations(r, warmPool)
+
+		// Pass 2, same instant: bucket empty, zero creates, same wait.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Equal(t, 2, countOwned(t, r, warmPool), "no creates may happen with an empty bucket")
+
+		// Pass 3, +500ms: exactly one token accrued.
+		now = now.Add(500 * time.Millisecond)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Equal(t, 3, countOwned(t, r, warmPool))
+		syncPoolExpectations(r, warmPool)
+
+		// Pass 4, +2s: accrual caps at capacity, which covers the remaining
+		// deficit exactly — no further requeue.
+		now = now.Add(2 * time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, 5, countOwned(t, r, warmPool))
+		syncPoolExpectations(r, warmPool)
+
+		// Steady state: full pool, nothing to pace.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, 5, countOwned(t, r, warmPool))
+	})
+
+	t.Run("pacing composes with the expectations gate: unobserved creates defer the grant and refund the tokens", func(t *testing.T) {
+		// Same shape as pass 1 above, but the watch never observes the two
+		// creates (no syncPoolExpectations): the next pass's token grant must
+		// be refused by the expectations gate — and refunded, so the paced
+		// stream is not starved for creates that never spent API budget.
+		now := time.Now()
+		warmPool := newReplenishTestPool(5)
+		r := newReconciler(2, 0, &now, createTemplate(poolNamespace))
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Equal(t, 2, countOwned(t, r, warmPool))
+
+		// Tokens have accrued, but the two creates are still unobserved: the
+		// gate refuses the pass (the 500ms token requeue composes below the
+		// 30s expectations fallback via minNonZeroDuration).
+		now = now.Add(time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Equal(t, 2, countOwned(t, r, warmPool), "no creates may be issued while prior creates are unobserved")
+
+		// Once the watch catches up, the refunded tokens are spent at once —
+		// the gate skip cost no bucket capacity.
+		syncPoolExpectations(r, warmPool)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 500*time.Millisecond, requeue)
+		require.Equal(t, 4, countOwned(t, r, warmPool))
+	})
+
+	t.Run("replenish delay defers the start, rate shapes the flow", func(t *testing.T) {
+		const delay = 5 * time.Second
+		now := time.Now()
+		warmPool := newReplenishTestPool(3)
+		template := createTemplate(poolNamespace)
+
+		// Start from a full pool of ready members so only the adoption drop
+		// exercises the delay+rate interaction (initial fill would otherwise
+		// consume the bucket).
+		makeSandbox := func(suffix string) *sandboxv1beta1.Sandbox {
+			sb := createPoolSandbox("test-pool", poolNamespace, poolNameHash, template, suffix)
+			sb.CreationTimestamp = metav1.Time{Time: now.Add(-time.Hour)}
+			sb.Status.Conditions = []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+			}}
+			return sb
+		}
+		r := newReconciler(1, delay, &now, template,
+			makeSandbox("-aaa"), makeSandbox("-bbb"), makeSandbox("-ccc"))
+
+		// Baseline: full pool, no hold, no pacing.
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+
+		// A claim burst adopts two members.
+		list := &sandboxv1beta1.SandboxList{}
+		require.NoError(t, r.List(ctx, list, &client.ListOptions{Namespace: poolNamespace}))
+		adopted := 0
+		for i := range list.Items {
+			if adopted == 2 {
+				break
+			}
+			sb := &list.Items[i]
+			if ref := metav1.GetControllerOf(sb); ref == nil || ref.UID != warmPool.UID {
+				continue
+			}
+			adoptSandboxByClaim(ctx, t, r.Client, sb, fmt.Sprintf("claim-uid-%d", adopted))
+			adopted++
+		}
+		require.Equal(t, 2, adopted)
+
+		// Drop observed: the hold defers the START — zero creates, no tokens
+		// consumed, status stays truthful.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, delay, requeue)
+		require.Equal(t, 1, countOwned(t, r, warmPool))
+		require.Equal(t, int32(1), warmPool.Status.Replicas)
+		require.Nil(t, r.refillState[types.NamespacedName{Namespace: poolNamespace, Name: "test-pool"}],
+			"the bucket must not be touched while the hold is active")
+
+		// Mid-window: still deferred for the remainder.
+		now = now.Add(2 * time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, 3*time.Second, requeue)
+		require.Equal(t, 1, countOwned(t, r, warmPool))
+
+		// Hold expired: the rate now shapes the FLOW — one create per second,
+		// starting with at most one second's worth (capacity 1).
+		now = now.Add(3500 * time.Millisecond)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, time.Second, requeue, "remainder paced at 1/rate")
+		require.Equal(t, 2, countOwned(t, r, warmPool))
+		syncPoolExpectations(r, warmPool)
+
+		// Next token: pool back to full, stream stops. Status keeps
+		// reporting the observed (pre-create) count, exactly as in the
+		// unshaped path.
+		now = now.Add(time.Second)
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, 3, countOwned(t, r, warmPool))
+		require.Equal(t, int32(2), warmPool.Status.Replicas, "status reflects the count observed at pass start")
+		syncPoolExpectations(r, warmPool)
+
+		// Steady state: the next pass observes the full pool.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, 3, countOwned(t, r, warmPool))
+		require.Equal(t, int32(3), warmPool.Status.Replicas)
+	})
+
+	t.Run("GC of stuck members proceeds while refill is paced", func(t *testing.T) {
+		now := time.Now()
+		warmPool := newReplenishTestPool(2)
+		template := createTemplate(poolNamespace)
+
+		// One healthy ready member and one stuck member past the readiness
+		// grace period; deficit after GC is 1, granted from the full bucket.
+		healthy := createPoolSandbox("test-pool", poolNamespace, poolNameHash, template, "-aaa")
+		healthy.CreationTimestamp = metav1.Time{Time: now.Add(-time.Hour)}
+		healthy.Status.Conditions = []metav1.Condition{{
+			Type:   string(sandboxv1beta1.SandboxConditionReady),
+			Status: metav1.ConditionTrue,
+		}}
+		stuck := createPoolSandbox("test-pool", poolNamespace, poolNameHash, template, "-bbb")
+		stuck.CreationTimestamp = metav1.Time{Time: now.Add(-time.Hour)}
+		stuck.Status.Conditions = []metav1.Condition{{
+			Type:   string(sandboxv1beta1.SandboxConditionReady),
+			Status: metav1.ConditionFalse,
+		}}
+		r := newReconciler(1, 0, &now, template, healthy, stuck)
+
+		// First pass: the stuck sandbox is GC'd; it still occupies capacity
+		// as terminating, so the replacement waits for the next pass.
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		err = r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: "test-pool-bbb"}, &sandboxv1beta1.Sandbox{})
+		require.True(t, k8serrors.IsNotFound(err), "stuck sandbox must be GC'd regardless of pacing")
+		require.Equal(t, 1, countOwned(t, r, warmPool))
+
+		// Second pass (deletion observed): the replacement fits in the
+		// initial full bucket, so pacing does not delay it.
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue, "replacement fits in the initial bucket")
+		require.Equal(t, 2, countOwned(t, r, warmPool))
+	})
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

When a burst of SandboxClaims adopts warm sandboxes, the SandboxWarmPool controller immediately fires the entire deficit at the API server through `slowStartBatch` (up to `--sandbox-warm-pool-max-batch-size` creates in one reconcile). Those replacement CREATEs compete with the claim burst's adoption writes for API server budget, slowing down exactly the traffic the warm pool exists to accelerate. This PR adds two independent, opt-in flags that shape refill around claim traffic:

- `--sandbox-warm-pool-replenish-delay` (duration, default `0`): defers the **start** of refill after pool members drop out of the pool (e.g. a claim burst adopting warm sandboxes), so the burst gets API server priority first. The hold re-arms while members keep dropping and clears when the pool is full. Initial pool fill and scale-ups are never deferred. The flag comment documents the sustained-arrival caveat: under continuous claim arrivals the hold re-arms indefinitely and the pool drains, so sustained load should prefer the rate flag with a small or zero delay.
- `--sandbox-warm-pool-max-refill-rate` (float, creates/second per pool, default `0`): shapes the **flow** of refill via a per-pool token bucket (capacity = one second of creates, i.e. `max(1, rate)`), turning full-deficit bursts into a smooth stream. When the bucket runs dry the reconcile creates what was granted and requeues exactly when the next token accrues, so pacing does not depend on watch events. Tokens spent on failed creates are deliberately not refunded — a failed POST spends the same API server budget the rate protects.

The two flags compose: the delay defers the start of refill, the rate shapes its flow once started.

**Both flags default to 0, and at 0 the behavior is byte-identical to today's controller**: the deferral bookkeeping and token bucket are bypassed entirely (no state is even allocated), and refill remains an immediate full-deficit `slowStartBatch`. `reconcilePool` now returns a requeue interval, which is always zero on the legacy path.

Evidence: in a 300-claim warm-adoption benchmark, the isolated per-pool refill ceiling measured ~70-85 creates/s (sandbox CREATE stage ~85/s with API Priority and Fairness queueing creates; pod scheduling ~70/s at the kube-scheduler default `--kube-api-qps=50`), so an unshaped 300-deficit refill burst monopolizes several seconds of write budget right when adoption needs it most. Sizing guidance derived from those measurements (pools needed >= ceil(arrival rate / per-pool rate), replicas sized as a shock absorber) is documented on the `MaxRefillRate` field.

Unit tests pin the semantics:
- token-bucket accrual/requeue math (`TestTakeRefillTokens`): initial full bucket, accrual capped at capacity, fractional rates, requeue landing exactly on the next whole token;
- replenish-delay state machine (`TestObserveMembersForReplenish`): drop detection, re-arming, full-pool reset, create-baseline compensation for informer cache lag;
- end-to-end reconcile behavior for both flags and their composition (`TestReconcilePoolReplenishDelay`, `TestReconcilePoolMaxRefillRate`), including that the default-0 paths create the whole deficit in one reconcile with no requeue and allocate no shaping state, and that stuck-sandbox GC proceeds during holds and pacing.

#### A/B benchmark (this change alone)

300-claim warm-adoption burst, one 6-node tuned cluster (kops GCP, CP n2-standard-16, workers 6x e2-standard-8, clean instrumentation, harness `--client-connections=4`), legs back-to-back on the SAME cluster, BASE first:

| leg | ready/failed | create->Ready p50 | p90 | p99 | all-ready |
|---|---|---|---|---|---|
| BASE (upstream main @ 9a4b3a0, stock) | 300/0 | 1345ms | 2850ms | 3274ms | 3.49s |
| this branch, both flags 0 (identity leg) | 300/0 | 1131ms | 2338ms | 2624ms | 2.77s |
| this branch, `--sandbox-warm-pool-replenish-delay=20s --sandbox-warm-pool-max-refill-rate=100` | 300/0 | 924ms | 1565ms | 1805ms | 1.89s |

Honest reading: the identity-leg delta is run-to-run noise (the flags at 0 are byte-identical legacy behavior — that is exactly what makes it a useful noise control). The shaped leg's p90 2850ms -> 1565ms (-45%) exceeds the observed noise band and matches the mechanism: with refill deferred past the burst window, replacement-sandbox creates stop competing with adoption writes during the burst. Single-run numbers; the flags were confirmed injected into the leg's deployment, and the deferral/token-bucket behavior itself is pinned by the unit tests in this PR.

All four legs of every pair completed with **300/300 claims Ready, zero failures** — correctness held everywhere. Noise context for reading the latency rows: across the four independent, identically-configured stock BASE legs run tonight (one per pair cluster), the 300-burst measured p50 913-1345ms and p90 1940-2850ms — i.e. a single-burst leg has roughly a +/-30-40% run-to-run band at this 6-node scale, and a byte-identical control leg (P2's identity leg, both flags at their 0 defaults) measured 16% "faster" than its own BASE purely from leg ordering.

#### Which issue(s) this PR is related to:

Ref #1182. This supersedes the stale PR #913 — credit to @truenorth-lj for the original rate-limiting direction there; this PR re-expresses it as a per-pool token bucket with token-timed requeues and adds the complementary replenish-delay for burst deferral.

#### Release Note

```release-note
Added two opt-in SandboxWarmPool refill shaping flags: --sandbox-warm-pool-replenish-delay defers the start of pool refill after members are claimed so claim bursts get API server priority, and --sandbox-warm-pool-max-refill-rate paces replacement sandbox creation per pool via a token bucket instead of full-deficit bursts. Both default to 0 (disabled), preserving existing behavior exactly.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two CLI options for warm-pool replenishment: **replenish delay** (defer replacements after member drops) and **maximum refill rate** (pace replacement creation).
  - Replenishment pacing/deferral behavior is now managed per warm pool and **cleared** when the pool is removed.
- **Bug Fixes**
  - Improved startup safety by **failing fast** on invalid maximum refill rate (must be finite and non-negative).
  - Refined reconcile requeue timing to better align with pacing/deferral windows.
- **Tests**
  - Added comprehensive coverage for delay handling, refill-token pacing, expectation gating/refunds, and correct cleanup while pacing is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**Composition with the expectations gate (post-#1266 rebase, 2026-07-24):** this PR's shaping now sits *in front of* the merged expectations gate: replenish-hold → token-bucket grant on the deficit → `TryExpectCreations` admits the granted creates. Three properties reviewers may want to check:
- **Gate refusal refunds tokens** — a pass the gate skips spends no POSTs, so its tokens return to the bucket (capped at capacity); failed POSTs still forfeit. A regression test pins that refunded tokens are spent as soon as the watch catches up while the gate holds creates meanwhile.
- **All requeues compose** through `minNonZeroDuration` (shaping holds, token waits, expectations fallback, unschedulable hold, grace deadline) — the earliest wake-up always wins.
- **Hold vs. create branches key on different deficits by design** (active vs. population) so a terminating member keeps the replenish wake-up armed without violating the never-overshoot invariant.
