### PR TITLE
docs: add high density benchmark and node tuning instructions for GKE swap

### DIFF
--- a/examples/gke-swap/README.md
+++ b/examples/gke-swap/README.md
@@ -27,7 +27,7 @@ Depending on your security and isolation requirements, `agent-sandbox` supports 
 
 ## Vanilla `runc` Performance Results
 
-### Moderate Density Benchmarks on `c4-standard-8` (30 GB RAM)
+### Moderate Density Benchmarks on `c4-standard-8` (30 GB RAM, 200 Pods)
 
 We evaluated and compared two node pools on GKE using `c4-standard-8` instances, running a concurrent density sweep of **120, 160, 200, and 240 pods**:
 
@@ -66,12 +66,12 @@ Because of these dynamics, memory pressure is not a static number. In our experi
 
 Repeating the tests multiple times, the aggregated data clearly shows that while the baseline pool *can* occasionally survive higher densities, **~120 pods is the limit for reliable deployments**. Beyond 120 pods, the baseline pool can become unstable or experience high latency. Conversely, the **swap-enabled pool can reliably sustain 200 pods** across all runs.
 
-### High & Extreme Density Benchmarks on `c4-standard-32` (120 GB RAM)
+### High & Extreme Density Benchmarks on `c4-standard-32` (120 GB RAM, 768 Pods)
 
 We evaluated baseline vs LSSD swap configurations on `c4-standard-32` instances (120 GB RAM) and tested densities up to 1024 pods.
 
 #### 1. The Critical Role of Node Tuning
-The high-density results detailed in the metrics below (particularly reaching 768 stable pods) are **only achievable when utilizing the provided Node Tuner DaemonSet**. 
+The high-density results detailed in the metrics below (particularly reaching 768 stable pods) are **only achievable when utilizing the provided [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml)**. 
 
 **Why is tuning required?**
 At extreme pod densities, system daemons experience heavy CPU churn handling pod creation, CRI/CNI setup, and health checks. Without CPU isolation, these pod initialization loops starve Kubelet of compute cycles, causing it to drop heartbeats and trigger node watchdog crashes. Additionally, rapid cgroup events and container thrashing flood `systemd-journald`, which creates high CPU load and saturates boot disk write queues.
