### PR TITLE
Expose sandbox service ports

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -585,9 +586,107 @@ func isControllerManagedPodAnnotation(key string) bool {
 	}
 }
 
+func servicePortsForSandbox(sandbox *sandboxv1beta1.Sandbox) []corev1.ServicePort {
+	type servicePortKey struct {
+		port     int32
+		protocol corev1.Protocol
+	}
+
+	explicitNamesByPort := map[servicePortKey]string{}
+	reservedNames := map[string]struct{}{}
+	addContainerPorts := func(container corev1.Container) {
+		for _, containerPort := range container.Ports {
+			if containerPort.ContainerPort == 0 {
+				continue
+			}
+			protocol := containerPort.Protocol
+			if protocol == "" {
+				protocol = corev1.ProtocolTCP
+			}
+			key := servicePortKey{
+				port:     containerPort.ContainerPort,
+				protocol: protocol,
+			}
+			if _, ok := explicitNamesByPort[key]; !ok {
+				explicitNamesByPort[key] = ""
+			}
+			// Deduplicate Service ports by (port, protocol). Preserve the first
+			// explicit container port name for each Service port. If another
+			// Service port reuses that explicit name, the first one keeps it,
+			// matching apiserver named-port lookup behavior.
+			if containerPort.Name == "" || explicitNamesByPort[key] != "" {
+				continue
+			}
+			if _, reserved := reservedNames[containerPort.Name]; reserved {
+				continue
+			}
+			explicitNamesByPort[key] = containerPort.Name
+			reservedNames[containerPort.Name] = struct{}{}
+		}
+	}
+	for _, container := range sandbox.Spec.PodTemplate.Spec.Containers {
+		addContainerPorts(container)
+	}
+	for _, container := range sandbox.Spec.PodTemplate.Spec.InitContainers {
+		if container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			addContainerPorts(container)
+		}
+	}
+	if len(explicitNamesByPort) == 0 {
+		return nil
+	}
+
+	keys := make([]servicePortKey, 0, len(explicitNamesByPort))
+	for key := range explicitNamesByPort {
+		keys = append(keys, key)
+	}
+	slices.SortFunc(keys, func(a, b servicePortKey) int {
+		if a.port < b.port {
+			return -1
+		}
+		if a.port > b.port {
+			return 1
+		}
+		return strings.Compare(string(a.protocol), string(b.protocol))
+	})
+
+	servicePorts := make([]corev1.ServicePort, 0, len(keys))
+	for _, key := range keys {
+		name := explicitNamesByPort[key]
+		if name == "" {
+			// Unnamed Service ports use a generated name. If the generated name
+			// conflicts with a reserved explicit name, change the generated name
+			// to preserve the user provided names for ports.
+			name = generatedServicePortName(key.port, key.protocol, reservedNames)
+		}
+		reservedNames[name] = struct{}{}
+		servicePorts = append(servicePorts, corev1.ServicePort{
+			Name:       name,
+			Protocol:   key.protocol,
+			Port:       key.port,
+			TargetPort: intstr.FromInt32(key.port),
+		})
+	}
+	return servicePorts
+}
+
+func generatedServicePortName(port int32, protocol corev1.Protocol, reservedNames map[string]struct{}) string {
+	baseName := fmt.Sprintf("p-%d-%s", port, strings.ToLower(string(protocol)))
+	if _, reserved := reservedNames[baseName]; !reserved {
+		return baseName
+	}
+	for suffix := 2; ; suffix++ {
+		name := fmt.Sprintf("%s-%d", baseName, suffix)
+		if _, reserved := reservedNames[name]; !reserved {
+			return name
+		}
+	}
+}
+
 func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandboxv1beta1.Sandbox, nameHash string) (*corev1.Service, error) {
 	logger := log.FromContext(ctx)
 	desired := sandbox.Spec.Service
+	desiredPorts := servicePortsForSandbox(sandbox)
 
 	service := &corev1.Service{}
 	if err := r.Get(ctx, types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}, service); err != nil {
@@ -611,6 +710,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 					Selector: map[string]string{
 						sandboxLabel: nameHash,
 					},
+					Ports: desiredPorts,
 				},
 			}
 			service.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
