### PR TITLE
Add multi-runtime benchmark study for gVisor and Kata Containers

### DIFF
--- a/examples/gke-swap/README.md
+++ b/examples/gke-swap/README.md
@@ -12,7 +12,20 @@ In a standard Kubernetes cluster, when physical memory is exhausted, the node's 
 
 By enabling swap on fast, local NVMe SSDs (Local SSDs), GKE can swap out idle memory pages, allowing you to overcommit memory safely and pack significantly more pods onto each node.
 
-## Performance Results
+## Container Runtimes & Isolation Options
+
+Depending on your security and isolation requirements, `agent-sandbox` supports multiple container isolation runtimes on GKE. We have conducted high-density swap benchmarks across three major runtimes:
+
+1. **Default `runc` (Process Isolation)**: Standard Linux container isolation. Lowest overhead, highest density (**200 pods/node** with swap, +66% gain).
+2. **gVisor `runsc` (Syscall Interception)**: User-space kernel sandboxing. Strong process isolation, medium density (**160 pods/node** with swap, +100% gain).
+3. **Kata Containers (`kata-clh` / `kata-qemu`) (MicroVMs)**: Hardware-assisted nested virtualization. Maximum VM-level security boundary (**50 pods/node** with swap under `kata-clh`, **20 pods/node** under `kata-qemu`).
+
+> [!TIP]
+> **Cross-Runtime Benchmark Summary**: For a comprehensive side-by-side comparison matrix, memory footprint analysis, and architectural trade-offs across runtimes, visit the [**Container Isolation Runtimes Overview**](./runtimes/README.md).
+
+---
+
+## Vanilla `runc` Performance Results
 
 We evaluated and compared two node pools on GKE using `c4-standard-8` instances, running a concurrent density sweep of **120, 160, 200, and 240 pods**:
 
@@ -133,3 +146,10 @@ chmod +x run_chromesandbox_density_test.sh
 #### Results:
 - Raw timing metrics are saved to `artifacts/<scenario>/<density>/.../density_metrics.json`.
 - A compiled performance results table is written to `artifacts/perf_test_summary.md`.
+
+## Alternative Runtimes
+
+For gVisor or Kata Containers deployments and benchmarks, refer to:
+- [**`runtimes/README.md`**](./runtimes/README.md) — Multi-runtime comparison summary
+- [**`runtimes/gVisor/README.md`**](./runtimes/gVisor/README.md) — gVisor setup & results (up to 180 pods)
+- [**`runtimes/kata/README.md`**](./runtimes/kata/README.md) — Kata Containers setup & results (`kata-clh` & `kata-qemu`, up to 50/60 pods)

--- a/examples/gke-swap/README.md
+++ b/examples/gke-swap/README.md
@@ -2,7 +2,7 @@
 
 This example demonstrates how to configure Google Kubernetes Engine (GKE) Memory Swap using dedicated Local SSDs to drastically increase the density of `agent-sandbox` workloads (specifically Chromium pods) on a single node.
 
-By enabling swap on a dedicated Local SSD, we can ensure 100% workload success up to the **200 pods per node** on a cost-effective `c4-standard-8` instance (8 vCPUs, 32 GB RAM), whereas the baseline pool collapses and experiences severe workload instability starting from 130 pods per node.
+By enabling swap on a dedicated Local SSD, we can ensure 100% workload success up to the **200 pods per node** on a cost-effective `c4-standard-8` instance (8 vCPUs, 30 GB RAM), whereas the baseline pool collapses and experiences severe workload instability starting from 130 pods per node.
 
 ## Why Swap for Agent Sandboxes?
 
@@ -151,5 +151,5 @@ chmod +x run_chromesandbox_density_test.sh
 
 For gVisor or Kata Containers deployments and benchmarks, refer to:
 - [**`runtimes/README.md`**](./runtimes/README.md) — Multi-runtime comparison summary
-- [**`runtimes/gVisor/README.md`**](./runtimes/gVisor/README.md) — gVisor setup & results (up to 180 pods)
-- [**`runtimes/kata/README.md`**](./runtimes/kata/README.md) — Kata Containers setup & results (`kata-clh` & `kata-qemu`, up to 50/60 pods)
+- [**`runtimes/gVisor/README.md`**](./runtimes/gVisor/README.md) — gVisor setup & results (160 pods max stable density)
+- [**`runtimes/kata/README.md`**](./runtimes/kata/README.md) — Kata Containers setup & results (`kata-clh` & `kata-qemu`, up to 50 pods (kata-clh) / 20 pods (kata-qemu))

--- a/examples/gke-swap/deploy_cluster.sh
+++ b/examples/gke-swap/deploy_cluster.sh
@@ -56,5 +56,5 @@ KUBECONFIG="${KUBECONFIG:-"${REPO_ROOT}/bin/KUBECONFIG"}" gcloud container clust
 
 echo "Cluster deployed successfully."
 echo "Please ensure the Agent Sandbox controller and CRDs are deployed on this cluster before running the tests."
-# Example installation:
-# kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox.yaml
+# Example installation (all-in-one controller + extension CRDs):
+# kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox-with-extensions.yaml

--- a/examples/gke-swap/node-tuner-daemonset.yaml
+++ b/examples/gke-swap/node-tuner-daemonset.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-tuner-ds
+  namespace: kube-system
+  labels:
+    app: node-tuner
+spec:
+  selector:
+    matchLabels:
+      app: node-tuner
+  template:
+    metadata:
+      labels:
+        app: node-tuner
+    spec:
+      hostPID: true
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: host-root
+        hostPath:
+          path: /
+          type: Directory
+      initContainers:
+      - name: apply-node-tuning
+        image: ubuntu:latest
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: host-root
+          mountPath: /host
+        command:
+         - /bin/bash
+         - -c
+         - |
+          set -e
+          
+          NUM_CPUS=$(chroot /host nproc)
+          echo "Node has $NUM_CPUS CPUs."
+          
+          if [ "$NUM_CPUS" -le 2 ]; then
+            # 1-2 cores: do not apply CPU isolation to avoid starved node
+            PIN_CPUS=""
+            KUBELET_CPUS=""
+          elif [ "$NUM_CPUS" -le 8 ]; then
+            # 4-8 cores: reserve 2 cores for system (0-1)
+            PIN_CPUS="0,1"
+            KUBELET_CPUS="0,1"
+          else
+            # 12+ cores (e.g. c4-standard-32): reserve 8 cores for system (0-7)
+            PIN_CPUS="0-7"
+            KUBELET_CPUS="0-7"
+          fi
+          
+          echo "1. Applying ARP cache sysctl settings for 1024 pods/node..."
+          chroot /host sysctl -w net.ipv4.neigh.default.gc_thresh1=2048
+          chroot /host sysctl -w net.ipv4.neigh.default.gc_thresh2=4096
+          chroot /host sysctl -w net.ipv4.neigh.default.gc_thresh3=8192
+          
+          if [ -n "$PIN_CPUS" ]; then
+            echo "2. Pinning system.slice to CPUs $PIN_CPUS..."
+            if [ -f /host/sys/fs/cgroup/system.slice/cpuset.cpus ]; then
+              echo "$PIN_CPUS" > /host/sys/fs/cgroup/system.slice/cpuset.cpus
+            elif [ -f /host/sys/fs/cgroup/cpuset/system.slice/cpuset.cpus ]; then
+              echo "$PIN_CPUS" > /host/sys/fs/cgroup/cpuset/system.slice/cpuset.cpus
+            else
+              echo "Warning: Could not find system.slice cpuset file."
+            fi
+          else
+            echo "2. Pinning system.slice: Skipped (node too small)."
+          fi
+          
+          echo "3. Redirecting journal logs to Local SSD and applying rate limits..."
+          mkdir -p /host/var/lib/containerd/systemd-journal
+          mkdir -p /host/var/log/journal
+          # Mount only if not already bind-mounted
+          if ! chroot /host mountpoint -q /var/log/journal; then
+            mount --bind /host/var/lib/containerd/systemd-journal /host/var/log/journal
+          fi
+          mkdir -p /host/etc/systemd/journald.conf.d
+          echo -e "[Journal]\nSystemMaxUse=500M\nRateLimitIntervalSec=30s\nRateLimitBurst=1000" > /host/etc/systemd/journald.conf.d/tuning.conf
+          chroot /host systemctl restart systemd-journald
+
+          if [ -n "$KUBELET_CPUS" ]; then
+            echo "4. Updating Kubelet config for reservedSystemCPUs and static CPU manager..."
+            KUBELET_CFG="/host/home/kubernetes/kubelet-config.yaml"
+            
+            if [ -f "$KUBELET_CFG" ]; then
+              NEEDS_RESTART=0
+              
+              # Add reservedSystemCPUs if missing, or update if present
+              if ! grep -q "reservedSystemCPUs" "$KUBELET_CFG"; then
+                echo "reservedSystemCPUs: \"$KUBELET_CPUS\"" >> "$KUBELET_CFG"
+                NEEDS_RESTART=1
+              else
+                # Update existing value to target cpuset
+                sed -i "s/reservedSystemCPUs:.*/reservedSystemCPUs: \"$KUBELET_CPUS\"/" "$KUBELET_CFG"
+                NEEDS_RESTART=1
+              fi
+              
+              # Enforce cpuManagerPolicy: "static"
+              if ! grep -q "cpuManagerPolicy" "$KUBELET_CFG"; then
+                echo 'cpuManagerPolicy: "static"' >> "$KUBELET_CFG"
+                NEEDS_RESTART=1
+              elif grep -q 'cpuManagerPolicy: "none"' "$KUBELET_CFG" || grep -q "cpuManagerPolicy: none" "$KUBELET_CFG"; then
+                sed -i 's/cpuManagerPolicy:.*/cpuManagerPolicy: "static"/' "$KUBELET_CFG"
+                NEEDS_RESTART=1
+              fi
+
+              if [ "$NEEDS_RESTART" -eq 1 ]; then
+                echo "Cleaning CPU manager state and restarting kubelet..."
+                rm -f /host/var/lib/kubelet/cpu_manager_state
+                chroot /host systemctl restart kubelet
+              else
+                echo "Kubelet configuration is already correct."
+              fi
+            fi
+          else
+            echo "4. Kubelet core isolation: Skipped (node too small)."
+          fi
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9

--- a/examples/gke-swap/node-tuner-daemonset.yaml
+++ b/examples/gke-swap/node-tuner-daemonset.yaml
@@ -25,12 +25,13 @@ spec:
           type: Directory
       initContainers:
       - name: apply-node-tuning
