### PR TITLE
Add kata-aks-sandbox and openclaw-kata-aks-sandbox examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,12 +17,15 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**hermes-agents-as-a-service**](./hermes-agents-as-a-service): The multi-user platform pattern distilled from a real agents-as-a-service product: per-user claims over a warm pool, suspend/resume as the cost dial, PVC state survival, and injection-policy enforcement.
 - [**hpa-swp-scaling**](./hpa-swp-scaling): An example of scaling a SandboxWarmPool using Kubernetes Horizontal Pod Autoscaler (HPA).
 - [**jupyterlab**](./jupyterlab): An example of running JupyterLab on Agent-Sandbox.
+- [**kata-aks-sandbox**](./kata-aks-sandbox): An example of running a sandbox with Kata Containers hardware-virtualized isolation on AKS, using the built-in Pod Sandboxing feature.
+- [**kata-gke-sandbox**](./kata-gke-sandbox): An example of running a sandbox with Kata Containers hardware-virtualized isolation on GKE.
 - [**keda-scale-to-zero**](./keda-scale-to-zero): An example of scaling a SandboxWarmPool down to zero (and back up) using KEDA and Google Managed Service for Prometheus (GMP).
 - [**langchain**](./langchain): An example of a coding agent using Agent-Sandbox and LangGraph.
 - [**manual-pdb**](./manual-pdb): An example of manual PodDisruptionBudget (PDB) configuration for sandboxes.
 - [**mcp-server-sandbox**](./mcp-server-sandbox): Run an MCP (Model Context Protocol) server inside a Sandbox with attached storage.
 - [**nullclaw-sandbox**](./nullclaw-sandbox): An example of running Nullclaw, a minimal AI assistant runtime, inside the Agent Sandbox.
 - [**openclaw-gvisor-sandbox**](./openclaw-gvisor-sandbox): A production-shaped, gVisor-isolated OpenClaw sandbox using the template/claim pattern and persistent storage.
+- [**openclaw-kata-aks-sandbox**](./openclaw-kata-aks-sandbox): An OpenClaw sandbox isolated by Kata Containers on AKS, so the agent runtime gets its own VM and guest kernel.
 - [**playwright-sandbox**](./playwright-sandbox): An example of running Playwright with Chromium in a sandbox for web scraping and screenshots.
 - [**policy**](./policy): Examples of using different policies with sandboxes.
 - [**python-runtime-sandbox**](./python-runtime-sandbox): An example of a Python runtime sandbox.