@@ -691,6 +791,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 		service.Spec.Selector = map[string]string{
 			sandboxLabel: nameHash,
 		}
+		service.Spec.Ports = desiredPorts
 
 		if err := ctrl.SetControllerReference(sandbox, service, r.Scheme); err != nil {
 			return nil, fmt.Errorf("SetControllerReference for Service failed: %w", err)
@@ -717,6 +818,10 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			service.Spec.Selector = desiredSelector
 			needsUpdate = true
 		}
+		if desired != nil && *desired && !servicePortsEqual(service.Spec.Ports, desiredPorts) {
+			service.Spec.Ports = desiredPorts
+			needsUpdate = true
+		}
 
 		if needsUpdate {
 			logger.Info("Reconciling owned service drift", "Service.Namespace", service.Namespace, "Service.Name", service.Name, "Sandbox.Namespace", sandbox.Namespace, "Sandbox.Name", sandbox.Name)
@@ -728,6 +833,21 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 
 	r.setServiceStatus(sandbox, service)
 	return service, nil
+}
+
+func servicePortsEqual(a, b []corev1.ServicePort) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name ||
+			a[i].Protocol != b[i].Protocol ||
+			a[i].Port != b[i].Port ||
+			a[i].TargetPort != b[i].TargetPort {
+			return false
+		}
+	}
+	return true
 }
 
 // clearPodNameAnnotation removes the pod name annotation from the sandbox if it exists.

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2623,6 +2625,24 @@ func TestReconcilePod(t *testing.T) {
 	}
 }
 
+func TestServicePortsForSandboxReturnsNilWithoutContainerPorts(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name: "main",
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	require.Nil(t, servicePortsForSandbox(sandbox))
+}
+
 func TestReconcileService(t *testing.T) {
 	sandboxName := "sandbox-name"
 	sandboxNs := "sandbox-ns"
@@ -2635,6 +2655,51 @@ func TestReconcileService(t *testing.T) {
 		},
 		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{Service: new(true)}, OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning},
 	}
