### PR TITLE
controller: reject concurrent fgprof profiles with 500

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -284,7 +285,18 @@ func main() {
 			metricsOpts.ExtraHandlers["/debug/pprof/block"] = pprof.Handler("block")
 			metricsOpts.ExtraHandlers["/debug/pprof/mutex"] = pprof.Handler("mutex")
 			metricsOpts.ExtraHandlers["/debug/pprof/trace"] = http.HandlerFunc(pprof.Trace)
-			metricsOpts.ExtraHandlers["/debug/fgprof"] = fgprof.Handler()
+			// Wrap fgprof handler with mutex to reject concurrent profiling requests,
+			// aligning with pprof CPU profiling behavior.
+			var fgprofMu sync.Mutex
+			fgprofHandler := fgprof.Handler()
+			metricsOpts.ExtraHandlers["/debug/fgprof"] = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if !fgprofMu.TryLock() {
+					http.Error(w, "Could not enable fgprof profiling: fgprof profiling already in use", http.StatusInternalServerError)
+					return
+				}
+				defer fgprofMu.Unlock()
+				fgprofHandler.ServeHTTP(w, r)
+			})
 		}
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add a mutex around the fgprof handler so that only one profile can run at a time. A second concurrent request returns 500 with an error message matching the pprof behaviour for CPU profiling already in use.

Without this protection, concurrent fgprof requests can cause issues as fgprof doesn't have built-in concurrency protection like pprof's CPU profiling does.

#### Which issue(s) this PR is related to:

N/A

#### Release Note

```release-note
[ENHANCEMENT] API: reject concurrent fgprof profiles.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping profiling requests from running concurrently.
  * Concurrent requests to the profiling endpoint are now rejected, improving stability during diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->