### PR TITLE
fix(sandboxclaim): never abandon a committed adoption assignment (optimistic-locked completeAdoption)

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -72,6 +72,17 @@ var ErrSandboxNotOwned = errors.New("sandbox not owned by this claim")
 // ErrWarmPoolNotFound is a sentinel error indicating a SandboxWarmPool was not found.
 var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 
+// errAdoptionConflict classifies expected contention on the optimistically
+// locked adoption writes: the in-pass annotation retry could not resolve its
+// 409 (e.g. the fresh read shows a different sandbox already assigned), or a
+// committed adoption could not be completed (the assigned sandbox was
+// deleted, was won by another owner, or its adoption patch kept
+// conflicting). It is contention, not a claim failure: the Ready condition
+// surfaces it with a benign AdoptionConflict reason instead of a generic
+// ReconcilerError, and the next pass re-enters or finishes the adoption from
+// the converged view.
+var errAdoptionConflict = errors.New("adoption write conflict")
+
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
 var exemptedMetadataKeys = []string{autoscalerSafeToEvictAnnotation}
 
@@ -140,9 +151,10 @@ func (m *observedTimeMap) LoadOrStore(key types.NamespacedName, entry observedTi
 type SandboxClaimReconciler struct {
 	client.Client
 	// APIReader reads directly from the API server, bypassing the informer
-	// cache. Used only to re-read a claim after an optimistic-lock conflict,
-	// where the cache is stale by definition. Falls back to Client when unset
-	// (e.g. in unit tests with a fake client).
+	// cache. Used only to re-read a claim, or its assigned sandbox, after an
+	// optimistic-lock conflict or a suspect 404, where the cache is stale by
+	// definition. Falls back to Client when unset (e.g. in unit tests with a
+	// fake client).
 	APIReader               client.Reader
 	Scheme                  *runtime.Scheme
 	WarmSandboxQueue        queue.SandboxQueue
@@ -623,6 +635,28 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 				ObservedGeneration: claim.Generation,
 			}
 		}
