### PR TITLE
tests: add a phase for testing with lots of pods, and reduce cost

### DIFF
--- a/dev/ci/periodics/benchmarks-kops-gcp-cilium
+++ b/dev/ci/periodics/benchmarks-kops-gcp-cilium
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Periodic variant of the cilium benchmark: same test, run on a schedule
-# against main so we get a continuous performance baseline.
+# Daily cilium benchmark against main: the continuous performance baseline,
+# on 20 nodes with a single control plane.
 
 set -o errexit
 set -o nounset
@@ -22,4 +22,8 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-exec "${REPO_ROOT}/dev/ci/presubmits/benchmarks-kops-gcp-cilium"
+export CNI=cilium
+export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
+
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/dev/ci/periodics/benchmarks-kops-gcp-kindnet
+++ b/dev/ci/periodics/benchmarks-kops-gcp-kindnet
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Periodic variant of the kindnet benchmark: same test, run on a schedule
-# against main so we get a continuous performance baseline.
+# Daily kindnet benchmark against main: the continuous performance baseline,
+# on 20 nodes with a single control plane.
 
 set -o errexit
 set -o nounset
@@ -22,4 +22,8 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-exec "${REPO_ROOT}/dev/ci/presubmits/benchmarks-kops-gcp-kindnet"
+export CNI=kindnet
+export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-20}"
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
+
+exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/dev/ci/presubmits/benchmarks-kops-gcp-cilium
+++ b/dev/ci/presubmits/benchmarks-kops-gcp-cilium
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 # Runs the kOps GCP benchmark + stress test with cilium as the CNI.
+#
+# This job exists to catch cilium-specific regressions: the endpoint-create
+# API rate limit, the agent's client-go budgets, and datapath/endpoint
+# regeneration latency. Those are per-node effects that show up at any
+# cluster size, so this presubmit runs a deliberately small cluster;
+# cluster-scale throughput baselines live in the daily periodics.
 
 set -o errexit
 set -o nounset
@@ -22,4 +28,13 @@ set -o pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 export CNI=cilium
+
+# 3 workers + 1 small control plane. The mif sweep is capped to fit
+# 3 * 110 pod slots, and still ends with the fill-pct:80 / mif50 pair so
+# the near-capacity path is exercised under cilium too (~95% of slots;
+# the stress tool logs a warning at that density but runs).
+export STRESS_NODE_COUNT="${STRESS_NODE_COUNT:-3}"
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-8}"
+export STRESS_PHASES="${STRESS_PHASES:-fill,probe,throughput-mif:200,throughput-mif:100,throughput-mif:50,fill-pct:80,throughput-mif:50-label:pct80}"
+
 exec "${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -378,16 +378,28 @@ echo "Benchmark completed successfully."
 
 # Run the stress test.
 #
-# Phases are a comma-separated list of names (see test/stress/main.go):
-#   fill              long-running background sandboxes (scale)
+# Phases are a comma-separated list of names (see test/stress/phase.go):
+#   fill              long-running background sandboxes (fill-per-node * nodes)
+#   fill-pct:N        top the cluster up to N% total worker pod utilization
 #   probe             low-concurrency launch latency
-#   throughput-mifN   closed-loop churn capped at N in-flight
+#   throughput-mif:N  closed-loop churn capped at N in flight (add label:<x>
+#                     to repeat a level under a distinct report name)
 #   claims-warm       SandboxClaim burst against a provisioned warm pool
 #
-# Keep fill (fill-per-node * nodes) + max(mifN) below spare pod capacity
-# (roughly 3 * 110 minus system pods on the default cluster); the test
-# refuses to run if they don't fit.
-# Defaults below are sized for the default 3-node cluster.
+# What the default list below does, on the default 20-node cluster
+# (2,200 pod slots):
+#   1. fill: 10 sandboxes per node = 200 pods, ~10% utilization.
+#   2. probe, then the descending mif sweep: launch latency and throughput
+#      on that mostly-empty cluster.
+#   3. fill-pct:80: top the cluster up to 80% utilization (~1,760 pods).
+#   4. throughput-mif:400-label:pct80: run mif400 again at density. 400 in
+#      flight is ~18% of the cluster, so this level peaks at ~98%
+#      utilization - it fits, and the tool's capacity preflight (which
+#      walks the phases in order, so it knows mif400 fits before the 80%
+#      fill and only barely after it) warns above 90% but allows it.
+# Comparing the two mif400 legs separates the launch pipeline's own cost
+# from the cost of resident-pod scale (kubelet status load, watch fanout,
+# etcd working set).
 STRESS_OUTPUT_DIR="${ARTIFACTS:-.}/stress-test/"
 mkdir -p "${STRESS_OUTPUT_DIR}"
 
@@ -409,7 +421,7 @@ set +o errexit
 # each one (e.g. --client-connections=4 in benchmarks-kops-gcp-claims).
 # shellcheck disable=SC2086
 go run ./test/stress \
-  --phases="${STRESS_PHASES:-fill,probe,throughput-mif600,throughput-mif400,throughput-mif200,throughput-mif100,throughput-mif50}" \
+  --phases="${STRESS_PHASES:-fill,probe,throughput-mif:600,throughput-mif:400,throughput-mif:200,throughput-mif:100,throughput-mif:50,fill-pct:80,throughput-mif:400-label:pct80}" \
   --fill-per-node="${STRESS_FILL_PER_NODE:-10}" \
   --probe-count="${STRESS_PROBE_COUNT:-30}" \
   --throughput-count="${STRESS_THROUGHPUT_COUNT:-500}" \

--- a/test/stress/generate-report/download_results.py
+++ b/test/stress/generate-report/download_results.py
@@ -15,6 +15,7 @@
 
 import argparse
 import json
+import re
 import ssl
 import sys
 import urllib.request
@@ -139,8 +140,12 @@ def main():
         else:
             phases = [p.get("name", "") if isinstance(p, dict) else str(p) for p in raw_phases]
         for phase in [p for p in phases if p]:
-            out_file_path = output_dir / f"pprof-apiserver-{phase}.pprof"
-            for candidate in (f"pprof-apiserver-{phase}.pprof", f"pprof-apiserver-{phase}.pb"):
+            # Mirror the stress tool's fileSafePhase (pprof.go): phase names
+            # may contain ':' (throughput-mif:600), which is flattened to '-'
+            # in artifact filenames.
+            safe = re.sub(r'[^A-Za-z0-9._-]', '-', phase)
+            out_file_path = output_dir / f"pprof-apiserver-{safe}.pprof"
+            for candidate in (f"pprof-apiserver-{safe}.pprof", f"pprof-apiserver-{safe}.pb"):
                 if download_file(f"{base_url}/{candidate}", out_file_path):
                     downloaded += 1
                     break

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -17,11 +17,15 @@
 // It runs an ordered list of phases (--phases), for example:
 //
 //   - fill: long-running background sandboxes so later phases measure a cluster at scale
+//   - fill-pct:N: like fill, but tops the cluster up to N% total worker pod
+//     utilization (counting pre-existing pods and earlier fills), so later
+//     phases measure a cluster running near capacity
 //   - probe: low-concurrency launches measuring clean per-sandbox launch latency
-//   - throughput-mifN: closed-loop churn capped at N in-flight, measuring sustained ready/sec
+//   - throughput-mif:N: closed-loop churn capped at N in-flight, measuring sustained ready/sec
 //
-// Phase names are plain strings today (throughput encodes max-in-flight in the name).
-// A more structured form (e.g. throughput{maxInFlight:200}) may be added later.
+// A phase name is a kind plus optional hyphen-separated key:value arguments;
+// every kind accepts label:<x> (e.g. throughput-mif:400-label:hot) so a run
+// that repeats a kind keeps distinct phase names in reports. See parsePhase.
 //
 // Outputs (in --output-dir):
 //
