### PR TITLE
chore(lint): add goheader and intrange linters

### DIFF
--- a/clients/go/sandbox/files.go
+++ b/clients/go/sandbox/files.go
@@ -40,7 +40,7 @@ const upperHex = "0123456789ABCDEF"
 func percentEncode(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' ||
 			c >= '0' && c <= '9' || c == '-' || c == '_' || c == '.' || c == '~' {

--- a/clients/go/sandbox/gateway.go
+++ b/clients/go/sandbox/gateway.go
@@ -211,7 +211,7 @@ func isValidGatewayHostname(s string) bool {
 	if len(s) == 0 || len(s) > 253 {
 		return false
 	}
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		switch {
 		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -201,7 +201,7 @@ func isValidDNSSubdomain(s string) bool {
 	if len(s) == 0 || len(s) > 253 {
 		return false
 	}
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		switch {
 		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -1272,7 +1272,7 @@ func TestReconcile(t *testing.T) {
 				reconcileCount = 1
 			}
 			var err error
-			for i := 0; i < reconcileCount; i++ {
+			for range reconcileCount {
 				_, err = r.Reconcile(t.Context(), ctrl.Request{
 					NamespacedName: types.NamespacedName{
 						Name:      sandboxName,
@@ -4616,14 +4616,14 @@ func TestNameHash_Correctness(t *testing.T) {
 
 func BenchmarkNameHashNew(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = NameHash("my-sandbox-name")
 	}
 }
 
 func BenchmarkNameHashOld(b *testing.B) {
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = fmt.Sprintf("%08x", GetNumericHash("my-sandbox-name"))
 	}
 }

--- a/dev/tools/.golangci.yaml
+++ b/dev/tools/.golangci.yaml
@@ -2,24 +2,26 @@ version: "2"
 linters:
   enable:
     - depguard
+    - errcheck
     - exptostd
     - godot
+    - goheader
+    - govet
     - iface
     - importas
+    - ineffassign
+    - intrange
     - iotamixing
+    - misspell
     - modernize
     - nilnesserr
     - recvcheck
     - revive
     - sloglint
+    - staticcheck
     - testifylint
     - unconvert
-    - govet
-    - staticcheck
     - unparam
-    - misspell
-    - errcheck
-    - ineffassign
   settings:
     depguard:
       rules:
@@ -27,6 +29,24 @@ linters:
           deny:
             - pkg: sort
               desc: Should be replaced with slices package
+    goheader:
+      values:
+        regexp:
+          YEAR: 20[2-9][0-9]
+      template: |-
+        Copyright {{ YEAR }} The Kubernetes Authors.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
     misspell:
       mode: default
   exclusions:

--- a/extensions/controllers/queue/simple_sandbox_queue_test.go
+++ b/extensions/controllers/queue/simple_sandbox_queue_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package queue
 
 import (

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -1054,7 +1054,7 @@ func slowStartBatch(ctx context.Context, count int, initialBatchSize int, fn fun
 		eg, _ := errgroup.WithContext(ctx)
 		var batchSuccesses atomic.Int64
 
-		for i := 0; i < batchSize; i++ {
+		for i := range batchSize {
 			index := successes + i
 			eg.Go(func() error {
 				if err := fn(index); err != nil {

--- a/sandbox-router/cache/cache.go
+++ b/sandbox-router/cache/cache.go
@@ -410,7 +410,7 @@ func apiVersionInGroup(apiVersion, group string) bool {
 	if apiVersion == group {
 		return true
 	}
-	for i := 0; i < len(apiVersion); i++ {
+	for i := range len(apiVersion) {
 		if apiVersion[i] == '/' {
 			return apiVersion[:i] == group
 		}

--- a/sandbox-router/proxy/headers.go
+++ b/sandbox-router/proxy/headers.go
@@ -148,7 +148,7 @@ func validDNSLabel(s string) bool {
 	if s == "" || len(s) > 63 {
 		return false
 	}
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		switch {
 		case c >= '0' && c <= '9':

--- a/test/e2e/framework/componentlogs.go
+++ b/test/e2e/framework/componentlogs.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package framework
 
 import (

--- a/test/e2e/framework/testlogs.go
+++ b/test/e2e/framework/testlogs.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package framework
 
 import (

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -1112,7 +1112,7 @@ func ForkJoin[K comparable, V any](ctx context.Context, items []K, concurrency i
 	var wg sync.WaitGroup
 	jobs := make(chan int, concurrency)
 
-	for w := 0; w < concurrency; w++ {
+	for range concurrency {
 		wg.Go(func() {
 			for i := range jobs {
 				k := items[i]


### PR DESCRIPTION
#### What this PR does / why we need it:

Add two new linters to `.golangci.yaml`:

- **goheader**: Enforces Apache 2.0 license header format with year validation
- **intrange**: Suggests using Go 1.22+ integer range syntax in for loops

Also alphabetically sorted the linter list for better maintainability.

Fixed all existing lint issues across 11 files:
- Converted traditional `for i := 0; i < n; i++` loops to `for i := range n`
- Fixed license header formatting (tab to spaces, added blank line after header)

#### Which issue(s) this PR is related to:

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized internal Go loop syntax without changing application behavior.
  * Standardized license header formatting across the codebase.
  * Updated linting rules to enforce loop style and license headers.

* **Tests**
  * Updated test and benchmark loops to use the modern Go iteration syntax while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->