### PR TITLE
Adding presubmit for performance test using kwok

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ hermes-sandbox-knowledge.md
 .claude
 .vscode
 .agents/skills/**/workspace/
+
+# KWOK simulated cluster test output
+.build-kwok/
+kwok-cl2-report/

--- a/dev/ci/presubmits/test-e2e-scalability-kwok
+++ b/dev/ci/presubmits/test-e2e-scalability-kwok
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${repo_root}"
+
+echo "======================================================="
+echo "Executing KWOK Cluster Scalability Presubmit"
+echo "======================================================="
+
+WORKDIR="${repo_root}/.build-kwok"
+rm -rf "${WORKDIR}"
+mkdir -p "${WORKDIR}/bin"
+BINDIR="${WORKDIR}/bin"
+export PATH="${BINDIR}:${PATH}"
+
+KWOK_VERSION="v0.6.0"
+KWOKCTL="${BINDIR}/kwokctl"
+
+if ! command -v kwokctl &>/devnull; then
+  echo "Installing kwokctl ${KWOK_VERSION}..."
+  curl -sL "https://github.com/kubernetes-sigs/kwok/releases/download/${KWOK_VERSION}/kwokctl-linux-amd64" -o "${KWOKCTL}"
+  chmod +x "${KWOKCTL}"
+  curl -sL "https://github.com/kubernetes-sigs/kwok/releases/download/${KWOK_VERSION}/kwok-linux-amd64" -o "${BINDIR}/kwok"
+  chmod +x "${BINDIR}/kwok"
+fi
+
+CLUSTER_NAME="kwok-sandbox-scale"
+
+cleanup() {
+  echo "Cleaning up controller & simulated cluster..."
+  if [[ -n "${CONTROLLER_PID:-}" ]]; then
+    kill "${CONTROLLER_PID}" || true
+  fi
+  "${KWOKCTL}" delete cluster --name="${CLUSTER_NAME}" || true
+  rm -rf "${WORKDIR}"
+  echo "Cleanup complete."
+}
+trap cleanup EXIT
+
+echo "Ensuring clean start for kwok simulated cluster..."
+"${KWOKCTL}" delete cluster --name="${CLUSTER_NAME}" || true
+"${KWOKCTL}" create cluster --name="${CLUSTER_NAME}" --wait=2m
+
+KUBECONFIG="${WORKDIR}/kubeconfig"
+"${KWOKCTL}" get kubeconfig --name="${CLUSTER_NAME}" > "${KUBECONFIG}"
+export KUBECONFIG
+
+echo "Creating simulated nodes..."
+NUM_NODES="${SIMULATED_NODES:-10}"
+"${KWOKCTL}" scale node --name="${CLUSTER_NAME}" --replicas="${NUM_NODES}"
+
+echo "Deploying Agent Sandbox CRDs & System Namespace..."
+kubectl create namespace agent-sandbox-system || true
+kubectl apply -f k8s/crds/
+
+echo "Waiting for CRDs to be established..."
+kubectl wait --for=condition=Established crd/sandboxes.agents.x-k8s.io --timeout=1m
+kubectl wait --for=condition=Established crd/sandboxclaims.extensions.agents.x-k8s.io --timeout=1m
+kubectl wait --for=condition=Established crd/sandboxtemplates.extensions.agents.x-k8s.io --timeout=1m
+kubectl wait --for=condition=Established crd/sandboxwarmpools.extensions.agents.x-k8s.io --timeout=1m
+
+echo "Starting Agent Sandbox Controller against simulated cluster..."
+go run ./cmd/agent-sandbox-controller \
+  --leader-election-namespace=agent-sandbox-system \
+  --extensions=true \
+  --metrics-bind-address=":8081" \
+  --health-probe-bind-address=":8082" \
+  --kube-api-qps=1000 \
+  --kube-api-burst=2000 \
+  --sandbox-concurrent-workers=100 \
+  --sandbox-claim-concurrent-workers=100 \
+  --sandbox-warm-pool-concurrent-workers=100 \
+  --sandbox-warm-pool-max-batch-size=300 &
+CONTROLLER_PID=$!
+sleep 3
+
+echo "Downloading ClusterLoader2 binary..."
+CL2_TMP_DIR="$(mktemp -d)"
+git clone --depth 1 https://github.com/kubernetes/perf-tests.git "${CL2_TMP_DIR}"
+(cd "${CL2_TMP_DIR}/clusterloader2" && GOBIN="${BINDIR}" go build -o "${BINDIR}/clusterloader2" ./cmd/clusterloader.go)
+
+CL2_REPORT_DIR="${ARTIFACTS:-.}/kwok-cl2-report"
+mkdir -p "${CL2_REPORT_DIR}"
+
+TEST_CONFIG="${repo_root}/test/benchmarks/config/agent-sandbox-continuous-burst.yaml"
+
+# Scale parameters: default to fast POC scale (QPS: 5, duration: 10s, warmpool: 5)
+QPS="${CL2_QPS:-5}"
+DURATION="${CL2_DURATION_SECONDS:-10}"
+WARMPOOL="${CL2_WARMPOOL_SIZE:-5}"
+
+echo "Running ClusterLoader2 benchmark (QPS=${QPS}, Duration=${DURATION}s, WarmPool=${WARMPOOL})..."
+CL2_QPS="${QPS}" CL2_DURATION_SECONDS="${DURATION}" CL2_WARMPOOL_SIZE="${WARMPOOL}" CL2_ENABLE_SCHEDULING_METRICS="false" "${BINDIR}/clusterloader2" \
+  --testconfig="${TEST_CONFIG}" \
+  --kubeconfig="${KUBECONFIG}" \
+  --provider=skeleton \
+  --delete-stale-namespaces=true \
+  --v=2 \
+  --report-dir="${CL2_REPORT_DIR}"
+
+rm -rf "${CL2_TMP_DIR}"
+echo "KWOK cluster benchmark completed successfully."

