### PR TITLE
stress-test: node root volumes on pd-ssd; control plane to c3-standard-22

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -148,7 +148,19 @@ echo "Using node count: ${STRESS_NODE_COUNT}"
 # controller's workqueue wait collapsing 445ms -> 3ms downstream. Override via
 # STRESS_CONTROL_PLANE_SIZE (e.g. back to n2-standard-8) to reproduce the
 # saturated-server regime.
-STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-n2-standard-16}"
+#
+# Second round: with the node I/O wall lifted, the bottleneck moved back to
+# control-plane CPU. The pd-ssd leg (run 2080670751672766464) reached 151
+# claims/s with the apiserver at 10.5 of 16 n2 cores and 8ms latency; the
+# 40-node leg (run 2080670827233153024) reached 145/s with the apiserver at
+# 12.0 cores and latency degrading to 20ms - saturation on the shared
+# 16-core box. Rather than doubling n2 again, move to c3 (Sapphire Rapids,
+# roughly +35% per core over n2's Cascade/Ice Lake): apiserver request
+# latency benefits from the faster cores directly, not just from more of
+# them. NOTE: c3/c4 machine families do not support pd-standard boot disks,
+# so the control-plane root volume is set to pd-ssd below alongside the
+# nodes'.
+STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
 echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
 
 echo "Creating kOps cluster configuration..."
@@ -178,13 +190,20 @@ kops create cluster \
 # 15ms/call), run_podsandbox mean rose ~130ms -> 1.0-1.2s under load, and
 # iowait hit ~2.1-2.5 cores/node while node CPU stayed under half busy.
 # pd-ssd raises IOPS/GB 40x over pd-standard and attacks that wall
-# directly. The control plane keeps the default: etcd-main fsync was 1.5ms
-# mean there (not a bottleneck), and changing one disk at a time keeps runs
-# attributable.
+# directly.
 STRESS_NODE_VOLUME_TYPE="${STRESS_NODE_VOLUME_TYPE:-pd-ssd}"
 echo "Using node root volume type: ${STRESS_NODE_VOLUME_TYPE}"
 kops edit instancegroup --name "${CLUSTER_NAME}" "nodes-${ZONE}" \
   --set "spec.rootVolume.type=${STRESS_NODE_VOLUME_TYPE}"
+
+# Control-plane root volume: required to be non-pd-standard by the c3
+# machine family (see the control-plane sizing note above), and it retires
+# the cluster's last spinning disk. Nothing latency-critical lives on the
+# CP root - the etcd data volumes are separate PDs and already pd-ssd by
+# kOps' GCE default (DefaultGCEEtcdVolumeType; measured 1.5ms mean fsync) -
+# so this is an enabler, not a tuning claim.
+kops edit instancegroup --name "${CLUSTER_NAME}" "control-plane-${ZONE}" \
+  --set "spec.rootVolume.type=pd-ssd"
 
 # authorizationAlwaysAllowPaths: allow unauthenticated GETs of /metrics on
 # kube-controller-manager and kube-scheduler so the stress test can scrape

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -171,6 +171,21 @@ kops create cluster \
 # list -- so tuning changes stop conflicting with each other. The edits
 # mutate the spec in the state store; `kops update cluster` below applies them.
 
+# Node root volumes: kOps' GCE default is pd-standard (spinning disk), and
+# the bpftrace node profiler (kindnet run 2080606920242106368, 20 nodes)
+# showed the pod launch pipeline is disk-sync-bound on it: containerd spent
+# 2,718s blocked across 923k fsync-family calls (kubelet another 987s at
+# 15ms/call), run_podsandbox mean rose ~130ms -> 1.0-1.2s under load, and
+# iowait hit ~2.1-2.5 cores/node while node CPU stayed under half busy.
+# pd-ssd raises IOPS/GB 40x over pd-standard and attacks that wall
+# directly. The control plane keeps the default: etcd-main fsync was 1.5ms
+# mean there (not a bottleneck), and changing one disk at a time keeps runs
+# attributable.
+STRESS_NODE_VOLUME_TYPE="${STRESS_NODE_VOLUME_TYPE:-pd-ssd}"
+echo "Using node root volume type: ${STRESS_NODE_VOLUME_TYPE}"
+kops edit instancegroup --name "${CLUSTER_NAME}" "nodes-${ZONE}" \
+  --set "spec.rootVolume.type=${STRESS_NODE_VOLUME_TYPE}"
+
 # authorizationAlwaysAllowPaths: allow unauthenticated GETs of /metrics on
 # kube-controller-manager and kube-scheduler so the stress test can scrape
 # them through the apiserver pod proxy (the apiserver strips the