+		if errors.Is(err, errAdoptionConflict) {
+			// Expected contention on the optimistically locked adoption write,
+			// not a claim failure: the next pass re-enters or completes the
+			// adoption from the converged view. The error text carries the
+			// per-case detail (concurrent update, sandbox deleted, or won by
+			// another owner), so surface it instead of asserting one cause —
+			// but trim the raw apiserver conflict text from the tail: that
+			// low-level detail belongs in logs, not in the condition users
+			// read via kubectl describe.
+			msg := err.Error()
+			var apiErr *k8errors.StatusError
+			if errors.As(err, &apiErr) && strings.HasSuffix(msg, apiErr.Error()) {
+				msg = strings.TrimSuffix(strings.TrimSuffix(msg, apiErr.Error()), ": ") + " (conflicting concurrent write)"
+			}
+			return metav1.Condition{
+				Type:               string(v1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             "AdoptionConflict",
+				Message:            fmt.Sprintf("%s; the next pass retries from a converged view", msg),
+				ObservedGeneration: claim.Generation,
+			}
+		}
 		if errors.Is(err, ErrInvalidMetadata) {
 			reason = "InvalidMetadata"
 			return metav1.Condition{
@@ -940,25 +974,46 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 				// the pass — this resolves in single-digit milliseconds and
 				// keeps the popped candidate from being burned on a doomed pass.
 				if retryErr := r.retryAdoptionAnnotation(ctx, claim, adopted.Name); retryErr != nil {
-					// Retries exhausted (persistent contention) or the fresh
-					// read showed the assignment moved: fail the pass and let
-					// the per-item failure backoff pace further retries.
 					r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
+					if k8errors.IsConflict(retryErr) {
+						// Retries exhausted on persistent contention: surface it
+						// with the benign AdoptionConflict condition reason and
+						// let the per-item failure backoff pace further retries.
+						return false, fmt.Errorf("%w: claim %s: %w", errAdoptionConflict, claim.Name, retryErr)
+					}
 					return false, retryErr
 				}
 			}
 
 			// Call helper to complete adoption (patch sandbox)
 			if err := r.completeAdoption(ctx, claim, adopted); err != nil {
-				if k8errors.IsNotFound(err) {
-					return false, nil
+				if !k8errors.IsNotFound(err) && !k8errors.IsConflict(err) {
+					r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
+					logger.Error(err, "Failed to complete adoption for candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
+					return false, err
 				}
-				r.WarmSandboxQueue.Add(namespacedWarmPoolNameForQueue, adoptedKey)
-				if k8errors.IsConflict(err) {
-					return false, nil
+				// A 404/409 here only proves the CANDIDATE's cache view was
+				// stale (deleted, already adopted, or concurrently written —
+				// freshly refilled pool sandboxes are actively written by the
+				// sandbox and warm-pool controllers). The adoption annotation
+				// is already committed on the claim, so this pass must NOT
+				// move on to another candidate: overwriting the committed
+				// assignment orphans the recorded sandbox and, under sustained
+				// load, cascades into assignment-flip storms, burned
+				// candidates, duplicate binds and cold-create status
+				// overwrites. Resolve the committed assignment against
+				// authoritative reads instead.
+				resolved, resolveErr := r.resolveAdoptionCompletion(ctx, claim, adopted.Name)
+				if resolveErr != nil {
+					// Terminal for this pass: the dead reference was cleaned up
+					// (deleted/stolen sandbox) or contention persists, and the
+					// retry is paced by the workqueue's per-item rate limiter.
+					// The candidate key is deliberately NOT re-queued: a
+					// still-adoptable sandbox re-enters the warm queue via its
+					// own watch events.
+					return false, resolveErr
 				}
-				logger.Error(err, "Failed to complete adoption for candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
-				return false, err
+				resolved.DeepCopyInto(adopted)
 			}
 
 			logger.Info("Successfully adopted sandbox from warm pool", "sandbox", adopted.Name, "claim", claim.Name)
@@ -1085,7 +1140,14 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		}
 	}
 
-	if err := r.Patch(ctx, adopted, client.MergeFrom(originalAdopted)); err != nil {
+	// Optimistic lock: the ownership transfer must only apply to the exact
+	// revision this pass computed it from. Without it, a patch built from a
+	// stale cache base can silently re-transfer a sandbox that another claim
+	// (or an earlier pass) already adopted. With it, any concurrent write —
+	// including the sandbox controller's own status/annotation writes on a
+	// freshly refilled candidate — surfaces as a 409 that the callers resolve
+	// against a fresh authoritative read (resolveAdoptionCompletion).
+	if err := r.Patch(ctx, adopted, client.MergeFromWithOptions(originalAdopted, client.MergeFromWithOptimisticLock{})); err != nil {
 		return err
 	}
 
@@ -1145,13 +1207,13 @@ func (r *SandboxClaimReconciler) updateClaimOnFreshBase(ctx context.Context, cla
 func (r *SandboxClaimReconciler) retryAdoptionAnnotation(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sandboxName string) error {
 	return r.updateClaimOnFreshBase(ctx, claim, func(fresh *extensionsv1beta1.SandboxClaim) (bool, error) {
 		if fresh.UID != claim.UID {
-			return false, fmt.Errorf("claim %s was deleted and recreated during adoption", claim.Name)
+			return false, fmt.Errorf("%w: claim %s was deleted and recreated during adoption", errAdoptionConflict, claim.Name)
 		}
 		if assigned := fresh.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation]; assigned != "" && assigned != sandboxName {
 			// A different sandbox is already recorded on the authoritative
 			// object; do not overwrite it. The annotation-recovery path of the
 			// next pass completes that adoption instead.
-			return false, fmt.Errorf("claim %s already assigned sandbox %s, not overwriting", claim.Name, assigned)
+			return false, fmt.Errorf("%w: claim %s already assigned sandbox %s", errAdoptionConflict, claim.Name, assigned)
 		}
 		if fresh.Annotations == nil {
 			fresh.Annotations = make(map[string]string)
@@ -1159,6 +1221,117 @@ func (r *SandboxClaimReconciler) retryAdoptionAnnotation(ctx context.Context, cl
 		fresh.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] = sandboxName
 		return true, nil
 	})
+}
+
+// resolveAdoptionCompletion resolves a completeAdoption failure (404, or 409
+// on the optimistically locked adoption patch) against authoritative reads.
+// It is called only AFTER the adoption annotation has been committed on the
+// claim, and it upholds one invariant: a committed assignment is never
+// abandoned for another candidate inside the same pass. A stale cache view of
+// the assigned sandbox must degrade to (in order):
+//
+//   - no write at all, when the fresh object shows the adoption already
+//     completed (an earlier pass's patch landed);
+//   - one re-patch on the fresh base, when the sandbox is genuinely still
+//     pool-owned and adoptable (the 409 came from a concurrent benign write,
+//     e.g. the sandbox controller's status transition on a fresh candidate);
+//   - authoritative cleanup of the dead reference plus a benign
+//     errAdoptionConflict, when the sandbox is deleted or was won by another
+//     owner. The next pass then re-enters adoption cleanly, paced by the
+//     workqueue's per-item rate limiter.
+//
+// Nothing here retries a write against a deleted object, requeues on a fixed
+// delay, or records any in-memory state.
+func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sandboxName string) (*v1beta1.Sandbox, error) {
+	logger := log.FromContext(ctx)
+	reader := r.authoritativeReader()
+	key := client.ObjectKey{Namespace: claim.Namespace, Name: sandboxName}
+	var resolved *v1beta1.Sandbox
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh := &v1beta1.Sandbox{}
+		if err := reader.Get(ctx, key, fresh); err != nil {
+			return err
+		}
+		if metav1.IsControlledBy(fresh, claim) {
+			// The adoption is already complete on the server; this pass has
+			// nothing left to write for it.
+			resolved = fresh
+			return nil
+		}
+		if !utils.MatchesGroupKind(metav1.GetControllerOf(fresh), extensionsv1beta1.GroupVersion.Group, extensionsv1beta1.SandboxWarmPoolKind) {
+			return fmt.Errorf("%w: sandbox %s is no longer pool-owned and not controlled by claim %s", errAdoptionConflict, sandboxName, claim.Name)
+		}
+		if err := verifySandboxCandidate(fresh, claim); err != nil {
+			return fmt.Errorf("%w: sandbox %s is no longer adoptable by claim %s: %s", errAdoptionConflict, sandboxName, claim.Name, err.Error())
+		}
+		// Still pool-owned and adoptable on the authoritative object:
+		// re-apply the adoption patch on the fresh base. A further 409 re-runs
+		// this closure with another fresh read.
+		if err := r.completeAdoption(ctx, claim, fresh); err != nil {
+			return err
+		}
+		resolved = fresh
+		return nil
+	})
+	if err == nil {
+		return resolved, nil
+	}
+	if k8errors.IsNotFound(err) || errors.Is(err, errAdoptionConflict) {
+		// The assigned sandbox is deleted or lost for good. Clear the
+		// committed reference on a fresh claim base so the next pass re-enters
+		// adoption cleanly instead of re-resolving a dead assignment.
+		logger.V(4).Info("Assigned sandbox unrecoverable; clearing reference", "sandbox", sandboxName, "claim", claim.Name, "reason", err.Error())
+		if cleanupErr := r.removeAssignedSandboxReference(ctx, claim, sandboxName); cleanupErr != nil {
+			return nil, fmt.Errorf("%w: sandbox %s unrecoverable and reference cleanup failed: %w", errAdoptionConflict, sandboxName, errors.Join(err, cleanupErr))
+		}
+		if errors.Is(err, errAdoptionConflict) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: sandbox %s deleted before adoption completed", errAdoptionConflict, sandboxName)
+	}
+	if k8errors.IsConflict(err) {
+		// Retries exhausted on persistent contention: keep the committed
+		// reference (the sandbox is still adoptable and assigned to us) and
+		// let the next event-driven or rate-limited pass finish it.
+		return nil, fmt.Errorf("%w: completing adoption of %s for claim %s: %w", errAdoptionConflict, sandboxName, claim.Name, err)
+	}
+	return nil, err
+}
+
+// removeAssignedSandboxReference clears the assigned-sandbox reference — the
+// annotation and, for legacy claims, the deprecated label — on a fresh claim
+// base via updateClaimOnFreshBase, guarded so it only removes the exact
+// reference it was asked to clean (a concurrent pass may already have moved
+// it). Both fields must be covered: getOrCreateSandbox still accepts the
+// deprecated label as the assigned reference, so clearing only the annotation
+// would leave a label-based claim re-deriving the same dead sandbox name on
+// subsequent stale passes until the informer converges.
+func (r *SandboxClaimReconciler) removeAssignedSandboxReference(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sandboxName string) error {
+	// A deleted or recreated claim means there is nothing left to clean: it
+	// must not surface as an error, and a recreated claim (different UID)
+	// must not be copied back over this pass's object.
+	errClaimGone := errors.New("claim gone")
+	err := r.updateClaimOnFreshBase(ctx, claim, func(fresh *extensionsv1beta1.SandboxClaim) (bool, error) {
+		if fresh.UID != claim.UID {
+			return false, errClaimGone
+		}
+		annotationMatches := fresh.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation] == sandboxName
+		labelMatches := fresh.Labels[extensionsv1beta1.DeprecatedAssignedSandboxNameLabel] == sandboxName
+		if !annotationMatches && !labelMatches {
+			return false, nil
+		}
+		if annotationMatches {
+			delete(fresh.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation)
+		}
+		if labelMatches {
+			delete(fresh.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel)
+		}
+		return true, nil
+	})
+	if k8errors.IsNotFound(err) || errors.Is(err, errClaimGone) {
+		return nil
+	}
+	return err
 }
 
 // isSandboxReady checks if a sandbox has Ready=True condition.
@@ -1658,27 +1831,38 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 					}
 				} else {
 					if err := r.completeAdoption(ctx, claim, sandbox); err != nil {
-						if k8errors.IsNotFound(err) || k8errors.IsConflict(err) {
-							logger.V(4).Info("Failed to complete adoption (conflict/notfound), falling through", "sandbox", sbName, "claim", claim.Name)
-						} else {
+						if !k8errors.IsNotFound(err) && !k8errors.IsConflict(err) {
 							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
 						}
-					} else {
-						if fromLabel {
-							if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
-								logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
-							} else {
-								logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
-							}
+						// A 404/409 here only proves the cached sandbox view is
+						// stale (deleted, already adopted, or concurrently
+						// written). Do NOT fall through to adopt a different
+						// candidate while the claim still references this one —
+						// overwriting the recorded assignment cascades under
+						// load. Resolve authoritatively instead: accept an
+						// already-completed adoption without a write, re-patch
+						// on a fresh base, or clean the dead reference and end
+						// the pass with the benign AdoptionConflict.
+						resolved, resolveErr := r.resolveAdoptionCompletion(ctx, claim, sbName)
+						if resolveErr != nil {
+							return nil, resolveErr
 						}
-						// completeAdoption wrote the API server's response back into
-						// `sandbox`, so returning it finalizes the claim status in this same
-						// pass. No requeue for cache lag: a stale pass just re-sends the
-						// idempotent patch, and the Owns(&Sandbox{}) watch drives convergence
-						// once the cache catches up (#1107).
-						logger.V(4).Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
-						return sandbox, nil
+						sandbox = resolved
 					}
+					if fromLabel {
+						if err := r.migrateLegacyAssignedSandboxLabel(ctx, claim, sbName); err != nil {
+							logger.Error(err, "Failed to migrate legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+						} else {
+							logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
+						}
+					}
+					// completeAdoption (or its fresh-base resolution) wrote the API
+					// server's response back into `sandbox`, so returning it finalizes
+					// the claim status in this same pass. No requeue for cache lag:
+					// the Owns(&Sandbox{}) watch drives convergence once the cache
+					// catches up (#1107).
+					logger.V(4).Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
+					return sandbox, nil
 				}
 			}
 			logger.V(4).Info("Sandbox recorded in claim metadata belongs to another claim, falling through", "sandbox", sbName, "claim", claim.Name)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -2158,17 +2158,20 @@ func TestSandboxClaimSandboxAdoption(t *testing.T) {
 			expectNewSandboxCreated: false,
 		},
 		{
-			name: "retries on conflict when adopting sandbox",
+			name: "resolves adoption-patch conflict on the same candidate",
 			existingObjects: []client.Object{
 				template,
 				claim,
 				createWarmPoolSandbox("pool-sb-1", metav1.Time{Time: metav1.Now().Add(-1 * time.Hour)}, true),
 				createWarmPoolSandbox("pool-sb-2", metav1.Now(), true),
 			},
-			expectSandboxAdoption:   true,
-			expectedAdoptedSandbox:  "pool-sb-2",
+			expectSandboxAdoption:  true,
+			expectedAdoptedSandbox: "pool-sb-1",
+			// The first adoption patch conflicts; the committed assignment must be
+			// completed on a fresh base for the SAME candidate, never by switching
+			// to the next candidate (the assignment-flip amplification defect).
 			expectNewSandboxCreated: false,
-			simulateConflicts:       1, // Fail update on the first sandbox, succeed on the second
+			simulateConflicts:       1,
 		},
 		{
 			name: "preserves template eviction annotation false when adopting sandbox",
@@ -4026,21 +4029,22 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 	// adopted sandbox returns the frozen warm-pool-owned view, no matter what
 	// was patched.
 	cacheStale := true
+	adoptedSandbox.ResourceVersion = "100"
 	staleSandbox := adoptedSandbox.DeepCopy()
-	fakeClient := fake.NewClientBuilder().
+	rawClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(template, warmPool, claim, adoptedSandbox, extraSandbox).
 		WithStatusSubresource(claim).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" && cacheStale {
-					staleSandbox.DeepCopyInto(sb)
-					return nil
-				}
-				return c.Get(ctx, key, obj, opts...)
-			},
-		}).
 		Build()
