### PR TITLE
refactor(api): move enum validation markers from fields to type definitions

### DIFF
--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -21,7 +21,6 @@ import (
 )
 
 // ConditionType is a type of condition for a resource.
-// +kubebuilder:validation:Enum=Suspended;Ready;Finished
 type ConditionType string
 
 func (c ConditionType) String() string { return string(c) }

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -22,6 +22,8 @@ import (
 
 // ConditionType is a type of condition for a resource.
 //
+// +kubebuilder:validation:Enum=Suspended;Ready;Finished
+//
 // Terminology: a Sandbox has two distinct notions that are easy to confuse.
 //   - "running" is a desired state expressed by the user via spec.replicas
 //     (replicas: 1 requests a running Sandbox, replicas: 0 suspends it). It says the

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -22,8 +22,6 @@ import (
 
 // ConditionType is a type of condition for a resource.
 //
-// +kubebuilder:validation:Enum=Suspended;Ready;Finished
-//
 // Terminology: a Sandbox has two distinct notions that are easy to confuse.
 //   - "running" is a desired state expressed by the user via spec.replicas
 //     (replicas: 1 requests a running Sandbox, replicas: 0 suspends it). It says the

--- a/api/v1alpha1/sandbox_types.go
+++ b/api/v1alpha1/sandbox_types.go
@@ -21,6 +21,7 @@ import (
 )
 
 // ConditionType is a type of condition for a resource.
+// +kubebuilder:validation:Enum=Suspended;Ready;Finished
 type ConditionType string
 
 func (c ConditionType) String() string { return string(c) }

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -21,7 +21,6 @@ import (
 )
 
 // ConditionType is a type of condition for a resource.
-// +kubebuilder:validation:Enum=Suspended;Ready;Finished
 type ConditionType string
 
 func (c ConditionType) String() string { return string(c) }

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -21,6 +21,7 @@ import (
 )
 
 // ConditionType is a type of condition for a resource.
+// +kubebuilder:validation:Enum=Suspended;Ready;Finished
 type ConditionType string
 
 func (c ConditionType) String() string { return string(c) }
@@ -145,6 +146,7 @@ type PersistentVolumeClaimTemplate struct {
 }
 
 // SandboxOperatingMode defines the desired operational state of the Sandbox.
+// +kubebuilder:validation:Enum=Running;Suspended
 type SandboxOperatingMode string
 
 const (
@@ -207,7 +209,6 @@ type SandboxSpec struct {
 	// operatingMode specifies the desired operational state of the Sandbox.
 	// Defaults to Running if not specified.
 	// +kubebuilder:default=Running
-	// +kubebuilder:validation:Enum=Running;Suspended
 	// +optional
 	OperatingMode SandboxOperatingMode `json:"operatingMode,omitempty"`
 }

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -22,8 +22,6 @@ import (
 
 // ConditionType is a type of condition for a resource.
 //
-// +kubebuilder:validation:Enum=Suspended;Ready;Finished
-//
 // Terminology: a Sandbox has two distinct notions that are easy to confuse.
 //   - "running" is a desired state expressed by the user via spec.operatingMode
 //     (see SandboxOperatingModeRunning). It says the controller should create and

--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -22,6 +22,8 @@ import (
 
 // ConditionType is a type of condition for a resource.
 //
+// +kubebuilder:validation:Enum=Suspended;Ready;Finished
+//
 // Terminology: a Sandbox has two distinct notions that are easy to confuse.
 //   - "running" is a desired state expressed by the user via spec.operatingMode
 //     (see SandboxOperatingModeRunning). It says the controller should create and
@@ -213,6 +215,8 @@ type PersistentVolumeClaimTemplate struct {
 }
 
 // SandboxOperatingMode defines the desired operational state of the Sandbox.
+// +kubebuilder:validation:Enum=Running;Suspended
+//
 // It expresses intent ("running" vs. "suspended"), not observed status; whether the
 // Sandbox has actually reached that state is reported by conditions (see
 // SandboxConditionReady and SandboxConditionSuspended).
@@ -292,7 +296,6 @@ type SandboxSpec struct {
 	// actually up (see SandboxConditionReady).
 	// Defaults to Running if not specified.
 	// +kubebuilder:default=Running
-	// +kubebuilder:validation:Enum=Running;Suspended
 	// +optional
 	OperatingMode SandboxOperatingMode `json:"operatingMode,omitempty"`
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,7 +346,8 @@ _Underlying type:_ _string_
 
 SandboxOperatingMode defines the desired operational state of the Sandbox.
 
-
+_Validation:_
+- Enum: [Running Suspended]
 
 _Appears in:_
 - [SandboxSpec](#sandboxspec)
@@ -457,7 +458,8 @@ _Underlying type:_ _string_
 
 EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
 
-
+_Validation:_
+- Enum: [Allowed Overrides Disallowed]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -494,7 +496,8 @@ _Underlying type:_ _string_
 NetworkPolicyManagement defines whether the controller automatically generates
 and manages a shared NetworkPolicy for this template.
 
-
+_Validation:_
+- Enum: [Managed Unmanaged]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -825,7 +828,8 @@ _Underlying type:_ _string_
 
 EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
 
-
+_Validation:_
+- Enum: [Allowed Overrides Disallowed]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -862,7 +866,8 @@ _Underlying type:_ _string_
 NetworkPolicyManagement defines whether the controller automatically generates
 and manages a shared NetworkPolicy for this template.
 
-
+_Validation:_
+- Enum: [Managed Unmanaged]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -1156,7 +1161,8 @@ _Underlying type:_ _string_
 
 VolumeClaimTemplatesPolicy defines whether a SandboxClaim is allowed to inject or override volume claim templates.
 
-
+_Validation:_
+- Enum: [Disallowed Allowed Overrides]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)

--- a/docs/api.md
+++ b/docs/api.md
@@ -349,7 +349,8 @@ It expresses intent ("running" vs. "suspended"), not observed status; whether th
 Sandbox has actually reached that state is reported by conditions (see
 SandboxConditionReady and SandboxConditionSuspended).
 
-
+_Validation:_
+- Enum: [Running Suspended]
 
 _Appears in:_
 - [SandboxSpec](#sandboxspec)
@@ -460,7 +461,8 @@ _Underlying type:_ _string_
 
 EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
 
-
+_Validation:_
+- Enum: [Allowed Overrides Disallowed]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -497,7 +499,8 @@ _Underlying type:_ _string_
 NetworkPolicyManagement defines whether the controller automatically generates
 and manages a shared NetworkPolicy for this template.
 
-
+_Validation:_
+- Enum: [Managed Unmanaged]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -828,7 +831,8 @@ _Underlying type:_ _string_
 
 EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
 
-
+_Validation:_
+- Enum: [Allowed Overrides Disallowed]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -865,7 +869,8 @@ _Underlying type:_ _string_
 NetworkPolicyManagement defines whether the controller automatically generates
 and manages a shared NetworkPolicy for this template.
 
-
+_Validation:_
+- Enum: [Managed Unmanaged]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)
@@ -1160,7 +1165,8 @@ _Underlying type:_ _string_
 
 VolumeClaimTemplatesPolicy defines whether a SandboxClaim is allowed to inject or override volume claim templates.
 
-
+_Validation:_
+- Enum: [Disallowed Allowed Overrides]
 
 _Appears in:_
 - [SandboxTemplateSpec](#sandboxtemplatespec)

--- a/docs/api.md
+++ b/docs/api.md
@@ -345,6 +345,7 @@ _Appears in:_
 _Underlying type:_ _string_
 
 SandboxOperatingMode defines the desired operational state of the Sandbox.
+
 It expresses intent ("running" vs. "suspended"), not observed status; whether the
 Sandbox has actually reached that state is reported by conditions (see
 SandboxConditionReady and SandboxConditionSuspended).

--- a/extensions/api/v1alpha1/sandboxtemplate_types.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_types.go
@@ -26,9 +26,11 @@ import (
 
 // NetworkPolicyManagement defines whether the controller automatically generates
 // and manages a shared NetworkPolicy for this template.
+// +kubebuilder:validation:Enum=Managed;Unmanaged
 type NetworkPolicyManagement string
 
 // EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
+// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 type EnvVarsInjectionPolicy string
 
 const (
@@ -116,14 +118,12 @@ type SandboxTemplateSpec struct {
 
 	// networkPolicyManagement defines whether the controller manages the NetworkPolicy.
 	// Valid values are "Managed" (default) or "Unmanaged".
-	// +kubebuilder:validation:Enum=Managed;Unmanaged
 	// +kubebuilder:default=Managed
 	// +optional
 	NetworkPolicyManagement NetworkPolicyManagement `json:"networkPolicyManagement,omitempty"`
 
 	// envVarsInjectionPolicy allows a SandboxClaim to inject or override environment variables defined in the template.
 	// If set to Disallowed, the SandboxClaim will be rejected if it specifies any environment variables.
-	// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 	// +kubebuilder:default=Disallowed
 	// +optional
 	EnvVarsInjectionPolicy EnvVarsInjectionPolicy `json:"envVarsInjectionPolicy,omitempty"`

--- a/extensions/api/v1alpha1/sandboxtemplate_types.go
+++ b/extensions/api/v1alpha1/sandboxtemplate_types.go
@@ -26,9 +26,11 @@ import (
 
 // NetworkPolicyManagement defines whether the controller automatically generates
 // and manages a shared NetworkPolicy for this template.
+// +kubebuilder:validation:Enum=Managed;Unmanaged
 type NetworkPolicyManagement string
 
 // EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
+// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 type EnvVarsInjectionPolicy string
 
 const (
@@ -116,7 +118,6 @@ type SandboxTemplateSpec struct {
 
 	// networkPolicyManagement defines whether the controller manages the NetworkPolicy.
 	// Valid values are "Managed" (default) or "Unmanaged".
-	// +kubebuilder:validation:Enum=Managed;Unmanaged
 	// +kubebuilder:default=Managed
 	// +optional
 	NetworkPolicyManagement NetworkPolicyManagement `json:"networkPolicyManagement,omitempty"`
@@ -134,7 +135,6 @@ type SandboxTemplateSpec struct {
 	// (Allowed or Overrides) only takes effect on a per-claim basis: any claim that actually
 	// sets spec.env is forced to cold-start a fresh Sandbox and cannot adopt a warm pool
 	// Sandbox. Claims that set no environment variables still use the warm pool normally.
-	// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 	// +kubebuilder:default=Disallowed
 	// +optional
 	EnvVarsInjectionPolicy EnvVarsInjectionPolicy `json:"envVarsInjectionPolicy,omitempty"`

--- a/extensions/api/v1beta1/sandboxtemplate_types.go
+++ b/extensions/api/v1beta1/sandboxtemplate_types.go
@@ -26,9 +26,11 @@ import (
 
 // NetworkPolicyManagement defines whether the controller automatically generates
 // and manages a shared NetworkPolicy for this template.
+// +kubebuilder:validation:Enum=Managed;Unmanaged
 type NetworkPolicyManagement string
 
 // EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
+// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 type EnvVarsInjectionPolicy string
 
 const (
@@ -57,6 +59,7 @@ const (
 )
 
 // VolumeClaimTemplatesPolicy defines whether a SandboxClaim is allowed to inject or override volume claim templates.
+// +kubebuilder:validation:Enum=Disallowed;Allowed;Overrides
 type VolumeClaimTemplatesPolicy string
 
 const (
@@ -120,21 +123,18 @@ type SandboxTemplateSpec struct {
 
 	// networkPolicyManagement defines whether the controller manages the NetworkPolicy.
 	// Valid values are "Managed" (default) or "Unmanaged".
-	// +kubebuilder:validation:Enum=Managed;Unmanaged
 	// +kubebuilder:default=Managed
 	// +optional
 	NetworkPolicyManagement NetworkPolicyManagement `json:"networkPolicyManagement,omitempty"`
 
 	// envVarsInjectionPolicy allows a SandboxClaim to inject or override environment variables defined in the template.
 	// If set to Disallowed, the SandboxClaim will be rejected if it specifies any environment variables.
-	// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 	// +kubebuilder:default=Disallowed
 	// +optional
 	EnvVarsInjectionPolicy EnvVarsInjectionPolicy `json:"envVarsInjectionPolicy,omitempty"`
 
 	// volumeClaimTemplatesPolicy allows a SandboxClaim to inject or override volume claim templates defined in the template.
 	// If set to Disallowed, the SandboxClaim will be rejected if it specifies any volume claim templates.
-	// +kubebuilder:validation:Enum=Disallowed;Allowed;Overrides
 	// +kubebuilder:default=Disallowed
 	// +optional
 	VolumeClaimTemplatesPolicy VolumeClaimTemplatesPolicy `json:"volumeClaimTemplatesPolicy,omitempty"`

--- a/extensions/api/v1beta1/sandboxtemplate_types.go
+++ b/extensions/api/v1beta1/sandboxtemplate_types.go
@@ -26,9 +26,11 @@ import (
 
 // NetworkPolicyManagement defines whether the controller automatically generates
 // and manages a shared NetworkPolicy for this template.
+// +kubebuilder:validation:Enum=Managed;Unmanaged
 type NetworkPolicyManagement string
 
 // EnvVarsInjectionPolicy defines whether a SandboxClaim is allowed to inject or override environment variables.
+// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 type EnvVarsInjectionPolicy string
 
 const (
@@ -57,6 +59,7 @@ const (
 )
 
 // VolumeClaimTemplatesPolicy defines whether a SandboxClaim is allowed to inject or override volume claim templates.
+// +kubebuilder:validation:Enum=Disallowed;Allowed;Overrides
 type VolumeClaimTemplatesPolicy string
 
 const (
@@ -120,7 +123,6 @@ type SandboxTemplateSpec struct {
 
 	// networkPolicyManagement defines whether the controller manages the NetworkPolicy.
 	// Valid values are "Managed" (default) or "Unmanaged".
-	// +kubebuilder:validation:Enum=Managed;Unmanaged
 	// +kubebuilder:default=Managed
 	// +optional
 	NetworkPolicyManagement NetworkPolicyManagement `json:"networkPolicyManagement,omitempty"`
@@ -138,14 +140,12 @@ type SandboxTemplateSpec struct {
 	// (Allowed or Overrides) only takes effect on a per-claim basis: any claim that actually
 	// sets spec.env is forced to cold-start a fresh Sandbox and cannot adopt a warm pool
 	// Sandbox. Claims that set no environment variables still use the warm pool normally.
-	// +kubebuilder:validation:Enum=Allowed;Overrides;Disallowed
 	// +kubebuilder:default=Disallowed
 	// +optional
 	EnvVarsInjectionPolicy EnvVarsInjectionPolicy `json:"envVarsInjectionPolicy,omitempty"`
 
 	// volumeClaimTemplatesPolicy allows a SandboxClaim to inject or override volume claim templates defined in the template.
 	// If set to Disallowed, the SandboxClaim will be rejected if it specifies any volume claim templates.
-	// +kubebuilder:validation:Enum=Disallowed;Allowed;Overrides
 	// +kubebuilder:default=Disallowed
 	// +optional
 	VolumeClaimTemplatesPolicy VolumeClaimTemplatesPolicy `json:"volumeClaimTemplatesPolicy,omitempty"`


### PR DESCRIPTION
#### What this PR does / why we need it:

Move `+kubebuilder:validation:Enum` markers from individual struct fields to the underlying type definitions, so enum validation is centralized at the type level rather than duplicated at each field usage.

This change:
- Moves enum markers to type definitions for `SandboxOperatingMode`, `NetworkPolicyManagement`, `EnvVarsInjectionPolicy`, and `VolumeClaimTemplatesPolicy`
- Adds previously missing enum validations for `ConditionType` (`Suspended;Ready;Finished`)
- Regenerates CRD manifests (`helm/crds`, `k8s/crds`, `olm/config/crd/bases`) and API docs (`docs/api.md`) to reflect the new enum constraints

Centralizing enum validation at the type level reduces redundancy, ensures consistency across all fields using these types, and catches invalid values at the CRD schema level.

#### Which issue(s) this PR is related to:

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API validation for sandbox configuration values.
  * Invalid operating modes, network policies, environment variable policies, and volume claim policies are now rejected consistently across supported API versions.
  * Existing defaults and optional settings remain unchanged.

* **Documentation**
  * Updated API reference documentation to clearly list all permitted values for supported configuration options.
  * Documented valid operating modes, network policies, environment variable policies, and volume claim policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->