@@ -151,9 +151,6 @@ MAX_PODS_PER_NODE=1024 BASELINE_MACHINE_TYPE="c4-standard-32" SWAP_MACHINE_TYPE=
 ```
 
 ### Step 3: Optional Node Tuning for High-Density Tests (>256 Pods)
-
-> [!NOTE]
-> Standard GKE node pools default to a maximum of 256 pods per node. Evaluating densities above 256 pods (512–1024) requires a benchmark cluster environment configured to support higher pod-per-node limits and sufficient Pod CIDR allocation.
 
 If you plan to run extreme density sweeps (512–1024 pods per node), apply the provided [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml) to configure CPU isolation, ARP cache expansion, and journald log rate-limiting, then wait for the rollout to complete:
 

--- a/examples/gke-swap/README.md
+++ b/examples/gke-swap/README.md
@@ -80,7 +80,7 @@ At extreme pod densities, system daemons experience heavy CPU churn handling pod
 To prevent system lockups during extreme pod density tests, the [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml) configuration must be applied:
 *   **Dynamic CPU Isolation:** Expands CPU pinning dynamically to ensure Kubelet and system daemons have enough compute cycles.
 *   **ARP Cache Tuning:** Increases ARP cache thresholds (`gc_thresh` 2048/4096/8192) to accommodate the massive number of pod IP addresses routing through the node.
-*   **Advanced Logging Mitigation:** Applies `systemd-journald` rate limits (`SystemMaxUse=500M`, `RateLimitIntervalSec=30s`, `RateLimitBurst=1000`) and redirects journal logging to NVMe Local SSDs (`/var/log/journal` bind-mounted to `/var/lib/containerd/systemd-journal`) to prevent logging loops from overwhelming system resources.
+*   **Advanced Logging Mitigation:** Applies `systemd-journald` rate limits (`SystemMaxUse=500M`, `RateLimitIntervalSec=30s`, `RateLimitBurst=1000`) and redirects journal logging to NVMe Local SSDs (bind-mounting `/var/lib/containerd/systemd-journal` onto `/var/log/journal`) to prevent logging loops from overwhelming system resources.
 
 
 #### 2. Performance Metrics (256, 512, 768, and 1024 Densities)
@@ -101,7 +101,7 @@ The table below compares the baseline and LSSD swap node pools under a 1000ms st
 1.  **512 Pods pushes the limits without swap**: In standard network PD pools, running 512 pods saturates physical memory allocations and triggers active page cache evictions. This pushes the node to the edge of stability due to slow disk-wait queues on standard PD.
 2.  **Significant Density Improvement (512 -> 768 Pods)**: By combining NVMe Local SSD swap with node-level CPU isolation and ARP cache tuning, we achieved a **50% increase in stable pod density** (from 512 pods up to 768 pods per node) without node crashes. 
 3.  **Local SSDs prevent Page Cache Bottlenecks**: Even when swap usage is 0B, if memory pressure evicts file-backed page caches (Chrome binaries), re-reading them from NVMe Local SSDs (mounted at `/var/lib/containerd`) takes milliseconds. On baseline PD pools, reading evicted binaries back from network disks saturates the 3,000 IOPS queue and causes watchdog timeouts.
-4.  **CPU isolation is mandatory**: Reserve at least 2 cores (`reservedSystemCPUs: "0,1"`) for Kubelet and OS services. For 768+ active pods under swap, reserve **4 to 8 cores** (`reservedSystemCPUs: "0-7"`).
+4.  **CPU isolation is mandatory**: Reserve at least 2 cores (`reservedSystemCPUs: "0,1"`) for Kubelet and OS services. For 768+ active pods on `c4-standard-32` under swap, reserve **8 cores** (`reservedSystemCPUs: "0-7"`).
 
 
 ## Run the Example
@@ -135,21 +135,31 @@ linuxConfig:
 
 ### Step 2: Deploy the GKE Cluster
 
-We provide a helper script [`deploy_cluster.sh`](deploy_cluster.sh) that automates the cluster provisioning, using `c4-standard-8` as the standard machine type. It will create the baseline node pool and the Memory Swap enabled node pool.
+We provide a helper script [`deploy_cluster.sh`](deploy_cluster.sh) that automates cluster provisioning by creating both the baseline node pool and the Memory Swap enabled node pool.
 
-Run the deployment script:
+For standard moderate density testing (`c4-standard-8`):
 
 ```bash
 chmod +x deploy_cluster.sh
 ./deploy_cluster.sh
 ```
 
+For high-density benchmarking (`c4-standard-32`):
+
+```bash
+MAX_PODS_PER_NODE=1024 BASELINE_MACHINE_TYPE="c4-standard-32" SWAP_MACHINE_TYPE="c4-standard-32-lssd" ./deploy_cluster.sh
+```
+
 ### Step 3: Optional Node Tuning for High-Density Tests (>256 Pods)
 
-If you plan to run extreme density sweeps (512–1024 pods per node), apply the provided [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml) to configure CPU isolation, ARP cache expansion, and journald log rate-limiting:
+> [!NOTE]
+> Standard GKE node pools default to a maximum of 256 pods per node. Evaluating densities above 256 pods (512–1024) requires a benchmark cluster environment configured to support higher pod-per-node limits and sufficient Pod CIDR allocation.
+
+If you plan to run extreme density sweeps (512–1024 pods per node), apply the provided [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml) to configure CPU isolation, ARP cache expansion, and journald log rate-limiting, then wait for the rollout to complete:
 
 ```bash
 kubectl apply -f node-tuner-daemonset.yaml
