### PR TITLE
feat(api): mirror backing pod's PodScheduled condition into Sandbox status

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -53,6 +53,20 @@ const (
 	// (i.e., intentional action by the user to suspend the Sandbox).
 	SandboxReasonSuspended = "SandboxSuspended"
 
+	// SandboxConditionPodScheduled mirrors the backing Pod's PodScheduled
+	// condition so consumers can see why a Sandbox is not scheduled (e.g.
+	// Unschedulable, SchedulingGated) without reading the Pod. The Pod
+	// condition's status, reason and message are copied through verbatim;
+	// the condition is absent while the Sandbox has no backing Pod.
+	SandboxConditionPodScheduled ConditionType = "PodScheduled"
+	// SandboxReasonPodScheduled indicates the backing Pod has been scheduled
+	// to a node. Used when the Pod's PodScheduled condition carries no reason
+	// of its own (the scheduler sets none on success).
+	SandboxReasonPodScheduled = "PodScheduled"
+	// SandboxReasonPodSchedulingUnknown indicates the backing Pod exists but
+	// has not reported a PodScheduled condition yet.
+	SandboxReasonPodSchedulingUnknown = "PodSchedulingUnknown"
+
 	// SandboxConditionFinished indicates the backing Pod reached a terminal phase.
 	SandboxConditionFinished ConditionType = "Finished"
 	// SandboxReasonPodSucceeded indicates the backing Pod completed successfully.

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -315,16 +315,25 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 
 	// compute and set overall conditions
 	conditions := r.computeConditions(sandbox, allErrors, svc, pod, podErr)
-	hasFinished := false
+	// Conditions that are only present while they apply: Finished has no
+	// meaning without a terminal pod, PodScheduled none without a pod at
+	// all. Any of these not computed this pass is removed from status.
+	// Suspended is deliberately NOT in this set: it is persistent and
+	// transitions to False rather than being removed (see #1150).
+	presentWhileApplicable := map[string]bool{
+		string(sandboxv1beta1.SandboxConditionFinished):     false,
+		string(sandboxv1beta1.SandboxConditionPodScheduled): false,
+	}
 	for _, condition := range conditions {
 		meta.SetStatusCondition(&sandbox.Status.Conditions, condition)
-		if condition.Type == string(sandboxv1beta1.SandboxConditionFinished) {
-			hasFinished = true
+		if _, ok := presentWhileApplicable[condition.Type]; ok {
+			presentWhileApplicable[condition.Type] = true
 		}
 	}
-
-	if !hasFinished {
-		meta.RemoveStatusCondition(&sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished))
+	for condType, present := range presentWhileApplicable {
+		if !present {
+			meta.RemoveStatusCondition(&sandbox.Status.Conditions, condType)
+		}
 	}
 
 	return allErrors
@@ -339,9 +348,69 @@ func (r *SandboxReconciler) computeConditions(sandbox *sandboxv1beta1.Sandbox, e
 		conditions = append(conditions, *finished)
 	}
 
+	if podScheduled := r.computePodScheduledCondition(sandbox, pod, podErr); podScheduled != nil {
+		conditions = append(conditions, *podScheduled)
+	}
+
 	conditions = append(conditions, r.computeReadyCondition(sandbox, err, svc, pod))
 
 	return conditions
+}
+
+// computePodScheduledCondition mirrors the backing Pod's PodScheduled
+// condition into the Sandbox so consumers can tell why a Sandbox is not
+// scheduled (Unschedulable, SchedulingGated, ...) without Pod access. The
+// Pod condition's status, reason and message are copied verbatim so future
+// scheduler reasons flow through unchanged. metav1.Condition requires a
+// non-empty reason, so an empty Pod reason maps to a fallback: PodScheduled
+// for status True (the scheduler sets no reason on success — the expected
+// case) and PodSchedulingUnknown for any other status missing a reason.
+// Returns nil when the Pod is confirmed absent: the condition is removed rather
+// than reporting a misleading False for suspended or expired sandboxes. A Pod
+// this Sandbox does not own is likewise not mirrored, so a foreign Pod holding
+// the name cannot leak its scheduling state into this Sandbox's status.
+func (r *SandboxReconciler) computePodScheduledCondition(sandbox *sandboxv1beta1.Sandbox, pod *corev1.Pod, podErr error) *metav1.Condition {
+	condition := &metav1.Condition{
+		Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+		ObservedGeneration: sandbox.Generation,
+	}
+
+	// Reconciling the Pod failed, so a nil pod does not prove the Pod is gone.
+	// Report the scheduling state as unknown instead of dropping the condition,
+	// which would read as "no backing Pod" on a transient API error.
+	if pod == nil && podErr != nil {
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = sandboxv1beta1.SandboxReasonPodSchedulingUnknown
+		condition.Message = "Pod state is unknown. Pod scheduling cannot be determined"
+		return condition
+	}
+
+	if !isOwnedBySandbox(pod, sandbox) {
+		return nil
+	}
+
+	for _, podCond := range pod.Status.Conditions {
+		if podCond.Type != corev1.PodScheduled {
+			continue
+		}
+		condition.Status = metav1.ConditionStatus(podCond.Status)
+		condition.Reason = podCond.Reason
+		condition.Message = podCond.Message
+		if condition.Reason == "" {
+			if condition.Status == metav1.ConditionTrue {
+				condition.Reason = sandboxv1beta1.SandboxReasonPodScheduled
+			} else {
+				condition.Reason = sandboxv1beta1.SandboxReasonPodSchedulingUnknown
+			}
+		}
+		return condition
+	}
+
+	// Pod exists but the scheduler has not reported yet.
+	condition.Status = metav1.ConditionUnknown
+	condition.Reason = sandboxv1beta1.SandboxReasonPodSchedulingUnknown
+	condition.Message = "Pod has not reported a PodScheduled condition yet"
+	return condition
 }
 
 func (r *SandboxReconciler) computeSuspendedCondition(sandbox *sandboxv1beta1.Sandbox, pod *corev1.Pod, podErr error) metav1.Condition {
@@ -1573,6 +1642,11 @@ func setSandboxExpiredCondition(sandbox *sandboxv1beta1.Sandbox) {
 		Reason:             sandboxv1beta1.SandboxReasonExpired,
 		Message:            "Sandbox has expired",
 	})
+	// Expiry tears down the backing pod and skips reconcileChildResources
+	// (where PodScheduled is normally maintained), so drop the mirrored
+	// condition here or it would linger with stale pre-expiry contents.
+	// Finished, by contrast, is deliberately preserved across expiry.
+	meta.RemoveStatusCondition(&sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
 }
 
 // sandboxMarkedExpired checks if the sandbox is already marked as expired.

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -357,6 +357,10 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	// Reconcile Pod
 	pod, err := r.reconcilePod(ctx, sandbox, nameHash, wd)
 	allErrors = errors.Join(allErrors, err)
+	// Keep the pod error: the Pod-derived conditions use it to tell a
+	// confirmed-absent Pod from one whose state could not be read, and the
+	// reconcileService call below reassigns err (its := only introduces svc).
+	podErr := err
 
 	if pod == nil {
 		sandbox.Status.PodIPs = nil
@@ -377,17 +381,26 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 
 	// compute and set overall conditions
-	conditions := r.computeConditions(sandbox, allErrors, svc, pod, err)
-	hasFinished := false
+	conditions := r.computeConditions(sandbox, allErrors, svc, pod, podErr)
+	// Conditions that are only present while they apply: Finished has no
+	// meaning without a terminal pod, PodScheduled none without a pod at
+	// all. Any of these not computed this pass is removed from status.
+	// Suspended is deliberately NOT in this set: it is persistent and
+	// transitions to False rather than being removed (see #1150).
+	presentWhileApplicable := map[string]bool{
+		string(sandboxv1beta1.SandboxConditionFinished):     false,
+		string(sandboxv1beta1.SandboxConditionPodScheduled): false,
+	}
 	for _, condition := range conditions {
 		meta.SetStatusCondition(&sandbox.Status.Conditions, condition)
-		if condition.Type == string(sandboxv1beta1.SandboxConditionFinished) {
-			hasFinished = true
+		if _, ok := presentWhileApplicable[condition.Type]; ok {
+			presentWhileApplicable[condition.Type] = true
 		}
 	}
-
-	if !hasFinished {
-		meta.RemoveStatusCondition(&sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished))
+	for condType, present := range presentWhileApplicable {
+		if !present {
+			meta.RemoveStatusCondition(&sandbox.Status.Conditions, condType)
+		}
 	}
 
 	return allErrors
@@ -402,9 +415,69 @@ func (r *SandboxReconciler) computeConditions(sandbox *sandboxv1beta1.Sandbox, e
 		conditions = append(conditions, *finished)
 	}
 
+	if podScheduled := r.computePodScheduledCondition(sandbox, pod, podErr); podScheduled != nil {
+		conditions = append(conditions, *podScheduled)
+	}
+
 	conditions = append(conditions, r.computeReadyCondition(sandbox, err, svc, pod))
 
 	return conditions
+}
+
+// computePodScheduledCondition mirrors the backing Pod's PodScheduled
+// condition into the Sandbox so consumers can tell why a Sandbox is not
+// scheduled (Unschedulable, SchedulingGated, ...) without Pod access. The
+// Pod condition's status, reason and message are copied verbatim so future
+// scheduler reasons flow through unchanged. metav1.Condition requires a
+// non-empty reason, so an empty Pod reason maps to a fallback: PodScheduled
+// for status True (the scheduler sets no reason on success — the expected
+// case) and PodSchedulingUnknown for any other status missing a reason.
+// Returns nil when the Pod is confirmed absent: the condition is removed rather
+// than reporting a misleading False for suspended or expired sandboxes. A Pod
+// this Sandbox does not own is likewise not mirrored, so a foreign Pod holding
+// the name cannot leak its scheduling state into this Sandbox's status.
+func (r *SandboxReconciler) computePodScheduledCondition(sandbox *sandboxv1beta1.Sandbox, pod *corev1.Pod, podErr error) *metav1.Condition {
+	condition := &metav1.Condition{
+		Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+		ObservedGeneration: sandbox.Generation,
+	}
+
+	// Reconciling the Pod failed, so a nil pod does not prove the Pod is gone.
+	// Report the scheduling state as unknown instead of dropping the condition,
+	// which would read as "no backing Pod" on a transient API error.
+	if pod == nil && podErr != nil {
+		condition.Status = metav1.ConditionUnknown
+		condition.Reason = sandboxv1beta1.SandboxReasonPodSchedulingUnknown
+		condition.Message = "Pod state is unknown. Pod scheduling cannot be determined"
+		return condition
+	}
+
+	if !isOwnedBySandbox(pod, sandbox) {
+		return nil
+	}
+
+	for _, podCond := range pod.Status.Conditions {
+		if podCond.Type != corev1.PodScheduled {
+			continue
+		}
+		condition.Status = metav1.ConditionStatus(podCond.Status)
+		condition.Reason = podCond.Reason
+		condition.Message = podCond.Message
+		if condition.Reason == "" {
+			if condition.Status == metav1.ConditionTrue {
+				condition.Reason = sandboxv1beta1.SandboxReasonPodScheduled
+			} else {
+				condition.Reason = sandboxv1beta1.SandboxReasonPodSchedulingUnknown
+			}
+		}
+		return condition
+	}
+
+	// Pod exists but the scheduler has not reported yet.
+	condition.Status = metav1.ConditionUnknown
+	condition.Reason = sandboxv1beta1.SandboxReasonPodSchedulingUnknown
+	condition.Message = "Pod has not reported a PodScheduled condition yet"
+	return condition
 }
 
 func (r *SandboxReconciler) computeSuspendedCondition(sandbox *sandboxv1beta1.Sandbox, pod *corev1.Pod, podErr error) metav1.Condition {
@@ -1671,6 +1744,11 @@ func setSandboxExpiredCondition(sandbox *sandboxv1beta1.Sandbox) {
 		Reason:             sandboxv1beta1.SandboxReasonExpired,
 		Message:            "Sandbox has expired",
 	})
+	// Expiry tears down the backing pod and skips reconcileChildResources
+	// (where PodScheduled is normally maintained), so drop the mirrored
+	// condition here or it would linger with stale pre-expiry contents.
+	// Finished, by contrast, is deliberately preserved across expiry.
+	meta.RemoveStatusCondition(&sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
 }
 
 // sandboxMarkedExpired checks if the sandbox is already marked as expired.

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -88,6 +89,20 @@ func TestComputeConditions(t *testing.T) {
 		return sb
 	}
 
+	// ownedPod stamps the controller ownerRef pointing at the fixture sandbox.
+	// Conditions that mirror Pod state (Finished, PodScheduled) only trust a Pod
+	// this Sandbox owns, so fixtures standing in for the real backing Pod need it.
+	ownedPod := func(pod *corev1.Pod) *corev1.Pod {
+		pod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: sandboxv1beta1.GroupVersion.String(),
+			Kind:       sandboxv1beta1.SandboxKind,
+			Name:       "test-sandbox",
+			UID:        "test-uid",
+			Controller: new(true),
+		}}
+		return pod
+	}
+
 	testCases := []struct {
 		name               string
 		sandbox            *sandboxv1beta1.Sandbox
@@ -121,9 +136,10 @@ func TestComputeConditions(t *testing.T) {
 			name:    "3. Pod Pending",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
+			pod:     ownedPod(&corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
 			},
 		},
@@ -131,17 +147,19 @@ func TestComputeConditions(t *testing.T) {
 			name:    "4. Pod Running but not Ready",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod: &corev1.Pod{
+			pod: ownedPod(&corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase:  corev1.PodRunning,
 					PodIPs: []corev1.PodIP{{IP: "10.244.0.1"}},
 					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
 					},
 				},
-			},
+			}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "True", ObservedGeneration: gen, Reason: "PodScheduled"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Running but not Ready; Service Exists"},
 			},
 		},