+	sandboxWithPodSpec := func(podSpec corev1.PodSpec) *sandboxv1beta1.Sandbox {
+		return &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sandboxName,
+				Namespace: sandboxNs,
+				UID:       sandboxUID,
+			},
+			Spec: sandboxv1beta1.SandboxSpec{
+				SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+					Service: new(true),
+					PodTemplate: sandboxv1beta1.PodTemplate{
+						Spec: podSpec,
+					},
+				},
+				OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+			},
+		}
+	}
+	sandboxWithContainers := func(containers ...corev1.Container) *sandboxv1beta1.Sandbox {
+		return sandboxWithPodSpec(corev1.PodSpec{Containers: containers})
+	}
+	sandboxWithPorts := func(containerPorts ...corev1.ContainerPort) *sandboxv1beta1.Sandbox {
+		return sandboxWithContainers(corev1.Container{
+			Name:  "main",
+			Ports: containerPorts,
+		})
+	}
+	sandboxWithNilServiceAndPorts := func(containerPorts ...corev1.ContainerPort) *sandboxv1beta1.Sandbox {
+		sandbox := sandboxWithPorts(containerPorts...)
+		sandbox.Spec.Service = nil
+		return sandbox
+	}
+	servicePortWithName := func(port int32, protocol corev1.Protocol, name string) corev1.ServicePort {
+		return corev1.ServicePort{
+			Name:       name,
+			Protocol:   protocol,
+			Port:       port,
+			TargetPort: intstr.FromInt32(port),
+		}
+	}
+	servicePort := func(port int32, protocol corev1.Protocol) corev1.ServicePort {
+		return servicePortWithName(port, protocol, fmt.Sprintf("p-%d-%s", port, strings.ToLower(string(protocol))))
+	}
+	alwaysRestart := corev1.ContainerRestartPolicyAlways
+	appProtocolHTTP := "http"
 
 	testCases := []struct {
 		name                  string
@@ -2665,6 +2730,187 @@ func TestReconcileService(t *testing.T) {
 					ClusterIP: "None",
 					Selector: map[string]string{
 						sandboxLabel: nameHash,
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "creates a new headless service with container ports when service is true",
+			sandbox: sandboxWithPorts(corev1.ContainerPort{
+				ContainerPort: 8080,
+			}),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePort(8080, corev1.ProtocolTCP),
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "creates a new headless service with native sidecar container ports",
+			sandbox: sandboxWithPodSpec(corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: "main",
+				}},
+				InitContainers: []corev1.Container{
+					{
+						Name: "setup",
+						Ports: []corev1.ContainerPort{{
+							Name:          "setup",
+							ContainerPort: 7070,
+						}},
+					},
+					{
+						Name:          "proxy",
+						RestartPolicy: &alwaysRestart,
+						Ports: []corev1.ContainerPort{{
+							Name:          "metrics",
+							ContainerPort: 15020,
+						}},
+					},
+				},
+			}),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePortWithName(15020, corev1.ProtocolTCP, "metrics"),
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "creates a new headless service with sorted unique container ports",
+			sandbox: sandboxWithPorts(
+				corev1.ContainerPort{ContainerPort: 9090, Protocol: corev1.ProtocolUDP},
+				corev1.ContainerPort{ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+				corev1.ContainerPort{Name: "http", ContainerPort: 8080},
+				corev1.ContainerPort{ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+				corev1.ContainerPort{ContainerPort: 0, Protocol: corev1.ProtocolTCP},
+			),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePortWithName(8080, corev1.ProtocolTCP, "http"),
+						servicePort(9090, corev1.ProtocolTCP),
+						servicePort(9090, corev1.ProtocolUDP),
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "uses the first container port name when duplicate names are reused",
+			sandbox: sandboxWithContainers(
+				corev1.Container{
+					Name: "main",
+					Ports: []corev1.ContainerPort{{
+						Name:          "http",
+						ContainerPort: 9090,
+					}},
+				},
+				corev1.Container{
+					Name: "sidecar",
+					Ports: []corev1.ContainerPort{{
+						Name:          "http",
+						ContainerPort: 8080,
+					}},
+				},
+			),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePort(8080, corev1.ProtocolTCP),
+						servicePortWithName(9090, corev1.ProtocolTCP, "http"),
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "adjusts generated service port name when it conflicts with an explicit name",
+			sandbox: sandboxWithPorts(
+				corev1.ContainerPort{Name: "p-8080-tcp", ContainerPort: 9090},
+				corev1.ContainerPort{ContainerPort: 8080},
+			),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePortWithName(8080, corev1.ProtocolTCP, "p-8080-tcp-2"),
+						servicePortWithName(9090, corev1.ProtocolTCP, "p-8080-tcp"),
 					},
 				},
 			},
@@ -2705,6 +2951,9 @@ func TestReconcileService(t *testing.T) {
 						Selector: map[string]string{
 							"app": "something-else",
 						},
+						Ports: []corev1.ServicePort{
+							servicePort(9090, corev1.ProtocolTCP),
+						},
 					},
 				},
 			},
@@ -2724,6 +2973,114 @@ func TestReconcileService(t *testing.T) {
 					Selector: map[string]string{
 						sandboxLabel: nameHash,
 					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "repairs port drift on service owned by this sandbox when service is true",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							"keep":       "me",
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						Ports: []corev1.ServicePort{
+							servicePort(9090, corev1.ProtocolTCP),
+						},
+					},
+				},
+			},
+			sandbox: sandboxWithPorts(corev1.ContainerPort{
+				ContainerPort: 8080,
+			}),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"keep":       "me",
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePort(8080, corev1.ProtocolTCP),
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "preserves unmanaged service port fields when controlled fields match",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Selector: map[string]string{
+							sandboxLabel: nameHash,
+						},
+						Ports: []corev1.ServicePort{{
+							Name:        "p-8080-tcp",
+							Protocol:    corev1.ProtocolTCP,
+							Port:        8080,
+							TargetPort:  intstr.FromInt32(8080),
+							AppProtocol: &appProtocolHTTP,
+						}},
+					},
+				},
+			},
+			sandbox: sandboxWithPorts(corev1.ContainerPort{
+				ContainerPort: 8080,
+			}),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "1",
+					Labels: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Selector: map[string]string{
+						sandboxLabel: nameHash,
+					},
+					Ports: []corev1.ServicePort{{
+						Name:        "p-8080-tcp",
+						Protocol:    corev1.ProtocolTCP,
+						Port:        8080,
+						TargetPort:  intstr.FromInt32(8080),
+						AppProtocol: &appProtocolHTTP,
+					}},
 				},
 			},
 			wantStatusService:     sandboxName,
