### PR TITLE
feat(mcp): add list_files and file_exists tools

### DIFF
--- a/clients/integrations/mcp-server/README.md
+++ b/clients/integrations/mcp-server/README.md
@@ -49,6 +49,22 @@ The MCP server exposes the following tools:
     * `timeout` (int, default: 60)
   * **Returns**: Content of the file and the number of bytes read.
 
+* **`list_files`**: Lists the contents of a directory in a sandbox.
+  * **Arguments**:
+    * `sandbox_claim_name` (str)
+    * `namespace` (str)
+    * `path` (str)
+    * `timeout` (int, default: 60)
+  * **Returns**: The directory entries, each with `name`, `size`, `type` (`file` or `directory`) and `mod_time` (POSIX timestamp).
+
+* **`file_exists`**: Checks whether a file or directory exists in a sandbox.
+  * **Arguments**:
+    * `sandbox_claim_name` (str)
+    * `namespace` (str)
+    * `path` (str)
+    * `timeout` (int, default: 60)
+  * **Returns**: Whether the path exists. A missing path is a successful `exists: false` result, not an error.
+
 *(The server also provides a `get_sandboxes` resource to fetch a list of existing sandboxes.)*
 
 ## Configuration

--- a/clients/integrations/mcp-server/README.md
+++ b/clients/integrations/mcp-server/README.md
@@ -55,7 +55,12 @@ The MCP server exposes the following tools:
     * `namespace` (str)
     * `path` (str)
     * `timeout` (int, default: 60)