-        image: ubuntu:latest
+        image: ubuntu:24.04
         securityContext:
           privileged: true
         volumeMounts:
         - name: host-root
           mountPath: /host
+          mountPropagation: Bidirectional
         command:
          - /bin/bash
          - -c
@@ -72,7 +73,7 @@ spec:
             echo "2. Pinning system.slice: Skipped (node too small)."
           fi
           
-          echo "3. Redirecting journal logs to Local SSD and applying rate limits..."
+          echo "3. Relocating journal logs and applying rate limits..."
           mkdir -p /host/var/lib/containerd/systemd-journal
           mkdir -p /host/var/log/journal
           # Mount only if not already bind-mounted
@@ -90,22 +91,23 @@ spec:
             if [ -f "$KUBELET_CFG" ]; then
               NEEDS_RESTART=0
               
-              # Add reservedSystemCPUs if missing, or update if present
-              if ! grep -q "reservedSystemCPUs" "$KUBELET_CFG"; then
-                echo "reservedSystemCPUs: \"$KUBELET_CPUS\"" >> "$KUBELET_CFG"
-                NEEDS_RESTART=1
-              else
-                # Update existing value to target cpuset
-                sed -i "s/reservedSystemCPUs:.*/reservedSystemCPUs: \"$KUBELET_CPUS\"/" "$KUBELET_CFG"
+              # Update reservedSystemCPUs only if not already set to target value
+              if ! grep -q "reservedSystemCPUs: \"$KUBELET_CPUS\"" "$KUBELET_CFG"; then
+                if ! grep -q "reservedSystemCPUs" "$KUBELET_CFG"; then
+                  echo "reservedSystemCPUs: \"$KUBELET_CPUS\"" >> "$KUBELET_CFG"
+                else
+                  sed -i "s/reservedSystemCPUs:.*/reservedSystemCPUs: \"$KUBELET_CPUS\"/" "$KUBELET_CFG"
+                fi
                 NEEDS_RESTART=1
               fi
               
-              # Enforce cpuManagerPolicy: "static"
-              if ! grep -q "cpuManagerPolicy" "$KUBELET_CFG"; then
-                echo 'cpuManagerPolicy: "static"' >> "$KUBELET_CFG"
-                NEEDS_RESTART=1
-              elif grep -q 'cpuManagerPolicy: "none"' "$KUBELET_CFG" || grep -q "cpuManagerPolicy: none" "$KUBELET_CFG"; then
-                sed -i 's/cpuManagerPolicy:.*/cpuManagerPolicy: "static"/' "$KUBELET_CFG"
+              # Enforce cpuManagerPolicy: "static" only if not already set
+              if ! grep -q 'cpuManagerPolicy: "static"' "$KUBELET_CFG"; then
+                if ! grep -q "cpuManagerPolicy" "$KUBELET_CFG"; then
+                  echo 'cpuManagerPolicy: "static"' >> "$KUBELET_CFG"
+                else
+                  sed -i 's/cpuManagerPolicy:.*/cpuManagerPolicy: "static"/' "$KUBELET_CFG"
+                fi
                 NEEDS_RESTART=1
               fi
 

--- a/examples/gke-swap/run_chromesandbox_density_test.sh
+++ b/examples/gke-swap/run_chromesandbox_density_test.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 IMAGE_PREFIX=${IMAGE_PREFIX:-"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/"}
 IMAGE_TAG=${IMAGE_TAG:-"latest-main"}
 
-
+# Use the user-specified runtime class, default to empty string (use node's default runtime class)
 RUNTIME_CLASS=${RUNTIME_CLASS:-""}
 
 # Get the directory of this script

--- a/examples/gke-swap/run_chromesandbox_density_test.sh
+++ b/examples/gke-swap/run_chromesandbox_density_test.sh
@@ -19,6 +19,9 @@ set -eo pipefail
 IMAGE_PREFIX=${IMAGE_PREFIX:-"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/"}
 IMAGE_TAG=${IMAGE_TAG:-"latest-main"}
 
+
+RUNTIME_CLASS=${RUNTIME_CLASS:-""}
+
 # Get the directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 REPO_ROOT="${DIR}/../.."
@@ -100,7 +103,8 @@ for scenario in "${NODE_SCENARIOS[@]}"; do
         -node-name="${NODE_NAME}" \
         -density="${density}" \
         -image-prefix="${IMAGE_PREFIX}" \
-        -image-tag="${IMAGE_TAG}"; then
+        -image-tag="${IMAGE_TAG}" \
+        -runtime-class-name="${RUNTIME_CLASS}"; then
       echo "Scenario ${scenario} at density ${density} completed successfully."
     else
       echo "Scenario ${scenario} at density ${density} failed."

--- a/examples/gke-swap/runtimes/README.md
+++ b/examples/gke-swap/runtimes/README.md
@@ -6,7 +6,7 @@ This directory contains configuration, deployment scripts, and a comprehensive p
 2. **Kata Containers (`kata-qemu`)**: Hardware-virtualized MicroVMs using the QEMU hypervisor.
 3. **Kata Containers (`kata-clh`)**: Hardware-virtualized MicroVMs using the Cloud Hypervisor (CLH) Rust-based VMM.
 
-All metrics reference benchmarks conducted on **`c4-standard-8`** GKE node instances (8 vCPUs, 32 GB physical RAM, ~28 GB allocatable).
+All metrics reference benchmarks conducted on **`c4-standard-8`** GKE node instances (8 vCPUs, 30 GB physical RAM, ~28 GB allocatable).
 
 ---
 
@@ -24,9 +24,9 @@ All metrics reference benchmarks conducted on **`c4-standard-8`** GKE node insta
 
 ## 2. Host Memory Footprint per Pod
 
-Process-level physical memory (Resident Set Size - RSS) and incremental unique RAM measured across sequential pod deployments on a clean cluster:
+Process-level physical memory (Resident Set Size - RSS) and incremental host RSS measured across sequential pod deployments on a clean cluster:
 
-| Runtime | Host RSS per Pod | Unique RAM per Pod | Process Component Breakdown |
+| Runtime | Host RSS per Pod | Incremental Host RSS | Process Component Breakdown |
 | :--- | :--- | :--- | :--- |
 | **gVisor (`runsc`)** | **~370 MiB** | **~206.0 MiB** | <ul><li>`runsc-sandbox` (Sentry): ~311 MiB</li><li>`runsc-gofer` (FS proxy): ~25 MiB</li><li>Control shim: ~34 MiB</li></ul> |
 | **Kata (`kata-qemu`)** | **~1,130 MiB** | **~631.5 MiB** | <ul><li>`qemu-system-x86_64` (VMM): ~678 MiB</li><li>`virtiofsd` (FS daemon): ~421 MiB</li><li>Control shim: ~35 MiB</li></ul> |
@@ -38,8 +38,8 @@ Process-level physical memory (Resident Set Size - RSS) and incremental unique R
 
 To push density ceilings higher, a custom node-tuning DaemonSet was developed and applied across the node pools:
 
-1. **CPU Pinning (`--reserved-cpus=0,1`)**: Linux cgroups and Kubelet static CPU management reserve Cores 0 and 1 strictly for host system daemons and Kubelet. Guaranteed workload containers are pinned exclusively to Cores 2–7, preventing workload pods from starving Kubelet of heartbeat check cycles.
-2. **`systemd-journald` Redirection & Rate-Limiting**: Log storage for `systemd-journald` is redirected away from rootfs to a dedicated Local SSD directory with strict rate limits (`RateLimitIntervalSec=30s`, `RateLimitBurst=10000`) to eliminate logging CPU spikes during boot storms.
+1. **CPU Isolation (`--reserved-cpus=0,1`)**: Linux cgroups and Kubelet static CPU management reserve Cores 0 and 1 strictly for host system daemons and Kubelet, allowing workload containers to run on Cores 2–7 without starving Kubelet of heartbeat check cycles.
+2. **`systemd-journald` Storage Rate-Limiting**: `systemd-journald` log storage is rate-limited (`RateLimitIntervalSec=30s`, `RateLimitBurst=1000`) to eliminate logging CPU spikes during boot storms.
 3. **Kernel ARP Table Scaling**: Linux kernel ARP garbage collection thresholds (`net.ipv4.neigh.default.gc_thresh1/2/3`) are scaled from `128/512/1024` to `2048/4096/8192` to eliminate packet drops across hundreds of internal container veth pairs.
 
 ### Performance Impact of Node Tuning:
@@ -78,8 +78,8 @@ GKE Memory Swap on dedicated Local SSDs significantly extends node capacity for 
 ## 6. Failure Modes Breakdown
 
 ### gVisor (`runsc`)
-- **Untuned Node**: Emulating syscalls for 180 Chrome instances consumes high host CPU. Emulation threads compete with system services, starving Kubelet of CPU cycles until GKE flags the node `NotReady`.
-- **Tuned Node + NVMe Swap**: CPU isolation protects Kubelet on Cores 0–1, enabling scaling to 180 pods. Beyond 180 pods, swapping ~42 GB of memory pages saturates the NVMe SSD controller write queues. Kubelet blocks in D-state attempting log writes, locking up the node.
+- **Untuned Node**: Emulating syscalls for high-density Chrome instances consumes high host CPU. Emulation threads compete with system services, starving Kubelet of CPU cycles until GKE flags the node `NotReady`.
+- **Tuned Node + NVMe Swap**: CPU isolation protects Kubelet on Cores 0–1, enabling scaling to 160 pods with 100% success. At 180 pods, swapping ~25.5 GB of memory pages saturates the NVMe SSD controller write queues, causing Kubelet to block in D-state attempting log writes and triggering workload failures (85.56% success).
 
 ### Kata Containers (`kata-qemu`)
 - **Host Boot Disk Sizing**: Chrome sparse cache files (`/tmp`) generate 80 GB+ of writes across 40+ sandboxes. On default 100 GB boot disks, this triggers host disk pressure GC and crashes `virtiofsd` with `SIGBUS` (exit code 135). Node boot disks must be sized to **≥150–250 GB**.
@@ -96,6 +96,6 @@ GKE Memory Swap on dedicated Local SSDs significantly extends node capacity for 
 
 Explore detailed runtime configuration, density sweep data, and setup instructions for each runtime:
 