@@ -2769,6 +3126,52 @@ func TestReconcileService(t *testing.T) {
 					},
 				},
 			},
+			sandbox: sandboxWithPorts(corev1.ContainerPort{
+				ContainerPort: 8080,
+			}),
+			wantService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            sandboxName,
+					Namespace:       sandboxNs,
+					ResourceVersion: "2",
+					Labels: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash":  nameHash,
+						sandboxv1beta1.SandboxAdoptableLabel: "true",
+					},
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePort(8080, corev1.ProtocolTCP),
+					},
+				},
+			},
+			wantStatusService:     sandboxName,
+			wantStatusServiceFQDN: sandboxName + "." + sandboxNs + ".svc.cluster.local",
+		},
+		{
+			name: "adopts unowned headless service and clears existing ports when sandbox has none",
+			initialObjs: []runtime.Object{
+				&corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            sandboxName,
+						Namespace:       sandboxNs,
+						ResourceVersion: "1",
+						Labels: map[string]string{
+							sandboxv1beta1.SandboxAdoptableLabel: "true",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+						Ports: []corev1.ServicePort{
+							servicePort(9090, corev1.ProtocolTCP),
+						},
+					},
+				},
+			},
 			sandbox: sandboxObj,
 			wantService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2782,6 +3185,7 @@ func TestReconcileService(t *testing.T) {
 					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
 				},
 				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
 					Selector: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
 					},
@@ -2921,17 +3325,15 @@ func TestReconcileService(t *testing.T) {
 					},
 					Spec: corev1.ServiceSpec{
 						ClusterIP: "None",
+						Ports: []corev1.ServicePort{
+							servicePort(9090, corev1.ProtocolTCP),
+						},
 					},
 				},
 			},
-			sandbox: &sandboxv1beta1.Sandbox{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      sandboxName,
-					Namespace: sandboxNs,
-					UID:       sandboxUID,
-				},
-				Spec: sandboxv1beta1.SandboxSpec{},
-			},
+			sandbox: sandboxWithNilServiceAndPorts(corev1.ContainerPort{
+				ContainerPort: 8080,
+			}),
 			wantService: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            sandboxName,
@@ -2946,6 +3348,9 @@ func TestReconcileService(t *testing.T) {
 					ClusterIP: "None",
 					Selector: map[string]string{
 						"agents.x-k8s.io/sandbox-name-hash": nameHash,
+					},
+					Ports: []corev1.ServicePort{
+						servicePort(9090, corev1.ProtocolTCP),
 					},
 				},
 			},


### PR DESCRIPTION
#### What this PR does / why we need it:
This fixes generated Sandbox headless Services so they include Service ports derived from regular container ports in `spec.podTemplate.spec.containers[].ports`.

Service meshes like Istio rely on the Service port list to classify and route traffic. Before this change, a Sandbox with `spec.service: true` could create a headless Service with no exposed ports even when the pod declared `containerPort`.

The controller now defaults omitted protocols to TCP, de-duplicates duplicate `(port, protocol)` pairs, gives generated ports valid names, and repairs port drift on controller-owned Services.

#### Which issue(s) this PR is related to:
Fixes #154 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```
Generated Sandbox headless Services now include ports derived from declared regular container ports.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox headless Services now automatically generate `spec.ports` from sandbox container ports, including init/sidecar ports where applicable.
  * Ports are normalized into a deterministic, de-duplicated set by `(port, protocol)` with stable, conflict-free naming and explicit target ports; missing protocols default to TCP.
* **Bug Fixes**
  * Sandbox-owned headless Services now reconcile `spec.ports` on drift (and adoption matches sandbox behavior, including clearing ports when none exist).
* **Tests**
  * Expanded coverage for deterministic generation, deduplication/sorting, naming conflicts, and reconciliation/adoption scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->