+	fakeClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" && cacheStale {
+				staleSandbox.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
 
 	warmSandboxQueue := queue.NewSimpleSandboxQueue()
 	if isAdoptable(extraSandbox) == nil {
@@ -4052,6 +4056,7 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 
 	reconciler := &SandboxClaimReconciler{
 		Client:           fakeClient,
+		APIReader:        rawClient,
 		Scheme:           scheme,
 		Recorder:         events.NewFakeRecorder(10),
 		Tracer:           asmetrics.NewNoOp(),
@@ -4162,10 +4167,11 @@ func TestSandboxClaimPreventsDuplicateAdoptionDuringCacheLag(t *testing.T) {
 
 // TestSandboxClaimAdoptionCacheLagRepatchesIdempotently verifies that while the informer
 // cache keeps returning the stale (warm-pool-owned) view of an already-adopted sandbox,
-// every pass finalizes the claim from the freshly re-patched object: no error, no polling
-// requeue (convergence is watch-driven via the Owns() Sandbox watch), and the finalized
-// status is never wiped. The idempotent adoption re-patch on stale passes is an accepted
-// trade-off of finalizing in-pass without per-claim in-memory dedup state.
+// every pass still finalizes the claim without error and without a polling requeue
+// (convergence is watch-driven via the Owns() Sandbox watch), and the finalized status is
+// never wiped. A stale pass costs at most one doomed re-patch (rejected by the optimistic
+// lock) that is then resolved from an authoritative read — an accepted trade-off of
+// finalizing in-pass without per-claim in-memory dedup state.
 func TestSandboxClaimAdoptionCacheLagRepatchesIdempotently(t *testing.T) {
 	scheme := newScheme(t)
 
@@ -4228,32 +4234,34 @@ func TestSandboxClaimAdoptionCacheLagRepatchesIdempotently(t *testing.T) {
 
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
 	// cache that has not converged yet, no matter what was patched.
+	adoptedSandbox.ResourceVersion = "100"
 	staleSandbox := adoptedSandbox.DeepCopy()
 
 	sandboxPatches := 0
-	fakeClient := fake.NewClientBuilder().
+	rawClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(template, warmPool, claim, adoptedSandbox).
 		WithStatusSubresource(claim).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" {
-					staleSandbox.DeepCopyInto(sb)
-					return nil
-				}
-				return c.Get(ctx, key, obj, opts...)
-			},
-			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
-					sandboxPatches++
-				}
-				return c.Patch(ctx, obj, patch, opts...)
-			},
-		}).
 		Build()
