### PR TITLE
WIP: metrics(controller): make client-side API transport queueing observable

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -252,6 +252,13 @@ func main() {
 	restConfig.QPS = float32(kubeAPIQPS)
 	restConfig.Burst = kubeAPIBurst
 
+	// Instrument the API client transport (rest_client_transport_* metrics):
+	// connection-acquisition wait, dial rate, and in-flight requests. This
+	// makes client-side HTTP/2 stream-slot saturation directly observable —
+	// it queues requests before they are sent, so no server-side metric can
+	// see it.
+	asmetrics.InstrumentRESTConfig(restConfig)
+
 	if enableWebhook {
 		if manageWebhookCerts {
 			// Create a temporary client to patch the CRDs and access Secrets

--- a/dev/ci/presubmits/benchmarks-kops-gcp-kindnet
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-kindnet
@@ -22,4 +22,14 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 export CNI=kindnet
+
+# Transport-contention experiment: 100 sandbox workers keep the controller's
+# in-flight API demand just under the apiserver's 100-stream per-connection
+# HTTP/2 cap (measured: ~75 busy workers, 87-99 in-flight at mif600). 200
+# workers push demand past the cap, so the rest_client_transport_* metrics
+# should show conn-wait queueing and dial churn if the shared connection is
+# the next bottleneck. The periodic job stays at the default 100 workers as
+# the baseline.
+export CONTROLLER_ARGS="--sandbox-concurrent-workers=200${CONTROLLER_ARGS:+ ${CONTROLLER_ARGS}}"
+
 exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/dev/ci/presubmits/benchmarks-kops-gcp-kindnet
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-kindnet
@@ -28,8 +28,12 @@ export CNI=kindnet
 # HTTP/2 cap (measured: ~75 busy workers, 87-99 in-flight at mif600). 200
 # workers push demand past the cap, so the rest_client_transport_* metrics
 # should show conn-wait queueing and dial churn if the shared connection is
-# the next bottleneck. The periodic job stays at the default 100 workers as
-# the baseline.
+# the next bottleneck. The stream cap only binds when concurrency meets
+# inflated RTTs, so this experiment deliberately stays on the stock 8-core
+# control plane, where the apiserver saturates and slows (a 16-core run
+# measured single-digit-ms server latency and ~9 in-flight — nowhere near
+# the cap). The periodic job stays at the default 100 workers as the
+# baseline.
 export CONTROLLER_ARGS="--sandbox-concurrent-workers=200${CONTROLLER_ARGS:+ ${CONTROLLER_ARGS}}"
 
 exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/internal/metrics/transport.go
+++ b/internal/metrics/transport.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:revive
+package metrics
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Client-side transport observability for the Kubernetes API client.
+//
+// kube-apiserver caps concurrent in-flight requests per HTTP/2 connection
+// (SETTINGS_MAX_CONCURRENT_STREAMS; it advertises 100 unless
+// --http2-max-streams-per-connection is set — see
+// k8s.io/apiserver/pkg/server/secure_serving.go), and client-go multiplexes
+// all requests from one rest.Config onto (effectively) a single connection.
+// When that connection saturates, requests queue *client-side* before they
+// are ever sent, which is invisible to every server-side metric:
+// apiserver_request_duration_seconds stays flat while the controller
+// observes ballooning RTTs.
+//
+// The direct signal is the time between starting a request and the
+// transport actually acquiring a usable connection for it (httptrace
+// GotConn). On a healthy client this is ~0 (the pooled connection has free
+// stream slots); under stream-slot saturation it is exactly the client-side
+// queue time.
+var (
+	// RestClientConnWait measures the time from the start of a Kubernetes
+	// API request until the underlying transport acquired the connection the
+	// request was actually sent on (httptrace GotConn).
+	// Labels:
+	// - method: HTTP method (GET, POST, PUT, PATCH, DELETE).
+	// - reused: whether the acquired connection was reused ("true") or
+	//   freshly dialed ("false").
+	RestClientConnWait = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "rest_client_transport_conn_wait_seconds",
+			Help: "Time from request start until the transport acquired a connection for it (httptrace GotConn). " +
+				"Sustained growth here while apiserver_request_duration_seconds stays flat indicates client-side " +
+				"queueing for HTTP/2 stream slots (SETTINGS_MAX_CONCURRENT_STREAMS saturation).",
+			Buckets: []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+		[]string{"method", "reused"},
+	)
+
+	// RestClientDials counts underlying TCP connection attempts to the API
+	// server (httptrace ConnectDone). A busy controller should sit at ~0
+	// dials/s; a sustained dial rate under load is the fingerprint of the
+	// transport repeatedly trying to escape a saturated connection (net/http
+	// dials a new connection on ErrNoCachedConn, and the HTTP/2 pool then
+	// discards it if the old connection freed a slot meanwhile).
+	// Labels:
+	// - result: "success" or "error".
+	RestClientDials = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rest_client_transport_dials_total",
+			Help: "Total TCP connection attempts by the Kubernetes API client transport, by result.",
+		},
+		[]string{"result"},
+	)
+
+	// RestClientInflightRequests tracks requests that currently hold an
+	// HTTP/2 stream (from RoundTrip start until the response body is
+	// closed, so long-lived watch streams are counted for their lifetime).
+	// A plateau at ~100 (the kube-apiserver per-connection stream cap)
+	// while workqueue depth grows means the client is connection-bound.
+	RestClientInflightRequests = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "rest_client_transport_inflight_requests",
+			Help: "In-flight Kubernetes API requests, counted from RoundTrip start until the response body is closed.",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(RestClientConnWait)
+	metrics.Registry.MustRegister(RestClientDials)
+	metrics.Registry.MustRegister(RestClientInflightRequests)
+}
+
+// InstrumentRESTConfig installs the transport instrumentation on cfg via
+// cfg.Wrap, composing with any wrapper already present. Every client built
+// from cfg (manager cache list/watches, manager client, event recorder,
+// leader election) is observed.
+func InstrumentRESTConfig(cfg *rest.Config) {
+	cfg.Wrap(NewTransportMetricsRoundTripper)
+}
+
+// NewTransportMetricsRoundTripper wraps rt with the rest_client_transport_*
+// instrumentation.
+func NewTransportMetricsRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	return &transportMetricsRoundTripper{next: rt}
+}
+
+type transportMetricsRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (t *transportMetricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	acq := &connAcquisition{start: time.Now()}
+	trace := &httptrace.ClientTrace{
+		GotConn: acq.gotConn,
+		ConnectDone: func(_, _ string, err error) {
+			result := "success"
+			if err != nil {
+				result = "error"
+			}
+			RestClientDials.WithLabelValues(result).Inc()
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	RestClientInflightRequests.Inc()
+	resp, err := t.next.RoundTrip(req)
+
+	// Observe the wait for the connection the request was finally sent on.
+	// GotConn can fire more than once per request (net/http retries with a
+	// fresh dial when the pooled HTTP/2 connection is at its stream limit),
+	// so the last acquisition is the one that carried the request.
+	if wait, reused, ok := acq.snapshot(); ok {
+		RestClientConnWait.WithLabelValues(req.Method, strconv.FormatBool(reused)).Observe(wait.Seconds())
+	}
+
+	if err != nil {
+		RestClientInflightRequests.Dec()
+		return nil, err
+	}
+	resp.Body = &inflightTrackingBody{ReadCloser: resp.Body}
+	return resp, nil
+}
+
+// CloseIdleConnections lets http.Client.CloseIdleConnections reach the
+// wrapped transport (net/http checks for this interface).
+func (t *transportMetricsRoundTripper) CloseIdleConnections() {
+	if ci, ok := t.next.(interface{ CloseIdleConnections() }); ok {
+		ci.CloseIdleConnections()
+	}
+}
+
+// WrappedRoundTripper implements k8s.io/apimachinery/pkg/util/net.RoundTripperWrapper.
+func (t *transportMetricsRoundTripper) WrappedRoundTripper() http.RoundTripper {
+	return t.next
+}
+
+// connAcquisition records the most recent GotConn event for one request.
+// Trace callbacks can fire from transport-internal goroutines, hence the
+// mutex; they always complete before RoundTrip returns the connection's
+// response.
+type connAcquisition struct {
+	start time.Time
+
+	mu     sync.Mutex
+	wait   time.Duration
+	reused bool
+	seen   bool
+}
+
+func (a *connAcquisition) gotConn(info httptrace.GotConnInfo) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.wait = time.Since(a.start)
+	a.reused = info.Reused
+	a.seen = true
+}
+
+func (a *connAcquisition) snapshot() (time.Duration, bool, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.wait, a.reused, a.seen
+}
+
+// inflightTrackingBody decrements the in-flight gauge when the response
+// body is closed (which is when the HTTP/2 stream is released).
+type inflightTrackingBody struct {
+	io.ReadCloser
+	once sync.Once
+}
+
+func (b *inflightTrackingBody) Close() error {
+	b.once.Do(RestClientInflightRequests.Dec)
+	return b.ReadCloser.Close()
+}

--- a/internal/metrics/transport_test.go
+++ b/internal/metrics/transport_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:revive
+package metrics
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// histogramTotals gathers the total sample count and sum across all label
+// combinations of vec.
+func histogramTotals(t *testing.T, vec *prometheus.HistogramVec) (count uint64, sum float64) {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(vec))
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			count += m.GetHistogram().GetSampleCount()
+			sum += m.GetHistogram().GetSampleSum()
+		}
+	}
+	return count, sum
+}
+
+func TestTransportMetricsRoundTripper(t *testing.T) {
+	RestClientConnWait.Reset()
+	RestClientDials.Reset()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	inflightBefore := testutil.ToFloat64(RestClientInflightRequests)
+	client := &http.Client{Transport: NewTransportMetricsRoundTripper(&http.Transport{})}
+
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+
+	// The response body is still open, so the request holds its slot.
+	require.InDelta(t, inflightBefore+1, testutil.ToFloat64(RestClientInflightRequests), 0)
+
+	_, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	// Double-close must not double-decrement.
+	require.NoError(t, resp.Body.Close())
+	require.InDelta(t, inflightBefore, testutil.ToFloat64(RestClientInflightRequests), 0)
+
+	count, _ := histogramTotals(t, RestClientConnWait)
+	require.Equal(t, uint64(1), count, "expected exactly one conn-wait observation")
+
+	require.GreaterOrEqual(t, testutil.ToFloat64(RestClientDials.WithLabelValues("success")), 1.0,
+		"expected at least one successful dial to be counted")
+}
+
+func TestConnWaitMeasuresConnectionQueueing(t *testing.T) {
+	RestClientConnWait.Reset()
+
+	const handlerDelay = 200 * time.Millisecond
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(handlerDelay)
+		_, _ = w.Write([]byte("slow"))
+	}))
+	defer srv.Close()
+
+	// One connection for two concurrent slow requests: the second request
+	// must wait for the first to release the connection, and that wait is
+	// what the conn-wait histogram exists to expose.
+	client := &http.Client{Transport: NewTransportMetricsRoundTripper(&http.Transport{MaxConnsPerHost: 1})}
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			resp, err := client.Get(srv.URL)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+		})
+	}
+	wg.Wait()
+
+	count, sum := histogramTotals(t, RestClientConnWait)
+	require.Equal(t, uint64(2), count)
+	require.GreaterOrEqual(t, sum, (handlerDelay / 2).Seconds(),
+		"the queued request's conn wait should reflect the time spent waiting for a free connection")
+}
+
+func TestTransportMetricsErrorPath(t *testing.T) {
+	inflightBefore := testutil.ToFloat64(RestClientInflightRequests)
+
+	// A just-closed listener's port refuses connections immediately.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	refusedAddr := l.Addr().String()
+	require.NoError(t, l.Close())
+
+	client := &http.Client{Transport: NewTransportMetricsRoundTripper(&http.Transport{})}
+	_, err = client.Get("http://" + refusedAddr)
+	require.Error(t, err)
+
+	require.GreaterOrEqual(t, testutil.ToFloat64(RestClientDials.WithLabelValues("error")), 1.0,
+		"the refused dial should be counted as an error")
+
+	require.InDelta(t, inflightBefore, testutil.ToFloat64(RestClientInflightRequests), 0,
+		"a failed request must not leak the in-flight gauge")
+}

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -137,6 +137,15 @@ echo "Using CNI: ${CNI}"
 STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
 echo "Using node count: ${STRESS_NODE_COUNT}"
 