--- a/test/benchmarks/config/agent-sandbox-continuous-burst.yaml
+++ b/test/benchmarks/config/agent-sandbox-continuous-burst.yaml
@@ -1,0 +1,269 @@
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+{{$qps := DefaultParam .CL2_QPS 300}}
+{{$durationSeconds := DefaultParam .CL2_DURATION_SECONDS 120}}
+{{$burstSize := MultiplyInt $qps $durationSeconds}}
+{{$warmpool_size := DefaultParam .CL2_WARMPOOL_SIZE 200}}
+{{$namespacePrefix := DefaultParam .CL2_NAMESPACE_PREFIX "agent-sandbox"}}
+{{$SLEEP_FOR_CLUSTER_PREP := DefaultParam .CL2_SLEEP_FOR_CLUSTER_PREP "0m"}}
+{{$ENABLE_SYSTEM_POD_METRICS := DefaultParam .CL2_ENABLE_SYSTEM_POD_METRICS true}}
+{{$ENABLE_CLUSTER_OOMS_TRACKER := DefaultParam .CL2_ENABLE_CLUSTER_OOMS_TRACKER false}}
+{{$CLUSTER_OOMS_FAILURE_ENABLED := DefaultParam .CL2_CLUSTER_OOMS_FAILURE_ENABLED true}}
+{{$sandboxClaimControllerStartupLatencyThreshold50Ms := DefaultParam .CL2_SANDBOX_CLAIM_CONTROLLER_STARTUP_LATENCY_THRESHOLD_50_MS 1000}}
+{{$sandboxClaimControllerStartupLatencyThreshold90Ms := DefaultParam .CL2_SANDBOX_CLAIM_CONTROLLER_STARTUP_LATENCY_THRESHOLD_90_MS 1000}}
+{{$sandboxClaimControllerStartupLatencyThreshold99Ms := DefaultParam .CL2_SANDBOX_CLAIM_CONTROLLER_STARTUP_LATENCY_THRESHOLD_99_MS 5000}}
+{{$ENABLE_SCHEDULING_METRICS := DefaultParam .CL2_ENABLE_SCHEDULING_METRICS true}}
+
+# Standard continuous throughput. Uses un-filtered irate since continuous scenario has no breaks or idle time.
+{{$claimThroughputQuery := `sum(irate(agent_sandbox_claim_controller_startup_latency_ms_count[5m])) by (launch_type, sandbox_template)[%v:5s]`}}
+{{$claimControllerStartupLatencyQuery := `sum(rate(agent_sandbox_claim_controller_startup_latency_ms_bucket{}[%v])) by (le)`}}
+
+name: agent-sandbox-continuous-burst
+namespace:
+  number: {{$namespaces}}
+  prefix: {{$namespacePrefix}}
+tuningSets:
+- name: BurstCreate
+  qpsLoad:
+    qps: {{$qps}}
+
+steps:
+- name: Waiting for {{$SLEEP_FOR_CLUSTER_PREP}} before starting the test to allow cluster preparation.
+  measurements:
+  - Identifier: WaitForClusterPrep
+    Method: Sleep
+    Params:
+      duration: {{$SLEEP_FOR_CLUSTER_PREP}}
+
+- name: Start Startup Latency Measurement
+  measurements:
+  - Identifier: SandboxStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: "app=agent-sandbox-load-test"
+  - Identifier: SandboxClaimControllerStartupLatency
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: Agent Sandbox Claim Controller Startup Latency (ms)
+      metricVersion: v1
+      unit: ms
+      queries:
+        - name: ControllerStartupLatency50
+          query: histogram_quantile(0.50, {{$claimControllerStartupLatencyQuery}})
+          threshold: {{$sandboxClaimControllerStartupLatencyThreshold50Ms}}
+          requireSamples: true
+        - name: ControllerStartupLatency90
+          query: histogram_quantile(0.90, {{$claimControllerStartupLatencyQuery}})
+          threshold: {{$sandboxClaimControllerStartupLatencyThreshold90Ms}}
+          requireSamples: true
+        - name: ControllerStartupLatency99
+          query: histogram_quantile(0.99, {{$claimControllerStartupLatencyQuery}})
+          threshold: {{$sandboxClaimControllerStartupLatencyThreshold99Ms}}
+          requireSamples: true
+
+  - Identifier: SandboxClaimControllerThroughput
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: Agent Sandbox Claim Throughput
+      metricVersion: v1
+      dimensions:
+      - launch_type
+      - sandbox_template
+      unit: 1/s
+      queries:
+      - name: Max
+        query: max_over_time({{$claimThroughputQuery}})
+      - name: Avg
+        query: avg_over_time({{$claimThroughputQuery}})
+      - name: Perc99
+        query: quantile_over_time(0.99, {{$claimThroughputQuery}})
+      - name: Perc90
+        query: quantile_over_time(0.90, {{$claimThroughputQuery}})
+      - name: Perc50
+        query: quantile_over_time(0.50, {{$claimThroughputQuery}})
+
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: start
+      labelSelector: "app=agent-sandbox-load-test"
+      measurmentInterval: 1s
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: SchedulingMetrics
+    Method: SchedulingMetrics
+    Params:
+      action: start
+{{end}}
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: start
+      pollFrequency: "5s"
+      hostPollTimeoutSeconds: 5
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: TestMetrics
+    Method: TestMetrics
+    Params:
+      action: start
+      systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
+      clusterOOMsFailureEnabled: {{$CLUSTER_OOMS_FAILURE_ENABLED}}
+{{end}}
+
+- name: Setup Sandbox Template
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: template
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"
+
+- name: Setup Sandbox Warm Pool
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: warmpool
+      objectTemplatePath: "cluster-loader-sandbox-warmpool-custom.yaml"
+
+- name: Wait for Warm Pool Sandboxes to be Ready
+  measurements:
+  - Identifier: WaitForWarmPoolSandboxes
+    Method: WaitForGenericK8sObjects
+    Params:
+      action: start
+      objectGroup: "agents.x-k8s.io"
+      objectVersion: "v1beta1"
+      objectResource: "sandboxes"
+      labelSelector: "agents.x-k8s.io/warm-pool-sandbox"
+      namespaceRange: {min: 1, max: {{$namespaces}}}
+      successfulConditions: ["Ready=True"]
+      failedConditions: []
+      minDesiredObjectCount: {{MultiplyInt $warmpool_size $namespaces}}
+      maxFailedObjectCount: 0
+      timeout: 20m
+
+- name: Create Continuous Burst Sandbox Claims ({{$burstSize}})
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: {{$burstSize}}
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: agent-claim
+      objectTemplatePath: "cluster-loader-sandbox-claim.yaml"
+
+- name: Wait for Continuous Burst Sandbox Claims to be Ready
+  measurements:
+  - Identifier: WaitForContinuousBurstSandboxClaims
+    Method: WaitForGenericK8sObjects
+    Params:
+      action: start
+      objectGroup: extensions.agents.x-k8s.io
+      objectVersion: v1beta1
+      objectResource: sandboxclaims
+      namespaceRange: {min: 1, max: {{$namespaces}}}
+      successfulConditions: ["Ready=True"]
+      failedConditions: []
+      minDesiredObjectCount: {{MultiplyInt $burstSize $namespaces}}
+      maxFailedObjectCount: 0
+      timeout: 60m
+      refreshInterval: 20ms
+
+- name: Pause 2m to allow Prometheus to scrape the metrics
+  measurements:
+  - Identifier: WaitAfterTest
+    Method: Sleep
+    Params:
+      duration: 2m
+
+- name: Gather Results
+  measurements:
+  - Identifier: SandboxStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+      labelSelector: "app=agent-sandbox-load-test"
+  - Identifier: SandboxClaimControllerStartupLatency
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+      enableViolations: true
+  - Identifier: SandboxClaimControllerThroughput
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: gather
+      enableViolations: false
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: SchedulingMetrics
+    Method: SchedulingMetrics
+    Params:
+      action: gather
+{{end}}
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+      enableViolations: false
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+      enableViolations: false
+      useSimpleLatencyQuery: true
+      summaryName: APIResponsivenessPrometheus_simple
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: gather
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: TestMetrics
+    Method: TestMetrics
+    Params:
+      action: gather
+      systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
+      clusterOOMsFailureEnabled: {{$CLUSTER_OOMS_FAILURE_ENABLED}}
+{{end}}
+
+- name: Delete Sandbox Claims
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: agent-claim
+      objectTemplatePath: "cluster-loader-sandbox-claim.yaml"
+
+- name: Delete Sandbox Warm Pool
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: warmpool
+      objectTemplatePath: "cluster-loader-sandbox-warmpool-custom.yaml"
+
+- name: Delete Sandbox Templates
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: template
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"