+kubectl rollout status daemonset/node-tuner-ds -n kube-system
 ```
 
 ### Step 4: Configure the Sandbox Workloads
@@ -184,11 +194,19 @@ spec:
 
 ### Step 5: Run the Performance/Density Tests
 
-Use the provided [`run_chromesandbox_density_test.sh`](run_chromesandbox_density_test.sh) script to run the density sweep (`120 160 200 240` pods) and compare the baseline and swap pools:
+Use the provided [`run_chromesandbox_density_test.sh`](run_chromesandbox_density_test.sh) script to run the density sweep.
+
+For moderate density testing on `c4-standard-8` (`120 160 200 240` pods):
 
 ```bash
 chmod +x run_chromesandbox_density_test.sh
 ./run_chromesandbox_density_test.sh
+```
+
+For high-density benchmarking on `c4-standard-32` (`256 512 768 1024` pods, requires node-tuner applied):
+
+```bash
+DENSITIES="256 512 768 1024" ./run_chromesandbox_density_test.sh
 ```
 
 #### Results:

--- a/examples/gke-swap/README.md
+++ b/examples/gke-swap/README.md
@@ -27,6 +27,8 @@ Depending on your security and isolation requirements, `agent-sandbox` supports 
 
 ## Vanilla `runc` Performance Results
 
+### Moderate Density Benchmarks on `c4-standard-8` (30 GB RAM)
+
 We evaluated and compared two node pools on GKE using `c4-standard-8` instances, running a concurrent density sweep of **120, 160, 200, and 240 pods**:
 
 1. **Baseline Pool**: `c4-standard-8` (No Swap)
@@ -43,11 +45,11 @@ The table below shows the P99 `ChromeReady` latency (the time it takes for the C
 | **200**     | 149 / 200 (74.7%)   | —                     | **200 / 200** (100%) | 268 s              | **Clear Threshold**: Baseline collapses (25% loss); Swap maintains 100% stability. |
 | 240         | 111 / 240 (46.4%)   | —                     | 170 / 240 (71.0%)    | —                  | **Limit Reached**: Both pools experience failures, but Swap keeps 71% alive vs Baseline's 46%. |
 
-### Key Takeaways
+#### Key Takeaways
 * **66% Density Increase**: Safely run **200 pods** instead of **120 pods** on the exact same hardware.
 * **Clear Collapse Threshold**: Without swap, the node collapses at 140 pods. With swap, the node gracefully offloads idle memory to the Local SSD, keeping workload alive and healthy.
 
-### Memory Dynamics & Thrashing Thresholds
+#### Memory Dynamics & Thrashing Thresholds
 
 Through direct measurement, we have determined that a Chrome sandbox pod typically consumes between 200 MiB and 250 MiB of memory at steady state. 
 
@@ -56,13 +58,51 @@ Given that a `c4-standard-8` node provides approximately **28 GiB** of allocatab
 
 Consequently, we expect the baseline pool (no swap) to start experiencing severe thrashing or crashes within the **110 to 140 pod range**, depending on the activity level of the pods and page cache usage.
 
-### The Fluctuating Nature of Swap & Methodology
+#### The Fluctuating Nature of Swap & Methodology
 
 Because of these dynamics, memory pressure is not a static number. In our experiments, we observed some variability in single-run tests:
 *   In some runs, the baseline pool was able to survive up to 170 pods.
 *   In other runs, the baseline pool crashed or experienced severe OOMs at 130 or 150 pods.
 
 Repeating the tests multiple times, the aggregated data clearly shows that while the baseline pool *can* occasionally survive higher densities, **~120 pods is the limit for reliable deployments**. Beyond 120 pods, the baseline pool can become unstable or experience high latency. Conversely, the **swap-enabled pool can reliably sustain 200 pods** across all runs.
+
+### High & Extreme Density Benchmarks on `c4-standard-32` (120 GB RAM)
+
+We evaluated baseline vs LSSD swap configurations on `c4-standard-32` instances (120 GB RAM) and tested densities up to 1024 pods.
+
+#### 1. The Critical Role of Node Tuning
+The high-density results detailed in the metrics below (particularly reaching 768 stable pods) are **only achievable when utilizing the provided Node Tuner DaemonSet**. 
+
+**Why is tuning required?**
+At extreme pod densities, system daemons experience heavy CPU churn handling pod creation, CRI/CNI setup, and health checks. Without CPU isolation, these pod initialization loops starve Kubelet of compute cycles, causing it to drop heartbeats and trigger node watchdog crashes. Additionally, rapid cgroup events and container thrashing flood `systemd-journald`, which creates high CPU load and saturates boot disk write queues.
+
+**How the Node Tuner fixes this:**
+To prevent system lockups during extreme pod density tests, the [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml) configuration must be applied:
+*   **Dynamic CPU Isolation:** Expands CPU pinning dynamically to ensure Kubelet and system daemons have enough compute cycles.
+*   **ARP Cache Tuning:** Increases ARP cache thresholds (`gc_thresh` 2048/4096/8192) to accommodate the massive number of pod IP addresses routing through the node.
+*   **Advanced Logging Mitigation:** Applies `systemd-journald` rate limits (`SystemMaxUse=500M`, `RateLimitIntervalSec=30s`, `RateLimitBurst=1000`) and redirects journal logging to NVMe Local SSDs (`/var/log/journal` bind-mounted to `/var/lib/containerd/systemd-journal`) to prevent logging loops from overwhelming system resources.
+
+
+#### 2. Performance Metrics (256, 512, 768, and 1024 Densities)
+The table below compares the baseline and LSSD swap node pools under a 1000ms staggered creation pacing.
+
+| Scenario / Pool | Density | Sandbox Ready (Avg/P99) | Chrome Ready (Avg/P99) | Total Time (Avg/P99) |
+| :--- | :--- | :--- | :--- | :--- |
+| **baseline-pool** | 256 | 1.62s / 2.65s | 2.75s / 3.86s | 2.75s / 3.86s |
+| **lssd-swap-pool** | 256 | **1.47s / 7.03s** | **2.58s / 8.15s** | **2.58s / 8.15s** |
+| **baseline-pool** | 512 | 95.86s / 789.12s | 97.53s / 791.60s | 97.53s / 791.60s |
+| **lssd-swap-pool** | 512 | **1.92s / 6.37s** | **3.09s / 7.77s** | **3.09s / 7.77s** |
+| **baseline-pool** | 768 | *Failed* (timeout) | *Failed* (timeout) | *Failed* (timeout) |
+| **lssd-swap-pool** | 768 | **4.51s / 35.10s** | **6.00s / 37.69s** | **6.00s / 37.69s** |
+| **baseline-pool** | 1024 | *Failed* | *Failed* | *Failed* |
+| **lssd-swap-pool** | 1024 | *Failed* | *Failed* | *Failed* |
+
+#### 3. Final Recommendations & Conclusions
+1.  **512 Pods pushes the limits without swap**: In standard network PD pools, running 512 pods saturates physical memory allocations and triggers active page cache evictions. This pushes the node to the edge of stability due to slow disk-wait queues on standard PD.
+2.  **Significant Density Improvement (512 -> 768 Pods)**: By combining NVMe Local SSD swap with node-level CPU isolation and ARP cache tuning, we achieved a **50% increase in stable pod density** (from 512 pods up to 768 pods per node) without node crashes. 
+3.  **Local SSDs prevent Page Cache Bottlenecks**: Even when swap usage is 0B, if memory pressure evicts file-backed page caches (Chrome binaries), re-reading them from NVMe Local SSDs (mounted at `/var/lib/containerd`) takes milliseconds. On baseline PD pools, reading evicted binaries back from network disks saturates the 3,000 IOPS queue and causes watchdog timeouts.
+4.  **CPU isolation is mandatory**: Reserve at least 2 cores (`reservedSystemCPUs: "0,1"`) for Kubelet and OS services. For 768+ active pods under swap, reserve **4 to 8 cores** (`reservedSystemCPUs: "0-7"`).
+
 
 ## Run the Example
 
@@ -104,7 +144,15 @@ chmod +x deploy_cluster.sh
 ./deploy_cluster.sh
 ```
 