-  * **Returns**: The directory entries, each with `name`, `size`, `type` (`file` or `directory`) and `mod_time` (POSIX timestamp).
+    * `max_entries` (int, default: 1000, max: 10000) — Caps how many entries are returned.
+  * **Returns**: The directory entries (each with `name`, `size`, `type` (`file` or `directory`) and `mod_time` as a POSIX timestamp), plus `total_entries` — the full count before truncation — and `truncated`.
+  * **Note**: the response is capped at `max_entries` so that listing a directory with very many
+    entries cannot exhaust an LLM's context window. When `truncated` is `True`, narrow the path or use
+    `execute_command` for a targeted listing. The cap bounds the MCP response only; the SDK's
+    `files.list()` has already materialized the full listing before this tool sees it.
 
 * **`file_exists`**: Checks whether a file or directory exists in a sandbox.
   * **Arguments**:

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/server.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/server.py
@@ -26,6 +26,8 @@ from .tools import (
     execute_command,
     upload_file,
     download_file,
+    list_files,
+    file_exists,
 )
 
 from .resources import (
@@ -62,6 +64,8 @@ def create_mcp_server(settings: Settings | None = None):
     mcp.add_tool(execute_command)
     mcp.add_tool(upload_file)
     mcp.add_tool(download_file)
+    mcp.add_tool(list_files)
+    mcp.add_tool(file_exists)
 
     return mcp
 

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/__init__.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/__init__.py
@@ -17,6 +17,8 @@ from .delete_sandbox import delete_sandbox
 from .execute_command import execute_command
 from .upload_file import upload_file
 from .download_file import download_file
+from .list_files import list_files
+from .file_exists import file_exists
 
 __all__ = [
     'create_sandbox',
@@ -24,4 +26,6 @@ __all__ = [
     'execute_command',
     'upload_file',
     'download_file',
+    'list_files',
+    'file_exists',
 ]

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/file_exists.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/file_exists.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+from fastmcp import Context
+
+from ..utils import (
+    get_sandbox,
+    TOOL_DEFAULT_TIMEOUT,
+    TOOL_MAX_TIMEOUT,
+)
+
+
+class FileExistsOutputSchema(BaseModel):
+    exists: bool = Field(description="Whether the path exists in the sandbox.")
+
+
+async def file_exists(
+    ctx: Context,
+    sandbox_claim_name: Annotated[str, Field(description="Name of a target sandbox claim.")],
+    namespace: Annotated[str, Field(description="Kubernetes namespace with a target sandbox.")],
+    path: Annotated[str, Field(description="The path to check.")],
+    timeout: Annotated[int, Field(
+        description="Time in seconds to check the path until the timeout.",
+        gt=0,
+        le=TOOL_MAX_TIMEOUT,
+    )] = TOOL_DEFAULT_TIMEOUT,
+) -> FileExistsOutputSchema:
+    """
+    Check whether a file or directory exists in a sandbox.
+    """
+    sandbox = await get_sandbox(ctx, sandbox_claim_name, namespace)
+
+    try:
+        exists = await sandbox.files.exists(path, timeout=timeout)
+    except Exception as e:
+        raise RuntimeError(f"Failed to check path in sandbox: {e}") from e
+
+    return FileExistsOutputSchema(exists=exists)

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/list_files.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/list_files.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Annotated, List, Literal
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+from fastmcp import Context
+
+from ..utils import (
+    get_sandbox,
+    TOOL_DEFAULT_TIMEOUT,
+    TOOL_MAX_TIMEOUT,
+)
+
+
+class FileEntrySchema(BaseModel):
+    name: str = Field(description="Name of the entry.")
+    size: int = Field(description="Size of the entry in bytes.")
+    type: Literal["file", "directory"] = Field(description="Whether the entry is a file or a directory.")
+    mod_time: float = Field(description="Last modification time as a POSIX timestamp.")
+
+
+class ListFilesOutputSchema(BaseModel):
+    entries: List[FileEntrySchema] = Field(description="Entries found in the directory.")
+
+
+async def list_files(
+    ctx: Context,
+    sandbox_claim_name: Annotated[str, Field(description="Name of a target sandbox claim.")],
+    namespace: Annotated[str, Field(description="Kubernetes namespace with a target sandbox.")],
+    path: Annotated[str, Field(description="The directory path to list.")],
+    timeout: Annotated[int, Field(
+        description="Time in seconds to list the directory until the timeout.",
+        gt=0,
+        le=TOOL_MAX_TIMEOUT,
+    )] = TOOL_DEFAULT_TIMEOUT,
+) -> ListFilesOutputSchema:
+    """
+    List the contents of a directory in a sandbox.
+    """
+    sandbox = await get_sandbox(ctx, sandbox_claim_name, namespace)
+
+    try:
+        entries = await sandbox.files.list(path, timeout=timeout)
+    except Exception as e:
+        raise RuntimeError(f"Failed to list directory in sandbox: {e}") from e
+
+    return ListFilesOutputSchema(
+        entries=[
+            FileEntrySchema(
+                name=entry.name,
+                size=entry.size,
+                type=entry.type,
+                mod_time=entry.mod_time,
+            )
+            for entry in entries
+        ],
+    )

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/list_files.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/tools/list_files.py
@@ -27,6 +27,24 @@ from ..utils import (
 )
 
 
+# Upper bound on how many entries a single list_files call returns.
+#
+# This bounds the *MCP response*, not sandbox-side memory: the SDK's
+# files.list() has already parsed the HTTP body and built the full
+# list[FileEntry] before this tool sees it, so truncating here cannot
+# reduce peak allocation. What it does prevent is a directory with tens of
+# thousands of entries being serialized into an LLM's context window,
+# where it would exhaust the token budget and crowd out the conversation.
+#
+# Callers that need a complete listing of a very large directory should
+# use execute_command with a targeted shell invocation instead.
+DEFAULT_MAX_ENTRIES = 1000
+
+# Ceiling for the caller-supplied max_entries, so a client cannot opt out
+# of the bound entirely.
+MAX_ENTRIES_LIMIT = 10000
+
+
 class FileEntrySchema(BaseModel):
     name: str = Field(description="Name of the entry.")
     size: int = Field(description="Size of the entry in bytes.")
@@ -36,6 +54,13 @@ class FileEntrySchema(BaseModel):
 
 class ListFilesOutputSchema(BaseModel):
     entries: List[FileEntrySchema] = Field(description="Entries found in the directory.")
+    total_entries: int = Field(
+        description="Total number of entries in the directory, before any truncation."
+    )
+    truncated: bool = Field(
+        description="True when the directory holds more entries than were returned. "
+                    "Narrow the path or use execute_command to inspect the rest."
+    )
 
 
 async def list_files(
@@ -48,9 +73,19 @@ async def list_files(
         gt=0,
         le=TOOL_MAX_TIMEOUT,
     )] = TOOL_DEFAULT_TIMEOUT,
+    max_entries: Annotated[int, Field(
+        description="Maximum number of entries to return. When the directory holds more, "
+                    "the response is truncated and 'truncated' is set to True.",
+        gt=0,
+        le=MAX_ENTRIES_LIMIT,
+    )] = DEFAULT_MAX_ENTRIES,
 ) -> ListFilesOutputSchema:
     """
     List the contents of a directory in a sandbox.
+
+    At most max_entries entries are returned (1000 by default). When the
+    directory holds more, the response is truncated and 'truncated' is True
+    while 'total_entries' reports the full count.
     """
     sandbox = await get_sandbox(ctx, sandbox_claim_name, namespace)
 
@@ -58,6 +93,8 @@ async def list_files(
         entries = await sandbox.files.list(path, timeout=timeout)
     except Exception as e:
         raise RuntimeError(f"Failed to list directory in sandbox: {e}") from e
+
+    total_entries = len(entries)
 
     return ListFilesOutputSchema(
         entries=[
@@ -67,6 +104,8 @@ async def list_files(
                 type=entry.type,
                 mod_time=entry.mod_time,
             )
-            for entry in entries
+            for entry in entries[:max_entries]
         ],
+        total_entries=total_entries,
+        truncated=total_entries > max_entries,
     )

--- a/clients/integrations/mcp-server/tests/unit/test_tools/test_file_exists.py
+++ b/clients/integrations/mcp-server/tests/unit/test_tools/test_file_exists.py
@@ -15,6 +15,8 @@
 import pytest
 from fastmcp.exceptions import ToolError
 
+from k8s_agent_sandbox_mcp_server.utils import TOOL_MAX_TIMEOUT
+
 
 @pytest.mark.anyio
 @pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
@@ -92,6 +94,28 @@ async def test_call_file_exists_tool_with_non_default_args(
         "some/path",
         timeout=20,
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+@pytest.mark.parametrize("timeout", [0, TOOL_MAX_TIMEOUT + 1])
+async def test_call_file_exists_tool_rejects_out_of_range_timeout(
+    mcp_client,
+    mock_sandbox,
+    timeout,
+):
+    with pytest.raises(ToolError):
+        await mcp_client.call_tool(
+            "file_exists",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+                "timeout": timeout,
+            },
+        )
+
+    mock_sandbox.files.exists.assert_not_called()
 
 
 @pytest.mark.anyio

--- a/clients/integrations/mcp-server/tests/unit/test_tools/test_file_exists.py
+++ b/clients/integrations/mcp-server/tests/unit/test_tools/test_file_exists.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_file_exists_tool_when_present(
+    mcp_client,
+    mock_sandbox_client,
+    mock_sandbox
+):
+    mock_sandbox.files.exists.return_value = True
+
+    result = await mcp_client.call_tool(
+        "file_exists",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/path",
+        },
+    )
+
+    assert result.structured_content == {"exists": True}
+    assert result.is_error is False
+    mock_sandbox_client.get_sandbox.assert_called_once_with(
+        "my-claim",
+        namespace="my-namespace",
+    )
+    mock_sandbox.files.exists.assert_called_once_with(
+        "some/path",
+        timeout=60,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_file_exists_tool_when_absent(
+    mcp_client,
+    mock_sandbox
+):
+    mock_sandbox.files.exists.return_value = False
+
+    result = await mcp_client.call_tool(
+        "file_exists",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "no/such/path",
+        },
+    )
+
+    # A missing path is a successful answer, not an error.
+    assert result.structured_content == {"exists": False}
+    assert result.is_error is False
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_file_exists_tool_with_non_default_args(
+    mcp_client,
+    mock_sandbox
+):
+    mock_sandbox.files.exists.return_value = True
+
+    result = await mcp_client.call_tool(
+        "file_exists",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/path",
+            "timeout": 20,
+        },
+    )
+
+    assert result.structured_content == {"exists": True}
+    assert result.is_error is False
+    mock_sandbox.files.exists.assert_called_once_with(
+        "some/path",
+        timeout=20,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_file_exists_tool_surfaces_sandbox_failure(
+    mcp_client,
+    mock_sandbox,
+):
+    mock_sandbox.files.exists.side_effect = RuntimeError("boom")
+
+    with pytest.raises(ToolError, match="Failed to check path in sandbox"):
+        await mcp_client.call_tool(
+            "file_exists",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+            },
+        )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_session_id_not_found(
+    mcp_client,
+    mock_sandbox_client,
+    mock_sandbox,
+):
+    mock_sandbox_client.list_all_sandboxes.return_value = []
+
+    with pytest.raises(ToolError, match="claim 'my-claim' is not found"):
+        await mcp_client.call_tool(
+            "file_exists",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+            },
+        )
+
+    # The ownership check must fail closed: no sandbox call may happen.
+    mock_sandbox.files.exists.assert_not_called()

