### PR TITLE
fix(benchmarks): pass --controller-args with = so dash-leading values parse

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -275,7 +275,7 @@ fi
 # actually fetch CPU/heap profiles; see benchmarks-kops-gcp-claims).
 echo "Deploying to cluster..."
 dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" --extensions \
-  ${CONTROLLER_ARGS:+--controller-args "${CONTROLLER_ARGS}"}
+  ${CONTROLLER_ARGS:+--controller-args="${CONTROLLER_ARGS}"}
 
 # Wait for controller to be ready
 echo "Waiting for controller to be ready..."


### PR DESCRIPTION
## What

One-character fix: pass `--controller-args` to `deploy-to-kube` using the `=` form so dash-leading values survive argparse.

## Why

The new `presubmit-agent-sandbox-benchmarks-kops-gcp-claims` job fails for any PR that triggers it, on upstream `main`'s own scripts:

- `test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run` exports `CONTROLLER_ARGS="--enable-pprof-debug"` — a single dash-leading token.
- The shared `benchmarks-kops-gcp/run` forwards it as `--controller-args "${CONTROLLER_ARGS}"`.
- Python argparse parses that as two separate options and exits with `deploy-to-kube: error: argument --controller-args: expected one argument`.

Example failures (PR #1240, both attempts, including one rebased onto current main): [run 1](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_agent-sandbox/1240/presubmit-agent-sandbox-benchmarks-kops-gcp-claims/2079931469421088768), [run 2](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_agent-sandbox/1240/presubmit-agent-sandbox-benchmarks-kops-gcp-claims/2079942398137339904).

Reproduce locally:

```console
$ python3 -c 'import argparse; p=argparse.ArgumentParser(); p.add_argument("--controller-args"); p.parse_args(["--controller-args","--enable-pprof-debug"])'
error: argument --controller-args: expected one argument
$ python3 -c 'import argparse; p=argparse.ArgumentParser(); p.add_argument("--controller-args"); print(p.parse_args(["--controller-args=--enable-pprof-debug"]))'
Namespace(controller_args='--enable-pprof-debug')
```

The `=` form is what argparse documents for option values that begin with `-`. Multi-token values (e.g. the cilium/kindnet scenarios' arg strings) are unaffected — they parse fine either way, and this PR's own claims presubmit run exercises the fixed path end-to-end.

## Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how controller arguments are passed during Kubernetes benchmark deployments.
  * Ensured configured controller arguments are delivered as a single option, improving compatibility with downstream argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->