+# Control-plane sizing: on n2-standard-8 the throughput phases pin
+# kube-apiserver at a flat ~5.6-5.7 cores across mif200/400/600 (a plateau
+# despite 3x offered load, i.e. saturation) on a node that also runs etcd,
+# KCM (~0.35) and the scheduler (~0.23). 16 vCPUs takes apiserver CPU out of
+# the picture so client-side bottlenecks (controller workers, HTTP/2
+# per-connection stream cap) are measured against a server that can keep up.
+STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-n2-standard-16}"
+echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
+
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
 kops create cluster \
@@ -147,7 +156,7 @@ kops create cluster \
   --zones="${ZONE}" \
   --project="${PROJECT_ID}" \
   --control-plane-count=1 \
-  --control-plane-size=n2-standard-8 \
+  --control-plane-size="${STRESS_CONTROL_PLANE_SIZE}" \
   --node-count="${STRESS_NODE_COUNT}" \
   --node-size=n2-standard-8
 

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -137,15 +137,6 @@ echo "Using CNI: ${CNI}"
 STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
 echo "Using node count: ${STRESS_NODE_COUNT}"
 
-# Control-plane sizing: on n2-standard-8 the throughput phases pin
-# kube-apiserver at a flat ~5.6-5.7 cores across mif200/400/600 (a plateau
-# despite 3x offered load, i.e. saturation) on a node that also runs etcd,
-# KCM (~0.35) and the scheduler (~0.23). 16 vCPUs takes apiserver CPU out of
-# the picture so client-side bottlenecks (controller workers, HTTP/2
-# per-connection stream cap) are measured against a server that can keep up.
-STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-n2-standard-16}"
-echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
-
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
 kops create cluster \
