### PR TITLE
WIP: stress-test: scale the benchmark to 40 worker nodes

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1595,6 +1595,24 @@ func sandboxMarkedExpired(sandbox *sandboxv1beta1.Sandbox) bool {
 	return cond != nil && (cond.Reason == sandboxv1beta1.SandboxReasonExpired)
 }
 
+// sandboxUpdatePredicate admits Sandbox UPDATE events only when the spec
+// changed (metadata.generation). Status-only updates are the controller's
+// own writes echoed back through the watch: without this filter every
+// status write re-enqueues the key. Run 2080848067543699456 measured 592
+// sandbox reconciles/s against 156 sandbox lifecycles/s with exactly 2
+// status writes per lifecycle — the echoes are ~half of all reconcile
+// executions. Creates, deletes, and pod events (via Owns) are unaffected.
+//
+// Pod metadata propagation is NOT affected: it reads
+// spec.podTemplate.metadata (Deployment-style), and podTemplate edits bump
+// the generation. Warm-pool adoption also passes for the same reason (the
+// SandboxClaim controller mutates spec.podTemplate during adoption). The
+// only filtered edits are to the Sandbox's own top-level labels and
+// annotations, which the reconciler does not act on apart from mirroring
+// two system labels (created-by, warm-pool hash) that are set at
+// creation/adoption time anyway.
+var sandboxUpdatePredicate predicate.Predicate = predicate.GenerationChangedPredicate{}
+
 // podSandboxNameHashIndexer extracts the sandboxLabel value for the
 // podSandboxNameHashIndex cache field index. Shared with tests so fake
 // clients register the same index the manager does.
