### PR TITLE
perf(controller): strip managedFields and unused pod-spec fields from informer caches; opt-in label-scoped watches

### DIFF
--- a/cmd/agent-sandbox-controller/cacheoptions.go
+++ b/cmd/agent-sandbox-controller/cacheoptions.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/agent-sandbox/controllers"
+)
+
+// buildCacheOptions constructs the manager's informer cache configuration.
+//
+// Always applied:
+//   - Strip metadata.managedFields from every cached object (CRs included).
+//     Nothing in this repo reads managedFields, other writers inflate it (the
+//     kubelet server-side-applies pod status on every update), and every
+//     write here is either a merge patch diffed between two equally-stripped
+//     copies (managedFields can never appear in the diff) or an
+//     update/create, where an absent managedFields means "leave server-side
+//     field management unchanged". Pure decode-CPU/memory win.
+//   - The Pod cache additionally drops the pod spec except spec.nodeName —
+//     the only spec field any controller reads (see PodCacheTransform).
+//
+// With scopeToTrackingLabel, the Pod and Service informers are additionally
+// restricted to objects carrying the sandbox tracking label; see the
+// --cache-label-selectors flag help for the trade-off.
+//
+// A single *corev1.Pod key is reused for every ByObject access: ByObject is
+// keyed by pointer identity for lookups within this function, so writing the
+// scoped entry through a second &corev1.Pod{} literal would ADD a duplicate
+// Pod entry instead of replacing the unscoped one.
+func buildCacheOptions(scopeToTrackingLabel bool) (cache.Options, error) {
+	pod := &corev1.Pod{}
+	opts := cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			pod: {Transform: controllers.PodCacheTransform},
+		},
+	}
+	if scopeToTrackingLabel {
+		trackedOnly, err := labels.NewRequirement(controllers.SandboxNameHashLabel, selection.Exists, nil)
+		if err != nil {
+			return cache.Options{}, fmt.Errorf("building cache label selector: %w", err)
+		}
+		sel := labels.NewSelector().Add(*trackedOnly)
+		podEntry := opts.ByObject[pod]
+		podEntry.Label = sel
+		opts.ByObject[pod] = podEntry
+		opts.ByObject[&corev1.Service{}] = cache.ByObject{Label: sel}
+	}
+	return opts, nil
+}

--- a/cmd/agent-sandbox-controller/cacheoptions_test.go
+++ b/cmd/agent-sandbox-controller/cacheoptions_test.go
@@ -18,10 +18,38 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"sigs.k8s.io/agent-sandbox/controllers"
 )
+
+// assertStripsManagedFields runs the configured DefaultTransform against an
+// object carrying managedFields and asserts they come out cleared — presence
+// of SOME transform is not enough, it must be the managedFields strip.
+func assertStripsManagedFields(t *testing.T, opts cache.Options) {
+	t.Helper()
+	if opts.DefaultTransform == nil {
+		t.Fatal("DefaultTransform (managedFields strip) not set")
+	}
+	in := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: "cm",
+		ManagedFields: []metav1.ManagedFieldsEntry{{
+			Manager: "kubelet", Operation: metav1.ManagedFieldsOperationApply,
+		}},
+	}}
+	out, err := opts.DefaultTransform(in)
+	if err != nil {
+		t.Fatalf("DefaultTransform: %v", err)
+	}
+	cm, ok := out.(*corev1.ConfigMap)
+	if !ok {
+		t.Fatalf("DefaultTransform returned %T, want *corev1.ConfigMap", out)
+	}
+	if len(cm.GetManagedFields()) != 0 {
+		t.Errorf("DefaultTransform left %d managedFields entries, want 0", len(cm.GetManagedFields()))
+	}
+}
 
 // entriesByType splits the ByObject map into the per-type entries, failing on
 // duplicates: ByObject is keyed by pointer, so an accidental second
@@ -53,9 +81,7 @@ func TestBuildCacheOptionsUnscoped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCacheOptions(false): %v", err)
 	}
-	if opts.DefaultTransform == nil {
-		t.Error("DefaultTransform (managedFields strip) not set")
-	}
+	assertStripsManagedFields(t, opts)
 	pod, svc := entriesByType(t, opts)
 	if pod == nil {
 		t.Fatal("no Pod entry in ByObject")
@@ -76,9 +102,7 @@ func TestBuildCacheOptionsScopedToTrackingLabel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCacheOptions(true): %v", err)
 	}