--- a/examples/kata-aks-sandbox/README.md
+++ b/examples/kata-aks-sandbox/README.md
@@ -1,0 +1,103 @@
+# Enabling Kata Containers on AKS
+
+## Overview
+
+This example demonstrates how to run sandboxed agents with a stronger security boundary by using [Kata Containers](https://github.com/kata-containers/kata-containers) on an Azure Kubernetes Service (AKS) cluster.
+
+By default, Agent Sandbox uses standard container runtimes that provide OS-level isolation where all sandboxes share the host node's kernel. AKS offers [Pod Sandboxing](https://learn.microsoft.com/azure/aks/use-pod-sandboxing) as a built-in feature: each sandboxed pod runs in its own lightweight VM with a dedicated guest kernel, on a stack composed of the [Azure Linux container host](https://learn.microsoft.com/azure/aks/use-azure-linux), the Microsoft Hyper-V hypervisor, the [Cloud Hypervisor](https://www.cloudhypervisor.org) VMM, and the Kata Containers runtime.
+
+Unlike environments where Kata must be installed manually (see the [GKE example](../kata-gke-sandbox)), AKS provisions everything when a node pool is created with the Kata workload runtime: the nodes come with Kata pre-installed, and the cluster ships a ready-to-use `kata-vm-isolation` RuntimeClass whose scheduling selector automatically places Kata pods onto those nodes. No DaemonSet installer and no manual RuntimeClass registration are needed.
+
+## Prerequisites
+
+1. [Install](https://learn.microsoft.com/cli/azure/install-azure-cli) the Azure CLI and sign in with `az login`.
+2. [Install kubectl](https://kubernetes.io/docs/tasks/tools/).
+3. Review the [Pod Sandboxing prerequisites and limitations](https://learn.microsoft.com/azure/aks/use-pod-sandboxing) in the official AKS documentation. In short (as of July 2026): the Kata node pool must use `--os-sku AzureLinux`, a [generation 2 VM size that supports nested virtualization](https://learn.microsoft.com/azure/virtual-machines/generation-2) (for example, the Dsv5 series), and — for existing clusters — Kubernetes 1.27.0 or higher.
+
+## Step 1: Run the Setup Script
+
+> **Note:** this script creates billable Azure resources: a resource group, an AKS cluster with Pod Sandboxing enabled (or, with `--reuse-cluster`, a new Kata node pool on your existing cluster). It then fetches cluster credentials and verifies that the AKS-provided `kata-vm-isolation` RuntimeClass is present. See the [Cleanup](#cleanup) section to remove everything.
+
+For details on available `[OPTIONS...]`, please see the script itself.
+
+```shell
+./setup.sh [OPTIONS...]
+```
+
+## Step 2: Install the Agent Sandbox Controller
+
+Before you can create a `Sandbox` resource, you must install the Agent Sandbox controller on your cluster following the [Installation Guide](../../README.md#installation).
+
+## Step 3: Deploy an Agent Sandbox
+
+With the Kata node pool ready, deploy an Agent Sandbox that uses it.
+
+The manifest below (`sandbox-kata-aks.yaml`) defines a `Sandbox` that requests the AKS-provided `kata-vm-isolation` runtime. The RuntimeClass carries its own scheduling `nodeSelector`, so the pod lands on the Kata node pool without any explicit selector in the manifest.
+
+```yaml
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: kata-aks-example
+spec:
+  podTemplate:
+    spec:
+      runtimeClassName: kata-vm-isolation
+      containers:
+      - name: hello-kata
+        image: busybox:1.37
+        command: ["sh", "-c", "echo 'Hello from an Agent Sandbox running in Kata on AKS!' && sleep 3600"]
+```
+
+Apply it:
+
+```shell
+kubectl apply -f sandbox-kata-aks.yaml
+```
+
+## Step 4: Verify the Isolation
+
+Check that the sandbox is ready and its pod is running:
+
+```shell
+kubectl get sandbox kata-aks-example
+kubectl get pod kata-aks-example
+kubectl logs kata-aks-example
+```
+
+You should see:
+
+```text
+Hello from an Agent Sandbox running in Kata on AKS!
+```
+
+Confirm the workload runs under its own guest kernel rather than the node's kernel:
+
+```shell
+# Kernel inside the sandbox (the Kata pod VM's guest kernel)
+kubectl exec kata-aks-example -- uname -r
+
+# Kernel on the node
+kubectl get node -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}'
+```
+
+The two versions differ: the sandboxed workload is running inside its own VM with a dedicated kernel, isolated from the host by the hypervisor boundary.
+
+Note on resources: the `kata-vm-isolation` RuntimeClass declares a fixed pod overhead for the VM and host-side components. For finer control, AKS supports [custom runtime classes with tuned overheads](https://learn.microsoft.com/azure/aks/considerations-pod-sandboxing#resource-management) on the same `kata` handler.
+
+## Cleanup
+
+```shell
+kubectl delete -f sandbox-kata-aks.yaml
+```
+
+To remove the Kata node pool or the demo cluster entirely:
+
+```shell
+# Node pool only (keeps the cluster)
+az aks nodepool delete --cluster-name <CLUSTER_NAME> --resource-group <RESOURCE_GROUP> --name <KATA_NODEPOOL_NAME>
+
+# Whole demo cluster and its resource group
+az aks delete --name <CLUSTER_NAME> --resource-group <RESOURCE_GROUP>
+az group delete --name <RESOURCE_GROUP>
+```

--- a/examples/kata-aks-sandbox/README.md
+++ b/examples/kata-aks-sandbox/README.md
@@ -77,8 +77,9 @@ Confirm the workload runs under its own guest kernel rather than the node's kern
 # Kernel inside the sandbox (the Kata pod VM's guest kernel)
 kubectl exec kata-aks-example -- uname -r
 
-# Kernel on the node
-kubectl get node -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}'
+# Kernel on the node hosting the sandbox
+SANDBOX_NODE="$(kubectl get pod kata-aks-example -o jsonpath='{.spec.nodeName}')"
+kubectl get node "${SANDBOX_NODE}" -o jsonpath='{.status.nodeInfo.kernelVersion}'
 ```
 
 The two versions differ: the sandboxed workload is running inside its own VM with a dedicated kernel, isolated from the host by the hypervisor boundary.

--- a/examples/kata-aks-sandbox/sandbox-kata-aks.yaml
+++ b/examples/kata-aks-sandbox/sandbox-kata-aks.yaml
@@ -1,0 +1,15 @@
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: kata-aks-example
+spec:
+  podTemplate:
+    spec:
+      # AKS ships this RuntimeClass on clusters with Pod Sandboxing enabled.
+      # Its scheduling nodeSelector automatically places the pod on a
+      # KataVmIsolation node pool, so no explicit nodeSelector is needed.
+      runtimeClassName: kata-vm-isolation
+      containers:
+      - name: hello-kata
+        image: busybox:1.37
+        command: ["sh", "-c", "echo 'Hello from an Agent Sandbox running in Kata on AKS!' && sleep 3600"]

--- a/examples/kata-aks-sandbox/setup.sh
+++ b/examples/kata-aks-sandbox/setup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script creates billable Azure resources: a resource group and an AKS
+# cluster with Pod Sandboxing (Kata) enabled, or -- with --reuse-cluster -- a
+# new Kata node pool on an existing cluster. It then fetches credentials and
+# verifies the AKS-provided kata-vm-isolation RuntimeClass.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Defaults
+RESOURCE_GROUP="kata-aks-demo"
+CLUSTER_NAME="kata-test"
+LOCATION="westus2"
+NODE_COUNT=1
+VM_SIZE="Standard_D4s_v5"
+KATA_NODEPOOL_NAME="katapool"
+RUNTIME_CLASS_NAME="kata-vm-isolation"
+REUSE_CLUSTER=false
+
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --resource-group) RESOURCE_GROUP="$2"; shift ;;
+        --cluster-name) CLUSTER_NAME="$2"; shift ;;
+        --location) LOCATION="$2"; shift ;;
+        --node-count) NODE_COUNT="$2"; shift ;;
+        --vm-size) VM_SIZE="$2"; shift ;;
+        --kata-nodepool-name) KATA_NODEPOOL_NAME="$2"; shift ;;
+        --reuse-cluster) REUSE_CLUSTER=true ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+echo "### Configuration ###"
+echo "RESOURCE_GROUP:      ${RESOURCE_GROUP}"
+echo "CLUSTER_NAME:        ${CLUSTER_NAME}"
+echo "LOCATION:            ${LOCATION}"
+echo "NODE_COUNT:          ${NODE_COUNT}"
+echo "VM_SIZE:             ${VM_SIZE}"
+echo "KATA_NODEPOOL_NAME:  ${KATA_NODEPOOL_NAME}"
+echo "REUSE_CLUSTER:       ${REUSE_CLUSTER}"
+echo "#####################"
+
+echo "### Step 1: Creating/Checking the Resource Group ###"
+if ! az group show --name "${RESOURCE_GROUP}" > /dev/null 2>&1; then
+    echo "--- Creating resource group '${RESOURCE_GROUP}' in '${LOCATION}' ---"
+    az group create --name "${RESOURCE_GROUP}" --location "${LOCATION}" --output none
+fi
+
+echo "### Step 2: Creating/Checking the AKS Cluster ###"
+
+if az aks show --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}" > /dev/null 2>&1; then
+    if [[ "${REUSE_CLUSTER}" != "true" ]]; then
+        echo "Error: Cluster '${CLUSTER_NAME}' already exists in resource group '${RESOURCE_GROUP}'."
+        echo "To add a Kata node pool to the existing cluster, re-run with the --reuse-cluster flag."
+        exit 1
+    fi
+    echo "### Cluster '${CLUSTER_NAME}' exists. Adding a Kata node pool (requires Kubernetes >= 1.27) ###"
+    # AKS provisions Kata (runtime, guest kernel, Cloud Hypervisor) on the pool
+    # and labels its nodes for the kata-vm-isolation RuntimeClass scheduling.
+    az aks nodepool add \
+        --cluster-name "${CLUSTER_NAME}" \
+        --resource-group "${RESOURCE_GROUP}" \
+        --name "${KATA_NODEPOOL_NAME}" \
+        --node-count "${NODE_COUNT}" \
+        --os-sku AzureLinux \
+        --workload-runtime KataVmIsolation \
+        --node-vm-size "${VM_SIZE}"
+    az aks update --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}" --output none
+else
+    echo "### Cluster '${CLUSTER_NAME}' not found. Creating it with Pod Sandboxing enabled ###"
+    az aks create \
+        --name "${CLUSTER_NAME}" \
+        --resource-group "${RESOURCE_GROUP}" \
+        --os-sku AzureLinux \
+        --workload-runtime KataVmIsolation \
+        --node-vm-size "${VM_SIZE}" \
+        --node-count "${NODE_COUNT}" \
+        --generate-ssh-keys
+fi
+
+echo "### Step 3: Getting Cluster Credentials ###"
+az aks get-credentials --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing
+
+echo "### Step 4: Verifying the Kata RuntimeClass ###"
+# AKS ships this RuntimeClass on Pod Sandboxing clusters; nothing to install.
+kubectl get runtimeclass "${RUNTIME_CLASS_NAME}"
+
+echo "### Setup Complete! ###"
+echo "You can now deploy an Agent Sandbox using the '${RUNTIME_CLASS_NAME}' RuntimeClass."
+echo "Follow 'Step 2' in the README to install the Agent Sandbox controller and 'Step 3' to deploy the sandbox."

--- a/examples/kata-aks-sandbox/setup.sh
+++ b/examples/kata-aks-sandbox/setup.sh
@@ -82,7 +82,6 @@ if az aks show --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}" > /
         --os-sku AzureLinux \
         --workload-runtime KataVmIsolation \
         --node-vm-size "${VM_SIZE}"
-    az aks update --name "${CLUSTER_NAME}" --resource-group "${RESOURCE_GROUP}" --output none
 else
     echo "### Cluster '${CLUSTER_NAME}' not found. Creating it with Pod Sandboxing enabled ###"
     az aks create \

--- a/examples/openclaw-kata-aks-sandbox/README.md
+++ b/examples/openclaw-kata-aks-sandbox/README.md
@@ -1,0 +1,83 @@
+# OpenClaw on Kata Containers (AKS)
+
+## Overview
+
+This example runs [OpenClaw](https://github.com/openclaw/openclaw) — a headless agent gateway with a web Control UI — inside an Agent Sandbox that is isolated by [Kata Containers](https://github.com/kata-containers/kata-containers) on Azure Kubernetes Service (AKS).
+
+It is the hardware-virtualized counterpart to the [gVisor-isolated OpenClaw example](../openclaw-gvisor-sandbox): where that one uses a syscall-interception sandbox and the template/warm-pool/claim pattern, this one uses a single `Sandbox` running in its own lightweight VM with a dedicated guest kernel, via the AKS [Pod Sandboxing](https://learn.microsoft.com/azure/aks/use-pod-sandboxing) feature.
+
+Isolating an agent runtime this way is useful when the agent executes untrusted, model-generated code: the blast radius of a container escape is the pod VM, not the node kernel.
+
+## Prerequisites
+
+1. An AKS cluster with a Pod Sandboxing (Kata) node pool, and the `kata-vm-isolation` RuntimeClass available. The [kata-aks-sandbox example](../kata-aks-sandbox) provides a `setup.sh` that creates one; see also the [AKS Pod Sandboxing documentation](https://learn.microsoft.com/azure/aks/use-pod-sandboxing).
+2. The Agent Sandbox controller installed on the cluster ([Installation Guide](../../README.md#installation)).
+3. A default StorageClass for the workspace `PersistentVolumeClaim` (AKS provides one).
+
+## Step 1: Deploy the Sandbox
+
+```shell
+kubectl apply -f openclaw-config.yaml
+kubectl apply -f openclaw-sandbox-kata-aks.yaml
+```
+
+Wait for it to become ready:
+
+```shell
+kubectl wait --for=condition=Ready sandbox/openclaw-kata-aks-sandbox --timeout=5m
+kubectl get pod openclaw-kata-aks-sandbox
+```
+
+The gateway takes a few seconds after the pod is Running before it starts listening; there is no readiness probe gating it.
+
+## Step 2: Reach the Control UI
+
+```shell
+kubectl port-forward openclaw-kata-aks-sandbox 18789:18789
+```
+
+Then open `http://localhost:18789/#token=dummy-token-for-sandbox`. The token fragment is required — the gateway rejects a bare load. The token is set by `OPENCLAW_GATEWAY_TOKEN` in the manifest; change it for anything beyond a local demo.
+
+## Step 3: Add a provider API key (optional)
+
+The sandbox starts with `--allow-unconfigured`, so the gateway runs without any model provider. To let the agent actually answer, create the Secret:
+
+```shell
+kubectl create secret generic openclaw-provider-keys \
+  --from-literal=ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+Then uncomment the `ANTHROPIC_API_KEY` block in `openclaw-sandbox-kata-aks.yaml` and re-apply it. Run an agent turn from inside the sandbox:
+
+```shell
+kubectl exec openclaw-kata-aks-sandbox -- \
+  openclaw agent --local --session-id demo -m "Say hi in three words"
+```
+
+Running the turn in-guest keeps it on the gateway's loopback interface, which avoids the device-pairing flow a remote client would need.
+
+## Step 4: Verify the isolation
+
+```shell
+# Kernel inside the sandbox (the Kata pod VM's guest kernel)
+kubectl exec openclaw-kata-aks-sandbox -- uname -r
+
+# Kernel on the node
+kubectl get node -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}'
+```
+
+The two differ: the agent runtime is running in its own VM, not sharing the host kernel.
+
+## Notes on sizing
+
+The pod VM is sized from the container's resource limits. The Node.js gateway needs considerably more memory than the default pod VM size, and an embedded agent turn (`--local`) needs more still — with too little guest memory the gateway is OOM-killed inside the VM. The manifest requests 2Gi / limits 4Gi, which leaves room for both. See the AKS [Pod Sandboxing resource management notes](https://learn.microsoft.com/azure/aks/considerations-pod-sandboxing#resource-management) for how pod VM sizing and RuntimeClass overhead interact.
+
+## Cleanup
+
+```shell
+kubectl delete -f openclaw-sandbox-kata-aks.yaml
+kubectl delete -f openclaw-config.yaml
+kubectl delete secret openclaw-provider-keys --ignore-not-found
+```
+
+Deleting the Sandbox does not delete the workspace `PersistentVolumeClaim`; remove it explicitly if you no longer need the agent's state.

--- a/examples/openclaw-kata-aks-sandbox/README.md
+++ b/examples/openclaw-kata-aks-sandbox/README.md
@@ -62,8 +62,9 @@ Running the turn in-guest keeps it on the gateway's loopback interface, which av
 # Kernel inside the sandbox (the Kata pod VM's guest kernel)
 kubectl exec openclaw-kata-aks-sandbox -- uname -r
 
-# Kernel on the node
-kubectl get node -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}'
+# Kernel on the node hosting the sandbox
+SANDBOX_NODE="$(kubectl get pod openclaw-kata-aks-sandbox -o jsonpath='{.spec.nodeName}')"
+kubectl get node "${SANDBOX_NODE}" -o jsonpath='{.status.nodeInfo.kernelVersion}'
 ```
 
 The two differ: the agent runtime is running in its own VM, not sharing the host kernel.

--- a/examples/openclaw-kata-aks-sandbox/openclaw-config.yaml
+++ b/examples/openclaw-kata-aks-sandbox/openclaw-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+data:
+  openclaw.json: |
+    {
+      "gateway": {
+        "controlUi": {
+          "allowedOrigins": [
+              "http://localhost:18789",
+              "http://127.0.0.1:18789"
+            ]
+        }
+      }
+    }

--- a/examples/openclaw-kata-aks-sandbox/openclaw-sandbox-kata-aks.yaml
+++ b/examples/openclaw-kata-aks-sandbox/openclaw-sandbox-kata-aks.yaml
@@ -22,7 +22,7 @@ spec:
         # The gateway rewrites its config on startup, so copy the read-only
         # ConfigMap into a writable volume first.
         - name: init-config
-          image: ghcr.io/openclaw/openclaw:2026.3.23
+          image: ghcr.io/openclaw/openclaw:2026.3.28
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -38,7 +38,7 @@ spec:
               mountPath: /etc/openclaw
       containers:
         - name: openclaw
-          image: ghcr.io/openclaw/openclaw:2026.3.23
+          image: ghcr.io/openclaw/openclaw:2026.3.28
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/examples/openclaw-kata-aks-sandbox/openclaw-sandbox-kata-aks.yaml
+++ b/examples/openclaw-kata-aks-sandbox/openclaw-sandbox-kata-aks.yaml
@@ -1,0 +1,107 @@
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: openclaw-kata-aks-sandbox
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: openclaw-kata-aks-sandbox
+    spec:
+      # AKS ships this RuntimeClass on clusters with Pod Sandboxing enabled. Its
+      # scheduling nodeSelector places the pod on a KataVmIsolation node pool, so
+      # no explicit nodeSelector is needed here.
+      runtimeClassName: kata-vm-isolation
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+      initContainers:
+        # The gateway rewrites its config on startup, so copy the read-only
+        # ConfigMap into a writable volume first.
+        - name: init-config
+          image: ghcr.io/openclaw/openclaw:2026.3.23
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          command:
+            - sh
+            - -c
+            - cp /etc/openclaw-readonly/openclaw.json /etc/openclaw/openclaw.json
+          volumeMounts:
+            - name: cm-volume
+              mountPath: /etc/openclaw-readonly
+            - name: openclaw-etc-writable
+              mountPath: /etc/openclaw
+      containers:
+        - name: openclaw
+          image: ghcr.io/openclaw/openclaw:2026.3.23
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          # The pod VM is sized from these limits. The Node gateway needs
+          # noticeably more than the default pod VM size, and an embedded agent
+          # turn needs more still: with too little guest memory the gateway is
+          # OOM-killed inside the VM.
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          env:
+            - name: OPENCLAW_GATEWAY_TOKEN
+              value: "dummy-token-for-sandbox"
+            - name: OPENCLAW_CONFIG_PATH
+              value: "/etc/openclaw/openclaw.json"
+            - name: HOME
+              value: "/workspace"
+            # Provider API key (required for chat to work). Create the Secret with:
+            #   kubectl create secret generic openclaw-provider-keys \
+            #     --from-literal=ANTHROPIC_API_KEY="sk-ant-..."
+            # Then uncomment the block below and re-apply this manifest.
+            # - name: ANTHROPIC_API_KEY
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: openclaw-provider-keys
+            #       key: ANTHROPIC_API_KEY
+          command:
+            - sh
+            - -c
+            - |
+              node dist/index.js gateway --bind=lan --port 18789 --allow-unconfigured --verbose
+          ports:
+            - containerPort: 18789
+            - containerPort: 18790
+          volumeMounts:
+            - mountPath: /workspace/.openclaw
+              name: workspaces-pvc
+            - mountPath: /etc/openclaw
+              name: openclaw-etc-writable
+            - mountPath: /workspace
+              name: home-dir
+      volumes:
+        - name: cm-volume
+          configMap:
+            name: openclaw-config
+        - name: openclaw-etc-writable
+          emptyDir: {}
+        - name: home-dir
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: workspaces-pvc
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi

--- a/site/content/docs/use-cases/examples/kata-aks-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/kata-aks-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Enabling Kata Containers on AKS"
+linkTitle: "Kata Containers on AKS"
+weight: 2
+description: >
+  This example demonstrates how to run sandboxed agents with Kata Containers providing hardware-virtualized isolation on AKS, using the built-in Pod Sandboxing feature.
+---
+{{% include-file file="additional/examples/kata-aks-sandbox/README.md" %}}

--- a/site/content/docs/use-cases/examples/openclaw-kata-aks-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/openclaw-kata-aks-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "OpenClaw on Kata Containers (AKS)"
+linkTitle: "OpenClaw on Kata (AKS)"
+weight: 2
+description: >
+  This example runs the OpenClaw agent gateway in an Agent Sandbox isolated by Kata Containers on AKS, giving the agent runtime its own VM and guest kernel.
+---
+{{% include-file file="additional/examples/openclaw-kata-aks-sandbox/README.md" %}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds two examples for running Agent Sandbox with hardware-virtualized isolation on Azure Kubernetes Service (AKS), using the built-in [Pod Sandboxing](https://learn.microsoft.com/azure/aks/use-pod-sandboxing) feature (Kata Containers with the Cloud Hypervisor VMM):

- **`examples/kata-aks-sandbox/`** — the AKS sibling of `examples/kata-gke-sandbox/`, deliberately mirroring its structure (README + `setup.sh` + a single `Sandbox` manifest). The AKS flow is simpler than GKE's: a node pool created with `--workload-runtime KataVmIsolation` comes with Kata pre-installed and the cluster ships a `kata-vm-isolation` RuntimeClass that carries its own scheduling nodeSelector, so there is no DaemonSet installer and no manual RuntimeClass registration — prerequisites link to the official AKS docs rather than duplicating them.
- **`examples/openclaw-kata-aks-sandbox/`** — the hardware-virtualized counterpart to `examples/openclaw-gvisor-sandbox/`: the OpenClaw agent gateway running in a `Sandbox` that gets its own VM and guest kernel. It follows the same credential pattern as the gVisor example (a commented-out `ANTHROPIC_API_KEY` block sourced from an `openclaw-provider-keys` Secret) and documents the pod-VM memory headroom a Node.js agent runtime needs.

Both examples get a docs-site page following the existing `include-file` pattern, and the `examples/README.md` index gains rows for both plus the previously missing `kata-gke-sandbox` row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AKS example for running sandboxes with Kata Containers VM isolation.
  * Added an OpenClaw sandbox with isolated execution, persistent workspace storage, configurable resources, and optional provider credentials.
  * Added setup automation for creating or reusing an AKS cluster with Kata Pod Sandboxing.
  * Added deployment manifests and configuration for both examples.

* **Documentation**
  * Added guides covering prerequisites, deployment, Control UI access, isolation verification, resource sizing, and cleanup.
  * Added both examples to the examples index and documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->