+	fakeClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" {
+				staleSandbox.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+				sandboxPatches++
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
 
 	reconciler := &SandboxClaimReconciler{
 		Client:           fakeClient,
+		APIReader:        rawClient,
 		Scheme:           scheme,
 		Recorder:         events.NewFakeRecorder(10),
 		Tracer:           asmetrics.NewNoOp(),
@@ -4282,8 +4290,9 @@ func TestSandboxClaimAdoptionCacheLagRepatchesIdempotently(t *testing.T) {
 		t.Fatalf("pass 1: expected status to be finalized with 'adopted-sb', got %q", updatedClaim.Status.SandboxStatus.Name)
 	}
 
-	// Passes 2 and 3: cache still stale — each pass re-sends the idempotent adoption
-	// patch, returns without error, and leaves the finalized status intact.
+	// Passes 2 and 3: cache still stale — each pass sends at most one doomed adoption
+	// re-patch (rejected by the optimistic lock and resolved from the authoritative
+	// read), returns without error, and leaves the finalized status intact.
 	for pass := 2; pass <= 3; pass++ {
 		res, err = reconciler.Reconcile(context.Background(), req)
 		if err != nil {
@@ -4398,26 +4407,28 @@ func TestSandboxClaimAdoptionCacheLagPreservesFinalizedStatus(t *testing.T) {
 
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
 	// cache that has not converged yet, no matter what was patched.
+	adoptedSandbox.ResourceVersion = "100"
 	staleSandbox := adoptedSandbox.DeepCopy()
 
-	fakeClient := fake.NewClientBuilder().
+	rawClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(template, warmPool, claim, adoptedSandbox).
 		WithStatusSubresource(claim).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" {
-					staleSandbox.DeepCopyInto(sb)
-					return nil
-				}
-				return c.Get(ctx, key, obj, opts...)
-			},
-		}).
 		Build()