@@ -149,7 +167,7 @@ func TestComputeConditions(t *testing.T) {
 			name:    "5. Pod ready but no IP yet",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod: &corev1.Pod{
+			pod: ownedPod(&corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
@@ -159,9 +177,10 @@ func TestComputeConditions(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Ready but has no podIPs yet; Service Exists"},
 			},
 		},
@@ -192,6 +211,7 @@ func TestComputeConditions(t *testing.T) {
 			},
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodTerminating", Message: "Pod is terminating. Sandbox is suspending"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "SandboxSuspended", Message: "Sandbox is suspending"},
 			},
 		},
@@ -242,6 +262,7 @@ func TestComputeConditions(t *testing.T) {
 			err:    errors.New("failed to delete pod: boom"),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodTerminating", Message: "Pod is terminating. Sandbox is suspending"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: failed to delete pod: boom"},
 			},
 		},
@@ -265,7 +286,24 @@ func TestComputeConditions(t *testing.T) {
 			err:    errors.New("pod get failed"),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "Unknown", ObservedGeneration: gen, Reason: "PodStateUnknown", Message: "Pod state is unknown. Sandbox suspension cannot be confirmed"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod state is unknown. Pod scheduling cannot be determined"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: pod get failed"},
+			},
+		},
+		{
+			// A failed pod lookup must not be mistaken for a confirmed absent pod:
+			// PodScheduled reports Unknown so pruning keeps it, rather than removing
+			// it and implying the sandbox has no backing pod.
+			name:    "7c. Running - pod reconcile failed keeps PodScheduled as Unknown",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod:     nil,
+			podErr:  errors.New("pod list failed"),
+			err:     errors.New("pod list failed"),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod state is unknown. Pod scheduling cannot be determined"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: pod list failed"},
 			},
 		},
 		{
@@ -286,9 +324,10 @@ func TestComputeConditions(t *testing.T) {
 			name:    "9. Unresponsive - Pod Status Unknown",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}},