@@ -44,7 +48,6 @@ import (
 	"fmt"
 	"log"
 	"maps"
-	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -87,13 +90,17 @@ type ClusterInfo struct {
 // PhaseSummary holds the aggregate results for one phase.
 type PhaseSummary struct {
 	// Number is the 1-based index of this entry in Summary.Phases / Config.Phases.
-	Number          PhaseNumber `json:"phaseNumber"`
-	Name            string      `json:"name"`
-	Requested       int         `json:"requested"`
-	Created         int         `json:"created"`
-	Ready           int         `json:"ready"`
-	Failed          int         `json:"failed"`
-	DurationSeconds float64     `json:"durationSeconds"`
+	Number PhaseNumber `json:"phaseNumber"`
+	Name   string      `json:"name"`
+	// Kind is the phase's base kind (fill, probe, throughput, ...): Name
+	// carries the phase's arguments (probe-label:x), so consumers picking
+	// kind-specific output must use Kind, not Name.
+	Kind            PhaseName `json:"kind,omitempty"`
+	Requested       int       `json:"requested"`
+	Created         int       `json:"created"`
+	Ready           int       `json:"ready"`
+	Failed          int       `json:"failed"`
+	DurationSeconds float64   `json:"durationSeconds"`
 	// StartOffsetSeconds is the phase's start relative to Summary.StartTime.
 	StartOffsetSeconds float64 `json:"startOffsetSeconds"`
 
@@ -145,11 +152,10 @@ type Config struct {
 	// Phases is the ordered list of phase names to run (see package comment).
 	Phases []string `json:"phases"`
 
-	// FillCount is the resolved fill phase size (FillPerNode * worker-node
-	// count), recorded here so it lands in summary.json.
-	FillCount int `json:"fillCount"`
-	// FillPerNode sizes the fill phase relative to the cluster: fill creates
-	// FillPerNode * worker-node-count sandboxes.
+	// FillPerNode sizes the plain fill phase relative to the cluster: fill
+	// creates FillPerNode * worker-node-count sandboxes. (fill-pct:N phases
+	// size themselves from pod capacity instead; each phase's resolved size
+	// is recorded in its summary.json entry as "requested".)
 	FillPerNode int `json:"fillPerNode"`
 
 	ProbeCount       int           `json:"probeCount"`
@@ -187,7 +193,7 @@ type Config struct {
 	SustainedPoolHeadroom time.Duration `json:"sustainedPoolHeadroomNanos"`
 	// SustainedLifecycleBudget is the assumed per-claim ready+delete pipeline
 	// time (everything outside the dwell) used when estimating the phase's
-	// peak concurrent pods in checkClusterCapacity. If the cluster's
+	// peak concurrent pods in resolvePhases. If the cluster's
 	// Ready/delete path is slower than this under load, raise it so the
 	// capacity check demands enough headroom to keep queueing out of the
 	// latency measurement.
@@ -244,7 +250,7 @@ func run(ctx context.Context) error {
 	flag.DurationVar(&cfg.Timeout, "timeout", 30*time.Minute, "Timeout for the entire test run")
 	flag.DurationVar(&cfg.PerSandboxTimeout, "per-sandbox-timeout", 5*time.Minute, "Timeout for a single sandbox to become ready / be deleted")
 	flag.IntVar(&cfg.CreateConcurrency, "create-concurrency", 20, "Number of concurrent workers creating Sandboxes (fill and throughput phases)")
-	phasesFlag := flag.String("phases", "probe,throughput-mif50", "Comma-separated phase names to run in order (fill, probe, claims-warm, claims-warm-sustained, throughput-mifN). Structured forms like throughput{maxInFlight:N} may be added later")
+	phasesFlag := flag.String("phases", "probe,throughput-mif:50", "Comma-separated phase names to run in order (fill, fill-pct:N, probe, claims-warm, claims-warm-sustained, throughput-mif:N); phases accept hyphen-separated key:value arguments, e.g. throughput-mif:400-label:hot")
 	flag.IntVar(&cfg.FillPerNode, "fill-per-node", 10, "Number of long-running background Sandboxes per worker node for the fill phase")
 	flag.IntVar(&cfg.ProbeCount, "probe-count", 20, "Number of latency probe Sandboxes for the probe phase")
 	flag.IntVar(&cfg.ProbeConcurrency, "probe-concurrency", 1, "Number of concurrent latency probes; keep low for clean latency numbers")
@@ -274,6 +280,12 @@ func run(ctx context.Context) error {
 	}
 	if len(cfg.Phases) == 0 {
 		return fmt.Errorf("--phases must list at least one phase")
+	}
+	// Parse the phase list and validate each phase's flag-derived
+	// configuration up front, before any cluster interaction.
+	phases, err := parsePhases(cfg.Phases, cfg)
+	if err != nil {
+		return err
 	}
 	if cfg.Timeout <= 0 || cfg.PerSandboxTimeout <= 0 {
 		return fmt.Errorf("timeouts must be > 0: timeout=%v per-sandbox-timeout=%v", cfg.Timeout, cfg.PerSandboxTimeout)
@@ -340,7 +352,7 @@ func run(ctx context.Context) error {
 	// for claims-warm (all claims fire at once, not concurrency-capped).
 	// Warn instead of failing: a run may deliberately probe that shape.
 	burstWidth := cfg.CreateConcurrency
-	if hasClaimsPhase(cfg.Phases) && cfg.ClaimsWarmCount > burstWidth {
+	if hasClaimsPhase(phases) && cfg.ClaimsWarmCount > burstWidth {
 		burstWidth = cfg.ClaimsWarmCount
 	}
 	if minConns := (burstWidth + 99) / 100; cfg.ClientConnections < minConns {
@@ -354,12 +366,11 @@ func run(ctx context.Context) error {
 	}
 	log.Printf("Cluster: kubernetes %s, %d worker nodes, pod capacity %d, %d pre-existing worker pods",
 		clusterInfo.KubernetesVersion, clusterInfo.Nodes, clusterInfo.PodCapacity, clusterInfo.PreexistingPods)
-	if slices.Contains(cfg.Phases, string(PhaseFill)) {
-		cfg.FillCount = cfg.FillPerNode * clusterInfo.Nodes
-		log.Printf("Fill phase: %d sandboxes (%d per worker node * %d nodes)", cfg.FillCount, cfg.FillPerNode, clusterInfo.Nodes)
-	}
-	if err := checkClusterCapacity(cfg, clusterInfo); err != nil {
+	if err := resolvePhases(phases, cfg, clusterInfo); err != nil {
 		return err
+	}
+	for i, p := range phases {
+		log.Printf("Phase #%d %s", i+1, p.Description())
 	}
 
 	// Create namespace
@@ -394,7 +405,7 @@ func run(ctx context.Context) error {
 	// classify into the exempt priority level before any latency-bearing
 	// phase runs; the verdict is logged and recorded in summary.json.
 	var apfVerification *APFVerification
-	if hasClaimsPhase(cfg.Phases) {
+	if hasClaimsPhase(phases) {
 		apfVerification = verifyClaimPostPriorityLevel(ctx, restConfig, cfg.Namespace)
 		logAPFVerification(apfVerification)
 	}
@@ -421,7 +432,7 @@ func run(ctx context.Context) error {
 	// Only watch SandboxClaims when a claims phase runs: the extensions
 	// CRDs may not be installed otherwise, and a missing CRD would make the
 	// watcher retry-loop for the whole run.
-	if hasClaimsPhase(cfg.Phases) {
+	if hasClaimsPhase(phases) {
 		gvrList = append(gvrList, gvrSandboxClaims)
 	}
 
@@ -503,7 +514,7 @@ func run(ctx context.Context) error {
 	// CPU/heap-profile the sandbox controller during the claims phases
 	// (the controller is the suspected bottleneck of the adoption path).
 	var ctrlProfiler *controllerProfiler
-	if cfg.ProfileController && hasClaimsPhase(cfg.Phases) {
+	if cfg.ProfileController && hasClaimsPhase(phases) {
 		ctrlProfiler, err = newControllerProfiler(restConfig, cfg.OutputDir)
 		if err != nil {
 			return fmt.Errorf("failed to build controller profiler: %w", err)
@@ -526,24 +537,20 @@ func run(ctx context.Context) error {
 		claimClient:    mutateClient.Resource(gvrSandboxClaims).Namespace(cfg.Namespace),
 	}
 
-	phaseRuns, err := buildPhaseRuns(test)
-	if err != nil {
-		return err
-	}
-
-	phaseResults := make([]phaseResult, 0, len(phaseRuns))
+	phaseResults := make([]phaseResult, 0, len(phases))
 	var phaseErr error
-	for _, phase := range phaseRuns {
+	for i, phase := range phases {
+		number := PhaseNumber(i + 1)
 		result := phaseResult{
-			number: phase.number,
-			name:   phase.name,
+			number: number,
+			name:   phase.Name(),
 			offset: time.Since(testStartTime),
 		}
 		start := time.Now()
-		if err := phase.fn(ctx); err != nil {
+		if err := phase.Run(ctx, test, number); err != nil {
 			result.duration = time.Since(start)
 			phaseResults = append(phaseResults, result)
-			phaseErr = fmt.Errorf("%s#%d phase: %w", phase.name, phase.number, err)
+			phaseErr = fmt.Errorf("%s#%d phase: %w", phase.Name(), number, err)
 			log.Printf("aborting after error: %v", phaseErr)
 			break
 		}
@@ -562,7 +569,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Write outputs even if a phase failed: partial data is still useful.
-	summary := buildSummary(runID, testStartTime, cfg, clusterInfo, tracker, phaseResults)
+	summary := buildSummary(runID, testStartTime, cfg, clusterInfo, tracker, phaseResults, phases)
 	summary.APFVerification = apfVerification
 	if err := writeOutputs(cfg.OutputDir, summary, tracker); err != nil {
 		if phaseErr == nil {
@@ -585,192 +592,12 @@ func run(ctx context.Context) error {
 	return waitErr
 }
 
-type phaseRun struct {
-	number PhaseNumber // 1-based index into Config.Phases
-	name   Phase
-	fn     func(context.Context) error
-}
-
 // phaseResult records wall-clock timing for one completed (or aborted) phase.
 type phaseResult struct {
 	number   PhaseNumber
-	name     Phase
+	name     PhaseName
 	offset   time.Duration // start relative to the test start
 	duration time.Duration
-}
-
-// buildPhaseRuns turns Config.Phases into concrete runners.
-// Recognized names today: fill, probe, throughput-mifN (N > 0).
-// Bare "throughput" is accepted as an alias for throughput-mif50.
-// Duplicate names are allowed; each entry gets a distinct PhaseNumber.
-func buildPhaseRuns(test *stressTest) ([]phaseRun, error) {
-	var runs []phaseRun
-	for i, raw := range test.cfg.Phases {
-		number := PhaseNumber(i + 1)
-		switch {
-		case raw == string(PhaseFill):
-			if test.cfg.FillCount <= 0 {
-				return nil, fmt.Errorf("phase %q requires --fill-per-node > 0", raw)
-			}
-			if test.cfg.CreateConcurrency <= 0 {
-				return nil, fmt.Errorf("--create-concurrency must be > 0 for phase %q", raw)
-			}
-			runs = append(runs, phaseRun{number, PhaseFill, func(ctx context.Context) error {
-				return test.runFillPhase(ctx, number)
-			}})
-		case raw == string(PhaseProbe):
-			if test.cfg.ProbeCount <= 0 {
-				return nil, fmt.Errorf("phase %q requires --probe-count > 0", raw)
-			}
-			if test.cfg.ProbeConcurrency <= 0 {
-				return nil, fmt.Errorf("--probe-concurrency must be > 0 for phase %q", raw)
-			}
-			runs = append(runs, phaseRun{number, PhaseProbe, func(ctx context.Context) error {
-				return test.runProbePhase(ctx, number)
-			}})
-		case raw == string(PhaseClaimsWarm):
-			if test.cfg.ClaimsWarmCount <= 0 {
-				return nil, fmt.Errorf("phase %q requires --claims-warm-count > 0", raw)
-			}
-			runs = append(runs, phaseRun{number, PhaseClaimsWarm, func(ctx context.Context) error {
-				return test.runClaimsWarmPhase(ctx, number)
-			}})
-		case raw == string(PhaseClaimsWarmSustained):
-			// Finite checks: flag.Float64Var accepts "NaN" and "+Inf" (NaN
-			// even passes a <= 0 test), and non-finite values would flow
-			// into pool sizing and the capacity estimate where float->int
-			// conversion is implementation-defined.
-			if test.cfg.SustainedRate <= 0 || math.IsNaN(test.cfg.SustainedRate) || math.IsInf(test.cfg.SustainedRate, 0) {
-				return nil, fmt.Errorf("phase %q requires a finite --sustained-rate > 0", raw)
-			}
-			if test.cfg.SustainedSeconds <= 0 || math.IsNaN(test.cfg.SustainedSeconds) || math.IsInf(test.cfg.SustainedSeconds, 0) {
-				return nil, fmt.Errorf("phase %q requires a finite --sustained-seconds > 0", raw)
-			}
-			if test.cfg.SustainedNamespaces < 1 {
-				return nil, fmt.Errorf("phase %q requires --sustained-namespaces >= 1", raw)
-			}
-			if test.cfg.SustainedPoolHeadroom <= 0 {
-				return nil, fmt.Errorf("phase %q requires --sustained-pool-headroom > 0", raw)
-			}
-			if test.cfg.SustainedLifecycleBudget <= 0 {
-				return nil, fmt.Errorf("phase %q requires --sustained-lifecycle-budget > 0", raw)
-			}
-			runs = append(runs, phaseRun{number, PhaseClaimsWarmSustained, func(ctx context.Context) error {
-				return test.runClaimsWarmSustainedPhase(ctx, number)
-			}})
-		default:
-			maxInFlight, ok := throughputMaxInFlight(raw)
-			if !ok {
-				return nil, fmt.Errorf("unknown phase %q (want fill, probe, claims-warm, claims-warm-sustained, or throughput-mifN)", raw)
-			}
-			if test.cfg.ThroughputCount <= 0 {
-				return nil, fmt.Errorf("phase %q requires --throughput-count > 0", raw)
-			}
-			if test.cfg.CreateConcurrency <= 0 {
-				return nil, fmt.Errorf("--create-concurrency must be > 0 for phase %q", raw)
-			}
-			name := Phase(raw)
-			if raw == string(PhaseThroughput) {
-				name = Phase(fmt.Sprintf("%s-mif%d", PhaseThroughput, maxInFlight))
-			}
-			mif := maxInFlight
-			runs = append(runs, phaseRun{number, name, func(ctx context.Context) error {
-				if test.profiler != nil {
-					// 5s in to skip the slot-fill burst; levels last >=45s
-					// (ThroughputMinSeconds), so the 20s window lands inside.
-					go test.profiler.CaptureCPUProfile(ctx, name, 5*time.Second, 20*time.Second)
-				}
-				return test.runThroughputLevel(ctx, name, number, mif)
-			}})
-		}
-	}
-	return runs, nil
-}
-
-// hasClaimsPhase reports whether any phase needs the SandboxClaim machinery
-// (claim watch, extensions CRDs, controller profiler). The claim watch is
-// cluster-wide, so it also covers the sustained phase's extra <ns>-s1..sN
-// shard namespaces.
-func hasClaimsPhase(phases []string) bool {
-	return slices.Contains(phases, string(PhaseClaimsWarm)) ||
-		slices.Contains(phases, string(PhaseClaimsWarmSustained))
-}
-
-// throughputMaxInFlight parses throughput / throughput-mifN phase names.
-func throughputMaxInFlight(name string) (int, bool) {
-	if name == string(PhaseThroughput) {
-		return 50, true
-	}
-	suffix, ok := strings.CutPrefix(name, string(PhaseThroughput)+"-mif")
-	if !ok || suffix == "" {
-		return 0, false
-	}
-	n, err := strconv.Atoi(suffix)
-	if err != nil || n <= 0 {
-		return 0, false
-	}
-	return n, true
-}
-
-// checkClusterCapacity returns an error when the test configuration would
-// exceed spare cluster pod capacity: in that case latency and throughput
-// results would measure queueing for capacity rather than the sandbox launch
-// pipeline, so the run would not test what it claims to test.
-//
-// Phases run sequentially, so peak concurrent test pods is fill plus the
-// largest of the probe/claims-warm/throughput in-flight caps (fill sandboxes
-// stay up). The claims-warm pool needs its full replica count in pods; on top
-// of that the warm pool controller replenishes claimed sandboxes, so the
-// phase can transiently reach ~2x its count — that overshoot is warned about
-// rather than required, because replenishment pods only queue (they do not
-// delay the claims being measured) and cleanup removes them. The
-// claims-warm-sustained budget covers its warm pools (kept full by refill)
-// plus the adopted-but-not-yet-deleted sandboxes.
-func checkClusterCapacity(cfg Config, info *ClusterInfo) error {
-	extra := 0
-	if slices.Contains(cfg.Phases, string(PhaseProbe)) && cfg.ProbeConcurrency > extra {
-		extra = cfg.ProbeConcurrency
-	}
-	claimsWarm := slices.Contains(cfg.Phases, string(PhaseClaimsWarm))
-	if claimsWarm && cfg.ClaimsWarmCount > extra {
-		extra = cfg.ClaimsWarmCount
-	}
-	if slices.Contains(cfg.Phases, string(PhaseClaimsWarmSustained)) {
-		// Steady state: the pools stay full (refill replaces adopted
-		// sandboxes) while adopted sandboxes live for roughly the ready
-		// latency + dwell + deletion pipeline before their pods go away;
-		// --sustained-lifecycle-budget bounds the pipeline part on top of
-		// the dwell.
-		poolTotal := sustainedPoolReplicasPerNamespace(cfg) * cfg.SustainedNamespaces
-		inFlight := int(math.Ceil(cfg.SustainedRate * (cfg.ClaimDwell.Seconds() + cfg.SustainedLifecycleBudget.Seconds())))
-		if n := poolTotal + inFlight; n > extra {
-			extra = n
-		}
-	}
-	for _, name := range cfg.Phases {
-		if maxInFlight, ok := throughputMaxInFlight(name); ok && maxInFlight > extra {
-			extra = maxInFlight
-		}
-	}
-	needed := 0
-	if slices.Contains(cfg.Phases, string(PhaseFill)) {
-		needed += cfg.FillCount
-	}
-	needed += extra
-	spare := info.PodCapacity - info.PreexistingPods
-	if needed == 0 {
-		return nil
-	}
-	switch {
-	case needed > spare:
-		return fmt.Errorf("test needs up to %d concurrent pods but the cluster only has %d spare pod slots; results would measure capacity queueing, not launch performance. Reduce --fill-per-node / --claims-warm-count / throughput-mifN or add nodes", needed, spare)
-	case spare > 0 && needed > spare*9/10:
-		log.Printf("WARNING: test needs up to %d concurrent pods, over 90%% of the %d spare pod slots; scheduling may interfere with measurements.", needed, spare)
-	}
-	if claimsWarm && 2*cfg.ClaimsWarmCount > spare {
-		log.Printf("WARNING: claims-warm pool replenishment can transiently need up to %d pods (2x --claims-warm-count) but only %d spare pod slots exist; replenishment pods will queue on capacity. Add nodes or reduce --claims-warm-count.", 2*cfg.ClaimsWarmCount, spare)
-	}
-	return nil
 }
 
 // inspectCluster records the apiserver version and counts worker-node pod
@@ -842,24 +669,14 @@ func isControlPlaneNode(u *unstructured.Unstructured) bool {
 }
 
 func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *ClusterInfo, tracker *Tracker,
-	phaseResults []phaseResult) *Summary {
+	phaseResults []phaseResult, phases []Phase) *Summary {
 	records := tracker.Records()
 
-	requested := func(phase Phase) int {
-		switch phase {
-		case PhaseFill:
-			return cfg.FillCount
-		case PhaseProbe:
-			return cfg.ProbeCount
-		case PhaseClaimsWarm:
-			return cfg.ClaimsWarmCount
-		case PhaseClaimsWarmSustained:
-			// Expected arrivals; the Poisson process varies the actual count.
-			return sustainedExpectedClaims(cfg)
-		default:
-			// Throughput phases (one per throughput-mifN entry).
-			return cfg.ThroughputCount
+	requested := func(number PhaseNumber) int {
+		if i := int(number) - 1; i >= 0 && i < len(phases) {
+			return phases[i].Requested()
 		}
+		return 0
 	}
 
 	summary := &Summary{
@@ -881,10 +698,15 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 		// Throughput levels overshoot the configured count when
 		// -throughput-min-seconds keeps them churning; every record was a
 		// real request.
-		req := max(requested(result.name), len(phaseRecords))
+		req := max(requested(result.number), len(phaseRecords))
+		var kind PhaseName
+		if i := int(result.number) - 1; i >= 0 && i < len(phases) {
+			kind = phases[i].Kind()
+		}
 		ps := &PhaseSummary{
 			Number:                result.number,
 			Name:                  string(result.name),
+			Kind:                  kind,
 			Requested:             req,
 			DurationSeconds:       result.duration.Seconds(),
 			StartOffsetSeconds:    result.offset.Seconds(),
@@ -908,7 +730,7 @@ func buildSummary(runID string, startTime time.Time, cfg Config, clusterInfo *Cl
 		}
 		ps.CreateThroughput = computeThroughputStats(createTimes)
 		ps.ReadyThroughput = computeThroughputStats(readyTimes)
-		if result.name == PhaseClaimsWarmSustained {
+		if kind == PhaseClaimsWarmSustained {
 			ps.SustainedWindows = computeWindowedLatencies(phaseRecords, sustainedWindow)
 		}
 		if clusterInfo != nil {
@@ -1047,7 +869,7 @@ func printReport(summary *Summary, clusterInfo *ClusterInfo) {
 		fmt.Printf("\n--- #%d %s: %d requested, %d created, %d ready, %d failed (%.1fs) ---\n",
 			ps.Number, ps.Name, ps.Requested, ps.Created, ps.Ready, ps.Failed, ps.DurationSeconds)
 
-		switch Phase(ps.Name) {
+		switch ps.Kind {
 		case PhaseProbe:
 			fmt.Println("  Launch latency breakdown:")
 			printBreakdown(ps.Latency)

--- a/test/stress/phase.go
+++ b/test/stress/phase.go
@@ -1,0 +1,496 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Phase is one parsed entry of --phases: a phase kind plus its arguments.
+//
+// Lifecycle: parsePhase turns the raw string into a Phase at flag time,
+// Validate rejects bad flag combinations before any cluster interaction,
+// Resolve sizes the phase once the cluster has been inspected (fills depend
+// on node count / pod capacity and on the pods left behind by earlier
+// phases), and Run executes it.
+type Phase interface {
+	// Name is the display name recorded in logs, summary.json and the
+	// report. It is the raw --phases entry, so a run that repeats a kind
+	// keeps distinct names via label arguments (throughput-mif:400-label:x).
+	Name() PhaseName
+
+	// Kind is the phase's base kind (fill, probe, throughput, claims-warm,
+	// claims-warm-sustained), unaffected by arguments: a labeled entry like
+	// probe-label:x still reports as kind probe, which is what selects the
+	// kind-specific output in summary.json and printReport.
+	Kind() PhaseName
+
+	// Validate rejects configurations that can be caught from flags alone.
+	Validate(cfg Config) error
+
+	// Resolve sizes the phase against the inspected cluster. resident is
+	// the worker-pod count when the phase starts (pre-existing pods plus
+	// earlier fills); it returns the resident count when the phase ends
+	// and the peak concurrent pods while it runs. resolvePhases walks the
+	// phase list calling this in order, and feeds peak into the capacity
+	// preflight.
+	Resolve(cfg Config, info *ClusterInfo, resident int) (after, peak int)
+
+	// Description is a one-line explanation of the resolved sizing,
+	// logged before the phases run. Call Resolve first.
+	Description() string
+
+	// Requested is the number of creations the phase intends to make.
+	// Call Resolve first.
+	Requested() int
+
+	// Run executes the phase.
+	Run(ctx context.Context, test *stressTest, number PhaseNumber) error
+}
+
+// parsePhase parses one --phases entry. The grammar is a phase kind,
+// optionally followed by hyphen-separated key:value arguments:
+//
+//	fill                          fill-per-node * worker-nodes background sandboxes
+//	fill-pct:80                   top the cluster up to 80% total pod utilization
+//	probe                         low-concurrency launch-latency probes
+//	throughput-mif:400            closed-loop churn, 400 in flight
+//	throughput-mif:400-label:hot  same, with a distinct name for reports
+//	claims-warm                   SandboxClaim burst against a warm pool
+//	claims-warm-sustained         Poisson claim stream at a target rate
+//
+// Every kind accepts label:<x> so repeated entries keep distinct names;
+// labels are limited to [a-z0-9_.] to keep the grammar unambiguous.
+// throughput-mifN and bare throughput (mif 50) are accepted as the legacy
+// spellings.
+func parsePhase(raw string) (Phase, error) {
+	kind, rest := raw, ""
+	// Kind names themselves contain hyphens (claims-warm-sustained), so
+	// match the longest known kind first, then treat any remainder as
+	// arguments.
+	found := false
+	for _, k := range []PhaseName{PhaseClaimsWarmSustained, PhaseClaimsWarm, PhaseThroughput, PhaseProbe, PhaseFill} {
+		if raw == string(k) {
+			kind, found = string(k), true
+			break
+		}
+		if s, ok := strings.CutPrefix(raw, string(k)+"-"); ok {
+			kind, rest, found = string(k), s, true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("unknown phase %q (want fill, fill-pct:N, probe, claims-warm, claims-warm-sustained, or throughput-mif:N)", raw)
+	}
+
+	// Legacy spellings: bare "throughput" is mif 50 (renamed so the report
+	// shows the level), and "throughput-mifN" predates the key:value form.
+	if kind == string(PhaseThroughput) {
+		if rest == "" {
+			return &throughputPhase{raw: PhaseName(raw) + "-mif50", mif: 50}, nil
+		}
+		if s, ok := strings.CutPrefix(rest, "mif"); ok && !strings.Contains(rest, ":") {
+			n, err := strconv.Atoi(s)
+			if err != nil || n <= 0 {
+				return nil, fmt.Errorf("phase %q: mif must be a positive integer", raw)
+			}
+			return &throughputPhase{raw: PhaseName(raw), mif: n}, nil
+		}
+	}
+
+	args, err := parsePhaseArgs(rest)
+	if err != nil {
+		return nil, fmt.Errorf("phase %q: %w", raw, err)
+	}
+	take := func(key string) (string, bool) {
+		v, ok := args[key]
+		delete(args, key)
+		return v, ok
+	}
+	if label, ok := take("label"); ok {
+		for _, r := range label {
+			if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' && r != '.' {
+				return nil, fmt.Errorf("phase %q: label may only contain [a-z0-9_.]", raw)
+			}
+		}
+	}
+
+	var phase Phase
+	switch kind {
+	case string(PhaseFill):
+		p := &fillPhase{raw: PhaseName(raw)}
+		if v, ok := take("pct"); ok {
+			n, err := strconv.Atoi(v)
+			if err != nil || n < 1 || n > 100 {
+				return nil, fmt.Errorf("phase %q: pct must be an integer in 1..100", raw)
+			}
+			p.pct = n
+		}
+		phase = p
+	case string(PhaseThroughput):
+		v, ok := take("mif")
+		if !ok {
+			return nil, fmt.Errorf("phase %q: throughput requires mif:N", raw)
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("phase %q: mif must be a positive integer", raw)
+		}
+		phase = &throughputPhase{raw: PhaseName(raw), mif: n}
+	case string(PhaseProbe):
+		phase = &probePhase{raw: PhaseName(raw)}
+	case string(PhaseClaimsWarm):
+		phase = &claimsWarmPhase{raw: PhaseName(raw)}
+	case string(PhaseClaimsWarmSustained):
+		phase = &claimsWarmSustainedPhase{raw: PhaseName(raw)}
+	}
+	for key := range args {
+		return nil, fmt.Errorf("phase %q: unknown argument %q", raw, key)
+	}
+	return phase, nil
+}
+
+// parsePhaseArgs splits "pct:80-label:foo" into {"pct": "80", "label": "foo"}.
+func parsePhaseArgs(rest string) (map[string]string, error) {
+	args := map[string]string{}
+	if rest == "" {
+		return args, nil
+	}
+	for seg := range strings.SplitSeq(rest, "-") {
+		key, value, ok := strings.Cut(seg, ":")
+		if !ok || key == "" || value == "" {
+			return nil, fmt.Errorf("argument %q is not key:value", seg)
+		}
+		if _, dup := args[key]; dup {
+			return nil, fmt.Errorf("duplicate argument %q", key)
+		}
+		args[key] = value
+	}
+	return args, nil
+}
+
+// parsePhases parses and validates the full --phases list.
+func parsePhases(raws []string, cfg Config) ([]Phase, error) {
+	phases := make([]Phase, 0, len(raws))
+	for _, raw := range raws {
+		p, err := parsePhase(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := p.Validate(cfg); err != nil {
+			return nil, err
+		}
+		phases = append(phases, p)
+	}
+	return phases, nil
+}
+
+// resolvePhases sizes each phase against the inspected cluster and returns
+// an error when the configuration would exceed spare pod capacity: in that
+// case latency and throughput results would measure queueing for capacity
+// rather than the sandbox launch pipeline, so the run would not test what
+// it claims to test.
+//
+// Phases run sequentially and fill sandboxes stay up, so the walk tracks
+// the resident pod count in phase order — a throughput-mif:600 fits before
+// a fill-pct:80 but not after it — and the error names the phase where the
+// peak lands.
+func resolvePhases(phases []Phase, cfg Config, info *ClusterInfo) error {
+	resident := info.PreexistingPods
+	peak, peakPhase := 0, PhaseName("")
+	claimsWarm := false
+	for _, p := range phases {
+		var phasePeak int
+		resident, phasePeak = p.Resolve(cfg, info, resident)
+		if phasePeak > peak {
+			peak, peakPhase = phasePeak, p.Name()
+		}
+		if _, ok := p.(*claimsWarmPhase); ok {
+			claimsWarm = true
+		}
+	}
+	needed := peak - info.PreexistingPods
+	spare := info.PodCapacity - info.PreexistingPods
+	if needed <= 0 {
+		return nil
+	}
+	switch {
+	case needed > spare:
+		return fmt.Errorf("test needs up to %d concurrent pods (peak during phase %q) but the cluster only has %d spare pod slots; results would measure capacity queueing, not launch performance. Reduce --fill-per-node / fill-pct / --claims-warm-count / throughput-mif or add nodes", needed, peakPhase, spare)
+	case spare > 0 && needed > spare*9/10:
+		log.Printf("WARNING: test needs up to %d concurrent pods (peak during phase %q), over 90%% of the %d spare pod slots; scheduling may interfere with measurements.", needed, peakPhase, spare)
+	}
+	// The warm pool controller replenishes claimed sandboxes, so claims-warm
+	// can transiently reach ~2x its count. Warn rather than fail:
+	// replenishment pods only queue (they do not delay the claims being
+	// measured) and cleanup removes them.
+	if claimsWarm && 2*cfg.ClaimsWarmCount > spare {
+		log.Printf("WARNING: claims-warm pool replenishment can transiently need up to %d pods (2x --claims-warm-count) but only %d spare pod slots exist; replenishment pods will queue on capacity. Add nodes or reduce --claims-warm-count.", 2*cfg.ClaimsWarmCount, spare)
+	}
+	return nil
+}
+
+// hasClaimsPhase reports whether any phase needs the SandboxClaim machinery
+// (claim watch, extensions CRDs, controller profiler). The claim watch is
+// cluster-wide, so it also covers the sustained phase's extra <ns>-s1..sN
+// shard namespaces.
+func hasClaimsPhase(phases []Phase) bool {
+	for _, p := range phases {
+		switch p.(type) {
+		case *claimsWarmPhase, *claimsWarmSustainedPhase:
+			return true
+		}
+	}
+	return false
+}
+
+// fillPhase implements fill and fill-pct:N: long-running background
+// sandboxes that stay up for the rest of the run, so later phases measure a
+// cluster at scale. pct == 0 sizes by --fill-per-node * worker nodes;
+// otherwise the phase tops the cluster up to pct% of total worker pod
+// capacity, counting the pods already there (pre-existing system pods and
+// earlier fills).
+type fillPhase struct {
+	raw PhaseName
+	pct int // 0 = FillPerNode * worker nodes
+
+	// Set by Resolve.
+	count    int
+	perNode  int
+	nodes    int
+	capacity int
+}
+
+func (p *fillPhase) Name() PhaseName { return p.raw }
+
+func (p *fillPhase) Kind() PhaseName { return PhaseFill }
+
+func (p *fillPhase) Validate(cfg Config) error {
+	if p.pct == 0 && cfg.FillPerNode <= 0 {
+		return fmt.Errorf("phase %q requires --fill-per-node > 0", p.raw)
+	}
+	if cfg.CreateConcurrency <= 0 {
+		return fmt.Errorf("--create-concurrency must be > 0 for phase %q", p.raw)
+	}
+	return nil
+}
+
+func (p *fillPhase) Resolve(cfg Config, info *ClusterInfo, resident int) (int, int) {
+	p.perNode, p.nodes, p.capacity = cfg.FillPerNode, info.Nodes, info.PodCapacity
+	if p.pct == 0 {
+		p.count = cfg.FillPerNode * info.Nodes
+	} else {
+		p.count = max(0, info.PodCapacity*p.pct/100-resident)
+	}
+	return resident + p.count, resident + p.count
+}
+
+func (p *fillPhase) Description() string {
+	if p.pct == 0 {
+		return fmt.Sprintf("%s: %d sandboxes (%d per worker node * %d nodes)", p.raw, p.count, p.perNode, p.nodes)
+	}
+	return fmt.Sprintf("%s: %d sandboxes (top up to %d%% of %d worker pod slots)", p.raw, p.count, p.pct, p.capacity)
+}
+
+func (p *fillPhase) Requested() int { return p.count }
+
+func (p *fillPhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	return test.runFillPhase(ctx, p.raw, number, p.count)
+}
+
+// probePhase measures clean launch latency at the current cluster scale.
+type probePhase struct {
+	raw PhaseName
+
+	// Set by Resolve.
+	count       int
+	concurrency int
+}
+
+func (p *probePhase) Name() PhaseName { return p.raw }
+
+func (p *probePhase) Kind() PhaseName { return PhaseProbe }
+
+func (p *probePhase) Validate(cfg Config) error {
+	if cfg.ProbeCount <= 0 {
+		return fmt.Errorf("phase %q requires --probe-count > 0", p.raw)
+	}
+	if cfg.ProbeConcurrency <= 0 {
+		return fmt.Errorf("--probe-concurrency must be > 0 for phase %q", p.raw)
+	}
+	return nil
+}
+
+func (p *probePhase) Resolve(cfg Config, _ *ClusterInfo, resident int) (int, int) {
+	p.count, p.concurrency = cfg.ProbeCount, cfg.ProbeConcurrency
+	// Probes are deleted as they are measured, so they do not accumulate.
+	return resident, resident + cfg.ProbeConcurrency
+}
+
+func (p *probePhase) Description() string {
+	return fmt.Sprintf("%s: %d sandboxes at concurrency %d", p.raw, p.count, p.concurrency)
+}
+
+func (p *probePhase) Requested() int { return p.count }
+
+func (p *probePhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	return test.runProbePhase(ctx, number)
+}
+
+// throughputPhase churns sandboxes (create -> ready -> delete) in a closed
+// loop capped at mif in flight, measuring sustained ready/sec.
+type throughputPhase struct {
+	raw PhaseName
+	mif int
+
+	// Set by Resolve.
+	count int
+}
+
+func (p *throughputPhase) Name() PhaseName { return p.raw }
+
+func (p *throughputPhase) Kind() PhaseName { return PhaseThroughput }
+
+func (p *throughputPhase) Validate(cfg Config) error {
+	if cfg.ThroughputCount <= 0 {
+		return fmt.Errorf("phase %q requires --throughput-count > 0", p.raw)
+	}
+	if cfg.CreateConcurrency <= 0 {
+		return fmt.Errorf("--create-concurrency must be > 0 for phase %q", p.raw)
+	}
+	return nil
+}
+
+func (p *throughputPhase) Resolve(cfg Config, _ *ClusterInfo, resident int) (int, int) {
+	p.count = cfg.ThroughputCount
+	return resident, resident + p.mif
+}
+
+func (p *throughputPhase) Description() string {
+	return fmt.Sprintf("%s: closed-loop churn, %d in flight, >=%d creations", p.raw, p.mif, p.count)
+}
+
+func (p *throughputPhase) Requested() int { return p.count }
+
+func (p *throughputPhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	if test.profiler != nil {
+		// 5s in to skip the slot-fill burst; levels last >=45s
+		// (ThroughputMinSeconds), so the 20s window lands inside.
+		go test.profiler.CaptureCPUProfile(ctx, p.raw, 5*time.Second, 20*time.Second)
+	}
+	return test.runThroughputLevel(ctx, p.raw, number, p.mif)
+}
+
+// claimsWarmPhase fires SandboxClaims simultaneously against a fully
+// provisioned SandboxWarmPool, measuring claim-create -> claim-Ready latency.
+type claimsWarmPhase struct {
+	raw PhaseName
+
+	// Set by Resolve.
+	count int
+}
+
+func (p *claimsWarmPhase) Name() PhaseName { return p.raw }
+
+func (p *claimsWarmPhase) Kind() PhaseName { return PhaseClaimsWarm }
+
+func (p *claimsWarmPhase) Validate(cfg Config) error {
+	if cfg.ClaimsWarmCount <= 0 {
+		return fmt.Errorf("phase %q requires --claims-warm-count > 0", p.raw)
+	}
+	return nil
+}
+
+func (p *claimsWarmPhase) Resolve(cfg Config, _ *ClusterInfo, resident int) (int, int) {
+	p.count = cfg.ClaimsWarmCount
+	// The pool and its claims are cleaned up at the end of the phase.
+	return resident, resident + p.count
+}
+
+func (p *claimsWarmPhase) Description() string {
+	return fmt.Sprintf("%s: %d simultaneous claims against a %d-replica warm pool", p.raw, p.count, p.count)
+}
+
+func (p *claimsWarmPhase) Requested() int { return p.count }
+
+func (p *claimsWarmPhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	return test.runClaimsWarmPhase(ctx, number)
+}
+
+// claimsWarmSustainedPhase streams SandboxClaims at a target rate with
+// Poisson jitter against continuously replenished warm pools (sustained.go).
+type claimsWarmSustainedPhase struct {
+	raw PhaseName
+
+	// Set by Resolve.
+	expected int
+	pods     int
+}
+
+func (p *claimsWarmSustainedPhase) Name() PhaseName { return p.raw }
+
+func (p *claimsWarmSustainedPhase) Kind() PhaseName { return PhaseClaimsWarmSustained }
+
+func (p *claimsWarmSustainedPhase) Validate(cfg Config) error {
+	// Finite checks: flag.Float64Var accepts "NaN" and "+Inf" (NaN even
+	// passes a <= 0 test), and non-finite values would flow into pool
+	// sizing and the capacity estimate where float->int conversion is
+	// implementation-defined.
+	if cfg.SustainedRate <= 0 || math.IsNaN(cfg.SustainedRate) || math.IsInf(cfg.SustainedRate, 0) {
+		return fmt.Errorf("phase %q requires a finite --sustained-rate > 0", p.raw)
+	}
+	if cfg.SustainedSeconds <= 0 || math.IsNaN(cfg.SustainedSeconds) || math.IsInf(cfg.SustainedSeconds, 0) {
+		return fmt.Errorf("phase %q requires a finite --sustained-seconds > 0", p.raw)
+	}
+	if cfg.SustainedNamespaces < 1 {
+		return fmt.Errorf("phase %q requires --sustained-namespaces >= 1", p.raw)
+	}
+	if cfg.SustainedPoolHeadroom <= 0 {
+		return fmt.Errorf("phase %q requires --sustained-pool-headroom > 0", p.raw)
+	}
+	if cfg.SustainedLifecycleBudget <= 0 {
+		return fmt.Errorf("phase %q requires --sustained-lifecycle-budget > 0", p.raw)
+	}
+	return nil
+}
+
+func (p *claimsWarmSustainedPhase) Resolve(cfg Config, _ *ClusterInfo, resident int) (int, int) {
+	// Steady state: the pools stay full (refill replaces adopted sandboxes)
+	// while adopted sandboxes live for roughly the ready latency + dwell +
+	// deletion pipeline before their pods go away; --sustained-lifecycle-budget
+	// bounds the pipeline part on top of the dwell.
+	poolTotal := sustainedPoolReplicasPerNamespace(cfg) * cfg.SustainedNamespaces
+	inFlight := int(math.Ceil(cfg.SustainedRate * (cfg.ClaimDwell.Seconds() + cfg.SustainedLifecycleBudget.Seconds())))
+	p.pods = poolTotal + inFlight
+	// Expected arrivals; the Poisson process varies the actual count.
+	p.expected = sustainedExpectedClaims(cfg)
+	return resident, resident + p.pods
+}
+
+func (p *claimsWarmSustainedPhase) Description() string {
+	return fmt.Sprintf("%s: ~%d claims expected, steady-state budget %d pods", p.raw, p.expected, p.pods)
+}
+
+func (p *claimsWarmSustainedPhase) Requested() int { return p.expected }
+
+func (p *claimsWarmSustainedPhase) Run(ctx context.Context, test *stressTest, number PhaseNumber) error {
+	return test.runClaimsWarmSustainedPhase(ctx, number)
+}

--- a/test/stress/phaseconfig_test.go
+++ b/test/stress/phaseconfig_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParsePhase(t *testing.T) {
+	tests := []struct {
+		raw string
+		// want is a non-nil prototype whose type and fields the parsed
+		// phase must match; nil means parsing must fail.
+		want Phase
+		// name overrides the expected Name() (defaults to raw).
+		name PhaseName
+	}{
+		{raw: "fill", want: &fillPhase{raw: "fill"}},
+		{raw: "fill-pct:80", want: &fillPhase{raw: "fill-pct:80", pct: 80}},
+		{raw: "fill-pct:1", want: &fillPhase{raw: "fill-pct:1", pct: 1}},
+		{raw: "fill-pct:100", want: &fillPhase{raw: "fill-pct:100", pct: 100}},
+		{raw: "fill-label:second", want: &fillPhase{raw: "fill-label:second"}},
+		{raw: "probe", want: &probePhase{raw: "probe"}},
+		{raw: "claims-warm", want: &claimsWarmPhase{raw: "claims-warm"}},
+		{raw: "claims-warm-sustained", want: &claimsWarmSustainedPhase{raw: "claims-warm-sustained"}},
+		{raw: "throughput", want: &throughputPhase{raw: "throughput-mif50", mif: 50}, name: "throughput-mif50"},
+		{raw: "throughput-mif:400", want: &throughputPhase{raw: "throughput-mif:400", mif: 400}},
+		{raw: "throughput-mif:400-label:hot", want: &throughputPhase{raw: "throughput-mif:400-label:hot", mif: 400}},
+		// Legacy spelling, predates the key:value form.
+		{raw: "throughput-mif600", want: &throughputPhase{raw: "throughput-mif600", mif: 600}},
+
+		{raw: ""},
+		{raw: "warmup"},
+		{raw: "fil"},
+		{raw: "fill-pct:0"},
+		{raw: "fill-pct:101"},
+		{raw: "fill-pct:abc"},
+		{raw: "fill-pct"},                     // missing :value
+		{raw: "fill-util80"},                  // pre-review spelling, no longer accepted
+		{raw: "throughput-mif"},               // legacy form without a number
+		{raw: "throughput-mif0"},              // mif must be positive
+		{raw: "throughput-label:x"},           // mif is required
+		{raw: "throughput-mif:400-mif:500"},   // duplicate key
+		{raw: "throughput-mif:400-label:HOT"}, // labels are [a-z0-9_.]
+		{raw: "throughput-mif:400-flavor:x"},  // unknown argument
+		{raw: "throughput-mif400-full"},       // labels need the key:value form
+		{raw: "claims-warm-sustained-pct:80"}, // pct is fill-only
+	}
+	for _, tc := range tests {
+		got, err := parsePhase(tc.raw)
+		if tc.want == nil {
+			if err == nil {
+				t.Errorf("parsePhase(%q) = %#v, want error", tc.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parsePhase(%q) returned error: %v", tc.raw, err)
+			continue
+		}
+		wantName := tc.name
+		if wantName == "" {
+			wantName = PhaseName(tc.raw)
+		}
+		if got.Name() != wantName {
+			t.Errorf("parsePhase(%q).Name() = %q, want %q", tc.raw, got.Name(), wantName)
+		}
+		switch want := tc.want.(type) {
+		case *fillPhase:
+			p, ok := got.(*fillPhase)
+			if !ok || p.pct != want.pct {
+				t.Errorf("parsePhase(%q) = %#v, want fillPhase pct=%d", tc.raw, got, want.pct)
+			}
+		case *throughputPhase:
+			p, ok := got.(*throughputPhase)
+			if !ok || p.mif != want.mif {
+				t.Errorf("parsePhase(%q) = %#v, want throughputPhase mif=%d", tc.raw, got, want.mif)
+			}
+		case *probePhase:
+			if _, ok := got.(*probePhase); !ok {
+				t.Errorf("parsePhase(%q) = %#v, want probePhase", tc.raw, got)
+			}
+		case *claimsWarmPhase:
+			if _, ok := got.(*claimsWarmPhase); !ok {
+				t.Errorf("parsePhase(%q) = %#v, want claimsWarmPhase", tc.raw, got)
+			}
+		case *claimsWarmSustainedPhase:
+			if _, ok := got.(*claimsWarmSustainedPhase); !ok {
+				t.Errorf("parsePhase(%q) = %#v, want claimsWarmSustainedPhase", tc.raw, got)
+			}
+		}
+	}
+}
+
+func TestPhaseKind(t *testing.T) {
+	// Kind must ignore arguments: labeled phases still select their
+	// kind-specific output in summary.json and printReport.
+	tests := map[string]PhaseName{
+		"fill":                         PhaseFill,
+		"fill-pct:80":                  PhaseFill,
+		"probe-label:x":                PhaseProbe,
+		"throughput-mif600":            PhaseThroughput,
+		"throughput-mif:400-label:hot": PhaseThroughput,
+		"claims-warm-label:x":          PhaseClaimsWarm,
+		"claims-warm-sustained":        PhaseClaimsWarmSustained,
+	}
+	for raw, want := range tests {
+		p, err := parsePhase(raw)
+		if err != nil {
+			t.Errorf("parsePhase(%q): %v", raw, err)
+			continue
+		}
+		if got := p.Kind(); got != want {
+			t.Errorf("parsePhase(%q).Kind() = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestFileSafePhase(t *testing.T) {
+	tests := map[PhaseName]string{
+		"throughput-mif:600":           "throughput-mif-600",
+		"throughput-mif:400-label:hot": "throughput-mif-400-label-hot",
+		"fill-pct:80":                  "fill-pct-80",
+		"throughput-mif600":            "throughput-mif600", // legacy names pass through
+		"probe":                        "probe",
+	}
+	for phase, want := range tests {
+		if got := fileSafePhase(phase); got != want {
+			t.Errorf("fileSafePhase(%q) = %q, want %q", phase, got, want)
+		}
+	}
+}
+
+// mustParsePhases parses a phase list that the test requires to be valid.
+func mustParsePhases(t *testing.T, cfg Config, raws ...string) []Phase {
+	t.Helper()
+	phases, err := parsePhases(raws, cfg)
+	if err != nil {
+		t.Fatalf("parsePhases(%v): %v", raws, err)
+	}
+	return phases
+}
+
+func TestResolveFillSizes(t *testing.T) {
+	// 20 nodes * 110 slots, ~100 system pods already running.
+	info := &ClusterInfo{Nodes: 20, PodCapacity: 2200, PreexistingPods: 100}
+	cfg := Config{
+		FillPerNode:       10,
+		CreateConcurrency: 50,
+		ThroughputCount:   500,
+	}
+	phases := mustParsePhases(t, cfg,
+		"fill",               // 10 * 20 = 200
+		"throughput-mif:600", // not a fill: leaves nothing resident
+		"fill-pct:80",        // 80% of 2200 = 1760, minus 100 resident + 200 fill = 1460
+		"fill-pct:50",        // target 1100 < 1760 already resident: 0
+		"fill-label:again",   // plain fill is unconditional: another 200
+	)
+	if err := resolvePhases(phases, cfg, info); err != nil {
+		t.Fatalf("resolvePhases: %v", err)
+	}
+	want := []int{200, 500, 1460, 0, 200} // non-fill entries report their own Requested
+	for i, p := range phases {
+		if got := p.Requested(); got != want[i] {
+			t.Errorf("phase %s Requested() = %d, want %d", p.Name(), got, want[i])
+		}
+	}
+}
+
+func TestResolvePhasesCapacityOrdering(t *testing.T) {
+	info := &ClusterInfo{Nodes: 20, PodCapacity: 2200, PreexistingPods: 100}
+	cfg := Config{
+		FillPerNode:       10,
+		CreateConcurrency: 50,
+		ThroughputCount:   500,
+	}
+
+	// mif600 BEFORE fill-pct:80: peak is the 1760 residents during the
+	// fill, which fits.
+	before := mustParsePhases(t, cfg, "fill", "throughput-mif:600", "fill-pct:80", "throughput-mif:400-label:hot")
+	if err := resolvePhases(before, cfg, info); err != nil {
+		t.Errorf("resolvePhases(mif600 before fill-pct:80) = %v, want nil", err)
+	}
+
+	// The same mif600 AFTER fill-pct:80 rides on 1760 residents: 2360 > 2200.
+	after := mustParsePhases(t, cfg, "fill", "fill-pct:80", "throughput-mif:600")
+	err := resolvePhases(after, cfg, info)
+	if err == nil {
+		t.Fatal("resolvePhases(mif600 after fill-pct:80) = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "throughput-mif:600") {
+		t.Errorf("capacity error should name the peak phase, got: %v", err)
+	}
+}

--- a/test/stress/phases.go
+++ b/test/stress/phases.go
@@ -104,7 +104,7 @@ func buildSandboxObject(id types.NamespacedName, image string) *unstructured.Uns
 // createSandbox registers a record and issues the Create call.
 // Create errors are recorded on the SandboxRecord rather than returned:
 // individual failures should not abort the run, they are reported in the summary.
-func (s *stressTest) createSandbox(ctx context.Context, id types.NamespacedName, name Phase, number PhaseNumber) error {
+func (s *stressTest) createSandbox(ctx context.Context, id types.NamespacedName, name PhaseName, number PhaseNumber) error {
 	sandbox := buildSandboxObject(id, s.cfg.Image)
 	s.tracker.Register(id, name, number)
 	_, err := s.sandboxClient.Create(ctx, sandbox, metav1.CreateOptions{})
@@ -132,15 +132,18 @@ func (s *stressTest) deleteSandbox(ctx context.Context, id types.NamespacedName)
 	}
 }
 
-// runFillPhase creates cfg.FillCount long-running sandboxes and waits for all of
+// runFillPhase creates count long-running sandboxes and waits for all of
 // them to become Ready. These stay running for the rest of the test, so the
 // probe and throughput phases measure performance on a cluster at scale.
-func (s *stressTest) runFillPhase(ctx context.Context, number PhaseNumber) error {
-	count := s.cfg.FillCount
-	if count == 0 {
+// name is the phase's display name (fill or fill-pct:N) and count its
+// resolved size (see fillPhase.Resolve); a fill-pct:N entry resolves to 0
+// when the cluster is already at its target utilization.
+func (s *stressTest) runFillPhase(ctx context.Context, name PhaseName, number PhaseNumber, count int) error {
+	if count <= 0 {
+		log.Printf("[%s#%d] cluster already at target; nothing to create", name, number)
 		return nil
 	}
-	log.Printf("[fill#%d] creating %d background sandboxes (create-concurrency=%d)", number, count, s.cfg.CreateConcurrency)
+	log.Printf("[%s#%d] creating %d background sandboxes (create-concurrency=%d)", name, number, count, s.cfg.CreateConcurrency)
 
 	names := make([]types.NamespacedName, 0, count)
 	for i := range count {
@@ -150,7 +153,7 @@ func (s *stressTest) runFillPhase(ctx context.Context, number PhaseNumber) error
 
 	if _, err := ForkJoin(ctx, names, s.cfg.CreateConcurrency, func(id types.NamespacedName) (struct{}, error) {
 		// Errors are recorded per-sandbox; do not abort the phase.
-		_ = s.createSandbox(ctx, id, PhaseFill, number)
+		_ = s.createSandbox(ctx, id, name, number)
 		return struct{}{}, nil
 	}); err != nil {
 		return err
@@ -163,11 +166,11 @@ func (s *stressTest) runFillPhase(ctx context.Context, number PhaseNumber) error
 	for {
 		counts := s.tracker.Snapshot()[number]
 		if counts.Created == 0 {
-			return fmt.Errorf("[fill#%d] all %d sandbox creations failed", number, counts.Failed)
+			return fmt.Errorf("[%s#%d] all %d sandbox creations failed", name, number, counts.Failed)
 		}
 		if counts.Ready >= counts.Created {
-			log.Printf("[fill#%d] all %d created sandboxes are Ready (%d failed to create)",
-				number, counts.Created, counts.Failed)
+			log.Printf("[%s#%d] all %d created sandboxes are Ready (%d failed to create)",
+				name, number, counts.Created, counts.Failed)
 			return nil
 		}
 		if counts.Ready != lastReady {
@@ -175,7 +178,7 @@ func (s *stressTest) runFillPhase(ctx context.Context, number PhaseNumber) error
 			lastProgress = time.Now()
 		}
 		if time.Since(lastProgress) > s.cfg.PerSandboxTimeout {
-			return fmt.Errorf("[fill#%d] stalled: %d/%d sandboxes Ready with no progress for %v", number, counts.Ready, counts.Created, s.cfg.PerSandboxTimeout)
+			return fmt.Errorf("[%s#%d] stalled: %d/%d sandboxes Ready with no progress for %v", name, number, counts.Ready, counts.Created, s.cfg.PerSandboxTimeout)
 		}
 		select {
 		case <-ctx.Done():
@@ -247,7 +250,7 @@ func (s *stressTest) runProbePhase(ctx context.Context, number PhaseNumber) erro
 // Multiple levels run back-to-back as separate phases (a max-in-flight sweep
 // within a single run): each level fully drains (every pod observed deleted)
 // before the next begins, so levels do not contaminate each other.
-func (s *stressTest) runThroughputLevel(ctx context.Context, name Phase, number PhaseNumber, maxInFlight int) error {
+func (s *stressTest) runThroughputLevel(ctx context.Context, name PhaseName, number PhaseNumber, maxInFlight int) error {
 	count := s.cfg.ThroughputCount
 	if count == 0 {
 		return nil
@@ -405,7 +408,7 @@ func buildClaimObject(id types.NamespacedName, poolName string) *unstructured.Un
 // createClaim registers a record and issues the SandboxClaim Create call via
 // the given (namespace-bound) client. Like createSandbox, Create errors are
 // recorded on the record rather than aborting the phase.
-func (s *stressTest) createClaim(ctx context.Context, claimClient dynamic.ResourceInterface, id types.NamespacedName, poolName string, phase Phase, number PhaseNumber) error {
+func (s *stressTest) createClaim(ctx context.Context, claimClient dynamic.ResourceInterface, id types.NamespacedName, poolName string, phase PhaseName, number PhaseNumber) error {
 	claim := buildClaimObject(id, poolName)
 	s.tracker.RegisterClaim(id, phase, number)
 	_, err := claimClient.Create(ctx, claim, metav1.CreateOptions{})
@@ -421,7 +424,7 @@ func (s *stressTest) createClaim(ctx context.Context, claimClient dynamic.Resour
 // latency against a fully provisioned pool rather than sandbox launch
 // latency. Progress-stall detection mirrors the fill phase: if readyReplicas
 // stops advancing for PerSandboxTimeout, fail.
-func (s *stressTest) waitWarmPoolReady(ctx context.Context, poolClient dynamic.ResourceInterface, phase Phase, poolName string, want int, number PhaseNumber) error {
+func (s *stressTest) waitWarmPoolReady(ctx context.Context, poolClient dynamic.ResourceInterface, phase PhaseName, poolName string, want int, number PhaseNumber) error {
 	lastReady := int64(-1)
 	lastProgress := time.Now()
 	for {
@@ -468,7 +471,7 @@ func (s *stressTest) waitWarmPoolReady(ctx context.Context, poolClient dynamic.R
 // Capacity: the pool itself needs ClaimsWarmCount pod slots, and the pool
 // controller replenishes claimed sandboxes, so up to ~2x ClaimsWarmCount pods
 // can transiently exist during and after the burst. Size the cluster with
-// headroom (see checkClusterCapacity's warning) or throttle replenishment via
+// headroom (see resolvePhases's warning) or throttle replenishment via
 // --sandbox-warm-pool-concurrent-workers.
 func (s *stressTest) runClaimsWarmPhase(ctx context.Context, number PhaseNumber) error {
 	count := s.cfg.ClaimsWarmCount

--- a/test/stress/pprof.go
+++ b/test/stress/pprof.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,12 +52,31 @@ func newAPIServerProfiler(restConfig *rest.Config, outputDir string) (*apiserver
 	return &apiserverProfiler{kube: kube, outputDir: outputDir}, nil
 }
 
+// fileSafePhase flattens a phase name for embedding in artifact filenames:
+// every character outside [a-zA-Z0-9._-] becomes '-'. Phase names may
+// contain ':' (throughput-mif:600), which browsers reject when the report's
+// pprof viewer fetches "pprof-...-mif:600.pprof" as a relative URL (the
+// text before the first ':' parses as a URL scheme), and which Windows
+// filesystems refuse outright. download_results.py mirrors this mapping
+// when it reconstructs profile names from summary.json phase names.
+func fileSafePhase(phase PhaseName) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, string(phase))
+}
+
 // CaptureCPUProfile records one CPU profile of the given duration, starting
 // after delay (to skip a phase's warm-up), and writes it to
 // pprof-apiserver-<phase>.pprof (the standard pprof format: gzip-compressed
 // profile.proto). Synchronous; run it in a goroutine alongside the phase.
 // Analyze with: go tool pprof -top <file>.
-func (p *apiserverProfiler) CaptureCPUProfile(ctx context.Context, phase Phase, delay, duration time.Duration) {
+func (p *apiserverProfiler) CaptureCPUProfile(ctx context.Context, phase PhaseName, delay, duration time.Duration) {
 	select {
 	case <-time.After(delay):
 	case <-ctx.Done():
@@ -77,7 +97,7 @@ func (p *apiserverProfiler) CaptureCPUProfile(ctx context.Context, phase Phase, 
 		return
 	}
 
-	path := filepath.Join(p.outputDir, fmt.Sprintf("pprof-apiserver-%s.pprof", phase))
+	path := filepath.Join(p.outputDir, fmt.Sprintf("pprof-apiserver-%s.pprof", fileSafePhase(phase)))
 	if err := os.WriteFile(path, raw, 0o644); err != nil {
 		log.Printf("[pprof] writing %s: %v", path, err)
 		return
@@ -156,7 +176,7 @@ func (p *controllerProfiler) capture(ctx context.Context, pod, endpoint, outFile
 // alongside the phase so the profile window covers the load being measured
 // (e.g. delay=0 started right as the claims burst fires).
 // Analyze with: go tool pprof -top pprof-controller-<phase>-<pod>.pprof.
-func (p *controllerProfiler) CaptureCPUProfile(ctx context.Context, phase Phase, delay, duration time.Duration) {
+func (p *controllerProfiler) CaptureCPUProfile(ctx context.Context, phase PhaseName, delay, duration time.Duration) {
 	select {
 	case <-time.After(delay):
 	case <-ctx.Done():
@@ -170,7 +190,7 @@ func (p *controllerProfiler) CaptureCPUProfile(ctx context.Context, phase Phase,
 	for _, pod := range p.podNames(ctx) {
 		wg.Go(func() {
 			p.capture(ctx, pod, "profile",
-				fmt.Sprintf("pprof-controller-%s-%s.pprof", phase, pod),
+				fmt.Sprintf("pprof-controller-%s-%s.pprof", fileSafePhase(phase), pod),
 				map[string]string{"seconds": strconv.Itoa(int(duration.Seconds()))})
 		})
 	}
@@ -181,12 +201,12 @@ func (p *controllerProfiler) CaptureCPUProfile(ctx context.Context, phase Phase,
 // (requires --enable-pprof-debug). label distinguishes multiple snapshots
 // within one phase (e.g. burst-start vs burst-end).
 // Analyze with: go tool pprof -top -sample_index=inuse_space <file>.
-func (p *controllerProfiler) CaptureHeapProfile(ctx context.Context, phase Phase, label string) {
+func (p *controllerProfiler) CaptureHeapProfile(ctx context.Context, phase PhaseName, label string) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	for _, pod := range p.podNames(ctx) {
 		p.capture(ctx, pod, "heap",
-			fmt.Sprintf("pprof-controller-heap-%s-%s-%s.pprof", phase, label, pod), nil)
+			fmt.Sprintf("pprof-controller-heap-%s-%s-%s.pprof", fileSafePhase(phase), label, pod), nil)
 	}
 }

--- a/test/stress/sustained.go
+++ b/test/stress/sustained.go
@@ -41,7 +41,7 @@ package main
 //
 // Cluster capacity: peak concurrent pods ~= pool total (kept full by refill)
 // + rate x (ready-latency + dwell + deletion pipeline) adopted-but-not-yet-
-// deleted sandboxes; checkClusterCapacity budgets this.
+// deleted sandboxes; resolvePhases budgets this.
 //
 // --sustained-namespaces=N pre-creates N namespaces (<run-ns>-s1..sN), each
 // with its own template + pool, and spreads arrivals round-robin across them.

--- a/test/stress/sustained_test.go
+++ b/test/stress/sustained_test.go
@@ -135,20 +135,27 @@ func TestSustainedExpectedClaims(t *testing.T) {
 	}
 }
 
-func TestCheckClusterCapacitySustained(t *testing.T) {
+func TestResolvePhasesCapacitySustained(t *testing.T) {
 	base := Config{
-		Phases:                   []string{string(PhaseClaimsWarmSustained)},
 		SustainedRate:            100,
+		SustainedSeconds:         60,
 		SustainedNamespaces:      1,
 		SustainedPoolHeadroom:    10 * time.Second,
 		ClaimDwell:               5 * time.Second,
 		SustainedLifecycleBudget: 5 * time.Second,
 	}
+	check := func(cfg Config, capacity int) error {
+		phases, err := parsePhases([]string{string(PhaseClaimsWarmSustained)}, cfg)
+		if err != nil {
+			t.Fatalf("parsePhases: %v", err)
+		}
+		return resolvePhases(phases, cfg, &ClusterInfo{PodCapacity: capacity})
+	}
 	// pool = ceil(100*10) = 1000, inFlight = ceil(100*(5+5)) = 1000 => 2000.
-	if err := checkClusterCapacity(base, &ClusterInfo{PodCapacity: 2000}); err != nil {
+	if err := check(base, 2000); err != nil {
 		t.Errorf("capacity 2000 should fit needed 2000: %v", err)
 	}
-	if err := checkClusterCapacity(base, &ClusterInfo{PodCapacity: 1999}); err == nil {
+	if err := check(base, 1999); err == nil {
 		t.Error("capacity 1999 should fail for needed 2000")
 	}
 
@@ -156,10 +163,10 @@ func TestCheckClusterCapacitySustained(t *testing.T) {
 	// budget 15s => inFlight = ceil(100*(5+15)) = 2000 => needed 3000.
 	slow := base
 	slow.SustainedLifecycleBudget = 15 * time.Second
-	if err := checkClusterCapacity(slow, &ClusterInfo{PodCapacity: 2000}); err == nil {
+	if err := check(slow, 2000); err == nil {
 		t.Error("capacity 2000 should fail once the lifecycle budget raises needed to 3000")
 	}
-	if err := checkClusterCapacity(slow, &ClusterInfo{PodCapacity: 3000}); err != nil {
+	if err := check(slow, 3000); err != nil {
 		t.Errorf("capacity 3000 should fit needed 3000: %v", err)
 	}
 }

--- a/test/stress/tracker.go
+++ b/test/stress/tracker.go
@@ -26,25 +26,27 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-// Phase identifies which part of the stress test a Sandbox belongs to by name
-// (fill, probe, throughput-mifN). Names may repeat across a run when --phases
-// lists the same entry more than once; PhaseNumber distinguishes those entries.
-type Phase string
+// PhaseName identifies which part of the stress test a Sandbox belongs to by
+// name (fill, probe, throughput-mif:N). Names may repeat across a run when
+// --phases lists the same entry more than once; PhaseNumber distinguishes
+// those entries. The parsed, runnable form of a phase is the Phase interface
+// (see phase.go); the constants below are the phase kind names it recognizes.
+type PhaseName string
 
 const (
 	// PhaseFill sandboxes provide background scale; they run until the test ends.
-	PhaseFill Phase = "fill"
+	PhaseFill PhaseName = "fill"
 	// PhaseProbe sandboxes measure launch latency against the filled cluster.
-	PhaseProbe Phase = "probe"
+	PhaseProbe PhaseName = "probe"
 	// PhaseThroughput sandboxes are churned (create -> ready -> delete) to measure sustained throughput.
-	PhaseThroughput Phase = "throughput"
+	PhaseThroughput PhaseName = "throughput"
 	// PhaseClaimsWarm fires SandboxClaims simultaneously against a fully
 	// provisioned SandboxWarmPool, measuring claim-create -> claim-Ready latency.
-	PhaseClaimsWarm Phase = "claims-warm"
+	PhaseClaimsWarm PhaseName = "claims-warm"
 	// PhaseClaimsWarmSustained streams SandboxClaims at a target rate with
 	// Poisson jitter against continuously replenished warm pools, measuring
 	// whether create -> Ready latency holds over time (see sustained.go).
-	PhaseClaimsWarmSustained Phase = "claims-warm-sustained"
+	PhaseClaimsWarmSustained PhaseName = "claims-warm-sustained"
 )
 
 // PhaseNumber is a 1-based index into the run's phase list (Config.Phases /
@@ -100,7 +102,7 @@ type SandboxRecord struct {
 	// Phase is the phase name for this sandbox (may repeat if --phases lists
 	// the same name more than once). PhaseNumber is the 1-based index of that
 	// run entry and is the key used when aggregating summary stats.
-	Phase       Phase       `json:"phase"`
+	Phase       PhaseName   `json:"phase"`
 	PhaseNumber PhaseNumber `json:"phaseNumber"`
 
 	// Pod identity, for joining against node-side data sources.
@@ -177,7 +179,7 @@ func NewTracker() *Tracker {
 // stamping CreateCalled with the current time.
 // number is the 1-based index of the phase entry in this run; name is that
 // entry's phase name (kept for sandboxes.jsonl readability).
-func (t *Tracker) Register(id types.NamespacedName, name Phase, number PhaseNumber) *SandboxRecord {
+func (t *Tracker) Register(id types.NamespacedName, name PhaseName, number PhaseNumber) *SandboxRecord {
 	rec := &SandboxRecord{
 		Name:         id.Name,
 		Namespace:    id.Namespace,
@@ -195,7 +197,7 @@ func (t *Tracker) Register(id types.NamespacedName, name Phase, number PhaseNumb
 
 // RegisterClaim is Register for a SandboxClaim: the record's milestones are
 // driven by the sandboxclaims watch only (see SandboxRecord.isClaim).
-func (t *Tracker) RegisterClaim(id types.NamespacedName, name Phase, number PhaseNumber) *SandboxRecord {
+func (t *Tracker) RegisterClaim(id types.NamespacedName, name PhaseName, number PhaseNumber) *SandboxRecord {
 	rec := t.Register(id, name, number)
 	t.mu.Lock()
 	rec.isClaim = true
@@ -311,7 +313,7 @@ func (t *Tracker) Records() []SandboxRecord {
 
 // PhaseCounts summarizes progress for one phase entry in the run.
 type PhaseCounts struct {
-	Name       Phase
+	Name       PhaseName
 	Registered int
 	Created    int
 	Ready      int


### PR DESCRIPTION
Refactor the tests so that the periodic tests run at moderate size, and the presubmit tests are a bit cheaper.  We seem to get a lot of signal even at a small number of nodes, we're identifying a lot of problems in upstream kube, and we've found a bunch of issues/configuration settings in our own code also.  We'll continue to find those in the periodic tests (and can probably justify even bigger size in the periodic tests).

Also in our tests add a phase so that we can test lots of pods / behaviour with lots of pods.  `fill` gains the ability to specify `pct:80` (for example) which will fill to 80% of capacity.  Then we can run additional phases, verifying e.g. the throughput we can achieve when at 80% instead of at 10%.

This lets us test at (essentially) 100% capacity - 1000 sandboxes with 10 nodes, 2000 with 20.  We can investigate maxPodsPerNode and ipv6 to see what happens when we go even denser - kOps supports both.  (The one I've not tested personally is swap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated benchmark periodics to run the daily continuous performance scenario directly with an explicit 20-node baseline.
  * Added clearer and more consistent default stress configurations for Cilium and Kindnet, including improved phase sequencing.
  * Enhanced stress phase handling to support `fill-pct` and `throughput-mif:<N>` formats, with richer phase resolution.
* **Bug Fixes**
  * Improved per-phase “requested” reporting accuracy.
  * Sanitized profiling artifact filenames for safe, consistent output.
* **Tests**
  * Added unit tests covering phase parsing, kind detection, resolution behavior, and capacity ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->