### PR TITLE
test/stress: warm-pool invariant phases (over-creation + unschedulable hold) with optional kops scenario

### DIFF
--- a/dev/ci/presubmits/benchmarks-kops-gcp-warmpool
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-warmpool
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the SandboxWarmPool invariant scenario on a kOps GCP cluster
+# (see test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool). The warm
+# pool fill path is CNI-insensitive for the invariants under test (create
+# counting and the unschedulable hold happen before any network datapath
+# matters), so only a cilium variant exists.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+export CNI=cilium
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
@@ -1,0 +1,142 @@
+# benchmarks-kops-gcp-warmpool
+
+An **optional, manually triggered** scenario that verifies the
+SandboxWarmPool controller's fill-time invariants against a real kOps GCP
+cluster. It is a pass/fail correctness gate, not a performance benchmark:
+the run fails loudly when the warm-pool reconciler regresses on either
+invariant below.
+
+It needs a real multi-node cluster because both invariants are shapes an
+envtest/fake-client setup cannot reproduce faithfully: the over-creation
+race lives in the latency between a controller's create call and its own
+informer observing the result (real apiserver + watch round-trips), and the
+unschedulable hold depends on the real scheduler marking pods
+`PodScheduled=False/Unschedulable`.
+
+## What it proves
+
+Both invariants come from the warm-pool over-creation issue (issue 1215,
+fixed by the expectations-gated reconciler in PR 1266):
+
+1. **No over-creation** (`warmpool-overcreate` phase): creating 20 pools x
+   25 replicas in one burst produces **exactly 500 distinct Sandbox
+   creates** — no more. Legitimate replacements (a create observed only
+   after a member's delete, e.g. the stuck-sandbox GC) are counted and
+   reported separately and tolerated up to `--wp-replacement-tolerance`
+   (default 2). The concurrent live population also never exceeds the
+   target: per pool, peak members <= 25 at all times. The pre-fix
+   controller computed its create count from a stale informer cache and
+   over-created ~10x under load (>= 5,000 creates for a 500 target,
+   log-confirmed on the issue), transiently flooding the cluster far above
+   the requested population.
+
+2. **Hold, don't churn, and say so once** (`warmpool-unschedulable` phase):
+   one pool of 3 replicas whose template requests `cpu: "1000"` (no machine
+   shape any cloud sells comes anywhere near 1000 cores, so the pods are
+   robustly unschedulable everywhere) is observed untouched for 8 minutes.
+   The controller must **hold** the unschedulable sandboxes — UIDs stay
+   exactly stable, zero deletes, zero extra creates — and must emit
+   **exactly one** `WarmPoolNotProgressing` Warning event on the pool, with
+   no duplicates. The event lands between ~5m and ~7m35s after pool
+   creation (the fixed 5-minute readiness grace plus the jittered
+   self-scheduled requeue). The pre-fix controller instead deleted and
+   recreated the "stuck" sandboxes forever — an unbounded churn loop whose
+   replacements were equally unschedulable — and emitted no signal at all.
+
+The phases are implemented in `test/stress/warmpool.go` (flags:
+`--wp-pools`, `--wp-replicas`, `--wp-image`, `--wp-replacement-tolerance`,
+`--wp-unsched-replicas`, `--wp-unsched-cpu`, `--wp-unsched-watch`).
+
+## Cluster shape and adversarial settings
+
+The wrapper reuses the tuned `benchmarks-kops-gcp/run` cluster bring-up
+(kOps on GCE: pd-ssd root volumes, KCM/scheduler client QPS at 500, etcd
+metrics listeners, node-exporter — see that script for each knob's
+rationale) with:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| Worker nodes | 12 x `n2-standard-8` (`STRESS_NODE_COUNT`) | ~1200 pod slots: headroom for the 500-sandbox target without a long fill |
+| Control plane | 1 x `c3-standard-22` (base scenario default) | keeps the control plane out of the way of the invariant measurement |
+| Controller | `--sandbox-warm-pool-concurrent-workers=1000` (`CONTROLLER_ARGS`) | the adversarial worker count the over-creation reproduced under; widens the create/observe race the expectations gate must close |
+| Template image | multi-GB `python-runtime-sandbox:latest-main`, not pre-pulled (`--wp-image` via `STRESS_EXTRA_ARGS`) | stretches the not-yet-Ready window so a regressed controller cannot win the race by luck; same image as the live reproductions |
+| Phases | `warmpool-overcreate,warmpool-unschedulable` (`STRESS_PHASES`) | over-creation gate first, then the quiet unschedulable window |
+
+## Running it
+
+Like the other kOps scenarios, this needs GCP credentials, a project with
+quota for the cluster above, and docker for the image push:
+
+```sh
+gcloud auth login && gcloud config set project <project>
+test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
+```
+
+The script creates the cluster, deploys the just-built controller with the
+extensions enabled, runs the two phases, writes the usual stress artifacts
+(`summary.json` carries the verdicts under `warmPoolOvercreate` /
+`warmPoolUnschedulable`), and tears the cluster down.
+
+### Expected PASS output (current main)
+
+The run exits 0 and the stress log contains both verdict lines:
+
+```
+[warmpool-overcreate#1] PASS: exactly 500 creates for 20 pools x 25 replicas (0 tolerated replacements), population never exceeded target
+[warmpool-unschedulable#2] PASS: 3 unschedulable sandboxes held with stable UIDs, exactly one WarmPoolNotProgressing event at +<300-455>s
+```
+
+with a final report shaped like:
+
+```
+--- #1 warmpool-overcreate: 500 requested, ... ---
+  pools x replicas (target):       20 x 25 = 500
+  distinct creates (POST-equiv):   500 (want 500 + replacements)
+  replacements / over-creates:     0 / 0 (want over-creates 0)
+  peak live per pool / global:     25 (cap 25) / 500 (cap 500)
+  time until ALL pools Ready:      <fill time>s
+
+--- #2 warmpool-unschedulable: 3 requested, ... ---
+  replicas (cpu request 1000):     3, watched 480s
+  distinct creates / deletes:      3 (want 3) / 0 (want 0), UIDs stable: true
+  NotProgressing Warning events:   1 (want exactly 1), first at +<300-455>s
+```
+
+### Expected FAIL shape (pre-fix controllers)
+
+Against a controller without the expectations gate (anything before the
+issue-1215 fix), the run exits non-zero with errors of the form:
+
+```
+warmpool-overcreate#1 phase: warm pool invariants violated: N sandbox creates
+beyond target without a preceding delete (over-creation); ... peak concurrent
+population exceeded target in M pool(s) ...
+```
+
+(historically N pushed the distinct-create count toward ~10x the target)
+and, for the unschedulable leg:
+
+```
+warmpool-unschedulable#2 phase: warm pool invariants violated: N pool sandbox
+deletes observed (delete/recreate churn on unschedulable pods); M distinct
+sandbox creates for 3 replicas (member UIDs not stable); no
+WarmPoolNotProgressing Warning event within 8m0s ...
+```
+
+## Cost / duration
+
+One ephemeral 12-node cluster (12 x n2-standard-8 + 1 x c3-standard-22,
+pd-ssd roots) for **~35-45 minutes** end to end: ~10 min cluster bring-up,
+a few minutes of image push/deploy and the e2e benchmark suite the base
+wrapper runs, ~5-10 min for the overcreate fill (multi-GB pulls) plus
+settle and drain, a fixed 8-minute unschedulable window, and teardown.
+
+## Why optional / manual
+
+The scenario needs a real GCP cluster (project quota, ~45 min of 13 VMs),
+so it is not part of the default presubmit set. Run it on demand — via
+`dev/ci/presubmits/benchmarks-kops-gcp-warmpool` — when touching the
+SandboxWarmPool reconciler's create/delete paths, the expectations tracker,
+or the readiness-grace/unschedulable handling. The unit and envtest suites
+cover the same logic deterministically on every PR; this scenario is the
+live, whole-system proof.

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
@@ -62,6 +62,10 @@ rationale) with:
 | Template image | multi-GB `python-runtime-sandbox:latest-main`, not pre-pulled (`--wp-image` via `STRESS_EXTRA_ARGS`) | stretches the not-yet-Ready window so a regressed controller cannot win the race by luck; same image as the live reproductions |
 | Phases | `warmpool-overcreate,warmpool-unschedulable` (`STRESS_PHASES`) | over-creation gate first, then the quiet unschedulable window |
 
+The invariants are node-shape-independent — pass/fail depends only on
+controller behavior, not node throughput (the live validation ran on
+`e2-standard-8` workers with identical verdicts).
+
 ## Running it
 
 Like the other kOps scenarios, this needs GCP credentials, a project with
@@ -104,24 +108,26 @@ with a final report shaped like:
 
 ### Expected FAIL shape (pre-fix controllers)
 
-Against a controller without the expectations gate (anything before the
-issue-1215 fix), the run exits non-zero with errors of the form:
+The stress harness aborts after the first failed phase, and against a
+controller without the expectations gate (anything before the issue-1215
+fix) that is the overcreate phase — so the **full-run FAIL output is the
+overcreate failure only**, exit non-zero with per-pool forensics:
 
 ```
 warmpool-overcreate#1 phase: warm pool invariants violated: N sandbox creates
-beyond target without a preceding delete (over-creation); ... peak concurrent
-population exceeded target in M pool(s) ...
+beyond target without a preceding delete (over-creation); T distinct creates,
+want exactly 500 + replacements; R replacements exceed tolerance 2; peak
+concurrent population exceeded target in M pool(s): max P > 25 replicas
+(worst pools: p1-wp-pool-...(creates=... over=... peak=...), ...)
 ```
 
-(historically N pushed the distinct-create count toward ~10x the target)
-and, for the unschedulable leg:
-
-```
-warmpool-unschedulable#2 phase: warm pool invariants violated: N pool sandbox
-deletes observed (delete/recreate churn on unschedulable pods); M distinct
-sandbox creates for 3 replicas (member UIDs not stable); no
-WarmPoolNotProgressing Warning event within 8m0s ...
-```
+(a live pre-fix run measured 1,535 distinct creates for the 500 target with
+every pool exceeding its population cap, worst peak 75 vs 25; the original
+issue logs showed up to ~10x). The unschedulable phase's failure signature
+on pre-fix controllers — delete/recreate churn, unstable member UIDs, and
+zero `WarmPoolNotProgressing` events within the window — never gets a
+chance to print in a full run; exercise it standalone with
+`STRESS_PHASES=warmpool-unschedulable`.
 
 ## Cost / duration
 

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
@@ -72,7 +72,7 @@ Like the other kOps scenarios, this needs GCP credentials, a project with
 quota for the cluster above, and docker for the image push:
 
 ```sh
-gcloud auth login && gcloud config set project <project>
+gcloud auth login && gcloud config set project YOUR_PROJECT_ID
 test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
 ```
 
@@ -85,14 +85,14 @@ extensions enabled, runs the two phases, writes the usual stress artifacts
 
 The run exits 0 and the stress log contains both verdict lines:
 
