### PR TITLE
stress-test report: identify kubelet status pacing

### DIFF
--- a/test/stress/generate-report/generate_report.py
+++ b/test/stress/generate-report/generate_report.py
@@ -680,6 +680,75 @@ def main():
             "avg_wait_ms": (wait_total / count_delta) * 1000 if count_delta > 0 else 0
         })
 
+    # Limiter regime per (phase, component): a client-go limiter hurts in
+    # two distinguishable ways. A saturated limiter with open-loop callers
+    # QUEUES - a backlog forms and waits grow into the tail (the classic,
+    # loud signature the >100ms finding below catches). A limiter running at
+    # exactly its QPS with closed-loop callers PACES - each request just
+    # waits for the next token, uniformly distributed over 0..1/QPS, so the
+    # mean wait is half the token interval and NO request ever exceeds one
+    # interval. Tail- and threshold-based checks read pacing as healthy: in
+    # run 2080987052014309376 the kubelets ran at ~50 req/s/node against
+    # kubeAPIQPS=50 and paid a uniform 9.1ms mean (0% of waits over 25ms),
+    # which was ~60% of the serialized status-sync lane's service time.
+    # The uniform shape also makes the mean a limit estimator: implied
+    # per-instance QPS ~= 1 / (2 * mean_wait).
+    print("Querying limiter regime by phase and component...")
+    # verb/host must be extracted even though we don't group by them: they
+    # partition the delta computation (mixing label streams corrupts deltas;
+    # see the module comment on _counter_deltas_cte).
+    limiter_regime_raw = metrics_by_phase(
+        conn, metrics_path_str,
+        metrics=["rest_client_rate_limiter_duration_seconds_count",
+                 "rest_client_rate_limiter_duration_seconds_sum"],
+        labels={"verb": "verb", "host": "host"},
+        group_by=["source", "verb", "instance"])
+    phase_durations = {name: (p_end - p_start).total_seconds()
+                       for name, p_start, p_end in phases}
+    regime_agg = {}
+    for phase_name, source, verb, instance, count_delta, wait_total in limiter_regime_raw:
+        if count_delta <= 0:
+            continue
+        entry = regime_agg.setdefault((phase_name, source, verb),
+                                      {"count": 0.0, "wait": 0.0, "instances": set()})
+        entry["count"] += count_delta
+        entry["wait"] += wait_total
+        entry["instances"].add(instance)
+
+    limiter_regime_ops = []
+    for (phase_name, source, verb), entry in regime_agg.items():
+        duration_s = phase_durations.get(phase_name, 0)
+        if duration_s <= 0 or entry["count"] < 100:
+            continue
+        n_instances = len(entry["instances"])
+        rate_per_instance = entry["count"] / duration_s / n_instances
+        mean_wait_ms = entry["wait"] / entry["count"] * 1000
+        implied_qps = 1000.0 / (2 * mean_wait_ms) if mean_wait_ms >= 1.0 else None
+        if mean_wait_ms >= 100:
+            verdict = "queueing"
+        elif implied_qps is not None and rate_per_instance >= 0.5 * implied_qps:
+            verdict = "pacing"
+        elif mean_wait_ms >= 1.0:
+            # Waits despite sustained-rate headroom: demand SPIKES exceed the
+            # bucket even though the average does not (observed on kubelets at
+            # ~59 req/s/node sustained vs a 100 QPS limit - PLEG-batch sync
+            # bursts drained the bucket; kOps exposes no kubelet burst field).
+            verdict = "bursty"
+        else:
+            verdict = "ok"
+        limiter_regime_ops.append({
+            "phase_name": phase_name,
+            "source": source,
+            "verb": verb,
+            "instances": n_instances,
+            "rate_per_instance": rate_per_instance,
+            "mean_wait_ms": mean_wait_ms,
+            "implied_qps": implied_qps,
+            "verdict": verdict,
+        })
+    limiter_regime_ops.sort(
+        key=lambda r: (phase_order_map_early.get(r["phase_name"], 99), -r["mean_wait_ms"]))
+
     print("Querying client throttling timeseries...")
     client_ratelimit_ts_raw = metrics_timeseries(
         conn, metrics_path_str,
@@ -1129,6 +1198,33 @@ def main():
             "link": "ratelimits.html"
         })
 
+    # Pacing check: the quiet failure mode the >100ms threshold above cannot
+    # see. A limiter running at its QPS with closed-loop callers paces every
+    # request by up to one token interval - mean wait of half the interval,
+    # zero tail - so it looks healthy to percentile checks while taxing 100%
+    # of requests (and any serialized caller loop proportionally).
+    pacing_worst = None
+    for row in limiter_regime_ops:
+        if (row['phase_name'].startswith('throughput') and row['verdict'] == 'pacing'
+                and row['rate_per_instance'] >= 10):
+            if pacing_worst is None or row['mean_wait_ms'] > pacing_worst['mean_wait_ms']:
+                pacing_worst = row
+
+    if pacing_worst:
+        w = pacing_worst
+        findings.append({
+            "severity": "warning",
+            "title": f"{w['source']} {w['verb']} is pacing at its client QPS limit (~{w['implied_qps']:.0f}/s per instance)",
+            "desc": f"During phase {w['phase_name']}, {w['source']} ({w['instances']} instance(s)) ran at "
+                    f"{w['rate_per_instance']:.0f} req/s per instance with a uniform {w['mean_wait_ms']:.1f}ms mean "
+                    f"rate-limiter wait - the signature of a token bucket metering requests at its QPS limit "
+                    f"(implied limit ~{w['implied_qps']:.0f}/s = 1/(2 x mean wait)). Pacing produces no latency tail, "
+                    f"so it evades percentile-based checks, but it taxes every request; serialized callers (e.g. the "
+                    f"kubelet status manager) lose throughput proportionally. Consider raising the component's client "
+                    f"QPS. See the Limiter Regime table on the Rate Limiting page.",
+            "link": "ratelimits.html"
+        })
+
     # Capacity saturation finding check
     max_active_pods = 0
     for pt in capacity_chart_data:
