### PR TITLE
examples: add envd-sandbox example with multi-language clients

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**containarium-ssh-sandbox**](./containarium-ssh-sandbox): An example of running Containarium's agent-box runtime in a Sandbox, reached over SSH with an in-container MCP server (no kube-apiserver token held by the agent).
+- [**envd-sandbox**](./envd-sandbox): An example of running E2B's envd daemon as the container entrypoint, providing an E2B-compatible REST and gRPC API for filesystem, process execution, and metrics.
 - [**firecracker-sandbox**](./firecracker-sandbox): An example of running a sandbox on Kata Containers with the Firecracker VMM (`kata-fc`) plus an envd-compatible runtime that matches the E2B data-plane contract.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
 - [**gke-swap**](./gke-swap): Demonstrates how to configure GKE node memory swap with dedicated Local SSDs to drastically increase Chrome pod density from 120 to 200 pods per node.

--- a/examples/envd-sandbox/Dockerfile
+++ b/examples/envd-sandbox/Dockerfile
@@ -60,10 +60,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /out/envd /usr/local/bin/envd
 
-# envd resolves file paths relative to the execution user's home directory
-# (default: /root). Running as root ensures file operations work correctly.
-# In production, use sandbox-router or network policies for access control.
-WORKDIR /root
+# Create a non-root user for subprocess execution.
+# Following the e2b-dev debug.Dockerfile pattern:
+#   https://github.com/e2b-dev/infra/blob/main/packages/envd/debug.Dockerfile
+#
+# Security model: envd runs as root (required for PTY, process management),
+# but user code spawned via /init's defaultUser runs as this unprivileged user.
+# This limits blast radius if user code is malicious.
+RUN useradd -ms /bin/bash user
+RUN chmod 777 -R /home/user
+
+WORKDIR /home/user
 
 # 49983 is envd's default HTTP/gRPC port.
 EXPOSE 49983

--- a/examples/envd-sandbox/Dockerfile
+++ b/examples/envd-sandbox/Dockerfile
@@ -1,0 +1,76 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Multi-stage build: compile envd from upstream E2B source, then package
+# into a minimal runtime image with GNU userland (needed for process exec).
+#
+# Build:
+#   docker build -t envd-sandbox:latest .
+#   docker build -t envd-sandbox:latest --build-arg ENVD_VERSION=main .
+
+# Stage 1: Build envd binary from e2b-dev/infra source.
+# NOTE: For production use, pin ENVD_VERSION to a specific commit or release
+# tag (e.g., --build-arg ENVD_VERSION=v0.1.0 or a commit hash) instead of
+# tracking the moving `main` branch.
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
+
+# Pinned to a known-good commit. Override with --build-arg ENVD_VERSION=<ref>
+# to track upstream or pin to a different revision.
+ARG ENVD_VERSION=411b63edf6dea8edd265d1c5e442f41a80b76b2a
+ARG TARGETARCH=amd64
+
+WORKDIR /src
+
+# envd lives under packages/envd in the e2b-dev/infra monorepo.
+# Clone then checkout supports branches, tags, and commit hashes.
+RUN git clone https://github.com/e2b-dev/infra.git /src/infra \
+    && cd /src/infra \
+    && git checkout ${ENVD_VERSION}
+
+WORKDIR /src/infra/packages/envd
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GOWORK=off GOTOOLCHAIN=auto \
+      go build -ldflags="-s -w" -trimpath -o /out/envd .
+
+# Stage 2: Runtime image with GNU userland for process exec support.
+# NOTE: debian:12-slim == debian:bookworm-slim (same image, different tag).
+FROM debian:12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      bash \
+      coreutils \
+      findutils \
+      grep \
+      sed \
+      tar \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out/envd /usr/local/bin/envd
+
+# envd resolves file paths relative to the execution user's home directory
+# (default: /root). Running as root ensures file operations work correctly.
+# In production, use sandbox-router or network policies for access control.
+WORKDIR /root
+
+# 49983 is envd's default HTTP/gRPC port.
+EXPOSE 49983
+
+# --isnotfc     : skip Firecracker MMDS polling (we're running in a plain
+#                 container, not a Firecracker microVM).
+# --no-cgroups  : skip cgroup v2 setup (not available in sandbox containers).
+# --verbose     : useful for debugging; remove in production.
+ENTRYPOINT ["/usr/local/bin/envd"]
+CMD ["--isnotfc", "--no-cgroups", "--port", "49983", "--verbose"]