### PR DESCRIPTION
#### What this PR does / why we need it

Puts the benchmark worker nodes' root volumes on **pd-ssd** (env-overridable as `STRESS_NODE_VOLUME_TYPE`). kOps' GCE default is `pd-standard` — spinning disk (`DefaultVolumeType` in `pkg/model/gcemodel`) — and the bpftrace node profiler from #1204 (kindnet run `2080606920242106368`, 20 nodes) shows the pod launch pipeline is disk-sync-bound on exactly that volume:

- containerd blocked **2,718s across 923,614 fsync-family calls** over the run (kubelet another 987s at 15ms/call) — ~128 fsyncs/s/node against containerd's serialized boltdb metadata store
- containerd `run_podsandbox` mean rises **~130ms → 1.0–1.2s** in the loaded phases
- **iowait 2.1–2.5 cores/node** while node CPU stays under half busy (3.3 of 8 cores)
- the cluster walls at ~90 pods/s = ~4.5 creates/s/node with the control plane healthy (apiserver 9.7/16 cores, etcd-main fsync 1.5ms, KCM/scheduler idle)

pd-ssd raises IOPS/GB ~40× over pd-standard on the exact path the profiler blames. The control plane keeps the default volume so only one disk changes at a time and runs stay attributable.

Related: the WIP local-NVMe (#1206) and tmpfs (#1208) `/var/lib/containerd` experiments are the aggressive versions of the same fix; this is the conservative, production-shaped leg, and the presubmit benchmark on this PR is its own A/B against the runs above. Companion experiment: the 40-node scale-out PR tests the same wall from the other side; the two are deliberately separate PRs so attribution stays clean.

#### Which issue(s) this PR fixes

None — follow-up to the #1204 profiler findings.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Benchmark runs can now configure the worker nodes’ root volume type.
  - Added support for selecting the volume type through a configurable setting, defaulting to `pd-ssd`.
  - The selected volume type is logged during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update (second commit): control plane → c3-standard-22 on pd-ssd.** The first run of this PR (`2080670751672766464`) lifted throughput 91 → **151 claims/s** (+66%) and moved the bottleneck back to control-plane CPU (apiserver 10.5 of 16 n2 cores; the 40-node leg on #1276 hit 12.0 cores with latency degrading to 20ms). Rather than doubling n2 again, this jumps to **c3 (Sapphire Rapids, ~+35%/core)** — apiserver latency benefits from faster cores directly, and 22 c3 cores ≈ 2× the n2-16's effective capacity.

Two consequences folded in deliberately:
- **The control-plane root volume moves to pd-ssd in this PR** (not a separate one): c3/c4 machine families reject pd-standard boot disks, so it's a hard prerequisite of the family change, and it retires the cluster's last spinning disk. Nothing latency-critical lives on the CP root.
- **No etcd disk PR is needed**: the etcd data volumes are separate PDs and already pd-ssd by kOps' GCE default (`DefaultGCEEtcdVolumeType` in `pkg/model/master_volumes.go`) — consistent with the measured 1.5ms mean fsync.

Quota note: c3 draws from a different quota bucket (`C3_CPUS`) than n2 in the boskos projects; if the presubmit fails on quota, the fallback is c2-standard-30 (Cascade Lake compute-optimized, supports pd-standard, ~+15-20%/core).