-- [**gVisor Guide & Benchmarks**](./gVisor/README.md) — Detailed gVisor execution guide, Sentry memory analysis, 60–180 density sweep matrix, and node tuner configuration.
+- [**gVisor Guide & Benchmarks**](./gVisor/README.md) — Detailed gVisor execution guide, Sentry memory analysis, 60–160 density sweep matrix (180 failure threshold), and node tuner configuration.
 - [**Kata Containers Guide & Benchmarks (`kata-qemu` & `kata-clh`)**](./kata/README.md) — Comprehensive Kata guide covering QEMU vs Cloud Hypervisor VMM comparison, 20–60 density sweeps, and memory limit tuning.
 - [**Default `runc` Baseline Guide**](../README.md) — Main GKE Local SSD Swap example landing page and native container baseline.

--- a/examples/gke-swap/runtimes/README.md
+++ b/examples/gke-swap/runtimes/README.md
@@ -1,0 +1,101 @@
+# Container Isolation Runtimes on GKE with Local SSD Swap
+
+This directory contains configuration, deployment scripts, and a comprehensive performance benchmark study for running high-density `agent-sandbox` workloads across sandboxed container runtimes on Google Kubernetes Engine (GKE):
+
+1. **gVisor (`runsc`)**: User-space kernel application sandboxing via syscall interception (Sentry & Gofer).
+2. **Kata Containers (`kata-qemu`)**: Hardware-virtualized MicroVMs using the QEMU hypervisor.
+3. **Kata Containers (`kata-clh`)**: Hardware-virtualized MicroVMs using the Cloud Hypervisor (CLH) Rust-based VMM.
+
+All metrics reference benchmarks conducted on **`c4-standard-8`** GKE node instances (8 vCPUs, 32 GB physical RAM, ~28 GB allocatable).
+
+---
+
+## 1. Architectural Profiles
+
+| Feature | gVisor (`runsc`) | Kata (`kata-qemu`) | Kata (`kata-clh`) |
+| :--- | :--- | :--- | :--- |
+| **Isolation Level** | User-space emulated kernel | Hardware-virtualized MicroVM | Hardware-virtualized MicroVM |
+| **VMM / Kernel Model** | Simulated kernel interface (`Sentry`) | Monolithic QEMU hypervisor & guest kernel | Async Rust Cloud Hypervisor VMM & guest kernel |
+| **Security Boundary** | Strong (restricts syscall access) | Strictest (nested virtualization) | Strictest (nested virtualization) |
+| **Memory Sharing** | Low (emulated address translation maps) | Lowest (hard boundaries between QEMU hypervisors) | Lowest (hard boundaries between CLH hypervisors) |
+| **VMM Config Protocol** | N/A (process shim) | Synchronous serial vCPU hotplugging | Single async HTTP PUT payload |
+
+---
+
+## 2. Host Memory Footprint per Pod
+
+Process-level physical memory (Resident Set Size - RSS) and incremental unique RAM measured across sequential pod deployments on a clean cluster:
+
+| Runtime | Host RSS per Pod | Unique RAM per Pod | Process Component Breakdown |
+| :--- | :--- | :--- | :--- |
+| **gVisor (`runsc`)** | **~370 MiB** | **~206.0 MiB** | <ul><li>`runsc-sandbox` (Sentry): ~311 MiB</li><li>`runsc-gofer` (FS proxy): ~25 MiB</li><li>Control shim: ~34 MiB</li></ul> |
+| **Kata (`kata-qemu`)** | **~1,130 MiB** | **~631.5 MiB** | <ul><li>`qemu-system-x86_64` (VMM): ~678 MiB</li><li>`virtiofsd` (FS daemon): ~421 MiB</li><li>Control shim: ~35 MiB</li></ul> |
+| **Kata (`kata-clh`)** | **~1,128 MiB** | **~687.5 MiB** | <ul><li>`cloud-hypervisor` (VMM): ~664.7 MiB</li><li>`virtiofsd` (FS daemon): ~426.8 MiB</li><li>Control shim: ~36.0 MiB</li></ul> |
+
+---
+
+## 3. Node Tuning & CPU Isolation Strategy
+
+To push density ceilings higher, a custom node-tuning DaemonSet was developed and applied across the node pools:
+
+1. **CPU Pinning (`--reserved-cpus=0,1`)**: Linux cgroups and Kubelet static CPU management reserve Cores 0 and 1 strictly for host system daemons and Kubelet. Guaranteed workload containers are pinned exclusively to Cores 2–7, preventing workload pods from starving Kubelet of heartbeat check cycles.
+2. **`systemd-journald` Redirection & Rate-Limiting**: Log storage for `systemd-journald` is redirected away from rootfs to a dedicated Local SSD directory with strict rate limits (`RateLimitIntervalSec=30s`, `RateLimitBurst=10000`) to eliminate logging CPU spikes during boot storms.
+3. **Kernel ARP Table Scaling**: Linux kernel ARP garbage collection thresholds (`net.ipv4.neigh.default.gc_thresh1/2/3`) are scaled from `128/512/1024` to `2048/4096/8192` to eliminate packet drops across hundreds of internal container veth pairs.
+
+### Performance Impact of Node Tuning:
+- **gVisor (`runsc`)**: Expanded maximum stable density on NVMe SSD swap from 140 pods (untuned) to **160 pods (tuned)**, while reducing Sandbox Ready P99 latency by ~60% and Chrome Ready P99 latency by ~40%.
+- **Kata Cloud Hypervisor (`kata-clh`)**: Expanded maximum stable density on NVMe SSD swap from 40 pods (untuned) to **50 pods (tuned)** with 100% success.
+
+---
+
+## 4. High Density Scaling Thresholds
+
+Summary comparison of maximum stable pod density and startup latency (P50/P99 Chrome Ready) across baseline (No Swap) and NVMe Local SSD Swap node pools:
+
+| Runtime | Config Type | Max Stable Density | Chrome Ready P50 (Avg) | Chrome Ready P99 |
+| :--- | :--- | :--- | :--- | :--- |
+| **gVisor (`runsc`)** | No Swap (Tuned) | **80 Pods** | **17.59s** | **41.07s** |
+| **gVisor (`runsc`)** | NVMe SSD Swap (Tuned) | **160 Pods** | **59.02s** | **214.95s** |
+| | | | | |
+| **Kata (`kata-qemu`)** | No Swap (Tuned) | **20 Pods** | **16.44s** | **24.92s** |
+| **Kata (`kata-qemu`)** | NVMe SSD Swap | **20 Pods** | **16.16s** | **24.28s** |
+| | | | | |
+| **Kata (`kata-clh`)** | No Swap (Tuned) | **40 Pods** | **34.54s** | **60.99s** |
+| **Kata (`kata-clh`)** | NVMe SSD Swap (Tuned) | **50 Pods** | **71.02s** | **174.14s** |
+
+---
+
+## 5. Key Takeaways: The Impact of Local SSD Swap
+
+GKE Memory Swap on dedicated Local SSDs significantly extends node capacity for memory-heavy sandbox workloads, but its effectiveness depends heavily on the underlying runtime architecture:
+
+- **gVisor (`runsc`) — +100% Density Increase (80 → 160 Pods)**: Swap doubles the maximum stable density. Without swap, gVisor Sentry user-space kernels exhaust host RAM at 80 pods. NVMe Local SSD Swap absorbs cold anonymous memory pages from idle Chrome processes, allowing gVisor to scale reliably to 160 pods. Scaling beyond 160 pods (to 180+) shifts the bottleneck from memory capacity to NVMe write queue depth saturation.
+- **Kata Cloud Hypervisor (`kata-clh`) — +25% Density Increase (40 → 50 Pods)**: Swap extends stable density from 40 to 50 pods with 100% success. Cloud Hypervisor's async Rust architecture decouples VMM communications from guest vCPUs (preventing I/O stalls). At 60 pods, physical CPU cores become the primary bottleneck due to parallel hypervisor scheduling and pageout workloads.
+- **Kata QEMU (`kata-qemu`) — No Density Gain (Stuck at 20 Pods)**: Swap does not improve density for QEMU microVMs. When host OS pages VM blocks to NVMe swap, guest page faults force uninterruptible disk reads (D-state). In QEMU's legacy monolithic architecture, the Big QEMU Lock (BQL) causes vCPU threads in D-state to lock up the main VMM event loop, triggering containerd-shim keep-alive timeouts.
+
+---
+
+## 6. Failure Modes Breakdown
+
+### gVisor (`runsc`)
+- **Untuned Node**: Emulating syscalls for 180 Chrome instances consumes high host CPU. Emulation threads compete with system services, starving Kubelet of CPU cycles until GKE flags the node `NotReady`.
+- **Tuned Node + NVMe Swap**: CPU isolation protects Kubelet on Cores 0–1, enabling scaling to 180 pods. Beyond 180 pods, swapping ~42 GB of memory pages saturates the NVMe SSD controller write queues. Kubelet blocks in D-state attempting log writes, locking up the node.
+
+### Kata Containers (`kata-qemu`)
+- **Host Boot Disk Sizing**: Chrome sparse cache files (`/tmp`) generate 80 GB+ of writes across 40+ sandboxes. On default 100 GB boot disks, this triggers host disk pressure GC and crashes `virtiofsd` with `SIGBUS` (exit code 135). Node boot disks must be sized to **≥150–250 GB**.
+- **Big QEMU Lock (BQL) Deadlock**: When host OS pages VM blocks to NVMe swap, subsequent guest page faults force uninterruptible disk reads (D-state). In QEMU's monolithic thread synchronization model, a vCPU thread in D-state locks up the main VMM event loop, failing containerd-shim keep-alive pings within 15 seconds.
+
+### Kata Containers (`kata-clh`)
+- **Async Rust Architecture**: Cloud Hypervisor decouples the VMM control channel from guest vCPU execution threads, reducing D-state stalls to 0.069% (13x fewer than QEMU).
+- **Fast Config Payload**: CLH boots via a single HTTP PUT request payload instead of QEMU's serial vCPU hotplugging, allowing **40 pods baseline** (2.5x density over QEMU without swap).
+- **CPU Bottleneck at 60 Pods**: With swap enabled and Kubelet protected on Cores 0–1, `kata-clh` reaches **50 pods with 100% success**. At 60 pods, the 6 physical workload cores are completely overwhelmed by 60 concurrent VMM hypervisor loops, stretching VM boot times past 3 minutes and causing timeouts.
+
+---
+
+## Subdirectory Navigation
+
+Explore detailed runtime configuration, density sweep data, and setup instructions for each runtime:
+
+- [**gVisor Guide & Benchmarks**](./gVisor/README.md) — Detailed gVisor execution guide, Sentry memory analysis, 60–180 density sweep matrix, and node tuner configuration.
+- [**Kata Containers Guide & Benchmarks (`kata-qemu` & `kata-clh`)**](./kata/README.md) — Comprehensive Kata guide covering QEMU vs Cloud Hypervisor VMM comparison, 20–60 density sweeps, and memory limit tuning.
+- [**Default `runc` Baseline Guide**](../README.md) — Main GKE Local SSD Swap example landing page and native container baseline.