@@ -156,7 +147,7 @@ kops create cluster \
   --zones="${ZONE}" \
   --project="${PROJECT_ID}" \
   --control-plane-count=1 \
-  --control-plane-size="${STRESS_CONTROL_PLANE_SIZE}" \
+  --control-plane-size=n2-standard-8 \
   --node-count="${STRESS_NODE_COUNT}" \
   --node-size=n2-standard-8
 

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -282,9 +282,12 @@ fi
 # Deploy to cluster. CONTROLLER_ARGS optionally appends controller flags
 # (e.g. "--enable-pprof-debug" so the stress tool's --profile-controller can
 # actually fetch CPU/heap profiles; see benchmarks-kops-gcp-claims).
+# --controller-args must use the = form: its value starts with a dash, and
+# argparse rejects dash-prefixed values passed as a separate argument
+# ("expected one argument").
 echo "Deploying to cluster..."
 dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" --extensions \
-  ${CONTROLLER_ARGS:+--controller-args "${CONTROLLER_ARGS}"}
+  ${CONTROLLER_ARGS:+--controller-args="${CONTROLLER_ARGS}"}
 
 # Wait for controller to be ready
 echo "Waiting for controller to be ready..."


### PR DESCRIPTION
#### What this PR does / why we need it

Follow-up to the discussion on #1240: the client-side HTTP/2 stream-slot saturation found there is invisible to every server-side metric, because requests queue in the client transport before they are ever sent. This PR adds the *direct* observable.