+			pod:     ownedPod(&corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Unknown; Service Exists"},
 			},
 		},
@@ -302,11 +341,17 @@ func TestComputeConditions(t *testing.T) {
 						{APIVersion: sandboxv1beta1.GroupVersion.String(), Kind: "Sandbox", Name: "test-sandbox", UID: "test-uid", Controller: new(true)},
 					},
 				},
-				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+					},
+				},
 			},
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
 				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodFailed", Message: "Pod failed"},
+				{Type: "PodScheduled", Status: "True", ObservedGeneration: gen, Reason: "PodScheduled"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "PodFailed", Message: "Pod failed"},
 			},
 		},
@@ -320,11 +365,17 @@ func TestComputeConditions(t *testing.T) {
 						{APIVersion: sandboxv1beta1.GroupVersion.String(), Kind: "Sandbox", Name: "test-sandbox", UID: "test-uid", Controller: new(true)},
 					},
 				},
-				Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+					},
+				},
 			},
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
 				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodSucceeded", Message: "Pod completed successfully"},
+				{Type: "PodScheduled", Status: "True", ObservedGeneration: gen, Reason: "PodScheduled"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "PodSucceeded", Message: "Pod completed successfully"},
 			},
 		},
@@ -352,6 +403,67 @@ func TestComputeConditions(t *testing.T) {
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: something went wrong"},
+			},
+		},
+		{
+			name:    "13. Pod unschedulable - reason and message mirrored verbatim",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod: ownedPod(&corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "0/3 nodes are available: 3 Insufficient cpu.",
+					},
+				},
+			}}),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "False", ObservedGeneration: gen, Reason: "Unschedulable", Message: "0/3 nodes are available: 3 Insufficient cpu."},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
+			},
+		},
+		{
+			name:    "14. Pod scheduling gated - reason passed through",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod: ownedPod(&corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonSchedulingGated,
+						Message: "Scheduling is blocked due to non-empty scheduling gates",
+					},
+				},
+			}}),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "False", ObservedGeneration: gen, Reason: "SchedulingGated", Message: "Scheduling is blocked due to non-empty scheduling gates"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
+			},
+		},
+		{
+			name:    "15. Pod not scheduled with empty reason - fallback reason keeps condition valid",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod: ownedPod(&corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			}}),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "False", ObservedGeneration: gen, Reason: "PodSchedulingUnknown"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
 			},
 		},
 	}