--- a/test/benchmarks/config/agent-sandbox-rapid-burst.yaml
+++ b/test/benchmarks/config/agent-sandbox-rapid-burst.yaml
@@ -1,0 +1,283 @@
+{{$namespaces := DefaultParam .CL2_NAMESPACES 1}}
+{{$qps := DefaultParam .CL2_QPS 100}}
+{{$warmpool_size := DefaultParam .CL2_WARMPOOL_SIZE 200}}
+{{$namespacePrefix := DefaultParam .CL2_NAMESPACE_PREFIX "agent-sandbox"}}
+{{$burstSize := DefaultParam .CL2_BURST_SIZE 50}}
+{{$totalBursts := DefaultParam .CL2_TOTAL_BURSTS 100}}
+{{$SLEEP_FOR_CLUSTER_PREP := DefaultParam .CL2_SLEEP_FOR_CLUSTER_PREP "10m"}}
+{{$ENABLE_SYSTEM_POD_METRICS := DefaultParam .CL2_ENABLE_SYSTEM_POD_METRICS true}}
+{{$ENABLE_CLUSTER_OOMS_TRACKER := DefaultParam .CL2_ENABLE_CLUSTER_OOMS_TRACKER false}}
+{{$CLUSTER_OOMS_FAILURE_ENABLED := DefaultParam .CL2_CLUSTER_OOMS_FAILURE_ENABLED true}}
+{{$sandboxClaimControllerStartupLatencyThreshold50Ms := DefaultParam .CL2_SANDBOX_CLAIM_CONTROLLER_STARTUP_LATENCY_THRESHOLD_50_MS 1000}}
+{{$sandboxClaimControllerStartupLatencyThreshold90Ms := DefaultParam .CL2_SANDBOX_CLAIM_CONTROLLER_STARTUP_LATENCY_THRESHOLD_90_MS 1000}}
+{{$sandboxClaimControllerStartupLatencyThreshold99Ms := DefaultParam .CL2_SANDBOX_CLAIM_CONTROLLER_STARTUP_LATENCY_THRESHOLD_99_MS 5000}}
+{{$ENABLE_SCHEDULING_METRICS := DefaultParam .CL2_ENABLE_SCHEDULING_METRICS true}}
+
+# Filtered burst throughput. Uses `> 0` to filter out pauses between bursts so that average/percentile metrics reflect active creation periods.
+{{$claimThroughputQuery := `((sum(irate(agent_sandbox_claim_controller_startup_latency_ms_count[5m])) by (launch_type, sandbox_template)) > 0)[%v:5s]`}}
+{{$claimControllerStartupLatencyQuery := `sum(rate(agent_sandbox_claim_controller_startup_latency_ms_bucket{}[%v])) by (le)`}}
+
+name: agent-sandbox-rapid-burst
+namespace:
+  number: {{$namespaces}}
+  prefix: {{$namespacePrefix}}
+tuningSets:
+- name: BurstCreate
+  qpsLoad:
+    qps: {{$qps}}
+
+steps:
+- name: Waiting for {{$SLEEP_FOR_CLUSTER_PREP}} before starting the test to allow cluster preparation.
+  measurements:
+  - Identifier: WaitForClusterPrep
+    Method: Sleep
+    Params:
+      duration: {{$SLEEP_FOR_CLUSTER_PREP}}
+
+- name: Start Startup Latency Measurement
+  measurements:
+  - Identifier: SandboxStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: start
+      labelSelector: "app=agent-sandbox-load-test"
+  - Identifier: SandboxClaimControllerStartupLatency
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: Agent Sandbox Claim Startup Latency (ms)
+      metricVersion: v1
+      unit: ms
+      queries:
+        - name: ControllerStartupLatency50
+          query: histogram_quantile(0.50, {{$claimControllerStartupLatencyQuery}})
+          threshold: {{$sandboxClaimControllerStartupLatencyThreshold50Ms}}
+          requireSamples: true
+        - name: ControllerStartupLatency90
+          query: histogram_quantile(0.90, {{$claimControllerStartupLatencyQuery}})
+          threshold: {{$sandboxClaimControllerStartupLatencyThreshold90Ms}}
+          requireSamples: true
+        - name: ControllerStartupLatency99
+          query: histogram_quantile(0.99, {{$claimControllerStartupLatencyQuery}})
+          threshold: {{$sandboxClaimControllerStartupLatencyThreshold99Ms}}
+          requireSamples: true
+
+  - Identifier: SandboxClaimControllerThroughput
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: Agent Sandbox Claim Throughput
+      metricVersion: v1
+      dimensions:
+      - launch_type
+      - sandbox_template
+      unit: 1/s
+      queries:
+      - name: Max
+        query: max_over_time({{$claimThroughputQuery}})
+      - name: Avg
+        query: avg_over_time({{$claimThroughputQuery}})
+      - name: Perc99
+        query: quantile_over_time(0.99, {{$claimThroughputQuery}})
+      - name: Perc90
+        query: quantile_over_time(0.90, {{$claimThroughputQuery}})
+      - name: Perc50
+        query: quantile_over_time(0.50, {{$claimThroughputQuery}})
+
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: start
+      labelSelector: "app=agent-sandbox-load-test"
+      measurmentInterval: 1s
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: SchedulingMetrics
+    Method: SchedulingMetrics
+    Params:
+      action: start
+{{end}}
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: start
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: start
+      pollFrequency: "5s"
+      hostPollTimeoutSeconds: 5
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: TestMetrics
+    Method: TestMetrics
+    Params:
+      action: start
+      systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
+      clusterOOMsFailureEnabled: {{$CLUSTER_OOMS_FAILURE_ENABLED}}
+{{end}}
+
+- name: Setup Sandbox Template
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: template
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"
+
+- name: Setup Sandbox Warm Pool
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 1
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: warmpool
+      objectTemplatePath: "cluster-loader-sandbox-warmpool-custom.yaml"
+
+- name: Wait for Warm Pool Sandboxes to be Ready
+  measurements:
+  - Identifier: WaitForWarmPoolSandboxes
+    Method: WaitForGenericK8sObjects
+    Params:
+      action: start
+      objectGroup: "agents.x-k8s.io"
+      objectVersion: "v1beta1"
+      objectResource: "sandboxes"
+      labelSelector: "agents.x-k8s.io/warm-pool-sandbox"
+      namespaceRange: {min: 1, max: {{$namespaces}}}
+      successfulConditions: ["Ready=True"]
+      failedConditions: []
+      minDesiredObjectCount: {{MultiplyInt $warmpool_size $namespaces}}
+      maxFailedObjectCount: 0
+      timeout: 20m
+
+# --- START BURST LOOP ---
+{{range $i := Loop $totalBursts}}
+{{$burstIteration := AddInt $i 1}}
+{{$replicaCount := MultiplyInt $burstIteration $burstSize}}
+
+- name: Create Burst {{$burstIteration}} Sandbox Claims ({{$burstSize}})
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: {{$replicaCount}}
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: agent-claim
+      objectTemplatePath: "cluster-loader-sandbox-claim.yaml"
+
+- name: Wait for Burst {{$burstIteration}} Sandbox Claims to be Ready
+  measurements:
+  - Identifier: WaitForBurst{{$burstIteration}}SandboxClaims
+    Method: WaitForGenericK8sObjects
+    Params:
+      action: start
+      objectGroup: extensions.agents.x-k8s.io
+      objectVersion: v1beta1
+      objectResource: sandboxclaims
+      namespaceRange: {min: 1, max: {{$namespaces}}}
+      successfulConditions: ["Ready=True"]
+      failedConditions: []
+      minDesiredObjectCount: {{MultiplyInt $replicaCount $namespaces}}
+      maxFailedObjectCount: 0
+      timeout: 2m
+      refreshInterval: 200ms
+
+- name: Pause 20 Seconds After Burst {{$burstIteration}}
+  measurements:
+  - Identifier: WaitAfterBurst{{$burstIteration}}
+    Method: Sleep
+    Params:
+      duration: 20s
+{{end}}
+# --- END BURST LOOP ---
+
+- name: Pause 2m to allow Prometheus to scrape the metrics
+  measurements:
+  - Identifier: WaitAfterTest
+    Method: Sleep
+    Params:
+      duration: 2m
+
+- name: Gather Results
+  measurements:
+  - Identifier: SandboxStartupLatency
+    Method: PodStartupLatency
+    Params:
+      action: gather
+      labelSelector: "app=agent-sandbox-load-test"
+  - Identifier: SandboxClaimControllerStartupLatency
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+      enableViolations: true
+  - Identifier: SandboxClaimControllerThroughput
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+  - Identifier: SchedulingThroughput
+    Method: SchedulingThroughput
+    Params:
+      action: gather
+      enableViolations: false
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: SchedulingMetrics
+    Method: SchedulingMetrics
+    Params:
+      action: gather
+{{end}}
+  - Identifier: APIResponsivenessPrometheus
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+      enableViolations: false
+  - Identifier: APIResponsivenessPrometheusSimple
+    Method: APIResponsivenessPrometheus
+    Params:
+      action: gather
+      enableViolations: false
+      useSimpleLatencyQuery: true
+      summaryName: APIResponsivenessPrometheus_simple
+  - Identifier: APIAvailability
+    Method: APIAvailability
+    Params:
+      action: gather
+{{if $ENABLE_SCHEDULING_METRICS}}
+  - Identifier: TestMetrics
+    Method: TestMetrics
+    Params:
+      action: gather
+      systemPodMetricsEnabled: {{$ENABLE_SYSTEM_POD_METRICS}}
+      clusterOOMsTrackerEnabled: {{$ENABLE_CLUSTER_OOMS_TRACKER}}
+      clusterOOMsFailureEnabled: {{$CLUSTER_OOMS_FAILURE_ENABLED}}
+{{end}}
+
+- name: Delete Sandbox Claims
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: agent-claim
+      objectTemplatePath: "cluster-loader-sandbox-claim.yaml"
+
+- name: Delete Sandbox Warm Pool
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: warmpool
+      objectTemplatePath: "cluster-loader-sandbox-warmpool-custom.yaml"
+
+- name: Delete Sandbox Templates
+  phases:
+  - namespaceRange: {min: 1, max: {{$namespaces}}}
+    replicasPerNamespace: 0
+    tuningSet: BurstCreate
+    objectBundle:
+    - basename: template
+      objectTemplatePath: "cluster-loader-sandbox-template.yaml"