-	if opts.DefaultTransform == nil {
-		t.Error("DefaultTransform (managedFields strip) not set")
-	}
+	assertStripsManagedFields(t, opts)
 	pod, svc := entriesByType(t, opts)
 	if pod == nil {
 		t.Fatal("no Pod entry in ByObject")

--- a/cmd/agent-sandbox-controller/cacheoptions_test.go
+++ b/cmd/agent-sandbox-controller/cacheoptions_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"sigs.k8s.io/agent-sandbox/controllers"
+)
+
+// entriesByType splits the ByObject map into the per-type entries, failing on
+// duplicates: ByObject is keyed by pointer, so an accidental second
+// &corev1.Pod{} key would silently produce two Pod configurations.
+func entriesByType(t *testing.T, opts cache.Options) (pod, svc *cache.ByObject) {
+	t.Helper()
+	for obj, entry := range opts.ByObject {
+		e := entry
+		switch obj.(type) {
+		case *corev1.Pod:
+			if pod != nil {
+				t.Fatal("duplicate *corev1.Pod entries in ByObject")
+			}
+			pod = &e
+		case *corev1.Service:
+			if svc != nil {
+				t.Fatal("duplicate *corev1.Service entries in ByObject")
+			}
+			svc = &e
+		default:
+			t.Fatalf("unexpected ByObject key type %T", obj)
+		}
+	}
+	return pod, svc
+}
+
+func TestBuildCacheOptionsUnscoped(t *testing.T) {
+	opts, err := buildCacheOptions(false)
+	if err != nil {
+		t.Fatalf("buildCacheOptions(false): %v", err)
+	}
+	if opts.DefaultTransform == nil {
+		t.Error("DefaultTransform (managedFields strip) not set")
+	}
+	pod, svc := entriesByType(t, opts)
+	if pod == nil {
+		t.Fatal("no Pod entry in ByObject")
+	}
+	if pod.Transform == nil {
+		t.Error("Pod entry lost PodCacheTransform")
+	}
+	if pod.Label != nil {
+		t.Errorf("Pod cache unexpectedly label-scoped without the flag: %v", pod.Label)
+	}
+	if svc != nil {
+		t.Errorf("Service entry present without the flag: %+v", svc)
+	}
+}
+
+func TestBuildCacheOptionsScopedToTrackingLabel(t *testing.T) {
+	opts, err := buildCacheOptions(true)
+	if err != nil {
+		t.Fatalf("buildCacheOptions(true): %v", err)
+	}
+	if opts.DefaultTransform == nil {
+		t.Error("DefaultTransform (managedFields strip) not set")
+	}
+	pod, svc := entriesByType(t, opts)
+	if pod == nil {
+		t.Fatal("no Pod entry in ByObject")
+	}
+	if pod.Transform == nil {
+		t.Error("scoping the Pod cache must retain PodCacheTransform")
+	}
+	if svc == nil {
+		t.Fatal("no Service entry in ByObject with the flag enabled")
+	}
+	want := controllers.SandboxNameHashLabel // selector: label exists
+	for name, entry := range map[string]*cache.ByObject{"Pod": pod, "Service": svc} {
+		if entry.Label == nil {
+			t.Errorf("%s cache not label-scoped", name)
+			continue
+		}
+		if got := entry.Label.String(); got != want {
+			t.Errorf("%s cache selector = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -33,10 +33,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/felixge/fgprof"
-	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	"sigs.k8s.io/agent-sandbox/controllers"
@@ -47,7 +44,6 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 	"sigs.k8s.io/agent-sandbox/internal/version"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -312,31 +308,15 @@ func main() {
 		LeaderElectionNamespace: leaderElectionNamespace,
 		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
 	}
-	// Strip metadata.managedFields from every cached object (CRs included).
-	// Nothing in this repo reads managedFields, other writers inflate it (the
-	// kubelet server-side-applies pod status on every update), and every
-	// write here is either a merge patch diffed between two equally-stripped
-	// copies (managedFields can never appear in the diff) or an
-	// update/create, where an absent managedFields means "leave server-side
-	// field management unchanged". Pure decode-CPU/memory win.
-	mgrOpts.Cache.DefaultTransform = cache.TransformStripManagedFields()
-	// The Pod cache additionally drops the pod spec except spec.nodeName —
-	// the only spec field any controller reads (see PodCacheTransform).
-	mgrOpts.Cache.ByObject = map[client.Object]cache.ByObject{
-		&corev1.Pod{}: {Transform: controllers.PodCacheTransform},
+	// managedFields stripping, the Pod spec diet, and (optionally) the
+	// tracking-label scoping; see buildCacheOptions for the rationale.
+	cacheOpts, err := buildCacheOptions(cacheLabelSelectors)
+	if err != nil {
+		setupLog.Error(err, "unable to build cache options")
+		os.Exit(1)
 	}
+	mgrOpts.Cache = cacheOpts
 	if cacheLabelSelectors {
-		trackedOnly, err := labels.NewRequirement(controllers.SandboxNameHashLabel, selection.Exists, nil)
-		if err != nil {
-			setupLog.Error(err, "unable to build cache label selector")
-			os.Exit(1)
-		}
-		sel := labels.NewSelector().Add(*trackedOnly)
-		mgrOpts.Cache.ByObject[&corev1.Pod{}] = cache.ByObject{
-			Label:     sel,
-			Transform: controllers.PodCacheTransform,
-		}
-		mgrOpts.Cache.ByObject[&corev1.Service{}] = cache.ByObject{Label: sel}
 		setupLog.Info("informer caches for Pods and Services scoped to the sandbox tracking label (--cache-label-selectors)",
 			"label", controllers.SandboxNameHashLabel)
 	}

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -33,7 +33,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/felixge/fgprof"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	"sigs.k8s.io/agent-sandbox/controllers"
@@ -44,6 +47,7 @@ import (
 	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
 	"sigs.k8s.io/agent-sandbox/internal/version"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -76,6 +80,7 @@ func main() {
 	var sandboxTemplateConcurrentWorkers int
 	var sandboxWarmPoolMaxBatchSize int
 	var enableWarmPoolEviction bool
+	var cacheLabelSelectors bool
 	var printVersion bool
 	var webhookPort int
 	var webhookCertDir string
@@ -119,6 +124,14 @@ func main() {
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300.")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
+	flag.BoolVar(&cacheLabelSelectors, "cache-label-selectors", false,
+		"Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label ("+
+			controllers.SandboxNameHashLabel+"). The controller only ever creates/looks up Pods and Services it "+
+			"labeled itself, so on shared or high-churn clusters this cuts informer list/watch volume, JSON decode "+
+			"CPU, and cache memory from O(cluster) to O(sandboxes). CAVEAT: externally pre-provisioned resources "+
+			"that rely on the "+sandboxv1beta1.SandboxAdoptableLabel+"=true adoption path MUST also carry the "+
+			"tracking label (value = the owning sandbox's name hash) to remain visible to the controller when "+
+			"this flag is enabled.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -298,6 +311,34 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionNamespace: leaderElectionNamespace,
 		LeaderElectionID:        "a3317529.agent-sandbox.x-k8s.io",
+	}
+	// Strip metadata.managedFields from every cached object (CRs included).
+	// Nothing in this repo reads managedFields, other writers inflate it (the
+	// kubelet server-side-applies pod status on every update), and every
+	// write here is either a merge patch diffed between two equally-stripped
+	// copies (managedFields can never appear in the diff) or an
+	// update/create, where an absent managedFields means "leave server-side
+	// field management unchanged". Pure decode-CPU/memory win.
+	mgrOpts.Cache.DefaultTransform = cache.TransformStripManagedFields()
+	// The Pod cache additionally drops the pod spec except spec.nodeName —
+	// the only spec field any controller reads (see PodCacheTransform).
+	mgrOpts.Cache.ByObject = map[client.Object]cache.ByObject{
+		&corev1.Pod{}: {Transform: controllers.PodCacheTransform},
+	}
+	if cacheLabelSelectors {
+		trackedOnly, err := labels.NewRequirement(controllers.SandboxNameHashLabel, selection.Exists, nil)
+		if err != nil {
+			setupLog.Error(err, "unable to build cache label selector")
+			os.Exit(1)
+		}
+		sel := labels.NewSelector().Add(*trackedOnly)
+		mgrOpts.Cache.ByObject[&corev1.Pod{}] = cache.ByObject{
+			Label:     sel,
+			Transform: controllers.PodCacheTransform,
+		}
+		mgrOpts.Cache.ByObject[&corev1.Service{}] = cache.ByObject{Label: sel}
+		setupLog.Info("informer caches for Pods and Services scoped to the sandbox tracking label (--cache-label-selectors)",
+			"label", controllers.SandboxNameHashLabel)
 	}
 	if enableWebhook {
 		mgrOpts.WebhookServer = webhook.NewServer(webhook.Options{

--- a/controllers/pod_cache_transform_test.go
+++ b/controllers/pod_cache_transform_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func fullPodFixture() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "ns",
+			Labels:    map[string]string{sandboxLabel: "hash-1"},
+			Annotations: map[string]string{
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+			},
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager: "kubelet", Operation: metav1.ManagedFieldsOperationApply,
+			}},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-7",
+			Containers: []corev1.Container{{
+				Name: "c", Image: "debian:latest",
+				Env: []corev1.EnvVar{{Name: "A", Value: "B"}},
+			}},
+			InitContainers: []corev1.Container{{Name: "init", Image: "busybox"}},
+			Volumes:        []corev1.Volume{{Name: "v"}},
+			Tolerations:    []corev1.Toleration{{Key: "k"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			PodIP:  "10.0.0.1",
+			PodIPs: []corev1.PodIP{{IP: "10.0.0.1"}},
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodReady, Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+// TestPodCacheTransform verifies exactly what the informer transform keeps
+// and drops: everything the controllers read survives (metadata, status,
+// spec.nodeName); managedFields and the bulky spec payload do not.
+func TestPodCacheTransform(t *testing.T) {
+	out, err := PodCacheTransform(fullPodFixture())
+	if err != nil {
+		t.Fatalf("PodCacheTransform error: %v", err)
+	}
+	pod, ok := out.(*corev1.Pod)
+	if !ok {
+		t.Fatalf("transform returned %T, want *corev1.Pod", out)
+	}
+
+	// Dropped.
+	if pod.ManagedFields != nil {
+		t.Error("managedFields not stripped")
+	}
+	if len(pod.Spec.Containers) != 0 || len(pod.Spec.InitContainers) != 0 ||
+		len(pod.Spec.Volumes) != 0 || len(pod.Spec.Tolerations) != 0 {
+		t.Errorf("pod spec not stripped: %+v", pod.Spec)
+	}
+
+	// Kept: the fields the controllers actually read.
+	if pod.Spec.NodeName != "node-7" {
+		t.Errorf("spec.nodeName lost: %q", pod.Spec.NodeName)
+	}
+	if pod.Labels[sandboxLabel] != "hash-1" {
+		t.Error("labels lost")
+	}
+	if pod.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] != "true" {
+		t.Error("annotations lost")
+	}
+	if pod.Status.Phase != corev1.PodRunning || pod.Status.PodIP != "10.0.0.1" || len(pod.Status.Conditions) != 1 {
+		t.Errorf("status lost: %+v", pod.Status)
+	}
+
+	// Non-pod objects pass through untouched.
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "s"}}
+	got, err := PodCacheTransform(svc)
+	if err != nil {
+		t.Fatalf("transform of non-pod errored: %v", err)
+	}
+	if got != any(svc) {
+		t.Error("non-pod object was not passed through unchanged")
+	}
+}
+
+// TestPodCacheTransformMergePatchUnaffected proves the transform's safety
+// claim: merge patches computed against a transform-stripped cache pod are
+// byte-identical to those computed against the full pod, because the patch is
+// a diff of the controller's own metadata mutations against a DeepCopy of the
+// same cached base — stripped fields appear on neither side, so they can
+// neither leak into nor be deleted by the patch.
+func TestPodCacheTransformMergePatchUnaffected(t *testing.T) {
+	// Metadata-only mutation of the kind the controllers perform: add a
+	// label, drop the safe-to-evict annotation.
+	mutate := func(p *corev1.Pod) {
+		p.Labels["example.com/extra"] = "v"
+		delete(p.Annotations, "cluster-autoscaler.kubernetes.io/safe-to-evict")
+	}
+
+	// Patch from the FULL pod (behavior without the cache transform).
+	full := fullPodFixture()
+	fullBase := client.MergeFrom(full.DeepCopy())
+	mutate(full)
+	fullData, err := fullBase.Data(full)
+	if err != nil {
+		t.Fatalf("full-pod patch data: %v", err)
+	}
+
+	// Patch from the TRANSFORMED pod (behavior with the cache transform).
+	strippedAny, err := PodCacheTransform(fullPodFixture())
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+	stripped := strippedAny.(*corev1.Pod)
+	strippedBase := client.MergeFrom(stripped.DeepCopy())
+	mutate(stripped)
+	strippedData, err := strippedBase.Data(stripped)
+	if err != nil {
+		t.Fatalf("stripped-pod patch data: %v", err)
+	}
+
+	if string(fullData) != string(strippedData) {
+		t.Errorf("merge patch changed by cache transform:\n full:     %s\n stripped: %s", fullData, strippedData)
+	}
+	if strings.Contains(string(strippedData), `"spec"`) {
+		t.Errorf("metadata-only mutation leaked a spec key into the patch: %s", strippedData)
+	}
+	if strings.Contains(string(strippedData), "managedFields") {
+		t.Errorf("patch touches managedFields: %s", strippedData)
+	}
+}

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -49,12 +49,46 @@ import (
 
 const (
 	sandboxLabel = "agents.x-k8s.io/sandbox-name-hash"
+	// SandboxNameHashLabel is the tracking label the controller stamps on
+	// every Pod and Service it creates or adopts. Exported so the manager
+	// setup (cmd/agent-sandbox-controller) can scope the Pod/Service informer
+	// caches to labeled objects (--cache-label-selectors).
+	SandboxNameHashLabel = sandboxLabel
 	// podSandboxNameHashIndex is the cache field index over the sandboxLabel
 	// value on Pods, so per-reconcile pod lookups are O(1).
 	podSandboxNameHashIndex     = ".metadata.labels[" + sandboxLabel + "]"
 	sandboxControllerFieldOwner = "sandbox-controller"
 	immediateRequeueDelay       = time.Millisecond
 )
+
+// PodCacheTransform is a client-go informer transform for the manager's Pod
+// cache. It strips fields the controllers never read, before the object is
+// stored, so cache memory and per-event JSON decode garbage stay O(what we
+// use) instead of O(pod spec):
+//
+//   - metadata.managedFields: written via server-side apply by the kubelet on
+//     every status update and never read by any controller here.
+//   - spec: the only spec field any controller reads is spec.nodeName
+//     (propagated to Sandbox status), so it is the only field preserved. The
+//     pod spec the controller WRITES is built from the Sandbox's PodTemplate
+//     (reconcilePod's create path), never from the cached pod, and every pod write in this
+//     repo is a metadata-only merge patch diffed against the same transformed
+//     cache object — stripped fields appear on neither side of the diff, so
+//     they can never leak into (or be deleted by) a patch. See
+//     TestPodCacheTransformMergePatchUnaffected.
+//
+// metadata (labels/annotations/ownerRefs) and status are kept in full.
+// Non-pod inputs (e.g. cache.DeletedFinalStateUnknown tombstones) pass
+// through unchanged.
+func PodCacheTransform(obj any) (any, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+	pod.ManagedFields = nil
+	pod.Spec = corev1.PodSpec{NodeName: pod.Spec.NodeName}
+	return pod, nil
+}
 
 // resourceOwnership represents the ownership state of a Kubernetes resource relative to a Sandbox.
 type resourceOwnership int


### PR DESCRIPTION
#### What this PR does / why we need it:

The manager's Pod and Service informers watch cluster-wide and cache full objects, filtering only client-side (event predicates) after every object has already been received and decoded. On shared or high-churn clusters the controller therefore pays list/watch network volume, JSON decode CPU, and cache memory proportional to O(cluster), not O(sandboxes). On top of that, `metadata.managedFields` — which the kubelet inflates via server-side apply on every pod status update — is decoded and cached for every object even though nothing in this repo ever reads it.

This PR puts the informer caches on a diet, in three independent layers:

1. **`Cache.DefaultTransform = cache.TransformStripManagedFields()`** — strips `metadata.managedFields` from every cached object (CRs included). Nothing here reads managedFields; every write is either a merge patch diffed between two equally-stripped copies (managedFields can never appear in the diff) or an update/create, where absent managedFields means "leave server-side field management unchanged". Pure decode-CPU/memory win, no behavior change.

2. **`PodCacheTransform`** — the Pod cache additionally drops the pod spec except `spec.nodeName`, the only spec field any controller reads from the cache (propagated to Sandbox status, #1225). The pod spec the controller *writes* is always built from the Sandbox's PodTemplate, never from the cached pod, and every pod write is a metadata-only merge patch diffed against a DeepCopy of the same transformed cache object — stripped fields appear on neither side of the diff, so they can neither leak into nor be deleted by a patch. `TestPodCacheTransformMergePatchUnaffected` pins this: merge patches built from transform-stripped cache pods are byte-identical to ones built from full pods and contain no `spec`/`managedFields` keys.

3. **`--cache-label-selectors` (default off)** — opt-in server-side scoping of the Pod and Service informer watches (`ByObject` label selectors) to objects carrying the sandbox tracking label (`agents.x-k8s.io/sandbox-name-hash`). The controller only ever creates/looks up Pods and Services it labeled itself, so this moves the existing client-side label filtering to the API server and cuts informer list/watch volume, decode CPU, and cache memory from O(cluster) to O(sandboxes). **Caveat** (documented in the flag help): with the flag on, externally pre-provisioned resources that rely on the `agents.x-k8s.io/adoptable=true` adoption path must also carry the tracking label (value = the owning sandbox's name hash) or the controller will not see them. Hence default-off.

Evidence: informer decode cost went from O(cluster) to O(sandboxes), measured in a 300-claim warm-adoption benchmark.

#### A/B benchmark (this change alone)

300-claim warm-adoption burst, one 6-node tuned cluster (kops GCP, CP n2-standard-16, workers 6x e2-standard-8, clean instrumentation, harness `--client-connections=4`), legs back-to-back on the SAME cluster, BASE first:

| leg | ready/failed | create->Ready p50 | p90 | p99 | all-ready |
|---|---|---|---|---|---|
| BASE (upstream main @ 9a4b3a0, stock) | 300/0 | 1098ms | 2337ms | 2739ms | 2.90s |
| this branch (transforms always-on) | 300/0 | 1171ms | 2252ms | 2723ms | 2.76s |
| this branch + `--cache-label-selectors` | 300/0 | 1045ms | 2276ms | 2618ms | 2.78s |

Honest reading: burst-latency parity within noise on all legs — expected, and worth stating plainly: on a 6-node bench cluster whose pods are almost all sandbox pods, O(cluster) and O(sandboxes) coincide, so the decode/memory savings cannot move burst latency here. The wins this PR claims are cache memory and list/watch decode volume on clusters where sandboxes share the cluster with other workloads (the 300-claim benchmark measured informer decode cost going from O(cluster) to O(sandboxes)), with byte-identity of merge patches pinned by test. The A/B's role for this PR is the correctness gate: 300/300 ready on every leg with the transforms and with server-side label scoping.

All four legs of every pair completed with **300/300 claims Ready, zero failures** — correctness held everywhere. Noise context for reading the latency rows: across the four independent, identically-configured stock BASE legs run tonight (one per pair cluster), the 300-burst measured p50 913-1345ms and p90 1940-2850ms — i.e. a single-burst leg has roughly a +/-30-40% run-to-run band at this 6-node scale, and a byte-identical control leg (P2's identity leg, both flags at their 0 defaults) measured 16% "faster" than its own BASE purely from leg ordering.

#### Which issue(s) this PR is related to:

Ref #836 — if high-cardinality labels move to annotations, the label-selector flag must adapt accordingly.
Ref #484

#### Release Note

```release-note
The controller's informer caches no longer store `metadata.managedFields`, and cached Pods retain only the spec field the controller reads (`spec.nodeName`), reducing controller memory and CPU. A new opt-in flag `--cache-label-selectors` (default false) scopes the Pod and Service watches server-side to sandbox-labeled objects; when enabled, externally pre-provisioned adoptable resources must carry the sandbox tracking label to be visible to the controller.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--cache-label-selectors` flag to optionally scope informer caches to only sandbox-tracked Pods and Services.
* **Performance**
  * Reduced controller cache payload by stripping non-essential Pod data (including `managedFields`) and limiting cached Pod spec to the required node information.
* **Reliability**
  * Added tests covering cache scoping, managed-field stripping, and ensuring merge-patch content remains stable and excludes `spec`/`managedFields`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->