@@ -454,6 +566,13 @@ func TestReconcile(t *testing.T) {
 						Message:            "Sandbox is not suspended",
 					},
 					{
+						Type:               "PodScheduled",
+						Status:             "Unknown",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
+					},
+					{
 						Type:               "Ready",
 						Status:             "False",
 						ObservedGeneration: 1,
@@ -510,6 +629,13 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+						Status:             metav1.ConditionUnknown,
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
 					},
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -611,6 +737,13 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+						Status:             metav1.ConditionUnknown,
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
 					},
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -720,6 +853,7 @@ func TestReconcile(t *testing.T) {
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}, {IP: "fd00::5"}},
 						Phase:  corev1.PodRunning,
 						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 						},
 					},
@@ -745,6 +879,12 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 					},
 					{
 						Type:               "Ready",
@@ -794,6 +934,7 @@ func TestReconcile(t *testing.T) {
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}, {IP: "fd00::5"}},
 						Phase:  corev1.PodRunning,
 						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 						},
 					},
@@ -818,6 +959,12 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 					},
 					{
 						Type:               "Ready",
@@ -868,6 +1015,7 @@ func TestReconcile(t *testing.T) {
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}},
 						Phase:  corev1.PodRunning,
 						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 						},
 					},
@@ -890,6 +1038,12 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 					},
 					{
 						Type:               "Ready",
@@ -1200,6 +1354,13 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "PodTerminating",
 						Message:            "Pod is terminating. Sandbox is suspending",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "Unknown",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
 					},
 					{
 						Type:               "Ready",
@@ -4219,6 +4380,168 @@ func TestReconcileChildResourcesSuspendedForeignPodDoesNotLeakIPOrNodeName(t *te
 	assert.Equal(t, sandboxv1beta1.SandboxReasonSuspendedPodNotOwned, cond.Reason)
 }
 
+// TestPodScheduledConditionRemovedWithPod verifies the PodScheduled condition
+// mirrors the backing pod's scheduling state while the pod exists and is
+// removed from status once the pod is gone (here via suspension), rather than
+// lingering or flipping to a misleading False.
+func TestPodScheduledConditionRemovedWithPod(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "podscheduled-sandbox",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sandbox.Name,
+			Namespace:       sandbox.Namespace,
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandbox.Name)},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test-container"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  corev1.PodReasonUnschedulable,
+					Message: "0/3 nodes are available: 3 Insufficient cpu.",
+				},
+			},
+		},
+	}
+
+	r := &SandboxReconciler{
+		Client: newFakeClient(sandbox, pod),
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	scheduledCondition := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	require.NotNil(t, scheduledCondition)
+	require.Equal(t, metav1.ConditionFalse, scheduledCondition.Status)
+	require.Equal(t, string(corev1.PodReasonUnschedulable), scheduledCondition.Reason)
+	require.Equal(t, pod.Status.Conditions[0].Message, scheduledCondition.Message)
+
+	// Suspend the sandbox; the pod is deleted and the mirrored condition
+	// must be removed along with it.
+	updatedSandbox.Spec.OperatingMode = sandboxv1beta1.SandboxOperatingModeSuspended
+	require.NoError(t, r.Update(t.Context(), updatedSandbox))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	// Second pass observes the deleted pod.
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	require.Nil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled)))
+	require.NotNil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionSuspended)))
+}
+
+// TestPodScheduledConditionUnknownWhenPodLookupFails verifies that a failed Pod
+// lookup is not mistaken for a confirmed absent Pod: PodScheduled must report
+// Unknown and survive pruning, rather than being removed and implying the
+// Sandbox has no backing Pod.
+func TestPodScheduledConditionUnknownWhenPodLookupFails(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "podscheduled-lookup-fail",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sandbox.Name,
+			Namespace:       sandbox.Namespace,
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandbox.Name)},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	// failPodGet toggles Pod Get failures on so the first reconcile can establish
+	// the condition and the second can observe the lookup failure.
+	failPodGet := false
+	inner := newFakeClient(sandbox, pod)
+	fc := interceptor.NewClient(inner, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod && failPodGet {
+				return k8serrors.NewInternalError(errors.New("pod get failed"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &SandboxReconciler{
+		Client: fc,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	scheduled := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	require.NotNil(t, scheduled)
+	require.Equal(t, metav1.ConditionTrue, scheduled.Status)
+
+	// Now make the Pod lookup fail. The condition must be retained as Unknown,
+	// not pruned as it would be for a genuinely absent pod.
+	failPodGet = true
+	_, err = r.Reconcile(t.Context(), req)
+	require.Error(t, err, "reconcile must surface the pod lookup failure")
+
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	scheduled = meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	require.NotNil(t, scheduled, "PodScheduled must be retained when the pod lookup fails")
+	require.Equal(t, metav1.ConditionUnknown, scheduled.Status)
+	require.Equal(t, sandboxv1beta1.SandboxReasonPodSchedulingUnknown, scheduled.Reason)
+}
+
 func TestSandboxShutdownExpiryUsesTwoPassAndPreservesFinishedCondition(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -4297,6 +4620,7 @@ func TestSandboxShutdownExpiryUsesTwoPassAndPreservesFinishedCondition(t *testin
 			finishedCondition := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished))
 			require.NotNil(t, finishedCondition)
 			require.Equal(t, tc.finishedReason, finishedCondition.Reason)
+			require.NotNil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled)))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &corev1.Pod{}))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{}))
 