--- a/clients/integrations/mcp-server/tests/unit/test_tools/test_list_files.py
+++ b/clients/integrations/mcp-server/tests/unit/test_tools/test_list_files.py
@@ -1,0 +1,176 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from k8s_agent_sandbox.models import FileEntry
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_list_files_tool_with_default_args(
+    mcp_client,
+    mock_sandbox_client,
+    mock_sandbox
+):
+    mock_sandbox.files.list.return_value = [
+        FileEntry(name="a.txt", size=12, type="file", mod_time=1700000000.0),
+        FileEntry(name="sub", size=4096, type="directory", mod_time=1700000001.5),
+    ]
+
+    result = await mcp_client.call_tool(
+        "list_files",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/path",
+        },
+    )
+
+    assert result.structured_content == {
+        "entries": [
+            {
+                "name": "a.txt",
+                "size": 12,
+                "type": "file",
+                "mod_time": 1700000000.0,
+            },
+            {
+                "name": "sub",
+                "size": 4096,
+                "type": "directory",
+                "mod_time": 1700000001.5,
+            },
+        ]
+    }
+    assert result.is_error is False
+    mock_sandbox_client.get_sandbox.assert_called_once_with(
+        "my-claim",
+        namespace="my-namespace",
+    )
+    mock_sandbox.files.list.assert_called_once_with(
+        "some/path",
+        timeout=60,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_list_files_tool_with_non_default_args(
+    mcp_client,
+    mock_sandbox_client,
+    mock_sandbox
+):
+    mock_sandbox.files.list.return_value = []
+
+    result = await mcp_client.call_tool(
+        "list_files",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/path",
+            "timeout": 20,
+        },
+    )
+
+    assert result.structured_content == {"entries": []}
+    assert result.is_error is False
+    mock_sandbox.files.list.assert_called_once_with(
+        "some/path",
+        timeout=20,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_list_files_tool_on_empty_directory(
+    mcp_client,
+    mock_sandbox,
+):
+    mock_sandbox.files.list.return_value = []
+
+    result = await mcp_client.call_tool(
+        "list_files",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/empty/path",
+        },
+    )
+
+    assert result.structured_content == {"entries": []}
+    assert result.is_error is False
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_list_files_tool_surfaces_sandbox_failure(
+    mcp_client,
+    mock_sandbox,
+):
+    mock_sandbox.files.list.side_effect = RuntimeError("boom")
+
+    with pytest.raises(ToolError, match="Failed to list directory in sandbox"):
+        await mcp_client.call_tool(
+            "list_files",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+            },
+        )
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_list_files_tool_rejects_out_of_range_timeout(
+    mcp_client,
+    mock_sandbox,
+):
+    with pytest.raises(ToolError):
+        await mcp_client.call_tool(
+            "list_files",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+                "timeout": 0,
+            },
+        )
+
+    mock_sandbox.files.list.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_session_id_not_found(
+    mcp_client,
+    mock_sandbox_client,
+    mock_sandbox,
+):
+    mock_sandbox_client.list_all_sandboxes.return_value = []
+
+    with pytest.raises(ToolError, match="claim 'my-claim' is not found"):
+        await mcp_client.call_tool(
+            "list_files",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+            },
+        )
+
+    # The ownership check must fail closed: no sandbox call may happen.
+    mock_sandbox.files.list.assert_not_called()

