### PR TITLE
test(sandboxclaim): adoption-conflict follow-ups — composed-conflict coverage, terse cleanup-failure surface

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1152,7 +1152,7 @@ func (r *SandboxClaimReconciler) authoritativeReader() client.Reader {
 func (r *SandboxClaimReconciler) updateClaimOnFreshBase(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, mutate func(fresh *extensionsv1beta1.SandboxClaim) (bool, error)) error {
 	reader := r.authoritativeReader()
 	key := client.ObjectKeyFromObject(claim)
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	attempt := func() error {
 		fresh := &extensionsv1beta1.SandboxClaim{}
 		if err := reader.Get(ctx, key, fresh); err != nil {
 			return err
@@ -1168,7 +1168,20 @@ func (r *SandboxClaimReconciler) updateClaimOnFreshBase(ctx context.Context, cla
 		}
 		fresh.DeepCopyInto(claim)
 		return nil
+	}
+	// client-go's retry helpers map an interrupted attempt (an error wrapping
+	// context.Canceled/DeadlineExceeded) to the last conflict error — nil when
+	// the first attempt is interrupted — which would report a canceled write
+	// as success. Keep the attempt's own error authoritative.
+	var attemptErr error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		attemptErr = attempt()
+		return attemptErr
 	})
+	if err == nil && attemptErr != nil {
+		return attemptErr
+	}
+	return err
 }
 
 // retryAdoptionAnnotation retries the optimistically locked claim update that
@@ -1207,7 +1220,7 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 	reader := r.authoritativeReader()
 	key := client.ObjectKey{Namespace: claim.Namespace, Name: sandboxName}
 	var resolved *v1beta1.Sandbox
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	attempt := func() error {
 		fresh := &v1beta1.Sandbox{}
 		if err := reader.Get(ctx, key, fresh); err != nil {
 			return err
@@ -1230,7 +1243,18 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 		}
 		resolved = fresh
 		return nil
+	}
+	// Same interrupted-attempt guard as updateClaimOnFreshBase: without it a
+	// canceled attempt reports success with resolved == nil, and callers
+	// would dereference nil.
+	var attemptErr error
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		attemptErr = attempt()
+		return attemptErr
 	})
+	if err == nil && attemptErr != nil {
+		err = attemptErr
+	}
 	if err == nil {
 		return resolved, nil
 	}