@@ -4315,6 +4639,9 @@ func TestSandboxShutdownExpiryUsesTwoPassAndPreservesFinishedCondition(t *testin
 			finishedCondition = meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished))
 			require.NotNil(t, finishedCondition)
 			require.Equal(t, tc.finishedReason, finishedCondition.Reason)
+			// Expiry removes the mirrored PodScheduled condition while
+			// Finished is preserved.
+			require.Nil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled)))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &corev1.Pod{}))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{}))
 
@@ -4461,10 +4788,16 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 		Status: corev1.PodStatus{
 			Phase:  corev1.PodRunning,
 			PodIPs: []corev1.PodIP{{IP: "10.0.0.1"}},
-			Conditions: []corev1.PodCondition{{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			}},
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
 		},
 	}
 
@@ -4498,7 +4831,8 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 
 	var got sandboxv1beta1.Sandbox
 	require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: sbName, Namespace: sbNs}, &got))
-	require.Len(t, got.Status.Conditions, 2,
+	// Steady state for a running, ready sandbox: Suspended, PodScheduled, Ready.
+	require.Len(t, got.Status.Conditions, 3,
 		"conditions slice must not grow across %d reconcile iterations — controller must upsert not append", iters)
 }
 

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -39,6 +39,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -88,6 +89,20 @@ func TestComputeConditions(t *testing.T) {
 		return sb
 	}
 
+	// ownedPod stamps the controller ownerRef pointing at the fixture sandbox.
+	// Conditions that mirror Pod state (Finished, PodScheduled) only trust a Pod
+	// this Sandbox owns, so fixtures standing in for the real backing Pod need it.
+	ownedPod := func(pod *corev1.Pod) *corev1.Pod {
+		pod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: sandboxv1beta1.GroupVersion.String(),
+			Kind:       sandboxv1beta1.SandboxKind,
+			Name:       "test-sandbox",
+			UID:        "test-uid",
+			Controller: new(true),
+		}}
+		return pod
+	}
+
 	testCases := []struct {
 		name               string
 		sandbox            *sandboxv1beta1.Sandbox
@@ -121,9 +136,10 @@ func TestComputeConditions(t *testing.T) {
 			name:    "3. Pod Pending",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}},
+			pod:     ownedPod(&corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodPending}}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
 			},
 		},
@@ -131,17 +147,19 @@ func TestComputeConditions(t *testing.T) {
 			name:    "4. Pod Running but not Ready",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod: &corev1.Pod{
+			pod: ownedPod(&corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase:  corev1.PodRunning,
 					PodIPs: []corev1.PodIP{{IP: "10.244.0.1"}},
 					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 						{Type: corev1.PodReady, Status: corev1.ConditionFalse},
 					},
 				},
-			},
+			}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "True", ObservedGeneration: gen, Reason: "PodScheduled"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Running but not Ready; Service Exists"},
 			},
 		},
@@ -149,7 +167,7 @@ func TestComputeConditions(t *testing.T) {
 			name:    "5. Pod ready but no IP yet",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod: &corev1.Pod{
+			pod: ownedPod(&corev1.Pod{
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 					Conditions: []corev1.PodCondition{
@@ -159,9 +177,10 @@ func TestComputeConditions(t *testing.T) {
 						},
 					},
 				},
-			},
+			}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod is Ready but has no podIPs yet; Service Exists"},
 			},
 		},
@@ -192,6 +211,7 @@ func TestComputeConditions(t *testing.T) {
 			},
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodTerminating", Message: "Pod is terminating. Sandbox is suspending"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "SandboxSuspended", Message: "Sandbox is suspending"},
 			},
 		},
@@ -242,6 +262,7 @@ func TestComputeConditions(t *testing.T) {
 			err:    errors.New("failed to delete pod: boom"),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "PodTerminating", Message: "Pod is terminating. Sandbox is suspending"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: failed to delete pod: boom"},
 			},
 		},
@@ -265,7 +286,24 @@ func TestComputeConditions(t *testing.T) {
 			err:    errors.New("pod get failed"),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "Unknown", ObservedGeneration: gen, Reason: "PodStateUnknown", Message: "Pod state is unknown. Sandbox suspension cannot be confirmed"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod state is unknown. Pod scheduling cannot be determined"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: pod get failed"},
+			},
+		},
+		{
+			// A failed pod lookup must not be mistaken for a confirmed absent pod:
+			// PodScheduled reports Unknown so pruning keeps it, rather than removing
+			// it and implying the sandbox has no backing pod.
+			name:    "7c. Running - pod reconcile failed keeps PodScheduled as Unknown",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod:     nil,
+			podErr:  errors.New("pod list failed"),
+			err:     errors.New("pod list failed"),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod state is unknown. Pod scheduling cannot be determined"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: pod list failed"},
 			},
 		},
 		{
@@ -286,9 +324,10 @@ func TestComputeConditions(t *testing.T) {
 			name:    "9. Unresponsive - Pod Status Unknown",
 			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
 			svc:     &corev1.Service{},
-			pod:     &corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}},
+			pod:     ownedPod(&corev1.Pod{Status: corev1.PodStatus{Phase: corev1.PodUnknown}}),
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "Unknown", ObservedGeneration: gen, Reason: "PodSchedulingUnknown", Message: "Pod has not reported a PodScheduled condition yet"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Unknown; Service Exists"},
 			},
 		},