--- a/clients/integrations/mcp-server/tests/unit/test_tools/test_list_files.py
+++ b/clients/integrations/mcp-server/tests/unit/test_tools/test_list_files.py
@@ -17,6 +17,9 @@ from fastmcp.exceptions import ToolError
 
 from k8s_agent_sandbox.models import FileEntry
 
+from k8s_agent_sandbox_mcp_server.tools.list_files import MAX_ENTRIES_LIMIT
+from k8s_agent_sandbox_mcp_server.utils import TOOL_MAX_TIMEOUT
+
 
 @pytest.mark.anyio
 @pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
@@ -53,7 +56,9 @@ async def test_call_list_files_tool_with_default_args(
                 "type": "directory",
                 "mod_time": 1700000001.5,
             },
-        ]
+        ],
+        "total_entries": 2,
+        "truncated": False,
     }
     assert result.is_error is False
     mock_sandbox_client.get_sandbox.assert_called_once_with(
@@ -85,7 +90,11 @@ async def test_call_list_files_tool_with_non_default_args(
         },
     )
 
-    assert result.structured_content == {"entries": []}
+    assert result.structured_content == {
+        "entries": [],
+        "total_entries": 0,
+        "truncated": False,
+    }
     assert result.is_error is False
     mock_sandbox.files.list.assert_called_once_with(
         "some/path",
@@ -110,7 +119,11 @@ async def test_call_list_files_tool_on_empty_directory(
         },
     )
 
