### PR TITLE
perf(sandbox): opt-in coalescing of recoverable metadata writes via RequeueAfter deferral

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -80,6 +80,7 @@ func main() {
 	var sandboxWarmPoolMaxBatchSize int
 	var sandboxWarmPoolReplenishDelay time.Duration
 	var sandboxWarmPoolMaxRefillRate float64
+	var sandboxWriteBehindWindow time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -170,6 +171,8 @@ func main() {
 			"metrics and trace propagation to the Sandbox keep working within the controller process. Costs the on-object "+
 			"debugging breadcrumbs and, after a controller restart, the startup-latency metric for claims first observed "+
 			"by the previous process. Default false (annotations persisted).")
+	flag.DurationVar(&sandboxWriteBehindWindow, "sandbox-write-behind-window", 0,
+		"Coalescing window for the Sandbox controller's recoverable metadata-only writes. 0 disables coalescing.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -216,6 +219,13 @@ func main() {
 	if math.IsNaN(sandboxWarmPoolMaxRefillRate) || math.IsInf(sandboxWarmPoolMaxRefillRate, 0) || sandboxWarmPoolMaxRefillRate < 0 {
 		setupLog.Error(nil, "sandbox-warm-pool-max-refill-rate must be a finite value >= 0 (0 disables pacing)",
 			"value", sandboxWarmPoolMaxRefillRate)
+		os.Exit(1)
+	}
+	// 0 means "write-behind disabled"; a negative window is always a
+	// misconfiguration, so fail fast instead of silently disabling.
+	if sandboxWriteBehindWindow < 0 {
+		setupLog.Error(nil, "sandbox-write-behind-window must be >= 0 (0 disables write-behind coalescing)",
+			"value", sandboxWriteBehindWindow)
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -442,11 +452,21 @@ func main() {
 	// Register the custom Sandbox metric collector globally.
 	asmetrics.RegisterSandboxCollector(mgr.GetClient(), mgr.GetLogger().WithName("sandbox-collector"))
 
+	// RequeueAfter-based write deferral for the Sandbox controller's
+	// recoverable metadata-only writes. Default (0) is fully synchronous:
+	// the controller keeps its stock write path. No background goroutine is
+	// involved; the workqueue's AddAfter provides the coalescing window.
+	if sandboxWriteBehindWindow > 0 {
+		setupLog.Info("Sandbox controller write deferral enabled (--sandbox-write-behind-window)",
+			"window", sandboxWriteBehindWindow, "podPatchBound", "1s")
+	}
+
 	if err = (&controllers.SandboxReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Tracer:        instrumenter,
-		ClusterDomain: clusterDomain,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Tracer:            instrumenter,
+		ClusterDomain:     clusterDomain,
+		WriteBehindWindow: sandboxWriteBehindWindow,
 	}).SetupWithManager(mgr, sandboxConcurrentWorkers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")
 		os.Exit(1)

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -77,6 +77,7 @@ func main() {
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
 	var sandboxWarmPoolMaxBatchSize int
+	var sandboxWriteBehindWindow time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -158,6 +159,8 @@ func main() {
 			"metrics and trace propagation to the Sandbox keep working within the controller process. Costs the on-object "+
 			"debugging breadcrumbs and, after a controller restart, the startup-latency metric for claims first observed "+
 			"by the previous process. Default false (annotations persisted).")
+	flag.DurationVar(&sandboxWriteBehindWindow, "sandbox-write-behind-window", 0,
+		"Coalescing window for the Sandbox controller's recoverable metadata-only writes. 0 disables coalescing.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -196,6 +199,13 @@ func main() {
 	// Validation checks for sandboxWarmPoolMaxBatchSize (maximum batch size for sandbox creation and deletion in SandboxWarmPool controller)
 	if sandboxWarmPoolMaxBatchSize <= 0 {
 		setupLog.Error(nil, "sandbox-warm-pool-max-batch-size must be greater than 0")
+		os.Exit(1)
+	}
+	// 0 means "write-behind disabled"; a negative window is always a
+	// misconfiguration, so fail fast instead of silently disabling.
+	if sandboxWriteBehindWindow < 0 {
+		setupLog.Error(nil, "sandbox-write-behind-window must be >= 0 (0 disables write-behind coalescing)",
+			"value", sandboxWriteBehindWindow)
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -422,11 +432,21 @@ func main() {
 	// Register the custom Sandbox metric collector globally.
 	asmetrics.RegisterSandboxCollector(mgr.GetClient(), mgr.GetLogger().WithName("sandbox-collector"))
 
+	// RequeueAfter-based write deferral for the Sandbox controller's
+	// recoverable metadata-only writes. Default (0) is fully synchronous:
+	// the controller keeps its stock write path. No background goroutine is
+	// involved; the workqueue's AddAfter provides the coalescing window.
+	if sandboxWriteBehindWindow > 0 {
+		setupLog.Info("Sandbox controller write deferral enabled (--sandbox-write-behind-window)",
+			"window", sandboxWriteBehindWindow, "podPatchBound", "1s")
+	}
+
 	if err = (&controllers.SandboxReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Tracer:        instrumenter,
-		ClusterDomain: clusterDomain,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Tracer:            instrumenter,
+		ClusterDomain:     clusterDomain,
+		WriteBehindWindow: sandboxWriteBehindWindow,
 	}).SetupWithManager(mgr, sandboxConcurrentWorkers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")
 		os.Exit(1)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -60,6 +60,14 @@ const (
 	podSandboxNameHashIndex     = ".metadata.labels[" + sandboxLabel + "]"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
+	// podMetadataFlushBound caps how long a write-behind pod metadata patch
+	// may stay pending. The pod metadata patch on the warm-pool adoption path
+	// is what strips the cluster-autoscaler.kubernetes.io/safe-to-evict
+	// annotation from the live Pod; the accepted risk bound for that eviction
+	// window is <1s (cluster-autoscaler scan intervals are 10s+, so a
+	// sub-second deferral cannot realistically lose the race), hence pod
+	// patches always flush within min(window, 1s).
+	podMetadataFlushBound = time.Second
 )
 
 // PodCacheTransform is a client-go informer transform for the manager's Pod
@@ -178,6 +186,32 @@ type SandboxReconciler struct {
 	Scheme        *runtime.Scheme
 	Tracer        asmetrics.Instrumenter
 	ClusterDomain string
+
+	// WriteBehindWindow, when > 0, defers this controller's RECOVERABLE
+	// metadata-only write — the pod label/annotation reconciliation patch —
+	// via RequeueAfter: the reconcile pass
+	// that detects the drift SKIPS the patch and returns
+	// ctrl.Result{RequeueAfter: <remaining window>}; the pass that runs once
+	// the window has elapsed recomputes the desired metadata from informer
+	// state and issues ONE targeted merge patch. Coalescing comes from the
+	// workqueue itself: redeliveries of the object within the window dedup
+	// in the queue, and every deferring pass recomputes the FULL desired
+	// state, so N deferred detections still flush as a single patch.
+	//
+	// 0 (the default) preserves the fully synchronous behavior on the exact
+	// same code paths. Only a write that the next level-based reconcile
+	// recomputes verbatim from informer state is deferred, so no mutation
+	// payload is ever held in memory and a crash cannot lose one. Writes
+	// that are NOT recoverable this way (status writes, ownerRef changes,
+	// creates/deletes) are never deferred. Gated by the
+	// --sandbox-write-behind-window flag.
+	WriteBehindWindow time.Duration
+
+	// deferralClock records when each request's pending deferral was first
+	// observed — timestamp-only, no mutation payload; see deferredWriteClock
+	// for why this one piece of in-memory state is unavoidable and why
+	// losing it is harmless.
+	deferralClock deferredWriteClock
 }
 
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
@@ -207,6 +241,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Get(ctx, req.NamespacedName, sandbox); err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("sandbox resource not found. Ignoring since object must be deleted")
+			r.deferralClock.clear(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -226,6 +261,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// If the sandbox is being deleted, do nothing
 	if !sandbox.DeletionTimestamp.IsZero() {
 		logger.Info("Sandbox is being deleted")
+		r.deferralClock.clear(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -261,12 +297,39 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
 		sandboxDeleted, err = r.handleSandboxExpiry(ctx, sandbox)
 	} else {
-		err = r.reconcileChildResources(ctx, sandbox)
+		// Per-pass deferral view for the recoverable pod metadata patch
+		// (--sandbox-write-behind-window > 0). The pod patch bound caps the
+		// deferral: the safe-to-evict strip must land within
+		// min(window, podMetadataFlushBound).
+		var wd *writeDeferral
+		if r.WriteBehindWindow > 0 {
+			wd = &writeDeferral{
+				clock:  &r.deferralClock,
+				key:    req.NamespacedName,
+				window: min(r.WriteBehindWindow, podMetadataFlushBound),
+			}
+		}
+		err = r.reconcileChildResources(ctx, sandbox, wd)
 		expiredAfterReconcile, requeueAfter := checkSandboxExpiry(sandbox, time.Now())
 		result.RequeueAfter = requeueAfter
 		if expiredAfterReconcile {
 			setSandboxExpiredCondition(sandbox)
 			result.RequeueAfter = immediateRequeueDelay
+		}
+		if wd != nil && err == nil {
+			if wd.deferred {
+				// A recoverable write was skipped this pass: wake this
+				// request when its deferral window elapses. The requeue is
+				// rate-limit-free (RequeueAfter → Forget + AddAfter) and
+				// dedups with any earlier pending requeue for the key.
+				if result.RequeueAfter == 0 || wd.wait < result.RequeueAfter {
+					result.RequeueAfter = wd.wait
+				}
+			} else {
+				// Nothing pending (no drift, or the due write flushed):
+				// drop the deferral clock entry for this request.
+				r.deferralClock.clear(req.NamespacedName)
+			}
 		}
 	}
 
@@ -281,7 +344,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return result, err
 }
 
-func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox *sandboxv1beta1.Sandbox) error {
+func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, wd *writeDeferral) error {
 	// Create a hash from the sandbox.Name and use it as label value
 	nameHash := NameHash(sandbox.Name)
 
@@ -292,8 +355,8 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 
 	// Reconcile Pod
-	pod, podErr := r.reconcilePod(ctx, sandbox, nameHash)
-	allErrors = errors.Join(allErrors, podErr)
+	pod, err := r.reconcilePod(ctx, sandbox, nameHash, wd)
+	allErrors = errors.Join(allErrors, err)
 
 	if pod == nil {
 		sandbox.Status.PodIPs = nil
@@ -314,7 +377,7 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 
 	// compute and set overall conditions
-	conditions := r.computeConditions(sandbox, allErrors, svc, pod, podErr)
+	conditions := r.computeConditions(sandbox, allErrors, svc, pod, err)
 	hasFinished := false
 	for _, condition := range conditions {
 		meta.SetStatusCondition(&sandbox.Status.Conditions, condition)
@@ -963,7 +1026,7 @@ func (r *SandboxReconciler) clearServiceStatus(sandbox *sandboxv1beta1.Sandbox) 
 	sandbox.Status.ServiceFQDN = ""
 }
 
-func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Pod, error) {
+func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string, wd *writeDeferral) (*corev1.Pod, error) {
 	logger := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
@@ -1115,10 +1178,45 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			// No additional action needed — label applied below.
 		}
 
+		// The pod metadata patch on the warm-pool adoption path is always a
+		// real patch: the adoption merge drops the warm-pool label from the
+		// pod, strips the safe-to-evict marker the pool stamped on it, and
+		// updates the propagated-keys tracking annotations.
+		//
+		// Nothing on the Sandbox-Ready path gates on this patch (the Service
+		// selector uses the name-hash label, which never changes), and every
+		// key it touches is recomputed from informer state on the next
+		// reconcile — so it is RECOVERABLE and eligible for deferral, with
+		// one bound: the safe-to-evict strip protects the adopted pod from
+		// cluster-autoscaler eviction, so a deferred write must land within
+		// min(window, podMetadataFlushBound) (<1s), well inside any
+		// realistic autoscaler scan interval. Synchronous mode
+		// (WriteBehindWindow 0, the default) keeps the single
+		// optimistic-lock-free merge patch: one API round-trip, no
+		// 409/backoff risk.
+		//
+		// Deferral mechanism (RequeueAfter): while the window has
+		// not elapsed, the patch is SKIPPED — the in-memory pod already
+		// carries the desired metadata for everything downstream of this
+		// pass (status/conditions computation) — and Reconcile returns
+		// RequeueAfter with the remaining window. The pass that runs at/after
+		// the deadline recomputes this exact drift from informer state and
+		// falls through to the same synchronous r.Patch below: identical
+		// targeted merge patch, no pending-mutation store.
+		//
+		// Deferral only applies when the pod is already owned by this
+		// sandbox: ownership transfers (SetControllerReference above,
+		// needsUpdate=true) are adoption-lock-adjacent and stay synchronous.
 		metadataUpdated := r.updatePodMetadata(ctx, pod, sandbox, nameHash)
 		if metadataUpdated || needsUpdate {
-			if err := r.Patch(ctx, pod, patch); err != nil {
-				return nil, fmt.Errorf("failed to patch pod: %w", err)
+			// deferred: no write this pass; Reconcile requeues this request
+			// for the flush pass.
+			deferrable := wd != nil && ownership == resourceOwnedBySandbox && !needsUpdate
+			deferred := deferrable && !wd.shouldWrite()
+			if !deferred {
+				if err := r.Patch(ctx, pod, patch); err != nil {
+					return nil, fmt.Errorf("failed to patch pod: %w", err)
+				}
 			}
 		}
 

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -60,6 +60,14 @@ const (
 	podSandboxNameHashIndex     = ".metadata.labels[" + sandboxLabel + "]"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
+	// podMetadataFlushBound caps how long a write-behind pod metadata patch
+	// may stay pending. The pod metadata patch on the warm-pool adoption path
+	// is what strips the cluster-autoscaler.kubernetes.io/safe-to-evict
+	// annotation from the live Pod; the accepted risk bound for that eviction
+	// window is <1s (cluster-autoscaler scan intervals are 10s+, so a
+	// sub-second deferral cannot realistically lose the race), hence pod
+	// patches always flush within min(window, 1s).
+	podMetadataFlushBound = time.Second
 )
 
 // PodCacheTransform is a client-go informer transform for the manager's Pod
@@ -178,6 +186,32 @@ type SandboxReconciler struct {
 	Scheme        *runtime.Scheme
 	Tracer        asmetrics.Instrumenter
 	ClusterDomain string
+
+	// WriteBehindWindow, when > 0, defers this controller's RECOVERABLE
+	// metadata-only write — the pod label/annotation reconciliation patch —
+	// via RequeueAfter: the reconcile pass
+	// that detects the drift SKIPS the patch and returns
+	// ctrl.Result{RequeueAfter: <remaining window>}; the pass that runs once
+	// the window has elapsed recomputes the desired metadata from informer
+	// state and issues ONE targeted merge patch. Coalescing comes from the
+	// workqueue itself: redeliveries of the object within the window dedup
+	// in the queue, and every deferring pass recomputes the FULL desired
+	// state, so N deferred detections still flush as a single patch.
+	//
+	// 0 (the default) preserves the fully synchronous behavior on the exact
+	// same code paths. Only a write that the next level-based reconcile
+	// recomputes verbatim from informer state is deferred, so no mutation
+	// payload is ever held in memory and a crash cannot lose one. Writes
+	// that are NOT recoverable this way (status writes, ownerRef changes,
+	// creates/deletes) are never deferred. Gated by the
+	// --sandbox-write-behind-window flag.
+	WriteBehindWindow time.Duration
+
+	// deferralClock records when each request's pending deferral was first
+	// observed — timestamp-only, no mutation payload; see deferredWriteClock
+	// for why this one piece of in-memory state is unavoidable and why
+	// losing it is harmless.
+	deferralClock deferredWriteClock
 }
 
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
@@ -207,6 +241,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Get(ctx, req.NamespacedName, sandbox); err != nil {
 		if k8serrors.IsNotFound(err) {
 			logger.Info("sandbox resource not found. Ignoring since object must be deleted")
+			r.deferralClock.clear(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -226,6 +261,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// If the sandbox is being deleted, do nothing
 	if !sandbox.DeletionTimestamp.IsZero() {
 		logger.Info("Sandbox is being deleted")
+		r.deferralClock.clear(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -261,12 +297,39 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		logger.Info("Sandbox has expired, deleting child resources and checking shutdown policy")
 		sandboxDeleted, err = r.handleSandboxExpiry(ctx, sandbox)
 	} else {
-		err = r.reconcileChildResources(ctx, sandbox)
+		// Per-pass deferral view for the recoverable pod metadata patch
+		// (--sandbox-write-behind-window > 0). The pod patch bound caps the
+		// deferral: the safe-to-evict strip must land within
+		// min(window, podMetadataFlushBound).
+		var wd *writeDeferral
+		if r.WriteBehindWindow > 0 {
+			wd = &writeDeferral{
+				clock:  &r.deferralClock,
+				key:    req.NamespacedName,
+				window: min(r.WriteBehindWindow, podMetadataFlushBound),
+			}
+		}
+		err = r.reconcileChildResources(ctx, sandbox, wd)
 		expiredAfterReconcile, requeueAfter := checkSandboxExpiry(sandbox, time.Now())
 		result.RequeueAfter = requeueAfter
 		if expiredAfterReconcile {
 			setSandboxExpiredCondition(sandbox)
 			result.RequeueAfter = immediateRequeueDelay
+		}
+		if wd != nil && err == nil {
+			if wd.deferred {
+				// A recoverable write was skipped this pass: wake this
+				// request when its deferral window elapses. The requeue is
+				// rate-limit-free (RequeueAfter → Forget + AddAfter) and
+				// dedups with any earlier pending requeue for the key.
+				if result.RequeueAfter == 0 || wd.wait < result.RequeueAfter {
+					result.RequeueAfter = wd.wait
+				}
+			} else {
+				// Nothing pending (no drift, or the due write flushed):
+				// drop the deferral clock entry for this request.
+				r.deferralClock.clear(req.NamespacedName)
+			}
 		}
 	}
 
@@ -281,7 +344,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return result, err
 }
 
-func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox *sandboxv1beta1.Sandbox) error {
+func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, wd *writeDeferral) error {
 	// Create a hash from the sandbox.Name and use it as label value
 	nameHash := NameHash(sandbox.Name)
 
@@ -292,7 +355,7 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 
 	// Reconcile Pod
-	pod, podErr := r.reconcilePod(ctx, sandbox, nameHash)
+	pod, podErr := r.reconcilePod(ctx, sandbox, nameHash, wd)
 	allErrors = errors.Join(allErrors, podErr)
 
 	if pod == nil {
@@ -963,7 +1026,7 @@ func (r *SandboxReconciler) clearServiceStatus(sandbox *sandboxv1beta1.Sandbox) 
 	sandbox.Status.ServiceFQDN = ""
 }
 
-func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Pod, error) {
+func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string, wd *writeDeferral) (*corev1.Pod, error) {
 	logger := log.FromContext(ctx)
 
 	// Start a child span of ReconcileSandbox
@@ -1115,10 +1178,45 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			// No additional action needed — label applied below.
 		}
 
+		// The pod metadata patch on the warm-pool adoption path is always a
+		// real patch: the adoption merge drops the warm-pool label from the
+		// pod, strips the safe-to-evict marker the pool stamped on it, and
+		// updates the propagated-keys tracking annotations.
+		//
+		// Nothing on the Sandbox-Ready path gates on this patch (the Service
+		// selector uses the name-hash label, which never changes), and every
+		// key it touches is recomputed from informer state on the next
+		// reconcile — so it is RECOVERABLE and eligible for deferral, with
+		// one bound: the safe-to-evict strip protects the adopted pod from
+		// cluster-autoscaler eviction, so a deferred write must land within
+		// min(window, podMetadataFlushBound) (<1s), well inside any
+		// realistic autoscaler scan interval. Synchronous mode
+		// (WriteBehindWindow 0, the default) keeps the single
+		// optimistic-lock-free merge patch: one API round-trip, no
+		// 409/backoff risk.
+		//
+		// Deferral mechanism (RequeueAfter): while the window has
+		// not elapsed, the patch is SKIPPED — the in-memory pod already
+		// carries the desired metadata for everything downstream of this
+		// pass (status/conditions computation) — and Reconcile returns
+		// RequeueAfter with the remaining window. The pass that runs at/after
+		// the deadline recomputes this exact drift from informer state and
+		// falls through to the same synchronous r.Patch below: identical
+		// targeted merge patch, no pending-mutation store.
+		//
+		// Deferral only applies when the pod is already owned by this
+		// sandbox: ownership transfers (SetControllerReference above,
+		// needsUpdate=true) are adoption-lock-adjacent and stay synchronous.
 		metadataUpdated := r.updatePodMetadata(ctx, pod, sandbox, nameHash)
 		if metadataUpdated || needsUpdate {
-			if err := r.Patch(ctx, pod, patch); err != nil {
-				return nil, fmt.Errorf("failed to patch pod: %w", err)
+			// deferred: no write this pass; Reconcile requeues this request
+			// for the flush pass.
+			deferrable := wd != nil && ownership == resourceOwnedBySandbox && !needsUpdate
+			deferred := deferrable && !wd.shouldWrite()
+			if !deferred {
+				if err := r.Patch(ctx, pod, patch); err != nil {
+					return nil, fmt.Errorf("failed to patch pod: %w", err)
+				}
 			}
 		}
 

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2862,7 +2862,7 @@ func TestReconcilePod(t *testing.T) {
 				ClusterDomain: "cluster.local",
 			}
 
-			pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+			pod, err := r.reconcilePod(t.Context(), sandbox, nameHash, nil)
 			if tc.expectErr {
 				require.Error(t, err)
 				// Verify that any initially unowned Pod remains unowned (never adopted)
@@ -4205,7 +4205,7 @@ func TestReconcileChildResourcesSuspendedForeignPodDoesNotLeakIPOrNodeName(t *te
 	}
 
 	// Refusing to delete a foreign pod is a steady state, not an error.
-	require.NoError(t, r.reconcileChildResources(t.Context(), sandboxObj))
+	require.NoError(t, r.reconcileChildResources(t.Context(), sandboxObj, nil))
 
 	assert.Nil(t, sandboxObj.Status.PodIPs, "foreign pod IPs must NOT leak into sandbox status")
 	assert.Empty(t, sandboxObj.Status.NodeName, "foreign pod NodeName must NOT leak into sandbox status")

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -2862,7 +2862,7 @@ func TestReconcilePod(t *testing.T) {
 				ClusterDomain: "cluster.local",
 			}
 
-			pod, err := r.reconcilePod(t.Context(), sandbox, nameHash)
+			pod, err := r.reconcilePod(t.Context(), sandbox, nameHash, nil)
 			if tc.expectErr {
 				require.Error(t, err)
 				// Verify that any initially unowned Pod remains unowned (never adopted)

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -4205,7 +4205,7 @@ func TestReconcileChildResourcesSuspendedForeignPodDoesNotLeakIPOrNodeName(t *te
 	}
 
 	// Refusing to delete a foreign pod is a steady state, not an error.
-	require.NoError(t, r.reconcileChildResources(t.Context(), sandboxObj))
+	require.NoError(t, r.reconcileChildResources(t.Context(), sandboxObj, nil))
 
 	assert.Nil(t, sandboxObj.Status.PodIPs, "foreign pod IPs must NOT leak into sandbox status")
 	assert.Empty(t, sandboxObj.Status.NodeName, "foreign pod NodeName must NOT leak into sandbox status")

--- a/controllers/writebehind_coalesce_test.go
+++ b/controllers/writebehind_coalesce_test.go
@@ -1,0 +1,382 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+// RequeueAfter write-deferral tests: opt-in deferral of the
+// sandbox controller's recoverable metadata-only writes
+// (--sandbox-write-behind-window), including the flag-off (window=0)
+// synchronous identity, workqueue-driven per-object coalescing, the
+// readiness-never-gated guarantee, and level-based crash recovery.
+
+import (
+	"context"
+	"maps"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
+)
+
+const (
+	wbNamespace = "wb-ns"
+	wbSandbox   = "wb-sandbox"
+	// autoscalerSafeToEvictAnnotation marks a pod as evictable by the cluster
+	// autoscaler. The warm pool stamps it "true" on pool-owned pods so idle
+	// warm capacity can be scaled down; once a pod backs a claimed sandbox it
+	// must NOT carry the marker (an eviction would kill an in-use sandbox).
+	autoscalerSafeToEvictAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+)
+
+func claimOwnerRef() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+		Kind:       "SandboxClaim",
+		Name:       "wb-claim",
+		UID:        "wb-claim-uid",
+		Controller: new(true),
+	}
+}
+
+// postAdoptionFixture models the state the sandbox controller observes right
+// after a warm-pool adoption: the sandbox is claim-owned and its template no
+// longer carries the safe-to-evict marker (deleted by the claim controller's
+// spec rewrite), while the live pod still does (plus the warm-pool label).
+// The pod metadata reconciliation must strip both and update the tracking
+// annotations.
+func postAdoptionFixture() (*sandboxv1beta1.Sandbox, *corev1.Pod) {
+	hash := NameHash(wbSandbox)
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       wbSandbox,
+			Namespace:  wbNamespace,
+			UID:        sandboxUID,
+			Generation: 3,
+			Annotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: wbSandbox,
+			},
+			OwnerReferences: []metav1.OwnerReference{claimOwnerRef()},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
+					// Post-adoption template: safe-to-evict deleted by the
+					// claim controller's spec rewrite.
+					ObjectMeta: sandboxv1beta1.PodMetadata{},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      wbSandbox,
+			Namespace: wbNamespace,
+			Labels: map[string]string{
+				sandboxLabel:                        hash,
+				sandboxv1beta1.SandboxWarmPoolLabel: NameHash("wb-pool"),
+			},
+			Annotations: map[string]string{
+				autoscalerSafeToEvictAnnotation:                       "true",
+				sandboxv1beta1.SandboxPropagatedAnnotationsAnnotation: autoscalerSafeToEvictAnnotation,
+			},
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(wbSandbox)},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-1",
+			Containers: []corev1.Container{{Name: "c"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			PodIPs:     []corev1.PodIP{{IP: "10.0.0.9"}},
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	return sb, pod
+}
+
+type wbCounters struct {
+	podPatches         int
+	sandboxPatches     int
+	subResourcePatches int
+}
+
+func (w *wbCounters) interceptors() interceptor.Funcs {
+	return interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			switch obj.(type) {
+			case *corev1.Pod:
+				w.podPatches++
+			case *sandboxv1beta1.Sandbox:
+				w.sandboxPatches++
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+		SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			w.subResourcePatches++
+			return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+		},
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			w.subResourcePatches++
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	}
+}
+
+func newWbClient(counters *wbCounters, objs ...runtime.Object) client.WithWatch {
+	return fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
+		WithIndex(&corev1.Pod{}, podSandboxNameHashIndex, podSandboxNameHashIndexer).
+		WithInterceptorFuncs(counters.interceptors()).
+		WithRuntimeObjects(objs...).
+		Build()
+}
+
+// newWbReconciler builds a SandboxReconciler; window == 0 models the default
+// flag-off configuration (fully synchronous writes), exactly as
+// cmd/agent-sandbox-controller wires it. window > 0 enables the
+// RequeueAfter-based deferral of the recoverable pod metadata patch.
+func newWbReconciler(t *testing.T, cl client.Client, window time.Duration) *SandboxReconciler {
+	t.Helper()
+	return &SandboxReconciler{
+		Client:            cl,
+		Scheme:            Scheme,
+		Tracer:            asmetrics.NewNoOp(),
+		ClusterDomain:     "cluster.local",
+		WriteBehindWindow: window,
+	}
+}
+
+func wbReconcile(t *testing.T, r *SandboxReconciler) ctrl.Result {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: wbSandbox, Namespace: wbNamespace},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	return res
+}
+
+func getWbPod(t *testing.T, cl client.Client) *corev1.Pod {
+	t.Helper()
+	pod := &corev1.Pod{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: wbSandbox, Namespace: wbNamespace}, pod); err != nil {
+		t.Fatalf("get pod: %v", err)
+	}
+	return pod
+}
+
+func getWbSandbox(t *testing.T, cl client.Client) *sandboxv1beta1.Sandbox {
+	t.Helper()
+	sb := &sandboxv1beta1.Sandbox{}
+	if err := cl.Get(context.Background(), types.NamespacedName{Name: wbSandbox, Namespace: wbNamespace}, sb); err != nil {
+		t.Fatalf("get sandbox: %v", err)
+	}
+	return sb
+}
+
+func wbReadyCondition(sb *sandboxv1beta1.Sandbox) *metav1.Condition {
+	for i := range sb.Status.Conditions {
+		if sb.Status.Conditions[i].Type == string(sandboxv1beta1.SandboxConditionReady) {
+			return &sb.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// TestWriteBehindDisabledIsSynchronous pins the flag-off identity: with
+// window=0 the reconcile runs the stock synchronous path — the pod metadata
+// patch is issued inline, exactly once, during the reconcile, and the pod
+// converges before Reconcile returns.
+func TestWriteBehindDisabledIsSynchronous(t *testing.T) {
+	counters := &wbCounters{}
+	sb, pod := postAdoptionFixture()
+	cl := newWbClient(counters, sb, pod)
+	r := newWbReconciler(t, cl, 0)
+
+	wbReconcile(t, r)
+	if counters.podPatches != 1 {
+		t.Fatalf("synchronous mode: %d pod patches during reconcile, want exactly 1", counters.podPatches)
+	}
+	got := getWbPod(t, cl)
+	if _, ok := got.Annotations[autoscalerSafeToEvictAnnotation]; ok {
+		t.Error("safe-to-evict marker not stripped synchronously during reconcile")
+	}
+	if _, ok := got.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
+		t.Error("warm-pool label not stripped synchronously during reconcile")
+	}
+
+	// Idempotence: a second reconcile is pod-write-free.
+	wbReconcile(t, r)
+	if counters.podPatches != 1 {
+		t.Fatalf("second synchronous reconcile issued %d extra pod patches, want 0", counters.podPatches-1)
+	}
+}
+
+// TestRequeueDeferralCoalescesAdoptionPodPatch: with the deferral enabled,
+// the adoption-path pod metadata reconciliation issues ZERO pod patches
+// while the window is open and instead returns RequeueAfter (bounded by the
+// 1s pod-patch cap); repeated redeliveries within the window coalesce (still
+// zero writes, the deferral clock is NOT re-armed); the pass that runs after
+// the window elapses recomputes the drift from informer state and issues
+// exactly ONE patch whose result is byte-identical to synchronous mode; and
+// readiness is NEVER gated on the deferred write — the deferring pass
+// finalizes the same status the synchronous pass would.
+func TestRequeueDeferralCoalescesAdoptionPodPatch(t *testing.T) {
+	// Reference run: synchronous mode (window=0, flag off).
+	syncCounters := &wbCounters{}
+	sbRef, podRef := postAdoptionFixture()
+	syncClient := newWbClient(syncCounters, sbRef, podRef)
+	syncR := newWbReconciler(t, syncClient, 0)
+	wbReconcile(t, syncR)
+	if syncCounters.podPatches != 1 {
+		t.Fatalf("synchronous mode: %d pod patches during reconcile, want 1 (flag-off identity)", syncCounters.podPatches)
+	}
+	wantPod := getWbPod(t, syncClient)
+	wantReady := wbReadyCondition(getWbSandbox(t, syncClient))
+
+	// Deferral run. A large flag window exercises the pod-patch bound:
+	// the effective window must be capped at podMetadataFlushBound (1s).
+	counters := &wbCounters{}
+	sb, pod := postAdoptionFixture()
+	cl := newWbClient(counters, sb, pod)
+	r := newWbReconciler(t, cl, time.Hour)
+
+	res := wbReconcile(t, r)
+	if counters.podPatches != 0 {
+		t.Fatalf("deferral mode: %d pod patches during reconcile, want 0 (deferred)", counters.podPatches)
+	}
+	if res.RequeueAfter <= 0 || res.RequeueAfter > podMetadataFlushBound {
+		t.Fatalf("deferring pass returned RequeueAfter=%v, want in (0, %v] (pod-patch bound caps the flag window)", res.RequeueAfter, podMetadataFlushBound)
+	}
+	if got := getWbPod(t, cl); got.Annotations[autoscalerSafeToEvictAnnotation] != "true" {
+		t.Fatal("pod mutated on the server before the deferral window elapsed")
+	}
+
+	// CRITICAL readiness guarantee: the deferring pass must have finalized
+	// the sandbox status identically to the synchronous pass — the ready
+	// path never waits on the deferred write.
+	if counters.subResourcePatches == 0 {
+		t.Fatal("deferring pass issued no status write: readiness was gated on the deferred patch")
+	}
+	gotReady := wbReadyCondition(getWbSandbox(t, cl))
+	if (wantReady == nil) != (gotReady == nil) {
+		t.Fatalf("Ready condition presence diverges from synchronous mode: sync=%v deferral=%v", wantReady, gotReady)
+	}
+	if wantReady != nil && gotReady.Status != wantReady.Status {
+		t.Fatalf("Ready condition diverges from synchronous mode: sync=%s deferral=%s", wantReady.Status, gotReady.Status)
+	}
+
+	// A second redelivery inside the window recomputes the same drift and
+	// coalesces: still zero patches, and the deferral clock is NOT re-armed
+	// (RequeueAfter shrinks toward the original deadline, never grows).
+	res2 := wbReconcile(t, r)
+	if counters.podPatches != 0 {
+		t.Fatalf("second reconcile issued %d pod patches, want 0 (coalesced)", counters.podPatches)
+	}
+	if res2.RequeueAfter <= 0 || res2.RequeueAfter > res.RequeueAfter {
+		t.Fatalf("second deferring pass returned RequeueAfter=%v, want in (0, %v] (window must not re-arm)", res2.RequeueAfter, res.RequeueAfter)
+	}
+
+	// The requeued pass after the window elapses flushes exactly once.
+	r.deferralClock.now = func() time.Time { return time.Now().Add(2 * podMetadataFlushBound) }
+	res3 := wbReconcile(t, r)
+	if counters.podPatches != 1 {
+		t.Fatalf("after the window: %d pod patches, want exactly 1 for all deferred detections", counters.podPatches)
+	}
+
+	got := getWbPod(t, cl)
+	if !maps.Equal(got.Labels, wantPod.Labels) {
+		t.Errorf("flushed labels diverge from synchronous mode:\n got %v\nwant %v", got.Labels, wantPod.Labels)
+	}
+	if !maps.Equal(got.Annotations, wantPod.Annotations) {
+		t.Errorf("flushed annotations diverge from synchronous mode:\n got %v\nwant %v", got.Annotations, wantPod.Annotations)
+	}
+	if _, ok := got.Annotations[autoscalerSafeToEvictAnnotation]; ok {
+		t.Error("safe-to-evict marker survived the flush")
+	}
+	if _, ok := got.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
+		t.Error("warm-pool label survived the flush")
+	}
+
+	// The flushing pass cleared its deferral clock entry and did not requeue
+	// for deferral reasons.
+	if n := len(r.deferralClock.first); n != 0 {
+		t.Fatalf("deferral clock entries after flush = %d, want 0", n)
+	}
+	_ = res3
+
+	// A converged follow-up pass performs no pod writes and books no deferral.
+	wbReconcile(t, r)
+	if counters.podPatches != 1 {
+		t.Fatalf("converged pass issued %d extra pod patches, want 0", counters.podPatches-1)
+	}
+	if n := len(r.deferralClock.first); n != 0 {
+		t.Fatalf("converged pass left %d deferral clock entries, want 0", n)
+	}
+}
+
+// TestRequeueDeferralCrashRecovery: the deferral clock lost with the process
+// holds NO mutation payload — a fresh reconciler (new process) recomputes
+// the pending write from informer state alone. The only cost of the crash is
+// a restarted (sub-second) deferral window on the replacement.
+func TestRequeueDeferralCrashRecovery(t *testing.T) {
+	counters := &wbCounters{}
+	sb, pod := postAdoptionFixture()
+	cl := newWbClient(counters, sb, pod)
+
+	// Process 1 defers but "crashes" before its requeue fires.
+	r1 := newWbReconciler(t, cl, 250*time.Millisecond)
+	wbReconcile(t, r1)
+	if counters.podPatches != 0 {
+		t.Fatalf("pre-crash: %d pod patches, want 0", counters.podPatches)
+	}
+
+	// Process 2 (fresh clock) re-detects the drift; the window restarts.
+	r2 := newWbReconciler(t, cl, 250*time.Millisecond)
+	res := wbReconcile(t, r2)
+	if counters.podPatches != 0 {
+		t.Fatalf("post-crash first pass: %d pod patches, want 0 (window restarts)", counters.podPatches)
+	}
+	if res.RequeueAfter <= 0 || res.RequeueAfter > 250*time.Millisecond {
+		t.Fatalf("post-crash deferring pass returned RequeueAfter=%v, want in (0, 250ms]", res.RequeueAfter)
+	}
+
+	// Its requeued pass flushes the exact mutation.
+	r2.deferralClock.now = func() time.Time { return time.Now().Add(time.Second) }
+	wbReconcile(t, r2)
+	if counters.podPatches != 1 {
+		t.Fatalf("post-crash flush issued %d pod patches, want 1", counters.podPatches)
+	}
+	got := getWbPod(t, cl)
+	if _, ok := got.Annotations[autoscalerSafeToEvictAnnotation]; ok {
+		t.Error("safe-to-evict marker not stripped by the recovery flush")
+	}
+	if _, ok := got.Labels[sandboxv1beta1.SandboxWarmPoolLabel]; ok {
+		t.Error("warm-pool label not stripped by the recovery flush")
+	}
+}

--- a/controllers/writebehind_requeue.go
+++ b/controllers/writebehind_requeue.go
@@ -1,0 +1,116 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+// RequeueAfter-based write deferral, per the review suggestion that a
+// controller "can also return with RequeueAfter ... and get some of this for
+// free". Instead of holding a pending mutation in memory, the reconciler
+// skips the recoverable write and asks the workqueue to redeliver the
+// request once the coalescing window has elapsed; the redelivered pass
+// recomputes the desired state from informer state and writes once. The
+// workqueue is the timer and its per-key dedup is the coalescing.
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// deferredWriteClock remembers, per reconcile request, WHEN the currently
+// pending recoverable-write deferral was first observed.
+//
+// This timestamp map is the one piece of in-memory state the mechanism cannot
+// avoid: "write once the window has elapsed" needs a first-seen clock, the
+// object carries no such clock in its own state, and stamping one onto the
+// object would itself be a write — the very thing being deferred. Re-arming
+// the window on every event instead (no state at all) would starve the write
+// under continuous redelivery.
+//
+// Crucially the map stores NO mutation payload: the deferred write is always
+// recomputed from informer state by the pass that flushes it. Losing the map
+// in a crash or failover therefore only restarts a (sub-second) deferral
+// window on the replacement leader's first pass — it can never lose a
+// mutation. Entries are dropped whenever a pass has nothing pending, and on
+// object deletion.
+type deferredWriteClock struct {
+	mu    sync.Mutex
+	first map[types.NamespacedName]time.Time
+
+	// now is overridable in tests; nil means time.Now.
+	now func() time.Time
+}
+
+// observe registers (or re-reads) the pending deferral for key and reports
+// whether its window has elapsed (due) and, if not, how long remains.
+func (c *deferredWriteClock) observe(key types.NamespacedName, window time.Duration) (due bool, wait time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	nowFn := c.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	now := nowFn()
+	if c.first == nil {
+		c.first = make(map[types.NamespacedName]time.Time)
+	}
+	firstSeen, ok := c.first[key]
+	if !ok {
+		c.first[key] = now
+		return false, window
+	}
+	deadline := firstSeen.Add(window)
+	if !now.Before(deadline) {
+		return true, 0
+	}
+	return false, deadline.Sub(now)
+}
+
+// clear drops the pending deferral for key, if any.
+func (c *deferredWriteClock) clear(key types.NamespacedName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.first, key)
+}
+
+// writeDeferral is the per-reconcile-pass view of the deferral clock for one
+// request. Write sites call shouldWrite; Reconcile's tail turns a deferred
+// pass into ctrl.Result{RequeueAfter: wait} and clears the clock entry when
+// nothing is pending.
+type writeDeferral struct {
+	clock  *deferredWriteClock
+	key    types.NamespacedName
+	window time.Duration
+
+	// deferred reports whether any write site skipped its write this pass.
+	deferred bool
+	// wait is the shortest remaining window across deferred sites this pass.
+	wait time.Duration
+}
+
+// shouldWrite reports whether the calling site must issue its write NOW
+// (the deferral window for this request has elapsed) or skip it (the write
+// is deferred to the requeued pass).
+func (d *writeDeferral) shouldWrite() bool {
+	due, wait := d.clock.observe(d.key, d.window)
+	if due {
+		return true
+	}
+	d.deferred = true
+	if d.wait == 0 || wait < d.wait {
+		d.wait = wait
+	}
+	return false
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

**Problem.** During a claim burst, the sandbox controller's recoverable metadata-only writes compete with latency-critical writes for APF seats: in a 300-claim warm-adoption benchmark we measured ~846 writes/s offered against a ~600-900/s seat-limited service rate, so every avoidable write in the burst window directly delays a critical one. On top of that, repeated mutations to the same object (level-triggered redeliveries recomputing the same drift) each pay a full write round-trip today.

**Mechanism: RequeueAfter deferral.** When `--sandbox-write-behind-window > 0`, the reconciler defers its one recoverable metadata-only write — the pod label/annotation reconciliation patch on the warm-pool adoption path (warm-pool label prune + `cluster-autoscaler.kubernetes.io/safe-to-evict` strip + propagated-keys tracking) — instead of issuing it immediately: while the window is open the pass SKIPS the patch and returns `ctrl.Result{RequeueAfter: <remaining window>}`; the flush pass that runs once the window has elapsed re-reads the object from informer state, recomputes the exact drift fresh, and applies it through the stock synchronous patch path. There is **no flusher goroutine and no stored mutation payloads** — the workqueue is the timer (`RequeueAfter` → `Forget` + `AddAfter`, rate-limit-free) and the workqueue's per-key dedup is the coalescing: N redeliveries within the window collapse into one flush pass issuing one targeted merge patch. The only in-memory state is a per-key first-seen timestamp; losing it in a crash merely restarts a sub-second window and can never lose a mutation.

Properties:

- **Opt-in window** (`--sandbox-write-behind-window`): repeated detections of the same drift within the window flush as ONE merge patch, computed from fresh state.
- **≤1s pod bound**: the deferral is capped at `min(window, 1s)`, so the safe-to-evict strip cannot lag the cluster autoscaler (scan intervals are 10s+).
- **Readiness never gated**: the deferring pass still finalizes status/conditions from the in-memory (already-correct) pod state — a Sandbox never waits on a deferred write to become Ready. Pinned by `TestRequeueDeferralCoalescesAdoptionPodPatch`, which fails if the deferring pass skips the status write or the Ready condition diverges from synchronous mode.
- **Level-based crash recovery**: the deferral holds no payload, so a crash/failover before the flush pass is recovered by the next reconcile re-detecting the drift from informer state and re-issuing the write — pinned by `TestRequeueDeferralCrashRecovery` (fresh reconciler, empty clock map, same end state).
- **Stays synchronous**: status writes, creates/deletes, and ownership transfers (adoption itself) are never deferred; only the already-owned pod's metadata patch is eligible.

**Default 0 = off.** With the flag unset the controller runs the identical, fully synchronous stock write path on the same code paths (pinned by `TestWriteBehindDisabledIsSynchronous` and the flag-off reference leg inside `TestRequeueDeferralCoalescesAdoptionPodPatch`, which also proves the flushed end state is byte-identical to the synchronous one).

**Measured cost:** the deferral adds one extra reconcile pass per deferred write — ~+10% sandbox reconciles in the benchmark below — with no correctness impact; that cost bought the fewest optimistic-concurrency 409s of all three arms.

#### Three-way A/B benchmark

Three legs on ONE fresh tuned 12-node kops cluster (redeploy only between legs; e2-standard-16 CP; each leg: 300-claim warm burst + 45/s × 60s sustained Poisson churn, 2s claim dwell, 0 failed claims everywhere):

| | immediate (window=0) | write-behind flusher (250ms) | **RequeueAfter (250ms)** |
|---|---|---|---|
| burst p50/p90 | 1465/3201ms | **1049/2243ms** | 1271/3158ms |
| sustained p50/p90 | **320/680ms** | 2139/7530ms (windows 399→4068ms, monotonic) | 507/1027ms (no collapse) |
| pod metadata PATCHes | 2,953 ok | **181 ok + 3,072 hit 404** | 2,997 ok |
| total controller writes | 48,624 | 64,823 (+33%) | 49,836 |
| optimistic 409s | 5,447 | 7,877 | **3,077 (fewest)** |
| sandbox reconciles | 53,462 | 55,641 | 58,819 (+10% — the "extra pass per deferred write" cost, confirmed and absorbed) |

(Earlier single-mechanism A/B on a 6-node cluster — 300-claim burst only — showed the same-direction burst win for coalescing: p90 2301ms → 1585ms, all legs 300/300 Ready.)

#### Why not the flusher

An earlier revision of this PR implemented the window with a background flusher goroutine holding pending mutation payloads (`internal/writebehind`). The three-way A/B above surfaced a churn-collapse mode in that design: under sustained churn, deferred writes routinely fire after their target objects are deleted, so the intended write reduction inverts into write amplification (181 useful patches vs 3,072 404s, +33% total writes) and a monotonic latency spiral. The RequeueAfter form eliminates that failure mode structurally — the flush pass re-reads current state before writing, so a deleted or changed object simply produces no patch — at the cost of ~+10% reconcile passes. The flusher's one honest remaining advantage (it won the burst leg) doesn't justify a mechanism with a collapse mode, so this PR now ships the RequeueAfter mechanism suggested by @justinsb in review — he was right that the workqueue gives us most of this for free.

#### Which issue(s) this PR is related to:

Ref #350, Ref #594

#### Release Note

```release-note
Added an opt-in `--sandbox-write-behind-window` flag (default 0 = disabled) to the sandbox controller. When set (e.g. 250ms), the recoverable pod metadata reconciliation patch is deferred via RequeueAfter and coalesced by the workqueue: redeliveries within the window collapse into one flush pass that recomputes the drift from fresh state and issues a single merge patch, always within min(window, 1s). The default keeps today's fully synchronous write behavior.
```
