### PR TITLE
feat(warmpool): configurable readiness grace period and unschedulable re-check interval

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -74,6 +74,8 @@ func main() {
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
 	var sandboxWarmPoolMaxBatchSize int
+	var sandboxWarmPoolReadinessGracePeriod time.Duration
+	var sandboxWarmPoolUnschedulableRecheckInterval time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -122,6 +124,8 @@ func main() {
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300. Creates advance one observed batch per watch round-trip (the expectations gate waits for a batch's add events before issuing the next), so a large pool fills in about ceil(replicas/batchSize) round-trips; raising this trades round-trips for burst size and is safe at any value under the gate.")
+	flag.DurationVar(&sandboxWarmPoolReadinessGracePeriod, "sandbox-warm-pool-readiness-grace-period", extensionscontrollers.DefaultWarmPoolReadinessGracePeriod, "How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be greater than 0.")
+	flag.DurationVar(&sandboxWarmPoolUnschedulableRecheckInterval, "sandbox-warm-pool-unschedulable-recheck-interval", extensionscontrollers.DefaultUnschedulableRecheckInterval, "Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be greater than 0.")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
 	flag.BoolVar(&cacheLabelSelectors, "cache-label-selectors", false,
 		"Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label ("+
@@ -150,6 +154,14 @@ func main() {
 	}
 	if strings.TrimSpace(webhookKeyName) == "" {
 		setupLog.Error(nil, "--webhook-key-name cannot be empty")
+		os.Exit(1)
+	}
+	if sandboxWarmPoolReadinessGracePeriod <= 0 {
+		setupLog.Error(nil, "--sandbox-warm-pool-readiness-grace-period must be greater than 0", "value", sandboxWarmPoolReadinessGracePeriod)
+		os.Exit(1)
+	}
+	if sandboxWarmPoolUnschedulableRecheckInterval <= 0 {
+		setupLog.Error(nil, "--sandbox-warm-pool-unschedulable-recheck-interval must be greater than 0", "value", sandboxWarmPoolUnschedulableRecheckInterval)
 		os.Exit(1)
 	}
 
@@ -426,11 +438,13 @@ func main() {
 		}
 
 		if err = (&extensionscontrollers.SandboxWarmPoolReconciler{
-			Client:                 mgr.GetClient(),
-			Scheme:                 mgr.GetScheme(),
-			MaxBatchSize:           sandboxWarmPoolMaxBatchSize,
-			EnableWarmPoolEviction: enableWarmPoolEviction,
-			Recorder:               mgr.GetEventRecorder("sandboxwarmpool-controller"),
+			Client:                       mgr.GetClient(),
+			Scheme:                       mgr.GetScheme(),
+			MaxBatchSize:                 sandboxWarmPoolMaxBatchSize,
+			EnableWarmPoolEviction:       enableWarmPoolEviction,
+			ReadinessGracePeriod:         sandboxWarmPoolReadinessGracePeriod,
+			UnschedulableRecheckInterval: sandboxWarmPoolUnschedulableRecheckInterval,
+			Recorder:                     mgr.GetEventRecorder("sandboxwarmpool-controller"),
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")
 			os.Exit(1)

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -82,6 +82,8 @@ func main() {
 	var sandboxWarmPoolReplenishDelay time.Duration
 	var sandboxWarmPoolMaxRefillRate float64
 	var sandboxWriteBehindWindow time.Duration
+	var sandboxWarmPoolReadinessGracePeriod time.Duration
+	var sandboxWarmPoolUnschedulableRecheckInterval time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -154,6 +156,8 @@ func main() {
 			"pacing refill into a smooth stream instead of full-deficit bursts that flood the write path and compete with claim adoption. "+
 			"Composes with --sandbox-warm-pool-replenish-delay: the delay defers the start of refill, the rate shapes its flow. "+
 			"0 (default) leaves refill unpaced (whole deficit per reconcile).")
+	flag.DurationVar(&sandboxWarmPoolReadinessGracePeriod, "sandbox-warm-pool-readiness-grace-period", extensionscontrollers.DefaultWarmPoolReadinessGracePeriod, "How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be greater than 0.")
+	flag.DurationVar(&sandboxWarmPoolUnschedulableRecheckInterval, "sandbox-warm-pool-unschedulable-recheck-interval", extensionscontrollers.DefaultUnschedulableRecheckInterval, "Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be greater than 0.")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
 	flag.BoolVar(&cacheLabelSelectors, "cache-label-selectors", false,
 		"Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label ("+
@@ -193,6 +197,14 @@ func main() {
 	}
 	if strings.TrimSpace(webhookKeyName) == "" {
 		setupLog.Error(nil, "--webhook-key-name cannot be empty")
+		os.Exit(1)
+	}
+	if sandboxWarmPoolReadinessGracePeriod <= 0 {
+		setupLog.Error(nil, "--sandbox-warm-pool-readiness-grace-period must be greater than 0", "value", sandboxWarmPoolReadinessGracePeriod)
+		os.Exit(1)
+	}
+	if sandboxWarmPoolUnschedulableRecheckInterval <= 0 {
+		setupLog.Error(nil, "--sandbox-warm-pool-unschedulable-recheck-interval must be greater than 0", "value", sandboxWarmPoolUnschedulableRecheckInterval)
 		os.Exit(1)
 	}
 
@@ -552,13 +564,15 @@ func main() {
 		}
 
 		if err = (&extensionscontrollers.SandboxWarmPoolReconciler{
-			Client:                 mgr.GetClient(),
-			Scheme:                 mgr.GetScheme(),
-			MaxBatchSize:           sandboxWarmPoolMaxBatchSize,
-			EnableWarmPoolEviction: enableWarmPoolEviction,
-			Recorder:               mgr.GetEventRecorder("sandboxwarmpool-controller"),
-			ReplenishDelay:         sandboxWarmPoolReplenishDelay,
-			MaxRefillRate:          sandboxWarmPoolMaxRefillRate,
+			Client:                       mgr.GetClient(),
+			Scheme:                       mgr.GetScheme(),
+			MaxBatchSize:                 sandboxWarmPoolMaxBatchSize,
+			EnableWarmPoolEviction:       enableWarmPoolEviction,
+			Recorder:                     mgr.GetEventRecorder("sandboxwarmpool-controller"),
+			ReplenishDelay:               sandboxWarmPoolReplenishDelay,
+			MaxRefillRate:                sandboxWarmPoolMaxRefillRate,
+			ReadinessGracePeriod:         sandboxWarmPoolReadinessGracePeriod,
+			UnschedulableRecheckInterval: sandboxWarmPoolUnschedulableRecheckInterval,
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")
 			os.Exit(1)

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -156,8 +156,8 @@ func main() {
 			"pacing refill into a smooth stream instead of full-deficit bursts that flood the write path and compete with claim adoption. "+
 			"Composes with --sandbox-warm-pool-replenish-delay: the delay defers the start of refill, the rate shapes its flow. "+
 			"0 (default) leaves refill unpaced (whole deficit per reconcile).")
-	flag.DurationVar(&sandboxWarmPoolReadinessGracePeriod, "sandbox-warm-pool-readiness-grace-period", extensionscontrollers.DefaultWarmPoolReadinessGracePeriod, "How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be greater than 0.")
-	flag.DurationVar(&sandboxWarmPoolUnschedulableRecheckInterval, "sandbox-warm-pool-unschedulable-recheck-interval", extensionscontrollers.DefaultUnschedulableRecheckInterval, "Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be greater than 0.")
+	flag.DurationVar(&sandboxWarmPoolReadinessGracePeriod, "sandbox-warm-pool-readiness-grace-period", extensionscontrollers.DefaultWarmPoolReadinessGracePeriod, "How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be a positive duration.")
+	flag.DurationVar(&sandboxWarmPoolUnschedulableRecheckInterval, "sandbox-warm-pool-unschedulable-recheck-interval", extensionscontrollers.DefaultUnschedulableRecheckInterval, "Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be a positive duration.")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
 	flag.BoolVar(&cacheLabelSelectors, "cache-label-selectors", false,
 		"Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label ("+
@@ -200,11 +200,11 @@ func main() {
 		os.Exit(1)
 	}
 	if sandboxWarmPoolReadinessGracePeriod <= 0 {
-		setupLog.Error(nil, "--sandbox-warm-pool-readiness-grace-period must be greater than 0", "value", sandboxWarmPoolReadinessGracePeriod)
+		setupLog.Error(nil, "--sandbox-warm-pool-readiness-grace-period must be a positive duration", "value", sandboxWarmPoolReadinessGracePeriod)
 		os.Exit(1)
 	}
 	if sandboxWarmPoolUnschedulableRecheckInterval <= 0 {
-		setupLog.Error(nil, "--sandbox-warm-pool-unschedulable-recheck-interval must be greater than 0", "value", sandboxWarmPoolUnschedulableRecheckInterval)
+		setupLog.Error(nil, "--sandbox-warm-pool-unschedulable-recheck-interval must be a positive duration", "value", sandboxWarmPoolUnschedulableRecheckInterval)
 		os.Exit(1)
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,8 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 * `--sandbox-claim-concurrent-workers` (default: 50): The maximum number of concurrent reconciles for the SandboxClaim controller.
 * `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller.
 * `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch.
+* `--sandbox-warm-pool-readiness-grace-period` (default: `5m`): How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be greater than 0.
+* `--sandbox-warm-pool-unschedulable-recheck-interval` (default: `1m`): Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be greater than 0.
 * `--kube-api-qps` (default: -1, no client-side rate limiting): Client-side QPS limit for the Kubernetes API client.
 * `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,8 +8,8 @@ The `agent-sandbox-controller` supports several command-line flags to tune perfo
 * `--sandbox-claim-concurrent-workers` (default: 50): The maximum number of concurrent reconciles for the SandboxClaim controller.
 * `--sandbox-warm-pool-concurrent-workers` (default: 1): The maximum number of concurrent reconciles for the SandboxWarmPool controller.
 * `--sandbox-warm-pool-max-batch-size` (default: 300): The maximum number of sandboxes the SandboxWarmPool controller will create/delete in a single batch.
-* `--sandbox-warm-pool-readiness-grace-period` (default: `5m`): How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be greater than 0.
-* `--sandbox-warm-pool-unschedulable-recheck-interval` (default: `1m`): Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be greater than 0.
+* `--sandbox-warm-pool-readiness-grace-period` (default: `5m`): How long a warm pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (or holds it, if its pod is unschedulable). Raise this for images with long initialization or clusters with slow node auto-provisioning. Must be a positive duration.
+* `--sandbox-warm-pool-unschedulable-recheck-interval` (default: `1m`): Requeue interval at which the SandboxWarmPool controller re-checks a pool holding unschedulable sandboxes past the readiness grace period. Must be a positive duration.
 * `--kube-api-qps` (default: -1, no client-side rate limiting): Client-side QPS limit for the Kubernetes API client.
 * `--kube-api-burst` (default: 10): The maximum burst for client-side throttling of the Kubernetes API client.
 

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -61,9 +61,10 @@ const (
 	// of O(sandboxes-in-namespace).
 	sandboxWarmPoolLabelIndex = ".metadata.labels[" + warmPoolSandboxLabel + "]"
 
-	// warmPoolReadinessGracePeriod is how long a pool sandbox may stay
-	// non-Ready before the reconciler considers it stuck and replaces it.
-	warmPoolReadinessGracePeriod = 5 * time.Minute
+	// DefaultWarmPoolReadinessGracePeriod is how long a pool sandbox may stay
+	// non-Ready before the reconciler considers it stuck and replaces it,
+	// unless overridden via SandboxWarmPoolReconciler.ReadinessGracePeriod.
+	DefaultWarmPoolReadinessGracePeriod = 5 * time.Minute
 
 	// expectationsPendingRequeueDelay is the fallback requeue used when create
 	// or delete work is skipped because previously issued writes have not been
@@ -71,9 +72,11 @@ const (
 	// pool much sooner; this only guards against lost events.
 	expectationsPendingRequeueDelay = 30 * time.Second
 
-	// unschedulableRequeueDelay is the rate-limited retry interval for a pool
-	// holding unschedulable sandboxes instead of churning delete/create (#1215).
-	unschedulableRequeueDelay = time.Minute
+	// DefaultUnschedulableRecheckInterval is the rate-limited retry interval
+	// for a pool holding unschedulable sandboxes instead of churning
+	// delete/create (#1215), unless overridden via
+	// SandboxWarmPoolReconciler.UnschedulableRecheckInterval.
+	DefaultUnschedulableRecheckInterval = time.Minute
 
 	// graceRequeueSlack pads the self-scheduled post-grace requeue so the
 	// re-evaluation lands strictly after the deadline despite clock jitter.
@@ -103,6 +106,14 @@ type SandboxWarmPoolReconciler struct {
 	Scheme                 *runtime.Scheme
 	MaxBatchSize           int
 	EnableWarmPoolEviction bool
+	// ReadinessGracePeriod is how long a pool sandbox may stay non-Ready
+	// before it is considered stuck (delete-and-replace, or held if its pod
+	// is unschedulable). Zero means DefaultWarmPoolReadinessGracePeriod.
+	ReadinessGracePeriod time.Duration
+	// UnschedulableRecheckInterval is the requeue interval while a pool holds
+	// unschedulable sandboxes past the readiness grace period. Zero means
+	// DefaultUnschedulableRecheckInterval.
+	UnschedulableRecheckInterval time.Duration
 	// Recorder emits pool-level Events (e.g. WarmPoolNotProgressing). May be
 	// nil (tests); all uses are nil-guarded.
 	Recorder events.EventRecorder
@@ -362,6 +373,24 @@ func (r *SandboxWarmPoolReconciler) clockNow() time.Time {
 	return time.Now()
 }
 
+// readinessGracePeriod returns the configured readiness grace period, falling
+// back to the default for zero-value construction (tests, bare literals).
+func (r *SandboxWarmPoolReconciler) readinessGracePeriod() time.Duration {
+	if r.ReadinessGracePeriod > 0 {
+		return r.ReadinessGracePeriod
+	}
+	return DefaultWarmPoolReadinessGracePeriod
+}
+
+// unschedulableRecheckInterval returns the configured unschedulable-hold
+// requeue interval, falling back to the default for zero-value construction.
+func (r *SandboxWarmPoolReconciler) unschedulableRecheckInterval() time.Duration {
+	if r.UnschedulableRecheckInterval > 0 {
+		return r.UnschedulableRecheckInterval
+	}
+	return DefaultUnschedulableRecheckInterval
+}
+
 // exp returns the reconciler's expectations tracker.
 //
 // In production the tracker is initialized before any reconcile runs:
@@ -489,7 +518,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	for _, sb := range activeSandboxes {
 		if !isSandboxReady(&sb) && !sb.CreationTimestamp.IsZero() {
 			age := now.Sub(sb.CreationTimestamp.Time)
-			if age <= warmPoolReadinessGracePeriod {
+			if age <= r.readinessGracePeriod() {
 				// Not Ready but still within the grace period. In a quiet
 				// cluster nothing else touches the Sandbox objects of a pool
 				// that settles at Ready=False (pod FailedScheduling events do
@@ -499,7 +528,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 				// unschedulable-hold/NotProgressing signal unreachable.
 				// Requeue for the earliest grace deadline so the evaluation
 				// is deterministic.
-				if remaining := warmPoolReadinessGracePeriod - age + graceRequeueSlack; nextGraceDeadline == 0 || remaining < nextGraceDeadline {
+				if remaining := r.readinessGracePeriod() - age + graceRequeueSlack; nextGraceDeadline == 0 || remaining < nextGraceDeadline {
 					nextGraceDeadline = remaining
 				}
 				healthySandboxes = append(healthySandboxes, sb)
@@ -739,8 +768,8 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	if unschedulableReplicas > 0 {
 		r.setNotProgressing(warmPool, poolKey, true, fmt.Sprintf(
 			"%d/%d sandboxes are unschedulable past the %s readiness grace period; holding them instead of replacing (replacements would be equally unschedulable)",
-			unschedulableReplicas, desiredReplicas, warmPoolReadinessGracePeriod))
-		requeueAfter = minNonZeroDuration(requeueAfter, unschedulableRequeueDelay)
+			unschedulableReplicas, desiredReplicas, r.readinessGracePeriod()))
+		requeueAfter = minNonZeroDuration(requeueAfter, r.unschedulableRecheckInterval())
 	} else {
 		r.setNotProgressing(warmPool, poolKey, false, "")
 	}

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -60,9 +60,10 @@ const (
 	// of O(sandboxes-in-namespace).
 	sandboxWarmPoolLabelIndex = ".metadata.labels[" + warmPoolSandboxLabel + "]"
 
-	// warmPoolReadinessGracePeriod is how long a pool sandbox may stay
-	// non-Ready before the reconciler considers it stuck and replaces it.
-	warmPoolReadinessGracePeriod = 5 * time.Minute
+	// DefaultWarmPoolReadinessGracePeriod is how long a pool sandbox may stay
+	// non-Ready before the reconciler considers it stuck and replaces it,
+	// unless overridden via SandboxWarmPoolReconciler.ReadinessGracePeriod.
+	DefaultWarmPoolReadinessGracePeriod = 5 * time.Minute
 
 	// expectationsPendingRequeueDelay is the fallback requeue used when create
 	// or delete work is skipped because previously issued writes have not been
@@ -70,9 +71,11 @@ const (
 	// pool much sooner; this only guards against lost events.
 	expectationsPendingRequeueDelay = 30 * time.Second
 
-	// unschedulableRequeueDelay is the rate-limited retry interval for a pool
-	// holding unschedulable sandboxes instead of churning delete/create (#1215).
-	unschedulableRequeueDelay = time.Minute
+	// DefaultUnschedulableRecheckInterval is the rate-limited retry interval
+	// for a pool holding unschedulable sandboxes instead of churning
+	// delete/create (#1215), unless overridden via
+	// SandboxWarmPoolReconciler.UnschedulableRecheckInterval.
+	DefaultUnschedulableRecheckInterval = time.Minute
 
 	// graceRequeueSlack pads the self-scheduled post-grace requeue so the
 	// re-evaluation lands strictly after the deadline despite clock jitter.
@@ -102,6 +105,14 @@ type SandboxWarmPoolReconciler struct {
 	Scheme                 *runtime.Scheme
 	MaxBatchSize           int
 	EnableWarmPoolEviction bool
+	// ReadinessGracePeriod is how long a pool sandbox may stay non-Ready
+	// before it is considered stuck (delete-and-replace, or held if its pod
+	// is unschedulable). Zero means DefaultWarmPoolReadinessGracePeriod.
+	ReadinessGracePeriod time.Duration
+	// UnschedulableRecheckInterval is the requeue interval while a pool holds
+	// unschedulable sandboxes past the readiness grace period. Zero means
+	// DefaultUnschedulableRecheckInterval.
+	UnschedulableRecheckInterval time.Duration
 	// Recorder emits pool-level Events (e.g. WarmPoolNotProgressing). May be
 	// nil (tests); all uses are nil-guarded.
 	Recorder events.EventRecorder
@@ -128,6 +139,24 @@ func (r *SandboxWarmPoolReconciler) clockNow() time.Time {
 		return r.now()
 	}
 	return time.Now()
+}
+
+// readinessGracePeriod returns the configured readiness grace period, falling
+// back to the default for zero-value construction (tests, bare literals).
+func (r *SandboxWarmPoolReconciler) readinessGracePeriod() time.Duration {
+	if r.ReadinessGracePeriod > 0 {
+		return r.ReadinessGracePeriod
+	}
+	return DefaultWarmPoolReadinessGracePeriod
+}
+
+// unschedulableRecheckInterval returns the configured unschedulable-hold
+// requeue interval, falling back to the default for zero-value construction.
+func (r *SandboxWarmPoolReconciler) unschedulableRecheckInterval() time.Duration {
+	if r.UnschedulableRecheckInterval > 0 {
+		return r.UnschedulableRecheckInterval
+	}
+	return DefaultUnschedulableRecheckInterval
 }
 
 // exp returns the reconciler's expectations tracker.
@@ -256,7 +285,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	for _, sb := range activeSandboxes {
 		if !isSandboxReady(&sb) && !sb.CreationTimestamp.IsZero() {
 			age := now.Sub(sb.CreationTimestamp.Time)
-			if age <= warmPoolReadinessGracePeriod {
+			if age <= r.readinessGracePeriod() {
 				// Not Ready but still within the grace period. In a quiet
 				// cluster nothing else touches the Sandbox objects of a pool
 				// that settles at Ready=False (pod FailedScheduling events do
@@ -266,7 +295,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 				// unschedulable-hold/NotProgressing signal unreachable.
 				// Requeue for the earliest grace deadline so the evaluation
 				// is deterministic.
-				if remaining := warmPoolReadinessGracePeriod - age + graceRequeueSlack; nextGraceDeadline == 0 || remaining < nextGraceDeadline {
+				if remaining := r.readinessGracePeriod() - age + graceRequeueSlack; nextGraceDeadline == 0 || remaining < nextGraceDeadline {
 					nextGraceDeadline = remaining
 				}
 				healthySandboxes = append(healthySandboxes, sb)
@@ -448,8 +477,8 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	if unschedulableReplicas > 0 {
 		r.setNotProgressing(warmPool, poolKey, true, fmt.Sprintf(
 			"%d/%d sandboxes are unschedulable past the %s readiness grace period; holding them instead of replacing (replacements would be equally unschedulable)",
-			unschedulableReplicas, desiredReplicas, warmPoolReadinessGracePeriod))
-		requeueAfter = minNonZeroDuration(requeueAfter, unschedulableRequeueDelay)
+			unschedulableReplicas, desiredReplicas, r.readinessGracePeriod()))
+		requeueAfter = minNonZeroDuration(requeueAfter, r.unschedulableRecheckInterval())
 	} else {
 		r.setNotProgressing(warmPool, poolKey, false, "")
 	}

--- a/extensions/controllers/sandboxwarmpool_overcreation_test.go
+++ b/extensions/controllers/sandboxwarmpool_overcreation_test.go
@@ -376,7 +376,7 @@ func TestReconcilePool_UnschedulableStuckGC(t *testing.T) {
 		got := &sandboxv1beta1.Sandbox{}
 		require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: sb.Name}, got))
 		require.Equal(t, 0, lc.createCount(), "no replacement may be created for an unschedulable sandbox")
-		require.Equal(t, unschedulableRequeueDelay, requeueAfter)
+		require.Equal(t, DefaultUnschedulableRecheckInterval, requeueAfter)
 		// It still counts as a (non-ready) replica.
 		require.Equal(t, replicas, warmPool.Status.Replicas)
 		require.Equal(t, int32(0), warmPool.Status.ReadyReplicas)
@@ -662,14 +662,14 @@ func TestReconcilePool_YoungNotReadyArmsGraceRequeue(t *testing.T) {
 	require.NoError(t, err)
 	// Earliest deadline wins: the 4-minute-old sandbox has 1 minute of grace
 	// left. The fake clock makes this exact.
-	require.Equal(t, warmPoolReadinessGracePeriod-4*time.Minute+graceRequeueSlack, requeueAfter,
+	require.Equal(t, DefaultWarmPoolReadinessGracePeriod-4*time.Minute+graceRequeueSlack, requeueAfter,
 		"requeue must target the earliest remaining grace deadline")
 
 	// With the default jitter factor, the requeue is spread inside
 	// [base, base*(1+factor)] — never earlier than the deadline, never more
 	// than 50% beyond it.
 	graceRequeueJitterFactor = 0.5
-	jitterBase := warmPoolReadinessGracePeriod - 4*time.Minute + graceRequeueSlack
+	jitterBase := DefaultWarmPoolReadinessGracePeriod - 4*time.Minute + graceRequeueSlack
 	for range 20 {
 		rj := SandboxWarmPoolReconciler{
 			Client: newFakeClient(scheme,
@@ -777,7 +777,7 @@ func TestReconcilePool_QuietClusterSelfScheduledGraceEvaluation(t *testing.T) {
 	// post-grace evaluation is self-scheduled.
 	requeueAfter, err := r.reconcilePool(ctx, warmPool)
 	require.NoError(t, err)
-	require.Equal(t, warmPoolReadinessGracePeriod+graceRequeueSlack, requeueAfter)
+	require.Equal(t, DefaultWarmPoolReadinessGracePeriod+graceRequeueSlack, requeueAfter)
 	select {
 	case e := <-recorder.Events:
 		t.Fatalf("no event may fire inside the grace period, got: %s", e)
@@ -793,7 +793,7 @@ func TestReconcilePool_QuietClusterSelfScheduledGraceEvaluation(t *testing.T) {
 	// and exactly one WarmPoolNotProgressing warning is emitted.
 	require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: sb.Name}, &sandboxv1beta1.Sandbox{}))
 	require.Equal(t, 0, lc.createCount())
-	require.Equal(t, unschedulableRequeueDelay, requeueAfter)
+	require.Equal(t, DefaultUnschedulableRecheckInterval, requeueAfter)
 	select {
 	case e := <-recorder.Events:
 		require.Contains(t, e, reasonWarmPoolNotProgressing)
@@ -810,6 +810,115 @@ func TestReconcilePool_QuietClusterSelfScheduledGraceEvaluation(t *testing.T) {
 	case e := <-recorder.Events:
 		t.Fatalf("unexpected duplicate event while state is unchanged: %s", e)
 	default:
+	}
+}
+
+// TestReconcilePool_ConfigurableGraceAndRecheck: ReadinessGracePeriod and
+// UnschedulableRecheckInterval override the defaults (#1274). A sandbox past
+// the default 5m grace but inside a configured 10m grace must be held as
+// still-warming (not delete-and-replaced, not unschedulable-held); once past
+// the configured grace with an unschedulable pod, the hold requeue must use
+// the configured recheck interval.
+func TestReconcilePool_ConfigurableGraceAndRecheck(t *testing.T) {
+	zeroGraceJitter(t)
+	const poolName = "test-pool"
+	const poolNamespace = "default"
+	const configuredGrace = 10 * time.Minute
+	const configuredRecheck = 30 * time.Second
+	replicas := int32(1)
+	template := createTemplate(poolNamespace)
+	poolNameHash := sandboxcontrollers.NameHash(poolName)
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+			UID:       "warmpool-uid-1274",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas:    &replicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name},
+		},
+	}
+
+	// Whole-second base: metav1.Time truncates to seconds on storage round-trips.
+	base := time.Now().Truncate(time.Second)
+	controller := true
+	sb := createPoolSandbox(poolName, poolNamespace, poolNameHash, template, "-cfg")
+	sb.UID = "uid-cfg"
+	// Age 6m at the first reconcile: past the 5m default, inside the 10m config.
+	sb.CreationTimestamp = metav1.Time{Time: base.Add(-6 * time.Minute)}
+	sb.Status.Conditions = []metav1.Condition{{
+		Type:   string(sandboxv1beta1.SandboxConditionReady),
+		Status: metav1.ConditionFalse,
+	}}
+	sb.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: extensionsv1beta1.GroupVersion.String(),
+		Kind:       "SandboxWarmPool",
+		Name:       poolName,
+		UID:        warmPool.UID,
+		Controller: &controller,
+	}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: sb.Name, Namespace: poolNamespace},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodScheduled,
+				Status: corev1.ConditionFalse,
+				Reason: corev1.PodReasonUnschedulable,
+			}},
+		},
+	}
+
+	current := base
+	recorder := events.NewFakeRecorder(16)
+	scheme := newTestScheme()
+	lc := newLaggingClient(newFakeClient(scheme, template, warmPool, sb, pod))
+	r := SandboxWarmPoolReconciler{
+		Client:                       lc,
+		Scheme:                       scheme,
+		MaxBatchSize:                 sandboxCreateDeleteMaxBatchSize,
+		Recorder:                     recorder,
+		ReadinessGracePeriod:         configuredGrace,
+		UnschedulableRecheckInterval: configuredRecheck,
+		now:                          func() time.Time { return current },
+	}
+	ctx := context.Background()
+
+	// Phase 1: at age 6m the sandbox is inside the configured grace. Under
+	// the 5m default it would have been GC'd (or unschedulable-held); with
+	// the override it must be kept as still-warming, with the requeue armed
+	// for the remaining configured grace — not the recheck interval.
+	requeueAfter, err := r.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: sb.Name}, &sandboxv1beta1.Sandbox{}),
+		"sandbox inside the configured grace must not be deleted")
+	require.Equal(t, 0, lc.createCount(), "no replacement may be created inside the configured grace")
+	require.Equal(t, configuredGrace-6*time.Minute+graceRequeueSlack, requeueAfter,
+		"requeue must target the remaining configured grace")
+	select {
+	case e := <-recorder.Events:
+		t.Fatalf("no event may fire inside the configured grace period, got: %s", e)
+	default:
+	}
+
+	// Phase 2: the self-scheduled requeue fires past the configured grace.
+	// The unschedulable pod now triggers the hold, re-checked at the
+	// configured interval.
+	current = current.Add(requeueAfter)
+	requeueAfter, err = r.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+	require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: sb.Name}, &sandboxv1beta1.Sandbox{}),
+		"unschedulable sandbox past grace must be held, not replaced")
+	require.Equal(t, 0, lc.createCount())
+	require.Equal(t, configuredRecheck, requeueAfter,
+		"hold requeue must use the configured recheck interval")
+	select {
+	case e := <-recorder.Events:
+		require.Contains(t, e, reasonWarmPoolNotProgressing)
+		require.Contains(t, e, corev1.EventTypeWarning)
+	default:
+		t.Fatal("expected WarmPoolNotProgressing after the configured grace elapsed")
 	}
 }
 

--- a/extensions/controllers/sandboxwarmpool_overcreation_test.go
+++ b/extensions/controllers/sandboxwarmpool_overcreation_test.go
@@ -922,6 +922,31 @@ func TestReconcilePool_ConfigurableGraceAndRecheck(t *testing.T) {
 	}
 }
 
+// TestWarmPoolDefaults pins the exported defaults behind the
+// --sandbox-warm-pool-readiness-grace-period and
+// --sandbox-warm-pool-unschedulable-recheck-interval flags. These are the
+// controller's user-visible flag defaults, so changing either is a behavioral
+// change for every existing deployment that does not set the flag: raising the
+// grace period delays replacement of stuck pool members, lowering it can GC
+// sandboxes that were merely slow to start. The assertions are deliberately
+// exact values rather than derived expressions so an accidental edit fails here
+// instead of silently shipping.
+func TestWarmPoolDefaults(t *testing.T) {
+	require.Equal(t, 5*time.Minute, DefaultWarmPoolReadinessGracePeriod,
+		"DefaultWarmPoolReadinessGracePeriod is the --sandbox-warm-pool-readiness-grace-period default; changing it alters replacement timing for every deployment that does not set the flag")
+	require.Equal(t, time.Minute, DefaultUnschedulableRecheckInterval,
+		"DefaultUnschedulableRecheckInterval is the --sandbox-warm-pool-unschedulable-recheck-interval default; changing it alters the requeue rate for pools holding unschedulable sandboxes")
+
+	// The zero value must remain the "use the default" sentinel: main.go
+	// rejects explicit non-positive flag values, so a zero field can only come
+	// from a programmatically constructed reconciler (or a test).
+	var r SandboxWarmPoolReconciler
+	require.Equal(t, DefaultWarmPoolReadinessGracePeriod, r.readinessGracePeriod(),
+		"zero ReadinessGracePeriod must fall back to the default")
+	require.Equal(t, DefaultUnschedulableRecheckInterval, r.unschedulableRecheckInterval(),
+		"zero UnschedulableRecheckInterval must fall back to the default")
+}
+
 // TestWarmPoolSandboxEventHandler_ObservesOwnedEvents covers the watch-side
 // bookkeeping: add/delete events for pool-owned sandboxes lower the matching
 // expectations; unowned or foreign-owned objects are ignored.

--- a/helm/README.md
+++ b/helm/README.md
@@ -93,8 +93,8 @@ The following table lists the configurable parameters and their defaults.
 | `controller.sandboxWarmPoolConcurrentWorkers` | Max concurrent reconciles for the SandboxWarmPool controller (extensions only) | `1` |
 | `controller.sandboxTemplateConcurrentWorkers` | Max concurrent reconciles for the SandboxTemplate controller (extensions only) | `1` |
 | `controller.sandboxWarmPoolMaxBatchSize` | Max batch size for parallel sandbox create/delete in the SandboxWarmPool controller (extensions only) | `300` |
-| `controller.sandboxWarmPoolReadinessGracePeriod` | How long a warm pool sandbox may stay non-Ready before it is considered stuck and replaced, or held if unschedulable (extensions only) | `5m` |
-| `controller.sandboxWarmPoolUnschedulableRecheckInterval` | Re-check interval for pools holding unschedulable sandboxes past the readiness grace period (extensions only) | `1m` |
+| `controller.sandboxWarmPoolReadinessGracePeriod` | How long a warm pool sandbox may stay non-Ready before it is considered stuck and replaced, or held if unschedulable (extensions only) | unset (controller default `5m`) |
+| `controller.sandboxWarmPoolUnschedulableRecheckInterval` | Re-check interval for pools holding unschedulable sandboxes past the readiness grace period (extensions only) | unset (controller default `1m`) |
 | `controller.enableWarmPoolEviction` | Mark pods created by a warm pool as safe to evict (extensions only) | `true` |
 | `controller.enableTracing` | Enable OpenTelemetry tracing via OTLP | `false` |
 | `controller.enablePprof` | Enable CPU profiling endpoint on the metrics server | `false` |

--- a/helm/README.md
+++ b/helm/README.md
@@ -93,6 +93,8 @@ The following table lists the configurable parameters and their defaults.
 | `controller.sandboxWarmPoolConcurrentWorkers` | Max concurrent reconciles for the SandboxWarmPool controller (extensions only) | `1` |
 | `controller.sandboxTemplateConcurrentWorkers` | Max concurrent reconciles for the SandboxTemplate controller (extensions only) | `1` |
 | `controller.sandboxWarmPoolMaxBatchSize` | Max batch size for parallel sandbox create/delete in the SandboxWarmPool controller (extensions only) | `300` |
+| `controller.sandboxWarmPoolReadinessGracePeriod` | How long a warm pool sandbox may stay non-Ready before it is considered stuck and replaced, or held if unschedulable (extensions only) | `5m` |
+| `controller.sandboxWarmPoolUnschedulableRecheckInterval` | Re-check interval for pools holding unschedulable sandboxes past the readiness grace period (extensions only) | `1m` |
 | `controller.enableWarmPoolEviction` | Mark pods created by a warm pool as safe to evict (extensions only) | `true` |
 | `controller.enableTracing` | Enable OpenTelemetry tracing via OTLP | `false` |
 | `controller.enablePprof` | Enable CPU profiling endpoint on the metrics server | `false` |

--- a/helm/templates/_controller-args.tpl
+++ b/helm/templates/_controller-args.tpl
@@ -47,6 +47,12 @@
 {{- if hasKey .Values.controller "sandboxWarmPoolMaxBatchSize" }}
 - --sandbox-warm-pool-max-batch-size={{ .Values.controller.sandboxWarmPoolMaxBatchSize }}
 {{- end }}
+{{- if hasKey .Values.controller "sandboxWarmPoolReadinessGracePeriod" }}
+- --sandbox-warm-pool-readiness-grace-period={{ .Values.controller.sandboxWarmPoolReadinessGracePeriod }}
+{{- end }}
+{{- if hasKey .Values.controller "sandboxWarmPoolUnschedulableRecheckInterval" }}
+- --sandbox-warm-pool-unschedulable-recheck-interval={{ .Values.controller.sandboxWarmPoolUnschedulableRecheckInterval }}
+{{- end }}
 {{- if hasKey .Values.controller "enableWarmPoolEviction" }}
 - --enable-warm-pool-eviction={{ .Values.controller.enableWarmPoolEviction }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -45,6 +45,8 @@ controller:
   # sandboxWarmPoolConcurrentWorkers: 1
   # sandboxTemplateConcurrentWorkers: 1
   # sandboxWarmPoolMaxBatchSize: 300  # max parallel sandbox create/delete batch in the SandboxWarmPool controller
+  # sandboxWarmPoolReadinessGracePeriod: 5m         # how long a warm pool sandbox may stay non-Ready before it is considered stuck
+  # sandboxWarmPoolUnschedulableRecheckInterval: 1m # re-check interval for pools holding unschedulable sandboxes past the grace period
   # enableWarmPoolEviction: true      # mark warm-pool-created pods as safe to evict
   ##### extraArgs passes additional flags not listed above (e.g. zap logging flags).
   extraArgs: []


### PR DESCRIPTION
## Summary

- Makes the SandboxWarmPool stuck-sandbox readiness grace period and the unschedulable-hold re-check interval configurable via controller flags, per the scope suggested in #1274:
  - `--sandbox-warm-pool-readiness-grace-period` (default `5m`, today's behavior)
  - `--sandbox-warm-pool-unschedulable-recheck-interval` (default `1m`, today's behavior)
- The former constants become exported defaults (`DefaultWarmPoolReadinessGracePeriod`, `DefaultUnschedulableRecheckInterval`) shared by the flag defaults and the reconciler's zero-value fallback, so the CLI default and the in-package fallback cannot drift. Bare reconciler literals (tests) keep current behavior.
- Flag values `<= 0` are rejected at startup — an explicit `=0` fails loudly rather than silently meaning the default.
- The `WarmPoolNotProgressing` event message now reports the configured grace period instead of the compile-time constant.
- Docs (`docs/configuration.md`) and Helm chart (`values.yaml`, `_controller-args.tpl`, `README.md`) updated; the new chart values are `hasKey`-guarded so unset values keep binary defaults.
- No API change — the per-pool `spec` knob mentioned in the issue is deliberately left to its own discussion.

## Motivation

- Images with heavy initialization can legitimately take longer than the fixed 5m grace to become Ready; previously they were delete-and-replaced in a loop even though they would have become Ready.
- Autopilot / node-auto-provisioning clusters can hold pods Pending well past 5m; post-#1266 those pods are held rather than churned, but the grace deadline and re-check cadence should match the cluster's provisioning latency profile.

## Test plan

- New two-phase fake-clock test `TestReconcilePool_ConfigurableGraceAndRecheck`:
  - Phase 1: a 6-minute-old not-Ready sandbox with a configured 10m grace (past the 5m default) is held as still-warming — not deleted, no replacement — with the requeue armed for the remaining configured grace.
  - Phase 2: past the configured grace with an Unschedulable pod, the sandbox enters the unschedulable hold and the requeue uses the configured 30s interval; exactly one `WarmPoolNotProgressing` event.
- Existing tests updated only for the constant rename (no assertion changes), demonstrating defaults preserve current behavior.
- Verified: `make build`, `go vet`, `go test ./controllers/... ./extensions/... ./internal/...` all green; `helm template` renders both flags when set and omits them when unset; the built binary rejects `--sandbox-warm-pool-readiness-grace-period=0` at startup and `--help` shows correct defaults.

Fixes #1274



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable warm-pool readiness grace periods.
  - Added configurable recheck intervals for unschedulable sandboxes.
  - Added Helm chart settings and controller options for both timing controls.
  - Added documented default values with validation requiring positive durations.

- **Bug Fixes**
  - Improved warm-pool timing consistency when evaluating sandbox readiness and retrying unschedulable sandboxes.
  - Added fallback behavior to preserve default timing when custom values are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->