### PR TITLE
stress-test: raise the benchmark control plane to n2-standard-16

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -137,6 +137,20 @@ echo "Using CNI: ${CNI}"
 STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
 echo "Using node count: ${STRESS_NODE_COUNT}"
 
+# Control-plane sizing: on n2-standard-8 the throughput phases pin
+# kube-apiserver at a flat ~5.6-5.7 cores across mif200/400/600 (a plateau
+# despite 3x offered load, i.e. saturation) on a node that also runs etcd,
+# KCM (~0.35 cores) and the scheduler (~0.23). Going to 16 vCPUs (8-core
+# kindnet run 2079750013621112832 vs 16-core cilium run 2079885693798060032;
+# CNI differs but the apiserver signals are CNI-independent) let the
+# apiserver burn 9.25 cores, dropped its mean request latency 34.7ms ->
+# 6.6ms, and lifted mif600 claim throughput 60/s -> 91/s, with the sandbox
+# controller's workqueue wait collapsing 445ms -> 3ms downstream. Override via
+# STRESS_CONTROL_PLANE_SIZE (e.g. back to n2-standard-8) to reproduce the
+# saturated-server regime.
+STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-n2-standard-16}"
+echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
+
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
 kops create cluster \
@@ -147,7 +161,7 @@ kops create cluster \
   --zones="${ZONE}" \
   --project="${PROJECT_ID}" \
   --control-plane-count=1 \
-  --control-plane-size=n2-standard-8 \
+  --control-plane-size="${STRESS_CONTROL_PLANE_SIZE}" \
   --node-count="${STRESS_NODE_COUNT}" \
   --node-size=n2-standard-8
 


### PR DESCRIPTION
#### What this PR does / why we need it

Raises the benchmark cluster's control plane from `n2-standard-8` to `n2-standard-16` (env-overridable as `STRESS_CONTROL_PLANE_SIZE`, following the `STRESS_NODE_COUNT` pattern).

**Why:** on the 8-core control plane, the throughput phases pin kube-apiserver at a flat ~5.6–5.7 cores across mif200/400/600 — a plateau despite 3× offered load, i.e. saturation — on a node that also runs etcd, KCM (~0.35 cores) and the scheduler (~0.23). The A/B (8-core kindnet run `2079750013621112832` vs 16-core cilium run `2079885693798060032`; CNI differs, but the apiserver-side signals are CNI-independent):

| mif600 | 8-core CP | 16-core CP |
|---|---|---|
| apiserver CPU | 5.7 cores (flat = saturated) | 9.25 cores |
| apiserver request latency (mean) | 34.7ms | 6.6ms |
| claims ready | 3054 (60/s) | 4650 (91/s) |
| sandbox workqueue wait (mean) | 445ms | 3ms |
| sandbox reconcile work time | 126ms | 5.5ms |

With the starved apiserver, the benchmark was measuring control-plane CPU, and every downstream number (reconcile time, queue wait, controller in-flight) was an echo of it. With headroom, it measures the launch pipeline.

Split out of #1259 deliberately: that PR's HTTP/2 transport-contention experiment **wants** the saturated 8-core control plane (the per-connection stream cap only binds when high concurrency meets inflated RTTs), so it keeps the stock size while this PR upgrades the default for everything else. Whichever lands second rebases trivially — #1259's net diff to the sizing block is zero.

#### Which issue(s) this PR fixes

None — stress-infrastructure follow-up to the #1259 investigation.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable control-plane instance sizing for kOps GCE benchmark clusters.
  - The selected instance size is now logged during setup.
  - Defaults to `n2-standard-16`, with an environment variable available for customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->