### PR TITLE
WIP: controller: strip managedFields from created Pods

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -532,6 +532,42 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	return nil
 }
 
+// stripManagedFieldsPatch resets a resource's managedFields: a non-nil empty
+// list (or a list of one empty entry) is the API server's documented reset
+// sentinel (apimachinery isResetManagedFields).
+var stripManagedFieldsPatch = []byte(`{"metadata":{"managedFields":[{}]}}`)
+
+// stripPodManagedFields clears managedFields on a just-created Pod, opting
+// its remaining lifecycle out of the API server's field tracking.
+//
+// Why: field tracking measured at 14.6% of kube-apiserver CPU during the
+// mif600 stress phase (run 2080880843894558720; FieldManager.Update alone
+// 9.1%), and pods are the dominant payer: every scheduler binding, kubelet
+// status PATCH, and teardown write converts the full object to
+// structured-merge-diff typed form twice and diffs it. The apiserver's
+// skipNonAppliedManager short-circuits all of that for plain (non-apply)
+// writes when the live object has no managedFields - and its subresource
+// path takes managedFields from the live object only, so a stripped pod
+// cannot be re-seeded by kubelet status writes. Cheaper pods/status PATCHes
+// feed straight into kubelet's serialized status-sync loop, the measured
+// end-to-end bottleneck.
+//
+// Objects are always born tracked (DefaultTrackOnCreateProbability=1, and
+// the reset sentinel is ignored on create), so the strip must be this
+// separate follow-up patch: one merge-patch write buys the fast path for
+// the pod's remaining ~6-10 writes. The only path that resumes tracking is
+// a server-side-apply against the pod, which nothing in the sandbox
+// lifecycle performs; if some external client does, tracking resumes with
+// before-first-apply semantics and only the CPU saving is lost.
+//
+// Best-effort by design: a failed strip leaves a normally-tracked pod.
+func stripPodManagedFields(ctx context.Context, c client.Client, pod *corev1.Pod) {
+	if err := c.Patch(ctx, pod, client.RawPatch(types.MergePatchType, stripManagedFieldsPatch)); err != nil {
+		log.FromContext(ctx).V(1).Info("Failed to strip pod managedFields; pod stays field-tracked",
+			"Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name, "error", err)
+	}
+}
+
 // nodeNameOnlyChange reports whether the node assignment is the only
 // difference between the two statuses.
 func nodeNameOnlyChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bool {
@@ -1192,6 +1228,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		logger.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
 		return nil, err
 	}
+
+	stripPodManagedFields(ctx, r.Client, pod)
 
 	if err := ensurePodNameAnnotation(pod.Name); err != nil {
 		return nil, err

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -51,6 +52,20 @@ func newFakeClient(initialObjs ...runtime.Object) client.WithWatch {
 		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
 		WithIndex(&corev1.Pod{}, podSandboxNameHashIndex, podSandboxNameHashIndexer).
 		WithRuntimeObjects(initialObjs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// The fake client has no field manager: applying the
+			// managedFields reset sentinel would store a literal empty
+			// entry and bump the pod's ResourceVersion, which the real
+			// API server does not do meaningfully here. Swallow it so
+			// tests observe the same object state as a real cluster.
+			// TestPodManagedFieldsStripped asserts the patch is issued.
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if data, err := patch.Data(obj); err == nil && string(data) == string(stripManagedFieldsPatch) {
+					return nil
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).
 		Build()
 }
 
@@ -4352,4 +4367,70 @@ func TestReconcileCoalescesNodeNameStatusWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
 	assert.Equal(t, "node-2", live.Status.NodeName, "node changes on a Ready sandbox must be written immediately")
+}
+
+// TestPodManagedFieldsStripped verifies that creating a Pod for a Sandbox is
+// followed by exactly one managedFields-reset merge patch against that Pod
+// (the apiserver-side fast-path opt-out; see stripPodManagedFields).
+func TestPodManagedFieldsStripped(t *testing.T) {
+	sandboxName := "strip-mf"
+	sandboxNs := "strip-ns"
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       sandboxName,
+			Namespace:  sandboxNs,
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "test-container"}},
+			},
+		}}},
+	}
+
+	var strippedPods []string
+	c := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithStatusSubresource(&sandboxv1beta1.Sandbox{}).
+		WithIndex(&corev1.Pod{}, podSandboxNameHashIndex, podSandboxNameHashIndexer).
+		WithRuntimeObjects(sb).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				data, err := patch.Data(obj)
+				if err != nil {
+					return err
+				}
+				if _, isPod := obj.(*corev1.Pod); isPod && string(data) == string(stripManagedFieldsPatch) {
+					// Record and swallow: the fake client has no field
+					// manager, so applying the reset sentinel would store a
+					// literal empty entry instead of clearing tracking.
+					strippedPods = append(strippedPods, obj.GetName())
+					return nil
+				}
+				return cl.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+
+	r := SandboxReconciler{
+		Client:        c,
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+	_, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{sandboxName}, strippedPods,
+		"expected exactly one managedFields strip patch for the created pod")
+
+	// A second reconcile must not strip again: the pod already exists.
+	_, err = r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: sandboxName, Namespace: sandboxNs},
+	})
+	require.NoError(t, err)
+	require.Len(t, strippedPods, 1, "strip must only happen on the create path")
 }

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -270,6 +270,21 @@ kops edit cluster --name "${CLUSTER_NAME}" \
   --set cluster.spec.kubeScheduler.qps=500 \
   --set cluster.spec.kubeScheduler.burst=500
 