@@ -1239,6 +1263,11 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 		// pass re-enters adoption cleanly.
 		logger.V(4).Info("Assigned sandbox unrecoverable; clearing reference", "sandbox", sandboxName, "claim", claim.Name, "reason", err.Error())
 		if cleanupErr := r.removeAssignedSandboxReference(ctx, claim, sandboxName); cleanupErr != nil {
+			// Cancellation/timeout is shutdown, not contention: propagate it
+			// instead of classifying it as a benign adoption conflict.
+			if errors.Is(cleanupErr, context.Canceled) || errors.Is(cleanupErr, context.DeadlineExceeded) {
+				return nil, fmt.Errorf("cleaning up unrecoverable sandbox reference %s: %w", sandboxName, cleanupErr)
+			}
 			// Full chain to logs only; the returned (and surfaced) message
 			// stays stable and terse.
 			logger.Error(errors.Join(err, cleanupErr), "Assigned sandbox unrecoverable and reference cleanup failed; retrying next pass", "sandbox", sandboxName, "claim", claim.Name)

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -73,14 +73,8 @@ var ErrSandboxNotOwned = errors.New("sandbox not owned by this claim")
 var ErrWarmPoolNotFound = errors.New("SandboxWarmPool not found")
 
 // errAdoptionConflict classifies expected contention on the optimistically
-// locked adoption writes: the in-pass annotation retry could not resolve its
-// 409 (e.g. the fresh read shows a different sandbox already assigned), or a
-// committed adoption could not be completed (the assigned sandbox was
-// deleted, was won by another owner, or its adoption patch kept
-// conflicting). It is contention, not a claim failure: the Ready condition
-// surfaces it with a benign AdoptionConflict reason instead of a generic
-// ReconcilerError, and the next pass re-enters or finishes the adoption from
-// the converged view.
+// locked adoption writes; the Ready condition surfaces it as the benign
+// AdoptionConflict reason instead of ReconcilerError.
 var errAdoptionConflict = errors.New("adoption write conflict")
 
 var restrictedDomains = []string{"kubernetes.io", "k8s.io", "agents.x-k8s.io"}
@@ -636,14 +630,9 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 			}
 		}
 		if errors.Is(err, errAdoptionConflict) {
-			// Expected contention on the optimistically locked adoption write,
-			// not a claim failure: the next pass re-enters or completes the
-			// adoption from the converged view. The error text carries the
-			// per-case detail (concurrent update, sandbox deleted, or won by
-			// another owner), so surface it instead of asserting one cause —
-			// but trim the raw apiserver conflict text from the tail: that
-			// low-level detail belongs in logs, not in the condition users
-			// read via kubectl describe.
+			// Expected contention, not a claim failure. Surface the per-case
+			// detail, but trim any raw apiserver conflict tail — that belongs
+			// in logs, not in kubectl describe output.
 			msg := err.Error()
 			var apiErr *k8errors.StatusError
 			if errors.As(err, &apiErr) && strings.HasSuffix(msg, apiErr.Error()) {
@@ -992,25 +981,13 @@ func (r *SandboxClaimReconciler) adoptSandboxFromCandidates(ctx context.Context,
 					logger.Error(err, "Failed to complete adoption for candidate sandbox", "sandbox candidate", adopted.Name, "claim", claim.Name)
 					return false, err
 				}
-				// A 404/409 here only proves the CANDIDATE's cache view was
-				// stale (deleted, already adopted, or concurrently written —
-				// freshly refilled pool sandboxes are actively written by the
-				// sandbox and warm-pool controllers). The adoption annotation
-				// is already committed on the claim, so this pass must NOT
-				// move on to another candidate: overwriting the committed
-				// assignment orphans the recorded sandbox and, under sustained
-				// load, cascades into assignment-flip storms, burned
-				// candidates, duplicate binds and cold-create status
-				// overwrites. Resolve the committed assignment against
-				// authoritative reads instead.
+				// A 404/409 only proves the cached candidate view is stale.
+				// The annotation is already committed: never move on to
+				// another candidate; resolve THIS assignment authoritatively.
 				resolved, resolveErr := r.resolveAdoptionCompletion(ctx, claim, adopted.Name)
 				if resolveErr != nil {
-					// Terminal for this pass: the dead reference was cleaned up
-					// (deleted/stolen sandbox) or contention persists, and the
-					// retry is paced by the workqueue's per-item rate limiter.
-					// The candidate key is deliberately NOT re-queued: a
-					// still-adoptable sandbox re-enters the warm queue via its
-					// own watch events.
+					// Terminal for this pass; the workqueue rate limiter paces
+					// the retry. The candidate key is deliberately not re-queued.
 					return false, resolveErr
 				}
 				resolved.DeepCopyInto(adopted)
@@ -1140,13 +1117,9 @@ func (r *SandboxClaimReconciler) completeAdoption(ctx context.Context, claim *ex
 		}
 	}
 
-	// Optimistic lock: the ownership transfer must only apply to the exact
-	// revision this pass computed it from. Without it, a patch built from a
-	// stale cache base can silently re-transfer a sandbox that another claim
-	// (or an earlier pass) already adopted. With it, any concurrent write —
-	// including the sandbox controller's own status/annotation writes on a
-	// freshly refilled candidate — surfaces as a 409 that the callers resolve
-	// against a fresh authoritative read (resolveAdoptionCompletion).
+	// Optimistic lock: a transfer computed from a stale base is rejected
+	// instead of silently re-transferring an already-adopted sandbox; 409s
+	// are resolved authoritatively by resolveAdoptionCompletion.
 	if err := r.Patch(ctx, adopted, client.MergeFromWithOptions(originalAdopted, client.MergeFromWithOptimisticLock{})); err != nil {
 		return err
 	}
@@ -1223,25 +1196,12 @@ func (r *SandboxClaimReconciler) retryAdoptionAnnotation(ctx context.Context, cl
 	})
 }
 
-// resolveAdoptionCompletion resolves a completeAdoption failure (404, or 409
-// on the optimistically locked adoption patch) against authoritative reads.
-// It is called only AFTER the adoption annotation has been committed on the
-// claim, and it upholds one invariant: a committed assignment is never
-// abandoned for another candidate inside the same pass. A stale cache view of
-// the assigned sandbox must degrade to (in order):
-//
-//   - no write at all, when the fresh object shows the adoption already
-//     completed (an earlier pass's patch landed);
-//   - one re-patch on the fresh base, when the sandbox is genuinely still
-//     pool-owned and adoptable (the 409 came from a concurrent benign write,
-//     e.g. the sandbox controller's status transition on a fresh candidate);
-//   - authoritative cleanup of the dead reference plus a benign
-//     errAdoptionConflict, when the sandbox is deleted or was won by another
-//     owner. The next pass then re-enters adoption cleanly, paced by the
-//     workqueue's per-item rate limiter.
-//
-// Nothing here retries a write against a deleted object, requeues on a fixed
-// delay, or records any in-memory state.
+// resolveAdoptionCompletion resolves a completeAdoption 404/409 against
+// authoritative reads, upholding one invariant: a committed assignment is
+// never abandoned for another candidate inside the same pass. Outcomes:
+// no-op when the adoption already completed; one fresh-base re-patch when
+// the sandbox is still pool-owned and adoptable; otherwise terminal cleanup
+// of the dead reference plus a benign errAdoptionConflict.
 func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sandboxName string) (*v1beta1.Sandbox, error) {
 	logger := log.FromContext(ctx)
 	reader := r.authoritativeReader()
@@ -1253,8 +1213,7 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 			return err
 		}
 		if metav1.IsControlledBy(fresh, claim) {
-			// The adoption is already complete on the server; this pass has
-			// nothing left to write for it.
+			// Already complete on the server; nothing left to write.
 			resolved = fresh
 			return nil
 		}
