### PR TITLE
docs, examples: opt-in APF insulation overlay for high-rate claim workloads

### DIFF
--- a/docs/apf-insulation.md
+++ b/docs/apf-insulation.md
@@ -44,9 +44,14 @@ priority order: **claim path > bulk refill > events**.
 
 | class | APF objects | contents |
 |---|---|---|
-| claim path | `agent-sandbox-critical` (PriorityLevelConfiguration + FlowSchema, precedence 900) | SandboxClaim writes and status, sandbox adoption update/patch and status, the synchronous adoption-time pod patch, leader-election leases |
-| bulk refill | `agent-sandbox-bulk` (PriorityLevelConfiguration + FlowSchema, precedence 1000) | everything else: refill creates/deletes, informer list/watch, child objects, discovery |
+| claim path | `agent-sandbox-critical` (PriorityLevelConfiguration + FlowSchema, precedence 900) | hot-path **write verbs only**: SandboxClaim `update`/`patch` (incl. status), sandbox `update`/`patch` (incl. status/finalizers), adoption-time pod `update`/`patch`, leader-election lease `get`/`create`/`update` |
+| bulk refill | `agent-sandbox-bulk` (PriorityLevelConfiguration + FlowSchema, precedence 1000) | everything else: refill creates/deletes, **all informer list/watch (relists land here by design)**, reads, child objects, discovery |
 | events | `agent-sandbox-events` (FlowSchema only, precedence 950) | controller Events, routed to the pre-existing shared `workload-low` level — sacrificial by design |
+
+The critical schema deliberately lists no read or collection verbs: routing
+informer relists or deletes through the critical level would dilute the very
+capacity guarantee it exists to provide, so those fall through to the bulk
+catch-rest schema (higher precedence number = evaluated after critical).
 
 ## How seats are derived (and why the manifest has no absolute numbers)
 

--- a/docs/apf-insulation.md
+++ b/docs/apf-insulation.md
@@ -10,6 +10,16 @@ the standard install is a cluster-operator decision: the right seat sizing
 depends on the server's inflight limits, the cluster's other tenants, and
 the target claim rate — there is no universally safe default.
 
+**What to expect:** this is an isolation and capacity-guarantee mechanism,
+**not a latency optimization at typical rates**. On a single-tenant cluster
+whose apiserver seats are not saturated, APF queueing wait is already ~0 and
+applying the overlay does not change request latency — measured A/B, the
+controller's traffic simply moves into its dedicated levels with no latency
+delta. The value is what happens under contention: other tenants can no
+longer queue the claim path, the controller's own refill bursts can no
+longer crowd out its adoption writes, and the claim path keeps guaranteed
+seats when the cluster is busy.
+
 ## The problem: everything shares `workload-low`
 
 Out of the box, all of the controller's API traffic matches the built-in
@@ -63,13 +73,23 @@ seats. Fractions are preserved; only the server limits move.
 ## The sizing rule: `seats(critical) >= 2x demand high watermark`
 
 Dedicated seats only help if there are enough of them — an undersized
-dedicated level becomes the queueing point itself. Measured on a 300-claim
-simultaneous-burst benchmark: with the server at the 600-seat defaults the
+dedicated level becomes the queueing point itself.
+
+*Historical context (measured during the latency investigation, at
+pre-optimization controller write volumes):* on a 300-claim
+simultaneous-burst benchmark, with the server at the 600-seat defaults, the
 critical level's ~77 seats were exceeded by a measured **272-seat demand
 high watermark**, producing an APF wait p99 of ~359ms *inside the
-controller's own priority level*. Raising the server limits to 4000 seats
+controller's own priority level*; raising the server limits to 4000 seats
 (critical ≈ 516) put the level back above demand with ~2x headroom, and the
-burst p90 improved 1740ms → 1094ms with no code or manifest change.
+burst p90 improved 1740ms → 1094ms with no manifest change. That experiment
+is why the sizing rule below exists — but note it reflects a controller
+that issued several times more writes per claim than the current one.
+**Current optimized write volumes do not saturate the stock 600-seat limits
+at a 45/s sustained claim rate** (measured demand high watermarks: 86 seats
+critical, 52 bulk), which is exactly why the overlay is protection for
+multi-tenant and higher-rate regimes rather than a latency optimization at
+typical rates.
 
 Rule of thumb: at your **peak** claim rate,
 