+# kubelet.kubeAPIQPS (default 50): the kubelets make multiple pod
+# status updates per pod.
+# Each kubelet status-manager sync is a GET plus a PATCH through one serialized loop,
+# so this becomes a bottleneck when churning more than 5 pods / second / node.
+#
+# kubelet.eventQPS/eventBurst: kubelet event emission has its own limiter,
+# not covered by kubeAPIQPS.
+# Note this is different from other rate limits: we drop extra events.
+# A diagnostics trade-off that is acceptable here, needs more careful
+# evaluation before using in production clusters.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set cluster.spec.kubelet.kubeAPIQPS=500 \
+  --set cluster.spec.kubelet.eventQPS=5 \
+  --set cluster.spec.kubelet.eventBurst=50
+
 
 if [[ "${CNI}" == "cilium" ]]; then
   # cilium.enablePrometheusMetrics: serve cilium-agent metrics on :9090 so the


### PR DESCRIPTION
#### What this PR does / why we need it

**Experiment**: opt sandbox Pods out of API-server managedFields tracking, by issuing one merge patch with the documented reset sentinel (`metadata.managedFields: [{}]`) right after Pod creation.

**Why**: profiling the mif600 stress phase (run `2080880843894558720`, 40 nodes, 214 claims/s) shows **field tracking at 14.6% of kube-apiserver CPU** (`FieldManager.Update` 9.1% cumulative — ~2.1 of 14.7 cores), and Pods are the dominant payer: every scheduler binding, kubelet status PATCH, and teardown write converts the full object to structured-merge-diff typed form twice and diffs it.

**Mechanism** (verified in apimachinery v0.34 source):
- `skipNonAppliedManager` short-circuits the entire smd chain for plain (non-apply) writes when the live object has no managedFields — this is an existing, deliberate fast path.
- Objects are always born tracked (`DefaultTrackOnCreateProbability=1`, and the reset sentinel is ignored on create), so the strip must be a follow-up write: one extra patch buys the fast path for the Pod's remaining ~6–10 writes.
- **Status writes cannot re-seed tracking**: the subresource path reads managedFields from the live object only (`fieldmanager.go:83-87`), and re-seeding would require the chain the skip manager returns above. The only way back to tracking is a server-side apply against the Pod — nothing in the sandbox lifecycle does that, and if an external client ever does, tracking resumes benignly (`before-first-apply`).

**Why it matters beyond apiserver headroom**: cheaper `pods/status` PATCHes feed directly into kubelet's *serialized* status-sync loop — the measured end-to-end bottleneck (bound→kubelet-first-status 818ms p50 at mif600). Reducing per-PATCH server cost speeds the exact lane that caps claim throughput.

**Trade-off, stated plainly**: stripped Pods lose SSA conflict-detection semantics (a later `kubectl apply`/SSA force-takes-over as `before-first-apply`). Sandbox Pods are controller-owned and ephemeral; per team discussion this ships unflagged as an experiment. Sandboxes themselves stay tracked for now (Pods first).

**What to read in the presubmit**: apiserver CPU and managedFields share in the mif600 pprof, `PATCH pods/status` server-side latency, kubelet-observed PATCH latency, mif600 claims/s, and the watch stream (stripped pods must show no managedFields entries after creation — a built-in correctness check).

```release-note
Sandbox Pods are created with API-server managedFields tracking disabled, reducing apiserver CPU per pod write. Server-side apply against sandbox Pods resumes tracking with before-first-apply semantics.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created Sandbox Pods no longer retain managed field tracking immediately after creation.
  * Reconciliation avoids repeating the cleanup when the Pod already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->