+	fakeClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "adopted-sb" {
+				staleSandbox.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
 
 	// Fresh reconciler, as after a controller restart.
 	reconciler := &SandboxClaimReconciler{
 		Client:           fakeClient,
+		APIReader:        rawClient,
 		Scheme:           scheme,
 		Recorder:         events.NewFakeRecorder(10),
 		Tracer:           asmetrics.NewNoOp(),
@@ -4514,29 +4525,30 @@ func TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus(t *testing.T) {
 
 	// Frozen warm-pool-owned view: served on every Get to simulate an informer
 	// cache that never converges within the test, no matter what was patched.
+	warmSandbox.ResourceVersion = "100"
 	staleSandbox := warmSandbox.DeepCopy()
 
 	sandboxPatches := 0
-	fakeClient := fake.NewClientBuilder().
+	rawClient := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(template, warmPool, claim, warmSandbox).
 		WithStatusSubresource(claim).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "warm-sb" {
-					staleSandbox.DeepCopyInto(sb)
-					return nil
-				}
-				return c.Get(ctx, key, obj, opts...)
-			},
-			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
-					sandboxPatches++
-				}
-				return c.Patch(ctx, obj, patch, opts...)
-			},
-		}).
 		Build()
+	fakeClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "warm-sb" {
+				staleSandbox.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if _, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+				sandboxPatches++
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
 
 	warmSandboxQueue := queue.NewSimpleSandboxQueue()
 	warmSandboxQueue.Add(
@@ -4546,6 +4558,7 @@ func TestSandboxClaimFreshAdoptionStaleCacheKeepsFinalizedStatus(t *testing.T) {
 
 	reconciler := &SandboxClaimReconciler{
 		Client:           fakeClient,
+		APIReader:        rawClient,
 		Scheme:           scheme,
 		Recorder:         events.NewFakeRecorder(10),
 		Tracer:           asmetrics.NewNoOp(),
@@ -6371,4 +6384,483 @@ func TestSandboxClaimAdoptionConflictRetriedInPass(t *testing.T) {
 	controllerRef := metav1.GetControllerOf(updatedSandbox)
 	require.NotNil(t, controllerRef)
 	require.Equal(t, types.UID("claim-uid-123"), controllerRef.UID, "candidate must be owned by the claim after the retried adoption")
+}
+
+// newPoolCandidateSandbox builds a Ready, adoptable warm-pool member for the
+// default/test-pool + test-template fixtures.
+func newPoolCandidateSandbox(name string) *sandboxv1beta1.Sandbox {
+	return &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(name + "-uid"),
+			Labels: map[string]string{
+				warmPoolSandboxLabel:   sandboxcontrollers.NameHash("test-pool"),
+				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       extensionsv1beta1.SandboxWarmPoolKind,
+				Name:       "test-pool",
+				UID:        "warmpool-uid-123",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+		}}},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+				Reason: "Ready",
+			}},
+		},
+	}
+}
+
+// TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates pins the
+// fix for the sustained-load amplification defect: once the adoption
+// annotation is committed for a candidate, a 409 on the (optimistically
+// locked) adoption patch must be resolved against a fresh read of THAT
+// candidate — never by popping the next candidate and overwriting the
+// committed assignment in the same pass (the measured assignment-flip storm:
+// stale candidate views under load flipped one claim through up to 8
+// sandboxes, orphaning each previous one).
+func TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid-123"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	sb1 := newPoolCandidateSandbox("pool-sb-1")
+	sb2 := newPoolCandidateSandbox("pool-sb-2")
+
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+		sb1.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, sb1, sb2).
+		WithStatusSubresource(claim).
+		Build()
+
+	// The first adoption patch against pool-sb-1 conflicts, as if the sandbox
+	// controller wrote the candidate between the cache read and the patch.
+	conflictOnce := true
+	patchAttempts := map[string]int{}
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok {
+				patchAttempts[sb.Name]++
+				if sb.Name == "pool-sb-1" && conflictOnce {
+					conflictOnce = false
+					return conflict
+				}
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	poolKey := queue.GetNamespacedWarmPoolName("default", "test-pool")
+	warmSandboxQueue.Add(poolKey, queue.SandboxKey{Namespace: "default", Name: "pool-sb-1"})
+	warmSandboxQueue.Add(poolKey, queue.SandboxKey{Namespace: "default", Name: "pool-sb-2"})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: warmSandboxQueue,
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("expected the adoption-patch conflict to be resolved on a fresh base, got error: %v", err)
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, "pool-sb-1", updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation],
+		"the committed assignment must never be overwritten with the next candidate on an adoption-patch conflict")
+	require.Equal(t, "pool-sb-1", updatedClaim.Status.SandboxStatus.Name, "status must bind the originally assigned candidate")
+
+	adopted := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, rawClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-1", Namespace: "default"}, adopted))
+	adoptedRef := metav1.GetControllerOf(adopted)
+	require.NotNil(t, adoptedRef)
+	require.Equal(t, types.UID("claim-uid-123"), adoptedRef.UID, "the assigned candidate must end up adopted")
+
+	untouched := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, rawClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-2", Namespace: "default"}, untouched))
+	untouchedRef := metav1.GetControllerOf(untouched)
+	require.NotNil(t, untouchedRef)
+	require.Equal(t, "SandboxWarmPool", untouchedRef.Kind, "the second candidate must not be touched")
+	require.Zero(t, patchAttempts["pool-sb-2"], "no adoption patch may be issued against the next candidate")
+	require.Equal(t, 2, patchAttempts["pool-sb-1"], "exactly one doomed patch plus one fresh-base re-patch")
+}
+
+// TestSandboxClaimStaleAdoptionRepatchIdempotentWithoutWrite verifies that a
+// pass whose CACHED view of the assigned sandbox predates the completed
+// adoption performs no further sandbox write: the doomed re-patch is rejected
+// by the optimistic lock, the fresh read shows the linkage already true, and
+// the pass finalizes status from the authoritative object.
+func TestSandboxClaimStaleAdoptionRepatchIdempotentWithoutWrite(t *testing.T) {
+	scheme := newScheme(t)
+	claim, template, warmPool, adopted := newOptimisticLockTestObjects()
+
+	// Frozen pre-adoption view of the assigned sandbox: still pool-owned,
+	// exactly what a lagging informer serves right after adoption committed.
+	staleAdopted := newPoolCandidateSandbox(adopted.Name)
+	staleAdopted.UID = adopted.UID
+	staleAdopted.ResourceVersion = "1"
+
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+		adopted.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, adopted).
+		WithStatusSubresource(claim).
+		Build()
+
+	staleView := true
+	stalePatchRejections := 0
+	adoptionPatches := 0
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == adopted.Name && staleView {
+				staleAdopted.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == adopted.Name {
+				data, derr := patch.Data(obj)
+				if derr != nil {
+					return derr
+				}
+				if strings.Contains(string(data), `"ownerReferences"`) {
+					adoptionPatches++
+				}
+				// Emulate the apiserver's optimistic-lock check: reject any
+				// patch whose precondition is the stale base's resourceVersion.
+				if strings.Contains(string(data), `"resourceVersion":"1"`) {
+					stalePatchRejections++
+					return conflict
+				}
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("expected the stale re-patch to resolve as already-complete, got error: %v", err)
+	}
+
+	if stalePatchRejections != 1 {
+		t.Errorf("expected exactly 1 stale-base patch rejection, got %d", stalePatchRejections)
+	}
+	if adoptionPatches != 1 {
+		t.Errorf("expected NO adoption re-patch once the fresh read shows the linkage already true (1 doomed attempt only), got %d", adoptionPatches)
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, adopted.Name, updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation], "the assignment must be untouched")
+	require.Equal(t, adopted.Name, updatedClaim.Status.SandboxStatus.Name, "status must finalize from the authoritative sandbox")
+}
+
+// TestSandboxClaimAssignedSandboxDeletedTerminalCleanup verifies that a
+// stale-view pass whose assigned sandbox is already deleted on the server is
+// TERMINAL: exactly one doomed write, authoritative cleanup of the dead
+// reference (the annotation, or the deprecated label on legacy claims), a
+// benign AdoptionConflict, and no in-pass rebinding to another candidate —
+// with the next (converged) pass re-adopting cleanly.
+func TestSandboxClaimAssignedSandboxDeletedTerminalCleanup(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		fromLabel bool
+	}{
+		{name: "annotation reference"},
+		{name: "deprecated label reference", fromLabel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newScheme(t)
+			_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+			claim := &extensionsv1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-claim",
+					Namespace: "default",
+					UID:       "claim-uid-123",
+				},
+				Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+			}
+			if tc.fromLabel {
+				claim.Labels = map[string]string{extensionsv1beta1.DeprecatedAssignedSandboxNameLabel: "ghost-sb"}
+			} else {
+				claim.Annotations = map[string]string{extensionsv1beta1.AssignedSandboxNameAnnotation: "ghost-sb"}
+			}
+			// ghost-sb exists only in the (stale) cache view; the server never has it.
+			ghost := newPoolCandidateSandbox("ghost-sb")
+			spare := newPoolCandidateSandbox("pool-sb-2")
+
+			rawClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(template, warmPool, claim, spare).
+				WithStatusSubresource(claim).
+				Build()
+
+			staleView := true
+			ghostWrites := 0
+			cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "ghost-sb" && staleView {
+						ghost.DeepCopyInto(sb)
+						return nil
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == "ghost-sb" {
+						ghostWrites++
+					}
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			warmSandboxQueue := queue.NewSimpleSandboxQueue()
+			poolKey := queue.GetNamespacedWarmPoolName("default", "test-pool")
+			warmSandboxQueue.Add(poolKey, queue.SandboxKey{Namespace: "default", Name: "pool-sb-2"})
+
+			reconciler := &SandboxClaimReconciler{
+				Client:           cachedClient,
+				APIReader:        rawClient,
+				Scheme:           scheme,
+				Recorder:         events.NewFakeRecorder(10),
+				Tracer:           asmetrics.NewNoOp(),
+				WarmSandboxQueue: warmSandboxQueue,
+			}
+
+			// Pass 1 (stale view): terminal cleanup, no rebind, benign conflict error
+			// so the workqueue's per-item rate limiter paces the retry.
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+			_, err := reconciler.Reconcile(context.Background(), req)
+			if err == nil || !errors.Is(err, errAdoptionConflict) {
+				t.Fatalf("expected a benign adoption-conflict error pacing the retry, got: %v", err)
+			}
+			if ghostWrites != 1 {
+				t.Errorf("expected exactly 1 doomed write against the deleted sandbox (terminal, not retried), got %d", ghostWrites)
+			}
+
+			afterPass1 := &extensionsv1beta1.SandboxClaim{}
+			require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, afterPass1))
+			require.NotContains(t, afterPass1.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation,
+				"the dead annotation reference must be cleaned up authoritatively in the terminal pass")
+			require.NotContains(t, afterPass1.Labels, extensionsv1beta1.DeprecatedAssignedSandboxNameLabel,
+				"the dead deprecated-label reference must be cleaned up authoritatively in the terminal pass")
+			require.Empty(t, afterPass1.Status.SandboxStatus.Name, "pass 1 must not rebind to another candidate in-pass")
+			readyCond := meta.FindStatusCondition(afterPass1.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+			require.NotNil(t, readyCond)
+			require.Equal(t, "AdoptionConflict", readyCond.Reason, "the terminal pass surfaces the benign AdoptionConflict reason")
+
+			spareAfter := &sandboxv1beta1.Sandbox{}
+			require.NoError(t, rawClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-2", Namespace: "default"}, spareAfter))
+			spareRef := metav1.GetControllerOf(spareAfter)
+			require.NotNil(t, spareRef)
+			require.Equal(t, "SandboxWarmPool", spareRef.Kind, "the spare candidate must not be adopted by the stale pass")
+
+			// Pass 2 (converged view): the cleaned claim re-adopts the spare candidate.
+			staleView = false
+			if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+				t.Fatalf("pass 2: expected clean re-adoption after cleanup, got: %v", err)
+			}
+			afterPass2 := &extensionsv1beta1.SandboxClaim{}
+			require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, afterPass2))
+			require.Equal(t, "pool-sb-2", afterPass2.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+			require.Equal(t, "pool-sb-2", afterPass2.Status.SandboxStatus.Name, "the converged pass re-adopts cleanly")
+		})
+	}
+}
+
+// TestSandboxClaimAdoptionCompletionExhaustedContentionKeepsReference covers
+// the exhausted-contention tail of resolveAdoptionCompletion: when the
+// assigned sandbox stays pool-owned and adoptable but every fresh-base
+// adoption patch keeps conflicting, the pass ends with the benign
+// AdoptionConflict and the committed reference is KEPT (the sandbox is still
+// ours to finish; the next event-driven or rate-limited pass completes it).
+// It also pins the surfaced condition message: the raw apiserver conflict
+// text must be trimmed from what kubectl describe shows.
+func TestSandboxClaimAdoptionCompletionExhaustedContentionKeepsReference(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "pool-sb-1",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	assigned := newPoolCandidateSandbox("pool-sb-1")
+
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+		assigned.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, assigned).
+		WithStatusSubresource(claim).
+		Build()
+
+	// Persistent contention: every adoption patch against the (genuinely
+	// still adoptable) assigned sandbox conflicts, exhausting the in-pass
+	// fresh-base retries.
+	sandboxPatches := 0
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == "pool-sb-1" {
+				sandboxPatches++
+				return conflict
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err == nil || !errors.Is(err, errAdoptionConflict) {
+		t.Fatalf("expected the exhausted contention to surface as a benign adoption conflict, got: %v", err)
+	}
+	if sandboxPatches < 2 {
+		t.Errorf("expected the adoption patch to be retried on fresh bases before exhausting, got %d attempts", sandboxPatches)
+	}
+
+	after := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
+	require.Equal(t, "pool-sb-1", after.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation],
+		"exhausted contention must KEEP the committed reference: the sandbox is still adoptable and assigned to us")
+	readyCond := meta.FindStatusCondition(after.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCond)
+	require.Equal(t, "AdoptionConflict", readyCond.Reason)
+	require.NotContains(t, readyCond.Message, "please apply your changes",
+		"the raw apiserver conflict text must be trimmed from the surfaced condition message")
+	require.Contains(t, readyCond.Message, "conflicting concurrent write")
+}
+
+// TestSandboxClaimAdoptionCleanupFailureSurfacesJoinedError covers the
+// cleanup-failure branch of resolveAdoptionCompletion: the assigned sandbox is
+// gone on the server AND clearing the dead reference fails too. The pass must
+// surface a benign AdoptionConflict (so the workqueue paces the retry), keep
+// the reference for the next pass to clean, and carry both failures in the
+// error.
+func TestSandboxClaimAdoptionCleanupFailureSurfacesJoinedError(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "ghost-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	// ghost-sb exists only in the (stale) cache view; the server never has it.
+	ghost := newPoolCandidateSandbox("ghost-sb")
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim).
+		WithStatusSubresource(claim).
+		Build()
+
+	claimUpdateFails := true
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "ghost-sb" {
+				ghost.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*extensionsv1beta1.SandboxClaim); ok && claimUpdateFails {
+				return k8errors.NewInternalError(errors.New("etcd hiccup"))
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err == nil || !errors.Is(err, errAdoptionConflict) {
+		t.Fatalf("expected a benign adoption conflict carrying the cleanup failure, got: %v", err)
+	}
+	require.Contains(t, err.Error(), "reference cleanup failed", "the cleanup failure must be carried in the surfaced error")
+	require.Contains(t, err.Error(), "etcd hiccup", "the underlying cleanup error must not be swallowed")
+
+	after := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
+	require.Equal(t, "ghost-sb", after.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation],
+		"the reference stays for the next pass to clean when cleanup itself failed")
+
+	// Next pass with the cleanup write healed: terminal cleanup completes.
+	claimUpdateFails = false
+	if _, err := reconciler.Reconcile(context.Background(), req); err == nil || !errors.Is(err, errAdoptionConflict) {
+		t.Fatalf("expected the healed pass to finish terminal cleanup with the benign conflict, got: %v", err)
+	}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
+	require.NotContains(t, after.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation,
+		"the healed pass must clean the dead reference")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Once a SandboxClaim's adoption annotation is committed for a warm-pool candidate, a 404/409 while patching that sandbox proves only that the pass's **cached view of the sandbox** is stale — it says nothing about who owns it now. Today the controller treats that failure as "try the next candidate", *after* the assignment is already committed, so the pass overwrites the committed annotation and moves on. Under sustained load this is an amplification loop: each overwrite orphans or steals a sandbox, feeds the sandbox controller's error-retry churn, grows informer lag, and produces more stale views. It is also the setup for the double-adoption races in #418 and #478 (one claim ending up bound to two warm pods).