--- a/examples/gke-swap/runtimes/gVisor/README.md
+++ b/examples/gke-swap/runtimes/gVisor/README.md
@@ -1,0 +1,109 @@
+# High-Density Agent Sandbox under gVisor on GKE with Local SSD Swap
+
+> **Note**: For a high-level comparison across all sandboxed container runtimes (`gVisor`, `kata-qemu`, `kata-clh`), see the [**Runtime Comparison Overview**](../README.md).
+
+This directory contains configuration, deployment instructions, and performance benchmark findings for running **gVisor (`runsc`)** isolated containers under high density (60–180 sandboxes) on a single `c4-standard-8` (32 GB RAM, 8 vCPU) GKE instance.
+
+By combining GKE Memory Swap on dedicated Local SSDs with node-level CPU pinning and system log rate-limiting, gVisor-isolated Chrome sandboxes can scale up to **180 concurrent instances** without node instability or Kubelet heartbeat evictions.
+
+---
+
+## 1. Host Memory Footprint & Page Cache Sharing
+
+### 1.1. Single Pod Memory Breakdown
+Process-level physical RAM (Resident Set Size - RSS) and incremental unique RAM measured across sequential pod deployments on a clean cluster:
+
+| Component | Host RSS | Role & Description |
+| :--- | :--- | :--- |
+| **gVisor Sentry** (`runsc-sandbox`) | **~311.0 MiB** | Emulated user-space kernel mapping the Chromium process tree. |
+| **gVisor Gofer** (`runsc-gofer`) | **~25.0 MiB** | Guest-to-host filesystem translation proxy. |
+| **Control Shim** | **~34.0 MiB** | Containerd gVisor runtime supervisor. |
+| **Total Resident Footprint** | **~370.0 MiB** | **Per-pod startup host RSS.** |
+| **Incremental Unique RAM** | **~206.0 MiB** | **Pure non-shareable host RAM required per pod.** |
+
+### 1.2. Shared Executable Page Cache & Swap Efficiency
+Multiplying single pod RSS by 180 pods suggests **~66.6 GiB** ($180 \times 370 \text{ MiB}$), exceeding physical 32 GB RAM. The benchmark succeeds because:
+1. **Shared Executable Binary Pages**: The host OS loads Chromium read-only binary pages into Page Cache **once**. All 180 sandboxes map to these shared pages via Gofer, reducing unique RAM to **~206 MiB**.
+2. **Local SSD Swap Eviction**: GKE Memory Swap offloads cold anonymous heaps of idle sandboxes to NVMe storage, preserving RAM for active pod creation.
+
+---
+
+## 2. Performance Results (gVisor Density Matrix)
+
+All benchmark runs below were conducted on `c4-standard-8` node pools (8 vCPUs, 32 GB RAM) with node tuning applied.
+
+### 2.1. Baseline Pool (No Swap)
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **baseline-pool** | 60 | 4.24s / 8.92s | 11.66s / 26.10s | 10.07 GB | 25.45% | 0.00% / 0.00% | 4.53% / 0.41% | **SUCCESS** |
+| **baseline-pool** | 80 | 6.40s / 20.90s | 17.59s / 41.07s | 23.15 GB | 73.50% | 0.01% / 0.00% | 31.65% / 0.90% | **SUCCESS** |
+| **baseline-pool** | **100** | — / — | — / — | N/A | 55.53% | 61.35% / 23.42% | 78.75% / 19.34% | **FAILED (93.0% Success)** |
+
+### 2.2. Local SSD Swap Pool (Tuned)
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | Peak Host Swap | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **lssd-swap-pool** | 60 | 4.51s / 11.43s | 9.84s / 22.10s | 16.81 GB | 0.00 GB | 71.64% | 0.03% / 0.00% | 13.51% / 1.37% | **SUCCESS** |
+| **lssd-swap-pool** | 80 | 5.03s / 12.63s | 13.41s / 30.62s | 21.98 GB | 0.23 GB | 67.61% | 1.70% / 0.35% | 24.83% / 1.08% | **SUCCESS** |
+| **lssd-swap-pool** | 100 | 8.82s / 41.81s | 19.99s / 76.11s | 23.63 GB | 7.30 GB | 88.16% | 23.66% / 1.74% | 49.83% / 0.80% | **SUCCESS** |
+| **lssd-swap-pool** | 120 | 13.79s / 50.11s | 31.31s / 97.40s | 21.56 GB | 11.60 GB | 78.69% | 29.66% / 2.17% | 38.22% / 1.21% | **SUCCESS** |
+| **lssd-swap-pool** | 140 | 20.98s / 65.20s | 48.29s / 149.32s | 21.77 GB | 19.20 GB | 85.20% | 46.76% / 3.54% | 52.77% / 1.09% | **SUCCESS** |
+| **lssd-swap-pool** | **160** | 27.13s / 101.54s | **59.02s / 214.95s** | 21.75 GB | **17.29 GB** | 89.24% | 63.27% / 5.76% | 62.25% / 0.85% | **SUCCESS** |
+| **lssd-swap-pool** | **180** | — / — | — / — | 18.20 GB | **25.51 GB** | 93.12% | 82.05% / 7.60% | 78.39% / 2.04% | **FAILED (85.56% Success)** |
+
+---
+
+## 3. Key Takeaways & Impact of Local SSD Swap
+
+### 3.1. Effect of Local SSD Swap on gVisor (+100% Density Gain)
+- **Doubled Maximum Stable Density (80 → 160 Pods)**: Without swap, gVisor Sentry user-space kernels exhaust host physical RAM at 80 pods. Dedicated Local SSD Swap absorbs cold anonymous memory heaps from idle Chrome processes, enabling gVisor to scale reliably to **160 pods with 100% success**.
+
+### 3.2. CPU Pinning & Kubelet Protection (Cores 0–1)
+On untuned nodes, emulating syscalls for 180 Chrome instances consumes high host CPU across all cores. Emulation threads starve Kubelet of CPU time, causing missed heartbeats and leading GKE to flag the node `NotReady`.
+
+Applying the node tuning DaemonSet enforces:
+- `--reserved-cpus=0,1` and `--cpu-manager-policy=static` on Kubelet.
+- Linux cgroups pinning system services and Kubelet strictly to Cores 0 and 1.
+- Guaranteed sandbox workload containers assigned exclusively Cores 2–7.
+- Log storage for `systemd-journald` redirected to Local SSD with rate limits (`RateLimitIntervalSec=30s`, `RateLimitBurst=10000`).
+
+Node tuning reduces overall Sandbox Ready P99 latency by **~60%** and Chrome Ready P99 latency by **~40%**, expanding maximum stable density from 140 (untuned) to 160–180 pods.
+
+### 3.2. NVMe SSD Write Queue Saturation (>180 Pods)
+Scaling past 180 pods forces the host to swap ~42 GB of memory pages. The massive parallel write volume saturates the NVMe SSD controller's write queue depths. Kubelet (on Core 0) blocks in D-state trying to write container logs to disk, locking up the node.
+
+---
+
+## How to Run the gVisor Density Benchmark
+
+### Step 1: Provision Cluster
+
+Deploy a cluster with gVisor enabled on both `baseline-pool` and `lssd-swap-pool`:
+
+```bash
+chmod +x deploy_cluster.sh
+./deploy_cluster.sh
+```
+
+### Step 2: Apply Node Tuner DaemonSet
+
+Apply host CPU pinning and system log rate limiting:
+
+```bash
+export KUBECONFIG="$(git rev-parse --show-toplevel)/bin/KUBECONFIG"
+kubectl apply -f ../../node-tuner-daemonset.yaml
+```
+
+### Step 3: Execute Benchmark
+
+Target the `gvisor` runtime class and execute the density sweep:
+
+```bash
+export RUNTIME_CLASS="gvisor"
+export SCENARIOS="lssd-swap-pool"
+export DENSITIES="60 80 100 120 140 160 180"
+
+../../run_chromesandbox_density_test.sh
+```
+
+### Step 4: Analyze Metrics
+Raw metric JSON files are saved to `artifacts/lssd-swap-pool/<density>/TestChromeSandboxDensity/density_metrics.json`.

--- a/examples/gke-swap/runtimes/gVisor/README.md
+++ b/examples/gke-swap/runtimes/gVisor/README.md
@@ -80,6 +80,7 @@ chmod +x deploy_cluster.sh
 Apply host CPU pinning and system log rate limiting:
 
 ```bash
+export KUBECONFIG="$(git rev-parse --show-toplevel)/bin/KUBECONFIG"
 kubectl apply -f ../../node-tuner-daemonset.yaml
 kubectl rollout status daemonset/node-tuner-ds -n kube-system
 ```

--- a/examples/gke-swap/runtimes/gVisor/README.md
+++ b/examples/gke-swap/runtimes/gVisor/README.md
@@ -2,16 +2,15 @@
 
 > **Note**: For a high-level comparison across all sandboxed container runtimes (`gVisor`, `kata-qemu`, `kata-clh`), see the [**Runtime Comparison Overview**](../README.md).
 
-This directory contains configuration, deployment instructions, and performance benchmark findings for running **gVisor (`runsc`)** isolated containers under high density (60–180 sandboxes) on a single `c4-standard-8` (32 GB RAM, 8 vCPU) GKE instance.
+This directory contains configuration, deployment instructions, and performance benchmark findings for running **gVisor (`runsc`)** isolated containers under high density (60–180 sandboxes) on a single `c4-standard-8` (30 GB RAM, 8 vCPU) GKE instance.
 