-    assert result.structured_content == {"entries": []}
+    assert result.structured_content == {
+        "entries": [],
+        "total_entries": 0,
+        "truncated": False,
+    }
     assert result.is_error is False
 
 
@@ -135,9 +148,68 @@ async def test_call_list_files_tool_surfaces_sandbox_failure(
 
 @pytest.mark.anyio
 @pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
-async def test_call_list_files_tool_rejects_out_of_range_timeout(
+async def test_call_list_files_tool_truncates_large_directory(
     mcp_client,
     mock_sandbox,
+):
+    mock_sandbox.files.list.return_value = [
+        FileEntry(name=f"f{i}.txt", size=1, type="file", mod_time=0.0)
+        for i in range(5)
+    ]
+
+    result = await mcp_client.call_tool(
+        "list_files",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/path",
+            "max_entries": 2,
+        },
+    )
+
+    content = result.structured_content
+    assert [e["name"] for e in content["entries"]] == ["f0.txt", "f1.txt"]
+    # total_entries reports the full directory, so the model is not misled
+    # into thinking it saw everything.
+    assert content["total_entries"] == 5
+    assert content["truncated"] is True
+    assert result.is_error is False
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+async def test_call_list_files_tool_not_truncated_at_exact_limit(
+    mcp_client,
+    mock_sandbox,
+):
+    mock_sandbox.files.list.return_value = [
+        FileEntry(name=f"f{i}.txt", size=1, type="file", mod_time=0.0)
+        for i in range(3)
+    ]
+
+    result = await mcp_client.call_tool(
+        "list_files",
+        {
+            "sandbox_claim_name": "my-claim",
+            "namespace": "my-namespace",
+            "path": "some/path",
+            "max_entries": 3,
+        },
+    )
+
+    # Exactly at the limit is complete, not truncated.
+    assert len(result.structured_content["entries"]) == 3
+    assert result.structured_content["truncated"] is False
+    assert result.is_error is False
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+@pytest.mark.parametrize("max_entries", [0, MAX_ENTRIES_LIMIT + 1])
+async def test_call_list_files_tool_rejects_out_of_range_max_entries(
+    mcp_client,
+    mock_sandbox,
+    max_entries,
 ):
     with pytest.raises(ToolError):
         await mcp_client.call_tool(
@@ -146,7 +218,29 @@ async def test_call_list_files_tool_rejects_out_of_range_timeout(
                 "sandbox_claim_name": "my-claim",
                 "namespace": "my-namespace",
                 "path": "some/path",
-                "timeout": 0,
+                "max_entries": max_entries,
+            },
+        )
+
+    mock_sandbox.files.list.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.usefixtures("mocked_servers_sandbox_client_class")
+@pytest.mark.parametrize("timeout", [0, TOOL_MAX_TIMEOUT + 1])
+async def test_call_list_files_tool_rejects_out_of_range_timeout(
+    mcp_client,
+    mock_sandbox,
+    timeout,
+):
+    with pytest.raises(ToolError):
+        await mcp_client.call_tool(
+            "list_files",
+            {
+                "sandbox_claim_name": "my-claim",
+                "namespace": "my-namespace",
+                "path": "some/path",
+                "timeout": timeout,
             },
         )
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The MCP server exposes `upload_file` and `download_file`, but there is no way to
list a directory or test whether a path exists. An agent can write a file and
read it back, yet cannot discover what is in a directory, and can only probe for
a path by attempting a read and interpreting the failure.

Both operations already exist on the Python SDK's filesystem interface —
`AsyncFilesystem.list()` and `.exists()` in
`clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/async_filesystem.py`
— and both are already exposed by the Go SDK (`Sandbox.List`, `Sandbox.Exists`).
So this is a **cross-SDK parity gap** rather than new functionality: the
capability is present and simply unexposed over MCP.

This PR adds two thin tools over those calls, following `download_file.py` line
for line:

* **`list_files`** — returns each entry's `name`, `size`, `type`
  (`file`/`directory`) and `mod_time` (POSIX timestamp), mapped from the SDK's
  `FileEntry`. An empty directory returns an empty list, not an error.
* **`file_exists`** — returns a boolean. A missing path is a successful
  `exists: false` answer rather than a failure, which is a more useful contract
  for an LLM caller than an exception.

Notes for reviewers:

* **Session isolation is preserved and now asserted.** Both tools go through the
  existing `get_sandbox()` helper, so they inherit the per-session ownership
  check unchanged — no new authorization path. Each tool's
  `test_session_id_not_found` additionally asserts the sandbox is **never**
  touched when that check rejects, so the tools provably fail closed.
* Timeouts reuse `TOOL_DEFAULT_TIMEOUT` / `TOOL_MAX_TIMEOUT`, so bounds and
  validation match the other file tools.
* Purely additive: no existing tool, schema, or behaviour is modified.
* `README.md` documents both tools in the established per-tool format.

#### Which issue(s) this PR is related to:

Follow-up to the MCP server added in https://github.com/kubernetes-sigs/agent-sandbox/pull/1141

#### Release Note
```release-note
Added `list_files` and `file_exists` tools to the Agent Sandbox MCP server, bringing its filesystem tool surface in line with the Go SDK.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool to list sandbox directory contents, including names, sizes, types, and modification times.
  * Added a tool to check whether a file or directory exists.
  * Documented both tools and their handling of missing paths.

* **Tests**
  * Added coverage for successful operations, empty or missing paths, validation, timeouts, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->