--- a/examples/envd-sandbox/README.md
+++ b/examples/envd-sandbox/README.md
@@ -1,0 +1,176 @@
+# envd Sandbox
+
+This example demonstrates running [envd](https://github.com/e2b-dev/infra/tree/main/packages/envd) — E2B's in-sandbox daemon — as the container entrypoint inside an agent-sandbox. envd exposes an E2B-compatible REST and gRPC API on port 49983, providing filesystem operations, process execution, environment management, and metrics.
+
+## Overview
+
+**envd** is the data-plane daemon that runs inside every E2B sandbox. It provides:
+
+- **Filesystem API** — upload, download, list, stat, watch files
+- **Process API** — start, connect, stream I/O (with PTY support)
+- **REST endpoints** — `/health`, `/metrics`, `/init`, `/envs`, `/freeze`, `/unfreeze`
+- **Port forwarding** — auto-discovers and forwards localhost ports
+
+This example builds envd from the upstream [e2b-dev/infra](https://github.com/e2b-dev/infra) source and runs it in a standard Linux container with the `--isnotfc` flag (skipping Firecracker MMDS polling). No KVM or kata-deploy is required.
+
+The [kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV) project uses envd in a similar way, packaging it into an ext4 tools drive attached to Firecracker microVMs for their AI agent RL training platform.
+
+## Architecture
+
+```
+  Client SDK (Python / Go / TS / curl)
+        │
+        │  HTTP / gRPC (port 49983)
+        │  ─── kubectl port-forward ───┐
+        ▼                               │
+  ┌─────────────────────────────────────┐
+  │  envd Pod (standard Linux container)│
+  │                                     │
+  │  REST API:                          │
+  │    GET  /health                     │
+  │    GET  /metrics                    │
+  │    POST /init                       │
+  │    GET  /envs                       │
+  │    GET  /files   (download)         │
+  │    POST /files   (upload)           │
+  │                                     │
+  │  gRPC (ConnectRPC):                 │
+  │    filesystem.{Stat,ListDir,...}    │
+  │    process.{Start,Connect,...}      │
+  │                                     │
+  │  Port Scanner + Forwarder           │
+  └─────────────────────────────────────┘
+        ▲
+        │
+  agent-sandbox controller
+```
+
+## Prerequisites
+
+1. Kubernetes cluster with agent-sandbox controller installed ([quickstart](../../README.md#quickstart))
+2. `kubectl` configured to access the cluster
+3. Docker (or other OCI builder) to build the envd image
+
+## Step 1 — Build and push the envd image
+
+```bash
+cd examples/envd-sandbox
+
+# Build (default uses a pinned envd commit; override with --build-arg ENVD_VERSION=<ref>)
+export IMAGE=<your-registry>/envd-sandbox:latest
+docker build -t ${IMAGE} .
+
+# Push (for Kind, use: kind load docker-image ${IMAGE})
+docker push ${IMAGE}
+```
+
+## Step 2 — Create the Sandbox
+
+```bash
+envsubst < sandbox-envd.yaml | kubectl apply -f -
+kubectl get sandbox envd-example
+```
+
+## Step 3 — Verify the pod is running
+
+```bash
+kubectl get pod -l sandbox=envd
+kubectl logs -l sandbox=envd
+# Should show envd startup banner and "listening on :49983"
+```
+
+## Step 4 — Run the verification scripts
+
+First, set up port-forwarding:
+
+```bash
+POD=$(kubectl get pod -l sandbox=envd -o jsonpath='{.items[0].metadata.name}')
+kubectl port-forward pod/$POD 49983:49983 &
+PF_PID=$!
+trap 'kill $PF_PID 2>/dev/null' EXIT
+
+export SANDBOX_BASE_URL=http://127.0.0.1:49983
+
+# Wait for readiness
+for i in $(seq 1 30); do
+  curl -sf ${SANDBOX_BASE_URL}/health >/dev/null 2>&1 && break
+  sleep 0.2
+done
+```
+
+Then run any of the four client scripts:
+
+### Python
+
+```bash
+pip install -r requirements.txt
+python test_client.py
+```
+
+### Shell (curl + jq)
+
+```bash
+chmod +x test_client.sh
+./test_client.sh
+```
+
+### Go
+
+```bash
+go run test_client.go
+```
+
+### TypeScript
+
+```bash
+npx tsx test_client.ts
+```
+
+All four scripts test the same operations:
+1. **health** — `GET /health` → 204
+2. **init** — `POST /init` → 204 (initializes sandbox runtime)
+3. **files** — upload + download round-trip via `POST/GET /files`
+4. **metrics** — `GET /metrics` → JSON with system stats (`ts`, `cpu_count`, `mem_total`, etc.)
+
+## Security Considerations
+
+> **WARNING**: envd in `--isnotfc` mode runs **without authentication** and as **root**. Do NOT expose port 49983 to a public network.
+
+The included `sandbox-envd.yaml` applies a **default-deny ingress NetworkPolicy** that restricts access to port 49983 to pods labeled `access: envd-client`. This prevents unauthorized workloads in the cluster from executing commands or accessing files in the sandbox.
+
+### Production hardening checklist
+
+- **NetworkPolicy**: The default manifest includes a deny-all ingress policy. Adjust the `podSelector` to match your cluster's access control model (e.g., allow only the sandbox-router pod).
+- **Pin envd version**: The Dockerfile pins `ENVD_VERSION` to a specific upstream commit. To update, override at build time:
+  ```bash
+  docker build --build-arg ENVD_VERSION=<commit-or-tag> -t ${IMAGE} .
+  ```
+- **Token authentication**: For authenticated access, set the `E2B_ACCESS_TOKEN` environment variable in the sandbox spec and send the `X-Access-Token` header in requests.
+- **Least-privilege user**: envd runs as root because file paths resolve relative to the user's home directory. If your use case allows it, create a non-root user and set `USER` in the Dockerfile.
+- **Ephemeral storage**: envd writes to the container's rootfs; pod restart wipes all state.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Pod stuck in `CrashLoopBackOff` | envd cannot reach MMDS (missing `--isnotfc`) | Verify the Dockerfile CMD includes `--isnotfc` |
+| `failed to create cgroup` in logs | cgroup v2 not available in container | Ensure `--no-cgroups` flag is set in CMD |
+| `connection refused` on port 49983 | envd not yet ready | Wait for readiness probe; check `kubectl logs` |
+| File upload returns 500 | Path resolution issue | envd runs as root; use relative paths (resolved to `/root/`) |
+| Port-forward drops | Pod restarted | Re-run `kubectl port-forward` |
+
+## Cleanup
+
+```bash
+kubectl delete -f <(envsubst < sandbox-envd.yaml)
+# Or individually:
+# kubectl delete sandbox envd-example
+# kubectl delete networkpolicy envd-deny-ingress
+```
+
+## Related
+
+- [envd source](https://github.com/e2b-dev/infra/tree/main/packages/envd) — upstream E2B daemon
+- [kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV/tree/main/thirdparty/envd) — envd in Firecracker microVMs
+- [E2B docs](https://e2b.dev/docs) — E2B sandbox platform documentation
+- [firecracker-sandbox](../firecracker-sandbox/) — VM-isolated sandbox with a similar API contract

--- a/examples/envd-sandbox/README.md
+++ b/examples/envd-sandbox/README.md
@@ -128,15 +128,19 @@ npx tsx test_client.ts
 
 All four scripts test the same operations:
 1. **health** — `GET /health` → 204
-2. **init** — `POST /init` → 204 (initializes sandbox runtime)
+2. **init** — `POST /init` → 204 (initializes sandbox with `defaultUser: user` for subprocess execution)
 3. **files** — upload + download round-trip via `POST/GET /files`
 4. **metrics** — `GET /metrics` → JSON with system stats (`ts`, `cpu_count`, `mem_total`, etc.)
 
 ## Security Considerations
 
-> **WARNING**: envd in `--isnotfc` mode runs **without authentication** and as **root**. Do NOT expose port 49983 to a public network.
+> **WARNING**: envd in `--isnotfc` mode runs **without authentication**. Do NOT expose port 49983 to a public network.
 
-The included `sandbox-envd.yaml` applies a **default-deny ingress NetworkPolicy** that restricts access to port 49983 to pods labeled `access: envd-client`. This prevents unauthorized workloads in the cluster from executing commands or accessing files in the sandbox.
+**Security model** (following [e2b-dev design](https://github.com/e2b-dev/infra/blob/main/packages/envd/debug.Dockerfile)):
+- **envd runs as root**: Required for PTY allocation, process management, and cgroup operations.
+- **User code runs as non-root**: The `/init` request sets `defaultUser: "user"` (uid 1000), so all user-spawned processes execute as an unprivileged user. This limits blast radius if user code is malicious.
+
+The included `sandbox-envd.yaml` applies a **default-deny ingress NetworkPolicy** that restricts access to port 49983 to pods labeled `access: envd-client`. This prevents unauthorized workloads in the cluster from reaching the envd API.
 
 ### Production hardening checklist
 
@@ -146,7 +150,7 @@ The included `sandbox-envd.yaml` applies a **default-deny ingress NetworkPolicy*
   docker build --build-arg ENVD_VERSION=<commit-or-tag> -t ${IMAGE} .
   ```
 - **Token authentication**: To enable authenticated access, send an initial `POST /init` request with an `accessToken` field to bootstrap the daemon's token. Subsequent requests must include the `X-Access-Token` header. Do **not** set `E2B_ACCESS_TOKEN` as an environment variable — the token is configured via the `/init` bootstrap flow.
-- **Least-privilege user**: envd runs as root because file paths resolve relative to the user's home directory. If your use case allows it, create a non-root user and set `USER` in the Dockerfile.
+- **Non-root subprocesses**: The Dockerfile creates a `user` (uid 1000) and the test clients set `defaultUser: "user"` in `/init`. All user code runs as this unprivileged user by default.
 - **Ephemeral storage**: envd writes to the container's rootfs; pod restart wipes all state.
 
 ## Troubleshooting
@@ -156,7 +160,7 @@ The included `sandbox-envd.yaml` applies a **default-deny ingress NetworkPolicy*
 | Pod stuck in `CrashLoopBackOff` | envd cannot reach MMDS (missing `--isnotfc`) | Verify the Dockerfile CMD includes `--isnotfc` |
 | `failed to create cgroup` in logs | cgroup v2 not available in container | Ensure `--no-cgroups` flag is set in CMD |
 | `connection refused` on port 49983 | envd not yet ready | Wait for readiness probe; check `kubectl logs` |
-| File upload returns 500 | Path resolution issue | envd runs as root; use relative paths (resolved to `/root/`) |
+| File upload returns 500 | Path resolution issue | File paths resolve relative to `/home/user`; use relative paths or absolute paths under `/home/user/` |
 | Port-forward drops | Pod restarted | Re-run `kubectl port-forward` |
 
 ## Cleanup

--- a/examples/envd-sandbox/README.md
+++ b/examples/envd-sandbox/README.md
@@ -145,7 +145,7 @@ The included `sandbox-envd.yaml` applies a **default-deny ingress NetworkPolicy*
   ```bash
   docker build --build-arg ENVD_VERSION=<commit-or-tag> -t ${IMAGE} .
   ```
-- **Token authentication**: For authenticated access, set the `E2B_ACCESS_TOKEN` environment variable in the sandbox spec and send the `X-Access-Token` header in requests.
+- **Token authentication**: To enable authenticated access, send an initial `POST /init` request with an `accessToken` field to bootstrap the daemon's token. Subsequent requests must include the `X-Access-Token` header. Do **not** set `E2B_ACCESS_TOKEN` as an environment variable — the token is configured via the `/init` bootstrap flow.
 - **Least-privilege user**: envd runs as root because file paths resolve relative to the user's home directory. If your use case allows it, create a non-root user and set `USER` in the Dockerfile.
 - **Ephemeral storage**: envd writes to the container's rootfs; pod restart wipes all state.
 

--- a/examples/envd-sandbox/requirements.txt
+++ b/examples/envd-sandbox/requirements.txt
@@ -1,0 +1,15 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+requests>=2.31.0,<3.0.0

--- a/examples/envd-sandbox/sandbox-envd.yaml
+++ b/examples/envd-sandbox/sandbox-envd.yaml
@@ -1,0 +1,88 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Bare Sandbox CR running envd as the container entrypoint.
+# Uses the direct-pod pattern (agents.x-k8s.io/v1beta1) since envd is a
+# stateful daemon — pooling is not applicable.
+#
+# Security: envd in --isnotfc mode runs without authentication and as root.
+# The NetworkPolicy below restricts ingress to pods with the label
+# `access: envd-client` (e.g., the sandbox-router or an authorized client pod).
+# Adjust the podSelector to match your cluster's access control model.
+#
+# Replace ${IMAGE} via:  envsubst < sandbox-envd.yaml | kubectl apply -f -
+---
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: envd-example
+  labels:
+    example: envd-sandbox
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: envd
+    spec:
+      containers:
+      - name: envd
+        image: ${IMAGE}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 49983
+          name: envd
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+          limits:
+            cpu: "2"
+            memory: "2Gi"
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 49983
+          initialDelaySeconds: 1
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 49983
+          initialDelaySeconds: 3
+          periodSeconds: 10
+---
+# Default-deny ingress NetworkPolicy: only pods labeled `access: envd-client`
+# can reach the envd API port. This prevents unauthorized workloads from
+# executing commands or accessing files in the sandbox.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: envd-deny-ingress
+  labels:
+    example: envd-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      sandbox: envd
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          access: envd-client
+    ports:
+    - protocol: TCP
+      port: 49983

--- a/examples/envd-sandbox/test_client.go
+++ b/examples/envd-sandbox/test_client.go
@@ -80,7 +80,7 @@ func main() {
 		}},
 		{"init", func() (string, error) {
 			body, _ := json.Marshal(map[string]any{
-				"envs": map[string]string{"HELLO": "envd"},
+				"envVars": map[string]string{"HELLO": "envd"},
 			})
 			resp, err := client.Post(baseURL+"/init", "application/json", bytes.NewReader(body))
 			if err != nil {

--- a/examples/envd-sandbox/test_client.go
+++ b/examples/envd-sandbox/test_client.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Verification script for the envd-sandbox example.
+// Drives the envd REST API endpoints over plain HTTP.
+//
+// Run:
+//
+//	SANDBOX_BASE_URL=http://127.0.0.1:49983 go run test_client.go
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type testResult struct {
+	name    string
+	passed  bool
+	detail  string
+	elapsed time.Duration
+}
+
+type testFunc struct {
+	name string
+	fn   func() (string, error)
+}
+
+func runTest(tf testFunc) testResult {
+	start := time.Now()
+	detail, err := tf.fn()
+	elapsed := time.Since(start)
+	if err != nil {
+		return testResult{tf.name, false, err.Error(), elapsed}
+	}
+	return testResult{tf.name, true, fmt.Sprintf("%s (%.2fs)", detail, elapsed.Seconds()), elapsed}
+}
+
+func main() {
+	baseURL := os.Getenv("SANDBOX_BASE_URL")
+	if baseURL == "" {
+		fmt.Fprintln(os.Stderr, "SANDBOX_BASE_URL is not set. Point it at a running envd sandbox pod,")
+		fmt.Fprintln(os.Stderr, "e.g. via `kubectl port-forward pod/<name> 49983:49983` and export")
+		fmt.Fprintln(os.Stderr, "SANDBOX_BASE_URL=http://127.0.0.1:49983")
+		os.Exit(1)
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	tests := []testFunc{
+		{"health", func() (string, error) {
+			resp, err := client.Get(baseURL + "/health")
+			if err != nil {
+				return "", fmt.Errorf("GET /health: %w", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 204 {
+				return "", fmt.Errorf("expected 204, got %d", resp.StatusCode)
+			}
+			return "204 No Content", nil
+		}},
+		{"init", func() (string, error) {
+			body, _ := json.Marshal(map[string]any{
+				"envs": map[string]string{"HELLO": "envd"},
+			})
+			resp, err := client.Post(baseURL+"/init", "application/json", bytes.NewReader(body))
+			if err != nil {
+				return "", fmt.Errorf("POST /init: %w", err)
+			}
+			defer resp.Body.Close()
+			// envd returns 204 No Content on success in --isnotfc mode.
+			if resp.StatusCode != 204 {
+				b, _ := io.ReadAll(resp.Body)
+				return "", fmt.Errorf("init: expected 204, got %d: %s", resp.StatusCode, string(b))
+			}
+			return "init ok", nil
+		}},
+		{"files", func() (string, error) {
+			var buf bytes.Buffer
+			w := multipart.NewWriter(&buf)
+			_ = w.WriteField("path", "hello.txt")
+			fw, _ := w.CreateFormFile("file", "hello.txt")
+			_, _ = fw.Write([]byte("hi from envd-sandbox"))
+			_ = w.Close()
+
+			resp, err := client.Post(baseURL+"/files", w.FormDataContentType(), &buf)
+			if err != nil {
+				return "", fmt.Errorf("POST /files upload: %w", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				b, _ := io.ReadAll(resp.Body)
+				return "", fmt.Errorf("upload: expected 200, got %d: %s", resp.StatusCode, string(b))
+			}
+
+			resp2, err := client.Get(baseURL + "/files?path=hello.txt")
+			if err != nil {
+				return "", fmt.Errorf("GET /files download: %w", err)
+			}
+			defer resp2.Body.Close()
+			content, _ := io.ReadAll(resp2.Body)
+			if string(content) != "hi from envd-sandbox" {
+				return "", fmt.Errorf("content mismatch: %q", string(content))
+			}
+			return "round-trip ok", nil
+		}},
+		{"metrics", func() (string, error) {
+			resp, err := client.Get(baseURL + "/metrics")
+			if err != nil {
+				return "", fmt.Errorf("GET /metrics: %w", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				b, _ := io.ReadAll(resp.Body)
+				return "", fmt.Errorf("expected 200, got %d: %s", resp.StatusCode, string(b))
+			}
+			var metrics map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&metrics); err != nil {
+				return "", fmt.Errorf("GET /metrics body decode: %w", err)
+			}
+			if _, ok := metrics["ts"]; !ok {
+				if _, ok := metrics["cpu_count"]; !ok {
+					return "", fmt.Errorf("unexpected metrics: %v", metrics)
+				}
+			}
+			keys := make([]string, 0, len(metrics))
+			for k := range metrics {
+				keys = append(keys, k)
+			}
+			return "keys=" + strings.Join(keys, ","), nil
+		}},
+	}
+
+	fmt.Print("\n=== envd-sandbox verification: Go HTTP ===\n")
+
+	var results []testResult
+	for i, tf := range tests {
+		fmt.Printf("[%d/%d] running %s...\n", i+1, len(tests), tf.name)
+		r := runTest(tf)
+		results = append(results, r)
+		status := "PASS"
+		if !r.passed {
+			status = "FAIL"
+		}
+		fmt.Printf("         %s: %s\n", status, r.detail)
+	}
+
+	fmt.Println("\n=== Summary ===")
+	failed := 0
+	for _, r := range results {
+		mark := "PASS"
+		if !r.passed {
+			mark = "FAIL"
+			failed++
+		}
+		fmt.Printf("  [%s] %s: %s\n", mark, r.name, r.detail)
+	}
+
+	if failed > 0 {
+		fmt.Printf("\n%d test(s) failed.\n", failed)
+		os.Exit(1)
+	}
+	fmt.Printf("\nAll %d test(s) passed.\n", len(results))
+}

--- a/examples/envd-sandbox/test_client.go
+++ b/examples/envd-sandbox/test_client.go
@@ -80,7 +80,8 @@ func main() {
 		}},
 		{"init", func() (string, error) {
 			body, err := json.Marshal(map[string]any{
-				"envVars": map[string]string{"HELLO": "envd"},
+				"envVars":     map[string]string{"HELLO": "envd"},
+				"defaultUser": "user",
 			})
 			if err != nil {
 				return "", fmt.Errorf("POST /init marshal: %w", err)

--- a/examples/envd-sandbox/test_client.go
+++ b/examples/envd-sandbox/test_client.go
@@ -79,9 +79,12 @@ func main() {
 			return "204 No Content", nil
 		}},
 		{"init", func() (string, error) {
-			body, _ := json.Marshal(map[string]any{
+			body, err := json.Marshal(map[string]any{
 				"envVars": map[string]string{"HELLO": "envd"},
 			})
+			if err != nil {
+				return "", fmt.Errorf("POST /init marshal: %w", err)
+			}
 			resp, err := client.Post(baseURL+"/init", "application/json", bytes.NewReader(body))
 			if err != nil {
 				return "", fmt.Errorf("POST /init: %w", err)
@@ -97,10 +100,19 @@ func main() {
 		{"files", func() (string, error) {
 			var buf bytes.Buffer
 			w := multipart.NewWriter(&buf)
-			_ = w.WriteField("path", "hello.txt")
-			fw, _ := w.CreateFormFile("file", "hello.txt")
-			_, _ = fw.Write([]byte("hi from envd-sandbox"))
-			_ = w.Close()
+			if err := w.WriteField("path", "hello.txt"); err != nil {
+				return "", fmt.Errorf("POST /files write path field: %w", err)
+			}
+			fw, err := w.CreateFormFile("file", "hello.txt")
+			if err != nil {
+				return "", fmt.Errorf("POST /files create form file: %w", err)
+			}
+			if _, err := fw.Write([]byte("hi from envd-sandbox")); err != nil {
+				return "", fmt.Errorf("POST /files write file content: %w", err)
+			}
+			if err := w.Close(); err != nil {
+				return "", fmt.Errorf("POST /files close multipart: %w", err)
+			}
 
 			resp, err := client.Post(baseURL+"/files", w.FormDataContentType(), &buf)
 			if err != nil {
@@ -117,7 +129,13 @@ func main() {
 				return "", fmt.Errorf("GET /files download: %w", err)
 			}
 			defer resp2.Body.Close()
-			content, _ := io.ReadAll(resp2.Body)
+			if resp2.StatusCode != 200 {
+				return "", fmt.Errorf("download: expected 200, got %d", resp2.StatusCode)
+			}
+			content, err := io.ReadAll(resp2.Body)
+			if err != nil {
+				return "", fmt.Errorf("GET /files read body: %w", err)
+			}
 			if string(content) != "hi from envd-sandbox" {
 				return "", fmt.Errorf("content mismatch: %q", string(content))
 			}

--- a/examples/envd-sandbox/test_client.py
+++ b/examples/envd-sandbox/test_client.py
@@ -76,11 +76,16 @@ def _build_tests() -> Tuple[str, List[Callable[[], str]]]:
     def _init() -> str:
         r = requests.post(
             f"{base_url}/init",
-            json={"envs": {"HELLO": "envd"}},
+            json={"envVars": {"HELLO": "envd"}},
             timeout=5,
         )
         # envd returns 204 No Content on success in --isnotfc mode.
         assert r.status_code == 204, r.status_code
+        # Verify the environment variable was set via /envs endpoint.
+        r = requests.get(f"{base_url}/envs", timeout=5)
+        assert r.status_code == 200, r.status_code
+        envs = r.json()
+        assert envs.get("HELLO") == "envd", envs
         return "init ok"
 
     def _files() -> str:

--- a/examples/envd-sandbox/test_client.py
+++ b/examples/envd-sandbox/test_client.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Verification script for the envd-sandbox example.
+
+Drives the envd REST API endpoints over plain HTTP. Set SANDBOX_BASE_URL
+to the pod's URL (typically via kubectl port-forward).
+
+Run::
+
+    SANDBOX_BASE_URL=http://127.0.0.1:49983 python test_client.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Callable, List, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+class TestResult:
+    def __init__(self, name: str, passed: bool, detail: str = "") -> None:
+        self.name = name
+        self.passed = passed
+        self.detail = detail
+
+
+def _run_test(name: str, fn: Callable[[], str]) -> TestResult:
+    start = time.time()
+    try:
+        detail = fn()
+        elapsed = time.time() - start
+        return TestResult(name, True, f"{detail} ({elapsed:.2f}s)")
+    except AssertionError as exc:
+        return TestResult(name, False, f"assertion: {exc}")
+    except Exception as exc:  # noqa: BLE001
+        return TestResult(name, False, f"{type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tests — envd REST API
+# ---------------------------------------------------------------------------
+def _build_tests() -> Tuple[str, List[Callable[[], str]]]:
+    base_url = os.environ.get("SANDBOX_BASE_URL")
+    if not base_url:
+        raise SystemExit(
+            "SANDBOX_BASE_URL is not set. Point it at a running "
+            "envd sandbox pod, e.g. via `kubectl port-forward "
+            "pod/<name> 49983:49983` and export "
+            "SANDBOX_BASE_URL=http://127.0.0.1:49983"
+        )
+
+    import requests
+
+    def _health() -> str:
+        r = requests.get(f"{base_url}/health", timeout=5)
+        assert r.status_code == 204, r.status_code
+        return "204 No Content"
+
+    def _init() -> str:
+        r = requests.post(
+            f"{base_url}/init",
+            json={"envs": {"HELLO": "envd"}},
+            timeout=5,
+        )
+        # envd returns 204 No Content on success in --isnotfc mode.
+        assert r.status_code == 204, r.status_code
+        return "init ok"
+
+    def _files() -> str:
+        r = requests.post(
+            f"{base_url}/files",
+            data={"path": "hello.txt"},
+            files={"file": ("hello.txt", b"hi from envd-sandbox")},
+            timeout=10,
+        )
+        assert r.status_code == 200, r.text
+        r = requests.get(
+            f"{base_url}/files",
+            params={"path": "hello.txt"},
+            timeout=5,
+        )
+        assert r.status_code == 200, r.text
+        assert r.content == b"hi from envd-sandbox", r.content
+        return "round-trip ok"
+
+    def _metrics() -> str:
+        r = requests.get(f"{base_url}/metrics", timeout=5)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "ts" in body or "cpu_count" in body, body
+        return f"keys={sorted(body.keys())}"
+
+    return "envd REST API", [_health, _init, _files, _metrics]
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+def main() -> int:
+    mode_name, tests = _build_tests()
+
+    print(f"\n=== envd-sandbox verification: {mode_name} ===\n")
+
+    results: List[TestResult] = []
+    for i, fn in enumerate(tests, 1):
+        name = fn.__name__.lstrip("_")
+        print(f"[{i}/{len(tests)}] running {name}...")
+        result = _run_test(name, fn)
+        results.append(result)
+        status = "PASS" if result.passed else "FAIL"
+        print(f"         {status}: {result.detail}")
+
+    print("\n=== Summary ===")
+    for r in results:
+        mark = "PASS" if r.passed else "FAIL"
+        print(f"  [{mark}] {r.name}: {r.detail}")
+
+    failed = [r for r in results if not r.passed]
+    if failed:
+        print(f"\n{len(failed)} test(s) failed.")
+        return 1
+    print(f"\nAll {len(results)} test(s) passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/envd-sandbox/test_client.py
+++ b/examples/envd-sandbox/test_client.py
@@ -80,12 +80,18 @@ def _build_tests() -> Tuple[str, List[Callable[[], str]]]:
             timeout=5,
         )
         # envd returns 204 No Content on success in --isnotfc mode.
-        assert r.status_code == 204, r.status_code
+        if r.status_code != 204:
+            raise AssertionError(f"POST /init: expected 204, got {r.status_code}")
         # Verify the environment variable was set via /envs endpoint.
         r = requests.get(f"{base_url}/envs", timeout=5)
-        assert r.status_code == 200, r.status_code
+        if r.status_code != 200:
+            raise AssertionError(f"GET /envs: expected 200, got {r.status_code}")
         envs = r.json()
-        assert envs.get("HELLO") == "envd", envs
+        if envs.get("HELLO") != "envd":
+            raise AssertionError(
+                f"GET /envs: HELLO key missing or incorrect; "
+                f"present keys: {sorted(envs.keys())}"
+            )
         return "init ok"
 
     def _files() -> str:

--- a/examples/envd-sandbox/test_client.py
+++ b/examples/envd-sandbox/test_client.py
@@ -76,7 +76,10 @@ def _build_tests() -> Tuple[str, List[Callable[[], str]]]:
     def _init() -> str:
         r = requests.post(
             f"{base_url}/init",
-            json={"envVars": {"HELLO": "envd"}},
+            json={
+                "envVars": {"HELLO": "envd"},
+                "defaultUser": "user",
+            },
             timeout=5,
         )
         # envd returns 204 No Content on success in --isnotfc mode.

--- a/examples/envd-sandbox/test_client.sh
+++ b/examples/envd-sandbox/test_client.sh
@@ -54,7 +54,7 @@ run_test "health" bash -c "
 run_test "init" bash -c "
   code=\$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 -X POST '${BASE_URL}/init' \
     -H 'Content-Type: application/json' \
-    -d '{\"envVars\":{\"HELLO\":\"envd\"}}')
+    -d '{\"envVars\":{\"HELLO\":\"envd\"},\"defaultUser\":\"user\"}')
   [[ \"\$code\" == '204' ]] || { echo \"expected 204, got \$code\"; exit 1; }
   echo 'init ok'
 "

--- a/examples/envd-sandbox/test_client.sh
+++ b/examples/envd-sandbox/test_client.sh
@@ -54,7 +54,7 @@ run_test "health" bash -c "
 run_test "init" bash -c "
   code=\$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 -X POST '${BASE_URL}/init' \
     -H 'Content-Type: application/json' \
-    -d '{\"envs\":{\"HELLO\":\"envd\"}}')
+    -d '{\"envVars\":{\"HELLO\":\"envd\"}}')
   [[ \"\$code\" == '204' ]] || { echo \"expected 204, got \$code\"; exit 1; }
   echo 'init ok'
 "

--- a/examples/envd-sandbox/test_client.sh
+++ b/examples/envd-sandbox/test_client.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verification script for the envd-sandbox example.
+# Drives the envd REST API using curl + jq.
+#
+# Run:
+#   SANDBOX_BASE_URL=http://127.0.0.1:49983 ./test_client.sh
+
+set -euo pipefail
+
+BASE_URL="${SANDBOX_BASE_URL:?Set SANDBOX_BASE_URL, e.g. http://127.0.0.1:49983}"
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  shift
+  printf "  running %s... " "$name"
+  if output=$("$@" 2>&1); then
+    printf "PASS: %s\n" "$output"
+    PASS=$((PASS + 1))
+  else
+    printf "FAIL: %s\n" "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "=== envd-sandbox verification: curl ==="
+echo ""
+
+# 1. Health check
+run_test "health" bash -c "
+  code=\$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 '${BASE_URL}/health')
+  [[ \"\$code\" == '204' ]] || { echo \"expected 204, got \$code\"; exit 1; }
+  echo '204 No Content'
+"
+
+# 2. Init
+run_test "init" bash -c "
+  code=\$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 -X POST '${BASE_URL}/init' \
+    -H 'Content-Type: application/json' \
+    -d '{\"envs\":{\"HELLO\":\"envd\"}}')
+  [[ \"\$code\" == '204' ]] || { echo \"expected 204, got \$code\"; exit 1; }
+  echo 'init ok'
+"
+
+# 3. File upload + download round-trip
+run_test "files" bash -c "
+  echo -n 'hi from envd-sandbox' > /tmp/envd-test-hello.txt
+  curl -s --connect-timeout 5 --max-time 10 -X POST '${BASE_URL}/files' \
+    -F 'path=hello.txt' \
+    -F 'file=@/tmp/envd-test-hello.txt' > /dev/null
+  content=\$(curl -s --connect-timeout 5 --max-time 10 '${BASE_URL}/files?path=hello.txt')
+  [[ \"\$content\" == 'hi from envd-sandbox' ]] || { echo \"content mismatch: \$content\"; exit 1; }
+  rm -f /tmp/envd-test-hello.txt
+  echo 'round-trip ok'
+"
+
+# 4. Metrics
+run_test "metrics" bash -c "
+  resp=\$(curl -s --connect-timeout 5 --max-time 10 '${BASE_URL}/metrics')
+  echo \"\$resp\" | jq -e 'has(\"ts\") or has(\"cpu_count\")' > /dev/null \
+    || { echo \"unexpected metrics response: \$resp\"; exit 1; }
+  echo \"keys: \$(echo \"\$resp\" | jq -r 'keys | join(\",\")')\"
+"
+
+echo ""
+echo "=== Summary ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+echo ""
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo "$FAIL test(s) failed."
+  exit 1
+fi
+
+echo "All $PASS test(s) passed."
+exit 0

--- a/examples/envd-sandbox/test_client.sh
+++ b/examples/envd-sandbox/test_client.sh
@@ -62,12 +62,13 @@ run_test "init" bash -c "
 # 3. File upload + download round-trip
 run_test "files" bash -c "
   echo -n 'hi from envd-sandbox' > /tmp/envd-test-hello.txt
-  curl -s --connect-timeout 5 --max-time 10 -X POST '${BASE_URL}/files' \
+  trap 'rm -f /tmp/envd-test-hello.txt' EXIT
+  code=\$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 -X POST '${BASE_URL}/files' \
     -F 'path=hello.txt' \
-    -F 'file=@/tmp/envd-test-hello.txt' > /dev/null
+    -F 'file=@/tmp/envd-test-hello.txt')
+  [[ \"\$code\" == '200' ]] || { echo \"upload: expected 200, got \$code\"; exit 1; }
   content=\$(curl -s --connect-timeout 5 --max-time 10 '${BASE_URL}/files?path=hello.txt')
   [[ \"\$content\" == 'hi from envd-sandbox' ]] || { echo \"content mismatch: \$content\"; exit 1; }
-  rm -f /tmp/envd-test-hello.txt
   echo 'round-trip ok'
 "
 

--- a/examples/envd-sandbox/test_client.ts
+++ b/examples/envd-sandbox/test_client.ts
@@ -75,7 +75,10 @@ async function main(): Promise<number> {
         const r = await fetch(`${url}/init`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ envVars: { HELLO: "envd" } }),
+          body: JSON.stringify({
+            envVars: { HELLO: "envd" },
+            defaultUser: "user",
+          }),
           signal: AbortSignal.timeout(10000),
         });
         // envd returns 204 No Content on success in --isnotfc mode.

--- a/examples/envd-sandbox/test_client.ts
+++ b/examples/envd-sandbox/test_client.ts
@@ -75,7 +75,7 @@ async function main(): Promise<number> {
         const r = await fetch(`${url}/init`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ envs: { HELLO: "envd" } }),
+          body: JSON.stringify({ envVars: { HELLO: "envd" } }),
           signal: AbortSignal.timeout(10000),
         });
         // envd returns 204 No Content on success in --isnotfc mode.

--- a/examples/envd-sandbox/test_client.ts
+++ b/examples/envd-sandbox/test_client.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Verification script for the envd-sandbox example.
+ * Drives the envd REST API endpoints using fetch.
+ *
+ * Run:
+ *   SANDBOX_BASE_URL=http://127.0.0.1:49983 npx tsx test_client.ts
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare var process: any;
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  detail: string;
+}
+
+async function runTest(
+  name: string,
+  fn: () => Promise<string>,
+): Promise<TestResult> {
+  const start = Date.now();
+  try {
+    const detail = await fn();
+    const elapsed = ((Date.now() - start) / 1000).toFixed(2);
+    return { name, passed: true, detail: `${detail} (${elapsed}s)` };
+  } catch (err: any) {
+    return { name, passed: false, detail: `${err.message}` };
+  }
+}
+
+async function main(): Promise<number> {
+  const baseURL = process.env.SANDBOX_BASE_URL;
+  if (!baseURL) {
+    console.error(
+      "SANDBOX_BASE_URL is not set. Point it at a running envd sandbox pod,",
+    );
+    console.error(
+      "e.g. via `kubectl port-forward pod/<name> 49983:49983` and export",
+    );
+    console.error("SANDBOX_BASE_URL=http://127.0.0.1:49983");
+    return 1;
+  }
+
+  const url = baseURL.replace(/\/+$/, "");
+
+  const tests: { name: string; fn: () => Promise<string> }[] = [
+    {
+      name: "health",
+      fn: async () => {
+        const r = await fetch(`${url}/health`, {
+          signal: AbortSignal.timeout(10000),
+        });
+        if (r.status !== 204) throw new Error(`expected 204, got ${r.status}`);
+        return "204 No Content";
+      },
+    },
+    {
+      name: "init",
+      fn: async () => {
+        const r = await fetch(`${url}/init`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ envs: { HELLO: "envd" } }),
+          signal: AbortSignal.timeout(10000),
+        });
+        // envd returns 204 No Content on success in --isnotfc mode.
+        if (r.status !== 204) {
+          throw new Error(`init: expected 204, got ${r.status}`);
+        }
+        return "init ok";
+      },
+    },
+    {
+      name: "files",
+      fn: async () => {
+        const formData = new FormData();
+        formData.append("path", "hello.txt");
+        formData.append(
+          "file",
+          new Blob(["hi from envd-sandbox"], { type: "text/plain" }),
+          "hello.txt",
+        );
+        const r = await fetch(`${url}/files`, {
+          method: "POST",
+          body: formData,
+          signal: AbortSignal.timeout(10000),
+        });
+        if (r.status !== 200) {
+          const text = await r.text();
+          throw new Error(`upload: expected 200, got ${r.status}: ${text}`);
+        }
+        const r2 = await fetch(`${url}/files?path=hello.txt`, {
+          signal: AbortSignal.timeout(10000),
+        });
+        const content = await r2.text();
+        if (content !== "hi from envd-sandbox") {
+          throw new Error(`content mismatch: ${content}`);
+        }
+        return "round-trip ok";
+      },
+    },
+    {
+      name: "metrics",
+      fn: async () => {
+        const r = await fetch(`${url}/metrics`, {
+          signal: AbortSignal.timeout(10000),
+        });
+        if (r.status !== 200) {
+          const text = await r.text();
+          throw new Error(`expected 200, got ${r.status}: ${text}`);
+        }
+        const body = (await r.json()) as Record<string, unknown>;
+        if (!("ts" in body) && !("cpu_count" in body)) {
+          throw new Error(`unexpected metrics: ${JSON.stringify(body)}`);
+        }
+        return `keys=${Object.keys(body).sort().join(",")}`;
+      },
+    },
+  ];
+
+  console.log("\n=== envd-sandbox verification: TypeScript fetch ===\n");
+
+  const results: TestResult[] = [];
+  for (let i = 0; i < tests.length; i++) {
+    const t = tests[i];
+    console.log(`[${i + 1}/${tests.length}] running ${t.name}...`);
+    const result = await runTest(t.name, t.fn);
+    results.push(result);
+    const status = result.passed ? "PASS" : "FAIL";
+    console.log(`         ${status}: ${result.detail}`);
+  }
+
+  console.log("\n=== Summary ===");
+  const failed = results.filter((r) => !r.passed);
+  for (const r of results) {
+    const mark = r.passed ? "PASS" : "FAIL";
+    console.log(`  [${mark}] ${r.name}: ${r.detail}`);
+  }
+
+  if (failed.length > 0) {
+    console.log(`\n${failed.length} test(s) failed.`);
+    return 1;
+  }
+  console.log(`\nAll ${results.length} test(s) passed.`);
+  return 0;
+}
+
+main().then((code) => process.exit(code));

--- a/site/content/docs/use-cases/examples/envd-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/envd-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Envd Sandbox"
+linkTitle: "Envd Sandbox"
+weight: 2
+description: >
+  This example demonstrates running E2B's envd daemon as the container entrypoint inside an agent-sandbox, providing an E2B-compatible REST and gRPC API for filesystem operations, process execution, and metrics.
+---
+{{% include-file file="additional/examples/envd-sandbox/README.md" %}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add an `envd-sandbox` example that demonstrates running [E2B's envd](https://github.com/e2b-dev/infra/tree/main/packages/envd) daemon as the container entrypoint inside an agent-sandbox. envd exposes an E2B-compatible REST and gRPC API on port 49983, providing:

- **Filesystem API** — upload, download, list, stat, watch files
- **Process API** — start, connect, stream I/O (with PTY support)
- **REST endpoints** — `/health`, `/metrics`, `/init`, `/envs`, `/files`
- **Port forwarding** — auto-discovers and forwards localhost ports

This example includes:
- Multi-stage Dockerfile building envd from upstream e2b-dev/infra source
- Sandbox CRD manifest (`agents.x-k8s.io/v1beta1`) with health probes
- Verification clients in **Python**, **Go**, **TypeScript**, and **Shell** (curl+jq)
- Complete README with architecture diagram, step-by-step guide, security notes, and troubleshooting

envd runs with `--isnotfc` (skip Firecracker MMDS polling) and `--no-cgroups` flags for compatibility with standard Linux containers without KVM or kata-deploy.

The example has been fully verified on both local Docker and Kind cluster with all four client languages.

#### Which issue(s) this PR is related to:

N/A — new example contribution

#### Release Note

```release-note
Add `examples/envd-sandbox` demonstrating E2B's envd daemon running as an agent-sandbox container entrypoint with REST/gRPC API and multi-language verification clients.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `envd-sandbox` example running an E2B-compatible REST (and gRPC) service with `envd` as the container entrypoint, exposing port `49983`.
  * Included Kubernetes manifests with `/health` probes and a default-deny ingress NetworkPolicy.
* **Documentation**
  * Published step-by-step build, deploy, and verification instructions, including security notes, troubleshooting, and cleanup guidance.
  * Added the example to the docs site and the Envds Sandbox documentation index.
* **Tests**
  * Added verification scripts in Go, Python, TypeScript, and Bash covering `/health`, `/init`, `/files`, and `/metrics`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->