-By combining GKE Memory Swap on dedicated Local SSDs with node-level CPU pinning and system log rate-limiting, gVisor-isolated Chrome sandboxes can scale up to **180 concurrent instances** without node instability or Kubelet heartbeat evictions.
+By combining GKE Memory Swap on dedicated Local SSDs with node-level CPU pinning and system log rate-limiting, gVisor-isolated Chrome sandboxes can scale up to **160 concurrent instances** with 100% success (with 180 pods representing the attempted failure threshold).
 
 ---
 
 ## 1. Host Memory Footprint & Page Cache Sharing
 
-### 1.1. Single Pod Memory Breakdown
-Process-level physical RAM (Resident Set Size - RSS) and incremental unique RAM measured across sequential pod deployments on a clean cluster:
+Process-level physical RAM (Resident Set Size - RSS) and incremental host RSS measured across sequential pod deployments on a clean cluster:
 
 | Component | Host RSS | Role & Description |
 | :--- | :--- | :--- |
@@ -19,18 +18,13 @@ Process-level physical RAM (Resident Set Size - RSS) and incremental unique RAM 
 | **gVisor Gofer** (`runsc-gofer`) | **~25.0 MiB** | Guest-to-host filesystem translation proxy. |
 | **Control Shim** | **~34.0 MiB** | Containerd gVisor runtime supervisor. |
 | **Total Resident Footprint** | **~370.0 MiB** | **Per-pod startup host RSS.** |
-| **Incremental Unique RAM** | **~206.0 MiB** | **Pure non-shareable host RAM required per pod.** |
-
-### 1.2. Shared Executable Page Cache & Swap Efficiency
-Multiplying single pod RSS by 180 pods suggests **~66.6 GiB** ($180 \times 370 \text{ MiB}$), exceeding physical 32 GB RAM. The benchmark succeeds because:
-1. **Shared Executable Binary Pages**: The host OS loads Chromium read-only binary pages into Page Cache **once**. All 180 sandboxes map to these shared pages via Gofer, reducing unique RAM to **~206 MiB**.
-2. **Local SSD Swap Eviction**: GKE Memory Swap offloads cold anonymous heaps of idle sandboxes to NVMe storage, preserving RAM for active pod creation.
+| **Incremental Host RSS** | **~206.0 MiB** | **Additional physical host RSS consumed per pod.** |
 
 ---
 
 ## 2. Performance Results (gVisor Density Matrix)
 
-All benchmark runs below were conducted on `c4-standard-8` node pools (8 vCPUs, 32 GB RAM) with node tuning applied.
+All benchmark runs below were conducted on `c4-standard-8` node pools with node tuning applied.
 
 ### 2.1. Baseline Pool (No Swap)
 | Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
@@ -55,21 +49,18 @@ All benchmark runs below were conducted on `c4-standard-8` node pools (8 vCPUs, 
 ## 3. Key Takeaways & Impact of Local SSD Swap
 
 ### 3.1. Effect of Local SSD Swap on gVisor (+100% Density Gain)
-- **Doubled Maximum Stable Density (80 → 160 Pods)**: Without swap, gVisor Sentry user-space kernels exhaust host physical RAM at 80 pods. Dedicated Local SSD Swap absorbs cold anonymous memory heaps from idle Chrome processes, enabling gVisor to scale reliably to **160 pods with 100% success**.
+- **Doubled Maximum Stable Density (80 → 160 Pods)**: Without swap, gVisor Sentry user-space kernels exhaust host physical RAM past 80 pods. Dedicated Local SSD Swap absorbs cold anonymous memory heaps from idle Chrome processes, enabling gVisor to scale reliably to **160 pods with 100% success**.
 
 ### 3.2. CPU Pinning & Kubelet Protection (Cores 0–1)
 On untuned nodes, emulating syscalls for 180 Chrome instances consumes high host CPU across all cores. Emulation threads starve Kubelet of CPU time, causing missed heartbeats and leading GKE to flag the node `NotReady`.
 
 Applying the node tuning DaemonSet enforces:
 - `--reserved-cpus=0,1` and `--cpu-manager-policy=static` on Kubelet.
-- Linux cgroups pinning system services and Kubelet strictly to Cores 0 and 1.
-- Guaranteed sandbox workload containers assigned exclusively Cores 2–7.
-- Log storage for `systemd-journald` redirected to Local SSD with rate limits (`RateLimitIntervalSec=30s`, `RateLimitBurst=10000`).
+- Linux cgroups reserving Cores 0 and 1 strictly for system services and Kubelet.
+- Workload containers execute on Cores 2–7, preventing host daemon CPU starvation.
+- Log storage for `systemd-journald` rate-limited (`RateLimitIntervalSec=30s`, `RateLimitBurst=1000`).
 
-Node tuning reduces overall Sandbox Ready P99 latency by **~60%** and Chrome Ready P99 latency by **~40%**, expanding maximum stable density from 140 (untuned) to 160–180 pods.
-
-### 3.2. NVMe SSD Write Queue Saturation (>180 Pods)
-Scaling past 180 pods forces the host to swap ~42 GB of memory pages. The massive parallel write volume saturates the NVMe SSD controller's write queue depths. Kubelet (on Core 0) blocks in D-state trying to write container logs to disk, locking up the node.
+Node tuning reduces overall Sandbox Ready P99 latency by **~60%** and Chrome Ready P99 latency by **~40%**, expanding maximum stable density from 140 (untuned) to **160 pods (tuned)**.
 
 ---
 
@@ -89,8 +80,8 @@ chmod +x deploy_cluster.sh
 Apply host CPU pinning and system log rate limiting:
 
 ```bash
-export KUBECONFIG="$(git rev-parse --show-toplevel)/bin/KUBECONFIG"
 kubectl apply -f ../../node-tuner-daemonset.yaml
+kubectl rollout status daemonset/node-tuner-ds -n kube-system
 ```
 
 ### Step 3: Execute Benchmark

--- a/examples/gke-swap/runtimes/gVisor/deploy_cluster.sh
+++ b/examples/gke-swap/runtimes/gVisor/deploy_cluster.sh
@@ -57,21 +57,6 @@ export KUBECONFIG="${KUBECONFIG:-"${REPO_ROOT}/bin/KUBECONFIG"}"
 gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${ZONE}"
 
 echo "Cluster deployed successfully."
-echo "Deploying Agent Sandbox CRDs and Controller..."
-
-# Use the repository's native deployment tool to parse all k8s/ manifests,
-# replace the image paths with the staging artifacts, and apply them.
-"${REPO_ROOT}/dev/tools/deploy-to-kube" \
-    --image-prefix="us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/" \
-    --image-tag="latest-main" \
-    --extensions
-
-# Wait for the controller to be ready
-kubectl rollout status deployment/agent-sandbox-controller -n agent-sandbox-system
-
-echo "Cluster is fully provisioned and ready for gVisor sandboxes."
-echo ""
-echo "================================================================================="
-echo "IMPORTANT: To interact with the cluster from your terminal, run the following:"
-echo "export KUBECONFIG=\"${KUBECONFIG}\""
-echo "================================================================================="
+echo "Please ensure the Agent Sandbox controller and CRDs (including extensions) are deployed on this cluster before running the tests."
+# Example installation (all-in-one controller + extension CRDs):
+# kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox-with-extensions.yaml

--- a/examples/gke-swap/runtimes/gVisor/deploy_cluster.sh
+++ b/examples/gke-swap/runtimes/gVisor/deploy_cluster.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-"agent-sandbox-gvisor-1"}
+ZONE=${ZONE:-"us-east1-b"}
+
+# Get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+echo "Creating GKE cluster base (with small default pool)..."
+gcloud container clusters create "${CLUSTER_NAME}" \
+    --zone "${ZONE}" \
+    --num-nodes 1 \
+    --machine-type e2-standard-4 \
+    --image-type cos_containerd \
+    --enable-ip-alias
+
+echo "Creating baseline node pool (no swap, gVisor enabled)..."
+gcloud container node-pools create baseline-pool \
+    --cluster "${CLUSTER_NAME}" \
+    --zone "${ZONE}" \
+    --sandbox type=gvisor \
+    --machine-type c4-standard-8 \
+    --num-nodes 1 \
+    --max-pods-per-node 256 \
+    --image-type cos_containerd
+
+echo "Creating lssd-swap node pool (with dedicated LSSD swap, gVisor enabled)..."
+gcloud container node-pools create lssd-swap-pool \
+    --cluster "${CLUSTER_NAME}" \
+    --zone "${ZONE}" \
+    --sandbox type=gvisor \
+    --machine-type c4-standard-8-lssd \
+    --num-nodes 1 \
+    --max-pods-per-node 256 \
+    --image-type cos_containerd \
+    --system-config-from-file "${DIR}/../../swap-dedicated-lssd.yaml"
+
+echo "Fetching cluster credentials..."
+REPO_ROOT="$(cd "${DIR}/../../../.." && pwd)"
+mkdir -p "${REPO_ROOT}/bin"
+export KUBECONFIG="${KUBECONFIG:-"${REPO_ROOT}/bin/KUBECONFIG"}"
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${ZONE}"
+
+echo "Cluster deployed successfully."
+echo "Deploying Agent Sandbox CRDs and Controller..."
+
+# Use the repository's native deployment tool to parse all k8s/ manifests,
+# replace the image paths with the staging artifacts, and apply them.
+"${REPO_ROOT}/dev/tools/deploy-to-kube" \
+    --image-prefix="us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/" \
+    --image-tag="latest-main" \
+    --extensions
+
+# Wait for the controller to be ready
+kubectl rollout status deployment/agent-sandbox-controller -n agent-sandbox-system
+
+echo "Cluster is fully provisioned and ready for gVisor sandboxes."
+echo ""
+echo "================================================================================="
+echo "IMPORTANT: To interact with the cluster from your terminal, run the following:"
+echo "export KUBECONFIG=\"${KUBECONFIG}\""
+echo "================================================================================="

--- a/examples/gke-swap/runtimes/kata/README.md
+++ b/examples/gke-swap/runtimes/kata/README.md
@@ -24,7 +24,7 @@ We evaluate two VMM (Virtual Machine Monitor) backends supported by Kata Contain
 
 ## 2. Host Memory Footprint per Pod
 
-Memory footprints were collected via process-level RSS (/proc/status) and sequential pod step-up measurements on a `c4-standard-8` (32 GB RAM, 8 vCPU) instance:
+Memory footprints were collected via process-level RSS (`/proc/<pid>/status`) and sequential pod step-up measurements on a `c4-standard-8` (30 GB RAM, 8 vCPU) instance:
 
 | Component | `kata-qemu` Host RSS | `kata-clh` Host RSS | Description / Function |
 | :--- | :--- | :--- | :--- |