@@ -1626,7 +1644,7 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&sandboxv1beta1.Sandbox{}).
+		For(&sandboxv1beta1.Sandbox{}, builder.WithPredicates(sandboxUpdatePredicate)).
 		Owns(&corev1.Pod{}, builder.WithPredicates(labelSelectorPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(labelSelectorPredicate)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -532,6 +532,42 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	return nil
 }
 
+// stripManagedFieldsPatch resets a resource's managedFields: a non-nil empty
+// list (or a list of one empty entry) is the API server's documented reset
+// sentinel (apimachinery isResetManagedFields).
+var stripManagedFieldsPatch = []byte(`{"metadata":{"managedFields":[{}]}}`)
+
+// stripPodManagedFields clears managedFields on a just-created Pod, opting
+// its remaining lifecycle out of the API server's field tracking.
+//
+// Why: field tracking measured at 14.6% of kube-apiserver CPU during the
+// mif600 stress phase (run 2080880843894558720; FieldManager.Update alone
+// 9.1%), and pods are the dominant payer: every scheduler binding, kubelet
+// status PATCH, and teardown write converts the full object to
+// structured-merge-diff typed form twice and diffs it. The apiserver's
+// skipNonAppliedManager short-circuits all of that for plain (non-apply)
+// writes when the live object has no managedFields - and its subresource
+// path takes managedFields from the live object only, so a stripped pod
+// cannot be re-seeded by kubelet status writes. Cheaper pods/status PATCHes
+// feed straight into kubelet's serialized status-sync loop, the measured
+// end-to-end bottleneck.
+//
+// Objects are always born tracked (DefaultTrackOnCreateProbability=1, and
+// the reset sentinel is ignored on create), so the strip must be this
+// separate follow-up patch: one merge-patch write buys the fast path for
+// the pod's remaining ~6-10 writes. The only path that resumes tracking is
+// a server-side-apply against the pod, which nothing in the sandbox
+// lifecycle performs; if some external client does, tracking resumes with
+// before-first-apply semantics and only the CPU saving is lost.
+//
+// Best-effort by design: a failed strip leaves a normally-tracked pod.
+func stripPodManagedFields(ctx context.Context, c client.Client, pod *corev1.Pod) {
+	if err := c.Patch(ctx, pod, client.RawPatch(types.MergePatchType, stripManagedFieldsPatch)); err != nil {
+		log.FromContext(ctx).V(1).Info("Failed to strip pod managedFields; pod stays field-tracked",
+			"Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name, "error", err)
+	}
+}
+
 // nodeNameOnlyChange reports whether the node assignment is the only
 // difference between the two statuses.
 func nodeNameOnlyChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bool {
@@ -1192,6 +1228,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		logger.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 		return nil, err
 	}
+
+	stripPodManagedFields(ctx, r.Client, pod)
 
 	if err := ensurePodNameAnnotation(pod.Name); err != nil {
 		return nil, err

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1060,6 +1060,15 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return nil
 		}
 
+		// The annotation exists to track a pod whose name differs from the
+		// sandbox name (a warm-pool adoption). Every reader falls back to
+		// the sandbox name when the annotation is absent (resolvePodName,
+		// the Go and Python SDKs), so recording the default would spend an
+		// API request per sandbox to say nothing.
+		if podName == sandbox.Name {
+			return nil
+		}
+
 		patch := client.MergeFrom(sandbox.DeepCopy())
 		if sandbox.Annotations == nil {
 			sandbox.Annotations = make(map[string]string)

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -51,6 +52,20 @@ func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
 		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
 		WithIndex(&corev1.Pod{}, podSandboxNameHashIndex, podSandboxNameHashIndexer).
 		WithRuntimeObjects(initialObjs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// The fake client has no field manager: applying the
+			// managedFields reset sentinel would store a literal empty
+			// entry and bump the pod's ResourceVersion, which the real
+			// API server does not do meaningfully here. Swallow it so
+			// tests observe the same object state as a real cluster.
+			// TestPodManagedFieldsStripped asserts the patch is issued.
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if data, err := patch.Data(obj); err == nil && string(data) == string(stripManagedFieldsPatch) {
+					return nil
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).
 		Build()
 }
 
@@ -4352,4 +4367,70 @@ func TestReconcileCoalescesNodeNameStatusWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
 	assert.Equal(t, "node-2", live.Status.NodeName, "node changes on a Ready sandbox must be written immediately")
+}
+
+// TestPodManagedFieldsStripped verifies that creating a Pod for a Sandbox is
+// followed by exactly one managedFields-reset merge patch against that Pod
+// (the apiserver-side fast-path opt-out; see stripPodManagedFields).
+func TestPodManagedFieldsStripped(t *testing.T) {
+	sandboxName := "strip-mf"
+	sandboxNs := "strip-ns"
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       sandboxName,
+			Namespace:  sandboxNs,
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "test-container"}},
+			},
+		}}},
+	}
+
+	var strippedPods []string
+	c := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
+		WithIndex(&corev1.Pod{}, podSandboxNameHashIndex, podSandboxNameHashIndexer).
+		WithRuntimeObjects(sb).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				data, err := patch.Data(obj)
+				if err != nil {
+					return err
+				}
+				if _, isPod := obj.(*corev1.Pod); isPod && string(data) == string(stripManagedFieldsPatch) {
+					// Record and swallow: the fake client has no field
+					// manager, so applying the reset sentinel would store a
+					// literal empty entry instead of clearing tracking.
+					strippedPods = append(strippedPods, obj.GetName())
+					return nil
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	r := SandboxReconciler{
+		Client:        c,
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+	_, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{sandboxName}, strippedPods,
+		"expected exactly one managedFields strip patch for the created pod")
+
+	// A second reconcile must not strip again: the pod already exists.
+	_, err = r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+	})
+	require.NoError(t, err)
+	require.Len(t, strippedPods, 1, "strip must only happen on the create path")
 }

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1172,9 +1172,9 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "persists owner reference when adopting unowned pod whose labels are already correct",
@@ -1224,9 +1224,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "adopts unowned pod carrying legacy tracking label when adoptable label is absent",
@@ -1272,9 +1272,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name:    "reconcilePod creates a new Pod",
@@ -1303,9 +1303,9 @@ func TestReconcilePod(t *testing.T) {
 					},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "drops user-supplied system-reserved labels and annotations to prevent hijacking",