@@ -302,11 +341,17 @@ func TestComputeConditions(t *testing.T) {
 						{APIVersion: sandboxv1beta1.GroupVersion.String(), Kind: "Sandbox", Name: "test-sandbox", UID: "test-uid", Controller: new(true)},
 					},
 				},
-				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+					},
+				},
 			},
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
 				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodFailed", Message: "Pod failed"},
+				{Type: "PodScheduled", Status: "True", ObservedGeneration: gen, Reason: "PodScheduled"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "PodFailed", Message: "Pod failed"},
 			},
 		},
@@ -320,11 +365,17 @@ func TestComputeConditions(t *testing.T) {
 						{APIVersion: sandboxv1beta1.GroupVersion.String(), Kind: "Sandbox", Name: "test-sandbox", UID: "test-uid", Controller: new(true)},
 					},
 				},
-				Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+					},
+				},
 			},
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
 				{Type: "Finished", Status: "True", ObservedGeneration: gen, Reason: "PodSucceeded", Message: "Pod completed successfully"},
+				{Type: "PodScheduled", Status: "True", ObservedGeneration: gen, Reason: "PodScheduled"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "PodSucceeded", Message: "Pod completed successfully"},
 			},
 		},
@@ -352,6 +403,67 @@ func TestComputeConditions(t *testing.T) {
 			expectedConditions: []metav1.Condition{
 				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "ReconcilerError", Message: "Error seen: something went wrong"},
+			},
+		},
+		{
+			name:    "13. Pod unschedulable - reason and message mirrored verbatim",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod: ownedPod(&corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonUnschedulable,
+						Message: "0/3 nodes are available: 3 Insufficient cpu.",
+					},
+				},
+			}}),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "False", ObservedGeneration: gen, Reason: "Unschedulable", Message: "0/3 nodes are available: 3 Insufficient cpu."},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
+			},
+		},
+		{
+			name:    "14. Pod scheduling gated - reason passed through",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod: ownedPod(&corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:    corev1.PodScheduled,
+						Status:  corev1.ConditionFalse,
+						Reason:  corev1.PodReasonSchedulingGated,
+						Message: "Scheduling is blocked due to non-empty scheduling gates",
+					},
+				},
+			}}),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "False", ObservedGeneration: gen, Reason: "SchedulingGated", Message: "Scheduling is blocked due to non-empty scheduling gates"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
+			},
+		},
+		{
+			name:    "15. Pod not scheduled with empty reason - fallback reason keeps condition valid",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			svc:     &corev1.Service{},
+			pod: ownedPod(&corev1.Pod{Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodScheduled,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			}}),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "PodScheduled", Status: "False", ObservedGeneration: gen, Reason: "PodSchedulingUnknown"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
 			},
 		},
 	}
@@ -454,6 +566,13 @@ func TestReconcile(t *testing.T) {
 						Message:            "Sandbox is not suspended",
 					},
 					{
+						Type:               "PodScheduled",
+						Status:             "Unknown",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
+					},
+					{
 						Type:               "Ready",
 						Status:             "False",
 						ObservedGeneration: 1,
@@ -510,6 +629,13 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+						Status:             metav1.ConditionUnknown,
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
 					},
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -611,6 +737,13 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+						Status:             metav1.ConditionUnknown,
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
 					},
 					{
 						Type:               string(sandboxv1beta1.SandboxConditionReady),
@@ -720,6 +853,7 @@ func TestReconcile(t *testing.T) {
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}, {IP: "fd00::5"}},
 						Phase:  corev1.PodRunning,
 						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 						},
 					},
@@ -745,6 +879,12 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 					},
 					{
 						Type:               "Ready",
@@ -794,6 +934,7 @@ func TestReconcile(t *testing.T) {
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}, {IP: "fd00::5"}},
 						Phase:  corev1.PodRunning,
 						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 						},
 					},
@@ -818,6 +959,12 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 					},
 					{
 						Type:               "Ready",
@@ -868,6 +1015,7 @@ func TestReconcile(t *testing.T) {
 						PodIPs: []corev1.PodIP{{IP: "10.244.0.5"}},
 						Phase:  corev1.PodRunning,
 						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 						},
 					},