@@ -32,27 +32,27 @@ Memory footprints were collected via process-level RSS (/proc/status) and sequen
 | **`virtiofsd`** | **~421.0 MiB** | **~426.8 MiB** | Filesystem translation proxy. Host Page Cache deduplicates shared binary pages. |
 | **Control Shim** | **~35.0 MiB** | **~36.0 MiB** | Containerd Kata runtime supervisor. |
 | **Total Resident Footprint** | **~1,130 MiB** | **~1,128 MiB** | Cumulative host RSS per pod. |
-| **Incremental Unique RAM** | **~631.5 MiB** | **~687.5 MiB** | Pure non-shareable host RAM required per pod. |
+| **Incremental Host RSS** | **~631.5 MiB** | **~687.5 MiB** | Additional physical host RSS consumed per pod. |
 
 ---
 
 ## 3. Performance Results & Density Sweeps
 
-All benchmark runs were conducted on `c4-standard-8` node instances (8 vCPUs, 32 GB RAM).
+All benchmark runs were conducted on `c4-standard-8` node pools with node tuning applied.
 
 ### 3.1. Kata QEMU (`kata-qemu`) Density Matrix
 
 #### Baseline Pool (No Swap)
 | Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **baseline-pool (Tuned)** | 20 | 4.86s / 8.40s | 16.44s / 24.92s | 10.72 GB | 53.59% | ~0% / ~0% | 10.14% / 2.44% | **SUCCESS** |
-| **baseline-pool (Tuned)** | **30** | — / — | — / — | 17.58 GB | 68.69% | 0.21% / 0.14% | 10.38% / 3.27% | **FAILED (83.3% Success)** |
+| **baseline-pool** | 20 | 4.86s / 8.40s | 16.44s / 24.92s | 10.72 GB | 53.59% | ~0% / ~0% | 10.14% / 2.44% | **SUCCESS** |
+| **baseline-pool** | **30** | — / — | — / — | 17.58 GB | 68.69% | 0.21% / 0.14% | 10.38% / 3.27% | **FAILED (83.3% Success)** |
 
 #### Local SSD Swap Pool
 | Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | Peak Host Swap | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **lssd-swap-pool (Tuned)** | 20 | 4.95s / 7.66s | 16.16s / 24.28s | 3.61 GB | 0.03 GB | — | — | — | **SUCCESS** |
-| **lssd-swap-pool (Tuned)** | **30** | — / — | — / — | 14.96 GB | 2.49 GB | 63.50% | 2.13% / 1.17% | 16.95% / 3.18% | **FAILED (86.7% Success)** |
+| **lssd-swap-pool** | 20 | 4.95s / 7.66s | 16.16s / 24.28s | 3.61 GB | 0.03 GB | — | — | — | **SUCCESS** |
+| **lssd-swap-pool** | **30** | — / — | — / — | 14.96 GB | 2.49 GB | 63.50% | 2.13% / 1.17% | 16.95% / 3.18% | **FAILED (86.7% Success)** |
 
 ---
 