@@ -1357,9 +1357,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "scrubs stale system labels/annotations recorded by an older controller",
@@ -1411,9 +1411,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "does not propagate system labels from Sandbox metadata to Pod",
@@ -1448,7 +1448,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "does not propagate system labels from Sandbox PodTemplate to Pod",
@@ -1485,7 +1485,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "does not propagate template-ref-hash from Sandbox metadata to Pod",
@@ -1520,7 +1520,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "propagates warm pool label from Sandbox owner reference to Pod",
@@ -1565,7 +1565,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes warm pool label from Pod when Sandbox is no longer owned by SandboxWarmPool",
@@ -1621,9 +1621,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "adds warm pool label to existing Pod when Sandbox is owned by SandboxWarmPool",
@@ -1691,9 +1691,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "propagates template-ref-hash label from Sandbox labels to new Pod",
@@ -1738,7 +1738,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "adds template-ref-hash label to existing Pod during reconciliation",
@@ -1802,7 +1802,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "both warm-pool-sandbox and template-ref-hash coexist on Pod",
@@ -1849,7 +1849,7 @@ func TestReconcilePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
 			},
-			wantSandboxAnnotations: map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: sandboxName},
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes template-ref-hash label from Pod when Sandbox is not owned by extensions controller",
@@ -1903,9 +1903,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes template-ref-hash label from Pod when absent from Sandbox labels but still extensions-owned",
@@ -1968,9 +1968,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "delete pod if mode is Suspended",
@@ -2354,9 +2354,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "refuses to adopt unowned pod that lacks pool authorization label",
@@ -2423,9 +2423,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name:        "normalizes invalid created-by label to unknown",
@@ -2458,9 +2458,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "updates and normalizes created-by label on existing Pod",
@@ -2516,9 +2516,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 		{
 			name: "removes created-by label from existing Pod when Sandbox lacks it",
@@ -2567,9 +2567,9 @@ func TestReconcilePod(t *testing.T) {
 					Containers: []corev1.Container{{Name: "test-container"}},
 				},
 			},
-			wantSandboxAnnotations: map[string]string{
-				sandboxv1beta1.SandboxPodNameAnnotation: sandboxName,
-			},
+			// The pod name matches the sandbox name (the resolvePodName
+			// fallback), so no tracking annotation is written.
+			wantSandboxAnnotations: map[string]string{},
 		},
 	}
 

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -4433,4 +4434,30 @@ func TestPodManagedFieldsStripped(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, strippedPods, 1, "strip must only happen on the create path")
+}
+
+// TestSandboxUpdatePredicate pins the event-filtering behavior: the
+// controller must not re-reconcile in response to its own status writes
+// (the reconcile-amplification fix), but must reconcile on spec changes —
+// including warm-pool adoption, which mutates spec.podTemplate.
+func TestSandboxUpdatePredicate(t *testing.T) {
+	base := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb", Generation: 1},
+	}
+
+	statusOnly := base.DeepCopy()
+	statusOnly.Status.Conditions = []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}}
+	statusOnly.Status.PodIPs = []string{"10.0.0.1"}
+	require.False(t, sandboxUpdatePredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: statusOnly}),
+		"status-only updates must be filtered")
+
+	specChange := base.DeepCopy()
+	specChange.Generation = 2
+	require.True(t, sandboxUpdatePredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: specChange}),
+		"generation changes must be admitted")
+
+	annotationOnly := base.DeepCopy()
+	annotationOnly.Annotations = map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: "some-pod"}
+	require.False(t, sandboxUpdatePredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: annotationOnly}),
+		"annotation-only updates are deliberately filtered (see sandboxUpdatePredicate)")
 }