This PR makes the adoption transfer safe and the committed assignment sticky:

- **`completeAdoption` applies the ownership patch with an optimistic lock** (`MergeFromWithOptimisticLock`), so a transfer computed from a stale base is rejected by the server instead of silently re-transferring a sandbox that another claim (or an earlier pass) already adopted.
- **`resolveAdoptionCompletion` resolves a completion failure against authoritative reads** (`APIReader`, falling back to the cached client in tests): no write when the fresh object shows the adoption already completed; exactly one fresh-base re-patch when the sandbox is genuinely still pool-owned and adoptable; terminal cleanup of the dead reference when it is deleted or was won by another owner — never a retry against a deleted object, never in-pass rebinding to another candidate.
- Both call sites (the candidate loop and the annotation-recovery path in `getOrCreateSandbox`) **stop falling through to the next candidate** while the claim still references the committed one.
- Terminal contention surfaces as a benign **`AdoptionConflict`** Ready reason instead of a generic `ReconcilerError`, with the retry paced by the workqueue's per-item rate limiter. No sentinel state, fixed-delay requeues, or in-memory tracking — convergence stays level-triggered.

Regression tests pin the three shapes: a completion conflict is resolved on the SAME candidate (no flip), a stale re-patch degrades to zero effective writes, and a deleted assigned sandbox gets exactly one doomed write + authoritative cleanup + clean re-adoption on the next pass.

