### PR TITLE
feat(warmpool): make the readiness grace period configurable

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -77,6 +77,7 @@ func main() {
 	var sandboxWarmPoolConcurrentWorkers int
 	var sandboxTemplateConcurrentWorkers int
 	var sandboxWarmPoolMaxBatchSize int
+	var sandboxWarmPoolReadinessGracePeriod time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -140,6 +141,7 @@ func main() {
 	flag.IntVar(&sandboxWarmPoolConcurrentWorkers, "sandbox-warm-pool-concurrent-workers", 1, "Max concurrent reconciles for the SandboxWarmPool controller")
 	flag.IntVar(&sandboxTemplateConcurrentWorkers, "sandbox-template-concurrent-workers", 1, "Max concurrent reconciles for the SandboxTemplate controller")
 	flag.IntVar(&sandboxWarmPoolMaxBatchSize, "sandbox-warm-pool-max-batch-size", 300, "Max batch size for parallel sandbox creation and deletion in SandboxWarmPool controller. Default is 300. Creates advance one observed batch per watch round-trip (the expectations gate waits for a batch's add events before issuing the next), so a large pool fills in about ceil(replicas/batchSize) round-trips; raising this trades round-trips for burst size and is safe at any value under the gate.")
+	flag.DurationVar(&sandboxWarmPoolReadinessGracePeriod, "sandbox-warm-pool-readiness-grace-period", 5*time.Minute, "How long a warm-pool sandbox may stay non-Ready before the SandboxWarmPool controller considers it stuck and replaces it (unschedulable sandboxes are held instead of replaced). Must exceed the expected time for a pool to reach Ready under your fill sizes: readiness-status lag behind a large fill can otherwise cause healthy sandboxes to be replaced, and even with no replacements, grace deadlines landing inside the fill make the self-scheduled post-grace evaluations re-reconcile pools near-continuously, which measurably slows large fills. Default is 5m.")
 	flag.BoolVar(&enableWarmPoolEviction, "enable-warm-pool-eviction", true, "Mark pods created by a warm pool as ready-to-evict by default.")
 	flag.BoolVar(&cacheLabelSelectors, "cache-label-selectors", false,
 		"Scope the manager's Pod and Service informer caches to objects carrying the sandbox tracking label ("+
@@ -196,6 +198,10 @@ func main() {
 	// Validation checks for sandboxWarmPoolMaxBatchSize (maximum batch size for sandbox creation and deletion in SandboxWarmPool controller)
 	if sandboxWarmPoolMaxBatchSize <= 0 {
 		setupLog.Error(nil, "sandbox-warm-pool-max-batch-size must be greater than 0")
+		os.Exit(1)
+	}
+	if sandboxWarmPoolReadinessGracePeriod <= 0 {
+		setupLog.Error(nil, "sandbox-warm-pool-readiness-grace-period must be greater than 0")
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -504,6 +510,7 @@ func main() {
 			Scheme:                 mgr.GetScheme(),
 			MaxBatchSize:           sandboxWarmPoolMaxBatchSize,
 			EnableWarmPoolEviction: enableWarmPoolEviction,
+			ReadinessGracePeriod:   sandboxWarmPoolReadinessGracePeriod,
 			Recorder:               mgr.GetEventRecorder("sandboxwarmpool-controller"),
 		}).SetupWithManager(mgr, sandboxWarmPoolConcurrentWorkers); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "SandboxWarmPool")

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -60,9 +60,15 @@ const (
 	// of O(sandboxes-in-namespace).
 	sandboxWarmPoolLabelIndex = ".metadata.labels[" + warmPoolSandboxLabel + "]"
 
-	// warmPoolReadinessGracePeriod is how long a pool sandbox may stay
-	// non-Ready before the reconciler considers it stuck and replaces it.
-	warmPoolReadinessGracePeriod = 5 * time.Minute
+	// defaultWarmPoolReadinessGracePeriod is the default for how long a pool
+	// sandbox may stay non-Ready before the reconciler considers it stuck and
+	// replaces it. Configurable via ReadinessGracePeriod on the reconciler
+	// (--sandbox-warm-pool-readiness-grace-period): the grace period must
+	// exceed the pool's expected fill horizon — when deadlines land inside a
+	// large fill, the self-scheduled post-grace evaluations keep pools
+	// re-reconciling near-continuously, which measurably slows the fill even
+	// when nothing is ever replaced.
+	defaultWarmPoolReadinessGracePeriod = 5 * time.Minute
 
 	// expectationsPendingRequeueDelay is the fallback requeue used when create
 	// or delete work is skipped because previously issued writes have not been
@@ -102,6 +108,13 @@ type SandboxWarmPoolReconciler struct {
 	Scheme                 *runtime.Scheme
 	MaxBatchSize           int
 	EnableWarmPoolEviction bool
+	// ReadinessGracePeriod is how long a pool sandbox may stay non-Ready
+	// before it is considered stuck and replaced (unschedulable sandboxes are
+	// held instead, #1215). Zero or negative means
+	// defaultWarmPoolReadinessGracePeriod. Operators should keep this above
+	// the pool's expected time-to-Ready under their fill sizes; see
+	// defaultWarmPoolReadinessGracePeriod for why.
+	ReadinessGracePeriod time.Duration
 	// Recorder emits pool-level Events (e.g. WarmPoolNotProgressing). May be
 	// nil (tests); all uses are nil-guarded.
 	Recorder events.EventRecorder
@@ -119,6 +132,15 @@ type SandboxWarmPoolReconciler struct {
 
 	// now is a test hook for the reconciler's clock; nil means time.Now.
 	now func() time.Time
+}
+
+// readinessGracePeriod returns the effective readiness grace period
+// (ReadinessGracePeriod, defaulted when unset).
+func (r *SandboxWarmPoolReconciler) readinessGracePeriod() time.Duration {
+	if r.ReadinessGracePeriod > 0 {
+		return r.ReadinessGracePeriod
+	}
+	return defaultWarmPoolReadinessGracePeriod
 }
 
 // clockNow returns the reconciler's current time (time.Now unless a test
@@ -248,6 +270,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	activeSandboxes, terminatingReplicas, allErrors := r.filterActiveSandboxes(ctx, poolKey, warmPool, sandboxList.Items, template, currentSandboxBlueprintHash, tmplErr)
 
 	now := r.clockNow()
+	readinessGrace := r.readinessGracePeriod()
 	var healthySandboxes []sandboxv1beta1.Sandbox
 	unschedulableReplicas := int32(0)
 	// nextGraceDeadline is the time remaining until the earliest readiness
@@ -256,7 +279,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	for _, sb := range activeSandboxes {
 		if !isSandboxReady(&sb) && !sb.CreationTimestamp.IsZero() {
 			age := now.Sub(sb.CreationTimestamp.Time)
-			if age <= warmPoolReadinessGracePeriod {
+			if age <= readinessGrace {
 				// Not Ready but still within the grace period. In a quiet
 				// cluster nothing else touches the Sandbox objects of a pool
 				// that settles at Ready=False (pod FailedScheduling events do
@@ -266,7 +289,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 				// unschedulable-hold/NotProgressing signal unreachable.
 				// Requeue for the earliest grace deadline so the evaluation
 				// is deterministic.
-				if remaining := warmPoolReadinessGracePeriod - age + graceRequeueSlack; nextGraceDeadline == 0 || remaining < nextGraceDeadline {
+				if remaining := readinessGrace - age + graceRequeueSlack; nextGraceDeadline == 0 || remaining < nextGraceDeadline {
 					nextGraceDeadline = remaining
 				}
 				healthySandboxes = append(healthySandboxes, sb)
@@ -448,7 +471,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 	if unschedulableReplicas > 0 {
 		r.setNotProgressing(warmPool, poolKey, true, fmt.Sprintf(
 			"%d/%d sandboxes are unschedulable past the %s readiness grace period; holding them instead of replacing (replacements would be equally unschedulable)",
-			unschedulableReplicas, desiredReplicas, warmPoolReadinessGracePeriod))
+			unschedulableReplicas, desiredReplicas, readinessGrace))
 		requeueAfter = minNonZeroDuration(requeueAfter, unschedulableRequeueDelay)
 	} else {
 		r.setNotProgressing(warmPool, poolKey, false, "")

--- a/extensions/controllers/sandboxwarmpool_overcreation_test.go
+++ b/extensions/controllers/sandboxwarmpool_overcreation_test.go
@@ -12,16 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Regression tests for #1215: SandboxWarmPool over-creates replicas.
-//
-// The production failure mode: reconcilePool computes
-// "toCreate = spec.replicas - len(cachedSandboxes)" from the informer cache,
-// which lags the controller's own just-issued creates. Every create event
-// re-enqueues the pool (ownership watch), so under load the same pool is
-// re-reconciled while the cache still shows the pre-create state, and each
-// pass creates toward the target again — ~10x over-creation observed at
-// --sandbox-warm-pool-concurrent-workers=1000 (>=5,000 creates for a 500-pod
-// target; log-confirmed by tomergee on the issue).
 package controllers
 
 import (
@@ -32,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -662,14 +653,14 @@ func TestReconcilePool_YoungNotReadyArmsGraceRequeue(t *testing.T) {
 	require.NoError(t, err)
 	// Earliest deadline wins: the 4-minute-old sandbox has 1 minute of grace
 	// left. The fake clock makes this exact.
-	require.Equal(t, warmPoolReadinessGracePeriod-4*time.Minute+graceRequeueSlack, requeueAfter,
+	require.Equal(t, defaultWarmPoolReadinessGracePeriod-4*time.Minute+graceRequeueSlack, requeueAfter,
 		"requeue must target the earliest remaining grace deadline")
 
 	// With the default jitter factor, the requeue is spread inside
 	// [base, base*(1+factor)] — never earlier than the deadline, never more
 	// than 50% beyond it.
 	graceRequeueJitterFactor = 0.5
-	jitterBase := warmPoolReadinessGracePeriod - 4*time.Minute + graceRequeueSlack
+	jitterBase := defaultWarmPoolReadinessGracePeriod - 4*time.Minute + graceRequeueSlack
 	for range 20 {
 		rj := SandboxWarmPoolReconciler{
 			Client: newFakeClient(scheme,
@@ -777,7 +768,7 @@ func TestReconcilePool_QuietClusterSelfScheduledGraceEvaluation(t *testing.T) {
 	// post-grace evaluation is self-scheduled.
 	requeueAfter, err := r.reconcilePool(ctx, warmPool)
 	require.NoError(t, err)
-	require.Equal(t, warmPoolReadinessGracePeriod+graceRequeueSlack, requeueAfter)
+	require.Equal(t, defaultWarmPoolReadinessGracePeriod+graceRequeueSlack, requeueAfter)
 	select {
 	case e := <-recorder.Events:
 		t.Fatalf("no event may fire inside the grace period, got: %s", e)
@@ -854,4 +845,92 @@ func TestWarmPoolSandboxEventHandler_ObservesOwnedEvents(t *testing.T) {
 	require.False(t, e.SatisfiedExpectations(poolKey))
 	h.Delete(ctx, event.DeleteEvent{Object: owned}, nil)
 	require.True(t, e.SatisfiedExpectations(poolKey))
+}
+
+// TestReconcilePool_ConfigurableReadinessGracePeriod verifies that
+// ReadinessGracePeriod on the reconciler overrides the default: a not-Ready
+// sandbox older than the default 5m is still held (and the post-grace requeue
+// targets the configured deadline) under a longer grace, and is replaced under
+// a shorter one. The grace period must track the operator's fill horizon —
+// at large fills, readiness-status lag past a short grace replaces healthy
+// sandboxes, and even without replacements the self-scheduled deadline
+// evaluations re-reconcile pools near-continuously.
+func TestReconcilePool_ConfigurableReadinessGracePeriod(t *testing.T) {
+	zeroGraceJitter(t)
+	const poolName = "test-pool"
+	const poolNamespace = "default"
+	replicas := int32(1)
+	template := createTemplate(poolNamespace)
+	poolNameHash := sandboxcontrollers.NameHash(poolName)
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: poolNamespace,
+			UID:       "warmpool-uid-grace",
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas:    &replicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name},
+		},
+	}
+
+	base := time.Now().Truncate(time.Second)
+	controller := true
+	newNotReadySandbox := func(age time.Duration) *sandboxv1beta1.Sandbox {
+		sb := createPoolSandbox(poolName, poolNamespace, poolNameHash, template, "-grace")
+		sb.UID = "uid-grace"
+		sb.CreationTimestamp = metav1.Time{Time: base.Add(-age)}
+		sb.Status.Conditions = []metav1.Condition{{
+			Type:   string(sandboxv1beta1.SandboxConditionReady),
+			Status: metav1.ConditionFalse,
+		}}
+		sb.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: extensionsv1beta1.GroupVersion.String(),
+			Kind:       "SandboxWarmPool",
+			Name:       poolName,
+			UID:        warmPool.UID,
+			Controller: &controller,
+		}}
+		return sb
+	}
+
+	scheme := newTestScheme()
+	ctx := context.Background()
+
+	// A 10-minute-old not-Ready sandbox is PAST the 5m default but within a
+	// 30m configured grace: it must be held, and the requeue must target the
+	// configured deadline (30m - 10m + slack), not the default's.
+	longGrace := SandboxWarmPoolReconciler{
+		Client:               newFakeClient(scheme, template, warmPool, newNotReadySandbox(10*time.Minute)),
+		Scheme:               scheme,
+		MaxBatchSize:         sandboxCreateDeleteMaxBatchSize,
+		ReadinessGracePeriod: 30 * time.Minute,
+		now:                  func() time.Time { return base },
+	}
+	requeueAfter, err := longGrace.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+	require.Equal(t, 30*time.Minute-10*time.Minute+graceRequeueSlack, requeueAfter,
+		"requeue must target the CONFIGURED grace deadline, not the default")
+	held := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, longGrace.Client.Get(ctx,
+		types.NamespacedName{Name: newNotReadySandbox(0).Name, Namespace: poolNamespace}, held),
+		"sandbox within the configured grace must be held, not replaced")
+
+	// The same sandbox under a 1m configured grace is stuck: it must be
+	// replaced (deleted) instead of held.
+	shortGrace := SandboxWarmPoolReconciler{
+		Client:               newFakeClient(scheme, template, warmPool, newNotReadySandbox(10*time.Minute)),
+		Scheme:               scheme,
+		MaxBatchSize:         sandboxCreateDeleteMaxBatchSize,
+		ReadinessGracePeriod: time.Minute,
+		now:                  func() time.Time { return base },
+	}
+	_, err = shortGrace.reconcilePool(ctx, warmPool)
+	require.NoError(t, err)
+	gone := &sandboxv1beta1.Sandbox{}
+	getErr := shortGrace.Client.Get(ctx,
+		types.NamespacedName{Name: newNotReadySandbox(0).Name, Namespace: poolNamespace}, gone)
+	require.True(t, apierrors.IsNotFound(getErr),
+		"sandbox past the configured grace must be replaced (deleted)")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
- Adds `--sandbox-warm-pool-readiness-grace-period` (duration, default 5m — behavior unchanged) and threads it into `SandboxWarmPoolReconciler` as `ReadinessGracePeriod`, replacing the hardcoded `warmPoolReadinessGracePeriod` const (which remains as the default). Follows the existing warm-pool flag family (`-concurrent-workers`, `-max-batch-size`).

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

**Note:** A sandbox's time-to-Ready is dominated by image pull for typical agent workloads — multi-GB images (SWE-bench-class, ~1.3 GB compressed and up) can take minutes to pull cold, so a fixed 5m grace sits uncomfortably close to normal startup time: a sandbox mid-pull past the deadline gets replaced by a new sandbox that begins the same pull. The measurements below deliberately exclude that effect (images were node-preloaded, ~1 s pulls) and show the grace period matters even then:

The grace period has to exceed a pool's expected fill horizon — and that's a property of the workload and cluster, not of the controller. Two measured failure modes when it doesn't (200K-sandbox scale test: 500 warmpoolpools × 400 replicas on 850 nodes, controller at 400-500 sandbox workers / 50 warm-pool workers / qps 1000):

1. Performance, even with zero reaping. One-constant controlled diff, otherwise identical builds and workload: 5m grace = 52.2 min to all-Ready; 60m grace = 17.6-18.8 min. Same exact result, zero replacements in both — the 3× comes from the self-scheduled post-grace evaluations: with deadlines landing inside a long fill, some sandbox's deadline is always seconds away, so pools requeue and re-scan near-continuously for the whole fill. (The existing requeue jitter spreads the spikes but can't remove the rescans while deadlines keep landing mid-fill.)
2. Correctness risk under status lag. On a saturated control plane, readiness-status writes can lag minutes behind pods actually being Ready; a grace shorter than that lag replaces healthy, Running sandboxes, feeding delete/create churn into exactly the conditions #1215/#1266 addressed.

New regression test (`TestReconcilePool_ConfigurableReadinessGracePeriod`) covers both directions: a longer configured grace holds a sandbox the default would replace (and the post-grace requeue targets the configured deadline), and a shorter one replaces a sandbox the default would hold. All existing tests construct the reconciler without the field, so they exercise the defaulting path unchanged.

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable readiness grace period for sandbox warm pools.
  * Added a command-line option with a five-minute default and validation for positive values.
  * Longer grace periods keep older not-ready sandboxes available longer; shorter periods allow them to be removed sooner.

* **Bug Fixes**
  * Improved warm-pool deadline scheduling and handling of stalled sandboxes based on the configured grace period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->