### PR TITLE
fix(build): add missing fix-api-docs Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ all: fix-go-generate fix-api-docs build lint-go lint-api test-unit toc-verify ve
 fix-go-generate:
 	dev/tools/fix-go-generate
 
+.PHONY: fix-api-docs
+fix-api-docs:
+	dev/tools/fix-api-docs
+
 .PHONY: install-gen-tools
 install-gen-tools:
 	dev/tools/fix-go-generate --install-only


### PR DESCRIPTION
#### What this PR does / why we need it:

The `all` target in the Makefile depends on `fix-api-docs`, but no rule was defined for it, causing `make` to fail with:

```
make: *** No rule to make target `fix-api-docs', needed by `all'.  Stop.
```

This PR adds the missing `.PHONY: fix-api-docs` target that delegates to the existing `dev/tools/fix-api-docs` script, matching the pattern used by the adjacent `fix-go-generate` target.

#### Which issue(s) this PR is related to:

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an automated API documentation cleanup step to the standard build workflow.
  * The aggregate build command now includes API documentation fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->