@@ -61,17 +61,17 @@ All benchmark runs were conducted on `c4-standard-8` node instances (8 vCPUs, 32
 #### Baseline Pool (No Swap)
 | Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **baseline-pool (Tuned)** | 30 | 7.00s / 12.90s | 22.11s / 35.59s | 17.92 GB | 75.49% | 0.76% / 0.33% | 14.73% / 1.28% | **SUCCESS** |
-| **baseline-pool (Tuned)** | **40** | 10.76s / 21.85s | 34.54s / 60.99s | 26.45 GB | 75.66% | 1.73% / 0.60% | 20.27% / 5.72% | **SUCCESS** |
-| **baseline-pool (Tuned)** | 50 | — / — | — / — | 26.45 GB | 73.13% | 1.27% / 0.44% | 21.93% / 7.52% | **FAILED (80% Success)** |
+| **baseline-pool** | 30 | 7.00s / 12.90s | 22.11s / 35.59s | 17.92 GB | 75.49% | 0.76% / 0.33% | 14.73% / 1.28% | **SUCCESS** |
+| **baseline-pool** | **40** | 10.76s / 21.85s | 34.54s / 60.99s | 26.45 GB | 75.66% | 1.73% / 0.60% | 20.27% / 5.72% | **SUCCESS** |
+| **baseline-pool** | 50 | — / — | — / — | 26.45 GB | 73.13% | 1.27% / 0.44% | 21.93% / 7.52% | **FAILED (80% Success)** |
 
-#### Local SSD Swap Pool (Tuned)
+#### Local SSD Swap Pool
 | Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | Peak Host Swap | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| **lssd-swap-pool (Tuned)** | 30 | 6.79s / 14.04s | 21.10s / 36.71s | 11.09 GB | 0.01 GB | 19.80% | 0.26% / 0.10% | 3.68% / 1.45% | **SUCCESS** |
-| **lssd-swap-pool (Tuned)** | 40 | 11.62s / 24.32s | 41.50s / 85.32s | 29.14 GB | 3.47 GB | 38.96% | 5.97% / 1.49% | 10.08% / 3.63% | **SUCCESS** |
-| **lssd-swap-pool (Tuned)** | **50** | 17.81s / 55.63s | **71.02s / 174.14s** | 29.14 GB | **12.31 GB** | 40.07% | 5.42% / 1.34% | 11.38% / 4.55% | **SUCCESS** |
-| **lssd-swap-pool (Tuned)** | 60 | — / — | — / — | 23.04 GB | 13.08 GB | 94.57% | 15.70% / 2.59% | 13.96% / 0.08% | **FAILED (81.0% Success)** |
+| **lssd-swap-pool** | 30 | 6.79s / 14.04s | 21.10s / 36.71s | 11.09 GB | 0.01 GB | 19.80% | 0.26% / 0.10% | 3.68% / 1.45% | **SUCCESS** |
+| **lssd-swap-pool** | 40 | 11.62s / 24.32s | 41.50s / 85.32s | 29.14 GB | 3.47 GB | 38.96% | 5.97% / 1.49% | 10.08% / 3.63% | **SUCCESS** |
+| **lssd-swap-pool** | **50** | 17.81s / 55.63s | **71.02s / 174.14s** | 29.14 GB | **12.31 GB** | 40.07% | 5.42% / 1.34% | 11.38% / 4.55% | **SUCCESS** |
+| **lssd-swap-pool** | 60 | — / — | — / — | 23.04 GB | 13.08 GB | 94.57% | 15.70% / 2.59% | 13.96% / 0.08% | **FAILED (81.0% Success)** |
 
 ---
 
@@ -85,12 +85,12 @@ All benchmark runs were conducted on `c4-standard-8` node instances (8 vCPUs, 32
 - **VMM Boot Payload**: `kata-qemu` hotplugs vCPUs one by one (synchronous, taking seconds per pod), whereas `kata-clh` sends a single HTTP PUT request containing the VM configuration payload, completing in milliseconds.
 - **BQL vs Async VMM Architecture**: Cloud Hypervisor's async Rust VMM architecture reduces D-state stalls to 0.069% (13x lower than QEMU), avoiding control channel deadlocks under memory pressure.
 
-### 2. Node Boot Disk Sizing Requirement (≥150–250 GB)
+### 3. Node Boot Disk Sizing Requirement (≥150–250 GB)
 Headless Chrome allocates a ~2 GB sparse cache file in `/tmp` (which maps via Virtio-FS to host OverlayFS). Across 40+ sandboxes, this generates 80 GB+ of logical write pressure. Combined with the base node OS image and container layers (~15–20 GB), a default 100 GB boot disk hits 95–100% capacity. This trips Kubelet `DiskPressure` evictions and crashes the host-side `virtiofsd` daemon with `SIGBUS` (exit code 135). 
 
 To ensure Kubelet never triggers `DiskPressure` GC during high-density boot storms, node boot disks should be provisioned with adequate headroom (**≥150–250 GB**; 250 GB was used in the benchmark study).
 
-### 3. CPU Core Exhaustion at 60 Pods (`kata-clh`)
+### 4. CPU Core Exhaustion at 60 Pods (`kata-clh`)
 With Local SSD Swap enabled and Kubelet protected by CPU isolation on Cores 0–1, `kata-clh` reaches **50 pods with 100% success**. At 60 pods, the remaining 6 physical workload cores are completely exhausted by 60 concurrent VMM hypervisor loops and pageout tasks. Guest boot times stretch past 3 minutes, causing timeouts in 19% of sandboxes.
 
 ---
@@ -106,27 +106,37 @@ chmod +x deploy_cluster.sh
 ./deploy_cluster.sh
 ```
 
-### Step 2: Execute Density Sweep
+### Step 2: Apply Node Tuner DaemonSet
+
+Apply host CPU isolation and system log rate limiting:
+
+```bash
+kubectl apply -f ../../node-tuner-daemonset.yaml
+kubectl rollout status daemonset/node-tuner-ds -n kube-system
+```
+
+### Step 3: Execute Density Sweep
 
 Target either `kata-qemu` or `kata-clh` by setting `RUNTIME_CLASS`:
 
 ```bash
-export KUBECONFIG="$(git rev-parse --show-toplevel)/bin/KUBECONFIG"
-
 # Run Cloud Hypervisor benchmark sweep (up to 50 density)
 export RUNTIME_CLASS="kata-clh"
-export GKE_POOLS="lssd-swap-pool"
+export SCENARIOS="lssd-swap-pool"
 export DENSITIES="20 30 40 50"
 
 ../../run_chromesandbox_density_test.sh
 ```
 
-### Step 3: Verify MicroVM Isolation
+### Step 4: Verify MicroVM Isolation
 
-Verify that sandboxes are executing inside isolated Kata guest kernels:
+Verify that sandboxes are assigned a Kata RuntimeClass and executing inside an isolated guest kernel:
 
 ```bash
-POD_NAME=$(kubectl get pods -n perf-chromesandbox -o jsonpath='{.items[0].metadata.name}')
+POD_NAME=$(kubectl get pods -n perf-chromesandbox -l app=chrome-sandbox -o jsonpath='{.items[0].metadata.name}')
+kubectl get pod $POD_NAME -n perf-chromesandbox -o jsonpath='{.spec.runtimeClassName}'
+# Output: kata-clh (or kata-qemu)
+
 kubectl exec -it $POD_NAME -n perf-chromesandbox -- uname -r
 ```
-If the pod kernel (e.g., `6.1.xx`) differs from the host kernel (`6.8.x`), the sandbox is executing inside an isolated Kata MicroVM guest.
+Checking `spec.runtimeClassName` verifies Kata MicroVM scheduling, and `uname -r` confirms the guest kernel version running inside the isolated sandbox.

--- a/examples/gke-swap/runtimes/kata/README.md
+++ b/examples/gke-swap/runtimes/kata/README.md
@@ -111,6 +111,7 @@ chmod +x deploy_cluster.sh
 Apply host CPU isolation and system log rate limiting:
 
 ```bash
+export KUBECONFIG="$(git rev-parse --show-toplevel)/bin/KUBECONFIG"
 kubectl apply -f ../../node-tuner-daemonset.yaml
 kubectl rollout status daemonset/node-tuner-ds -n kube-system
 ```

--- a/examples/gke-swap/runtimes/kata/README.md
+++ b/examples/gke-swap/runtimes/kata/README.md
@@ -1,0 +1,132 @@
+# High-Density Agent Sandbox under Kata Containers on GKE with Local SSD Swap
+
+> **Note**: For a high-level comparison across all sandboxed container runtimes (`gVisor`, `kata-qemu`, `kata-clh`), see the [**Runtime Comparison Overview**](../README.md).
+
+This directory contains configuration, deployment instructions, and performance benchmark findings for running **Kata Containers** isolated MicroVM sandboxes on Google Kubernetes Engine (GKE).
+
+We evaluate two VMM (Virtual Machine Monitor) backends supported by Kata Containers on GKE:
+1. **`kata-qemu`**: Hardware-virtualized MicroVMs using the standard QEMU hypervisor.
+2. **`kata-clh`**: Hardware-virtualized MicroVMs using the Rust-based Cloud Hypervisor VMM.
+
+---
+
+## 1. VMM Architectural Comparison: QEMU vs. Cloud Hypervisor
+
+| Dimension / Feature | Kata QEMU (`kata-qemu`) | Kata Cloud Hypervisor (`kata-clh`) |
+| :--- | :--- | :--- |
+| **VMM Architecture** | Legacy monolithic C hypervisor | Async-first Rust VMM |
+| **VMM Config Payload** | Synchronous serial vCPU hotplugging (seconds) | Single HTTP PUT payload (milliseconds) |
+| **Thread Synchronization** | Big QEMU Lock (BQL) monolithic mutex | Decoupled VMM control channel & guest vCPU threads |
+| **Max Stable Density (No Swap)** | **20 Pods** | **40 Pods** |
+| **Max Stable Density (LSSD Swap)**| **20 Pods** | **50 Pods** |
+
+---
+
+## 2. Host Memory Footprint per Pod
+
+Memory footprints were collected via process-level RSS (/proc/status) and sequential pod step-up measurements on a `c4-standard-8` (32 GB RAM, 8 vCPU) instance:
+
+| Component | `kata-qemu` Host RSS | `kata-clh` Host RSS | Description / Function |
+| :--- | :--- | :--- | :--- |
+| **MicroVM Hypervisor** | **~678.0 MiB** (`qemu`) | **~664.7 MiB** (`cloud-hypervisor`) | Non-shareable VMM process holding guest kernel & Chrome heap. |
+| **`virtiofsd`** | **~421.0 MiB** | **~426.8 MiB** | Filesystem translation proxy. Host Page Cache deduplicates shared binary pages. |
+| **Control Shim** | **~35.0 MiB** | **~36.0 MiB** | Containerd Kata runtime supervisor. |
+| **Total Resident Footprint** | **~1,130 MiB** | **~1,128 MiB** | Cumulative host RSS per pod. |
+| **Incremental Unique RAM** | **~631.5 MiB** | **~687.5 MiB** | Pure non-shareable host RAM required per pod. |
+
+---
+
+## 3. Performance Results & Density Sweeps
+
+All benchmark runs were conducted on `c4-standard-8` node instances (8 vCPUs, 32 GB RAM).
+
+### 3.1. Kata QEMU (`kata-qemu`) Density Matrix
+
+#### Baseline Pool (No Swap)
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **baseline-pool (Tuned)** | 20 | 4.86s / 8.40s | 16.44s / 24.92s | 10.72 GB | 53.59% | ~0% / ~0% | 10.14% / 2.44% | **SUCCESS** |
+| **baseline-pool (Tuned)** | **30** | — / — | — / — | 17.58 GB | 68.69% | 0.21% / 0.14% | 10.38% / 3.27% | **FAILED (83.3% Success)** |
+
+#### Local SSD Swap Pool
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | Peak Host Swap | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **lssd-swap-pool (Tuned)** | 20 | 4.95s / 7.66s | 16.16s / 24.28s | 3.61 GB | 0.03 GB | — | — | — | **SUCCESS** |
+| **lssd-swap-pool (Tuned)** | **30** | — / — | — / — | 14.96 GB | 2.49 GB | 63.50% | 2.13% / 1.17% | 16.95% / 3.18% | **FAILED (86.7% Success)** |
+
+---
+
+### 3.2. Kata Cloud Hypervisor (`kata-clh`) Density Matrix
+
+#### Baseline Pool (No Swap)
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **baseline-pool (Tuned)** | 30 | 7.00s / 12.90s | 22.11s / 35.59s | 17.92 GB | 75.49% | 0.76% / 0.33% | 14.73% / 1.28% | **SUCCESS** |
+| **baseline-pool (Tuned)** | **40** | 10.76s / 21.85s | 34.54s / 60.99s | 26.45 GB | 75.66% | 1.73% / 0.60% | 20.27% / 5.72% | **SUCCESS** |
+| **baseline-pool (Tuned)** | 50 | — / — | — / — | 26.45 GB | 73.13% | 1.27% / 0.44% | 21.93% / 7.52% | **FAILED (80% Success)** |
+
+#### Local SSD Swap Pool (Tuned)
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Peak Host RAM | Peak Host Swap | CPU PSI Avg | Mem PSI Avg | IO PSI Avg | Test Status |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **lssd-swap-pool (Tuned)** | 30 | 6.79s / 14.04s | 21.10s / 36.71s | 11.09 GB | 0.01 GB | 19.80% | 0.26% / 0.10% | 3.68% / 1.45% | **SUCCESS** |
+| **lssd-swap-pool (Tuned)** | 40 | 11.62s / 24.32s | 41.50s / 85.32s | 29.14 GB | 3.47 GB | 38.96% | 5.97% / 1.49% | 10.08% / 3.63% | **SUCCESS** |
+| **lssd-swap-pool (Tuned)** | **50** | 17.81s / 55.63s | **71.02s / 174.14s** | 29.14 GB | **12.31 GB** | 40.07% | 5.42% / 1.34% | 11.38% / 4.55% | **SUCCESS** |
+| **lssd-swap-pool (Tuned)** | 60 | — / — | — / — | 23.04 GB | 13.08 GB | 94.57% | 15.70% / 2.59% | 13.96% / 0.08% | **FAILED (81.0% Success)** |
+
+---
+
+## 4. Key Takeaways & Failure Modes Analysis
+
+### 1. Effect of Local SSD Swap on Kata MicroVMs
+- **Kata Cloud Hypervisor (`kata-clh`)**: Local SSD Swap expands stable pod density from **40 pods to 50 pods (+25% density gain)** with 100% success. Cloud Hypervisor's async Rust architecture decouples VMM communications from vCPUs, allowing swap to absorb memory overcommit safely. At 60 pods, physical CPU cores become the primary bottleneck.
+- **Kata QEMU (`kata-qemu`)**: Local SSD Swap **provides zero density gain** (stuck at 20 pods) and introduces a new failure mode. When host OS pages VM blocks to NVMe swap, guest page faults block host threads in D-state. In QEMU, the legacy monolithic Big QEMU Lock (BQL) causes vCPU threads in D-state to lock up the main VMM event loop, triggering containerd-shim keep-alive timeouts (15s).
+
+### 2. Why `kata-clh` Outperforms `kata-qemu` (40 vs 20 Baseline, 50 vs 20 Swap)
+- **VMM Boot Payload**: `kata-qemu` hotplugs vCPUs one by one (synchronous, taking seconds per pod), whereas `kata-clh` sends a single HTTP PUT request containing the VM configuration payload, completing in milliseconds.
+- **BQL vs Async VMM Architecture**: Cloud Hypervisor's async Rust VMM architecture reduces D-state stalls to 0.069% (13x lower than QEMU), avoiding control channel deadlocks under memory pressure.
+
+### 2. Node Boot Disk Sizing Requirement (≥150–250 GB)
+Headless Chrome allocates a ~2 GB sparse cache file in `/tmp` (which maps via Virtio-FS to host OverlayFS). Across 40+ sandboxes, this generates 80 GB+ of logical write pressure. Combined with the base node OS image and container layers (~15–20 GB), a default 100 GB boot disk hits 95–100% capacity. This trips Kubelet `DiskPressure` evictions and crashes the host-side `virtiofsd` daemon with `SIGBUS` (exit code 135). 
+
+To ensure Kubelet never triggers `DiskPressure` GC during high-density boot storms, node boot disks should be provisioned with adequate headroom (**≥150–250 GB**; 250 GB was used in the benchmark study).
+
+### 3. CPU Core Exhaustion at 60 Pods (`kata-clh`)
+With Local SSD Swap enabled and Kubelet protected by CPU isolation on Cores 0–1, `kata-clh` reaches **50 pods with 100% success**. At 60 pods, the remaining 6 physical workload cores are completely exhausted by 60 concurrent VMM hypervisor loops and pageout tasks. Guest boot times stretch past 3 minutes, causing timeouts in 19% of sandboxes.
+
+---
+
+## How to Run the Kata Density Benchmark
+
+### Step 1: Provision Cluster & Register RuntimeClasses
+
+The provided [`deploy_cluster.sh`](deploy_cluster.sh) script automatically creates nested-virtualization node pools and registers both `kata-qemu` and `kata-clh` RuntimeClasses:
+
+```bash
+chmod +x deploy_cluster.sh
+./deploy_cluster.sh
+```
+
+### Step 2: Execute Density Sweep
+
+Target either `kata-qemu` or `kata-clh` by setting `RUNTIME_CLASS`:
+
+```bash
+export KUBECONFIG="$(git rev-parse --show-toplevel)/bin/KUBECONFIG"
+
+# Run Cloud Hypervisor benchmark sweep (up to 50 density)
+export RUNTIME_CLASS="kata-clh"
+export GKE_POOLS="lssd-swap-pool"
+export DENSITIES="20 30 40 50"
+
+../../run_chromesandbox_density_test.sh
+```
+
+### Step 3: Verify MicroVM Isolation
+
+Verify that sandboxes are executing inside isolated Kata guest kernels:
+
+```bash
+POD_NAME=$(kubectl get pods -n perf-chromesandbox -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -it $POD_NAME -n perf-chromesandbox -- uname -r
+```
+If the pod kernel (e.g., `6.1.xx`) differs from the host kernel (`6.8.x`), the sandbox is executing inside an isolated Kata MicroVM guest.

--- a/examples/gke-swap/runtimes/kata/deploy_cluster.sh
+++ b/examples/gke-swap/runtimes/kata/deploy_cluster.sh
@@ -39,9 +39,10 @@ gcloud container node-pools create baseline-pool \
     --machine-type c4-standard-8 \
     --num-nodes 1 \
     --max-pods-per-node 256 \
-    --disk-size 250GB \
+    --disk-size 250 \
     --image-type ubuntu_containerd \
-    --enable-nested-virtualization
+    --enable-nested-virtualization \
+    --node-labels sandbox.gke.io/kata=true
 
 echo "Creating lssd-swap node pool (with dedicated LSSD swap, Ubuntu, Nested Virtualization enabled)..."
 gcloud container node-pools create lssd-swap-pool \
@@ -50,9 +51,10 @@ gcloud container node-pools create lssd-swap-pool \
     --machine-type c4-standard-8-lssd \
     --num-nodes 1 \
     --max-pods-per-node 256 \
-    --disk-size 250GB \
+    --disk-size 250 \
     --image-type ubuntu_containerd \
     --enable-nested-virtualization \
+    --node-labels sandbox.gke.io/kata=true \
     --system-config-from-file "${DIR}/../../swap-dedicated-lssd.yaml"
 
 echo "Fetching cluster credentials..."
@@ -79,6 +81,7 @@ handler: kata-qemu
 scheduling:
   nodeSelector:
     kubernetes.io/os: linux
+    sandbox.gke.io/kata: "true"
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -90,18 +93,10 @@ handler: kata-clh
 scheduling:
   nodeSelector:
     kubernetes.io/os: linux
+    sandbox.gke.io/kata: "true"
 EOF
 
-echo "Deploying Agent Sandbox CRDs and Controller..."
-"${REPO_ROOT}/dev/tools/deploy-to-kube" \
-    --image-prefix="us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/" \
-    --image-tag="latest-main" \
-    --extensions
-
-kubectl rollout status deployment/agent-sandbox-controller -n agent-sandbox-system
-
-echo "================================================================================="
-echo "Cluster is fully provisioned and ready for Cloud Hypervisor sandboxes."
-echo "To interact with the cluster from your terminal, run:"
-echo "export KUBECONFIG=\"${KUBECONFIG}\""
-echo "================================================================================="
+echo "Cluster deployed successfully."
+echo "Please ensure the Agent Sandbox controller and CRDs (including extensions) are deployed on this cluster before running the tests."
+# Example installation (all-in-one controller + extension CRDs):
+# kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/sandbox-with-extensions.yaml

--- a/examples/gke-swap/runtimes/kata/deploy_cluster.sh
+++ b/examples/gke-swap/runtimes/kata/deploy_cluster.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-"agent-sandbox-kata"}
+ZONE=${ZONE:-"us-east1-b"}
+KATA_VERSION=${KATA_VERSION:-"3.2.0"}
+
+# Get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+REPO_ROOT="$(cd "${DIR}/../../../.." && pwd)"
+export KUBECONFIG="${KUBECONFIG:-"${REPO_ROOT}/bin/KUBECONFIG"}"
+
+echo "Creating GKE cluster base (with small default pool, Ubuntu)..."
+gcloud container clusters create "${CLUSTER_NAME}" \
+    --zone "${ZONE}" \
+    --num-nodes 1 \
+    --machine-type e2-standard-4 \
+    --image-type ubuntu_containerd \
+    --enable-ip-alias
+
+echo "Creating baseline node pool (no swap, Ubuntu, Nested Virtualization enabled)..."
+gcloud container node-pools create baseline-pool \
+    --cluster "${CLUSTER_NAME}" \
+    --zone "${ZONE}" \
+    --machine-type c4-standard-8 \
+    --num-nodes 1 \
+    --max-pods-per-node 256 \
+    --disk-size 250GB \
+    --image-type ubuntu_containerd \
+    --enable-nested-virtualization
+
+echo "Creating lssd-swap node pool (with dedicated LSSD swap, Ubuntu, Nested Virtualization enabled)..."
+gcloud container node-pools create lssd-swap-pool \
+    --cluster "${CLUSTER_NAME}" \
+    --zone "${ZONE}" \
+    --machine-type c4-standard-8-lssd \
+    --num-nodes 1 \
+    --max-pods-per-node 256 \
+    --disk-size 250GB \
+    --image-type ubuntu_containerd \
+    --enable-nested-virtualization \
+    --system-config-from-file "${DIR}/../../swap-dedicated-lssd.yaml"
+
+echo "Fetching cluster credentials..."
+mkdir -p "${REPO_ROOT}/bin"
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${ZONE}"
+
+echo "Installing Kata Containers via kata-deploy..."
+KATA_RBAC_URL="https://raw.githubusercontent.com/kata-containers/kata-containers/${KATA_VERSION}/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml"
+kubectl apply -f "${KATA_RBAC_URL}"
+
+KATA_DEPLOY_URL="https://raw.githubusercontent.com/kata-containers/kata-containers/${KATA_VERSION}/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
+kubectl apply -f "${KATA_DEPLOY_URL}"
+
+echo "Waiting for Kata installation to complete..."
+kubectl -n kube-system rollout status daemonset/kata-deploy --timeout=10m
+
+echo "Registering RuntimeClasses 'kata-qemu' and 'kata-clh'..."
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu
+handler: kata-qemu
+scheduling:
+  nodeSelector:
+    kubernetes.io/os: linux
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-clh
+handler: kata-clh
+scheduling:
+  nodeSelector:
+    kubernetes.io/os: linux
+EOF
+
+echo "Deploying Agent Sandbox CRDs and Controller..."
+"${REPO_ROOT}/dev/tools/deploy-to-kube" \
+    --image-prefix="us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/" \
+    --image-tag="latest-main" \
+    --extensions
+
+kubectl rollout status deployment/agent-sandbox-controller -n agent-sandbox-system
+
+echo "================================================================================="
+echo "Cluster is fully provisioned and ready for Cloud Hypervisor sandboxes."
+echo "To interact with the cluster from your terminal, run:"
+echo "export KUBECONFIG=\"${KUBECONFIG}\""
+echo "================================================================================="

--- a/examples/gke-swap/runtimes/kata/deploy_cluster.sh
+++ b/examples/gke-swap/runtimes/kata/deploy_cluster.sh
@@ -42,7 +42,7 @@ gcloud container node-pools create baseline-pool \
     --disk-size 250 \
     --image-type ubuntu_containerd \
     --enable-nested-virtualization \
-    --node-labels sandbox.gke.io/kata=true
+    --node-labels agent-sandbox.dev/kata=true
 
 echo "Creating lssd-swap node pool (with dedicated LSSD swap, Ubuntu, Nested Virtualization enabled)..."
 gcloud container node-pools create lssd-swap-pool \
@@ -54,7 +54,7 @@ gcloud container node-pools create lssd-swap-pool \
     --disk-size 250 \
     --image-type ubuntu_containerd \
     --enable-nested-virtualization \
-    --node-labels sandbox.gke.io/kata=true \
+    --node-labels agent-sandbox.dev/kata=true \
     --system-config-from-file "${DIR}/../../swap-dedicated-lssd.yaml"
 
 echo "Fetching cluster credentials..."
@@ -81,7 +81,7 @@ handler: kata-qemu
 scheduling:
   nodeSelector:
     kubernetes.io/os: linux
-    sandbox.gke.io/kata: "true"
+    agent-sandbox.dev/kata: "true"
 EOF
 
 cat <<EOF | kubectl apply -f -
@@ -93,7 +93,7 @@ handler: kata-clh
 scheduling:
   nodeSelector:
     kubernetes.io/os: linux
-    sandbox.gke.io/kata: "true"
+    agent-sandbox.dev/kata: "true"
 EOF
 
 echo "Cluster deployed successfully."


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR expands the GKE Memory Swap example (examples/gke-swap/) into a comprehensive multi-runtime performance study across sandboxed container isolation runtimes on GKE: gVisor (runsc), Kata Containers (kata-qemu), and Kata Containers (kata-clh) (Cloud Hypervisor).

Key changes introduced:
- examples/gke-swap/runtimes/README.md: Created a central comparative overview mapping architectural profiles, host memory footprints per pod (Sentry vs. QEMU vs. Cloud Hypervisor VMMs), high-density scaling thresholds, and the impact of Local SSD Swap across all sandboxed runtimes.
- examples/gke-swap/runtimes/gVisor/README.md: Updated with single pod memory breakdowns, full baseline vs. swap performance matrices, and system task CPU pinning strategies.
- examples/gke-swap/runtimes/kata/README.md: Expanded to cover both kata-clh (Cloud Hypervisor) and kata-qemu. Highlights why Cloud Hypervisor achieves higher density over QEMU, and details the node boot disk sizing requirement to prevent virtiofsd SIGBUS crashes.
- Node Tuning DaemonSet (examples/gke-swap/node-tuner-daemonset.yaml): Added a host tuner manifest to isolate Kubelet and system daemons to Cores 0–1 and limit `systemd-journald` logging.
- Test Harness Script: Updated run_chromesandbox_density_test.sh to accept RUNTIME_CLASS environment variable.

#### Which issue(s) this PR is related to:
NONE

#### Release Note
NONE

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end GKE example deployment workflows for gVisor and Kata Containers, including cluster provisioning and runtime registration.
  - Added runtime-class selection to the density benchmark workflow.
  - Added a node-tuning DaemonSet to improve high-density stability via CPU reservation/pinning and node-level logging/network tuning.

- **Documentation**
  - Expanded runtime documentation with container isolation comparisons, benchmark highlights, scaling limits, and troubleshooting for gVisor and Kata (QEMU/CLH).
  - Updated the main example documentation and run instructions with revised hardware baseline and clearer benchmark section scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->