-```
+```text
 [warmpool-overcreate#1] PASS: exactly 500 creates for 20 pools x 25 replicas (0 tolerated replacements), population never exceeded target
 [warmpool-unschedulable#2] PASS: 3 unschedulable sandboxes held with stable UIDs, exactly one WarmPoolNotProgressing event at +<300-455>s
 ```
 
 with a final report shaped like:
 
-```
+```text
 --- #1 warmpool-overcreate: 500 requested, ... ---
   pools x replicas (target):       20 x 25 = 500
   distinct creates (POST-equiv):   500 (want 500 + replacements)
@@ -113,7 +113,7 @@ controller without the expectations gate (anything before the issue-1215
 fix) that is the overcreate phase — so the **full-run FAIL output is the
 overcreate failure only**, exit non-zero with per-pool forensics:
 
-```
+```text
 warmpool-overcreate#1 phase: warm pool invariants violated: N sandbox creates
 beyond target without a preceding delete (over-creation); T distinct creates,
 want exactly 500 + replacements; R replacements exceed tolerance 2; peak

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
@@ -62,9 +62,21 @@ rationale) with:
 | Template image | the standard small test image (the stress tool's `--image` default) | measured to trip pre-fix asserts HARDER than a multi-GB image at this shape (6.1x the create target vs 3.1x — see the FAIL section): fast readiness transitions drive more status-update reconciles/sec against the stale cache, and the quick create->Ready->excess-delete cycle adds delete churn a slow pull never reaches. Also keeps nodes free of a multi-GB image; `--wp-image` (via `STRESS_EXTRA_ARGS`) remains the escape hatch for slow-pull shapes |
 | Phases | `warmpool-overcreate,warmpool-unschedulable` (`STRESS_PHASES`) | over-creation gate first, then the quiet unschedulable window |
 
-The invariants are node-shape-independent — pass/fail depends only on
-controller behavior, not node throughput (the live validation ran on
-`e2-standard-8` workers with identical verdicts).
+Two distinct properties here, easy to conflate:
+
+* The **invariants** are node-shape-independent: creates == target, peaks
+  <= caps, and the unschedulable hold define correct controller behavior
+  on any cluster, and a correct controller passes them on any shape (the
+  live validations ran on `e2-standard-8` workers with the same PASS
+  verdicts as the documented shape).
+* The **FAIL-direction sensitivity** is not: how hard a broken controller
+  trips the asserts scales with readiness speed and cluster shape. Fast
+  readiness (small image, quick nodes) amplifies the stale-cache race —
+  6.1x the create target vs the multi-GB image's 3.1x on the same pre-fix
+  controller — so a marginal regression could in principle trip loudly on
+  a fast shape and quietly (or not at all) on a slow one. That is why the
+  scenario pins the amplifying defaults (small image, workers=1000) and
+  documents this cluster shape: use them for comparable magnitudes.
 
 ## Running it
 

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/README.md
@@ -59,7 +59,7 @@ rationale) with:
 | Worker nodes | 12 x `n2-standard-8` (`STRESS_NODE_COUNT`) | ~1200 pod slots: headroom for the 500-sandbox target without a long fill |
 | Control plane | 1 x `c3-standard-22` (base scenario default) | keeps the control plane out of the way of the invariant measurement |
 | Controller | `--sandbox-warm-pool-concurrent-workers=1000` (`CONTROLLER_ARGS`) | the adversarial worker count the over-creation reproduced under; widens the create/observe race the expectations gate must close |
-| Template image | multi-GB `python-runtime-sandbox:latest-main`, not pre-pulled (`--wp-image` via `STRESS_EXTRA_ARGS`) | stretches the not-yet-Ready window so a regressed controller cannot win the race by luck; same image as the live reproductions |
+| Template image | the standard small test image (the stress tool's `--image` default) | measured to trip pre-fix asserts HARDER than a multi-GB image at this shape (6.1x the create target vs 3.1x — see the FAIL section): fast readiness transitions drive more status-update reconciles/sec against the stale cache, and the quick create->Ready->excess-delete cycle adds delete churn a slow pull never reaches. Also keeps nodes free of a multi-GB image; `--wp-image` (via `STRESS_EXTRA_ARGS`) remains the escape hatch for slow-pull shapes |
 | Phases | `warmpool-overcreate,warmpool-unschedulable` (`STRESS_PHASES`) | over-creation gate first, then the quiet unschedulable window |
 
 The invariants are node-shape-independent — pass/fail depends only on
@@ -121,9 +121,22 @@ concurrent population exceeded target in M pool(s): max P > 25 replicas
 (worst pools: p1-wp-pool-...(creates=... over=... peak=...), ...)
 ```
 
-(a live pre-fix run measured 1,535 distinct creates for the 500 target with
-every pool exceeding its population cap, worst peak 75 vs 25; the original
-issue logs showed up to ~10x). The unschedulable phase's failure signature
+Live pre-fix measurements at this exact shape (20x25, workers=1000):
+
+* **small image (the scenario default): 3,070 distinct creates for the 500
+  target (6.1x)** — 1,312 over-creates, 1,258 replacements, worst pool peak
+  117 vs 25, global peak 1,796 vs 500, 2,570 deletes during the fill;
+  failing leg wall time ~7 minutes.
+* multi-GB not-pre-pulled image (supplementary, via `--wp-image`): 1,535
+  distinct creates (3.1x), every pool over its cap, worst peak 75 vs 25.
+* The original issue logs showed up to ~10x at larger scale.
+
+PASS-direction evidence with the same small image: the fixed controller
+produced exactly-600-for-600 in the single-pool gate-cost run, alongside
+the two-direction 20x25 validation (PASS leg on the fixed controller, FAIL
+legs above).
+
+The unschedulable phase's failure signature
 on pre-fix controllers — delete/recreate churn, unstable member UIDs, and
 zero `WarmPoolNotProgressing` events within the window — never gets a
 chance to print in a full run; exercise it standalone with
@@ -134,8 +147,9 @@ chance to print in a full run; exercise it standalone with
 One ephemeral 12-node cluster (12 x n2-standard-8 + 1 x c3-standard-22,
 pd-ssd roots) for **~35-45 minutes** end to end: ~10 min cluster bring-up,
 a few minutes of image push/deploy and the e2e benchmark suite the base
-wrapper runs, ~5-10 min for the overcreate fill (multi-GB pulls) plus
-settle and drain, a fixed 8-minute unschedulable window, and teardown.
+wrapper runs, a fast overcreate fill (small image; the failing leg on a
+pre-fix controller completes in ~7 min) plus settle and drain, a fixed
+8-minute unschedulable window, and teardown.
 
 ## Why optional / manual
 

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# benchmarks-kops-gcp-warmpool checks the SandboxWarmPool controller's
+# fill-time invariants under adversarial settings (see README.md next to
+# this script, and the warmpool-overcreate / warmpool-unschedulable phases
+# in test/stress/warmpool.go):
+#
+#   * warmpool-overcreate: 20 pools x 25 replicas created in one burst must
+#     produce EXACTLY 500 distinct sandbox creates, and no pool's concurrent
+#     population may ever exceed its replica target.
+#   * warmpool-unschedulable: a pool whose pods can never schedule must be
+#     HELD (stable sandbox UIDs, zero delete/recreate churn) and must emit
+#     exactly one WarmPoolNotProgressing Warning event.
+#
+# This is a dedicated, on-demand scenario rather than phases appended to the
+# main benchmarks-kops-gcp run: it is a pass/fail correctness gate for the
+# warm-pool reconciler, not a performance measurement, and its unschedulable
+# leg deliberately idles the cluster for ~8 minutes -- dead time the
+# throughput scenarios should not pay on every run.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# 12 worker nodes give ~1200 pod slots: comfortable headroom for the
+# 500-sandbox overcreate target (the phase refuses to run when the target
+# does not fit spare capacity) while keeping the fill fast enough that the
+# whole scenario stays inside one job.
+export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-12}"
+
+export STRESS_PHASES="${STRESS_PHASES:-warmpool-overcreate,warmpool-unschedulable}"
+
+# The unschedulable leg alone holds a quiet 8-minute window (the controller's
+# 5-minute readiness grace plus its jittered post-grace requeue, worst case
+# ~7m35s), and the overcreate leg pulls a multi-GB image on every node.
+export STRESS_TIMEOUT="${STRESS_TIMEOUT:-40m}"
+
+# A multi-GB, not-pre-pulled image stretches the not-yet-Ready window the
+# historical over-creation raced in (a fast image can mask a regressed
+# controller by simply winning the race): this is the same image the live
+# reproductions used. Swap in any slow-to-pull image via STRESS_EXTRA_ARGS.
+export STRESS_EXTRA_ARGS="${STRESS_EXTRA_ARGS:---wp-image=us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/python-runtime-sandbox:latest-main}"
+
+# 1000 concurrent warm-pool workers is the adversarial setting the historical
+# over-creation reproduced under (~10x the create target): high worker
+# concurrency widens the window between a create being issued and the
+# informer cache observing it, which is exactly the race the expectations
+# gate closes. A correct controller must hold the invariants at ANY worker
+# count, so the scenario pins the worst one.
+export CONTROLLER_ARGS="${CONTROLLER_ARGS:---sandbox-warm-pool-concurrent-workers=1000}"
+
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
@@ -49,14 +49,19 @@ export STRESS_PHASES="${STRESS_PHASES:-warmpool-overcreate,warmpool-unschedulabl
 
 # The unschedulable leg alone holds a quiet 8-minute window (the controller's
 # 5-minute readiness grace plus its jittered post-grace requeue, worst case
-# ~7m35s), and the overcreate leg pulls a multi-GB image on every node.
+# ~7m35s).
 export STRESS_TIMEOUT="${STRESS_TIMEOUT:-40m}"
 
-# A multi-GB, not-pre-pulled image stretches the not-yet-Ready window the
-# historical over-creation raced in (a fast image can mask a regressed
-# controller by simply winning the race): this is the same image the live
-# reproductions used. Swap in any slow-to-pull image via STRESS_EXTRA_ARGS.
-export STRESS_EXTRA_ARGS="${STRESS_EXTRA_ARGS:---wp-image=us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/python-runtime-sandbox:latest-main}"
+# The overcreate template uses the stress tool's standard small image (the
+# --image default). Measured on a pre-fix controller at this exact shape
+# (20x25, workers=1000), the small image trips the asserts HARDER than a
+# multi-GB one -- 6.1x the create target vs 3.1x -- because fast readiness
+# transitions drive more status-update reconciles per second against the
+# stale cache, and the quick create->Ready->excess-delete cycle adds delete
+# churn a slow pull never reaches. It also keeps nodes free of a multi-GB
+# image and makes the failing leg ~7 minutes. --wp-image (via
+# STRESS_EXTRA_ARGS) remains the escape hatch for probing slow-pull shapes.
+export STRESS_EXTRA_ARGS="${STRESS_EXTRA_ARGS:-}"
 
 # 1000 concurrent warm-pool workers is the adversarial setting the historical
 # over-creation reproduced under (~10x the create target): high worker

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/run
@@ -19,8 +19,10 @@
 # in test/stress/warmpool.go):
 #
 #   * warmpool-overcreate: 20 pools x 25 replicas created in one burst must
-#     produce EXACTLY 500 distinct sandbox creates, and no pool's concurrent
-#     population may ever exceed its replica target.
+#     produce exactly the 500 target sandbox creates (plus separately
+#     tolerated post-delete replacements, capped by
+#     --wp-replacement-tolerance), and no pool's concurrent population may
+#     ever exceed its replica target.
 #   * warmpool-unschedulable: a pool whose pods can never schedule must be
 #     HELD (stable sandbox UIDs, zero delete/recreate churn) and must emit
 #     exactly one WarmPoolNotProgressing Warning event.

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -122,6 +122,11 @@ type PhaseSummary struct {
 	// per-10s-window create->Ready stats (arrival-time bucketed): the
 	// "latency holds over time" evidence. Set only for that phase.
 	SustainedWindows []WindowedLatency `json:"sustainedWindows,omitempty"`
+
+	// Warm-pool invariant phase reports (see warmpool.go). Set only for the
+	// warmpool-overcreate / warmpool-unschedulable phases respectively.
+	WarmPoolOvercreate    *WarmPoolOvercreateReport    `json:"warmPoolOvercreate,omitempty"`
+	WarmPoolUnschedulable *WarmPoolUnschedulableReport `json:"warmPoolUnschedulable,omitempty"`
 }
 
 // Summary is written to summary.json at the end of the test.
@@ -199,6 +204,29 @@ type Config struct {
 	// latency measurement.
 	SustainedLifecycleBudget time.Duration `json:"sustainedLifecycleBudgetNanos"`
 
+	// warmpool-overcreate parameters (see warmpool.go).
+	// WPPools x WPReplicas is the exact number of Sandboxes a correct
+	// controller creates; the phase asserts it.
+	WPPools    int `json:"wpPools"`
+	WPReplicas int `json:"wpReplicas"`
+	// WPImage is the warmpool-overcreate template image ("" = --image). A
+	// large, not-pre-pulled image stretches the not-yet-Ready window the
+	// pre-fix over-creation raced in, making the phase more adversarial.
+	WPImage string `json:"wpImage,omitempty"`
+	// WPReplacementTolerance caps legitimate replacements (create observed
+	// after a member's delete) tolerated across all pools.
+	WPReplacementTolerance int `json:"wpReplacementTolerance"`
+
+	// warmpool-unschedulable parameters (see warmpool.go).
+	WPUnschedReplicas int `json:"wpUnschedReplicas"`
+	// WPUnschedCPU is the per-container CPU request that makes the pool's
+	// pods robustly unschedulable.
+	WPUnschedCPU string `json:"wpUnschedCPU"`
+	// WPUnschedWatch is the quiet observation window measured from pool
+	// creation. Must exceed ~1.5x the controller's 5-minute readiness grace
+	// (the jittered post-grace requeue can land up to ~7m35s in).
+	WPUnschedWatch time.Duration `json:"wpUnschedWatchNanos"`
+
 	// ClientConnections shards the harness's own mutating requests across N
 	// HTTP/2 connections (1 = share the watches' single connection, the
 	// historical behavior). The apiserver caps ~100 concurrent streams per
@@ -250,7 +278,7 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.Timeout, "timeout", 30*time.Minute, "Timeout for the entire test run")
 	flag.DurationVar(&cfg.PerSandboxTimeout, "per-sandbox-timeout", 5*time.Minute, "Timeout for a single sandbox to become ready / be deleted")
 	flag.IntVar(&cfg.CreateConcurrency, "create-concurrency", 20, "Number of concurrent workers creating Sandboxes (fill and throughput phases)")
-	phasesFlag := flag.String("phases", "probe,throughput-mif:50", "Comma-separated phase names to run in order (fill, fill-pct:N, probe, claims-warm, claims-warm-sustained, throughput-mif:N); phases accept hyphen-separated key:value arguments, e.g. throughput-mif:400-label:hot")
+	phasesFlag := flag.String("phases", "probe,throughput-mif:50", "Comma-separated phase names to run in order (fill, fill-pct:N, probe, claims-warm, claims-warm-sustained, warmpool-overcreate, warmpool-unschedulable, throughput-mif:N); phases accept hyphen-separated key:value arguments, e.g. throughput-mif:400-label:hot")
 	flag.IntVar(&cfg.FillPerNode, "fill-per-node", 10, "Number of long-running background Sandboxes per worker node for the fill phase")
 	flag.IntVar(&cfg.ProbeCount, "probe-count", 20, "Number of latency probe Sandboxes for the probe phase")
 	flag.IntVar(&cfg.ProbeConcurrency, "probe-concurrency", 1, "Number of concurrent latency probes; keep low for clean latency numbers")
@@ -264,6 +292,13 @@ func run(ctx context.Context) error {
 	flag.IntVar(&cfg.SustainedNamespaces, "sustained-namespaces", 1, "Spread the sustained phase's pools and claims across N pre-created namespaces (1 = run in the test namespace)")
 	flag.DurationVar(&cfg.SustainedPoolHeadroom, "sustained-pool-headroom", 10*time.Second, "Warm pool sizing for the sustained phase: each namespace's pool has ceil(rate/namespaces * headroom-seconds) replicas; must cover the controller's worst-case refill latency")
 	flag.DurationVar(&cfg.SustainedLifecycleBudget, "sustained-lifecycle-budget", 5*time.Second, "Assumed per-claim ready+delete pipeline time (beyond --claim-dwell) used to size the sustained phase's pod-capacity estimate; raise it if the cluster's Ready/delete path is slower under load")
+	flag.IntVar(&cfg.WPPools, "wp-pools", 20, "Number of SandboxWarmPools created at once by the warmpool-overcreate phase (requires the extensions controller)")
+	flag.IntVar(&cfg.WPReplicas, "wp-replicas", 25, "Replicas per pool for the warmpool-overcreate phase; the phase asserts exactly wp-pools*wp-replicas distinct sandbox creates")
+	flag.StringVar(&cfg.WPImage, "wp-image", "", "Container image for the warmpool-overcreate template (default: the --image value). A multi-GB, not-pre-pulled image stretches the not-yet-Ready window the historical over-creation raced in")
+	flag.IntVar(&cfg.WPReplacementTolerance, "wp-replacement-tolerance", 2, "Maximum legitimate replacements (a create observed after a member's delete) tolerated across all warmpool-overcreate pools; replacements are reported separately from over-creates")
+	flag.IntVar(&cfg.WPUnschedReplicas, "wp-unsched-replicas", 3, "Replica count of the warmpool-unschedulable phase's single pool")
+	flag.StringVar(&cfg.WPUnschedCPU, "wp-unsched-cpu", "1000", "Per-container CPU request (kubernetes quantity) that makes the warmpool-unschedulable pods robustly unschedulable; 1000 cores exceeds any machine shape any cloud sells today")
+	flag.DurationVar(&cfg.WPUnschedWatch, "wp-unsched-watch", 8*time.Minute, "Quiet observation window of the warmpool-unschedulable phase, measured from pool creation; must exceed ~1.5x the controller's 5-minute readiness grace so the jittered WarmPoolNotProgressing event (latest ~7m35s) lands inside it")
 	flag.IntVar(&cfg.ClientConnections, "client-connections", 1, "Shard the harness's mutating API requests across N HTTP/2 connections; 1 = single connection shared with watches (historical behavior, subject to the apiserver's ~100-streams-per-connection cap)")
 	flag.BoolVar(&cfg.CollectMetrics, "collect-metrics", true, "Whether to scrape Prometheus metrics from the control plane, the sandbox controller, and kubelets to metrics.jsonl.gz")
 	flag.DurationVar(&cfg.MetricsInterval, "metrics-interval", 15*time.Second, "Interval between Prometheus metrics scrapes")
@@ -571,6 +606,7 @@ func run(ctx context.Context) error {
 	// Write outputs even if a phase failed: partial data is still useful.
 	summary := buildSummary(runID, testStartTime, cfg, clusterInfo, tracker, phaseResults, phases)
 	summary.APFVerification = apfVerification
+	test.attachWarmPoolReports(summary)
 	if err := writeOutputs(cfg.OutputDir, summary, tracker); err != nil {
 		if phaseErr == nil {
 			phaseErr = err
@@ -910,6 +946,34 @@ func printReport(summary *Summary, clusterInfo *ClusterInfo) {
 				}
 				fmt.Printf("    [%4.0fs-%4.0fs) arrivals=%-5d ready=%-5d %s\n",
 					w.StartOffsetSeconds, w.EndOffsetSeconds, w.Arrivals, w.Ready, lat)
+			}
+		case PhaseWarmPoolOvercreate:
+			// Invariant verdicts, not latency: the controller creates the
+			// sandboxes, the harness only observes (see warmpool.go).
+			if r := ps.WarmPoolOvercreate; r != nil {
+				fmt.Printf("  pools x replicas (target):       %d x %d = %d\n", r.Pools, r.ReplicasPerPool, r.TargetSandboxes)
+				fmt.Printf("  distinct creates (POST-equiv):   %d (want %d + replacements)\n", r.DistinctCreates, r.TargetSandboxes)
+				fmt.Printf("  replacements / over-creates:     %d / %d (want over-creates 0)\n", r.Replacements, r.OverCreates)
+				fmt.Printf("  peak live per pool / global:     %d (cap %d) / %d (cap %d)\n", r.MaxPoolPeakLive, r.ReplicasPerPool, r.PeakLiveTotal, r.TargetSandboxes)
+				if r.TimeToAllReadySeconds != nil {
+					fmt.Printf("  time until ALL pools Ready:      %.2fs\n", *r.TimeToAllReadySeconds)
+				} else {
+					fmt.Printf("  time until ALL pools Ready:      n/a (not all pools became Ready)\n")
+				}
+			} else {
+				fmt.Printf("  no report (phase aborted before observation)\n")
+			}
+		case PhaseWarmPoolUnschedulable:
+			if r := ps.WarmPoolUnschedulable; r != nil {
+				fmt.Printf("  replicas (cpu request %s):     %d, watched %.0fs\n", r.CPURequest, r.Replicas, r.WatchSeconds)
+				fmt.Printf("  distinct creates / deletes:      %d (want %d) / %d (want 0), UIDs stable: %v\n", r.DistinctCreates, r.Replicas, r.ObservedDeletes, r.UIDsStable)
+				if r.FirstEventOffsetSeconds != nil {
+					fmt.Printf("  NotProgressing Warning events:   %d (want exactly 1), first at +%.0fs\n", r.NotProgressingEvents, *r.FirstEventOffsetSeconds)
+				} else {
+					fmt.Printf("  NotProgressing Warning events:   %d (want exactly 1)\n", r.NotProgressingEvents)
+				}
+			} else {
+				fmt.Printf("  no report (phase aborted before observation)\n")
 			}
 		default:
 			fmt.Printf("  end-to-end ready latency:        %s\n", formatLatency(ps.Latency.EndToEndReady))

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -209,9 +209,11 @@ type Config struct {
 	// controller creates; the phase asserts it.
 	WPPools    int `json:"wpPools"`
 	WPReplicas int `json:"wpReplicas"`
-	// WPImage is the warmpool-overcreate template image ("" = --image). A
-	// large, not-pre-pulled image stretches the not-yet-Ready window the
-	// pre-fix over-creation raced in, making the phase more adversarial.
+	// WPImage is the warmpool-overcreate template image ("" = --image).
+	// Measured on a pre-fix controller, the standard small image trips the
+	// over-creation asserts hardest (fast readiness transitions drive more
+	// reconciles/sec against the stale cache); the override exists for
+	// probing slow-pull shapes.
 	WPImage string `json:"wpImage,omitempty"`
 	// WPReplacementTolerance caps legitimate replacements (create observed
 	// after a member's delete) tolerated across all pools.
@@ -294,7 +296,7 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.SustainedLifecycleBudget, "sustained-lifecycle-budget", 5*time.Second, "Assumed per-claim ready+delete pipeline time (beyond --claim-dwell) used to size the sustained phase's pod-capacity estimate; raise it if the cluster's Ready/delete path is slower under load")
 	flag.IntVar(&cfg.WPPools, "wp-pools", 20, "Number of SandboxWarmPools created at once by the warmpool-overcreate phase (requires the extensions controller)")
 	flag.IntVar(&cfg.WPReplicas, "wp-replicas", 25, "Replicas per pool for the warmpool-overcreate phase; the phase asserts exactly wp-pools*wp-replicas distinct sandbox creates")
-	flag.StringVar(&cfg.WPImage, "wp-image", "", "Container image for the warmpool-overcreate template (default: the --image value). A multi-GB, not-pre-pulled image stretches the not-yet-Ready window the historical over-creation raced in")
+	flag.StringVar(&cfg.WPImage, "wp-image", "", "Container image for the warmpool-overcreate template (default: the --image value, which also trips pre-fix over-creation hardest -- fast readiness means more reconciles against the stale cache); override to probe slow-pull shapes")
 	flag.IntVar(&cfg.WPReplacementTolerance, "wp-replacement-tolerance", 2, "Maximum legitimate replacements (a create observed after a member's delete) tolerated across all warmpool-overcreate pools; replacements are reported separately from over-creates")
 	flag.IntVar(&cfg.WPUnschedReplicas, "wp-unsched-replicas", 3, "Replica count of the warmpool-unschedulable phase's single pool")
 	flag.StringVar(&cfg.WPUnschedCPU, "wp-unsched-cpu", "1000", "Per-container CPU request (kubernetes quantity) that makes the warmpool-unschedulable pods robustly unschedulable; 1000 cores exceeds any machine shape any cloud sells today")

--- a/test/stress/phase.go
+++ b/test/stress/phase.go
@@ -87,7 +87,7 @@ func parsePhase(raw string) (Phase, error) {
 	// match the longest known kind first, then treat any remainder as
 	// arguments.
 	found := false
-	for _, k := range []PhaseName{PhaseClaimsWarmSustained, PhaseClaimsWarm, PhaseThroughput, PhaseProbe, PhaseFill} {
+	for _, k := range []PhaseName{PhaseClaimsWarmSustained, PhaseClaimsWarm, PhaseWarmPoolOvercreate, PhaseWarmPoolUnschedulable, PhaseThroughput, PhaseProbe, PhaseFill} {
 		if raw == string(k) {
 			kind, found = string(k), true
 			break
@@ -98,7 +98,7 @@ func parsePhase(raw string) (Phase, error) {
 		}
 	}
 	if !found {
-		return nil, fmt.Errorf("unknown phase %q (want fill, fill-pct:N, probe, claims-warm, claims-warm-sustained, or throughput-mif:N)", raw)
+		return nil, fmt.Errorf("unknown phase %q (want fill, fill-pct:N, probe, claims-warm, claims-warm-sustained, warmpool-overcreate, warmpool-unschedulable, or throughput-mif:N)", raw)
 	}
 
 	// Legacy spellings: bare "throughput" is mif 50 (renamed so the report
@@ -161,6 +161,10 @@ func parsePhase(raw string) (Phase, error) {
 		phase = &claimsWarmPhase{raw: PhaseName(raw)}
 	case string(PhaseClaimsWarmSustained):
 		phase = &claimsWarmSustainedPhase{raw: PhaseName(raw)}
+	case string(PhaseWarmPoolOvercreate):
+		phase = &warmPoolOvercreatePhase{raw: PhaseName(raw)}
+	case string(PhaseWarmPoolUnschedulable):
+		phase = &warmPoolUnschedulablePhase{raw: PhaseName(raw)}
 	}
 	for key := range args {
 		return nil, fmt.Errorf("phase %q: unknown argument %q", raw, key)

--- a/test/stress/phases.go
+++ b/test/stress/phases.go
@@ -58,6 +58,14 @@ type stressTest struct {
 	// claims-warm burst (nil when --profile-controller is false or the
 	// phase does not run).
 	ctrlProfiler *controllerProfiler
+
+	// Warm-pool phase reports, keyed by phase number; attached to the
+	// summary after the phase loop (see attachWarmPoolReports). Guarded by
+	// wpMu (phases run sequentially, but reports are also written on the
+	// failure path while other goroutines may still be draining).
+	wpMu            sync.Mutex
+	wpOvercreate    map[PhaseNumber]*WarmPoolOvercreateReport
+	wpUnschedulable map[PhaseNumber]*WarmPoolUnschedulableReport
 }
 
 // buildSandboxObject returns a minimal long-running Sandbox.
@@ -597,19 +605,25 @@ func (s *stressTest) cleanupClaimsWarm(ctx context.Context, number PhaseNumber, 
 		log.Printf("[%s#%d] failed to delete template %s: %v", PhaseClaimsWarm, number, templateID.Name, err)
 	}
 
-	// Wait for the sandboxes owned by the pool or the claims to be deleted,
-	// so their pods stop occupying capacity that a later phase counts on.
-	// Best-effort: on timeout we log and move on.
+	s.waitOwnedSandboxesDrained(ctx, PhaseClaimsWarm, number)
+}
+
+// waitOwnedSandboxesDrained waits for the sandboxes owned by a
+// SandboxWarmPool or SandboxClaim in the test namespace to be deleted, so
+// their pods stop occupying capacity that a later phase counts on.
+// Best-effort: on timeout it logs and moves on (namespace deletion is the
+// backstop). Progress-stall detection mirrors the fill phase.
+func (s *stressTest) waitOwnedSandboxesDrained(ctx context.Context, phase PhaseName, number PhaseNumber) {
 	lastRemaining := -1
 	lastProgress := time.Now()
 	for {
 		remaining, err := s.countOwnedSandboxes(ctx)
 		if err != nil {
-			log.Printf("[%s#%d] failed to list sandboxes during cleanup: %v", PhaseClaimsWarm, number, err)
+			log.Printf("[%s#%d] failed to list sandboxes during cleanup: %v", phase, number, err)
 			return
 		}
 		if remaining == 0 {
-			log.Printf("[%s#%d] cleanup complete", PhaseClaimsWarm, number)
+			log.Printf("[%s#%d] cleanup complete", phase, number)
 			return
 		}
 		if remaining != lastRemaining {
@@ -617,7 +631,7 @@ func (s *stressTest) cleanupClaimsWarm(ctx context.Context, number PhaseNumber, 
 			lastProgress = time.Now()
 		}
 		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
-			log.Printf("[%s#%d] WARNING: %d pool/claim-owned sandboxes still present after %v; later phases may see reduced spare capacity", PhaseClaimsWarm, number, remaining, s.cfg.PerSandboxTimeout)
+			log.Printf("[%s#%d] WARNING: %d pool/claim-owned sandboxes still present after %v; later phases may see reduced spare capacity", phase, number, remaining, s.cfg.PerSandboxTimeout)
 			return
 		}
 		select {

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -47,6 +47,15 @@ const (
 	// Poisson jitter against continuously replenished warm pools, measuring
 	// whether create -> Ready latency holds over time (see sustained.go).
 	PhaseClaimsWarmSustained PhaseName = "claims-warm-sustained"
+	// PhaseWarmPoolOvercreate fills many SandboxWarmPools at once and asserts
+	// the controller's exactly-N-creates and never-above-target population
+	// invariants (see warmpool.go).
+	PhaseWarmPoolOvercreate PhaseName = "warmpool-overcreate"
+	// PhaseWarmPoolUnschedulable parks one SandboxWarmPool on an impossible
+	// resource request and asserts the controller holds the unschedulable
+	// sandboxes (no delete/recreate churn) and emits exactly one
+	// WarmPoolNotProgressing Warning event (see warmpool.go).
+	PhaseWarmPoolUnschedulable PhaseName = "warmpool-unschedulable"
 )
 
 // PhaseNumber is a 1-based index into the run's phase list (Config.Phases /
@@ -167,11 +176,41 @@ type SandboxRecord struct {
 type Tracker struct {
 	mu      sync.Mutex
 	records map[types.NamespacedName]*SandboxRecord
+
+	// observers receive every decoded watch event after milestone processing.
+	// Phases that assert on objects the harness did not create itself (the
+	// warm-pool phases watch controller-owned Sandboxes and pool Events)
+	// register one for the duration of the phase. Keyed for removal.
+	observers  map[int]watchObserver
+	observerID int
 }
+
+// watchObserver is a phase-installed callback for raw watch events. It runs
+// on the watch decode path, so implementations must be fast and must not
+// block; observers do their own locking.
+type watchObserver func(resource string, eventType watch.EventType, u *unstructured.Unstructured)
 
 func NewTracker() *Tracker {
 	return &Tracker{
 		records: make(map[types.NamespacedName]*SandboxRecord),
+	}
+}
+
+// AddObserver registers fn to receive every watch event (all resources) and
+// returns a function that removes it again. Removal is idempotent.
+func (t *Tracker) AddObserver(fn watchObserver) (remove func()) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.observers == nil {
+		t.observers = make(map[int]watchObserver)
+	}
+	id := t.observerID
+	t.observerID++
+	t.observers[id] = fn
+	return func() {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		delete(t.observers, id)
 	}
 }
 
@@ -361,6 +400,22 @@ func (t *Tracker) HandleWatchEvent(resource string, eventType watch.EventType, u
 		t.handlePodEvent(eventType, u)
 	case "sandboxclaims":
 		t.handleClaimEvent(eventType, u)
+	}
+
+	// Fan out to phase-installed observers. Snapshot under the lock, invoke
+	// outside it: observers take their own locks and must not nest inside
+	// ours (the milestone handlers above also lock t.mu).
+	t.mu.Lock()
+	var observers []watchObserver
+	if len(t.observers) > 0 {
+		observers = make([]watchObserver, 0, len(t.observers))
+		for _, fn := range t.observers {
+			observers = append(observers, fn)
+		}
+	}
+	t.mu.Unlock()
+	for _, fn := range observers {
+		fn(resource, eventType, u)
 	}
 }
 

--- a/test/stress/warmpool.go
+++ b/test/stress/warmpool.go
@@ -32,9 +32,12 @@ package main
 //     observed on the sandboxes watch is the result of exactly one successful
 //     POST, so this is the POST-equivalent count; failed POSTs never produce
 //     an object and are invisible here). Legitimate replacements — a create
-//     observed AFTER a delete of a prior member of the same pool — are
-//     counted and reported separately, tolerated up to
-//     --wp-replacement-tolerance in total.
+//     BEYOND the pool's replica target that is covered by a previously
+//     observed delete of a member of the same pool (creates that merely
+//     complete the initial fill after an early delete are part of the
+//     target, and the delete's credit carries forward) — are counted and
+//     reported separately, tolerated up to --wp-replacement-tolerance in
+//     total.
 //   - The concurrent live population never exceeds the target: per pool,
 //     peak live members <= replicas at all times (the fixed controller gates
 //     creates on the whole live population, terminating included).
@@ -105,9 +108,12 @@ type WarmPoolOvercreateReport struct {
 	// the watch: the POST-equivalent count (one successful create call per
 	// UID). Invariant: DistinctCreates == TargetSandboxes + Replacements.
 	DistinctCreates int `json:"distinctCreates"`
-	// Replacements are creates observed after a delete of a prior member of
-	// the same pool (legitimate: e.g. the stuck-sandbox GC replacing a
-	// genuinely wedged sandbox). Tolerated up to --wp-replacement-tolerance.
+	// Replacements are distinct creates BEYOND the pool's replica target
+	// that were covered by a previously observed delete of a member of the
+	// same pool (legitimate: e.g. the stuck-sandbox GC replacing a genuinely
+	// wedged sandbox). A create that merely completes the initial fill after
+	// an early delete counts toward the target instead, with the delete's
+	// credit carried forward. Tolerated up to --wp-replacement-tolerance.
 	Replacements int `json:"replacements"`
 	// OverCreates are creates beyond the pool's target that were NOT covered
 	// by a previously observed delete: the issue-1215 over-creation shape.
@@ -166,6 +172,11 @@ type poolAccountant struct {
 	// pools (exact: updated on every observed create/delete).
 	liveAll     int
 	peakLiveAll int
+	// stopped makes stop() a hard boundary: Tracker.HandleWatchEvent invokes
+	// a snapshot of the observer list outside the Tracker lock, so a removed
+	// observer can still see one in-flight callback — without the flag that
+	// callback could mutate the accounting after the phase computed totals().
+	stopped bool
 }
 
 type poolAccount struct {
@@ -225,6 +236,9 @@ func (a *poolAccountant) observe(resource string, eventType watch.EventType, u *
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.stopped {
+		return
+	}
 	acct, ok := a.pools[poolName]
 	if !ok {
 		return
@@ -267,6 +281,14 @@ func (a *poolAccountant) observe(resource string, eventType watch.EventType, u *
 	if a.liveAll > a.peakLiveAll {
 		a.peakLiveAll = a.liveAll
 	}
+}
+
+// stop freezes the accounting: any observer callback still in flight (see
+// the stopped field) becomes a no-op. Call before removing the observer.
+func (a *poolAccountant) stop() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.stopped = true
 }
 
 // poolTotals aggregates the accountant's per-pool state.
@@ -321,6 +343,8 @@ type warmPoolEventCounter struct {
 	reason    string
 	firstSeen time.Time
 	counts    map[types.UID]int64
+	// stopped: same hard-boundary contract as poolAccountant.stopped.
+	stopped bool
 }
 
 func newWarmPoolEventCounter(namespace, pool, reason string) *warmPoolEventCounter {
@@ -355,12 +379,22 @@ func (c *warmPoolEventCounter) observe(resource string, eventType watch.EventTyp
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.stopped {
+		return
+	}
 	if c.firstSeen.IsZero() {
 		c.firstSeen = time.Now()
 	}
 	if count > c.counts[u.GetUID()] {
 		c.counts[u.GetUID()] = count
 	}
+}
+
+// stop freezes the counter (see poolAccountant.stop).
+func (c *warmPoolEventCounter) stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopped = true
 }
 
 // occurrences returns the deduplication-aware event count and the time the
@@ -426,6 +460,10 @@ func (s *stressTest) runWarmPoolOvercreatePhase(ctx context.Context, number Phas
 	observing := true
 	stopObserving := func() {
 		if observing {
+			// Freeze the accounting BEFORE removing the observer: removal
+			// only stops future snapshots, an in-flight callback could still
+			// fire (see poolAccountant.stopped).
+			acct.stop()
 			removeObserver()
 			observing = false
 		}
@@ -453,7 +491,7 @@ func (s *stressTest) runWarmPoolOvercreatePhase(ctx context.Context, number Phas
 
 	// Pool provisioning is part of the observation (the over-creation race
 	// lives in the fill), but readiness itself is just the phase's endpoint.
-	readyErr := s.waitAllWarmPoolsReady(ctx, PhaseWarmPoolOvercreate, number, replicas, pools)
+	readyErr := s.waitAllWarmPoolsReady(ctx, PhaseWarmPoolOvercreate, number, replicas, poolNames)
 	var timeToAllReady *float64
 	if readyErr == nil {
 		d := time.Since(start).Seconds()
@@ -522,9 +560,16 @@ func (s *stressTest) runWarmPoolOvercreatePhase(ctx context.Context, number Phas
 }
 
 // waitAllWarmPoolsReady polls the phase's pools until every one reports
-// readyReplicas >= want. Progress-stall detection mirrors the fill phase
-// (total ready count must advance within PerSandboxTimeout).
-func (s *stressTest) waitAllWarmPoolsReady(ctx context.Context, phase PhaseName, number PhaseNumber, want, pools int) error {
+// readyReplicas >= want. Only the named pools count: the namespace may still
+// hold a lingering pool from an earlier phase (cleanup drains are
+// best-effort), which must neither satisfy nor stall this gate.
+// Progress-stall detection mirrors the fill phase (total ready count must
+// advance within PerSandboxTimeout).
+func (s *stressTest) waitAllWarmPoolsReady(ctx context.Context, phase PhaseName, number PhaseNumber, want int, poolNames []string) error {
+	wanted := make(map[string]struct{}, len(poolNames))
+	for _, name := range poolNames {
+		wanted[name] = struct{}{}
+	}
 	lastReadySum := int64(-1)
 	lastProgress := time.Now()
 	for {
@@ -535,13 +580,16 @@ func (s *stressTest) waitAllWarmPoolsReady(ctx context.Context, phase PhaseName,
 		readyPools := 0
 		readySum := int64(0)
 		for i := range list.Items {
+			if _, ok := wanted[list.Items[i].GetName()]; !ok {
+				continue
+			}
 			ready, _, _ := unstructured.NestedInt64(list.Items[i].Object, "status", "readyReplicas")
 			readySum += ready
 			if ready >= int64(want) {
 				readyPools++
 			}
 		}
-		if readyPools >= pools {
+		if readyPools >= len(poolNames) {
 			return nil
 		}
 		if readySum != lastReadySum {
@@ -549,7 +597,7 @@ func (s *stressTest) waitAllWarmPoolsReady(ctx context.Context, phase PhaseName,
 			lastProgress = time.Now()
 		}
 		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
-			return fmt.Errorf("[%s#%d] pools stalled: %d/%d pools Ready (%d total ready replicas) with no progress for %v", phase, number, readyPools, pools, readySum, s.cfg.PerSandboxTimeout)
+			return fmt.Errorf("[%s#%d] pools stalled: %d/%d pools Ready (%d total ready replicas) with no progress for %v", phase, number, readyPools, len(poolNames), readySum, s.cfg.PerSandboxTimeout)
 		}
 		select {
 		case <-ctx.Done():
@@ -579,6 +627,10 @@ func (s *stressTest) runWarmPoolUnschedulablePhase(ctx context.Context, number P
 	observing := true
 	stopObserving := func() {
 		if observing {
+			// Freeze before removal so an in-flight snapshot callback cannot
+			// mutate the verdict inputs (see poolAccountant.stopped).
+			acct.stop()
+			events.stop()
 			removeAcct()
 			removeEvents()
 			observing = false

--- a/test/stress/warmpool.go
+++ b/test/stress/warmpool.go
@@ -1,0 +1,828 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// warmpool-overcreate and warmpool-unschedulable: SandboxWarmPool controller
+// invariant phases (correctness gates, not performance measurements).
+//
+// Both phases encode the invariants from issue 1215 (warm pools over-created
+// replicas ~10x off a stale informer cache, and churned delete/create forever
+// on unschedulable pods), fixed by the expectations-gated reconciler. They
+// PASS on a fixed controller and FAIL loudly on a pre-fix one, so the
+// scenario doubles as a regression gate and as live evidence when the
+// reconciler's create/delete paths change.
+//
+// warmpool-overcreate: creates --wp-pools SandboxWarmPools of --wp-replicas
+// each in one burst and watches every pool-owned Sandbox in the namespace.
+// Invariants asserted once all pools are Ready (plus a short settle window):
+//
+//   - Exactly pools x replicas DISTINCT Sandbox creates (each distinct UID
+//     observed on the sandboxes watch is the result of exactly one successful
+//     POST, so this is the POST-equivalent count; failed POSTs never produce
+//     an object and are invisible here). Legitimate replacements — a create
+//     observed AFTER a delete of a prior member of the same pool — are
+//     counted and reported separately, tolerated up to
+//     --wp-replacement-tolerance in total.
+//   - The concurrent live population never exceeds the target: per pool,
+//     peak live members <= replicas at all times (the fixed controller gates
+//     creates on the whole live population, terminating included).
+//
+// Ordering makes the replacement attribution race-free: events for one
+// resource arrive in resourceVersion order on a single watch, and the fixed
+// controller only creates a replacement after its own informer observed the
+// deletion, so the DELETED event precedes the replacement's ADDED event in
+// our stream too.
+//
+// warmpool-unschedulable: creates ONE pool of --wp-unsched-replicas whose
+// template requests --wp-unsched-cpu CPUs (default 1000 — no machine
+// anywhere near that exists in any cloud today, so the pods are robustly
+// Unschedulable), then observes for --wp-unsched-watch. Invariants:
+//
+//   - Zero delete/recreate churn: no pool sandbox is deleted and no extra
+//     one is created, i.e. the member UID set stays exactly stable (the
+//     pre-fix controller replaced "stuck" sandboxes past the readiness grace
+//     with equally unschedulable ones, forever).
+//   - Exactly one WarmPoolNotProgressing Warning event for the pool, no
+//     duplicates. The controller emits it when unschedulable sandboxes cross
+//     the (fixed, 5-minute) readiness grace period; the self-scheduled
+//     post-grace requeue is jittered up to +50%, so the event lands between
+//     ~5m02s and ~7m35s after pool creation — the 8m default watch window
+//     covers the worst case.
+//
+// Neither phase registers tracker records (the controller, not the harness,
+// creates the Sandboxes); results are attached to the summary as structured
+// reports (WarmPoolOvercreateReport / WarmPoolUnschedulableReport) instead.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// warmPoolNotProgressingReason is the Event reason the SandboxWarmPool
+// controller emits when a pool holds unschedulable sandboxes past the
+// readiness grace period (see extensions/controllers, issue 1215).
+const warmPoolNotProgressingReason = "WarmPoolNotProgressing"
+
+// warmPoolSettleWindow is how long warmpool-overcreate keeps observing after
+// all pools report Ready: the pre-fix controller cleaned up its surplus
+// AFTER the fill, so trailing deletes/creates must land in the accounting.
+const warmPoolSettleWindow = 15 * time.Second
+
+// WarmPoolOvercreateReport carries the warmpool-overcreate phase's observed
+// counts and verdict inputs into summary.json (PhaseSummary.WarmPoolOvercreate).
+type WarmPoolOvercreateReport struct {
+	Pools           int `json:"pools"`
+	ReplicasPerPool int `json:"replicasPerPool"`
+	// TargetSandboxes is Pools * ReplicasPerPool: the exact number of
+	// distinct creates a correct controller performs (plus replacements).
+	TargetSandboxes int `json:"targetSandboxes"`
+	// DistinctCreates counts distinct pool-owned Sandbox UIDs observed on
+	// the watch: the POST-equivalent count (one successful create call per
+	// UID). Invariant: DistinctCreates == TargetSandboxes + Replacements.
+	DistinctCreates int `json:"distinctCreates"`
+	// Replacements are creates observed after a delete of a prior member of
+	// the same pool (legitimate: e.g. the stuck-sandbox GC replacing a
+	// genuinely wedged sandbox). Tolerated up to --wp-replacement-tolerance.
+	Replacements int `json:"replacements"`
+	// OverCreates are creates beyond the pool's target that were NOT covered
+	// by a previously observed delete: the issue-1215 over-creation shape.
+	// Invariant: 0.
+	OverCreates int `json:"overCreates"`
+	// ObservedDeletes counts pool-member DELETED watch events during the
+	// observation window (cleanup is excluded; observation stops before it).
+	ObservedDeletes int `json:"observedDeletes"`
+	// MaxPoolPeakLive is the largest concurrent live-member count any single
+	// pool reached. Invariant: <= ReplicasPerPool.
+	MaxPoolPeakLive int `json:"maxPoolPeakLive"`
+	// PoolsExceedingTarget counts pools whose peak live population exceeded
+	// their replica target at any moment. Invariant: 0.
+	PoolsExceedingTarget int `json:"poolsExceedingTarget"`
+	// PeakLiveTotal is the largest concurrent live-member count across all
+	// pools combined (informational; bounded by pools x replicas when the
+	// per-pool invariant holds).
+	PeakLiveTotal int `json:"peakLiveTotal"`
+	// TimeToAllReadySeconds is first pool Create -> every pool reporting
+	// readyReplicas >= replicas, set only when all pools became Ready.
+	TimeToAllReadySeconds *float64 `json:"timeToAllReadySeconds,omitempty"`
+}
+
+// WarmPoolUnschedulableReport carries the warmpool-unschedulable phase's
+// observations into summary.json (PhaseSummary.WarmPoolUnschedulable).
+type WarmPoolUnschedulableReport struct {
+	Replicas   int    `json:"replicas"`
+	CPURequest string `json:"cpuRequest"`
+	// WatchSeconds is the observation window measured from pool creation.
+	WatchSeconds float64 `json:"watchSeconds"`
+	// DistinctCreates counts distinct pool-owned Sandbox UIDs observed.
+	// Invariant: == Replicas (no recreates).
+	DistinctCreates int `json:"distinctCreates"`
+	// ObservedDeletes counts pool-member DELETED watch events. Invariant: 0
+	// (the pre-fix controller churned delete->create on unschedulable pods).
+	ObservedDeletes int `json:"observedDeletes"`
+	// UIDsStable is the combined churn verdict: exactly Replicas distinct
+	// UIDs, none deleted.
+	UIDsStable bool `json:"uidsStable"`
+	// NotProgressingEvents is the deduplication-aware occurrence count of
+	// Warning WarmPoolNotProgressing events for the pool (sum of each event
+	// object's count field, min 1). Invariant: exactly 1.
+	NotProgressingEvents int `json:"notProgressingEvents"`
+	// FirstEventOffsetSeconds is pool creation -> first NotProgressing event
+	// observed (expected between the 5m readiness grace and ~1.5x it).
+	FirstEventOffsetSeconds *float64 `json:"firstEventOffsetSeconds,omitempty"`
+}
+
+// poolAccountant consumes the shared sandboxes watch stream (via a Tracker
+// observer) and keeps create/delete/live accounting per SandboxWarmPool.
+type poolAccountant struct {
+	mu        sync.Mutex
+	namespace string
+	pools     map[string]*poolAccount
+	// liveAll / peakLiveAll track the concurrent live population across all
+	// pools (exact: updated on every observed create/delete).
+	liveAll     int
+	peakLiveAll int
+}
+
+type poolAccount struct {
+	replicas int
+	// seen holds every distinct member UID ever observed (creates).
+	seen map[types.UID]struct{}
+	// live holds currently existing member UIDs.
+	live     map[types.UID]struct{}
+	peakLive int
+	// deleteCredits counts observed deletes not yet matched to a
+	// replacement create.
+	deleteCredits int
+	replacements  int
+	overCreates   int
+	deletes       int
+}
+
+func newPoolAccountant(namespace string, poolNames []string, replicas int) *poolAccountant {
+	a := &poolAccountant{
+		namespace: namespace,
+		pools:     make(map[string]*poolAccount, len(poolNames)),
+	}
+	for _, name := range poolNames {
+		a.pools[name] = &poolAccount{
+			replicas: replicas,
+			seen:     make(map[types.UID]struct{}),
+			live:     make(map[types.UID]struct{}),
+		}
+	}
+	return a
+}
+
+// owningWarmPool returns the name of the SandboxWarmPool owning u, or "".
+func owningWarmPool(u *unstructured.Unstructured) string {
+	for _, ref := range u.GetOwnerReferences() {
+		if ref.Kind == "SandboxWarmPool" {
+			return ref.Name
+		}
+	}
+	return ""
+}
+
+// observe is a Tracker watch observer (see Tracker.AddObserver). It runs on
+// the watch decode path and must stay cheap.
+func (a *poolAccountant) observe(resource string, eventType watch.EventType, u *unstructured.Unstructured) {
+	if resource != "sandboxes" || u.GetNamespace() != a.namespace {
+		return
+	}
+	poolName := owningWarmPool(u)
+	if poolName == "" {
+		return
+	}
+	uid := u.GetUID()
+	if uid == "" {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	acct, ok := a.pools[poolName]
+	if !ok {
+		return
+	}
+
+	if eventType == watch.Deleted {
+		if _, isLive := acct.live[uid]; isLive {
+			delete(acct.live, uid)
+			acct.deletes++
+			acct.deleteCredits++
+			a.liveAll--
+		}
+		return
+	}
+
+	// A create is the first sighting of a UID. That is normally the ADDED
+	// event, but a re-established watch can start "at most recent" and hand
+	// us a MODIFIED first — count that sighting, and ignore all later events
+	// for a known UID.
+	if _, known := acct.seen[uid]; known {
+		return
+	}
+	acct.seen[uid] = struct{}{}
+	acct.live[uid] = struct{}{}
+	if len(acct.seen) > acct.replicas {
+		// Beyond the initial fill: legitimate only as a replacement for an
+		// already-observed deletion (see the package comment for why the
+		// DELETED event is guaranteed to precede its replacement's ADDED).
+		if acct.deleteCredits > 0 {
+			acct.deleteCredits--
+			acct.replacements++
+		} else {
+			acct.overCreates++
+		}
+	}
+	if n := len(acct.live); n > acct.peakLive {
+		acct.peakLive = n
+	}
+	a.liveAll++
+	if a.liveAll > a.peakLiveAll {
+		a.peakLiveAll = a.liveAll
+	}
+}
+
+// poolTotals aggregates the accountant's per-pool state.
+type poolTotals struct {
+	distinctCreates      int
+	replacements         int
+	overCreates          int
+	deletes              int
+	maxPoolPeakLive      int
+	poolsExceedingTarget int
+	peakLiveAll          int
+	// worstPools lists pools with over-creates or peak violations (sorted,
+	// truncated by the caller for logging).
+	worstPools []string
+}
+
+func (a *poolAccountant) totals() poolTotals {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var t poolTotals
+	for name, acct := range a.pools {
+		t.distinctCreates += len(acct.seen)
+		t.replacements += acct.replacements
+		t.overCreates += acct.overCreates
+		t.deletes += acct.deletes
+		if acct.peakLive > t.maxPoolPeakLive {
+			t.maxPoolPeakLive = acct.peakLive
+		}
+		if acct.peakLive > acct.replicas {
+			t.poolsExceedingTarget++
+		}
+		if acct.overCreates > 0 || acct.peakLive > acct.replicas {
+			t.worstPools = append(t.worstPools, fmt.Sprintf("%s(creates=%d over=%d peak=%d)", name, len(acct.seen), acct.overCreates, acct.peakLive))
+		}
+	}
+	t.peakLiveAll = a.peakLiveAll
+	slices.Sort(t.worstPools)
+	return t
+}
+
+// warmPoolEventCounter counts occurrences of one Event reason for one
+// SandboxWarmPool from the shared core-v1 events watch. The controller emits
+// through the events.k8s.io recorder; those events surface on the core v1
+// events resource with reason/type/involvedObject preserved, and repeats are
+// deduplicated into the SAME event object with a bumped count — so
+// occurrences sums max(1, count) per distinct event UID, and a re-emit
+// folded into an existing object still fails an exactly-once assertion.
+type warmPoolEventCounter struct {
+	mu        sync.Mutex
+	namespace string
+	pool      string
+	reason    string
+	firstSeen time.Time
+	counts    map[types.UID]int64
+}
+
+func newWarmPoolEventCounter(namespace, pool, reason string) *warmPoolEventCounter {
+	return &warmPoolEventCounter{
+		namespace: namespace,
+		pool:      pool,
+		reason:    reason,
+		counts:    make(map[types.UID]int64),
+	}
+}
+
+// observe is a Tracker watch observer (see Tracker.AddObserver).
+func (c *warmPoolEventCounter) observe(resource string, eventType watch.EventType, u *unstructured.Unstructured) {
+	if resource != "events" || eventType == watch.Deleted || u.GetNamespace() != c.namespace {
+		return
+	}
+	if reason, _, _ := unstructured.NestedString(u.Object, "reason"); reason != c.reason {
+		return
+	}
+	if etype, _, _ := unstructured.NestedString(u.Object, "type"); etype != "Warning" {
+		return
+	}
+	if kind, _, _ := unstructured.NestedString(u.Object, "involvedObject", "kind"); kind != "SandboxWarmPool" {
+		return
+	}
+	if name, _, _ := unstructured.NestedString(u.Object, "involvedObject", "name"); name != c.pool {
+		return
+	}
+	count, found, _ := unstructured.NestedInt64(u.Object, "count")
+	if !found || count < 1 {
+		count = 1
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.firstSeen.IsZero() {
+		c.firstSeen = time.Now()
+	}
+	if count > c.counts[u.GetUID()] {
+		c.counts[u.GetUID()] = count
+	}
+}
+
+// occurrences returns the deduplication-aware event count and the time the
+// first matching event was observed (zero when none was).
+func (c *warmPoolEventCounter) occurrences() (int, time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	total := int64(0)
+	for _, n := range c.counts {
+		total += n
+	}
+	return int(total), c.firstSeen
+}
+
+// buildUnschedulableTemplateObject returns a SandboxTemplate whose pod can
+// never schedule: the main container requests cpu CPUs (the
+// --wp-unsched-cpu default of "1000" exceeds any machine shape sold by any
+// cloud today by more than 2x, so the scheduler reports
+// PodScheduled=False/Unschedulable everywhere — which is exactly the
+// condition the controller's unschedulable hold keys on). Built on
+// buildTemplateObject so the rest of the spec matches the other phases.
+func buildUnschedulableTemplateObject(id types.NamespacedName, image, cpu string) *unstructured.Unstructured {
+	obj := buildTemplateObject(id, image)
+	// Mutate the freshly built map directly: the unstructured helpers
+	// deep-copy via DeepCopyJSON, which rejects the []string command value
+	// buildTemplateObject uses, and a copy is pointless on our own object.
+	podSpec := obj.Object["spec"].(map[string]any)["podTemplate"].(map[string]any)["spec"].(map[string]any)
+	container := podSpec["containers"].([]any)[0].(map[string]any)
+	container["resources"] = map[string]any{
+		"requests": map[string]any{
+			"cpu":    cpu,
+			"memory": "64Mi",
+		},
+	}
+	return obj
+}
+
+// runWarmPoolOvercreatePhase creates --wp-pools pools of --wp-replicas and
+// asserts the exactly-N-creates and never-above-target invariants (see the
+// package comment).
+func (s *stressTest) runWarmPoolOvercreatePhase(ctx context.Context, number PhaseNumber) error {
+	pools := s.cfg.WPPools
+	replicas := s.cfg.WPReplicas
+	target := pools * replicas
+	image := s.cfg.WPImage
+	if image == "" {
+		image = s.cfg.Image
+	}
+
+	templateID := types.NamespacedName{Name: fmt.Sprintf("p%d-wp-template", number), Namespace: s.namespace}
+	poolNames := make([]string, 0, pools)
+	for i := range pools {
+		poolNames = append(poolNames, fmt.Sprintf("p%d-wp-pool-%d", number, i))
+	}
+
+	log.Printf("[%s#%d] creating %d pools x %d replicas = %d sandboxes (image %s, replacement tolerance %d)",
+		PhaseWarmPoolOvercreate, number, pools, replicas, target, image, s.cfg.WPReplacementTolerance)
+
+	// Observe pool-owned sandboxes from BEFORE the first pool exists so the
+	// very first creates are accounted.
+	acct := newPoolAccountant(s.namespace, poolNames, replicas)
+	removeObserver := s.tracker.AddObserver(acct.observe)
+	observing := true
+	stopObserving := func() {
+		if observing {
+			removeObserver()
+			observing = false
+		}
+	}
+	defer stopObserving()
+
+	if _, err := s.templateClient.Create(ctx, buildTemplateObject(templateID, image), metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("[%s#%d] failed to create sandbox template: %w", PhaseWarmPoolOvercreate, number, err)
+	}
+	// Clean up even when the phase fails partway: later phases assume the
+	// cluster's spare capacity is back. stopObserving runs first so cleanup
+	// deletes never pollute the accounting.
+	defer s.cleanupWarmPoolPhase(ctx, PhaseWarmPoolOvercreate, number, poolNames, templateID, stopObserving)
+
+	start := time.Now()
+	if _, err := ForkJoin(ctx, poolNames, s.cfg.CreateConcurrency, func(name string) (struct{}, error) {
+		id := types.NamespacedName{Name: name, Namespace: s.namespace}
+		if _, err := s.warmPoolClient.Create(ctx, buildWarmPoolObject(id, templateID.Name, replicas), metav1.CreateOptions{}); err != nil {
+			return struct{}{}, fmt.Errorf("failed to create warm pool %s: %w", name, err)
+		}
+		return struct{}{}, nil
+	}); err != nil {
+		return fmt.Errorf("[%s#%d] %w", PhaseWarmPoolOvercreate, number, err)
+	}
+
+	// Pool provisioning is part of the observation (the over-creation race
+	// lives in the fill), but readiness itself is just the phase's endpoint.
+	readyErr := s.waitAllWarmPoolsReady(ctx, PhaseWarmPoolOvercreate, number, replicas, pools)
+	var timeToAllReady *float64
+	if readyErr == nil {
+		d := time.Since(start).Seconds()
+		timeToAllReady = &d
+		log.Printf("[%s#%d] all %d pools Ready after %.1fs; settling %s to catch trailing churn",
+			PhaseWarmPoolOvercreate, number, pools, d, warmPoolSettleWindow)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(warmPoolSettleWindow):
+		}
+	}
+
+	stopObserving()
+
+	totals := acct.totals()
+	report := &WarmPoolOvercreateReport{
+		Pools:                 pools,
+		ReplicasPerPool:       replicas,
+		TargetSandboxes:       target,
+		DistinctCreates:       totals.distinctCreates,
+		Replacements:          totals.replacements,
+		OverCreates:           totals.overCreates,
+		ObservedDeletes:       totals.deletes,
+		MaxPoolPeakLive:       totals.maxPoolPeakLive,
+		PoolsExceedingTarget:  totals.poolsExceedingTarget,
+		PeakLiveTotal:         totals.peakLiveAll,
+		TimeToAllReadySeconds: timeToAllReady,
+	}
+	s.setWarmPoolOvercreateReport(number, report)
+
+	log.Printf("[%s#%d] observed: %d distinct creates (target %d), %d replacements, %d over-creates, %d deletes, max pool peak %d/%d, global peak %d/%d",
+		PhaseWarmPoolOvercreate, number, report.DistinctCreates, target, report.Replacements, report.OverCreates,
+		report.ObservedDeletes, report.MaxPoolPeakLive, replicas, report.PeakLiveTotal, target)
+
+	var problems []string
+	if readyErr != nil {
+		problems = append(problems, readyErr.Error())
+	}
+	if report.OverCreates > 0 {
+		problems = append(problems, fmt.Sprintf("%d sandbox creates beyond target without a preceding delete (over-creation)", report.OverCreates))
+	}
+	if want := target + report.Replacements; report.DistinctCreates != want {
+		problems = append(problems, fmt.Sprintf("%d distinct creates, want exactly %d (target %d + %d replacements)", report.DistinctCreates, want, target, report.Replacements))
+	}
+	if report.Replacements > s.cfg.WPReplacementTolerance {
+		problems = append(problems, fmt.Sprintf("%d replacements exceed tolerance %d", report.Replacements, s.cfg.WPReplacementTolerance))
+	}
+	if report.MaxPoolPeakLive > replicas {
+		problems = append(problems, fmt.Sprintf("peak concurrent population exceeded target in %d pool(s): max %d > %d replicas", report.PoolsExceedingTarget, report.MaxPoolPeakLive, replicas))
+	}
+	if len(problems) > 0 {
+		detail := ""
+		if len(totals.worstPools) > 0 {
+			shown := totals.worstPools
+			if len(shown) > 5 {
+				shown = shown[:5]
+			}
+			detail = fmt.Sprintf(" (worst pools: %s)", strings.Join(shown, ", "))
+		}
+		return fmt.Errorf("[%s#%d] warm pool invariants violated: %s%s", PhaseWarmPoolOvercreate, number, strings.Join(problems, "; "), detail)
+	}
+	log.Printf("[%s#%d] PASS: exactly %d creates for %d pools x %d replicas (%d tolerated replacements), population never exceeded target",
+		PhaseWarmPoolOvercreate, number, report.DistinctCreates, pools, replicas, report.Replacements)
+	return nil
+}
+
+// waitAllWarmPoolsReady polls the phase's pools until every one reports
+// readyReplicas >= want. Progress-stall detection mirrors the fill phase
+// (total ready count must advance within PerSandboxTimeout).
+func (s *stressTest) waitAllWarmPoolsReady(ctx context.Context, phase PhaseName, number PhaseNumber, want, pools int) error {
+	lastReadySum := int64(-1)
+	lastProgress := time.Now()
+	for {
+		list, err := s.warmPoolClient.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("[%s#%d] failed to list warm pools: %w", phase, number, err)
+		}
+		readyPools := 0
+		readySum := int64(0)
+		for i := range list.Items {
+			ready, _, _ := unstructured.NestedInt64(list.Items[i].Object, "status", "readyReplicas")
+			readySum += ready
+			if ready >= int64(want) {
+				readyPools++
+			}
+		}
+		if readyPools >= pools {
+			return nil
+		}
+		if readySum != lastReadySum {
+			lastReadySum = readySum
+			lastProgress = time.Now()
+		}
+		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
+			return fmt.Errorf("[%s#%d] pools stalled: %d/%d pools Ready (%d total ready replicas) with no progress for %v", phase, number, readyPools, pools, readySum, s.cfg.PerSandboxTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// runWarmPoolUnschedulablePhase creates one pool with an impossible resource
+// request and asserts the hold-don't-churn and exactly-one-NotProgressing
+// invariants (see the package comment).
+func (s *stressTest) runWarmPoolUnschedulablePhase(ctx context.Context, number PhaseNumber) error {
+	replicas := s.cfg.WPUnschedReplicas
+	window := s.cfg.WPUnschedWatch
+
+	templateID := types.NamespacedName{Name: fmt.Sprintf("p%d-wpu-template", number), Namespace: s.namespace}
+	poolID := types.NamespacedName{Name: fmt.Sprintf("p%d-wpu-pool", number), Namespace: s.namespace}
+
+	log.Printf("[%s#%d] creating pool %s with %d unschedulable replicas (cpu request %s); observing for %s (readiness grace 5m + jittered requeue means the NotProgressing event lands between ~5m and ~7m35s)",
+		PhaseWarmPoolUnschedulable, number, poolID.Name, replicas, s.cfg.WPUnschedCPU, window)
+
+	acct := newPoolAccountant(s.namespace, []string{poolID.Name}, replicas)
+	events := newWarmPoolEventCounter(s.namespace, poolID.Name, warmPoolNotProgressingReason)
+	removeAcct := s.tracker.AddObserver(acct.observe)
+	removeEvents := s.tracker.AddObserver(events.observe)
+	observing := true
+	stopObserving := func() {
+		if observing {
+			removeAcct()
+			removeEvents()
+			observing = false
+		}
+	}
+	defer stopObserving()
+
+	if _, err := s.templateClient.Create(ctx, buildUnschedulableTemplateObject(templateID, s.cfg.Image, s.cfg.WPUnschedCPU), metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("[%s#%d] failed to create sandbox template: %w", PhaseWarmPoolUnschedulable, number, err)
+	}
+	defer s.cleanupWarmPoolPhase(ctx, PhaseWarmPoolUnschedulable, number, []string{poolID.Name}, templateID, stopObserving)
+
+	start := time.Now()
+	if _, err := s.warmPoolClient.Create(ctx, buildWarmPoolObject(poolID, templateID.Name, replicas), metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("[%s#%d] failed to create warm pool: %w", PhaseWarmPoolUnschedulable, number, err)
+	}
+
+	// The controller should create the members promptly (they just never
+	// become Ready); require that before the quiet window starts.
+	for acct.totals().distinctCreates < replicas {
+		if time.Since(start) > s.cfg.PerSandboxTimeout {
+			return fmt.Errorf("[%s#%d] pool created only %d/%d sandboxes within %v", PhaseWarmPoolUnschedulable, number, acct.totals().distinctCreates, replicas, s.cfg.PerSandboxTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	log.Printf("[%s#%d] %d pool sandboxes created; holding quiet until +%s", PhaseWarmPoolUnschedulable, number, replicas, window)
+
+	// Quiet observation window, measured from pool creation. No touches: the
+	// controller's self-scheduled post-grace requeue must fire on its own.
+	deadline := start.Add(window)
+	lastLog := time.Now()
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(min(5*time.Second, time.Until(deadline))):
+		}
+		if time.Since(lastLog) >= 30*time.Second {
+			t := acct.totals()
+			n, _ := events.occurrences()
+			log.Printf("[%s#%d] +%s: creates=%d deletes=%d notProgressingEvents=%d",
+				PhaseWarmPoolUnschedulable, number, time.Since(start).Round(time.Second), t.distinctCreates, t.deletes, n)
+			lastLog = time.Now()
+		}
+	}
+
+	stopObserving()
+	totals := acct.totals()
+	occurrences, firstSeen := events.occurrences()
+	report := &WarmPoolUnschedulableReport{
+		Replicas:             replicas,
+		CPURequest:           s.cfg.WPUnschedCPU,
+		WatchSeconds:         time.Since(start).Seconds(),
+		DistinctCreates:      totals.distinctCreates,
+		ObservedDeletes:      totals.deletes,
+		UIDsStable:           totals.distinctCreates == replicas && totals.deletes == 0,
+		NotProgressingEvents: occurrences,
+	}
+	if !firstSeen.IsZero() {
+		off := firstSeen.Sub(start).Seconds()
+		report.FirstEventOffsetSeconds = &off
+	}
+	s.setWarmPoolUnschedulableReport(number, report)
+
+	log.Printf("[%s#%d] observed over %s: %d distinct creates (want %d), %d deletes (want 0), %d NotProgressing event(s) (want exactly 1)",
+		PhaseWarmPoolUnschedulable, number, window, report.DistinctCreates, replicas, report.ObservedDeletes, occurrences)
+
+	var problems []string
+	if report.ObservedDeletes > 0 {
+		problems = append(problems, fmt.Sprintf("%d pool sandbox deletes observed (delete/recreate churn on unschedulable pods)", report.ObservedDeletes))
+	}
+	if report.DistinctCreates != replicas {
+		problems = append(problems, fmt.Sprintf("%d distinct sandbox creates for %d replicas (member UIDs not stable)", report.DistinctCreates, replicas))
+	}
+	switch {
+	case occurrences == 0:
+		problems = append(problems, fmt.Sprintf("no %s Warning event within %s (expected exactly one between the 5m readiness grace and ~1.5x it)", warmPoolNotProgressingReason, window))
+	case occurrences > 1:
+		problems = append(problems, fmt.Sprintf("%d %s Warning occurrences, want exactly 1 (duplicate emission)", occurrences, warmPoolNotProgressingReason))
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("[%s#%d] warm pool invariants violated: %s", PhaseWarmPoolUnschedulable, number, strings.Join(problems, "; "))
+	}
+	log.Printf("[%s#%d] PASS: %d unschedulable sandboxes held with stable UIDs, exactly one %s event at +%.0fs",
+		PhaseWarmPoolUnschedulable, number, replicas, warmPoolNotProgressingReason, *report.FirstEventOffsetSeconds)
+	return nil
+}
+
+// cleanupWarmPoolPhase deletes the phase's pools and template, then waits
+// (best-effort) for the pool-owned sandboxes to drain so later phases start
+// from the same spare capacity. stopObserving is called first so cleanup
+// deletes never land in the phase's accounting. Failures are logged, not
+// returned; namespace deletion is the backstop.
+func (s *stressTest) cleanupWarmPoolPhase(ctx context.Context, phase PhaseName, number PhaseNumber, poolNames []string, templateID types.NamespacedName, stopObserving func()) {
+	stopObserving()
+	if ctx.Err() != nil {
+		// Shutting down; namespace cleanup will remove remaining objects.
+		return
+	}
+	log.Printf("[%s#%d] cleaning up %d pool(s) and template %s", phase, number, len(poolNames), templateID.Name)
+
+	_, _ = ForkJoin(ctx, poolNames, max(s.cfg.CreateConcurrency, 1), func(name string) (struct{}, error) {
+		if err := s.warmPoolClient.Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			log.Printf("[%s#%d] failed to delete warm pool %s: %v", phase, number, name, err)
+		}
+		return struct{}{}, nil
+	})
+	if err := s.templateClient.Delete(ctx, templateID.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		log.Printf("[%s#%d] failed to delete template %s: %v", phase, number, templateID.Name, err)
+	}
+
+	s.waitOwnedSandboxesDrained(ctx, phase, number)
+}
+
+// setWarmPoolOvercreateReport stores the phase's report for the summary.
+// Reports are stored even when the phase fails its assertions, so the
+// violation counts land in summary.json alongside the error.
+func (s *stressTest) setWarmPoolOvercreateReport(number PhaseNumber, report *WarmPoolOvercreateReport) {
+	s.wpMu.Lock()
+	defer s.wpMu.Unlock()
+	if s.wpOvercreate == nil {
+		s.wpOvercreate = make(map[PhaseNumber]*WarmPoolOvercreateReport)
+	}
+	s.wpOvercreate[number] = report
+}
+
+// setWarmPoolUnschedulableReport stores the phase's report for the summary.
+func (s *stressTest) setWarmPoolUnschedulableReport(number PhaseNumber, report *WarmPoolUnschedulableReport) {
+	s.wpMu.Lock()
+	defer s.wpMu.Unlock()
+	if s.wpUnschedulable == nil {
+		s.wpUnschedulable = make(map[PhaseNumber]*WarmPoolUnschedulableReport)
+	}
+	s.wpUnschedulable[number] = report
+}
+
+// attachWarmPoolReports copies the warm-pool phases' reports onto the
+// matching PhaseSummary entries (buildSummary is tracker-driven and knows
+// nothing about phase-private results).
+func (s *stressTest) attachWarmPoolReports(summary *Summary) {
+	s.wpMu.Lock()
+	defer s.wpMu.Unlock()
+	for _, ps := range summary.Phases {
+		if r, ok := s.wpOvercreate[ps.Number]; ok {
+			ps.WarmPoolOvercreate = r
+		}
+		if r, ok := s.wpUnschedulable[ps.Number]; ok {
+			ps.WarmPoolUnschedulable = r
+		}
+	}
+}
+
+// warmPoolOvercreatePhase adapts warmpool-overcreate to the Phase interface
+// (see phase.go): flag validation up front, sizing against the inspected
+// cluster in Resolve, then runWarmPoolOvercreatePhase.
+type warmPoolOvercreatePhase struct {
+	raw PhaseName
+
+	// Set by Resolve.
+	pools    int
+	replicas int
+}
+
+func (p *warmPoolOvercreatePhase) Name() PhaseName { return p.raw }
+
+func (p *warmPoolOvercreatePhase) Kind() PhaseName { return PhaseWarmPoolOvercreate }
+
+func (p *warmPoolOvercreatePhase) Validate(cfg Config) error {
+	if cfg.WPPools <= 0 || cfg.WPReplicas <= 0 {
+		return fmt.Errorf("phase %q requires --wp-pools > 0 and --wp-replicas > 0", p.raw)
+	}
+	if cfg.WPReplacementTolerance < 0 {
+		return fmt.Errorf("--wp-replacement-tolerance must be >= 0 for phase %q", p.raw)
+	}
+	if cfg.CreateConcurrency <= 0 {
+		return fmt.Errorf("--create-concurrency must be > 0 for phase %q", p.raw)
+	}
+	return nil
+}
+
+func (p *warmPoolOvercreatePhase) Resolve(cfg Config, _ *ClusterInfo, resident int) (int, int) {
+	p.pools, p.replicas = cfg.WPPools, cfg.WPReplicas
+	// The phase itself asserts the live population never exceeds
+	// pools*replicas, and its cleanup waits for the drain, so nothing
+	// accumulates past the phase.
+	return resident, resident + p.pools*p.replicas
+}
+
+func (p *warmPoolOvercreatePhase) Description() string {
+	return fmt.Sprintf("%s: %d pools x %d replicas = %d controller-created sandboxes (invariant gate)",
+		p.raw, p.pools, p.replicas, p.pools*p.replicas)
+}
+
+func (p *warmPoolOvercreatePhase) Requested() int { return p.pools * p.replicas }
+
+func (p *warmPoolOvercreatePhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	return test.runWarmPoolOvercreatePhase(ctx, number)
+}
+
+// warmPoolUnschedulablePhase adapts warmpool-unschedulable to the Phase
+// interface (see phase.go).
+type warmPoolUnschedulablePhase struct {
+	raw PhaseName
+
+	// Set by Resolve.
+	replicas int
+}
+
+func (p *warmPoolUnschedulablePhase) Name() PhaseName { return p.raw }
+
+func (p *warmPoolUnschedulablePhase) Kind() PhaseName { return PhaseWarmPoolUnschedulable }
+
+func (p *warmPoolUnschedulablePhase) Validate(cfg Config) error {
+	if cfg.WPUnschedReplicas <= 0 {
+		return fmt.Errorf("phase %q requires --wp-unsched-replicas > 0", p.raw)
+	}
+	if cfg.WPUnschedWatch <= 0 {
+		return fmt.Errorf("phase %q requires --wp-unsched-watch > 0", p.raw)
+	}
+	if _, err := resource.ParseQuantity(cfg.WPUnschedCPU); err != nil {
+		return fmt.Errorf("--wp-unsched-cpu %q is not a valid quantity: %w", cfg.WPUnschedCPU, err)
+	}
+	return nil
+}
+
+func (p *warmPoolUnschedulablePhase) Resolve(cfg Config, _ *ClusterInfo, resident int) (int, int) {
+	p.replicas = cfg.WPUnschedReplicas
+	// The pool's pods stay Pending/Unschedulable by design, so the phase
+	// consumes no pod slots: it raises neither the resident count nor the
+	// peak.
+	return resident, resident
+}
+
+func (p *warmPoolUnschedulablePhase) Description() string {
+	return fmt.Sprintf("%s: one pool with %d permanently unschedulable replicas, quiet watch window (invariant gate)",
+		p.raw, p.replicas)
+}
+
+func (p *warmPoolUnschedulablePhase) Requested() int { return p.replicas }
+
+func (p *warmPoolUnschedulablePhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	return test.runWarmPoolUnschedulablePhase(ctx, number)
+}

--- a/test/stress/warmpool_test.go
+++ b/test/stress/warmpool_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -117,6 +118,15 @@ func TestPoolAccountant(t *testing.T) {
 	if len(totals.worstPools) != 2 || !strings.Contains(totals.worstPools[0], "pool-a") {
 		t.Errorf("worstPools = %v, want both pools flagged", totals.worstPools)
 	}
+
+	// stop() is a hard boundary: an in-flight observer callback delivered
+	// after it must not mutate the accounting.
+	a.stop()
+	add("pool-b", "b5")
+	del("pool-a", "a1")
+	if after := a.totals(); !reflect.DeepEqual(after, totals) {
+		t.Errorf("totals changed after stop(): %+v -> %+v", totals, after)
+	}
 }
 
 func TestPoolAccountantCleanShape(t *testing.T) {
@@ -201,6 +211,13 @@ func TestWarmPoolEventCounter(t *testing.T) {
 	c.observe("events", watch.Added, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "evt2", 0))
 	if n, _ := c.occurrences(); n != 4 {
 		t.Fatalf("occurrences after second event object = %d, want 4", n)
+	}
+
+	// stop() is a hard boundary: late in-flight callbacks are no-ops.
+	c.stop()
+	c.observe("events", watch.Added, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "evt3", 0))
+	if n, _ := c.occurrences(); n != 4 {
+		t.Fatalf("occurrences after stop() = %d, want 4", n)
 	}
 }
 

--- a/test/stress/warmpool_test.go
+++ b/test/stress/warmpool_test.go
@@ -1,0 +1,334 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// poolSandboxObj builds an unstructured Sandbox owned by the given pool
+// (pool "" = no SandboxWarmPool owner reference).
+func poolSandboxObj(namespace, name, pool string, uid types.UID) *unstructured.Unstructured {
+	metadata := map[string]any{
+		"name":      name,
+		"namespace": namespace,
+		"uid":       string(uid),
+	}
+	if pool != "" {
+		metadata["ownerReferences"] = []any{
+			map[string]any{
+				"apiVersion": extensionsGroupVersion,
+				"kind":       "SandboxWarmPool",
+				"name":       pool,
+				"uid":        "owner-" + pool,
+			},
+		}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "agents.x-k8s.io/v1beta1",
+			"kind":       "Sandbox",
+			"metadata":   metadata,
+		},
+	}
+}
+
+func TestPoolAccountant(t *testing.T) {
+	a := newPoolAccountant("ns", []string{"pool-a", "pool-b"}, 3)
+
+	add := func(pool string, uid types.UID) {
+		a.observe("sandboxes", watch.Added, poolSandboxObj("ns", pool+"-"+string(uid), pool, uid))
+	}
+	del := func(pool string, uid types.UID) {
+		a.observe("sandboxes", watch.Deleted, poolSandboxObj("ns", pool+"-"+string(uid), pool, uid))
+	}
+
+	// Initial fill of pool-a: exactly 3 distinct creates, no violations.
+	add("pool-a", "a1")
+	add("pool-a", "a2")
+	add("pool-a", "a3")
+	// Duplicate events for a known UID (e.g. MODIFIED updates) are not creates.
+	a.observe("sandboxes", watch.Modified, poolSandboxObj("ns", "pool-a-a1", "pool-a", "a1"))
+
+	// A legitimate replacement: delete observed BEFORE the extra create.
+	del("pool-a", "a2")
+	add("pool-a", "a4")
+
+	// An over-create: a 4th live member with no delete credit.
+	add("pool-a", "a5")
+
+	// pool-b: first sighting via MODIFIED (re-established watch) counts as a
+	// create; events in other namespaces or without a pool owner are ignored.
+	a.observe("sandboxes", watch.Modified, poolSandboxObj("ns", "pool-b-b1", "pool-b", "b1"))
+	a.observe("sandboxes", watch.Added, poolSandboxObj("other-ns", "pool-b-x", "pool-b", "x1"))
+	a.observe("sandboxes", watch.Added, poolSandboxObj("ns", "orphan", "", "o1"))
+	a.observe("sandboxes", watch.Added, poolSandboxObj("ns", "unknown-pool-sb", "pool-c", "c1"))
+	a.observe("pods", watch.Added, poolSandboxObj("ns", "pool-b-b9", "pool-b", "b9"))
+	// A delete for a UID never seen live is ignored (no phantom credit).
+	del("pool-b", "b7")
+	add("pool-b", "b2")
+	add("pool-b", "b3")
+	add("pool-b", "b4") // over-create: no delete was observed in pool-b
+
+	totals := a.totals()
+	if got, want := totals.distinctCreates, 5+4; got != want {
+		t.Errorf("distinctCreates = %d, want %d", got, want)
+	}
+	if got, want := totals.replacements, 1; got != want {
+		t.Errorf("replacements = %d, want %d", got, want)
+	}
+	if got, want := totals.overCreates, 2; got != want {
+		t.Errorf("overCreates = %d, want %d", got, want)
+	}
+	if got, want := totals.deletes, 1; got != want {
+		t.Errorf("deletes = %d, want %d", got, want)
+	}
+	// pool-a live peaked at 4 ({a1,a3,a4,a5}); pool-b at 4 ({b1..b4}).
+	if got, want := totals.maxPoolPeakLive, 4; got != want {
+		t.Errorf("maxPoolPeakLive = %d, want %d", got, want)
+	}
+	if got, want := totals.poolsExceedingTarget, 2; got != want {
+		t.Errorf("poolsExceedingTarget = %d, want %d", got, want)
+	}
+	// Global concurrent peak: pool-a contributes 4 live and pool-b 4 live at
+	// the end; the peak is reached at the final add (8 concurrent).
+	if got, want := totals.peakLiveAll, 8; got != want {
+		t.Errorf("peakLiveAll = %d, want %d", got, want)
+	}
+	if len(totals.worstPools) != 2 || !strings.Contains(totals.worstPools[0], "pool-a") {
+		t.Errorf("worstPools = %v, want both pools flagged", totals.worstPools)
+	}
+}
+
+func TestPoolAccountantCleanShape(t *testing.T) {
+	// The PASS shape: exactly replicas creates per pool, nothing else.
+	a := newPoolAccountant("ns", []string{"p"}, 2)
+	a.observe("sandboxes", watch.Added, poolSandboxObj("ns", "p-1", "p", "u1"))
+	a.observe("sandboxes", watch.Added, poolSandboxObj("ns", "p-2", "p", "u2"))
+	totals := a.totals()
+	if totals.distinctCreates != 2 || totals.replacements != 0 || totals.overCreates != 0 || totals.deletes != 0 {
+		t.Errorf("unexpected totals for clean shape: %+v", totals)
+	}
+	if totals.maxPoolPeakLive != 2 || totals.poolsExceedingTarget != 0 || totals.peakLiveAll != 2 {
+		t.Errorf("unexpected peaks for clean shape: %+v", totals)
+	}
+}
+
+// poolEvent builds an unstructured core-v1 Event for a SandboxWarmPool.
+func poolEvent(namespace, pool, reason, eventType string, uid types.UID, count int64) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Event",
+		"metadata": map[string]any{
+			"name":      "evt-" + string(uid),
+			"namespace": namespace,
+			"uid":       string(uid),
+		},
+		"reason": reason,
+		"type":   eventType,
+		"involvedObject": map[string]any{
+			"kind":      "SandboxWarmPool",
+			"name":      pool,
+			"namespace": namespace,
+		},
+	}
+	if count > 0 {
+		obj["count"] = count
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestWarmPoolEventCounter(t *testing.T) {
+	c := newWarmPoolEventCounter("ns", "pool", warmPoolNotProgressingReason)
+
+	if n, first := c.occurrences(); n != 0 || !first.IsZero() {
+		t.Fatalf("occurrences before any event = %d, firstSeen zero = %v", n, first.IsZero())
+	}
+
+	// Non-matching events are ignored: wrong reason, type, kind, pool,
+	// namespace, resource, and DELETED events.
+	c.observe("events", watch.Added, poolEvent("ns", "pool", "WarmPoolProgressing", "Normal", "e0", 0))
+	c.observe("events", watch.Added, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Normal", "e1", 0))
+	c.observe("events", watch.Added, poolEvent("ns", "other", warmPoolNotProgressingReason, "Warning", "e2", 0))
+	c.observe("events", watch.Added, poolEvent("other", "pool", warmPoolNotProgressingReason, "Warning", "e3", 0))
+	c.observe("pods", watch.Added, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "e4", 0))
+	c.observe("events", watch.Deleted, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "e5", 0))
+	notPool := poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "e6", 0)
+	_ = unstructured.SetNestedField(notPool.Object, "Sandbox", "involvedObject", "kind")
+	c.observe("events", watch.Added, notPool)
+	if n, _ := c.occurrences(); n != 0 {
+		t.Fatalf("occurrences after non-matching events = %d, want 0", n)
+	}
+
+	// One matching event without a count field counts once.
+	c.observe("events", watch.Added, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "evt1", 0))
+	if n, first := c.occurrences(); n != 1 || first.IsZero() {
+		t.Fatalf("occurrences = %d (firstSeen zero=%v), want 1 with firstSeen set", n, first.IsZero())
+	}
+
+	// A dedup bump on the SAME event object (count=3) raises occurrences to
+	// 3: a re-emit folded into one object still fails exactly-once.
+	c.observe("events", watch.Modified, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "evt1", 3))
+	if n, _ := c.occurrences(); n != 3 {
+		t.Fatalf("occurrences after count bump = %d, want 3", n)
+	}
+	// Stale re-delivery with a lower count does not decrease.
+	c.observe("events", watch.Modified, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "evt1", 2))
+	if n, _ := c.occurrences(); n != 3 {
+		t.Fatalf("occurrences after stale re-delivery = %d, want 3", n)
+	}
+
+	// A second distinct event object adds its own occurrence.
+	c.observe("events", watch.Added, poolEvent("ns", "pool", warmPoolNotProgressingReason, "Warning", "evt2", 0))
+	if n, _ := c.occurrences(); n != 4 {
+		t.Fatalf("occurrences after second event object = %d, want 4", n)
+	}
+}
+
+func TestBuildUnschedulableTemplateObject(t *testing.T) {
+	id := types.NamespacedName{Name: "tmpl", Namespace: "ns"}
+	obj := buildUnschedulableTemplateObject(id, "debian:latest", "1000")
+
+	// Direct map access: the unstructured helpers deep-copy via DeepCopyJSON,
+	// which rejects the template's []string command value.
+	containers := obj.Object["spec"].(map[string]any)["podTemplate"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)
+	if len(containers) != 1 {
+		t.Fatalf("want 1 container, got %d", len(containers))
+	}
+	container := containers[0].(map[string]any)
+	cpu, found, err := unstructured.NestedString(container, "resources", "requests", "cpu")
+	if err != nil || !found {
+		t.Fatalf("cpu request not found: found=%v err=%v", found, err)
+	}
+	if q, err := resource.ParseQuantity(cpu); err != nil || q.Value() != 1000 {
+		t.Errorf("cpu request %q: parse err=%v value=%v, want 1000 cores", cpu, err, q.Value())
+	}
+	// The rest of the template must keep the shared shape (service-free).
+	service, found, _ := unstructured.NestedBool(obj.Object, "spec", "service")
+	if !found || service {
+		t.Errorf("spec.service = %v (found=%v), want explicit false", service, found)
+	}
+}
+
+func TestParseWarmPoolPhases(t *testing.T) {
+	valid := Config{
+		WPPools:                20,
+		WPReplicas:             25,
+		WPReplacementTolerance: 2,
+		WPUnschedReplicas:      3,
+		WPUnschedCPU:           "1000",
+		WPUnschedWatch:         8 * time.Minute,
+		CreateConcurrency:      20,
+	}
+
+	phases, err := parsePhases([]string{string(PhaseWarmPoolOvercreate), string(PhaseWarmPoolUnschedulable)}, valid)
+	if err != nil {
+		t.Fatalf("parsePhases(valid) error: %v", err)
+	}
+	if len(phases) != 2 {
+		t.Fatalf("parsePhases returned %d phases, want 2", len(phases))
+	}
+	oc, ok := phases[0].(*warmPoolOvercreatePhase)
+	if !ok || oc.Name() != PhaseWarmPoolOvercreate || oc.Kind() != PhaseWarmPoolOvercreate {
+		t.Fatalf("phases[0] = %#v, want warmPoolOvercreatePhase", phases[0])
+	}
+	un, ok := phases[1].(*warmPoolUnschedulablePhase)
+	if !ok || un.Name() != PhaseWarmPoolUnschedulable || un.Kind() != PhaseWarmPoolUnschedulable {
+		t.Fatalf("phases[1] = %#v, want warmPoolUnschedulablePhase", phases[1])
+	}
+
+	// Labeled entries keep distinct names but report the base kind.
+	labeled, err := parsePhase("warmpool-overcreate-label:x2")
+	if err != nil {
+		t.Fatalf("parsePhase(labeled) error: %v", err)
+	}
+	if labeled.Name() != "warmpool-overcreate-label:x2" || labeled.Kind() != PhaseWarmPoolOvercreate {
+		t.Errorf("labeled Name/Kind = %q/%q", labeled.Name(), labeled.Kind())
+	}
+	if _, err := parsePhase("warmpool-overcreate-pct:80"); err == nil {
+		t.Errorf("parsePhase accepted a fill-only argument on warmpool-overcreate")
+	}
+
+	// Resolve sizes the phases: overcreate budgets pools*replicas pods at
+	// peak and drains before the phase ends; unschedulable consumes none.
+	info := &ClusterInfo{Nodes: 12, PodCapacity: 1320, PreexistingPods: 28}
+	after, peak := oc.Resolve(valid, info, 28)
+	if after != 28 || peak != 28+500 {
+		t.Errorf("overcreate Resolve = (%d, %d), want (28, 528)", after, peak)
+	}
+	if oc.Requested() != 500 {
+		t.Errorf("overcreate Requested = %d, want 500", oc.Requested())
+	}
+	after, peak = un.Resolve(valid, info, 28)
+	if after != 28 || peak != 28 {
+		t.Errorf("unschedulable Resolve = (%d, %d), want (28, 28)", after, peak)
+	}
+	if un.Requested() != 3 {
+		t.Errorf("unschedulable Requested = %d, want 3", un.Requested())
+	}
+
+	invalid := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"zero pools", func(c *Config) { c.WPPools = 0 }},
+		{"zero replicas", func(c *Config) { c.WPReplicas = 0 }},
+		{"negative tolerance", func(c *Config) { c.WPReplacementTolerance = -1 }},
+		{"zero unsched replicas", func(c *Config) { c.WPUnschedReplicas = 0 }},
+		{"zero watch window", func(c *Config) { c.WPUnschedWatch = 0 }},
+		{"bad cpu quantity", func(c *Config) { c.WPUnschedCPU = "a-lot" }},
+	}
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := valid
+			tc.mutate(&cfg)
+			if _, err := parsePhases([]string{string(PhaseWarmPoolOvercreate), string(PhaseWarmPoolUnschedulable)}, cfg); err == nil {
+				t.Errorf("parsePhases accepted invalid config (%s)", tc.name)
+			}
+		})
+	}
+}
+
+func TestAttachWarmPoolReports(t *testing.T) {
+	s := &stressTest{}
+	oc := &WarmPoolOvercreateReport{Pools: 20, ReplicasPerPool: 25, TargetSandboxes: 500}
+	un := &WarmPoolUnschedulableReport{Replicas: 3, NotProgressingEvents: 1}
+	s.setWarmPoolOvercreateReport(1, oc)
+	s.setWarmPoolUnschedulableReport(2, un)
+
+	summary := &Summary{Phases: []*PhaseSummary{
+		{Number: 1, Name: string(PhaseWarmPoolOvercreate)},
+		{Number: 2, Name: string(PhaseWarmPoolUnschedulable)},
+		{Number: 3, Name: string(PhaseProbe)},
+	}}
+	s.attachWarmPoolReports(summary)
+
+	if summary.Phases[0].WarmPoolOvercreate != oc {
+		t.Errorf("phase 1 missing overcreate report")
+	}
+	if summary.Phases[1].WarmPoolUnschedulable != un {
+		t.Errorf("phase 2 missing unschedulable report")
+	}
+	if summary.Phases[2].WarmPoolOvercreate != nil || summary.Phases[2].WarmPoolUnschedulable != nil {
+		t.Errorf("phase 3 unexpectedly got warm pool reports")
+	}
+}


### PR DESCRIPTION
# stress: add warm-pool invariant phases + optional benchmarks-kops-gcp-warmpool scenario

## What

Adds the warm-pool over-creation / unschedulable-hold reproduction from the
issue-1215 investigation to the stress tool as two permanent, optional
phases, plus a dedicated scenario wrapper — as requested by @barney-s on the
merged fix (https://github.com/kubernetes-sigs/agent-sandbox/pull/1266#issuecomment-5074791006,
referring to https://github.com/kubernetes-sigs/agent-sandbox/pull/1266#issuecomment-5074246533).

**New stress phases** (`test/stress/warmpool.go`):

* `warmpool-overcreate` — creates `--wp-pools` (20) x `--wp-replicas` (25)
  SandboxWarmPools in one burst and watches every pool-owned Sandbox.
  Asserts:
  * exactly pools x replicas **distinct sandbox creates** (distinct UIDs on
    the watch = POST-equivalent count), with legitimate replacements — a
    create observed only *after* a member's delete — counted and reported
    separately, tolerated up to `--wp-replacement-tolerance` (2);
  * the **concurrent live population never exceeds the target** (per pool,
    peak <= replicas at all times);
  * reports time-to-all-pools-Ready; cleans up pools/template and waits for
    the drain.
* `warmpool-unschedulable` — one pool of `--wp-unsched-replicas` (3) whose
  template requests `--wp-unsched-cpu` (1000) CPUs, robustly unschedulable
  on any machine shape sold today; quiet `--wp-unsched-watch` (8m) window
  covering the 5-minute readiness grace plus the jittered post-grace
  requeue (worst case ~7m35s). Asserts:
  * **zero delete/recreate churn** — member UIDs exactly stable;
  * **exactly one** `WarmPoolNotProgressing` Warning event for the pool,
    no duplicates (deduplication-aware: a count-bumped event object also
    fails exactly-once).

Verdicts land in `summary.json` (`warmPoolOvercreate` /
`warmPoolUnschedulable` per-phase reports) and in the printed report; both
phases PASS on current main and FAIL loudly on pre-fix controllers.

**Scenario wrapper** (`test/benchmarks/scenarios/benchmarks-kops-gcp-warmpool/`
+ `dev/ci/presubmits/benchmarks-kops-gcp-warmpool`, mirroring the
benchmarks-kops-gcp-claims structure): 12 worker nodes, the two phases, and
the adversarial `--sandbox-warm-pool-concurrent-workers=1000` controller
setting the over-creation reproduced under. The overcreate template uses
the stress tool's standard small image — a review question ("once pulled,
the image sits on the nodes — any need for a big one?") prompted a
head-to-head measurement showing the small image trips the pre-fix asserts
*harder* (6.1x vs 3.1x, table below), so the multi-GB default was dropped
and `--wp-image` kept as the escape hatch. The scenario README documents
the kOps config and steps, the expected PASS/FAIL shapes, and the
~35-45 min / one-12-node-cluster cost — it is optional/manual because it
needs a real GCP cluster.

**Harness plumbing**: `Tracker.AddObserver` (phases can observe watch events
for objects the harness did not create — here: controller-owned Sandboxes
and pool Events), phase registration/validation/capacity-check/report
wiring in `main.go`, and a shared `waitOwnedSandboxesDrained` helper
(extracted from the claims-warm cleanup).

## Why

The invariants these phases encode were only provable by ad-hoc live runs
during the issue-1215 / PR-1266 work. Encoding them as a permanent scenario
gives warm-pool reconciler changes (expectations tracker, create/delete
gating, readiness-grace/unschedulable handling) a repeatable, whole-system
regression gate with a documented runbook, instead of a one-off script in a
GCS bucket.

## Validation

* `go build ./...`, `go vet`, `gofmt`, `dev/tools/lint-go` (0 issues).
* `go test -race ./test/stress/` — new unit tests cover the watch
  accounting (replacement vs over-create attribution, per-pool and global
  peaks, namespace/owner filtering), the dedup-aware event counting, the
  unschedulable template shape, phase flag validation, and report
  attachment.
* Live two-direction run on a kOps GCP cluster (one tuned cluster, both
  controllers deployed back to back):

| Leg | Controller | Result |
| --- | --- | --- |
| PASS | fixed (current main, af8a790) | **rc=0.** overcreate: 500/500 distinct creates, 0 replacements, 0 over-creates, per-pool peak 25/25, all pools Ready in 18.1s. unschedulable: 3 creates / 0 deletes over the 480s window, UIDs stable, exactly one `WarmPoolNotProgressing` Warning at +365s (inside the 5m-7m35s jitter window). |
| FAIL, small image (the scenario default) | pre-fix (95380d9, before the expectations gate) | **rc=1 in phase 1:** 3,070 distinct creates for the 500 target (**6.1x**), 1,312 over-creates, 1,258 replacements (tolerance 2), worst pool peak 117 vs 25, global peak 1,796 vs 500, 2,570 deletes during the fill; failing leg wall ~7 min. |
| FAIL, multi-GB image (supplementary, via `--wp-image`) | pre-fix (95380d9) | **rc=1 in phase 1:** 1,535 distinct creates (3.1x), all 20 pools exceeded their population caps (worst peak 75 vs 25), replacement tolerance blown (534 vs 2). |

  The small-image leg is why the scenario default changed during review
  (see the wrapper paragraph above): fast readiness transitions drive more
  status-update reconciles/sec against the stale cache, and the quick
  create->Ready->excess-delete cycle adds delete churn a slow pull never
  reaches. PASS-direction evidence with the same small image: the fixed
  controller produced exactly-600-for-600 in the single-pool gate-cost
  run. Optional follow-up validation (not blocking): a 20x25 small-image
  PASS leg can ride along a future cluster run as belt-and-braces.

  Verbatim abort from the small-image FAIL leg (the scenario default; the
  per-pool forensics the phase reports):

  ```
  aborting after error: warmpool-overcreate#1 phase: [warmpool-overcreate#1] warm pool
  invariants violated: 1312 sandbox creates beyond target without a preceding delete
  (over-creation); 3070 distinct creates, want exactly 1758 (target 500 + 1258
  replacements); 1258 replacements exceed tolerance 2; peak concurrent population
  exceeded target in 20 pool(s): max 117 > 25 replicas (worst pools:
  p1-wp-pool-0(creates=141 over=46 peak=71), p1-wp-pool-1(creates=140 over=58 peak=83),
  p1-wp-pool-10(creates=152 over=66 peak=91), p1-wp-pool-11(creates=158 over=68 peak=93),
  p1-wp-pool-12(creates=181 over=92 peak=117))
  ```

  Cluster shape for the validation run: `e2-standard-8` workers +
  `e2-standard-16` control plane (quota); the invariants are
  node-shape-independent (pass/fail depends only on controller behavior).
  Full artifacts (run logs, summary.json, watch streams, reports) retained.

## Suggested follow-up (maintainers)

Wiring `benchmarks-kops-gcp-warmpool` up as an optional/manual prow job is
deliberately **not** part of this PR: the job definitions live in
kubernetes/test-infra, so that is a separate change on that side (same
split as the existing benchmark presubmits).

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an on-demand GCP benchmark presubmit for SandboxWarmPool with `warmpool-overcreate` and `warmpool-unschedulable`.
  - Introduced a dedicated warm-pool scenario runner and extended the stress harness with new warm-pool phases and invariant reporting.
- **Documentation**
  - Added a scenario README detailing required configuration and expected PASS/FAIL output patterns.
- **Tests**
  - Added unit tests covering warm-pool accounting, event counting/deduping, phase parsing, and attaching warm-pool phase reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->