-### Step 3: Configure the Sandbox Workloads
+### Step 3: Optional Node Tuning for High-Density Tests (>256 Pods)
+
+If you plan to run extreme density sweeps (512–1024 pods per node), apply the provided [`node-tuner-daemonset.yaml`](node-tuner-daemonset.yaml) to configure CPU isolation, ARP cache expansion, and journald log rate-limiting:
+
+```bash
+kubectl apply -f node-tuner-daemonset.yaml
+```
+
+### Step 4: Configure the Sandbox Workloads
 
 Kubernetes Limited Swap requires **Burstable QoS** pods. Configure your sandboxes with a memory request and a higher limit. In `LimitedSwap` mode, the swap limit allocated to a container is proportional to its memory request, calculated as:
 `Swap Limit = (Container Memory Request / Node Allocatable Memory) * Node Allocatable Swap`
@@ -134,7 +182,7 @@ spec:
 
 ---
 
-### Step 4: Run the Performance/Density Tests
+### Step 5: Run the Performance/Density Tests
 
 Use the provided [`run_chromesandbox_density_test.sh`](run_chromesandbox_density_test.sh) script to run the density sweep (`120 160 200 240` pods) and compare the baseline and swap pools:
 

--- a/examples/gke-swap/deploy_cluster.sh
+++ b/examples/gke-swap/deploy_cluster.sh
@@ -20,6 +20,7 @@ REGION=${REGION:-"us-east4"}
 ZONE=${ZONE:-"us-east4-a"}
 BASELINE_MACHINE_TYPE=${BASELINE_MACHINE_TYPE:-"c4-standard-8"}
 SWAP_MACHINE_TYPE=${SWAP_MACHINE_TYPE:-"c4-standard-8-lssd"}
