### PR TITLE
refactor: replace reflect.DeepEqual with Semantic.DeepEqual

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
-	"reflect"
 	"slices"
 	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -483,7 +483,7 @@ func podIPsFromStatus(podIPs []corev1.PodIP) []string {
 func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1beta1.SandboxStatus, sandbox *sandboxv1beta1.Sandbox) error {
 	logger := log.FromContext(ctx)
 
-	if reflect.DeepEqual(oldStatus, &sandbox.Status) {
+	if apiequality.Semantic.DeepEqual(oldStatus, &sandbox.Status) {
 		return nil
 	}
 
@@ -518,7 +518,7 @@ func nodeNameOnlyChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bool
 	}
 	scratch := newStatus.DeepCopy()
 	scratch.NodeName = oldStatus.NodeName
-	return reflect.DeepEqual(oldStatus, scratch)
+	return apiequality.Semantic.DeepEqual(oldStatus, scratch)
 }
 
 // GetNumericHash generates a raw FNV-1a hash value.
@@ -747,7 +747,7 @@ func (r *SandboxReconciler) reconcileService(ctx context.Context, sandbox *sandb
 			service.Labels[sandboxLabel] = nameHash
 			needsUpdate = true
 		}
-		if !reflect.DeepEqual(service.Spec.Selector, desiredSelector) {
+		if !apiequality.Semantic.DeepEqual(service.Spec.Selector, desiredSelector) {
 			service.Spec.Selector = desiredSelector
 			needsUpdate = true
 		}


### PR DESCRIPTION
Replaces standard `reflect.DeepEqual` with `apiequality.Semantic.DeepEqual` for comparing Kubernetes API objects in `controllers/sandbox_controller.go`.

Using `reflect.DeepEqual` on Kubernetes API objects is risky because:
1. It can fail on `metav1.Time` fields (e.g. in status conditions) if internal timezone location pointers differ, even if they represent the exact same time.
2. It treats `nil` and empty slices/maps as different.

Using `apiequality.Semantic.DeepEqual` is the standard and safer practice in Kubernetes controllers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison of Kubernetes resources to recognize semantically equivalent values consistently.
  * Prevented unnecessary status updates, node changes, and service reconciliation when differences are only representational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->