#### Evidence (measured on this half's fix specifically)

Watch-stream forensics from the #1256 isolation-leg A/B (12-node kops/GCP, 45/s × 60s sustained + burst; leg B = without this fix, leg A = with it):

- **Assignment flips (nonempty→different assigned-sandbox annotation): 340 → 0** (max 8 flips/claim in leg B), with **323 status rebinds** (incl. 21 cold-create overwrites of already-bound claims) and **74 Ready True→False regressions** — all eliminated in leg A.
- The flip storm drove sandbox-controller error churn of **10,880 PUT 409s + 8,200 PUT 404s** (18,709 workqueue retries, ~19 reconciles/sandbox) and 3,845 stale-view PATCH 404s, producing a monotonic sustained-latency ramp (p50 637→2089ms); leg A shows none of this signature — sustained p50/p90 108/221ms, flat windows, parity with main.
- Exonerated with data during the RCA: APIReader GET volume (432 total) and the claim workqueue (1,064 retries) were not the amplifier.

#### Relationship to #1129

Complementary, not competing, and trivially rebaseable in either order. #1129 clears an already-stale assigned-sandbox reference (annotation *and* deprecated label) in the recovery path on a **later pass**, when the recorded sandbox turns out to be controlled by another claim. This PR enforces the **in-pass** invariant: a committed assignment is never abandoned or overwritten mid-pass, and dead references are cleaned authoritatively at conflict time — which stops the flip loop at its source and reduces how often the state #1129 cleans up is created at all. The hunks are textually adjacent (both sit around the "belongs to another claim, falling through" branch), so whichever lands second rebases mechanically.