--- a/test/benchmarks/config/cluster-loader-sandbox-claim.yaml
+++ b/test/benchmarks/config/cluster-loader-sandbox-claim.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxClaim
+metadata:
+  name: {{.Name}}
+spec:
+  warmPoolRef:
+    name: warmpool-0

--- a/test/benchmarks/config/cluster-loader-sandbox-template.yaml
+++ b/test/benchmarks/config/cluster-loader-sandbox-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: load-test-template
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        app: agent-sandbox-load-test
+    spec:
+      containers:
+      - name: sandbox
+        image: alpine
+        command: ["/bin/sh", "-c", "echo 'Hello from the Agent Sandbox!'; sleep 28800"]

--- a/test/benchmarks/config/cluster-loader-sandbox-warmpool-custom.yaml
+++ b/test/benchmarks/config/cluster-loader-sandbox-warmpool-custom.yaml
@@ -1,0 +1,8 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: warmpool-{{.Index}}
+spec:
+  sandboxTemplateRef:
+    name: template-{{.Index}}
+  replicas: {{DefaultParam .CL2_WARMPOOL_SIZE 200}}

--- a/test/benchmarks/config/monitor/agent-sandbox-controller-monitor.yaml
+++ b/test/benchmarks/config/monitor/agent-sandbox-controller-monitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: agent-sandbox-controller-monitor
+  namespace: monitoring
+  labels:
+    k8s-app: agent-sandbox-controller
+spec:
+  selector:
+    matchLabels:
+      app: agent-sandbox-controller
+  namespaceSelector:
+    matchNames:
+      - agent-sandbox-system
+  endpoints:
+  - port: metrics
+    path: /metrics
+    interval: 10s

