### PR TITLE
docs: clarify repo scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 This project is developing a `Sandbox` Custom Resource Definition (CRD) and controller for Kubernetes, under the umbrella of [SIG Apps](https://github.com/kubernetes/community/tree/master/sig-apps). The goal is to provide a declarative, standardized API for managing workloads that require the characteristics of a long-running, stateful, singleton container with a stable identity, much like a lightweight, single-container VM experience built on Kubernetes primitives.
 
+> [!NOTE]
+> **Scope:** Agent Sandbox is a *sandbox orchestrator*. It delegates low-level container isolation to secure "Sandbox Runtimes" (like gVisor or Kata Containers) by managing Pods configured to use these runtimes (via `RuntimeClass`).
+
 ## Overview
 
 ### Core: Sandbox


### PR DESCRIPTION
## What changed
Added a `[!NOTE]` block to the `README.md` to clarify the scope of the `agent-sandbox` project. It clarifies that this project is a sandbox orchestrator (workload controller) and delegates low-level container isolation to secure runtimes like gVisor or Kata Containers.

## Why
Based on community feedback to clarify the distinction between "Sandbox Runtime" and "Agent Sandbox" (this repo).

## Verification results
- Verified markdown rendering.
- Ran `make toc-verify` (passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clarification that Agent Sandbox orchestrates sandboxes while secure Sandbox Runtimes provide container isolation.
  * Documented that runtimes are managed through Pods configured with a RuntimeClass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->