--- a/docs/apf-insulation.md
+++ b/docs/apf-insulation.md
@@ -1,0 +1,162 @@
+# APF insulation for high-rate claim workloads
+
+An opt-in overlay of [API Priority and Fairness (APF)](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/)
+objects that gives the agent-sandbox controller dedicated apiserver
+concurrency: [`examples/apf-insulation/apf-insulation.yaml`](../examples/apf-insulation/apf-insulation.yaml).
+
+**This overlay changes nothing unless a cluster operator applies it.** It is
+not part of the default or release manifests. Whether APF defaults belong in
+the standard install is a cluster-operator decision: the right seat sizing
+depends on the server's inflight limits, the cluster's other tenants, and
+the target claim rate — there is no universally safe default.
+
+## The problem: everything shares `workload-low`
+
+Out of the box, all of the controller's API traffic matches the built-in
+`service-accounts` FlowSchema (matchingPrecedence 9000) and is served by the
+shared `workload-low` priority level, together with every other
+non-kube-system ServiceAccount in the cluster. At high SandboxClaim rates
+this produces two distinct failure modes:
+
+1. **Cross-tenant interference.** Any other workload's ServiceAccount can
+   flood `workload-low` and queue the controller's claim-adoption writes
+   behind its traffic.
+2. **Self-interference.** The controller's own bulk traffic — warm-pool
+   replenishment creating hundreds of sandboxes, pods and services right
+   after a claim burst drains the pool — competes for the same seats as the
+   latency-critical adoption writes.
+
+The overlay splits the controller's traffic into three classes, in strict
+priority order: **claim path > bulk refill > events**.
+
+| class | APF objects | contents |
+|---|---|---|
+| claim path | `agent-sandbox-critical` (PriorityLevelConfiguration + FlowSchema, precedence 900) | SandboxClaim writes and status, sandbox adoption update/patch and status, the synchronous adoption-time pod patch, leader-election leases |
+| bulk refill | `agent-sandbox-bulk` (PriorityLevelConfiguration + FlowSchema, precedence 1000) | everything else: refill creates/deletes, informer list/watch, child objects, discovery |
+| events | `agent-sandbox-events` (FlowSchema only, precedence 950) | controller Events, routed to the pre-existing shared `workload-low` level — sacrificial by design |
+
+## How seats are derived (and why the manifest has no absolute numbers)
+
+APF seat counts are **fractions**, not absolutes:
+
+```
+seats(level) = shares(level) / sum(all levels' shares)
+               x (--max-requests-inflight + --max-mutating-requests-inflight)
+```
+
+On Kubernetes 1.35 the built-in mandatory + suggested levels sum to 245
+nominal concurrency shares. The overlay adds `critical = 40` and
+`bulk = 25`, bringing the total to 310:
+
+* `agent-sandbox-critical`: 40/310 ≈ 13% of the server's seats.
+* `agent-sandbox-bulk`: 25/310 ≈ 8%.
+
+Because the shares are fractions, **raising the server-wide inflight limits
+multiplies every level's seats with no manifest change**. For example, with
+the apiserver defaults (`--max-requests-inflight=400`,
+`--max-mutating-requests-inflight=200`, i.e. 600 seats total) the critical
+level gets ~77 seats; on a control plane tuned to 3000 read + 1000 mutating
+(4000 seats total — e.g. raising mutating inflight 200 → 1000 alongside the
+read limit) the same manifest yields ~516 critical seats and ~322 bulk
+seats. Fractions are preserved; only the server limits move.
+
+## The sizing rule: `seats(critical) >= 2x demand high watermark`
+
+Dedicated seats only help if there are enough of them — an undersized
+dedicated level becomes the queueing point itself. Measured on a 300-claim
+simultaneous-burst benchmark: with the server at the 600-seat defaults the
+critical level's ~77 seats were exceeded by a measured **272-seat demand
+high watermark**, producing an APF wait p99 of ~359ms *inside the
+controller's own priority level*. Raising the server limits to 4000 seats
+(critical ≈ 516) put the level back above demand with ~2x headroom, and the
+burst p90 improved 1740ms → 1094ms with no code or manifest change.
+
+Rule of thumb: at your **peak** claim rate,
+
+```
+seats(agent-sandbox-critical) >= 2 x demand-seats high watermark
+```
+
+and fix a shortfall by raising the server inflight limits (which scales
+every level proportionally), not by editing the shares.
+
+## How to measure
+
+All metrics below are served by the kube-apiserver (`/metrics`); they carry
+a `priority_level` label once the overlay is applied.
+
+**Demand high watermark** (peak seats the level *wanted* during each
+sampling window — compare against the level's seat count):
+
+```promql
+max_over_time(
+  apiserver_flowcontrol_demand_seats_high_watermark{priority_level="agent-sandbox-critical"}[1h]
+)
+```
+
+Run your peak workload (e.g. a full-scale claim burst) inside the range
+window. Repeat with `priority_level="agent-sandbox-bulk"`.
+
+**Current seat allocation** (what the fractions currently resolve to):
+
+```promql
+apiserver_flowcontrol_nominal_limit_seats{priority_level=~"agent-sandbox-.*"}
+```
+
+**APF wait p99** (time requests spent queued at the level before executing —
+the direct "is my level big enough" signal; healthy is single-digit
+milliseconds):
+
+```promql
+histogram_quantile(0.99, sum by (le) (
+  rate(apiserver_flowcontrol_request_wait_duration_seconds_bucket{
+    priority_level="agent-sandbox-critical", execute="true"
+  }[5m])
+))
+```
+
+**Rejections** (must stay zero — both levels queue rather than 429, so any
+rejection means the queue length limit was exhausted):
+
+```promql
+sum by (priority_level) (
+  rate(apiserver_flowcontrol_rejected_requests_total{priority_level=~"agent-sandbox-.*"}[5m])
+)
+```
+
+**Verify the schemas actually match** (non-zero dispatch on both dedicated
+levels while the controller is busy):
+
+```promql
+sum by (priority_level) (
+  rate(apiserver_flowcontrol_dispatched_requests_total{priority_level=~"agent-sandbox-.*"}[5m])
+)
+```
+
+## Rollback
+
+```sh
+kubectl delete -f examples/apf-insulation/apf-insulation.yaml
+```
+
+Deletion is immediate and safe: the controller's traffic falls back to the
+built-in `service-accounts` FlowSchema (shared `workload-low`), which is the
+stock behavior.
+
+## Caveats
+
+* **Opt-in by design.** The default and release manifests do not include
+  these objects; applying them is a deliberate cluster-operator action, and
+  the seat math above should be re-derived for your server limits and claim
+  rate before relying on the overlay in production.
+* **Third-party priority levels change the denominator.** The share
+  fractions assume the stock built-in levels (245 shares). Other add-ons
+  that install PriorityLevelConfigurations shift every level's fraction;
+  re-check `apiserver_flowcontrol_nominal_limit_seats` after installing any.
+* **Clients with `system:masters` bypass APF entirely** (they match the
+  mandatory `exempt` FlowSchema). If you load-test with an admin kubeconfig,
+  the test client's requests are not shaped by this overlay — check
+  `kubectl auth whoami` before drawing conclusions from a benchmark.
+* **Events are deliberately sacrificial.** If you rely on controller Events
+  for alerting at high rates, be aware they share `workload-low` with the
+  rest of the cluster under this overlay.

--- a/docs/apf-insulation.md
+++ b/docs/apf-insulation.md
@@ -18,7 +18,10 @@ controller's traffic simply moves into its dedicated levels with no latency
 delta. The value is what happens under contention: other tenants can no
 longer queue the claim path, the controller's own refill bursts can no
 longer crowd out its adoption writes, and the claim path keeps guaranteed
-seats when the cluster is busy.
+seats when the cluster is busy. The critical level lends none of its seats
+(`lendablePercent: 0`), so its allocation is a hard floor other levels can
+never borrow from; the bulk level deliberately lends most of its capacity
+back to the cluster when the pool is quiescent.
 
 ## The problem: everything shares `workload-low`
 
@@ -58,8 +61,11 @@ On Kubernetes 1.35 the built-in mandatory + suggested levels sum to 245
 nominal concurrency shares. The overlay adds `critical = 40` and
 `bulk = 25`, bringing the total to 310:
 
-* `agent-sandbox-critical`: 40/310 ≈ 13% of the server's seats.
-* `agent-sandbox-bulk`: 25/310 ≈ 8%.
+* `agent-sandbox-critical`: 40/310 ≈ 13% of the server's seats —
+  non-lendable (`lendablePercent: 0`), so this entire allocation is the
+  guaranteed floor the sizing rule below is stated against.
+* `agent-sandbox-bulk`: 25/310 ≈ 8% — 75% lendable, so only ~25% of it is a
+  guaranteed floor; refill is throughput work and borrows back under load.
 
 Because the shares are fractions, **raising the server-wide inflight limits
 multiplies every level's seats with no manifest change**. For example, with
@@ -135,8 +141,9 @@ histogram_quantile(0.99, sum by (le) (
 ))
 ```
 
-**Rejections** (must stay zero — both levels queue rather than 429, so any
-rejection means the queue length limit was exhausted):
+**Rejections** (must stay zero — both levels buffer requests up to their
+per-queue `queueLengthLimit`, and anything beyond an exhausted queue is
+rejected with 429, so any rejection here means a queue overflowed):
 
 ```promql
 sum by (priority_level) (
@@ -144,12 +151,15 @@ sum by (priority_level) (
 )
 ```
 
-**Verify the schemas actually match** (non-zero dispatch on both dedicated
-levels while the controller is busy):
+**Verify the schemas actually match** (non-zero dispatch for all three
+FlowSchemas while the controller is busy — grouping by `flow_schema` as well
+as `priority_level` proves the intended schema did the routing, and covers
+`agent-sandbox-events`, whose traffic lands in `workload-low` and would be
+invisible to a priority-level-only filter):
 
 ```promql
-sum by (priority_level) (
-  rate(apiserver_flowcontrol_dispatched_requests_total{priority_level=~"agent-sandbox-.*"}[5m])
+sum by (flow_schema, priority_level) (
+  rate(apiserver_flowcontrol_dispatched_requests_total{flow_schema=~"agent-sandbox-.*"}[5m])
 )
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 
 - [**agent-sandbox-rl**](./agent-sandbox-rl): Generic, multi-cluster batch orchestration for running SWE-bench-style RL/eval workloads on Agent Sandbox warm pools.
 - [**aio-sandbox**](./aio-sandbox): An example of running All-in-One (AIO) Sandbox using agent-sandbox.
+- [**apf-insulation**](./apf-insulation): An opt-in API Priority and Fairness overlay giving the controller dedicated apiserver concurrency for high-rate claim workloads (claim path > bulk refill > events).
 - [**chrome-sandbox**](./chrome-sandbox): An example of running a Chrome browser in a sandbox.
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.

--- a/examples/apf-insulation/README.md
+++ b/examples/apf-insulation/README.md
@@ -1,0 +1,45 @@
+# APF Insulation for the Agent Sandbox Controller
+
+An **opt-in** [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/)
+overlay that gives the agent-sandbox controller dedicated apiserver
+concurrency, so that high-rate SandboxClaim workloads are insulated from
+other tenants' API traffic — and the controller's own bulk warm-pool refill
+traffic is insulated from its latency-critical claim-adoption writes.
+
+This is a cluster-operator decision. **Nothing in the default install
+applies these manifests, and they change nothing until you apply them.**
+
+## Apply
+
+```sh
+kubectl apply -f examples/apf-insulation/apf-insulation.yaml
+```
+
+## Roll back
+
+```sh
+kubectl delete -f examples/apf-insulation/apf-insulation.yaml
+```
+
+Deleting the FlowSchemas immediately returns the controller's traffic to the
+built-in `service-accounts` schema (shared `workload-low` level), i.e. the
+stock behavior.
+
+## What it creates
+
+| object | kind | purpose |
+|---|---|---|
+| `agent-sandbox-critical` | PriorityLevelConfiguration + FlowSchema | the SandboxClaim → Ready hot path (claim writes, sandbox adoption update/patch + status, the adoption-time pod patch, leader-election leases) |
+| `agent-sandbox-bulk` | PriorityLevelConfiguration + FlowSchema | everything else the controller does (warm-pool refill creates/deletes, informer list/watch, child objects, discovery) |
+| `agent-sandbox-events` | FlowSchema | routes controller Events to the shared `workload-low` level (sacrificial) |
+
+## Sizing
+
+Seat counts are **fractions of the server-wide inflight limits**, so the same
+manifest scales with `--max-requests-inflight` /
+`--max-mutating-requests-inflight` without edits. Before relying on this
+overlay at high claim rates, read
+[docs/apf-insulation.md](../../docs/apf-insulation.md) for the sizing rule
+(`seats(critical) >= 2x` the measured demand high watermark), the exact
+PromQL to measure demand and APF wait from apiserver metrics, and the
+caveats.

--- a/examples/apf-insulation/README.md
+++ b/examples/apf-insulation/README.md
@@ -9,6 +9,12 @@ traffic is insulated from its latency-critical claim-adoption writes.
 This is a cluster-operator decision. **Nothing in the default install
 applies these manifests, and they change nothing until you apply them.**
 
+Note this is isolation, **not a latency optimization at typical rates**: on
+an uncontended cluster APF wait is already ~0 and the overlay does not
+change request latency (measured A/B). Its value is guaranteed claim-path
+capacity under multi-tenant contention and at higher claim rates — see
+[docs/apf-insulation.md](../../docs/apf-insulation.md).
+
 ## Apply
 
 ```sh

--- a/examples/apf-insulation/apf-insulation.yaml
+++ b/examples/apf-insulation/apf-insulation.yaml
@@ -1,0 +1,219 @@
+# API Priority and Fairness (APF) insulation for the agent-sandbox controller.
+#
+# OPT-IN OVERLAY: nothing in the default install applies this file. It changes
+# cluster behavior only when a cluster operator runs
+#   kubectl apply -f examples/apf-insulation/apf-insulation.yaml
+# and is fully reverted by
+#   kubectl delete -f examples/apf-insulation/apf-insulation.yaml
+# See docs/apf-insulation.md for the sizing rule, how to measure, and caveats.
+#
+# WHY: out of the box, ALL of the controller's API traffic matches the
+# built-in `service-accounts` FlowSchema (matchingPrecedence 9000) and lands
+# in the shared `workload-low` priority level, together with every other
+# non-kube-system ServiceAccount in the cluster. Two failure modes follow:
+#   1. Another tenant's ServiceAccount can flood workload-low and queue the
+#      claim-adoption writes behind its traffic (cross-tenant interference).
+#   2. The controller's OWN bulk traffic — warm-pool replenishment creates
+#      (hundreds of sandboxes + pods + services after a large claim burst) —
+#      shares the same seats as the latency-critical adoption writes
+#      (self-interference).
+#
+# This overlay gives the controller two dedicated priority levels:
+#   - agent-sandbox-critical: the SandboxClaim -> Ready hot path (claim
+#     writes, sandbox adoption update/patch + status, the synchronous
+#     adoption-time pod patch) plus coordination leases (losing leader
+#     election mid-burst would abort every in-flight reconcile, and lease
+#     renewals are tiny).
+#   - agent-sandbox-bulk: everything else the controller does —
+#     replenishment creates/deletes, informer lists/watches, child-object
+#     management, discovery. Still dedicated (other tenants cannot queue
+#     it), but it can never crowd out the critical level.
+# Controller events are explicitly routed to the pre-existing shared
+# `workload-low` level: they are sacrificial and must never compete with
+# either dedicated level.
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: PriorityLevelConfiguration
+metadata:
+  name: agent-sandbox-critical
+  labels:
+    app: agent-sandbox-controller
+spec:
+  type: Limited
+  limited:
+    # 40 shares. Seats are FRACTIONS of the server-wide seat total:
+    #   seats(level) = shares(level) / sum(all levels' shares)
+    #                  x (--max-requests-inflight + --max-mutating-requests-inflight)
+    # On Kubernetes 1.35 the built-in mandatory+suggested levels sum to 245
+    # shares (catch-all 5, global-default 20, leader-election 10, node-high
+    # 40, system 30, workload-high 40, workload-low 100); adding critical=40
+    # and bulk=25 brings the total to 310, so critical gets 40/310 ~= 13% of
+    # the server's seats: ~77 seats at the apiserver defaults (400 read +
+    # 200 mutating = 600 seats), ~516 seats on a control plane tuned to
+    # 3000 read + 1000 mutating = 4000 seats. Size so that seats(critical)
+    # >= 2x the demand-seats high watermark measured at your peak claim rate
+    # (see docs/apf-insulation.md: a 300-claim simultaneous burst measured a
+    # 272-seat demand high watermark, so the 600-seat default server limits
+    # are NOT enough at that rate — raise the server limits, not the shares).
+    nominalConcurrencyShares: 40
+    # Keep 75% of the critical seats reserved even when other levels want to
+    # borrow; only 25% is lendable. The hot path must never find its seats
+    # loaned out at the start of a burst.
+    lendablePercent: 25
+    limitResponse:
+      # Queue (never 429): the controller retries with backoff, but a
+      # rejected adoption write costs a full reconcile round-trip.
+      type: Queue
+      queuing:
+        # This level serves a single flow (one ServiceAccount), so
+        # shuffle-sharding width is mostly irrelevant; 16 queues x hand size
+        # 4 are the upstream-suggested defaults for a dedicated level.
+        queues: 16
+        handSize: 4
+        # Deep enough to absorb a full burst's write storm (hundreds of
+        # in-flight adoption writes) without rejections.
+        queueLengthLimit: 100
+---
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: PriorityLevelConfiguration
+metadata:
+  name: agent-sandbox-bulk
+  labels:
+    app: agent-sandbox-controller
+spec:
+  type: Limited
+  limited:
+    # 25 shares = 25/310 ~= 8% of the server's seats (~48 seats at the
+    # 600-seat apiserver defaults, ~322 at 4000 seats). Replenishment bursts
+    # get real dedicated capacity, but always less than the critical level,
+    # so refill can never crowd out adoption writes. Same derivation as
+    # above: seats scale with the server-wide inflight limits, fractions
+    # preserved.
+    nominalConcurrencyShares: 25
+    # Most bulk capacity is lendable back to the rest of the cluster when
+    # the pool is quiescent; refill is throughput work, not latency work.
+    lendablePercent: 75
+    limitResponse:
+      type: Queue
+      queuing:
+        # Same single-flow reasoning as the critical level.
+        queues: 16
+        handSize: 4
+        # Replenishment offers large batches; queue them rather than 429
+        # them (a rejected create is retried by the pool controller anyway,
+        # at strictly higher total cost).
+        queueLengthLimit: 100
+---
+# Latency-critical hot path: everything on the SandboxClaim -> Ready chain.
+# matchingPrecedence must beat agent-sandbox-bulk (1000) and the built-in
+# service-accounts schema (9000); lower number wins.
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: agent-sandbox-critical
+  labels:
+    app: agent-sandbox-controller
+spec:
+  priorityLevelConfiguration:
+    name: agent-sandbox-critical
+  matchingPrecedence: 900
+  distinguisherMethod:
+    type: ByUser
+  rules:
+    - subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: agent-sandbox-controller
+            namespace: agent-sandbox-system
+      resourceRules:
+        # Claim reconcile writes: annotation updates, adoption update
+        # (optimistic lock), status patch.
+        - apiGroups: ["extensions.agents.x-k8s.io"]
+          resources: ["sandboxclaims", "sandboxclaims/status"]
+          verbs: ["*"]
+          clusterScope: true
+          namespaces: ["*"]
+        # Claim adoption on the Sandbox object (ownership/label patch) and
+        # the sandbox status patch that forwards Ready to the claim.
+        # Creates/deletes/lists/watches of sandboxes are deliberately NOT
+        # here — they are replenishment bulk.
+        - apiGroups: ["agents.x-k8s.io"]
+          resources: ["sandboxes", "sandboxes/status", "sandboxes/finalizers"]
+          verbs: ["get", "update", "patch"]
+          clusterScope: true
+          namespaces: ["*"]
+        # Synchronous adoption-time pod patch (strips safe-to-evict, applies
+        # claim labels) — sits on the pod-Ready -> claim-Ready chain.
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["update", "patch"]
+          clusterScope: true
+          namespaces: ["*"]
+        # Leader-election lease renewals: tiny, and starving them mid-burst
+        # would drop leadership and abort every in-flight reconcile.
+        - apiGroups: ["coordination.k8s.io"]
+          resources: ["leases"]
+          verbs: ["*"]
+          clusterScope: true
+          namespaces: ["*"]
+---
+# Controller events: sacrificial. Route to the pre-existing shared
+# workload-low level so they never occupy a seat in either dedicated level.
+# Precedence must be lower (= match earlier) than agent-sandbox-bulk's
+# catch-rest rule below.
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: agent-sandbox-events
+  labels:
+    app: agent-sandbox-controller
+spec:
+  priorityLevelConfiguration:
+    name: workload-low
+  matchingPrecedence: 950
+  distinguisherMethod:
+    type: ByUser
+  rules:
+    - subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: agent-sandbox-controller
+            namespace: agent-sandbox-system
+      resourceRules:
+        - apiGroups: ["", "events.k8s.io"]
+          resources: ["events"]
+          verbs: ["*"]
+          clusterScope: true
+          namespaces: ["*"]
+---
+# Catch-rest for the controller: replenishment creates/deletes, informer
+# list/watch, child objects (pods, services, PVCs, secrets, configmaps),
+# CRD patching, discovery. Dedicated seats so no other tenant can queue it,
+# below-critical shares so it cannot crowd out adoption writes.
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: agent-sandbox-bulk
+  labels:
+    app: agent-sandbox-controller
+spec:
+  priorityLevelConfiguration:
+    name: agent-sandbox-bulk
+  matchingPrecedence: 1000
+  distinguisherMethod:
+    type: ByUser
+  rules:
+    - subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: agent-sandbox-controller
+            namespace: agent-sandbox-system
+      resourceRules:
+        - apiGroups: ["*"]
+          resources: ["*"]
+          verbs: ["*"]
+          clusterScope: true
+          namespaces: ["*"]
+      nonResourceRules:
+        - nonResourceURLs: ["*"]
+          verbs: ["*"]

--- a/examples/apf-insulation/apf-insulation.yaml
+++ b/examples/apf-insulation/apf-insulation.yaml
@@ -62,13 +62,20 @@ spec:
     # isolation for multi-tenant and higher-rate regimes, not a latency
     # optimization at typical rates.
     nominalConcurrencyShares: 40
-    # Keep 75% of the critical seats reserved even when other levels want to
-    # borrow; only 25% is lendable. The hot path must never find its seats
-    # loaned out at the start of a burst.
-    lendablePercent: 25
+    # Lend NOTHING from the critical level (0 = the v1 default, stated
+    # explicitly): the hot path's allocation is a hard floor that other
+    # levels can never borrow from, matching the guarantee the docs
+    # advertise. Any lendablePercent > 0 would let other levels (which
+    # default to an unbounded borrowingLimitPercent) hold part of these
+    # seats exactly when a burst starts.
+    lendablePercent: 0
     limitResponse:
-      # Queue (never 429): the controller retries with backoff, but a
-      # rejected adoption write costs a full reconcile round-trip.
+      # Queue rather than reject: requests buffer up to queueLengthLimit
+      # per queue, and only overflow beyond that is rejected with 429.
+      # The controller retries a rejected adoption write with backoff, but
+      # it costs a full reconcile round-trip — so prefer queueing and watch
+      # the rejected-requests PromQL in docs/apf-insulation.md (it must
+      # stay zero).
       type: Queue
       queuing:
         # This level serves a single flow (one ServiceAccount), so
@@ -76,8 +83,9 @@ spec:
         # 4 are the upstream-suggested defaults for a dedicated level.
         queues: 16
         handSize: 4
-        # Deep enough to absorb a full burst's write storm (hundreds of
-        # in-flight adoption writes) without rejections.
+        # PER-QUEUE depth (not a total): sized to absorb a full burst's
+        # write storm across the flow's hand of queues; overflow beyond a
+        # full queue is rejected with 429.
         queueLengthLimit: 100
 ---
 apiVersion: flowcontrol.apiserver.k8s.io/v1
@@ -105,9 +113,10 @@ spec:
         # Same single-flow reasoning as the critical level.
         queues: 16
         handSize: 4
-        # Replenishment offers large batches; queue them rather than 429
-        # them (a rejected create is retried by the pool controller anyway,
-        # at strictly higher total cost).
+        # PER-QUEUE depth: buffer replenishment batches up to this limit
+        # per queue; overflow beyond a full queue is rejected with 429 (a
+        # rejected create is retried by the pool controller anyway, at
+        # strictly higher total cost — keep rejections at zero).
         queueLengthLimit: 100
 ---
 # Latency-critical hot path: everything on the SandboxClaim -> Ready chain.

--- a/examples/apf-insulation/apf-insulation.yaml
+++ b/examples/apf-insulation/apf-insulation.yaml
@@ -52,9 +52,15 @@ spec:
     # 200 mutating = 600 seats), ~516 seats on a control plane tuned to
     # 3000 read + 1000 mutating = 4000 seats. Size so that seats(critical)
     # >= 2x the demand-seats high watermark measured at your peak claim rate
-    # (see docs/apf-insulation.md: a 300-claim simultaneous burst measured a
-    # 272-seat demand high watermark, so the 600-seat default server limits
-    # are NOT enough at that rate — raise the server limits, not the shares).
+    # (see docs/apf-insulation.md). Historical context: during the latency
+    # investigation, at PRE-optimization controller write volumes, a
+    # 300-claim simultaneous burst measured a 272-seat demand high watermark
+    # — above the 600-seat default server limits; the fix is raising the
+    # server limits, not the shares. Current optimized write volumes measure
+    # far lower demand (86-seat critical high watermark at 45 claims/s
+    # sustained) and do not saturate stock limits — this overlay is
+    # isolation for multi-tenant and higher-rate regimes, not a latency
+    # optimization at typical rates.
     nominalConcurrencyShares: 40
     # Keep 75% of the critical seats reserved even when other levels want to
     # borrow; only 25% is lendable. The hot path must never find its seats

--- a/examples/apf-insulation/apf-insulation.yaml
+++ b/examples/apf-insulation/apf-insulation.yaml
@@ -140,21 +140,32 @@ spec:
           serviceAccount:
             name: agent-sandbox-controller
             namespace: agent-sandbox-system
+      # VERBS ARE DELIBERATELY NARROW: only the write verbs each resource
+      # needs on the reconcile hot path are listed. Everything else —
+      # informer list/watch (including relists), reads, deletes,
+      # deletecollection — deliberately falls through to agent-sandbox-bulk
+      # (the catch-rest schema for this ServiceAccount at precedence 1000;
+      # this schema matches first at 900 only for the verbs below). A
+      # wildcard here would route informer relists into the critical level
+      # and dilute the guarantee it exists to provide.
       resourceRules:
-        # Claim reconcile writes: annotation updates, adoption update
-        # (optimistic lock), status patch.
+        # Claim reconcile writes: annotation/adoption update (optimistic
+        # lock) and metadata patches = update; status patch and annotation
+        # merge patches = patch. The controller never creates or deletes
+        # claims (users do), and claim reads come from the informer cache.
         - apiGroups: ["extensions.agents.x-k8s.io"]
           resources: ["sandboxclaims", "sandboxclaims/status"]
-          verbs: ["*"]
+          verbs: ["update", "patch"]
           clusterScope: true
           namespaces: ["*"]
         # Claim adoption on the Sandbox object (ownership/label patch) and
-        # the sandbox status patch that forwards Ready to the claim.
+        # the sandbox status update/patch that forwards Ready to the claim.
         # Creates/deletes/lists/watches of sandboxes are deliberately NOT
-        # here — they are replenishment bulk.
+        # here — they are replenishment bulk; sandbox reads come from the
+        # informer cache.
         - apiGroups: ["agents.x-k8s.io"]
           resources: ["sandboxes", "sandboxes/status", "sandboxes/finalizers"]
-          verbs: ["get", "update", "patch"]
+          verbs: ["update", "patch"]
           clusterScope: true
           namespaces: ["*"]
         # Synchronous adoption-time pod patch (strips safe-to-evict, applies
@@ -164,11 +175,13 @@ spec:
           verbs: ["update", "patch"]
           clusterScope: true
           namespaces: ["*"]
-        # Leader-election lease renewals: tiny, and starving them mid-burst
-        # would drop leadership and abort every in-flight reconcile.
+        # Leader election: each renewal is a lease get + update, and
+        # (re)acquisition is a create; starving any of them mid-burst would
+        # drop leadership and abort every in-flight reconcile. No
+        # list/watch/delete — leader election issues none on the hot path.
         - apiGroups: ["coordination.k8s.io"]
           resources: ["leases"]
-          verbs: ["*"]
+          verbs: ["get", "create", "update"]
           clusterScope: true
           namespaces: ["*"]
 ---
@@ -202,9 +215,12 @@ spec:
           namespaces: ["*"]
 ---
 # Catch-rest for the controller: replenishment creates/deletes, informer
-# list/watch, child objects (pods, services, PVCs, secrets, configmaps),
-# CRD patching, discovery. Dedicated seats so no other tenant can queue it,
-# below-critical shares so it cannot crowd out adoption writes.
+# list/watch — including full relists, which land here BY DESIGN because the
+# critical schema lists only hot-path write verbs — child objects (pods,
+# services, PVCs, secrets, configmaps), CRD patching, discovery, and any
+# read/delete verb the critical schema deliberately excludes. Dedicated
+# seats so no other tenant can queue it, below-critical shares so it cannot
+# crowd out adoption writes.
 apiVersion: flowcontrol.apiserver.k8s.io/v1
 kind: FlowSchema
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds an **opt-in** API Priority and Fairness overlay
(`examples/apf-insulation/`) plus an operator guide
(`docs/apf-insulation.md`). Manifests and docs only — no code changes, and
the default/release manifests are untouched: **nothing changes on any
cluster unless an operator explicitly applies the overlay**, and
`kubectl delete -f` reverts it completely.

Out of the box, all of the controller's API traffic matches the built-in
`service-accounts` FlowSchema and shares the `workload-low` priority level
with every other non-kube-system ServiceAccount. At high SandboxClaim rates
that leaves two exposure points: other tenants can queue the controller's
claim-adoption writes behind their traffic, and the controller's own
warm-pool refill bursts compete for the same seats as its latency-critical
adoption writes.

The overlay splits the controller's traffic into three classes with strict
priority ordering — claim path (`agent-sandbox-critical`, 40 shares) > bulk
refill (`agent-sandbox-bulk`, 25 shares) > events (routed to the shared
`workload-low`, sacrificial). Every numeric in the manifest carries a
comment tying it to its derivation; because APF seats are fractions of the
server-wide inflight limits, raising
`--max-requests-inflight`/`--max-mutating-requests-inflight` scales every
level proportionally with no manifest edits (600 → 4000 total seats takes
the critical level from ~77 to ~516 seats). The docs page gives the sizing
rule (`seats(critical) >= 2x` the demand-seats high watermark at peak claim
rate) and the exact PromQL to measure demand, current seats, APF wait p99,
and rejections from apiserver metrics.

**Measured verification** (2026-07-23; kops, 12 worker nodes, Kubernetes
v1.35.6, controller at current main dcd2fb4; 45 claims/s sustained
workload):

- *Routing (same-cluster A/B, stock inflight limits):* with the overlay
  applied, the controller's traffic moved out of `workload-low` (75.0k
  requests, demand high watermark 161 seats, in the baseline leg) into
  `agent-sandbox-critical` (51.0k requests, HWM 86) and
  `agent-sandbox-bulk` (21.1k requests, HWM 52), leaving `workload-low`
  with events only (3.4k requests). APF wait p99 stayed ≤20ms on all
  levels; zero rejections.
- *Neutrality for the rest of the cluster:* the `system`, `workload-high`,
  `leader-election` and `node-high` levels all held wait p50 and p99 ≤5ms
  with unchanged demand and zero rejections — the two new levels take
  their fraction without disturbing built-in traffic.
- *Sizing rule (second cluster, tuned limits, mutating inflight raised to
  1000):* the critical level resolved to ≈516 seats against a measured
  demand HWM of 115 — the `>=2x` rule holds with ~4.5x headroom; wait p99
  ≤5ms on every level in both configurations; zero rejections.

**What this does NOT claim:** there was no request-latency delta
attributable to the overlay in either configuration — APF queueing waits
are ~0 in all legs, because the current controller's optimized write
volumes do not saturate the stock 600-seat limits at this rate. The
overlay's value is isolation and guaranteed claim-path capacity under
multi-tenant contention and at higher rates, not a latency win at typical
rates. (Historical context, kept in the docs as the motivation for the
sizing rule: at pre-optimization controller write volumes, a 300-claim
burst saturated an undersized dedicated level — 272-seat demand HWM against
77 seats, APF wait p99 ~359ms — which is the failure mode the sizing rule
and the measurement PromQL exist to catch.)

Defaults are deliberately left to cluster operators: correct sizing depends
on the server's inflight limits, the cluster's other tenants, and the
target claim rate, so this ships as an example overlay rather than part of
the install manifests.

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an opt-in API Priority and Fairness (APF) insulation overlay for Agent Sandbox controller workloads, prioritizing the claim hot path, isolating bulk work, and routing controller event writes to a shared lower-priority level.

- **Documentation**
  - Added a dedicated APF guidance page with priority breakdown, seat allocation and sizing rules (based on server inflight concurrency), PromQL examples for demand/allocation and p99 wait, and operational caveats/rollback steps.
  - Added and documented a new `apf-insulation` example with apply/rollback instructions and a manifest overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->