### PR TITLE
Add OWNERS file for sandbox-router

### DIFF
--- a/sandbox-router/OWNERS
+++ b/sandbox-router/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - janetkuo
+  - justinsb
+  - barney-s
+  - vicentefb
+  - igooch
+  - SHRUTI6991


### PR DESCRIPTION
Adds an OWNERS file under `sandbox-router/`, copying the approvers list from `clients/OWNERS`, so sandbox-router changes can be reviewed and approved by the same group.

No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code ownership configuration for the sandbox router.
  * Defined the designated approvers for changes in this area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->