@@ -1264,9 +1223,8 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 		if err := verifySandboxCandidate(fresh, claim); err != nil {
 			return fmt.Errorf("%w: sandbox %s is no longer adoptable by claim %s: %s", errAdoptionConflict, sandboxName, claim.Name, err.Error())
 		}
-		// Still pool-owned and adoptable on the authoritative object:
-		// re-apply the adoption patch on the fresh base. A further 409 re-runs
-		// this closure with another fresh read.
+		// Still pool-owned and adoptable: re-patch on the fresh base; a
+		// further 409 re-runs this closure with another fresh read.
 		if err := r.completeAdoption(ctx, claim, fresh); err != nil {
 			return err
 		}
@@ -1277,12 +1235,14 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 		return resolved, nil
 	}
 	if k8errors.IsNotFound(err) || errors.Is(err, errAdoptionConflict) {
-		// The assigned sandbox is deleted or lost for good. Clear the
-		// committed reference on a fresh claim base so the next pass re-enters
-		// adoption cleanly instead of re-resolving a dead assignment.
+		// Deleted or lost for good: clear the committed reference so the next
+		// pass re-enters adoption cleanly.
 		logger.V(4).Info("Assigned sandbox unrecoverable; clearing reference", "sandbox", sandboxName, "claim", claim.Name, "reason", err.Error())
 		if cleanupErr := r.removeAssignedSandboxReference(ctx, claim, sandboxName); cleanupErr != nil {
-			return nil, fmt.Errorf("%w: sandbox %s unrecoverable and reference cleanup failed: %w", errAdoptionConflict, sandboxName, errors.Join(err, cleanupErr))
+			// Full chain to logs only; the returned (and surfaced) message
+			// stays stable and terse.
+			logger.Error(errors.Join(err, cleanupErr), "Assigned sandbox unrecoverable and reference cleanup failed; retrying next pass", "sandbox", sandboxName, "claim", claim.Name)
+			return nil, fmt.Errorf("%w: sandbox %s unrecoverable and reference cleanup failed", errAdoptionConflict, sandboxName)
 		}
 		if errors.Is(err, errAdoptionConflict) {
 			return nil, err
@@ -1290,26 +1250,20 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 		return nil, fmt.Errorf("%w: sandbox %s deleted before adoption completed", errAdoptionConflict, sandboxName)
 	}
 	if k8errors.IsConflict(err) {
-		// Retries exhausted on persistent contention: keep the committed
-		// reference (the sandbox is still adoptable and assigned to us) and
-		// let the next event-driven or rate-limited pass finish it.
+		// Retries exhausted: keep the committed reference (still ours to
+		// finish); the next event-driven or rate-limited pass completes it.
 		return nil, fmt.Errorf("%w: completing adoption of %s for claim %s: %w", errAdoptionConflict, sandboxName, claim.Name, err)
 	}
 	return nil, err
 }
 
