### PR TITLE
perf(sandboxclaim): reconcile claims when template is created

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -344,8 +344,8 @@ func (r *SandboxClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			logger.V(1).Info("SandboxTemplate of the warmpool not found yet, will retry", "warmPool", claim.Spec.WarmPoolRef.Name, "error", reconcileErr)
 		}
 
-		// TODO: This 1-minute requeue creates a latency regression vs an immediate watch trigger.
-		// Consider adding a lightweight SandboxTemplate -> claims map watch to reconcile promptly.
+		// The dependency watches normally trigger an immediate retry. Keep this
+		// delayed requeue as a fallback for missed watch events or cache lag.
 		requeueDelay := 1 * time.Minute
 		if result.RequeueAfter > 0 && result.RequeueAfter < requeueDelay {
 			requeueDelay = result.RequeueAfter
@@ -2069,20 +2069,85 @@ func (r *SandboxClaimReconciler) mapWarmPoolToClaims(ctx context.Context, obj cl
 		log.FromContext(ctx).Error(fmt.Errorf("unexpected object type %T", obj), "expected SandboxWarmPool in watch map function")
 		return nil
 	}
-	var claims extensionsv1beta1.SandboxClaimList
-	if err := r.List(ctx, &claims, client.InNamespace(warmPool.Namespace), client.MatchingFields{extensionsv1beta1.WarmPoolRefField: warmPool.Name}); err != nil {
+
+	claims, err := r.listClaimsForWarmPool(ctx, warmPool)
+	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to list SandboxClaims for SandboxWarmPool", "namespace", warmPool.Namespace, "name", warmPool.Name)
 		return nil
 	}
-	requests := make([]ctrl.Request, 0, len(claims.Items))
-	for i := range claims.Items {
-		claim := &claims.Items[i]
+
+	requests := make([]ctrl.Request, 0, len(claims))
+	for i := range claims {
+		claim := &claims[i]
 		if claim.Status.SandboxStatus.Name != "" || !claim.DeletionTimestamp.IsZero() {
 			continue
 		}
 		requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: claim.Namespace, Name: claim.Name}})
 	}
 	return requests
+}
+
+func (r *SandboxClaimReconciler) listClaimsForWarmPool(ctx context.Context, warmPool *extensionsv1beta1.SandboxWarmPool) ([]extensionsv1beta1.SandboxClaim, error) {
+	var claims extensionsv1beta1.SandboxClaimList
+	if err := r.List(ctx, &claims, client.InNamespace(warmPool.Namespace), client.MatchingFields{extensionsv1beta1.WarmPoolRefField: warmPool.Name}); err != nil {
+		return nil, err
+	}
+	return claims.Items, nil
+}
+
+// mapSandboxTemplateToClaims maps a newly created SandboxTemplate to
+// SandboxClaims whose referenced SandboxWarmPool uses that template. The
+// TemplateRefField index is registered by SandboxWarmPoolReconciler before the
+// manager starts. Unlike pool events, template creation also wakes bound claims:
+// they can be waiting on a missing template to validate and propagate metadata.
+func (r *SandboxClaimReconciler) mapSandboxTemplateToClaims(ctx context.Context, obj client.Object) []ctrl.Request {
+	template, ok := obj.(*extensionsv1beta1.SandboxTemplate)
+	if !ok {
+		log.FromContext(ctx).Error(fmt.Errorf("unexpected object type %T", obj), "expected SandboxTemplate in watch map function")
+		return nil
+	}
+
+	var warmPools extensionsv1beta1.SandboxWarmPoolList
+	if err := r.List(ctx, &warmPools, client.InNamespace(template.Namespace), client.MatchingFields{extensionsv1beta1.TemplateRefField: template.Name}); err != nil {
+		log.FromContext(ctx).Error(err, "failed to list SandboxWarmPools for SandboxTemplate", "namespace", template.Namespace, "name", template.Name)
+		return nil
+	}
+
+	seen := make(map[types.NamespacedName]struct{})
+	var requests []ctrl.Request
+	for i := range warmPools.Items {
+		warmPool := &warmPools.Items[i]
+		claims, err := r.listClaimsForWarmPool(ctx, warmPool)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to list SandboxClaims for SandboxWarmPool", "namespace", warmPool.Namespace, "name", warmPool.Name)
+			continue
+		}
+		for j := range claims {
+			claim := &claims[j]
+			if !claim.DeletionTimestamp.IsZero() {
+				continue
+			}
+			key := types.NamespacedName{Namespace: claim.Namespace, Name: claim.Name}
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			requests = append(requests, ctrl.Request{NamespacedName: key})
+		}
+	}
+	return requests
+}
+
+// sandboxTemplateCreatePredicate admits only template create events. Template
+// updates are handled by warm-pool rollout semantics and must not fan out to
+// claims through this latency-oriented watch.
+func sandboxTemplateCreatePredicate() predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
 }
 
 // sandboxStatusRelevantChange reports whether a Sandbox update changed a field
@@ -2176,8 +2241,11 @@ func (r *SandboxClaimReconciler) SetupWithManager(mgr ctrl.Manager, concurrentWo
 			// ErrWarmPoolNotFound / ErrTemplateNotFound.
 			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
 		).