#### Relationship to #1256

Split out of #1256 at reviewer request (igooch's scope preference): #1256 now carries only the optimistic-locked claim **status** writes and exactly-once startup-latency metrics; this PR carries the adoption-assignment half. The two are independent — each builds, tests, and ships alone — but they touch neighboring code in `sandboxclaim_controller.go` (and both wire `APIReader`), so whichever merges second will need a small mechanical rebase. That is expected.

#### Which issue(s) this PR is related to:

Fixes #418
Ref #478 (the failed-write wedge after a committed adoption is the same class: the committed assignment must survive subsequent write failures instead of triggering re-adoption)

#### Release Note

```release-note
The SandboxClaim controller no longer abandons a committed warm-pool adoption when its cached view of the assigned sandbox is stale: the ownership transfer is applied with an optimistic lock and failures are resolved against authoritative reads (complete, re-patch once, or clean up the dead reference), preventing assignment flips, orphaned/stolen sandboxes, and duplicate adoptions under load. Benign adoption contention now surfaces as an AdoptionConflict Ready reason instead of a reconciler error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warm-pool sandbox adoption during conflicts and stale-cache conditions.
  * Prevented the controller from switching to another sandbox after an adoption conflict.
  * Reconciles assignments using the latest authoritative state, retrying or cleaning up stale references as appropriate.
  * Reports adoption conflicts with clearer readiness status and retry guidance.
  * Preserves finalized claim status during repeated reconciliation attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->