-// removeAssignedSandboxReference clears the assigned-sandbox reference — the
-// annotation and, for legacy claims, the deprecated label — on a fresh claim
-// base via updateClaimOnFreshBase, guarded so it only removes the exact
-// reference it was asked to clean (a concurrent pass may already have moved
-// it). Both fields must be covered: getOrCreateSandbox still accepts the
-// deprecated label as the assigned reference, so clearing only the annotation
-// would leave a label-based claim re-deriving the same dead sandbox name on
-// subsequent stale passes until the informer converges.
+// removeAssignedSandboxReference clears the assigned-sandbox annotation and,
+// for legacy claims, the deprecated label (getOrCreateSandbox still accepts
+// the label as the assigned reference) on a fresh claim base, guarded to the
+// exact reference being cleaned.
 func (r *SandboxClaimReconciler) removeAssignedSandboxReference(ctx context.Context, claim *extensionsv1beta1.SandboxClaim, sandboxName string) error {
-	// A deleted or recreated claim means there is nothing left to clean: it
-	// must not surface as an error, and a recreated claim (different UID)
-	// must not be copied back over this pass's object.
+	// A deleted or recreated claim leaves nothing to clean and must not be
+	// copied back over this pass's object.
 	errClaimGone := errors.New("claim gone")
 	err := r.updateClaimOnFreshBase(ctx, claim, func(fresh *extensionsv1beta1.SandboxClaim) (bool, error) {
 		if fresh.UID != claim.UID {
@@ -1834,15 +1788,9 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 						if !k8errors.IsNotFound(err) && !k8errors.IsConflict(err) {
 							return nil, fmt.Errorf("failed to complete adoption of %q: %w", sbName, err)
 						}
-						// A 404/409 here only proves the cached sandbox view is
-						// stale (deleted, already adopted, or concurrently
-						// written). Do NOT fall through to adopt a different
-						// candidate while the claim still references this one —
-						// overwriting the recorded assignment cascades under
-						// load. Resolve authoritatively instead: accept an
-						// already-completed adoption without a write, re-patch
-						// on a fresh base, or clean the dead reference and end
-						// the pass with the benign AdoptionConflict.
+						// A 404/409 only proves the cached view is stale; never
+						// fall through to another candidate while the claim
+						// references this one — resolve authoritatively.
 						resolved, resolveErr := r.resolveAdoptionCompletion(ctx, claim, sbName)
 						if resolveErr != nil {
 							return nil, resolveErr
@@ -1856,11 +1804,9 @@ func (r *SandboxClaimReconciler) getOrCreateSandbox(ctx context.Context, claim *
 							logger.Info("Successfully migrated legacy sandbox label to annotation during adoption completion", "claim", claim.Name)
 						}
 					}
-					// completeAdoption (or its fresh-base resolution) wrote the API
-					// server's response back into `sandbox`, so returning it finalizes
-					// the claim status in this same pass. No requeue for cache lag:
-					// the Owns(&Sandbox{}) watch drives convergence once the cache
-					// catches up (#1107).
+					// The server's response is in `sandbox`; returning it finalizes
+					// status in this pass. No requeue: the Owns(&Sandbox{}) watch
+					// drives convergence (#1107).
 					logger.V(4).Info("Completed adoption for sandbox", "sandbox", sbName, "claim", claim.Name)
 					return sandbox, nil
 				}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1169,16 +1169,22 @@ func (r *SandboxClaimReconciler) updateClaimOnFreshBase(ctx context.Context, cla
 		fresh.DeepCopyInto(claim)
 		return nil
 	}
-	// client-go's retry helpers map an interrupted attempt (an error wrapping
-	// context.Canceled/DeadlineExceeded) to the last conflict error — nil when
-	// the first attempt is interrupted — which would report a canceled write
-	// as success. Keep the attempt's own error authoritative.
+	return retryOnConflictKeepingAttemptErr(attempt)
+}
+
+// retryOnConflictKeepingAttemptErr runs fn under RetryOnConflict but keeps the
+// last attempt's own error authoritative: client-go maps an interrupted
+// attempt (an error wrapping context.Canceled/DeadlineExceeded) to the last
+// conflict — nil when the first attempt is interrupted — which would report a
+// canceled write as success, or mask a cancellation that followed an earlier
+// conflict as contention.
+func retryOnConflictKeepingAttemptErr(fn func() error) error {
 	var attemptErr error
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		attemptErr = attempt()
+		attemptErr = fn()
 		return attemptErr
 	})
-	if err == nil && attemptErr != nil {
+	if errors.Is(attemptErr, context.Canceled) || errors.Is(attemptErr, context.DeadlineExceeded) || (err == nil && attemptErr != nil) {
 		return attemptErr
 	}
 	return err
@@ -1244,17 +1250,9 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 		resolved = fresh
 		return nil
 	}
-	// Same interrupted-attempt guard as updateClaimOnFreshBase: without it a
-	// canceled attempt reports success with resolved == nil, and callers
-	// would dereference nil.
-	var attemptErr error
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		attemptErr = attempt()
-		return attemptErr
-	})
-	if err == nil && attemptErr != nil {
-		err = attemptErr
-	}
+	// Without the attempt-error guard a canceled attempt reports success
+	// with resolved == nil, and callers would dereference nil.
+	err := retryOnConflictKeepingAttemptErr(attempt)
 	if err == nil {
 		return resolved, nil
 	}
@@ -1269,9 +1267,13 @@ func (r *SandboxClaimReconciler) resolveAdoptionCompletion(ctx context.Context, 
 				return nil, fmt.Errorf("cleaning up unrecoverable sandbox reference %s: %w", sandboxName, cleanupErr)
 			}
 			// Full chain to logs only; the returned (and surfaced) message
-			// stays stable and terse.
+			// stays stable and terse, keeping the deleted-vs-won distinction.
 			logger.Error(errors.Join(err, cleanupErr), "Assigned sandbox unrecoverable and reference cleanup failed; retrying next pass", "sandbox", sandboxName, "claim", claim.Name)