It instruments the controller's API client via `rest.Config.Wrap` + `net/http/httptrace`, exporting three metrics on the existing controller-runtime registry:

- **`rest_client_transport_conn_wait_seconds{method,reused}`** — time from request start until the transport acquired the connection the request was actually sent on (httptrace `GotConn`). On a healthy client this is ~0 (the pooled connection has free stream slots). When the shared connection saturates its `SETTINGS_MAX_CONCURRENT_STREAMS` budget (kube-apiserver advertises **100** unless `--http2-max-streams-per-connection` is set — see `k8s.io/apiserver/pkg/server/secure_serving.go`, the deliberate rapid-reset mitigation matching the Go client's initial assumption), this histogram captures exactly the client-side queue time. `GotConn` can fire multiple times per request (net/http retries with a fresh dial when the pooled h2 connection is full); we record the acquisition that carried the request.
- **`rest_client_transport_dials_total{result}`** — TCP connection attempts. A steady-state controller should sit at ~0 dials/s; a sustained dial rate under load is the fingerprint of the transport repeatedly dialing to escape a full connection while `addConnIfNeeded` discards the new connection because the old one freed a slot meanwhile.
- **`rest_client_transport_inflight_requests`** — requests holding a stream slot (RoundTrip start → response body close, so watch streams count for their lifetime). A plateau at ~100 while workqueue depth grows means the client is connection-bound — no Little's-law estimation needed.

Always on, no flag: the overhead is one small allocation and one context wrap per request, in line with the existing always-on workqueue/rest_client metrics.

#### Interaction with #1240

Installed via `cfg.Wrap(...)`, which composes with other wrappers. If #1240 lands, its `configureAPIConnections` (which refuses a *pre-set* `WrapTransport`) should run **before** this instrumentation is installed, so the metrics observe the sharded transport from above; the `GotConn` trace propagates through the shard transports via the request context either way. Happy to rebase whichever lands second.

#### Stress-test visibility

The stress harness captures the controller `/metrics` endpoint wholesale into `metrics.jsonl`, so these series appear in the next stress run with no harness changes. Expected picture when reproducing the #1240 baseline (single connection, 300-claim warm burst): `conn_wait` p90 climbing into the hundreds of ms and `inflight` pinned at ~100 on BASE; both collapsing with `--separate-watch-connection --api-connections=4`.

If this proves out in a stress run, the natural next step is proposing the `GotConn`-wait metric upstream in client-go's metrics package (it already has hooks for request/rate-limiter latency, but nothing observes transport connection acquisition).

#### Which issue(s) this PR fixes

None — observability follow-up to #1240.

```release-note
Add client transport metrics `rest_client_transport_conn_wait_seconds`, `rest_client_transport_dials_total`, and `rest_client_transport_inflight_requests` to make client-side API connection saturation observable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for Kubernetes API client activity, including in-flight requests, connection wait time, and TCP dial attempts.
  * Metrics distinguish successful and failed connection attempts and account for connection reuse.

* **Bug Fixes**
  * Improved tracking for requests that encounter connection errors, ensuring in-flight request counts remain accurate.

* **Tests**
  * Added coverage for request tracking, connection queuing, successful connections, and connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->