### PR TITLE
fix: honor controller-only image selection

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -112,9 +112,7 @@ def build_and_push_image(args, service_name, srcdir, dockerfile_path, image_tag)
 def main(args):
     """Builds and pushes all discovered Docker images."""
     if args.controller_only:
-        non_controller_images = (
-            set(args.images) - {"agent-sandbox-controller"}
-        )
+        non_controller_images = set(args.images) - {"agent-sandbox-controller"}
         if non_controller_images:
             sys.exit(
                 "ERROR: --controller-only cannot request non-controller "

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -111,6 +111,16 @@ def build_and_push_image(args, service_name, srcdir, dockerfile_path, image_tag)
 
 def main(args):
     """Builds and pushes all discovered Docker images."""
+    if args.controller_only:
+        non_controller_images = (
+            set(args.images) - {"agent-sandbox-controller"}
+        )
+        if non_controller_images:
+            sys.exit(
+                "ERROR: --controller-only cannot request non-controller "
+                f"image(s) via --images: {sorted(non_controller_images)}"
+            )
+
     image_tag = args.image_tag or utils.get_image_tag()
     excluded_dirs = {"bin", "dev", "docs", "k8s", "site",
                      "temp", "tests", "tmp", ".venv"}

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -116,7 +116,9 @@ def main(args):
                      "temp", "tests", "tmp", ".venv"}
 
     if args.controller_only:
-        # TODO: Implement an explicit inclusion strategy for controller only Dockerfile.
+        # Avoid walking the largest image-only subtrees. The explicit image
+        # selection below enforces controller-only mode for Dockerfiles in
+        # every other directory.
         excluded_dirs.update({"examples", "clients"})
 
     built = set()
@@ -144,6 +146,9 @@ def main(args):
             if root == go_router_dir:
                 context_dir = "."
                 service_name = "sandbox-router-go"
+
+            if args.controller_only and service_name != "agent-sandbox-controller":
+                continue
 
             if args.images and service_name not in args.images:
                 continue

--- a/dev/tools/push_images_test.py
+++ b/dev/tools/push_images_test.py
@@ -101,6 +101,22 @@ class BuildxDockerfileArgTest(unittest.TestCase):
 class ControllerOnlySelectionTest(unittest.TestCase):
     """The controller-only mode must not build other discovered images."""
 
+    def test_controller_only_rejects_non_controller_image_request(self):
+        args = argparse.Namespace(
+            controller_only=True,
+            image_tag="testtag",
+            images=["sandbox-router-go"],
+        )
+
+        with (
+            mock.patch.object(push_images.os, "walk", return_value=[]),
+            self.assertRaisesRegex(
+                SystemExit,
+                "--controller-only cannot request non-controller image",
+            ),
+        ):
+            push_images.main(args)
+
     def test_controller_only_builds_only_controller_image(self):
         args = argparse.Namespace(
             controller_only=True,

--- a/dev/tools/push_images_test.py
+++ b/dev/tools/push_images_test.py
@@ -153,6 +153,44 @@ class ControllerOnlySelectionTest(unittest.TestCase):
             "testtag",
         )
 
+    def test_controller_only_permits_explicit_controller_image_request(self):
+        # Positive side of the guard: requesting the controller image by name
+        # must stay valid, so a future tightening cannot break it unnoticed.
+        args = argparse.Namespace(
+            controller_only=True,
+            image_tag="testtag",
+            images=["agent-sandbox-controller"],
+        )
+        discovered_dockerfiles = [
+            (".", ["sandbox-router"], ["Dockerfile"]),
+            (os.path.join(".", "sandbox-router"), [], ["Dockerfile"]),
+        ]
+
+        with (
+            mock.patch.object(
+                push_images.os,
+                "walk",
+                return_value=discovered_dockerfiles,
+            ),
+            mock.patch.object(
+                push_images,
+                "create_buildx_builder_if_not_exists",
+            ),
+            mock.patch.object(
+                push_images,
+                "build_and_push_image",
+            ) as build_image,
+        ):
+            push_images.main(args)
+
+        build_image.assert_called_once_with(
+            args,
+            "agent-sandbox-controller",
+            ".",
+            os.path.join(".", "Dockerfile"),
+            "testtag",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dev/tools/push_images_test.py
+++ b/dev/tools/push_images_test.py
@@ -20,6 +20,7 @@ import os
 import sys
 import unittest
 from importlib.machinery import SourceFileLoader
+from unittest import mock
 
 # The push-images tool is an extensionless script, so load it via importlib
 # rather than a normal import (same pattern as release_test.py). The tools dir
@@ -95,6 +96,46 @@ class BuildxDockerfileArgTest(unittest.TestCase):
             os.path.join("sandbox-router", "Dockerfile"),
         )
         self.assertEqual(captured["cwd"], ".")
+
+
+class ControllerOnlySelectionTest(unittest.TestCase):
+    """The controller-only mode must not build other discovered images."""
+
+    def test_controller_only_builds_only_controller_image(self):
+        args = argparse.Namespace(
+            controller_only=True,
+            image_tag="testtag",
+            images=[],
+        )
+        discovered_dockerfiles = [
+            (".", ["sandbox-router"], ["Dockerfile"]),
+            (os.path.join(".", "sandbox-router"), [], ["Dockerfile"]),
+        ]
+
+        with (
+            mock.patch.object(
+                push_images.os,
+                "walk",
+                return_value=discovered_dockerfiles,
+            ),
+            mock.patch.object(
+                push_images,
+                "create_buildx_builder_if_not_exists",
+            ),
+            mock.patch.object(
+                push_images,
+                "build_and_push_image",
+            ) as build_image,
+        ):
+            push_images.main(args)
+
+        build_image.assert_called_once_with(
+            args,
+            "agent-sandbox-controller",
+            ".",
+            os.path.join(".", "Dockerfile"),
+            "testtag",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### What this PR does / why we need it:

`CONTROLLER_ONLY=true make deploy-kind` is intended to build only the
`agent-sandbox-controller` image. However, controller-only mode previously
pruned only the `examples` and `clients` directories, so other discovered
Dockerfiles such as `sandbox-router/Dockerfile` were still built.

This change explicitly skips every non-controller service in controller-only
mode and adds a regression test covering controller and Go router Dockerfiles.

#### Which issue(s) this PR is related to:

N/A — discovered while testing the local kind deployment workflow.

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller-only image publishing so that only the controller image is built and pushed.
  * Rejected requests for non-controller images in controller-only mode.
  * Prevented unrelated images discovered during directory scanning from being processed.

* **Tests**
  * Added coverage for image selection, rejection of invalid requests, and explicit controller image requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->