--- a/test/benchmarks/config/monitor/pprof-config.yaml
+++ b/test/benchmarks/config/monitor/pprof-config.yaml
@@ -1,0 +1,56 @@
+# Note: This config is kept separate from the global perf-tests/pprof.yaml to avoid
+# log spam in tests where the agent-sandbox controller is not installed.
+# This config assumes the agent-sandbox controller is installed as a workload on the node.
+# Once agent-sandbox controller is a GKE addon in the control plane, this config should be updated.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: scraper-proxy-role
+rules:
+- apiGroups: [""]
+  resources: ["services/proxy"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: scraper-proxy-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: scraper-proxy-role
+subjects:
+- kind: User
+  name: system:mastertest
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-sandbox-controller
+  namespace: scraper
+  labels:
+    pprof-scraper: "true"
+data:
+  config: |
+    - name: cpu
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/profile?seconds=30
+      interval: 1m
+    - name: heap
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/heap
+      interval: 1m
+    - name: goroutine
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/goroutine
+      interval: 1m
+    - name: allocs
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/allocs
+      interval: 1m
+    - name: block
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/block
+      interval: 1m
+    - name: mutex
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/mutex
+      interval: 1m
+    - name: trace
+      url: https://127.0.0.1:443/api/v1/namespaces/agent-sandbox-system/services/agent-sandbox-controller:8080/proxy/debug/pprof/trace?seconds=30
+      interval: 1m


### PR DESCRIPTION
#### What this PR does / why we need it:
    
This PR introduces a fast, lightweight presubmit test (`dev/ci/presubmits/test-e2e-scalability-kwok`) designed to **automatically benchmark performance and catch scalability regressions on every Pull Request**.

Key highlights:
    - **Performance Verification on Every PR**: Runs ClusterLoader2 load benchmarks against the exact controller code submitted in the PR, ensuring no latency or throughput regressions are introduced.
    - **Fast Presubmit Execution**: Uses [KWOK](https://github.com/kubernetes-sigs/kwok) (Kubernetes WithOut Kubelet) to run simulated 10-node scale tests in **~20–30 seconds**, giving immediate performance feedback without waiting for cloud VM provisioning.
    - **Direct PR Code Benchmarking**: Compiles and executes the `agent-sandbox-controller` directly from the PR source code (`go run ./cmd/agent-sandbox-controller`) with high-concurrency QPS flags (`--kube-api-qps=1000`, `--sandbox-claim-concurrent-workers=100`).
    - **Self-Contained Benchmark Definitions**: Consolidates ClusterLoader2 scenarios (`agent-sandbox-continuous-burst.yaml`, `agent-sandbox-rapid-burst.yaml`) into `test/benchmarks/config/`.
    - **Simulated Provider Compatibility**: Makes `SchedulingMetrics` conditional via `CL2_ENABLE_SCHEDULING_METRICS="false"`, enabling ClusterLoader2 to collect Pod startup latency metrics (P50/P90/P99) cleanly without requiring master SSH access.

#### Which issue(s) this PR is related to:
NONE

#### Release Note
```release-note
NONE