@@ -890,6 +1038,12 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "NotSuspended",
 						Message:            "Sandbox is not suspended",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "True",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 					},
 					{
 						Type:               "Ready",
@@ -1200,6 +1354,13 @@ func TestReconcile(t *testing.T) {
 						ObservedGeneration: 1,
 						Reason:             "PodTerminating",
 						Message:            "Pod is terminating. Sandbox is suspending",
+					},
+					{
+						Type:               "PodScheduled",
+						Status:             "Unknown",
+						ObservedGeneration: 1,
+						Reason:             sandboxv1beta1.SandboxReasonPodSchedulingUnknown,
+						Message:            "Pod has not reported a PodScheduled condition yet",
 					},
 					{
 						Type:               "Ready",
@@ -4219,6 +4380,223 @@ func TestReconcileChildResourcesSuspendedForeignPodDoesNotLeakIPOrNodeName(t *te
 	assert.Equal(t, sandboxv1beta1.SandboxReasonSuspendedPodNotOwned, cond.Reason)
 }
 
+// TestPodScheduledConditionRemovedWithPod verifies the PodScheduled condition
+// mirrors the backing pod's scheduling state while the pod exists and is
+// removed from status once the pod is gone (here via suspension), rather than
+// lingering or flipping to a misleading False.
+func TestPodScheduledConditionRemovedWithPod(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "podscheduled-sandbox",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sandbox.Name,
+			Namespace:       sandbox.Namespace,
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandbox.Name)},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test-container"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:    corev1.PodScheduled,
+					Status:  corev1.ConditionFalse,
+					Reason:  corev1.PodReasonUnschedulable,
+					Message: "0/3 nodes are available: 3 Insufficient cpu.",
+				},
+			},
+		},
+	}
+
+	r := &SandboxReconciler{
+		Client: newFakeClient(sandbox, pod),
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	scheduledCondition := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	require.NotNil(t, scheduledCondition)
+	require.Equal(t, metav1.ConditionFalse, scheduledCondition.Status)
+	require.Equal(t, string(corev1.PodReasonUnschedulable), scheduledCondition.Reason)
+	require.Equal(t, pod.Status.Conditions[0].Message, scheduledCondition.Message)
+
+	// Suspend the sandbox; the pod is deleted and the mirrored condition
+	// must be removed along with it.
+	updatedSandbox.Spec.OperatingMode = sandboxv1beta1.SandboxOperatingModeSuspended
+	require.NoError(t, r.Update(t.Context(), updatedSandbox))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	// Second pass observes the deleted pod.
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	require.Nil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled)))
+	require.NotNil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionSuspended)))
+}
+
+// TestPodScheduledConditionUnknownWhenPodLookupFails verifies that a failed Pod
+// lookup is not mistaken for a confirmed absent Pod: PodScheduled must report
+// Unknown and survive pruning, rather than being removed and implying the
+// Sandbox has no backing Pod.
+func TestPodScheduledConditionUnknownWhenPodLookupFails(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "podscheduled-lookup-fail",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sandbox.Name,
+			Namespace:       sandbox.Namespace,
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandbox.Name)},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	// failPodGet toggles Pod Get failures on so the first reconcile can establish
+	// the condition and the second can observe the lookup failure.
+	failPodGet := false
+	inner := newFakeClient(sandbox, pod)
+	fc := interceptor.NewClient(inner, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod && failPodGet {
+				return k8serrors.NewInternalError(errors.New("pod get failed"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &SandboxReconciler{
+		Client: fc,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	scheduled := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	require.NotNil(t, scheduled)
+	require.Equal(t, metav1.ConditionTrue, scheduled.Status)
+
+	// Now make the Pod lookup fail. The condition must be retained as Unknown,
+	// not pruned as it would be for a genuinely absent pod.
+	failPodGet = true
+	_, err = r.Reconcile(t.Context(), req)
+	require.Error(t, err, "reconcile must surface the pod lookup failure")
+
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	scheduled = meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	require.NotNil(t, scheduled, "PodScheduled must be retained when the pod lookup fails")
+	require.Equal(t, metav1.ConditionUnknown, scheduled.Status)
+	require.Equal(t, sandboxv1beta1.SandboxReasonPodSchedulingUnknown, scheduled.Reason)
+}
+
+// TestSuspendedConditionUnknownWhenPodLookupFails pins the pod error reaching
+// the Pod-derived conditions. reconcileChildResources reuses err for both the
+// Pod and the Service (the Service's := only introduces svc), so passing it
+// straight through hands computeSuspendedCondition the Service error and makes
+// its pod-state-unknown branch unreachable: a suspended Sandbox whose Pod could
+// not be read then reports Suspended=True/PodTerminated, claiming the Pod is
+// gone when its state is simply unknown.
+func TestSuspendedConditionUnknownWhenPodLookupFails(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "suspended-lookup-fail",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "test-container"}},
+					},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeSuspended,
+		},
+	}
+
+	fc := interceptor.NewClient(newFakeClient(sandbox), interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				return k8serrors.NewInternalError(errors.New("pod get failed"))
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+
+	r := &SandboxReconciler{
+		Client: fc,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.Error(t, err, "reconcile must surface the pod lookup failure")
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, updatedSandbox))
+	suspended := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionSuspended))
+	require.NotNil(t, suspended)
+	require.Equal(t, metav1.ConditionUnknown, suspended.Status,
+		"the pod lookup failed, so suspension cannot be confirmed")
+	require.Equal(t, sandboxv1beta1.SandboxReasonSuspendedPodStateUnknown, suspended.Reason)
+}
+
 func TestSandboxShutdownExpiryUsesTwoPassAndPreservesFinishedCondition(t *testing.T) {
 	testCases := []struct {
 		name           string
@@ -4297,6 +4675,7 @@ func TestSandboxShutdownExpiryUsesTwoPassAndPreservesFinishedCondition(t *testin
 			finishedCondition := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished))
 			require.NotNil(t, finishedCondition)
 			require.Equal(t, tc.finishedReason, finishedCondition.Reason)
+			require.NotNil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled)))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &corev1.Pod{}))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{}))
 
@@ -4315,6 +4694,9 @@ func TestSandboxShutdownExpiryUsesTwoPassAndPreservesFinishedCondition(t *testin
 			finishedCondition = meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionFinished))
 			require.NotNil(t, finishedCondition)
 			require.Equal(t, tc.finishedReason, finishedCondition.Reason)
+			// Expiry removes the mirrored PodScheduled condition while
+			// Finished is preserved.
+			require.Nil(t, meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled)))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, &corev1.Pod{}))
 			require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, &corev1.Service{}))
 
@@ -4461,10 +4843,16 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 		Status: corev1.PodStatus{
 			Phase:  corev1.PodRunning,
 			PodIPs: []corev1.PodIP{{IP: "10.0.0.1"}},
-			Conditions: []corev1.PodCondition{{
-				Type:   corev1.PodReady,
-				Status: corev1.ConditionTrue,
-			}},
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
 		},
 	}
 