+MAX_PODS_PER_NODE=${MAX_PODS_PER_NODE:-256}
 
 # Get the directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -36,17 +37,15 @@ gcloud container node-pools create baseline-pool \
     --zone "${ZONE}" \
     --machine-type "${BASELINE_MACHINE_TYPE}" \
     --num-nodes 1 \
-    --max-pods-per-node 256
+    --max-pods-per-node "${MAX_PODS_PER_NODE}"
  
 echo "Creating lssd-swap node pool (with dedicated LSSD swap)..."
-# We use c4-standard-8-lssd which comes with 1 local SSD.
-# We dedicate this single SSD entirely to swap (via swap-dedicated-lssd.yaml).
 gcloud container node-pools create lssd-swap-pool \
     --cluster "${CLUSTER_NAME}" \
     --zone "${ZONE}" \
     --machine-type "${SWAP_MACHINE_TYPE}" \
     --num-nodes 1 \
-    --max-pods-per-node 256 \
+    --max-pods-per-node "${MAX_PODS_PER_NODE}" \
     --system-config-from-file "${DIR}/swap-dedicated-lssd.yaml"
 
 echo "Fetching cluster credentials..."


### PR DESCRIPTION
… swap

#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This PR updates the GKE swap example documentation with high-density benchmark results and node tuning recommendations for running large-scale pod densities.

#### Which issue(s) this PR is related to:
None

#### Release Note
```release-note
None
```
<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added benchmark guidance for high- and extreme-density workloads on `c4-standard-32` nodes.
  * Documented optional node-tuning steps, performance results through 1,024 pods, and findings related to swap, Local SSDs, and CPU isolation.
  * Reorganized benchmark sections and updated test instructions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->