### PR TITLE
fix(sandboxclaim): default Delete+TTL=0 lifecycle for warm pool claims

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -925,7 +925,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `warmPoolRef` _[SandboxWarmPoolRef](#sandboxwarmpoolref)_ | warmPoolRef targets the specific pre-warmed infrastructure pool to check out from. |  | Required: \{\} <br /> |
-| `lifecycle` _[Lifecycle](#lifecycle)_ | lifecycle defines when and how the SandboxClaim should be shut down. |  | Optional: \{\} <br /> |
+| `lifecycle` _[Lifecycle](#lifecycle)_ | lifecycle defines when and how the SandboxClaim should be shut down.<br />When omitted on a claim with a warmPoolRef, the controller defaults to<br />ShutdownPolicy=Delete with TTLSecondsAfterFinished=0 so that finished<br />warm-pool claims are automatically cleaned up. Set explicitly to override. |  | Optional: \{\} <br /> |
 | `additionalPodMetadata` _[PodMetadata](#podmetadata)_ | additionalPodMetadata defines the labels and annotations to be propagated to the Sandbox Pod.<br />Label values are limited to 63 characters and must match Kubernetes label value patterns.<br />Annotations in restricted system domains are rejected, except cluster-autoscaler.kubernetes.io/safe-to-evict. |  | Optional: \{\} <br /> |
 | `env` _[EnvVar](#envvar) array_ | env is a list of environment variables to inject into the sandbox.<br />Please note adding this field means the Sandbox will always be cold-started from the<br />template of the warmpool. |  | Optional: \{\} <br /> |
 | `volumeClaimTemplates` _[PersistentVolumeClaimTemplate](#persistentvolumeclaimtemplate) array_ | volumeClaimTemplates is a list of persistent volume claims to be created for the sandbox.<br />Specifying this field forces a cold start because warm pool pods will not have these volumes. |  | Optional: \{\} <br /> |

--- a/extensions/api/v1beta1/sandboxclaim_types.go
+++ b/extensions/api/v1beta1/sandboxclaim_types.go
@@ -112,6 +112,9 @@ type SandboxClaimSpec struct {
 	WarmPoolRef SandboxWarmPoolRef `json:"warmPoolRef"`
 
 	// lifecycle defines when and how the SandboxClaim should be shut down.
+	// When omitted on a claim with a warmPoolRef, the controller defaults to
+	// ShutdownPolicy=Delete with TTLSecondsAfterFinished=0 so that finished
+	// warm-pool claims are automatically cleaned up. Set explicitly to override.
 	// +optional
 	Lifecycle *Lifecycle `json:"lifecycle,omitempty"`
 

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -425,7 +425,18 @@ func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, clai
 // checkExpiration calculates if the claim is expired and how much time is left.
 func (r *SandboxClaimReconciler) checkExpiration(claim *extensionsv1beta1.SandboxClaim) (bool, time.Duration) {
 	if claim.Spec.Lifecycle == nil {
-		return false, 0
+		if claim.Spec.WarmPoolRef.Name == "" {
+			return false, 0
+		}
+		// Warm-pool claims without an explicit lifecycle default to
+		// immediate deletion after the workload finishes. Without this,
+		// finished claims accumulate indefinitely — leaking VMs, pod IPs,
+		// and auto-refreshing SA tokens. See #1306.
+		ttl := int32(0)
+		claim.Spec.Lifecycle = &extensionsv1beta1.Lifecycle{
+			ShutdownPolicy:          extensionsv1beta1.ShutdownPolicyDelete,
+			TTLSecondsAfterFinished: &ttl,
+		}
 	}
 
 	finishedCondition := lifecycle.FinishedCondition(claim.Status.Conditions, string(v1beta1.SandboxConditionFinished))

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -234,7 +234,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Check Expiration
 	// We calculate this upfront to decide the flow.
-	claimExpired, timeLeft := r.checkExpiration(claim)
+	claimExpired, timeLeft, effectiveLifecycle := r.checkExpiration(claim)
 	if claimExpired && !hasClaimExpiredCondition(claim.Status.Conditions) {
 		meta.SetStatusCondition(&claim.Status.Conditions, r.computeReadyCondition(claim, nil, nil, true))
 		if _, updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
@@ -251,11 +251,11 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Handle "Delete" and "DeleteForeground" policies immediately.
 	// If we delete the claim, we return immediately.
 	// Continuing would try to update the status of a deleted object, causing a crash/error.
-	if claimExpired && claim.Spec.Lifecycle != nil &&
-		(claim.Spec.Lifecycle.ShutdownPolicy == extensionsv1beta1.ShutdownPolicyDelete ||
-			claim.Spec.Lifecycle.ShutdownPolicy == extensionsv1beta1.ShutdownPolicyDeleteForeground) {
+	if claimExpired && effectiveLifecycle != nil &&
+		(effectiveLifecycle.ShutdownPolicy == extensionsv1beta1.ShutdownPolicyDelete ||
+			effectiveLifecycle.ShutdownPolicy == extensionsv1beta1.ShutdownPolicyDeleteForeground) {
 
-		policy := claim.Spec.Lifecycle.ShutdownPolicy
+		policy := effectiveLifecycle.ShutdownPolicy
 		logger.Info("Deleting Claim because time has expired", "shutdownPolicy", policy, "claim", claim.Name)
 		if r.Recorder != nil {
 			r.Recorder.Eventf(claim, nil, corev1.EventTypeNormal, extensionsv1beta1.ClaimExpiredReason, "Deleting", fmt.Sprintf("Deleting Claim (ShutdownPolicy=%s)", policy))
@@ -287,7 +287,7 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Update Status & Events
 	r.computeAndSetStatus(claim, sandbox, reconcileErr, claimExpired)
-	postExpiration, postTimeLeft := r.checkExpiration(claim)
+	postExpiration, postTimeLeft, _ := r.checkExpiration(claim)
 	if postExpiration && !hasClaimExpiredCondition(claim.Status.Conditions) {
 		meta.SetStatusCondition(&claim.Status.Conditions, r.computeReadyCondition(claim, sandbox, reconcileErr, true))
 		if _, updateErr := r.updateStatus(ctx, originalClaimStatus, claim); updateErr != nil {
@@ -423,27 +423,26 @@ func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, clai
 }
 
 // checkExpiration calculates if the claim is expired and how much time is left.
-// For warm-pool claims with nil Lifecycle, it injects an in-memory default
-// (Delete + TTL=0) so the expiration reconciler can clean up finished claims.
-// The injection is never persisted — the reconciler re-derives it each cycle.
-func (r *SandboxClaimReconciler) checkExpiration(claim *extensionsv1beta1.SandboxClaim) (bool, time.Duration) {
-	if claim.Spec.Lifecycle == nil {
+// It returns the effective lifecycle used for the calculation: for warm-pool
+// claims with nil Lifecycle it defaults to Delete + TTL=0 so finished claims
+// are cleaned up. The default is never written back to claim.Spec — callers
+// must use the returned lifecycle for policy decisions. See #1306.
+func (r *SandboxClaimReconciler) checkExpiration(claim *extensionsv1beta1.SandboxClaim) (bool, time.Duration, *extensionsv1beta1.Lifecycle) {
+	lc := claim.Spec.Lifecycle
+	if lc == nil {
 		if claim.Spec.WarmPoolRef.Name == "" {
-			return false, 0
+			return false, 0, nil
 		}
-		// Warm-pool claims without an explicit lifecycle default to
-		// immediate deletion after the workload finishes. Without this,
-		// finished claims accumulate indefinitely — leaking VMs, pod IPs,
-		// and auto-refreshing SA tokens. See #1306.
 		ttl := int32(0)
-		claim.Spec.Lifecycle = &extensionsv1beta1.Lifecycle{
+		lc = &extensionsv1beta1.Lifecycle{
 			ShutdownPolicy:          extensionsv1beta1.ShutdownPolicyDelete,
 			TTLSecondsAfterFinished: &ttl,
 		}
 	}
 
 	finishedCondition := lifecycle.FinishedCondition(claim.Status.Conditions, string(v1beta1.SandboxConditionFinished))
-	return lifecycle.TimeLeft(time.Now(), claim.Spec.Lifecycle.ShutdownTime, claim.Spec.Lifecycle.TTLSecondsAfterFinished, finishedCondition)
+	expired, timeLeft := lifecycle.TimeLeft(time.Now(), lc.ShutdownTime, lc.TTLSecondsAfterFinished, finishedCondition)
+	return expired, timeLeft, lc
 }
 
 // reconcileActive handles the creation and updates of running sandboxes.

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -423,6 +423,9 @@ func (r *SandboxClaimReconciler) initializeAnnotations(ctx context.Context, clai
 }
 
 // checkExpiration calculates if the claim is expired and how much time is left.
+// For warm-pool claims with nil Lifecycle, it injects an in-memory default
+// (Delete + TTL=0) so the expiration reconciler can clean up finished claims.
+// The injection is never persisted — the reconciler re-derives it each cycle.
 func (r *SandboxClaimReconciler) checkExpiration(claim *extensionsv1beta1.SandboxClaim) (bool, time.Duration) {
 	if claim.Spec.Lifecycle == nil {
 		if claim.Spec.WarmPoolRef.Name == "" {

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1801,7 +1801,18 @@ func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
 					"expected claim to still exist")
 				if tc.lifecycle == nil {
 					require.Nil(t, updatedClaim.Spec.Lifecycle,
-						"in-memory lifecycle injection must not be persisted to the API server")
+						"effective lifecycle default must not be persisted to claim.Spec")
+				} else {
+					require.Equal(t, tc.lifecycle.ShutdownPolicy, updatedClaim.Spec.Lifecycle.ShutdownPolicy,
+						"explicit lifecycle policy must be preserved after reconciliation")
+				}
+				if !tc.finished {
+					expiredCond := meta.FindStatusCondition(updatedClaim.Status.Conditions,
+						string(sandboxv1beta1.SandboxConditionReady))
+					if expiredCond != nil {
+						require.NotEqual(t, extensionsv1beta1.ClaimExpiredReason, expiredCond.Reason,
+							"active claim must not be marked expired")
+					}
 				}
 			}
 		})

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1706,6 +1706,7 @@ func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
 
 	testCases := []struct {
 		name               string
+		slug               string
 		lifecycle          *extensionsv1beta1.Lifecycle
 		warmPoolRef        string
 		finished           bool
@@ -1713,18 +1714,21 @@ func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
 	}{
 		{
 			name:               "warm pool claim with nil lifecycle is deleted after finish",
+			slug:               "warm-nil-finished",
 			warmPoolRef:        "default-lifecycle-pool",
 			finished:           true,
 			expectClaimDeleted: true,
 		},
 		{
 			name:               "warm pool claim with nil lifecycle stays active before finish",
+			slug:               "warm-nil-active",
 			warmPoolRef:        "default-lifecycle-pool",
 			finished:           false,
 			expectClaimDeleted: false,
 		},
 		{
 			name: "warm pool claim with explicit Retain is not overridden",
+			slug: "warm-retain",
 			lifecycle: &extensionsv1beta1.Lifecycle{
 				ShutdownPolicy: extensionsv1beta1.ShutdownPolicyRetain,
 			},
@@ -1734,6 +1738,7 @@ func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
 		},
 		{
 			name:               "non-warm-pool claim with nil lifecycle stays immortal",
+			slug:               "no-pool-nil",
 			warmPoolRef:        "",
 			finished:           true,
 			expectClaimDeleted: false,
@@ -1743,7 +1748,7 @@ func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			claim := &extensionsv1beta1.SandboxClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: tc.name, Namespace: "default", UID: types.UID(tc.name)},
+				ObjectMeta: metav1.ObjectMeta{Name: tc.slug, Namespace: "default", UID: types.UID(tc.slug)},
 				Spec: extensionsv1beta1.SandboxClaimSpec{
 					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: tc.warmPoolRef},
 					Lifecycle:   tc.lifecycle,

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1794,6 +1794,10 @@ func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
 			} else {
 				require.NoError(t, getErr,
 					"expected claim to still exist")
+				if tc.lifecycle == nil {
+					require.Nil(t, updatedClaim.Spec.Lifecycle,
+						"in-memory lifecycle injection must not be persisted to the API server")
+				}
 			}
 		})
 	}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -1656,6 +1656,149 @@ func TestSandboxClaimTTLAfterFinishedCleanupPolicy(t *testing.T) {
 	}
 }
 
+func TestSandboxClaimWarmPoolDefaultLifecycle(t *testing.T) {
+	scheme := newScheme(t)
+	finishedAt := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-lifecycle-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "default-lifecycle-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-lifecycle-template", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{}}},
+	}
+
+	controller := true
+	createSandbox := func(claim *extensionsv1beta1.SandboxClaim, finished bool) *sandboxv1beta1.Sandbox {
+		sb := &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      claim.Name,
+				Namespace: claim.Namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: extensionsv1beta1.GroupVersion.String(),
+					Kind:       extensionsv1beta1.SandboxClaimKind,
+					Name:       claim.Name,
+					UID:        claim.UID,
+					Controller: &controller,
+				}},
+			},
+			Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{}}},
+		}
+		if finished {
+			sb.Status.Conditions = []metav1.Condition{{
+				Type:               string(sandboxv1beta1.SandboxConditionFinished),
+				Status:             metav1.ConditionTrue,
+				Reason:             sandboxv1beta1.SandboxReasonPodSucceeded,
+				LastTransitionTime: finishedAt,
+			}}
+		} else {
+			sb.Status.Conditions = []metav1.Condition{{
+				Type:               string(sandboxv1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				Reason:             "DependenciesReady",
+				LastTransitionTime: finishedAt,
+			}}
+		}
+		return sb
+	}
+
+	testCases := []struct {
+		name               string
+		lifecycle          *extensionsv1beta1.Lifecycle
+		warmPoolRef        string
+		finished           bool
+		expectClaimDeleted bool
+	}{
+		{
+			name:               "warm pool claim with nil lifecycle is deleted after finish",
+			warmPoolRef:        "default-lifecycle-pool",
+			finished:           true,
+			expectClaimDeleted: true,
+		},
+		{
+			name:               "warm pool claim with nil lifecycle stays active before finish",
+			warmPoolRef:        "default-lifecycle-pool",
+			finished:           false,
+			expectClaimDeleted: false,
+		},
+		{
+			name: "warm pool claim with explicit Retain is not overridden",
+			lifecycle: &extensionsv1beta1.Lifecycle{
+				ShutdownPolicy: extensionsv1beta1.ShutdownPolicyRetain,
+			},
+			warmPoolRef:        "default-lifecycle-pool",
+			finished:           true,
+			expectClaimDeleted: false,
+		},
+		{
+			name:               "non-warm-pool claim with nil lifecycle stays immortal",
+			warmPoolRef:        "",
+			finished:           true,
+			expectClaimDeleted: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			claim := &extensionsv1beta1.SandboxClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: tc.name, Namespace: "default", UID: types.UID(tc.name)},
+				Spec: extensionsv1beta1.SandboxClaimSpec{
+					WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: tc.warmPoolRef},
+					Lifecycle:   tc.lifecycle,
+				},
+			}
+			if tc.finished {
+				claim.Status.Conditions = []metav1.Condition{{
+					Type:               string(sandboxv1beta1.SandboxConditionFinished),
+					Status:             metav1.ConditionTrue,
+					Reason:             sandboxv1beta1.SandboxReasonPodSucceeded,
+					LastTransitionTime: finishedAt,
+				}}
+			}
+
+			sandbox := createSandbox(claim, tc.finished)
+			objs := []client.Object{claim, sandbox, template}
+			if tc.warmPoolRef != "" {
+				objs = append(objs, warmPool)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(objs...).
+				WithStatusSubresource(claim).
+				Build()
+
+			reconciler := &SandboxClaimReconciler{
+				Client:           fakeClient,
+				Scheme:           scheme,
+				Recorder:         events.NewFakeRecorder(10),
+				Tracer:           asmetrics.NewNoOp(),
+				WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+			}
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claim.Name, Namespace: claim.Namespace}}
+
+			// First reconcile: sets Expired condition (if applicable).
+			_, err := reconciler.Reconcile(context.Background(), req)
+			require.NoError(t, err)
+
+			// Second reconcile: acts on the policy.
+			_, err = reconciler.Reconcile(context.Background(), req)
+			require.NoError(t, err)
+
+			updatedClaim := &extensionsv1beta1.SandboxClaim{}
+			getErr := fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim)
+			if tc.expectClaimDeleted {
+				require.True(t, k8errors.IsNotFound(getErr),
+					"expected claim to be deleted, but it still exists")
+			} else {
+				require.NoError(t, getErr,
+					"expected claim to still exist")
+			}
+		})
+	}
+}
+
 func TestSandboxClaimTTLCleanupRequiresPersistedExpiredStatus(t *testing.T) {
 	scheme := newScheme(t)
 	ttlZero := int32(0)

--- a/test/e2e/extensions/warmpool_sandbox_watcher_test.go
+++ b/test/e2e/extensions/warmpool_sandbox_watcher_test.go
@@ -176,6 +176,11 @@ func TestWarmPoolSandboxWatcher(t *testing.T) {
 	claim.Name = "test-claim"
 	claim.Namespace = ns.Name
 	claim.Spec.WarmPoolRef.Name = warmPool.Name
+	// Retain so the sandbox survives pod deletion — this test observes
+	// the not-ready condition, which requires the object to still exist.
+	claim.Spec.Lifecycle = &extensionsv1beta1.Lifecycle{
+		ShutdownPolicy: extensionsv1beta1.ShutdownPolicyRetain,
+	}
 	require.NoError(t, tc.CreateWithCleanup(t.Context(), claim))
 
 	// Wait for claim to be ready with sandbox name in status


### PR DESCRIPTION
## Summary

- When a `SandboxClaim` references a `WarmPool` but omits `spec.lifecycle`, `checkExpiration()` short-circuits at the nil check and returns `(false, 0)` — the expiration reconciler never runs, so the claim, sandbox, pod, and VM persist **indefinitely**
- This leaks VPC IPs, auto-refreshes SA tokens, and holds cloud IMDS access with no expiration path
- Inject an in-memory default `Lifecycle{ShutdownPolicy: Delete, TTLSecondsAfterFinished: 0}` for warm-pool-sourced claims that omit it — the default is deterministic and reconcile-local (not persisted to the API server)
- Non-warm-pool claims retain the existing behavior (immortal when Lifecycle is nil)
- Explicit Lifecycle settings (e.g. `Retain` for debugging) are never overridden

## Details

The root cause is in `checkExpiration` ([sandboxclaim_controller.go:427](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/extensions/controllers/sandboxclaim_controller.go#L427)):

```go
if claim.Spec.Lifecycle == nil {
    return false, 0  // claim never expires
}
```

This is correct for bare `Sandbox` objects (GitOps safety — see #201), but warm pool claims are ephemeral by definition and should not accumulate indefinitely. The fix adds a warm pool check before the early return:

```go
if claim.Spec.Lifecycle == nil {
    if claim.Spec.WarmPoolRef.Name == "" {
        return false, 0  // non-warm-pool: preserve existing behavior
    }
    // Inject default: Delete + TTL=0
    ttl := int32(0)
    claim.Spec.Lifecycle = &extensionsv1beta1.Lifecycle{
        ShutdownPolicy:          extensionsv1beta1.ShutdownPolicyDelete,
        TTLSecondsAfterFinished: &ttl,
    }
}
```

### Follow-up (not in this PR)

A configurable default reaper TTL for explicit `Retain` claims could prevent stale object accumulation for debugging scenarios. See #1306 comment for the full security analysis.

Fixes #1306

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] New unit tests (4 cases):
  - Warm pool claim, nil lifecycle, finished → claim deleted ✅
  - Warm pool claim, nil lifecycle, not finished → claim stays active ✅
  - Warm pool claim, explicit Retain → respected, no override ✅
  - Non-warm-pool claim, nil lifecycle → immortal (old behavior) ✅
- [x] All existing controller tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warm-pool SandboxClaims without an explicit lifecycle now automatically delete after their workload finishes.
  * Claims remain active before completion and continue honoring explicit retention settings.
  * SandboxClaims not associated with a warm pool retain their existing behavior.

* **Documentation**
  * Clarified lifecycle defaults and how explicit settings override them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->