@@ -4498,7 +4886,8 @@ func TestSandboxReconcile_ConditionsDoNotAccumulate(t *testing.T) {
 
 	var got sandboxv1beta1.Sandbox
 	require.NoError(t, fc.Get(ctx, types.NamespacedName{Name: sbName, Namespace: sbNs}, &got))
-	require.Len(t, got.Status.Conditions, 2,
+	// Steady state for a running, ready sandbox: Suspended, PodScheduled, Ready.
+	require.Len(t, got.Status.Conditions, 3,
 		"conditions slice must not grow across %d reconcile iterations — controller must upsert not append", iters)
 }
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -99,6 +99,12 @@ func TestSimpleSandbox(t *testing.T) {
 					Message:            "Sandbox is not suspended",
 				},
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,

--- a/test/e2e/framework/predicates/sandbox.go
+++ b/test/e2e/framework/predicates/sandbox.go
@@ -58,6 +58,10 @@ func (s *sandboxHasStatusPredicate) Matches(obj client.Object) (bool, error) {
 	opts := []cmp.Option{
 		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 		cmpopts.IgnoreFields(sandboxv1beta1.SandboxStatus{}, "PodIPs", "NodeName"),
+		// Condition order carries no meaning: conditions are addressed by type, and
+		// a condition removed and later re-added is appended at the end, so the
+		// order reflects history rather than state. Compare as a set by type.
+		cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
 	}
 	if diff := cmp.Diff(s.WantStatus, sandbox.Status, opts...); diff != "" {
 		return false, nil

--- a/test/e2e/mode_test.go
+++ b/test/e2e/mode_test.go
@@ -64,6 +64,12 @@ func TestSandboxSuspendResumeCycleWithOperatingMode(t *testing.T) {
 					Message:            "Sandbox is not suspended",
 				},
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: gen,
+					Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: gen,
@@ -180,6 +186,12 @@ func TestSandboxSuspensionWithTerminatingPod(t *testing.T) {
 					Message:            "Sandbox is not suspended",
 				},
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,
@@ -251,6 +263,14 @@ func TestSandboxSuspensionWithTerminatingPod(t *testing.T) {
 					ObservedGeneration: 2,
 					Reason:             sandboxv1beta1.SandboxReasonSuspendedPodTerminating,
 					Message:            "Pod is terminating. Sandbox is suspending",
+				},
+				{
+					// The Pod is terminating but still present and owned, so its
+					// scheduling state is still mirrored.
+					Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 2,
+					Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 				},
 				{
 					Type:               "Ready",
@@ -344,6 +364,12 @@ func TestSandboxPodDeletionKeepsSuspendedFalse(t *testing.T) {
 				ObservedGeneration: 1,
 				Reason:             sandboxv1beta1.SandboxReasonNotSuspended,
 				Message:            "Sandbox is not suspended",
+			},
+			{
+				Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+				Status:             metav1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
 			},
 			{
 				Type:               "Ready",

--- a/test/e2e/shutdown_test.go
+++ b/test/e2e/shutdown_test.go
@@ -55,6 +55,12 @@ func TestSandboxShutdownTime(t *testing.T) {
 					Message:            "Sandbox is not suspended",
 				},
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,

--- a/test/e2e/volumeclaimtemplate_test.go
+++ b/test/e2e/volumeclaimtemplate_test.go
@@ -90,6 +90,12 @@ func TestSandboxVolumeClaimTemplates(t *testing.T) {
 					Message:            "Sandbox is not suspended",
 				},
 				{
+					Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
+				},
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a `PodScheduled` condition to `Sandbox.status.conditions` that mirrors the backing pod's scheduling state, so controllers, SDKs, and humans running `kubectl get sandbox -o yaml` can tell **why** a sandbox is not Ready (`Unschedulable`, `SchedulingGated`, ...) without pod access or pod RBAC.

Mirroring rules:

- The pod condition's `status`, `reason`, and `message` are copied through verbatim, so current and future scheduler reasons surface without controller changes. The only mapping: the scheduler sets an empty reason on `PodScheduled=True`, and `metav1.Condition` requires a non-empty one, so empty maps to a `PodScheduled` reason constant.
- Pod exists but hasn't reported a `PodScheduled` condition yet → `Unknown` / `PodSchedulingUnknown`.
- No backing pod (suspended / expired / not yet created) → the condition is **removed**, following the existing `Finished` condition lifecycle, rather than reporting a misleading `False` on a deliberately suspended sandbox.

No CRD schema change (the conditions array already exists), no RBAC change; codegen produces no diff. `Ready` semantics are untouched — consumers match on `Ready` reasons, so this is a separate condition rather than new `Ready` reasons.

Deferred to follow-ups (per the design comment on the issue): container-level signals (image pull, waiting reasons), and switching the warm-pool unschedulable-hold to consume this condition instead of reading pods.

#### Which issue(s) this PR is related to:

Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1281

#### Release Note

```release-note
Sandbox status now includes a `PodScheduled` condition mirroring the backing pod's scheduling state (e.g. reason `Unschedulable` or `SchedulingGated`), so consumers can see why a sandbox is not scheduled without reading the pod.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `PodScheduled` condition to Sandbox resources, mirroring the backing Pod’s scheduling status/reason/message (including an `Unknown` state when not yet reported).
* **Bug Fixes**
  * Improved condition lifecycle so `PodScheduled` is pruned when no longer applicable (including during suspension/expiry), while keeping `Finished` behavior intact.
* **Tests**
  * Updated unit and e2e assertions to validate `PodScheduled` presence, values, and removal across provisioning, suspension, and shutdown flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->