-			return nil, fmt.Errorf("%w: sandbox %s unrecoverable and reference cleanup failed", errAdoptionConflict, sandboxName)
+			reason := "lost to another owner"
+			if k8errors.IsNotFound(err) {
+				reason = "deleted"
+			}
+			return nil, fmt.Errorf("%w: sandbox %s %s and reference cleanup failed", errAdoptionConflict, sandboxName, reason)
 		}
 		if errors.Is(err, errAdoptionConflict) {
 			return nil, err

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -6959,3 +6959,125 @@ func TestSandboxClaimAdoptionAnnotationAndCompletionConflictsResolvedSamePass(t 
 	require.NotNil(t, adoptedRef)
 	require.Equal(t, types.UID("claim-uid-123"), adoptedRef.UID)
 }
+
+// TestSandboxClaimAdoptionCleanupCancellationPropagates verifies a canceled
+// cleanup write is propagated as cancellation, not classified as a benign
+// adoption conflict.
+func TestSandboxClaimAdoptionCleanupCancellationPropagates(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "ghost-sb",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	ghost := newPoolCandidateSandbox("ghost-sb")
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim).
+		WithStatusSubresource(claim).
+		Build()
+
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == "ghost-sb" {
+				ghost.DeepCopyInto(sb)
+				return nil
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*extensionsv1beta1.SandboxClaim); ok {
+				return fmt.Errorf("client rate limiter wait: %w", context.Canceled)
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the cancellation to propagate, got: %v", err)
+	}
+	if errors.Is(err, errAdoptionConflict) {
+		t.Fatalf("cancellation must not be classified as a benign adoption conflict, got: %v", err)
+	}
+}
+
+// TestSandboxClaimAdoptionResolveCancellationPropagates verifies a canceled
+// completion patch during authoritative resolution propagates as
+// cancellation — client-go's retry maps interrupted attempts to nil, which
+// without the guard reported success with a nil resolved sandbox (panic).
+func TestSandboxClaimAdoptionResolveCancellationPropagates(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "pool-sb-1",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	assigned := newPoolCandidateSandbox("pool-sb-1")
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, assigned).
+		WithStatusSubresource(claim).
+		Build()
+
+	// Every adoption patch is interrupted, as during controller shutdown.
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == "pool-sb-1" {
+				return fmt.Errorf("client rate limiter wait: %w", context.Canceled)
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the cancellation to propagate (not success or panic), got: %v", err)
+	}
+	if errors.Is(err, errAdoptionConflict) {
+		t.Fatalf("cancellation must not be classified as a benign adoption conflict, got: %v", err)
+	}
+
+	// The committed reference must be untouched for the next process to finish.
+	after := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
+	require.Equal(t, "pool-sb-1", after.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -6047,8 +6047,8 @@ func newOptimisticLockTestObjects() (*extensionsv1beta1.SandboxClaim, *extension
 				extensionsv1beta1.SandboxIDLabel: "claim-uid-123",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
-				Kind:       "SandboxClaim",
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       extensionsv1beta1.SandboxClaimKind,
 				Name:       "test-claim",
 				UID:        "claim-uid-123",
 				Controller: ptr.To(true), // nolint:modernize
@@ -6298,8 +6298,8 @@ func TestSandboxClaimAdoptionConflictRetriedInPass(t *testing.T) {
 				sandboxTemplateRefHash: sandboxcontrollers.NameHash("test-template"),
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
-				Kind:       "SandboxWarmPool",
+				APIVersion: extensionsv1beta1.GroupVersion.String(),
+				Kind:       extensionsv1beta1.SandboxWarmPoolKind,
 				Name:       "test-pool",
 				UID:        "warmpool-uid-123",
 				Controller: ptr.To(true), // nolint:modernize
@@ -6420,13 +6420,8 @@ func newPoolCandidateSandbox(name string) *sandboxv1beta1.Sandbox {
 }
 
 // TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates pins the
-// fix for the sustained-load amplification defect: once the adoption
-// annotation is committed for a candidate, a 409 on the (optimistically
-// locked) adoption patch must be resolved against a fresh read of THAT
-// candidate — never by popping the next candidate and overwriting the
-// committed assignment in the same pass (the measured assignment-flip storm:
-// stale candidate views under load flipped one claim through up to 8
-// sandboxes, orphaning each previous one).
+// no-flip invariant: a 409 on the adoption patch is resolved on the SAME
+// candidate, never by switching to the next one mid-pass.
 func TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates(t *testing.T) {
 	scheme := newScheme(t)
 	_, template, warmPool, _ := newOptimisticLockTestObjects()
@@ -6507,11 +6502,9 @@ func TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates(t *testin
 	require.Equal(t, 2, patchAttempts["pool-sb-1"], "exactly one doomed patch plus one fresh-base re-patch")
 }
 
-// TestSandboxClaimStaleAdoptionRepatchIdempotentWithoutWrite verifies that a
-// pass whose CACHED view of the assigned sandbox predates the completed
-// adoption performs no further sandbox write: the doomed re-patch is rejected
-// by the optimistic lock, the fresh read shows the linkage already true, and
-// the pass finalizes status from the authoritative object.
+// TestSandboxClaimStaleAdoptionRepatchIdempotentWithoutWrite verifies a stale
+// pass costs one doomed re-patch, zero effective writes: the fresh read shows
+// the linkage already true and status finalizes from it.
 func TestSandboxClaimStaleAdoptionRepatchIdempotentWithoutWrite(t *testing.T) {
 	scheme := newScheme(t)
 	claim, template, warmPool, adopted := newOptimisticLockTestObjects()
@@ -6592,12 +6585,10 @@ func TestSandboxClaimStaleAdoptionRepatchIdempotentWithoutWrite(t *testing.T) {
 	require.Equal(t, adopted.Name, updatedClaim.Status.SandboxStatus.Name, "status must finalize from the authoritative sandbox")
 }
 
-// TestSandboxClaimAssignedSandboxDeletedTerminalCleanup verifies that a
-// stale-view pass whose assigned sandbox is already deleted on the server is
-// TERMINAL: exactly one doomed write, authoritative cleanup of the dead
-// reference (the annotation, or the deprecated label on legacy claims), a
-// benign AdoptionConflict, and no in-pass rebinding to another candidate —
-// with the next (converged) pass re-adopting cleanly.
+// TestSandboxClaimAssignedSandboxDeletedTerminalCleanup verifies a deleted
+// assigned sandbox is terminal: one doomed write, authoritative cleanup of
+// the reference (annotation or deprecated label), benign AdoptionConflict,
+// no in-pass rebinding; the next pass re-adopts cleanly.
 func TestSandboxClaimAssignedSandboxDeletedTerminalCleanup(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -6706,13 +6697,9 @@ func TestSandboxClaimAssignedSandboxDeletedTerminalCleanup(t *testing.T) {
 }
 
 // TestSandboxClaimAdoptionCompletionExhaustedContentionKeepsReference covers
-// the exhausted-contention tail of resolveAdoptionCompletion: when the
-// assigned sandbox stays pool-owned and adoptable but every fresh-base
-// adoption patch keeps conflicting, the pass ends with the benign
-// AdoptionConflict and the committed reference is KEPT (the sandbox is still
-// ours to finish; the next event-driven or rate-limited pass completes it).
-// It also pins the surfaced condition message: the raw apiserver conflict
-// text must be trimmed from what kubectl describe shows.
+// the exhausted-contention tail: persistent 409s end the pass with a benign
+// AdoptionConflict, the committed reference KEPT, and the raw apiserver
+// conflict text trimmed from the surfaced condition message.
 func TestSandboxClaimAdoptionCompletionExhaustedContentionKeepsReference(t *testing.T) {
 	scheme := newScheme(t)
 	_, template, warmPool, _ := newOptimisticLockTestObjects()
@@ -6786,13 +6773,11 @@ func TestSandboxClaimAdoptionCompletionExhaustedContentionKeepsReference(t *test
 	require.Contains(t, readyCond.Message, "conflicting concurrent write")
 }
 
-// TestSandboxClaimAdoptionCleanupFailureSurfacesJoinedError covers the
-// cleanup-failure branch of resolveAdoptionCompletion: the assigned sandbox is
-// gone on the server AND clearing the dead reference fails too. The pass must
-// surface a benign AdoptionConflict (so the workqueue paces the retry), keep
-// the reference for the next pass to clean, and carry both failures in the
-// error.
-func TestSandboxClaimAdoptionCleanupFailureSurfacesJoinedError(t *testing.T) {
+// TestSandboxClaimAdoptionCleanupFailureKeepsReferenceAndRetries covers the
+// cleanup-failure branch: sandbox gone AND reference cleanup failing must
+// surface a stable, terse AdoptionConflict (internals go to logs only), keep
+// the reference, and complete cleanup on a healed pass.
+func TestSandboxClaimAdoptionCleanupFailureKeepsReferenceAndRetries(t *testing.T) {
 	scheme := newScheme(t)
 	_, template, warmPool, _ := newOptimisticLockTestObjects()
 
@@ -6847,11 +6832,18 @@ func TestSandboxClaimAdoptionCleanupFailureSurfacesJoinedError(t *testing.T) {
 	if err == nil || !errors.Is(err, errAdoptionConflict) {
 		t.Fatalf("expected a benign adoption conflict carrying the cleanup failure, got: %v", err)
 	}
-	require.Contains(t, err.Error(), "reference cleanup failed", "the cleanup failure must be carried in the surfaced error")
-	require.Contains(t, err.Error(), "etcd hiccup", "the underlying cleanup error must not be swallowed")
+	require.Contains(t, err.Error(), "reference cleanup failed", "the cleanup failure must be named in the surfaced error")
+	require.NotContains(t, err.Error(), "etcd hiccup", "internal cleanup error text belongs in logs, not the surfaced error")
 
 	after := &extensionsv1beta1.SandboxClaim{}
 	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
+	readyCond := meta.FindStatusCondition(after.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCond)
+	require.Equal(t, "AdoptionConflict", readyCond.Reason)
+	require.NotContains(t, readyCond.Message, "etcd hiccup",
+		"internal cleanup error text must never reach the condition message")
+	require.NotContains(t, readyCond.Message, "Internal error occurred",
+		"apiserver internal-error boilerplate must never reach the condition message")
 	require.Equal(t, "ghost-sb", after.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation],
 		"the reference stays for the next pass to clean when cleanup itself failed")
 
@@ -6863,4 +6855,107 @@ func TestSandboxClaimAdoptionCleanupFailureSurfacesJoinedError(t *testing.T) {
 	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
 	require.NotContains(t, after.Annotations, extensionsv1beta1.AssignedSandboxNameAnnotation,
 		"the healed pass must clean the dead reference")
+}
+
+// TestSandboxClaimAdoptionAnnotationAndCompletionConflictsResolvedSamePass
+// covers the two conflict mechanisms composing in ONE reconcile pass: the
+// annotation write 409s and is retried in-pass on a fresh base, then the
+// completion patch 409s and is resolved on the same candidate — the pass
+// still finishes the adoption with no error and no requeue.
+func TestSandboxClaimAdoptionAnnotationAndCompletionConflictsResolvedSamePass(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: "default", UID: "claim-uid-123"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	candidate := newPoolCandidateSandbox("pool-sb-1")
+
+	claimConflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "extensions.agents.x-k8s.io", Resource: "sandboxclaims"},
+		claim.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+	sandboxConflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+		candidate.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, candidate).
+		WithStatusSubresource(claim).
+		Build()
+
+	// First annotation Update 409s (stale claim base), then the first
+	// adoption patch 409s (concurrent candidate write): both in one pass.
+	claimConflictOnce := true
+	sandboxConflictOnce := true
+	claimUpdates := 0
+	sandboxPatches := 0
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*extensionsv1beta1.SandboxClaim); ok {
+				claimUpdates++
+				if claimConflictOnce {
+					claimConflictOnce = false
+					return claimConflict
+				}
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == "pool-sb-1" {
+				sandboxPatches++
+				if sandboxConflictOnce {
+					sandboxConflictOnce = false
+					return sandboxConflict
+				}
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	warmSandboxQueue := queue.NewSimpleSandboxQueue()
+	warmSandboxQueue.Add(
+		queue.GetNamespacedWarmPoolName("default", "test-pool"),
+		queue.SandboxKey{Namespace: "default", Name: "pool-sb-1"},
+	)
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: warmSandboxQueue,
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	res, err := reconciler.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("expected both conflicts resolved in the same pass, got error: %v", err)
+	}
+	if !res.IsZero() {
+		t.Fatalf("expected no requeue, got %+v", res)
+	}
+	if claimUpdates < 2 {
+		t.Errorf("expected the annotation write to be retried in-pass (>=2 claim updates), got %d", claimUpdates)
+	}
+	if sandboxPatches != 2 {
+		t.Errorf("expected exactly one doomed adoption patch plus one fresh-base re-patch, got %d", sandboxPatches)
+	}
+
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, "pool-sb-1", updatedClaim.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+	require.Equal(t, "pool-sb-1", updatedClaim.Status.SandboxStatus.Name, "the pass must finalize the binding despite both conflicts")
+
+	adopted := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, rawClient.Get(context.Background(), types.NamespacedName{Name: "pool-sb-1", Namespace: "default"}, adopted))
+	adoptedRef := metav1.GetControllerOf(adopted)
+	require.NotNil(t, adoptedRef)
+	require.Equal(t, types.UID("claim-uid-123"), adoptedRef.UID)
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -6421,7 +6421,8 @@ func newPoolCandidateSandbox(name string) *sandboxv1beta1.Sandbox {
 
 // TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates pins the
 // no-flip invariant: a 409 on the adoption patch is resolved on the SAME
-// candidate, never by switching to the next one mid-pass.
+// candidate, never by switching to the next one mid-pass (measured: stale
+// candidate views flipped one claim through 8 sandboxes under load).
 func TestSandboxClaimAdoptionCompletionConflictDoesNotSwitchCandidates(t *testing.T) {
 	scheme := newScheme(t)
 	_, template, warmPool, _ := newOptimisticLockTestObjects()
@@ -7048,10 +7049,21 @@ func TestSandboxClaimAdoptionResolveCancellationPropagates(t *testing.T) {
 		WithStatusSubresource(claim).
 		Build()
 
-	// Every adoption patch is interrupted, as during controller shutdown.
+	// First adoption patch 409s so the pass enters authoritative resolution;
+	// the resolution's own re-patch is then interrupted, as during shutdown.
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+		assigned.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+	patches := 0
 	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == "pool-sb-1" {
+				patches++
+				if patches == 1 {
+					return conflict
+				}
 				return fmt.Errorf("client rate limiter wait: %w", context.Canceled)
 			}
 			return c.Patch(ctx, obj, patch, opts...)
@@ -7076,8 +7088,79 @@ func TestSandboxClaimAdoptionResolveCancellationPropagates(t *testing.T) {
 		t.Fatalf("cancellation must not be classified as a benign adoption conflict, got: %v", err)
 	}
 
+	require.GreaterOrEqual(t, patches, 2, "the pass must enter resolution (doomed patch) and be canceled on the re-patch")
+
 	// The committed reference must be untouched for the next process to finish.
 	after := &extensionsv1beta1.SandboxClaim{}
 	require.NoError(t, rawClient.Get(context.Background(), req.NamespacedName, after))
 	require.Equal(t, "pool-sb-1", after.Annotations[extensionsv1beta1.AssignedSandboxNameAnnotation])
+}
+
+// TestSandboxClaimAdoptionResolveConflictThenCancellationPropagates pins the
+// conflict-then-cancel ordering: a conflict inside the resolution retry makes
+// client-go report the conflict as the loop error, which must not mask the
+// later cancellation as a benign AdoptionConflict.
+func TestSandboxClaimAdoptionResolveConflictThenCancellationPropagates(t *testing.T) {
+	scheme := newScheme(t)
+	_, template, warmPool, _ := newOptimisticLockTestObjects()
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-claim",
+			Namespace: "default",
+			UID:       "claim-uid-123",
+			Annotations: map[string]string{
+				extensionsv1beta1.AssignedSandboxNameAnnotation: "pool-sb-1",
+			},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"}},
+	}
+	assigned := newPoolCandidateSandbox("pool-sb-1")
+
+	conflict := k8errors.NewConflict(
+		schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+		assigned.Name,
+		errors.New("the object has been modified; please apply your changes to the latest version and try again"),
+	)
+
+	rawClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(template, warmPool, claim, assigned).
+		WithStatusSubresource(claim).
+		Build()
+
+	// Patch 1 (outer completeAdoption) and patch 2 (resolution attempt 1)
+	// conflict; patch 3 (resolution attempt 2) is interrupted.
+	patches := 0
+	cachedClient := interceptor.NewClient(rawClient, interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if sb, ok := obj.(*sandboxv1beta1.Sandbox); ok && sb.Name == "pool-sb-1" {
+				patches++
+				if patches <= 2 {
+					return conflict
+				}
+				return fmt.Errorf("client rate limiter wait: %w", context.Canceled)
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           cachedClient,
+		APIReader:        rawClient,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-claim", Namespace: "default"}}
+	_, err := reconciler.Reconcile(context.Background(), req)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the cancellation to propagate past the earlier conflict, got: %v", err)
+	}
+	if errors.Is(err, errAdoptionConflict) {
+		t.Fatalf("a cancellation after a conflict must not be masked as a benign adoption conflict, got: %v", err)
+	}
+	require.Equal(t, 3, patches, "two conflicted patches then the interrupted one")
 }


### PR DESCRIPTION
Follow-ups from the review of the adoption-assignment fix ([review](https://github.com/kubernetes-sigs/agent-sandbox/pull/1277#pullrequestreview-4801992429)); all three non-blocking comments addressed:

- **Combined-sequence test:** annotation-409 retried in-pass, then completion-409 resolved on the same candidate — both mechanisms composing in a single reconcile pass (`TestSandboxClaimAdoptionAnnotationAndCompletionConflictsResolvedSamePass`).
- **Cleanup-failure surface:** joined internal error text can no longer reach the AdoptionConflict condition (the suffix-trim missed mid-chain internals); the surfaced message is now stable and terse, with the full chain logged at the site. Tested.
- **Cosmetic:** `newOptimisticLockTestObjects` (and the retried-in-pass fixture) now use the group/kind constants; verbose comments in the touched files tersened to constraint-bearing content.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved adoption handling for optimistic-lock contention, ensuring the claim does not switch candidates after an assignment is committed.
  - Hardened adoption resolution to treat stale candidate state authoritatively and to clean up committed reference details safely.
  - Refined user-facing conflict messaging to avoid exposing low-level internal errors, while correctly propagating cancellations/timeouts.

- **Tests**
  - Added/updated adoption tests to validate same-pass resolution of multiple conflicts, terminal cleanup vs requeue behavior, and correct cancellation propagation without masking as benign conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Scope note:** audited every `RetryOnConflict`/`retry.OnError`/hand-rolled retry site repo-wide — the two loops fixed here are the only production paths where an interrupted attempt could masquerade as success; all others either guard `ctx.Err()` explicitly or are fail-fast test paths.
