### PR TITLE
fix(sandboxclaim): duplicate startup-latency metrics and stale-status overwrites via optimistic-locked status writes

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -405,6 +405,7 @@ func main() {
 
 		if err = (&extensionscontrollers.SandboxClaimReconciler{
 			Client:              mgr.GetClient(),
+			APIReader:           mgr.GetAPIReader(),
 			Scheme:              mgr.GetScheme(),
 			WarmSandboxQueue:    warmSandboxQueue,
 			Recorder:            mgr.GetEventRecorder("sandboxclaim-controller"),

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -138,6 +139,11 @@ func (m *observedTimeMap) LoadOrStore(key types.NamespacedName, entry observedTi
 // SandboxClaimReconciler reconciles a SandboxClaim object.
 type SandboxClaimReconciler struct {
 	client.Client
+	// APIReader reads directly from the API server, bypassing the informer
+	// cache. Used only to re-read a claim after an optimistic-lock conflict,
+	// where the cache is stale by definition. Falls back to Client when unset
+	// (e.g. in unit tests with a fake client).
+	APIReader               client.Reader
 	Scheme                  *runtime.Scheme
 	WarmSandboxQueue        queue.SandboxQueue
 	Recorder                events.EventRecorder
@@ -209,7 +215,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	claimExpired, timeLeft := r.checkExpiration(claim)
 	if claimExpired && !hasClaimExpiredCondition(claim.Status.Conditions) {
 		meta.SetStatusCondition(&claim.Status.Conditions, r.computeReadyCondition(claim, nil, nil, true))
-		if updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
+		if _, updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
 			logger.V(1).Info("Sandboxclaim UpdateStatus error encountered", "errors", updateErr, "request", req.NamespacedName)
 			return ctrl.Result{}, updateErr
 		}
@@ -262,7 +268,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	postExpiration, postTimeLeft := r.checkExpiration(claim)
 	if postExpiration && !hasClaimExpiredCondition(claim.Status.Conditions) {
 		meta.SetStatusCondition(&claim.Status.Conditions, r.computeReadyCondition(claim, sandbox, reconcileErr, true))
-		if updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
+		if _, updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
 			errs := errors.Join(reconcileErr, updateErr)
 			logger.V(1).Info("Sandboxclaim UpdateStatus error encountered", "errors", errs, "request", req.NamespacedName)
 			return ctrl.Result{}, errs
@@ -273,7 +279,8 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 	}
 
-	if updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
+	statusAuthoritative, updateErr := r.updateStatus(ctx, originalClaimStatus, claim)
+	if updateErr != nil {
 		errs := errors.Join(reconcileErr, updateErr)
 		logger.V(1).Info("Sandboxclaim UpdateStatus error encountered", "errors", errs, "request", req.NamespacedName)
 		return ctrl.Result{}, errs
@@ -286,7 +293,22 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// exponential failure limiter. The bounded-requeue path relies on the
 	// follow-up pass to retry the annotation patch; non-sentinel returns Join
 	// both errors (mirroring updateStatus).
-	metricsErr := r.recordCreationLatencyMetric(ctx, claim, originalClaimStatus, sandbox)
+	//
+	// The recording is additionally gated on this pass's status view being
+	// authoritative. A dropped optimistic-lock conflict means the pass read a
+	// stale cache view of a transition an earlier pass already committed and
+	// recorded — observing it again would double-count the startup-latency
+	// histograms (#940). The persistent first-ready annotation still guards
+	// re-records across readiness flaps and resume/restart; this gate closes
+	// the stale-view window before that annotation is visible in the cache
+	// (a view stale enough to predate the committed status also predates the
+	// annotation stamp from the same pass). Skipping the whole call on a
+	// stale pass is safe for the backfill path too: it is idempotent and
+	// re-runs on the next converged pass.
+	var metricsErr error
+	if statusAuthoritative {
+		metricsErr = r.recordCreationLatencyMetric(ctx, claim, originalClaimStatus, sandbox)
+	}
 
 	// Determine Result
 	var result ctrl.Result
@@ -503,7 +525,25 @@ func (r *SandboxClaimReconciler) reconcileExpired(ctx context.Context, claim *ex
 	return sandbox, nil
 }
 
-func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *extensionsv1beta1.SandboxClaimStatus, claim *extensionsv1beta1.SandboxClaim) error {
+// updateStatus persists the computed claim status with an optimistically
+// locked merge patch. The lock is on the object-wide resourceVersion, so a
+// 409 here means the pass computed its status from a cache view that is
+// stale relative to some committed write on the claim — most often an
+// earlier write by this controller (the claim status has a single writer,
+// serialized per key by the workqueue), but equally any concurrent writer
+// touching the object (a user label edit, TTL tooling, a webhook-driven
+// update). Either way the stale patch must not commit — it could transiently
+// regress the persisted status (and re-record the Ready-latency histograms,
+// #940) — so the conflict is dropped as benign: whichever write bumped the
+// resourceVersion emitted its own claim watch event that re-enqueues the
+// claim, and the next pass recomputes from the converged view.
+//
+// The first return value reports whether the pass's view of the status is
+// authoritative (the patch was persisted, or no write was needed); it is
+// false only on the dropped optimistic-lock conflict, in which case callers
+// must not treat the computed status as having been observed (e.g. must not
+// record Ready-transition metrics).
+func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *extensionsv1beta1.SandboxClaimStatus, claim *extensionsv1beta1.SandboxClaim) (bool, error) {
 	logger := log.FromContext(ctx)
 
 	slices.SortFunc(oldStatus.Conditions, func(a, b metav1.Condition) int {
@@ -520,28 +560,43 @@ func (r *SandboxClaimReconciler) updateStatus(ctx context.Context, oldStatus *ex
 	})
 
 	if equality.Semantic.DeepEqual(oldStatus, &claim.Status) {
-		return nil
+		return true, nil
 	}
 
 	oldClaim := claim.DeepCopy()
 	oldClaim.Status = *oldStatus
 
-	patch := client.MergeFrom(oldClaim)
+	patch := client.MergeFromWithOptions(oldClaim, client.MergeFromWithOptimisticLock{})
 
 	if err := r.Status().Patch(ctx, claim, patch); err != nil {
 		if k8errors.IsNotFound(err) {
-			// Claim was deleted mid-reconcile
-			return nil
+			// Claim was deleted mid-reconcile. Nothing to persist and no
+			// later pass exists for this object, so treat the computed view
+			// as authoritative (preserves the pre-existing behavior where
+			// the pass continues without error).
+			return true, nil
+		}
+		if k8errors.IsConflict(err) {
+			// Dropping the conflict with a nil error and no requeue relies
+			// entirely on the conflicting write emitting a claim watch event
+			// that re-enqueues this key. That holds because getTimingPredicate
+			// returns true for every update; if the claim watch ever gains an
+			// event-filtering predicate, this path must requeue explicitly.
+			logger.V(4).Info("Dropping claim status patch computed from a stale cache view (optimistic-lock conflict); awaiting converged watch event",
+				"name", claim.Name,
+				"namespace", claim.Namespace,
+				"staleResourceVersion", oldClaim.ResourceVersion)
+			return false, nil
 		}
 		logger.Error(err, "Failed to patch sandboxclaim status")
-		return err
+		return false, err
 	}
 
 	logger.V(4).Info("Successfully patched sandboxclaim status",
 		"name", claim.Name,
 		"namespace", claim.Namespace,
 		"observedGeneration", claim.Generation)
-	return nil
+	return true, nil
 }
 
 func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.SandboxClaim, sandbox *v1beta1.Sandbox, err error, isClaimExpired bool) metav1.Condition {
@@ -874,13 +929,23 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 			}
 			claim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = adopted.Name
 			if err := r.Update(ctx, claim); err != nil {
-				r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
-				if k8errors.IsConflict(err) {
-					// Conflict means someone else updated the claim. We fail and retry.
+				if !k8errors.IsConflict(err) {
+					r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
+					logger.Error(err, "Failed to update claim for adoption", "claim", claim.Name, "sandbox", adopted.Name)
 					return false, err
 				}
-				logger.Error(err, "Failed to update claim for adoption", "claim", claim.Name, "sandbox", adopted.Name)
-				return false, err
+				// 409: the cached base was stale (typically behind a write this
+				// controller committed itself, e.g. the observability annotation
+				// patch). Retry in-pass against a fresh read instead of failing
+				// the pass — this resolves in single-digit milliseconds and
+				// keeps the popped candidate from being burned on a doomed pass.
+				if retryErr := r.retryAdoptionAnnotation(ctx, claim, adopted.Name); retryErr != nil {
+					// Retries exhausted (persistent contention) or the fresh
+					// read showed the assignment moved: fail the pass and let
+					// the per-item failure backoff pace further retries.
+					r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
+					return false, retryErr
+				}
 			}
 
 			// Call helper to complete adoption (patch sandbox)
@@ -1025,6 +1090,75 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 	}
 
 	return nil
+}
+
+// authoritativeReader returns the reader used to resolve write conflicts
+// against the API server directly (APIReader), falling back to the
+// cache-backed client when none is configured (tests).
+func (r *SandboxClaimReconciler) authoritativeReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// updateClaimOnFreshBase applies a guarded mutation to the claim in the
+// shared fetch-fresh/guard/mutate/copy-back shape: inside a
+// retry.RetryOnConflict loop, re-read the claim from the authoritative reader
+// (the informer cache is stale by definition when the caller conflicted), let
+// mutate inspect and modify the fresh object, persist it when mutate asks for
+// a write, and copy the server-accepted object back into claim so the rest of
+// the pass operates on the accepted base.
+//
+// mutate returns (false, nil) to skip the write; the fresh base is still
+// copied back. Any error from the fresh read or from mutate aborts the
+// attempt with claim left untouched (RetryOnConflict re-runs the closure on
+// conflict errors only).
+func (r *SandboxClaimReconciler) updateClaimOnFreshBase(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, mutate func(fresh *extensionsv1beta1.SandboxClaim) (bool, error)) error {
+	reader := r.authoritativeReader()
+	key := client.ObjectKeyFromObject(claim)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh := &extensionsv1beta1.SandboxClaim{}
+		if err := reader.Get(ctx, key, fresh); err != nil {
+			return err
+		}
+		write, err := mutate(fresh)
+		if err != nil {
+			return err
+		}
+		if write {
+			if err := r.Update(ctx, fresh); err != nil {
+				return err
+			}
+		}
+		fresh.DeepCopyInto(claim)
+		return nil
+	})
+}
+
+// retryAdoptionAnnotation retries the optimistically locked claim update that
+// records an adoption after a 409: verify on a fresh base that no other
+// sandbox has been assigned in the meantime, then re-apply the assignment. On
+// success the fresh, annotated object is copied back into claim so the rest
+// of the adoption pass (sandbox patch, status finalization) operates on the
+// object the server accepted.
+func (r *SandboxClaimReconciler) retryAdoptionAnnotation(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sandboxName string) error {
+	return r.updateClaimOnFreshBase(ctx, claim, func(fresh *extensionsv1beta1.SandboxClaim) (bool, error) {
+		if fresh.UID != claim.UID {
+			return false, fmt.Errorf("claim %s was deleted and recreated during adoption", claim.Name)
+		}
+		if assigned := fresh.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]; assigned != "" && assigned != sandboxName {
+			// A different sandbox is already recorded on the authoritative
+			// object; do not overwrite it. The annotation-recovery path of the
+			// next pass completes that adoption instead.
+			return false, fmt.Errorf("claim %s already assigned sandbox %s, not overwriting", claim.Name, assigned)
+		}
+		if fresh.Annotations == nil {
+			fresh.Annotations = make(map[string]string)
+		}
+		fresh.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sandboxName
+		return true, nil
+	})
 }
 
 // isSandboxReady checks if a sandbox has Ready=True condition.
@@ -1690,6 +1824,11 @@ func (r *SandboxClaimReconciler) getOrRecordObservedTime(obj client.Object) time
 
 // getTimingPredicate returns a predicate that stores the first time an object is seen by the
 // controller, and cleans up the in-memory map entry when the object is deleted.
+//
+// Every event handler returns true: updateStatus's benign drop of
+// optimistic-lock 409s depends on the conflicting write's update event always
+// passing this predicate (it is what re-enqueues the claim). Do not add event
+// filtering here without revisiting that path.
 func (r *SandboxClaimReconciler) getTimingPredicate() predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -21,10 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
@@ -5993,4 +5996,379 @@ func TestSandboxStatusRelevantChange(t *testing.T) {
 			require.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+// newOptimisticLockTestObjects builds a claim already annotated with an
+// adopted, claim-owned, Ready sandbox — the shape of the pass that finalizes
+// (or re-finalizes) a bound claim's status.
+func newOptimisticLockTestObjects() (*extensionsv1beta1.SandboxClaim, *extensionsv1beta1.SandboxTemplate, *extensionsv1beta1.SandboxWarmPool, *sandboxv1beta1.Sandbox) {
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "adopted-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+		}}},
+	}
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default", UID: "warmpool-uid-123"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+	adopted := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "adopted-sb",
+			Namespace: "default",
+			UID:       "adopted-sb-uid",
+			Labels: map[string]string{
+				extensionsv1beta1.SandboxIDLabel: "claim-uid-123",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxClaim",
+				Name:       "test-claim",
+				UID:        "claim-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+		}}},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(sandboxv1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				Reason:             "Ready",
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+			}},
+		},
+	}
+	return claim, template, warmPool, adopted
+}
+
+// TestSandboxClaimStatusPatchCarriesOptimisticLock verifies the claim status
+// patch embeds the base object's resourceVersion, so a patch computed from a
+// stale cache view fails with a 409 instead of committing a stale overwrite.
+func TestSandboxClaimStatusPatchCarriesOptimisticLock(t *testing.T) {
+	scheme := newScheme(t)
+	claim, template, warmPool, adopted := newOptimisticLockTestObjects()
+
+	var statusPatchData []byte
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, adopted).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if _, ok := obj.(*extensionsv1beta1.SandboxClaim); ok && subResourceName == "status" {
+					data, err := patch.Data(obj)
+					if err != nil {
+						return err
+					}
+					statusPatchData = data
+				}
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("expected reconcile to succeed, got: %v", err)
+	}
+
+	if statusPatchData == nil {
+		t.Fatal("expected a claim status patch to be issued")
+	}
+	if !strings.Contains(string(statusPatchData), `"resourceVersion"`) {
+		t.Errorf("expected the status patch to carry an optimistic-lock resourceVersion precondition, got: %s", statusPatchData)
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, "adopted-sb", updatedClaim.Status.SandboxStatus.Name)
+}
+
+// histogramSampleCount sums the observation counts across all series of a histogram
+// collector by gathering it through a dedicated registry. (testutil.CollectAndCount
+// counts series, not observations, so it cannot detect duplicate records landing in
+// an existing series — and >1 observations per claim is exactly the #940 failure
+// mode this suite guards against.)
+func histogramSampleCount(t *testing.T, c prometheus.Collector) uint64 {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		t.Fatalf("failed to register collector: %v", err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	var total uint64
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			total += m.GetHistogram().GetSampleCount()
+		}
+	}
+	return total
+}
+
+// TestSandboxClaimStaleStatusPatchConflictDroppedWithoutMetrics verifies the
+// #940 fix end to end: an authoritative pass records the startup-latency
+// histograms EXACTLY once, and a later pass that computed status from a stale
+// (pre-Ready) cache view has its optimistic-lock 409 dropped as benign — no
+// reconcile error, no requeue storm, no stale status commit, and no second
+// histogram observation. The guarded failure mode is >1 observations per
+// claim (328 observations for 320 claims measured on post-#1118 main), so the
+// assertions pin exact sample counts, not series counts.
+func TestSandboxClaimStaleStatusPatchConflictDroppedWithoutMetrics(t *testing.T) {
+	scheme := newScheme(t)
+	claim, template, warmPool, adopted := newOptimisticLockTestObjects()
+	// Annotations normally stamped by the webhook / an earlier controller pass,
+	// required for the two startup-latency histograms to record at all.
+	claim.Annotations[asmetrics.WebhookAnnotation] = time.Now().Add(-5 * time.Second).Format(time.RFC3339Nano)
+	claim.Annotations[asmetrics.ObservabilityAnnotation] = time.Now().Add(-4 * time.Second).Format(time.RFC3339Nano)
+
+	asmetrics.ClaimStartupLatency.Reset()
+	asmetrics.ClaimControllerStartupLatency.Reset()
+
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "extensions.agents.x-k8s.io", Resource: "sandboxclaims"},
+		claim.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	// Pass 1 runs against live state; pass 2 serves a frozen pre-Ready claim
+	// view and rejects its doomed status patch with the optimistic-lock 409.
+	staleClaimView := false
+	var preReadyClaim *extensionsv1beta1.SandboxClaim
+	statusPatchAttempts := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, adopted).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if cl, ok := obj.(*extensionsv1beta1.SandboxClaim); ok && key.Name == "test-claim" && staleClaimView {
+					preReadyClaim.DeepCopyInto(cl)
+					return nil
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if _, ok := obj.(*extensionsv1beta1.SandboxClaim); ok && subResourceName == "status" {
+					statusPatchAttempts++
+					if staleClaimView {
+						return conflict
+					}
+				}
+				return c.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	// Pass 1 (authoritative): the status patch persists and the Ready
+	// transition is observed exactly once.
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("pass 1: expected nil error, got: %v", err)
+	}
+	if statusPatchAttempts != 1 {
+		t.Fatalf("pass 1: expected exactly 1 status patch, got %d", statusPatchAttempts)
+	}
+	if got := histogramSampleCount(t, asmetrics.ClaimStartupLatency); got != 1 {
+		t.Fatalf("pass 1: expected exactly 1 ClaimStartupLatency observation, got %d", got)
+	}
+	if got := histogramSampleCount(t, asmetrics.ClaimControllerStartupLatency); got != 1 {
+		t.Fatalf("pass 1: expected exactly 1 ClaimControllerStartupLatency observation, got %d", got)
+	}
+
+	// Freeze the stale view: the claim as a lagging cache would serve it —
+	// binding annotation present, status not yet converged. A view stale
+	// enough to predate the committed Ready status also predates the
+	// first-ready annotation stamped in the same pass, so drop it too:
+	// otherwise the annotation guard alone would mask what this test pins
+	// (the authoritative-write gate on metric recording).
+	bound := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, bound))
+	preReadyClaim = bound.DeepCopy()
+	preReadyClaim.Status = extensionsv1beta1.SandboxClaimStatus{}
+	delete(preReadyClaim.Annotations, asmetrics.ClaimFirstReadyAnnotation)
+	staleClaimView = true
+
+	// Pass 2 (stale): the recomputed "fresh" Ready transition must be
+	// arbitrated away by the server-side optimistic lock.
+	res, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("pass 2: expected the stale status conflict to be dropped as benign (nil error), got: %v", err)
+	}
+	if !res.IsZero() {
+		t.Fatalf("pass 2: expected no requeue (convergence is watch-driven), got %+v", res)
+	}
+	if statusPatchAttempts != 2 {
+		t.Errorf("pass 2: expected the doomed stale patch to be attempted once (2 attempts total), got %d", statusPatchAttempts)
+	}
+
+	// Exactly-once metrics: a count >1 here is the #940 duplicate-observation
+	// regression this test exists to catch.
+	if got := histogramSampleCount(t, asmetrics.ClaimStartupLatency); got != 1 {
+		t.Errorf("expected exactly 1 ClaimStartupLatency observation after the stale pass (>1 = #940 duplicate records), got %d", got)
+	}
+	if got := histogramSampleCount(t, asmetrics.ClaimControllerStartupLatency); got != 1 {
+		t.Errorf("expected exactly 1 ClaimControllerStartupLatency observation after the stale pass (>1 = #940 duplicate records), got %d", got)
+	}
+
+	// The stale pass must not have regressed the persisted status. (Unfreeze
+	// the stale view so this reads the live object.)
+	staleClaimView = false
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, "adopted-sb", updatedClaim.Status.SandboxStatus.Name, "dropped conflict must not clear the committed binding")
+	readyCond := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCond, "dropped conflict must not remove the committed Ready condition")
+	require.Equal(t, metav1.ConditionTrue, readyCond.Status, "dropped conflict must not flip the committed Ready condition")
+}
+
+// TestSandboxClaimAdoptionConflictRetriedInPass verifies that a 409 on the
+// optimistically locked claim update recording a warm-pool adoption is retried
+// in the same pass against a fresh read (retry.RetryOnConflict shape): the
+// adoption completes without surfacing an error and without burning the
+// candidate or deferring to another reconcile pass.
+func TestSandboxClaimAdoptionConflictRetriedInPass(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+	poolNameHash := sandboxcontrollers.NameHash("test-pool")
+	candidate := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pool-sb-1",
+			Namespace: "default",
+			UID:       "pool-sb-1-uid",
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   poolNameHash,
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxWarmPool",
+				Name:       "test-pool",
+				UID:        "warmpool-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+		}}},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "extensions.agents.x-k8s.io", Resource: "sandboxclaims"},
+		claim.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	// The first claim Update (the adoption annotation write) conflicts, as if
+	// the cached base predated an earlier write; the in-pass retry re-reads and
+	// succeeds.
+	conflictOnce := true
+	claimUpdates := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, candidate).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*extensionsv1beta1.SandboxClaim); ok {
+					claimUpdates++
+					if conflictOnce {
+						conflictOnce = false
+						return conflict
+					}
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	warmSandboxQueue.Add(
+		queue.GetNamespacedWarmPoolName("default", "test-pool"),
+		queue.SandboxKey{Namespace: "default", Name: "pool-sb-1"},
+	)
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: warmSandboxQueue,
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	res, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected the adoption conflict to be resolved in-pass, got error: %v", err)
+	}
+	if !res.IsZero() {
+		t.Fatalf("expected adoption to complete in this pass with no requeue, got %+v", res)
+	}
+	if claimUpdates < 2 {
+		t.Errorf("expected the conflicted update to be retried in-pass (>=2 claim updates), got %d", claimUpdates)
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, "pool-sb-1", updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation],
+		"in-pass retry must record the adoption on the fresh base")
+	require.Equal(t, "pool-sb-1", updatedClaim.Status.SandboxStatus.Name,
+		"adoption must finalize status in the same pass")
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-1", Namespace: "default"}, updatedSandbox))
+	controllerRef := metav1.GetControllerOf(updatedSandbox)
+	require.NotNil(t, controllerRef)
+	require.Equal(t, types.UID("claim-uid-123"), controllerRef.UID, "candidate must be owned by the claim after the retried adoption")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Puts an optimistic lock on the SandboxClaim controller's status and adoption-annotation writes so the API server — not controller memory — arbitrates stale cache views. This fixes the duplicate startup-latency histogram observations (#940) and prevents stale status patches from overwriting newer committed status, with no per-claim in-memory state.

