### PR TITLE
docs(rl): update warm-pool worker guidance for controller v0.5.4

### DIFF
--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `agent-sandbox-rl`. Format loosely follows
 
 ## [0.1.0.dev0] — unreleased
 
+### Changed (docs / guidance)
+- **Warm-pool worker guidance updated for Agent Sandbox v0.5.4**: the #1215
+  over-creation churn is fixed upstream by
+  [#1266](https://github.com/kubernetes-sigs/agent-sandbox/pull/1266)
+  (expectations-gated creates, terminating-aware counting), so the long-standing
+  "keep `--sandbox-warm-pool-concurrent-workers` ≤10" advice now applies **only to
+  controllers ≤ v0.5.3**. On v0.5.4+ the recommendation is **`100`** (validated clean
+  at `500` workers with 500 warm pools). `FleetConfig.warm_create_budget` is
+  correspondingly reframed from a required #1215 mitigation to an optional apiserver
+  burst bound. Updated: README (controller-flags table + staged-fill notes),
+  `docs/strategies.md`, `examples/rl_integration.md`, `config.py` field comment,
+  the `plan()` deep-warm advisory in `fleet.py`, and `plan_benchmark()` now emits a
+  controller-flags advisory in its rationale.
+
 Initial implementation (design phases 1–7), live-verified on GKE against Agent
 Sandbox `v0.5.0rc1` (v1beta1).
 

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -270,13 +270,16 @@ fleet.run(process_fn, strategy="naive")          # warm everything, full depth, 
   ask the controller to create tens of thousands of replicas at once. `start_warmpools`
   fills in **waves** of ≤ `warm_create_budget` (default 1000) creates, waiting for each
   wave to be Ready before the next. Set `warm_create_budget=0` to warm all at once.
-  > ⚠️ **Staging alone is not sufficient at scale.** Current Agent Sandbox releases
-  > (≤ v0.5.2) have a warm-pool over-creation *churn* bug
-  > ([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)) that
-  > staging only *slows*. For large/deep *cold* warms, also set the controller flag
-  > **`--sandbox-warm-pool-concurrent-workers` low (≤10)** (leave sandbox/claim workers
-  > high). The RL-safe path avoids the regime entirely — **recycle** one sandbox per
-  > problem (see **Sandbox recycling** below) instead of deep-warming.
+  > **Version note:** staging bounds the controller's create burst on any version, but
+  > on releases **≤ v0.5.3** it only *mitigates* (not prevents) the warm-pool
+  > over-creation *churn* bug
+  > ([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)) — there, also
+  > set the controller flag **`--sandbox-warm-pool-concurrent-workers` low (≤10)**
+  > (leave sandbox/claim workers high). On **v0.5.4+**
+  > ([#1266](https://github.com/kubernetes-sigs/agent-sandbox/pull/1266))
+  > the bug is fixed and `100` is a good default (see the controller-flags table below).
+  > For deep warms on any version, **recycle** one sandbox per problem (see **Sandbox
+  > recycling** below) remains the lower-footprint alternative to deep-warming.
 
 > **When does this help?** Only when an image carries **more than one task**. A 1:1
 > eval sweep (one image per task — see below) gets `min(1, …) = 1` replica, so
@@ -410,9 +413,9 @@ split across pools with different pod caps.)
 **FleetConfig:** `clusters`, `placement`, `max_concurrent` (1), `max_warmpool_size`
 (8), `warm_per_task` (False — one warm replica per task for instant claims),
 `window_size` (None=auto), `ready_timeout` (900), `warm_create_budget` (1000 — stage
-the warm fill in waves of ≤ N sandbox creates in flight to curb the controller's
-over-creation race; pair with a low `--sandbox-warm-pool-concurrent-workers` for
-large/deep cold warms; `0` = warm all at once), `template`
+the warm fill in waves of ≤ N sandbox creates in flight to bound the controller's
+create burst; on controllers ≤ v0.5.3 also pair with a low
+`--sandbox-warm-pool-concurrent-workers` to dodge #1215; `0` = warm all at once), `template`
 (`TemplateSpec`), `template_name_prefix` (`r2e-img-`), `labels`. Disk-aware sizing (optional):
 `avg_image_gb`, `node_ephemeral_gb`, `disk_headroom` (0.25), `cluster_nodes`
 (None) — when set, the auto window for `sliding`/`pipelined` is capped so resident
@@ -606,7 +609,7 @@ the controller Deployment's container args, namespace `agent-sandbox-system`):
 | `--kube-api-burst` | `10` | n/a | **Moot while `qps=-1`** (burst is only consulted when QPS > 0). Only raise if you set a positive QPS. |
 | `--sandbox-concurrent-workers` | `100` | **`1000`** | Sandbox reconciles (claim binding → Ready) are the main serializer; match your peak concurrent sandboxes. |
 | `--sandbox-claim-concurrent-workers` | `50` | **`1000`** | Concurrent `SandboxClaim` reconciles; match peak in-flight claims. |
-| `--sandbox-warm-pool-concurrent-workers` | `1` | **`≤10`** ⚠️ | **Do _not_ raise to 1000.** High values trigger the warm-pool over-creation *churn* bug ([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)): parallel reconciles race a stale informer cache and over-create → delete → re-create sandboxes; with lagging pod GC the pod count balloons (observed ~17K pods for an 8K target). Keep it **low (≤10; `1` fully serializes)** until #1215 is fixed upstream. Warm-pool provisioning is a one-time setup cost, so low concurrency here barely affects steady-state throughput. |
+| `--sandbox-warm-pool-concurrent-workers` | `1` | **`100`** (v0.5.4+) | On **v0.5.4+** the over-creation *churn* bug ([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215), fixed by [#1266](https://github.com/kubernetes-sigs/agent-sandbox/pull/1266): expectations-gated creates, terminating-aware counting) is gone — parallel warm-pool reconciles are safe. **`100`** is a good default (fast replenishment, bounded apiserver burst); raise toward your warm width if the warm-fill wall matters (validated clean at `500` with 500 pools). **On ≤ v0.5.3 keep it low (≤10; `1` fully serializes)** — there high values race a stale informer cache and over-create → delete → re-create sandboxes (observed ~17K pods for an 8K target). |
 | `--sandbox-template-concurrent-workers` | `1` | **`1000`** | Parallel template reconciles. |
 | `--sandbox-warm-pool-max-batch-size` | `300` | **`1000`** | Parallel pod create/delete *within* one warm-pool reconcile. |
 
@@ -615,18 +618,20 @@ controller's API client is already uncapped at `qps=-1`. The **worker concurrenc
 flags are what unblock high-scale claims. Size them to your `max_concurrent`. Also
 size this package's client pool (`build_api_client` defaults the urllib3
 `connection_pool_maxsize` to 1000) to match — otherwise the driver throttles before
-the controller does. **One exception:** `--sandbox-warm-pool-concurrent-workers` — keep
-it **low (≤10)**, not 1000 (see the ⚠️ row above): warm-pool provisioning is a one-time
-setup cost, and high concurrency there triggers the #1215 over-creation churn. Pair with
-this package's staged warm fill (`FleetConfig.warm_create_budget`, default 1000).
+the controller does. **Version note:** `--sandbox-warm-pool-concurrent-workers` is
+release-gated (see the row above) — `100` on v0.5.4+ (#1266 fixed the #1215 churn;
+validated up to 500), but **≤10 on ≤ v0.5.3**. The staged warm fill
+(`FleetConfig.warm_create_budget`, default 1000) remains useful on any version to
+bound the create burst of very large/deep warms.
 
-Example patch:
+Example patch (**v0.5.4+ values** — on controllers ≤ v0.5.3 use
+`--sandbox-warm-pool-concurrent-workers=10` instead, per the table above):
 
 ```bash
 kubectl -n agent-sandbox-system patch deploy agent-sandbox-controller --type=json -p '[
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-concurrent-workers=1000"},
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-claim-concurrent-workers=1000"},
-  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-warm-pool-concurrent-workers=10"},
+  {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-warm-pool-concurrent-workers=100"},
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-template-concurrent-workers=1000"},
   {"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--sandbox-warm-pool-max-batch-size=1000"}
 ]'

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/capacity.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/capacity.py
@@ -267,6 +267,12 @@ def plan_benchmark(cap: ClusterCapacity, n_images: int, tasks_per_image: int = 1
             f"{tasks_per_image} tasks/image -> warm_per_task + colocate_replicas "
             f"({replicas} replicas/image, instant claims).")
 
+    rationale.append(
+        "Controller flags: --sandbox-concurrent-workers / "
+        f"--sandbox-claim-concurrent-workers >= {max_concurrent} (peak in-flight); "
+        "--sandbox-warm-pool-concurrent-workers=100 on v0.5.4+ (#1266; validated to "
+        "500), <=10 on <= v0.5.3 (#1215 over-creation churn).")
+
     return BenchmarkPlan(
         strategy=strategy, max_concurrent=max_concurrent, window_size=window_size,
         warm_per_task=warm_per_task, colocate=colocate, replicas_per_image=replicas,

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
@@ -121,10 +121,9 @@ class FleetConfig(BaseModel):
   ready_timeout: int = 900
   # Stage the warm fill in waves of <= this many sandbox creates in flight,
   # waiting for each wave to reach Ready before the next. Bounds the controller's
-  # concurrent create burst (Σ pools×replicas) so a large/deep warm can't trip the
-  # SandboxWarmPool over-creation race (#1215). 0 = warm everything at once (old
-  # behavior). The safe value scales inversely with controller warm-pool worker
-  # concurrency; 1000 is calibrated for a high-worker controller.
+  # concurrent create burst (Σ pools×replicas). On controllers <= v0.5.3 this also
+  # keeps a large/deep warm from tripping the SandboxWarmPool over-creation race
+  # (#1215; fixed in v0.5.4 by #1266). 0 = warm everything at once (old behavior).
   warm_create_budget: int = 1000
   # --- runaway safeguards (see plans/sdk-runaway-safeguards.md) ------------- #
   # Circuit breaker (#1, fail-safe): abort + teardown if live sandboxes this run

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
@@ -121,9 +121,10 @@ class FleetConfig(BaseModel):
   ready_timeout: int = 900
   # Stage the warm fill in waves of <= this many sandbox creates in flight,
   # waiting for each wave to reach Ready before the next. Bounds the controller's
-  # concurrent create burst (Σ pools×replicas). On controllers <= v0.5.3 this also
-  # keeps a large/deep warm from tripping the SandboxWarmPool over-creation race
-  # (#1215; fixed in v0.5.4 by #1266). 0 = warm everything at once (old behavior).
+  # concurrent create burst (Σ pools×replicas). On controllers <= v0.5.3 this
+  # mitigates (but does NOT prevent) the SandboxWarmPool over-creation race
+  # (issue 1215; fixed in v0.5.4 by PR 1266) — those controllers still need
+  # --sandbox-warm-pool-concurrent-workers <= 10. 0 = warm all at once (old behavior).
   warm_create_budget: int = 1000
   # --- runaway safeguards (see plans/sdk-runaway-safeguards.md) ------------- #
   # Circuit breaker (#1, fail-safe): abort + teardown if live sandboxes this run

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -500,9 +500,10 @@ class SandboxFleet:
           f"over-creation; consider staging claims or a lower cap.")
     if total > 20000:
       plan.warnings.append(
-          f"warm footprint {total} is very large; deep warm can trip the warm-pool "
-          f"over-creation race (#1215) — keep the controller's "
-          f"--sandbox-warm-pool-concurrent-workers low and stage the fill.")
+          f"warm footprint {total} is very large — stage the fill "
+          f"(warm_create_budget); on controllers <= v0.5.3 deep warm can also trip "
+          f"the warm-pool over-creation race (#1215, fixed in v0.5.4 by #1266) — "
+          f"there, keep --sandbox-warm-pool-concurrent-workers low (<=10).")
     for msg in plan.warnings:
       logger.warning("plan advisory: %s", msg)
 

--- a/examples/agent-sandbox-rl/docs/strategies.md
+++ b/examples/agent-sandbox-rl/docs/strategies.md
@@ -54,7 +54,7 @@ fleet.run(rollout_fn, strategy="naive", keep_warm=True)       # reuse across ste
 | **Warm-pool strategy** | when pools exist & footprint | `run(strategy=…)`: `naive` / `sliding` / `pipelined` / `none` | `pipelined` eval; `naive`/`sliding` RL |
 | **Concurrency-aware sizing** (default) | pool depth = image's share of the budget | `max_concurrent`, `max_warmpool_size` | eval (1:1), minimal footprint |
 | **Instant-claim (pre-warm)** | one warm replica **per task** | `FleetConfig.warm_per_task=True` | RL (G rollouts share an image) |
-| **Staged warm fill** | warm in waves to bound the controller's create burst | `FleetConfig.warm_create_budget` (1000; `0`=all at once) | large/deep warms — mitigates the #1215 over-creation race (bounds the burst) |
+| **Staged warm fill** | warm in waves to bound the controller's create burst | `FleetConfig.warm_create_budget` (1000; `0`=all at once) | large/deep warms — bounds the apiserver create burst (on controllers ≤ v0.5.3 it also mitigates the #1215 over-creation race, fixed in v0.5.4 by #1266) |
 | **Replica co-location** | pack a pool's replicas on one node → 1 pull/node | `TemplateSpec.colocate_replicas=True` | deep pools (RL), cache reuse |
 | **Cross-epoch reuse** | keep pools resident across passes | `run(epochs=N)` / `keep_warm=True` | repeated passes (RL epochs) |
 | **Node layer cache** | re-use already-pulled layers | `TemplateSpec.image_pull_policy=IfNotPresent` (default) | every repeated run |

--- a/examples/agent-sandbox-rl/examples/rl_integration.md
+++ b/examples/agent-sandbox-rl/examples/rl_integration.md
@@ -90,9 +90,10 @@ results = fleet.run(rollout_fn, strategy="naive", concurrency=500,
   image set); `claim_concurrency=N` staged-claims to stay under the apiserver.
 
 ### Safeguards at scale (on by default)
-Large/deep warm pools can stress the warm-pool controller
-([#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215)); the SDK is
-fail-safe by default:
+Large/deep warm pools can stress the warm-pool controller (on releases ≤ v0.5.3, the
+[#1215](https://github.com/kubernetes-sigs/agent-sandbox/issues/1215) over-creation churn —
+fixed in v0.5.4 by [#1266](https://github.com/kubernetes-sigs/agent-sandbox/pull/1266));
+the SDK is fail-safe by default:
 - **Circuit breaker** — `FleetConfig.overcommit_factor` (1.5) / `max_live_sandboxes`: if
   live sandboxes exceed the ceiling, the fleet tears down and raises `FleetOvercommitError`
   (catches accidental over-creation — runaway / orphan).
@@ -100,8 +101,8 @@ fail-safe by default:
   `atexit`/SIGINT/SIGTERM tear down on graceful exit, and **`reap(run_id=…)`** /
   `python -m agent_sandbox_rl.reaper` sweeps an **orphaned** run (SIGKILL / OOM / node loss).
 - **Staged fill/claims** — `warm_create_budget` (staged warm) + `claim_concurrency` bound
-  concurrent apiserver ops; for large deep warms also keep the controller's
-  `--sandbox-warm-pool-concurrent-workers` low (≤10).
+  concurrent apiserver ops. Controller side: `--sandbox-warm-pool-concurrent-workers=100`
+  on v0.5.4+ (validated up to 500); keep it low (≤10) only on ≤ v0.5.3 (#1215).
 
 ## Generic env wrapper (primitives)
 


### PR DESCRIPTION
## What

Refreshes the agent-sandbox-rl example's controller tuning guidance now that v0.5.4 ships #1266 (expectations-gated creates, terminating-aware counting), which fixes the #1215 warm-pool over-creation churn.

- README controller-flags table + staged-warm-fill notes: the `--sandbox-warm-pool-concurrent-workers` recommendation changes from "keep <=10" (now only for <= v0.5.3) to **100 on v0.5.4+** — validated clean at 500 workers with 500 warm pools (SWE-bench-500x6, 0 errors).
- `docs/strategies.md`, `examples/rl_integration.md`, `config.py`: `warm_create_budget` reframed from required #1215 mitigation to optional apiserver burst bound.
- `fleet.py` `plan()` deep-warm advisory and `capacity.plan_benchmark()` rationale now emit version-gated controller-flag advice.

## Why

Post-v0.5.4, the old blanket throttle needlessly serializes warm-pool replenishment and starves wide fresh-claim bursts.

## Testing

`pytest tests/` — 307 passed. Docs plus advisory-string changes; no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated warm-pool guidance by controller version: use up to 10 workers with versions ≤v0.5.3 and up to 100 with v0.5.4+.
  * Clarified staged warm fills, burst limits, deep-warming, capacity planning, and high-scale controller settings.
  * Documented the v0.5.4 warm-pool fix, related safeguards, and version-specific behavior.
  * Retained guidance for the `recycle=True` lower-footprint alternative and added clearer concurrency advisories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->