### PR TITLE
fix(sandboxclaim): use claim generation for Ready condition

### DIFF
--- a/extensions/controllers/sandboxclaim_conditions_test.go
+++ b/extensions/controllers/sandboxclaim_conditions_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
+)
+
+func TestSandboxClaimReadyConditionUsesClaimGeneration(t *testing.T) {
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Generation: 4},
+	}
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Generation: 2},
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{
+				Type:               string(sandboxv1beta1.SandboxConditionReady),
+				Status:             metav1.ConditionTrue,
+				Reason:             "DependenciesReady",
+				Message:            "Pod is Ready",
+				ObservedGeneration: 2,
+			}},
+		},
+	}
+
+	want := sandbox.Status.Conditions[0]
+	want.ObservedGeneration = claim.Generation
+	got := (&SandboxClaimReconciler{}).computeReadyCondition(claim, sandbox, nil, false)
+
+	if got != want {
+		t.Errorf("computeReadyCondition() = %+v, want %+v", got, want)
+	}
+}

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -759,6 +759,7 @@ func (r *SandboxClaimReconciler) computeReadyCondition(claim *extensionsv1beta1.
 	// Forward the condition from Sandbox Status
 	for _, condition := range sandbox.Status.Conditions {
 		if condition.Type == string(v1beta1.SandboxConditionReady) {
+			condition.ObservedGeneration = claim.Generation
 			return condition
 		}
 	}


### PR DESCRIPTION
#### What this PR does / why we need it:

A `SandboxClaim` copied the `Ready` condition from its backing `Sandbox` unchanged. After a claim-only spec update, the condition's `observedGeneration` could still refer to the older Sandbox generation, causing clients to treat the Claim status as stale.

This change preserves the backing Sandbox `Ready` condition details while setting `observedGeneration` to the current `SandboxClaim` generation. It also adds a regression test covering mismatched Claim and Sandbox generations.

#### How has this been tested?

- `go test -race ./extensions/controllers`
- `make test-unit`
- `make build`
- `make lint-go`

#### Which issue(s) this PR is related to:

Fixes #1316

#### Release Note

```release-note
Fix SandboxClaim Ready conditions to report the SandboxClaim generation.
```