> **Scope note (split at reviewer request):** this PR now carries only the status-write half. The adoption-assignment half — the optimistic lock on the `completeAdoption` ownership patch, the authoritative 404/409 resolution with terminal dead-reference cleanup, the no-fall-through change, the `AdoptionConflict` Ready reason, and the assignment-flip regression tests — moved to #1277, based directly on main. The two PRs are independent; whichever merges second needs a small mechanical rebase in `sandboxclaim_controller.go` (adjacent hunks, both wire `APIReader`).

#### What this adds on top of #1118

#1118 finalizes adoption in the same reconcile pass and removed the deferral
machinery around it (sentinel errors, fixed-delay requeues, the
`triggeredAdoptions` map), accepting that "a stale pass degrades to one
idempotent re-patch". That was the right trade, and this PR keeps it. But
three residual effects of stale cache views remain measurable after #1118,
all reproduced on current main (post-#1118):

1. **Duplicate startup-latency histogram observations (#940).** A pass that
   reads a pre-Ready claim view after the Ready transition was already
   committed and recorded re-detects the transition and re-observes the
   startup-latency histograms, skewing every histogram-derived quantile.
   On current main the histogram over-records: 4,503 samples for 2,955
   claims (+52%) in one run, and 4,232 samples for 2,680 claims (1.58x) in
   an independent run — including 333 samples for the 320-claim burst label,
   the #940 signature. With this PR: 3,022 samples for 3,022 claims —
   exactly-once, exact on every label (revalidation run; independently,
   2,773 samples for exactly 2,740+20+8+5 accountable events in a second
   leg).
2. **Doomed adoption writes from stale pre-adoption views.** A pass whose
   claim view predates the committed binding re-enters candidate adoption and
   issues writes that can only fail with a 409 — and if the warm queue is
   momentarily drained when that pass falls through, it can duplicate a
   cold-create POST for a claim that is already bound.
3. **Stale status overwrites.** The claim status patch carries no
   optimistic lock today, so a patch computed from a stale view can land
   after a newer bound status and transiently regress it (a visible
   Ready flap).

#### Approach

Stateless: let the server arbitrate staleness instead of tracking it in the
controller.

- The claim status patch uses `client.MergeFromWithOptimisticLock`. The lock
  is on the object-wide resourceVersion, so a 409 means the pass computed
  status from a cache view that is stale relative to some committed write on
  the claim — most often this controller's own earlier write (claim status
  has a single writer, serialized per key by the workqueue), but equally any
  concurrent writer touching the object (a user label edit, TTL tooling, a
  webhook). The conflict is dropped as benign (V(4) log); whichever write
  bumped the resourceVersion emitted its own claim watch event that
  re-enqueues the claim.
- The startup-latency metrics record only after an authoritative status write
  (persisted, or no write needed). A dropped conflict means the transition
  was already committed and recorded by an earlier pass — closing the #940
  double-count durably, including across controller restarts, because the
  arbitration is server-side. (This composes with the persistent first-ready
  annotation guard — #1087, which replaced the #1114 one-shot annotation —
  that prevents re-records across readiness flaps and suspend/resume; the
  authoritative-write gate closes the stale-view window before that
  annotation is visible in the cache, since a view stale enough to predate
  the committed status also predates the annotation stamp.)
- A 409 on the optimistically locked adoption-annotation update is retried
  in-pass with `retry.RetryOnConflict` against a fresh API-server read
  (`mgr.GetAPIReader()` — the informer cache is stale by definition when the
  update conflicted), instead of failing the pass and burning the popped warm
  candidate. Residual exhausted conflicts (rare) fail the pass and are paced
  by the workqueue's per-item rate limiter; the sibling PR #1277 upgrades
  them to a benign `AdoptionConflict` Ready reason.

Explicitly NOT in this design: no sentinel errors, no fixed-delay requeues,
no per-claim in-memory state. Convergence stays purely level-triggered and
event-driven, so self-healing is preserved: if an external actor wipes or
mangles the claim status, the next pass reads the current object and repairs
it — verified by a chaos check that externally clears a bound claim's status
mid-run. Across runs, 20 externally wiped claim statuses (zero controller
restarts): current main repairs in 18-52ms; this PR repairs in 19-77ms. The
previous revision of this PR repaired 0 of 5 — never, absent a controller
restart — which is why the memory-guard design was abandoned.

#### What changed since the first revision

The first revision of this PR used an in-memory map of the last status this
controller instance had written, and bailed out of passes that looked stale
against it. @igooch's review correctly identified that as reintroducing the
class of per-claim tracking machinery #1118 deliberately removed, and that
guarding on remembered state breaks level-triggered self-healing (a pass
that trusts its memory over the cluster will refuse to repair externally
damaged status). She suggested arbitrating staleness with an optimistic lock
on the status write instead; this revision is that design. The in-memory
guard, the stale-view sentinel, and the fixed 50ms requeue are all gone.

Extending her optimistic-lock principle to the adoption-annotation patch
also caught a further latent defect the v1 design would have masked: an
assignment-flip loop, where a stale-view `completeAdoption` failure could
overwrite an already-committed assignment and re-bind the claim across
candidates. That fix — never abandoning a committed adoption assignment on
a stale-view patch failure — changes adoption-failure semantics, so per her
scope preference it now lives in the sibling PR #1277 together with its
regression tests and forensics.

#### Performance

Measured A/B on identically tuned 12-node clusters, same harness build,
current main as base (includes #1118 and #1245). 0 failed claims in every
phase of every run. *Honesty note on scope:* these runs were measured on the
combined pre-split branch (this PR + #1277 together). The rows that are
specifically THIS PR's evidence are the #940 exactly-once histograms, the
stale-overwrite prevention, the chaos self-healing check, and the watch
probe; the burst/sustained parity was measured with #1277's fix also
applied (the sustained-collapse forensics belong to #1277's body).

| scenario | main → this PR |
|---|---|
| 300-claim warm-adoption burst (create→Ready p50/p90/p99, all-ready) | 1082/2096/2401ms, all-300 in 2.44s → 1097/2394/2571ms, all-300 in 2.63s (fresh-cluster revalidation) — parity within cross-cluster noise; this PR claims correctness, not burst speedup |
| sustained warm-adoption rate, 45/s x 60s (claim-path p50/p90 with supply present) | 108/236ms → 108/221ms; a second back-to-back sustained run on the same controller: 115/262ms, flat 92-139ms windows, no degradation |
| byte-identical status re-patch watch probe (events emitted by redundant patches) | 0 byte-identical MODIFIED events in every arm (normalized minus resourceVersion/managedFields) — the server already short-circuits them; what this PR removes is the client-side cost and the non-identical stale overwrites |
| adoption 409s and retry-gap cost (histogram observations per claim, the #940 1:1 signal, and time lost per conflicted adoption) | main: conflict-driven, workqueue-rate-limited requeues, histograms at 1.58x inflation (4,232/2,680); v1 of this PR: fast fixed-requeue churn (23k workqueue retries under post-burst sustained load, degrading to multi-second p50 with 46 cold starts); this PR: optimistic 409s dropped benignly + workqueue-rate-limited retry, histograms exactly-once (3,022/3,022), sustained parity with main |

(One note on the watch probe: a truly byte-identical status patch is
short-circuited by the apiserver before etcd — no resourceVersion bump, no
watch event (k8s.io/apiserver etcd3 `GuaranteedUpdate`) — so the residual
cost of #1118's "one idempotent re-patch" is a round trip, not a watch
storm. The probe confirms that server-side behavior across all arms, and the
remaining wins here come from the non-identical cases: the doomed adoption
writes, the stale overwrites, and the metric double-counts.)

#### Which issue(s) this PR is related to:

Fixes #940. Ref #527, Ref #1042. The adoption-assignment half (double
adoption, assignment flips — Fixes-class for #418) moved to #1277.

#### Release Note

```release-note
The SandboxClaim controller now applies its status patches with an optimistic lock: a patch computed from a stale cache view is rejected by the server and dropped as benign instead of overwriting newer status, startup-latency histograms record exactly once per Ready transition (fixes duplicate observations, #940), and a conflict on the adoption annotation write is retried in-pass against a fresh read instead of failing the pass.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate readiness/startup-latency histogram observations by dropping stale status updates when optimistic-lock conflicts occur.
  * Improved warm-pool adoption by retrying optimistic-lock conflicts and re-applying sandbox assignment using a fresh read to avoid prematurely failing.
  * Ensured metrics are emitted only for authoritative status/adoption updates.
* **Tests**
  * Added optimistic-lock precondition validation for status subresource patches.
  * Added coverage for benign 409 conflict dropping (no error/requeue) and single-time metric observation.
  * Added verification that adoption conflicts are retried within the same reconcile pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