@@ -1333,6 +1429,7 @@ def main():
         "active_page": "ratelimits",
         "summary": summary,
         "client_ratelimit_ops": client_ratelimit_ops,
+        "limiter_regime_ops": limiter_regime_ops,
         "apf_ops": apf_ops,
         "chart_data": client_ratelimit_chart_data,
         "phases": js_phases

--- a/test/stress/generate-report/templates/ratelimits.html
+++ b/test/stress/generate-report/templates/ratelimits.html
@@ -31,6 +31,34 @@
     </div>
 </div>
 
+{% if limiter_regime_ops %}
+<div class="card">
+    <div class="card-title">Limiter Regime by Component</div>
+    <div class="card-desc" style="margin-bottom: 8px;">
+        A client-go rate limiter hurts in two ways with opposite statistical signatures.
+        <strong>Queueing</strong>: sustained demand above the QPS limit builds a backlog — waits
+        grow into the tail and every percentile alarm fires. <strong>Pacing</strong>: demand sits
+        <em>at</em> the limit, so the token bucket meters each request by up to one token interval
+        (uniform wait between 0 and 1/QPS) — the mean is half the interval and <em>no request ever
+        exceeds it</em>, so tail-based checks read it as healthy while 100% of requests pay the tax
+        and serialized callers (e.g. the kubelet status manager's one-at-a-time GET+PATCH loop)
+        lose throughput proportionally. The uniform shape makes the mean a limit estimator:
+        implied per-instance QPS &asymp; 1 / (2 &times; mean wait) — compare it to the measured
+        request rate to see how hard the limiter is engaged. Rows are split by verb because one
+        process can host several limiters behind this single metric (the kubelet's main API client
+        vs its event client): a load-invariant wait confined to one verb is a deliberately
+        configured choke (e.g. <code>eventQPS</code>), while a wait spanning all verbs is the
+        shared main limiter. A <em>bursty</em> verdict means waits appear despite sustained-rate
+        headroom (measured rate well under the implied limit): demand spikes are draining the
+        bucket faster than tokens refill — the cure is more burst, not more QPS (where the
+        component exposes a burst knob; the kubelet via kOps does not).
+    </div>
+    <div class="table-container">
+        <table id="limiter-regime-table"></table>
+    </div>
+</div>
+{% endif %}
+
 <div class="card">
     <div class="card-title">Client-side API Throttling by Phase</div>
     <div class="card-desc" style="margin-bottom: 8px;">
@@ -71,6 +99,25 @@
 </div>
 
 <script>
+    const limiterRegime = {{ limiter_regime_ops | tojson }};
+    const verdictBadge = v =>
+        v === 'queueing' ? badge('danger', 'QUEUEING')
+        : v === 'pacing' ? badge('warning', 'PACING AT LIMIT')
+        : v === 'bursty' ? badge('info', 'BURSTY')
+        : badge('success', 'OK');
+    if (limiterRegime.length) {
+        renderTable('#limiter-regime-table', [
+            {key: 'phase_name', label: 'Phase', render: v => `<strong>${escapeHtml(v)}</strong>`},
+            {key: 'source', label: 'Component', render: v => `<code>${escapeHtml(v)}</code>`},
+            {key: 'verb', label: 'Verb', render: v => `<code>${escapeHtml(v)}</code>`},
+            {key: 'instances', label: 'Instances'},
+            {key: 'rate_per_instance', label: 'Req/s per Instance', render: v => v.toFixed(1)},
+            {key: 'mean_wait_ms', label: 'Mean Wait', render: v => v.toFixed(1) + 'ms'},
+            {key: 'implied_qps', label: 'Implied QPS Limit', render: v => v == null ? '—' : '~' + v.toFixed(0) + '/s'},
+            {key: 'verdict', label: 'Verdict', render: verdictBadge}
+        ], limiterRegime);
+    }
+
     const clientThrottle = {{ client_ratelimit_ops | tojson }};
     const waitBadge = v =>
         v > 1000 ? badge('danger', (v / 1000).toFixed(2) + 's')


### PR DESCRIPTION
A client-go rate limiter hurts in two ways with opposite statistical
signatures, and the report only caught one of them. Queueing (demand
above QPS, open-loop callers) builds a backlog with a growing tail -
the existing >100ms finding fires. Pacing (demand at QPS, closed-loop
callers) meters every request by up to one token interval: waits are
uniform on [0, 1/QPS], the mean is half the interval, and no request
ever exceeds it - so tail- and threshold-based checks read a fully
engaged limiter as healthy.

The uniform shape also makes the mean a limit estimator: implied
per-instance QPS ~= 1/(2 x mean wait). New 'Limiter Regime by
Component' table on the Rate Limiting page shows per phase/component:
instances, req/s per instance, mean wait, implied QPS limit, and a
verdict badge (queueing / pacing / metered / ok); a new index finding
fires on pacing during throughput phases.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **“Limiter Regime by Component”** report card that visualizes client REST rate-limiting behavior across phases, components, and verbs.
  * Displays per-instance **rate**, **mean limiter wait**, **implied client QPS limit**, and a **verdict badge** (e.g., queueing vs pacing).
  * Introduced a **pacing warning** during **throughput** phases when pacing is detected, reporting the inferred per-instance client QPS limit and mean-wait details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->