### PR TITLE
WIP: controller: reconcile Sandbox updates only on generation change

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -1548,6 +1548,24 @@ func sandboxMarkedExpired(sandbox *sandboxv1beta1.Sandbox) bool {
 	return cond != nil && (cond.Reason == sandboxv1beta1.SandboxReasonExpired)
 }
 
+// sandboxUpdatePredicate admits Sandbox UPDATE events only when the spec
+// changed (metadata.generation). Status-only updates are the controller's
+// own writes echoed back through the watch: without this filter every
+// status write re-enqueues the key. Run 2080848067543699456 measured 592
+// sandbox reconciles/s against 156 sandbox lifecycles/s with exactly 2
+// status writes per lifecycle — the echoes are ~half of all reconcile
+// executions. Creates, deletes, and pod events (via Owns) are unaffected.
+//
+// Pod metadata propagation is NOT affected: it reads
+// spec.podTemplate.metadata (Deployment-style), and podTemplate edits bump
+// the generation. Warm-pool adoption also passes for the same reason (the
+// SandboxClaim controller mutates spec.podTemplate during adoption). The
+// only filtered edits are to the Sandbox's own top-level labels and
+// annotations, which the reconciler does not act on apart from mirroring
+// two system labels (created-by, warm-pool hash) that are set at
+// creation/adoption time anyway.
+var sandboxUpdatePredicate predicate.Predicate = predicate.GenerationChangedPredicate{}
+
 // podSandboxNameHashIndexer extracts the sandboxLabel value for the
 // podSandboxNameHashIndex cache field index. Shared with tests so fake
 // clients register the same index the manager does.
@@ -1579,7 +1597,7 @@ func (r *SandboxReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWorkers
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&sandboxv1beta1.Sandbox{}).
+		For(&sandboxv1beta1.Sandbox{}, builder.WithPredicates(sandboxUpdatePredicate)).
 		Owns(&corev1.Pod{}, builder.WithPredicates(labelSelectorPredicate)).
 		Owns(&corev1.Service{}, builder.WithPredicates(labelSelectorPredicate)).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -4352,4 +4353,30 @@ func TestReconcileCoalescesNodeNameStatusWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
 	assert.Equal(t, "node-2", live.Status.NodeName, "node changes on a Ready sandbox must be written immediately")
+}
+
+// TestSandboxUpdatePredicate pins the event-filtering behavior: the
+// controller must not re-reconcile in response to its own status writes
+// (the reconcile-amplification fix), but must reconcile on spec changes —
+// including warm-pool adoption, which mutates spec.podTemplate.
+func TestSandboxUpdatePredicate(t *testing.T) {
+	base := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sb", Generation: 1},
+	}
+
+	statusOnly := base.DeepCopy()
+	statusOnly.Status.Conditions = []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}}
+	statusOnly.Status.PodIPs = []string{"10.0.0.1"}
+	require.False(t, sandboxUpdatePredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: statusOnly}),
+		"status-only updates must be filtered")
+
+	specChange := base.DeepCopy()
+	specChange.Generation = 2
+	require.True(t, sandboxUpdatePredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: specChange}),
+		"generation changes must be admitted")
+
+	annotationOnly := base.DeepCopy()
+	annotationOnly.Annotations = map[string]string{sandboxv1beta1.SandboxPodNameAnnotation: "some-pod"}
+	require.False(t, sandboxUpdatePredicate.Update(event.UpdateEvent{ObjectOld: base, ObjectNew: annotationOnly}),
+		"annotation-only updates are deliberately filtered (see sandboxUpdatePredicate)")
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Adds `GenerationChangedPredicate` to the Sandbox controller's `For()` watch, so status-only Sandbox updates — which are overwhelmingly the controller's *own* status writes echoed back through the informer — no longer re-enqueue a reconcile that reads an unchanged spec and writes nothing (`updateStatus` already no-ops on `DeepEqual`).

**Measured on current main** (run `2080848067543699456`): 592 sandbox reconciles/s against 156 sandbox lifecycles/s, with exactly 2 status writes per lifecycle — i.e. the echo is roughly **half of all reconcile executions**. This is also the amplifier that made raising worker counts counterproductive in the #1259 200-worker experiment (5× request volume, throughput halved): more workers processing echo reconciles against a loaded apiserver is pure waste. The predicate removes the amplifier rather than tuning around it.

Correctness analysis (also in the code comment):
- Creates, deletes, and child Pod/Service events (via `Owns`) are unaffected — only Sandbox UPDATE events are filtered.
- Pod metadata propagation reads `spec.podTemplate.metadata`, and warm-pool adoption mutates `spec.podTemplate` — both bump `metadata.generation` and still reconcile.
- The only filtered edits are the Sandbox's own top-level labels/annotations, which the reconciler doesn't act on.

Cherry-picked from #1122 (`0f969efb`), with the reconcile-echo numbers re-measured against current main (the original ~44-reconciles/lifecycle figure predates other churn fixes that have since landed). Includes the test from the original commit.

Note: this was audited alongside the other #1122 controller optimizations; two of them (stable Ready message, pod-name annotation skip) were *dropped* after measurement showed their churn no longer reproduces on current main — see the analysis on run `2080848067543699456`: all 22,776 throughput sandboxes show exactly 2 status writes with a single message sequence. The fast-path child deletion commit remains a candidate for a separate PR.

```release-note
The Sandbox controller no longer re-reconciles on status-only Sandbox updates, roughly halving reconcile volume under churn.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary Sandbox reconciliation triggered by status-only updates.
  * Prevented annotation-only changes from causing redundant processing.
  * Continued processing Sandbox specification and generation changes as expected.

* **Tests**
  * Added coverage validating event filtering for status, annotation, and specification updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->