--- a/dev/ci/presubmits/benchmarks-kops-gcp-cilium
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-cilium
@@ -22,4 +22,14 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 export CNI=cilium
+
+# Cost control: the cilium leg exists to isolate CNI costs, which shows at
+# any scale - it does not need the kindnet hero-run cluster (80 nodes,
+# c3-standard-44). 10 nodes on the small control plane, with the sweep
+# capped at mif600 (10 nodes = ~1,100 pod capacity; mif1200+ would
+# oversubscribe it).
+export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-10}"
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
+export STRESS_PHASES="${STRESS_PHASES:-fill,probe,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}"
+
 exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-claims/run
@@ -37,6 +37,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # replenishment without the pool provisioning step dominating the job's
 # wall-clock the way the 20-node churn scenario's sizing would suggest.
 export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-6}"
+# 6 nodes do not need the hero-run control plane; keep the smaller box.
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
 
 # claims-warm only: pool provisioning is setup (untimed), the burst is the
 # measurement. Sharding the harness's creates over 4 HTTP/2 connections keeps

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -127,14 +127,16 @@ trap cleanup EXIT
 CNI="${CNI:-cilium}"
 echo "Using CNI: ${CNI}"
 
-# Cluster-scale experiment: 20 worker nodes instead of 3. Per-node launch
-# throughput is wall-limited at ~5 pods/s (node I/O; see the Node Kernel
-# report page), so cluster throughput scales with node count -- this run
-# pushes ~100 pods/s through the control plane to find the cluster-scale
-# bottlenecks (apiserver CPU hit 4.5-5.5 cores at ~87/s in the 1122-era
-# runs; the sandbox controller workqueue and KCM client QPS are the other
-# candidates).
-STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
+# Cluster-scale experiment: 40 worker nodes. At 20 nodes the cluster walls
+# at ~90 pods/s = ~4.5 creates/s/node, and the wall is node-local (kindnet
+# run 2080606920242106368: containerd run_podsandbox mean ~130ms -> 1.0-1.2s
+# under load, iowait 2.1-2.5 cores/node, node CPU under half busy) while the
+# control plane has headroom (apiserver 9.7 of 16 cores, etcd fsync 1.5ms,
+# KCM/scheduler idle). If the per-node wall holds, 40 nodes should approach
+# ~180 pods/s; the run also probes what saturates next (apiserver CPU is the
+# leading candidate at ~2x its current burn). 40x n2-standard-8 + the
+# n2-standard-16 control plane = 336 N2 vCPUs from the boskos project.
+STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-40}"
 echo "Using node count: ${STRESS_NODE_COUNT}"
 
 # Control-plane sizing: on n2-standard-8 the throughput phases pin

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -136,7 +136,7 @@ echo "Using CNI: ${CNI}"
 # ~180 pods/s; the run also probes what saturates next (apiserver CPU is the
 # leading candidate at ~2x its current burn). 40x n2-standard-8 + the
 # n2-standard-16 control plane = 336 N2 vCPUs from the boskos project.
-STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-40}"
+STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-80}"
 echo "Using node count: ${STRESS_NODE_COUNT}"
 
 # Control-plane sizing: on n2-standard-8 the throughput phases pin
@@ -162,7 +162,7 @@ echo "Using node count: ${STRESS_NODE_COUNT}"
 # them. NOTE: c3/c4 machine families do not support pd-standard boot disks,
 # so the control-plane root volume is set to pd-ssd below alongside the
 # nodes'.
-STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
+STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-44}"
 echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
 
 echo "Creating kOps cluster configuration..."
@@ -236,8 +236,8 @@ kops edit cluster --name "${CLUSTER_NAME}" \
 # left KCM throttling client-side, so go to 500/500 to take the client
 # limiter out of the measurement entirely.
 kops edit cluster --name "${CLUSTER_NAME}" \