-		// TODO: Keep a lightweight SandboxTemplate -> claims map watch to promptly reconcile
-		// claims when a missing template is created, instead of relying on the 1-minute fallback.
+		Watches(
+			&extensionsv1beta1.SandboxTemplate{},
+			handler.EnqueueRequestsFromMapFunc(r.mapSandboxTemplateToClaims),
+			builder.WithPredicates(sandboxTemplateCreatePredicate()),
+		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: concurrentWorkers}).
 		Complete(r)
 }

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -4904,6 +4904,99 @@ func TestWarmPoolMapWatchPredicate(t *testing.T) {
 	}
 }
 
+func TestMapSandboxTemplateToClaims(t *testing.T) {
+	scheme := newScheme(t)
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "target-template", Namespace: "default"},
+	}
+	warmPool1 := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+	warmPool2 := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-2", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+	otherTemplatePool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-template-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "other-template"}},
+	}
+	otherNamespacePool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-namespace-pool", Namespace: "other"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name}},
+	}
+
+	claim1 := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim-1", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPool1.Name}},
+	}
+	claim2 := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim-2", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPool2.Name}},
+	}
+	boundClaim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "bound-claim", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPool1.Name},
+			AdditionalPodMetadata: sandboxv1beta1.PodMetadata{
+				Labels: map[string]string{"example.com/reconcile": "required"},
+			},
+		},
+		Status: extensionsv1beta1.SandboxClaimStatus{
+			SandboxStatus: extensionsv1beta1.SandboxStatus{Name: "bound-sandbox"},
+		},
+	}
+	deletingClaim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting-claim",
+			Namespace:         "default",
+			DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			Finalizers:        []string{"test-finalizer"},
+		},
+		Spec: extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: warmPool1.Name}},
+	}
+	otherTemplateClaim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-template-claim", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: otherTemplatePool.Name}},
+	}
+	otherNamespaceClaim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-namespace-claim", Namespace: "other"},
+		Spec:       extensionsv1beta1.SandboxClaimSpec{WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: otherNamespacePool.Name}},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(warmPool1, warmPool2, otherTemplatePool, otherNamespacePool, claim1, claim2, boundClaim, deletingClaim, otherTemplateClaim, otherNamespaceClaim).
+		WithIndex(&extensionsv1beta1.SandboxWarmPool{}, extensionsv1beta1.TemplateRefField, sandboxTemplateRefNameIndexer).
+		WithIndex(&extensionsv1beta1.SandboxClaim{}, extensionsv1beta1.WarmPoolRefField, func(obj client.Object) []string {
+			claim := obj.(*extensionsv1beta1.SandboxClaim)
+			if claim.Spec.WarmPoolRef.Name == "" {
+				return nil
+			}
+			return []string{claim.Spec.WarmPoolRef.Name}
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{Client: fakeClient, Scheme: scheme}
+	requests := reconciler.mapSandboxTemplateToClaims(context.Background(), template)
+
+	require.ElementsMatch(t, []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: claim1.Name, Namespace: claim1.Namespace}},
+		{NamespacedName: types.NamespacedName{Name: claim2.Name, Namespace: claim2.Namespace}},
+		{NamespacedName: types.NamespacedName{Name: boundClaim.Name, Namespace: boundClaim.Namespace}},
+	}, requests)
+}
+
+func TestSandboxTemplateCreatePredicate(t *testing.T) {
+	pred := sandboxTemplateCreatePredicate()
+	template := &extensionsv1beta1.SandboxTemplate{}
+
+	require.True(t, pred.Create(event.CreateEvent{Object: template}))
+	require.False(t, pred.Update(event.UpdateEvent{ObjectOld: template, ObjectNew: template.DeepCopy()}))
+	require.False(t, pred.Delete(event.DeleteEvent{Object: template}))
+	require.False(t, pred.Generic(event.GenericEvent{Object: template}))
+}
+
 func TestSandboxClaimLegacyLabelMigration(t *testing.T) {
 	scheme := newScheme(t)
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Creating a previously missing `SandboxTemplate` now immediately enqueues affected `SandboxClaim` resources instead of making them wait for the one-minute fallback requeue.

The claim controller watches `SandboxTemplate` create events only and uses the existing field indexes to map each template through its referencing `SandboxWarmPool` resources to the relevant claims. Template updates, deletes, and generic events do not fan out to claims, so the rollout and adoption semantics covered by #764 and #1078 remain unchanged. The existing one-minute requeue is retained as a fallback for missed watch events or cache lag.

The mapping includes bound claims because claims with additional pod metadata can still be waiting for a missing template to validate and propagate that metadata. Claims being deleted are excluded.

#### Which issue(s) this PR is related to:
Fixes #1310

#### Release Note
```release-note
SandboxClaims are reconciled immediately when a previously missing SandboxTemplate is created.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox claim processing when dependency watch events are missed or caches are delayed.
  * Sandbox claims now respond appropriately when related sandbox templates are created.
  * Prevented reconciliation of claims that are already bound or being deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->