### PR TITLE
chore(controller): strip Pod finalizers from informer cache transform

### DIFF
--- a/cmd/agent-sandbox-controller/cacheoptions.go
+++ b/cmd/agent-sandbox-controller/cacheoptions.go
@@ -37,7 +37,8 @@ import (
 //     update/create, where an absent managedFields means "leave server-side
 //     field management unchanged". Pure decode-CPU/memory win.
 //   - The Pod cache additionally drops the pod spec except spec.nodeName —
-//     the only spec field any controller reads (see PodCacheTransform).
+//     the only spec field any controller reads (see PodCacheTransform) —
+//     and metadata.finalizers, which no controller reads on Pods.
 //
 // With scopeToTrackingLabel, the Pod and Service informers are additionally
 // restricted to objects carrying the sandbox tracking label; see the

--- a/controllers/pod_cache_transform_test.go
+++ b/controllers/pod_cache_transform_test.go
@@ -35,6 +35,7 @@ func fullPodFixture() *corev1.Pod {
 			ManagedFields: []metav1.ManagedFieldsEntry{{
 				Manager: "kubelet", Operation: metav1.ManagedFieldsOperationApply,
 			}},
+			Finalizers: []string{"test-finalizer"},
 		},
 		Spec: corev1.PodSpec{
 			NodeName: "node-7",
@@ -73,6 +74,9 @@ func TestPodCacheTransform(t *testing.T) {
 	// Dropped.
 	if pod.ManagedFields != nil {
 		t.Error("managedFields not stripped")
+	}
+	if pod.Finalizers != nil {
+		t.Error("finalizers not stripped")
 	}
 	if len(pod.Spec.Containers) != 0 || len(pod.Spec.InitContainers) != 0 ||
 		len(pod.Spec.Volumes) != 0 || len(pod.Spec.Tolerations) != 0 {

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -68,6 +68,9 @@ const (
 //
 //   - metadata.managedFields: written via server-side apply by the kubelet on
 //     every status update and never read by any controller here.
+//   - metadata.finalizers: never read on Pods by any controller in this repo
+//     (the sandboxes/finalizers RBAC is for the Sandbox CR itself, not Pods).
+//     Stripping is safe and saves a trivial amount of memory.
 //   - spec: the only spec field any controller reads is spec.nodeName
 //     (propagated to Sandbox status), so it is the only field preserved. The
 //     pod spec the controller WRITES is built from the Sandbox's PodTemplate
@@ -86,6 +89,7 @@ func PodCacheTransform(obj any) (any, error) {
 		return obj, nil
 	}
 	pod.ManagedFields = nil
+	pod.Finalizers = nil
 	pod.Spec = corev1.PodSpec{NodeName: pod.Spec.NodeName}
 	return pod, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

`PodCacheTransform` already strips `managedFields` and the entire Pod `spec` (except `spec.nodeName`) before objects enter the informer cache, keeping cache memory and per-event JSON-decode cost proportional to what the
controllers actually read.

This PR adds `metadata.finalizers` to the strip list. No controller in thisrepo reads finalizers on Pod objects — the `sandboxes/finalizers` RBAC rule applies to the Sandbox CR itself, not Pods — so carrying them in the cache is pure waste.

The change is safe for merge-patch correctness: controllers never write Pod finalizers either, so stripped finalizers appear on neither side of the `client.MergeFrom` diff and can never leak into (or be deleted by) a patch.

#### Which issue(s) this PR is related to:

Follow-up to #1253 (which introduced `PodCacheTransform` and `DefaultTransform`).

#### Release Note

```release-note
chore(controller): drop Pod finalizers from informer cache transform
```