-  --set cluster.spec.kubeControllerManager.kubeAPIQPS=500 \
-  --set cluster.spec.kubeControllerManager.kubeAPIBurst=500
+  --set cluster.spec.kubeControllerManager.kubeAPIQPS=1000 \
+  --set cluster.spec.kubeControllerManager.kubeAPIBurst=1000
 
 # etcdClusters[].manager.listenMetricsURLs: have etcd serve its dedicated
 # plain-HTTP metrics listener. etcd's client port requires mTLS, so the
@@ -269,8 +269,8 @@ kops edit cluster --name "${CLUSTER_NAME}" \
 # --kube-api-qps/--kube-api-burst flags, which current kube-schedulers no
 # longer accept).
 kops edit cluster --name "${CLUSTER_NAME}" \
-  --set cluster.spec.kubeScheduler.qps=500 \
-  --set cluster.spec.kubeScheduler.burst=500
+  --set cluster.spec.kubeScheduler.qps=1000 \
+  --set cluster.spec.kubeScheduler.burst=1000
 
 # kubelet.kubeAPIQPS (default 50): the kubelets make multiple pod
 # status updates per pod.
@@ -346,6 +346,11 @@ kubectl --namespace kube-system rollout status daemonset/node-exporter --timeout
 # Deploy to cluster. CONTROLLER_ARGS optionally appends controller flags
 # (e.g. "--enable-pprof-debug" so the stress tool's --profile-controller can
 # actually fetch CPU/heap profiles; see benchmarks-kops-gcp-claims).
+# Hero run: 200 sandbox workers. Safe now that the generation predicate is
+# in the stack (status-write echoes no longer amplify reconciles); at
+# mif1200 the sandbox workqueue showed queueing with 100 workers.
+CONTROLLER_ARGS="${CONTROLLER_ARGS:---sandbox-concurrent-workers=200}"
+
 echo "Deploying to cluster..."
 dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" --extensions \
   ${CONTROLLER_ARGS:+--controller-args="${CONTROLLER_ARGS}"}
@@ -419,7 +424,7 @@ set +o errexit
 # load to find the first genuinely saturated component.
 # shellcheck disable=SC2086
 go run ./test/stress \
-  --phases="${STRESS_PHASES:-fill,probe,throughput-mif1200,throughput-mif800,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
+  --phases="${STRESS_PHASES:-fill,probe,throughput-mif1600,throughput-mif1200,throughput-mif800,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
   --fill-per-node="${STRESS_FILL_PER_NODE:-10}" \
   --probe-count="${STRESS_PROBE_COUNT:-30}" \
   --throughput-count="${STRESS_THROUGHPUT_COUNT:-500}" \

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -282,6 +282,20 @@ kops edit cluster --name "${CLUSTER_NAME}" \
 # Note this is different from other rate limits: we drop extra events.
 # A diagnostics trade-off that is acceptable here, needs more careful
 # evaluation before using in production clusters.
+# kubeAPIServer.maxRequestsInflight/maxMutatingRequestsInflight (defaults
+# 400/200): APF's total seat budget is derived from these two flags and
+# scales with NOTHING else - not CPU, not node count. Hero run
+# 2081124465281863680 (80 nodes, c3-standard-44): the system priority
+# level (kubelet traffic) queued 53ms mean at 1,663 req/s while the
+# apiserver sat at 35% CPU - pods PATCH 54ms / DELETE 45ms / GET 30ms are
+# the kubelet verbs wearing that APF wait, and throughput regressed below
+# the 40-node run's because twice the kubelets contended for the same 600
+# seats. 1600/800 scales the pool ~2.7x to match the 2x box and 4x nodes;
+# the system level's nominal share grows proportionally.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set cluster.spec.kubeAPIServer.maxRequestsInflight=1600 \
+  --set cluster.spec.kubeAPIServer.maxMutatingRequestsInflight=800
+
 kops edit cluster --name "${CLUSTER_NAME}" \
   --set cluster.spec.kubelet.kubeAPIQPS=500 \
   --set cluster.spec.kubelet.eventQPS=5 \

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -162,7 +162,16 @@ echo "Using node count: ${STRESS_NODE_COUNT}"
 # them. NOTE: c3/c4 machine families do not support pd-standard boot disks,
 # so the control-plane root volume is set to pd-ssd below alongside the
 # nodes'.
-STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-44}"
+# c3-standard-88: at mif1600 on c3-standard-44 (run 2081142826250276864)
+# the control-plane NODE ran 86% busy - apiserver 29 cores + etcd 4.9 +
+# KCM/scheduler 2.4 + node overhead - and at that utilization run-queue
+# delay taxes every latency-sensitive thread: etcd round trips doubled
+# (5.9ms -> 11ms) with etcd's own CPU modest, apiserver latency rose to
+# 18ms, and the kubelet status lane (whose service time IS that latency)
+# queued 1.1s. Note the per-process view misleads here: the apiserver
+# alone showed 15 "idle" cores while the box was nearly full. 88 vCPUs
+# targets ~45% node utilization at the same load.
+STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-88}"
 echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
 
 echo "Creating kOps cluster configuration..."

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -321,6 +321,42 @@ if [[ "${CNI}" == "cilium" ]]; then
 fi
 
 echo "Applying cluster configuration..."
+# etcd backend quota + compaction: the default quota-backend-bytes (2GiB)
+# is a fixed ceiling that scales with nothing. Hero run at ~459 claims/s
+# sustained ~5k etcd writes/s; between compactions (apiserver default:
+# every 5min) that accrues 1.5-3GB of MVCC revision history, and when the
+# boltdb file hits the quota etcd raises the NOSPACE alarm and rejects ALL
+# writes cluster-wide ("mvcc: database space exceeded") until
+# compact+defrag+disarm - observed mid-sweep on the c3-standard-88 run.
+# 8GiB quota + 2-minute periodic auto-compaction gives ~10x headroom (the
+# same remedy as the #1240 benchmark rig). manager.env is a structured
+# list that `kops edit --set` cannot express, so patch the spec YAML and
+# replace it (same throwaway-venv pattern as the report step).
+python3 -m venv "${BINDIR}/specedit-venv"
+"${BINDIR}/specedit-venv/bin/pip" install --quiet 'pyyaml>=6,<7'
+kops get cluster --name "${CLUSTER_NAME}" -o yaml > "${WORKDIR}/cluster-spec.yaml"
+"${BINDIR}/specedit-venv/bin/python3" - "${WORKDIR}/cluster-spec.yaml" << 'PYEOF'
+import sys, yaml
+path = sys.argv[1]
+docs = list(yaml.safe_load_all(open(path)))
+env = [
+    {"name": "ETCD_QUOTA_BACKEND_BYTES", "value": "8589934592"},
+    {"name": "ETCD_AUTO_COMPACTION_MODE", "value": "periodic"},
+    {"name": "ETCD_AUTO_COMPACTION_RETENTION", "value": "2m"},
+]
+for doc in docs:
+    if not doc or doc.get("kind") != "Cluster":
+        continue
+    for ec in doc["spec"]["etcdClusters"]:
+        mgr = ec.setdefault("manager", {})
+        have = {e["name"] for e in mgr.get("env", [])}
+        mgr.setdefault("env", []).extend(e for e in env if e["name"] not in have)
+with open(path, "w") as f:
+    yaml.safe_dump_all(docs, f, default_flow_style=False)
+print("etcd quota/compaction env injected")
+PYEOF
+kops replace --name "${CLUSTER_NAME}" -f "${WORKDIR}/cluster-spec.yaml"
+
 kops update cluster --name "${CLUSTER_NAME}" --yes
 
 echo "Exporting kubeconfig..."

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -409,9 +409,17 @@ set +o errexit
 # STRESS_EXTRA_ARGS appends verbatim extra flags (word-split on purpose) so
 # scenarios can pass tool flags without this script growing an env knob for
 # each one (e.g. --client-connections=4 in benchmarks-kops-gcp-claims).
+# The mif sweep tops out at 1200: run 2081094034931060736 (40 nodes, full
+# tuning stack) showed NO component saturated at mif600 - apiserver at
+# 14.8/22 cores, status lane at 477ms p50, 409s at 2 - while measured
+# throughput matched slots/cycle exactly at every level (600/2.52s =
+# 238/s). The offered load, not the cluster, was the ceiling: mif is the
+# stress client's closed-loop concurrency, and each slot's cycle has a
+# ~1.8s floor (mostly the delete/recycle half). 800/1200 raise the offered
+# load to find the first genuinely saturated component.
 # shellcheck disable=SC2086
 go run ./test/stress \
-  --phases="${STRESS_PHASES:-fill,probe,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
+  --phases="${STRESS_PHASES:-fill,probe,throughput-mif1200,throughput-mif800,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
   --fill-per-node="${STRESS_FILL_PER_NODE:-10}" \
   --probe-count="${STRESS_PROBE_COUNT:-30}" \
   --throughput-count="${STRESS_THROUGHPUT_COUNT:-500}" \

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -270,6 +270,21 @@ kops edit cluster --name "${CLUSTER_NAME}" \
   --set cluster.spec.kubeScheduler.qps=500 \
   --set cluster.spec.kubeScheduler.burst=500
 
+# kubelet.kubeAPIQPS (default 50): the kubelets make multiple pod
+# status updates per pod.
+# Each kubelet status-manager sync is a GET plus a PATCH through one serialized loop,
+# so this becomes a bottleneck when churning more than 5 pods / second / node.
+#
+# kubelet.eventQPS/eventBurst: kubelet event emission has its own limiter,
+# not covered by kubeAPIQPS.
+# Note this is different from other rate limits: we drop extra events.
+# A diagnostics trade-off that is acceptable here, needs more careful
+# evaluation before using in production clusters.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set cluster.spec.kubelet.kubeAPIQPS=500 \
+  --set cluster.spec.kubelet.eventQPS=5 \
+  --set cluster.spec.kubelet.eventBurst=50
+
 
 if [[ "${CNI}" == "cilium" ]]; then
   # cilium.enablePrometheusMetrics: serve cilium-agent metrics on :9090 so the


### PR DESCRIPTION
#### What this PR does / why we need it

Scales the benchmark from 20 to **40 worker nodes** (still env-overridable via `STRESS_NODE_COUNT`).

**Why this is the right lever:** at 20 nodes the cluster walls at ~90 pods/s = ~4.5 creates/s/node, and the #1204 profiler data (kindnet run `2080606920242106368`) places the wall on the nodes, not the control plane: containerd `run_podsandbox` mean rises ~130ms → 1.0–1.2s under load with iowait at 2.1–2.5 cores/node, while the apiserver runs at 9.7 of 16 cores, etcd fsync at 1.5ms, and KCM/scheduler idle.

**The falsifiable prediction:** if the per-node wall holds, 40 nodes approaches ~180 pods/s. If throughput lands short of that, whatever saturates next is the next bottleneck, found — the leading candidate is apiserver CPU (~2× its current burn would hit the 16-core box), with the sandbox controller's single API connection as the dark-horse (in-flight scales with server latency; see #1259's instrumentation, which will be watching if it merges first).

**Resource note:** 40× n2-standard-8 workers + the n2-standard-16 control plane = 336 N2 vCPUs per concurrent job from the boskos project. If the presubmit hits quota, this PR is the cheap place to find that out.

Companion experiment: the pd-ssd PR (#1275) attacks the same per-node wall from the other side (make each node faster vs. add nodes). Deliberately separate PRs so each presubmit run is a clean single-variable A/B against run `2080606920242106368`.

#### Which issue(s) this PR fixes

None — follow-up to the #1204 profiler findings.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Increased the default worker-node count for cluster-scale experiments from 20 to 40.
  * Updated the related sizing guidance to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->