### PR TITLE
fix: enforce strict Sandbox-to-Pod mapping

### DIFF
--- a/api/v1beta1/sandbox_types.go
+++ b/api/v1beta1/sandbox_types.go
@@ -49,6 +49,10 @@ const (
 	// SandboxReasonDependenciesNotReady indicates the Sandbox is expected to be running
 	// but its underlying dependencies are not fully provisioned or ready yet.
 	SandboxReasonDependenciesNotReady = "DependenciesNotReady"
+	// SandboxReasonMultiplePods indicates the Sandbox cannot become ready because
+	// more than one Pod is controlled by its UID and the controller cannot choose
+	// a canonical stateful Pod safely.
+	SandboxReasonMultiplePods = "MultiplePods"
 	// SandboxReasonSuspended indicates the Sandbox has been administratively suspended
 	// (i.e., intentional action by the user to suspend the Sandbox).
 	SandboxReasonSuspended = "SandboxSuspended"

--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -488,6 +488,7 @@ func main() {
 	if err = (&controllers.SandboxReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
+		Recorder:          mgr.GetEventRecorder("sandbox-controller"),
 		Tracer:            instrumenter,
 		ClusterDomain:     clusterDomain,
 		WriteBehindWindow: sandboxWriteBehindWindow,

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -151,9 +151,16 @@ func (e *multipleSandboxPodsError) Error() string {
 	return fmt.Sprintf("multiple Pods (%d) are controlled by this Sandbox; refusing to choose or create a Pod", e.count)
 }
 
-func isMultipleSandboxPodsError(err error) bool {
+func asMultipleSandboxPodsError(err error) *multipleSandboxPodsError {
 	var multiplePodsErr *multipleSandboxPodsError
-	return errors.As(err, &multiplePodsErr)
+	if errors.As(err, &multiplePodsErr) {
+		return multiplePodsErr
+	}
+	return nil
+}
+
+func isMultipleSandboxPodsError(err error) bool {
+	return asMultipleSandboxPodsError(err) != nil
 }
 
 // sandboxOwnedPods filters tracking-label candidates by controller owner UID.
@@ -589,9 +596,9 @@ func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1beta1.Sandbo
 	}
 
 	if err != nil {
-		if isMultipleSandboxPodsError(err) {
+		if multiplePodsErr := asMultipleSandboxPodsError(err); multiplePodsErr != nil {
 			readyCondition.Reason = sandboxv1beta1.SandboxReasonMultiplePods
-			readyCondition.Message = err.Error()
+			readyCondition.Message = multiplePodsErr.Error()
 			return readyCondition
 		}
 		readyCondition.Reason = "ReconcilerError"

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -139,6 +140,43 @@ func isOwnedBySandbox(pod *corev1.Pod, sandbox *sandboxv1beta1.Sandbox) bool {
 	return ownership == resourceOwnedBySandbox
 }
 
+// multipleSandboxPodsError reports an ownership invariant violation. It is
+// distinct from transient reconcile errors so the controller can surface a
+// stable condition without hot-looping until a Pod event changes the state.
+type multipleSandboxPodsError struct {
+	count int
+}
+
+func (e *multipleSandboxPodsError) Error() string {
+	return fmt.Sprintf("multiple Pods (%d) are controlled by this Sandbox; refusing to choose or create a Pod", e.count)
+}
+
+func isMultipleSandboxPodsError(err error) bool {
+	var multiplePodsErr *multipleSandboxPodsError
+	return errors.As(err, &multiplePodsErr)
+}
+
+// sandboxOwnedPods filters tracking-label candidates by controller owner UID.
+// The tracking label is only an index; ownership is the authoritative mapping.
+func sandboxOwnedPods(pods []corev1.Pod, sandbox *sandboxv1beta1.Sandbox) []*corev1.Pod {
+	owned := make([]*corev1.Pod, 0, len(pods))
+	for i := range pods {
+		if isOwnedBySandbox(&pods[i], sandbox) {
+			owned = append(owned, &pods[i])
+		}
+	}
+	return owned
+}
+
+func containsPod(pods []*corev1.Pod, pod *corev1.Pod) bool {
+	for _, candidate := range pods {
+		if candidate.Namespace == pod.Namespace && candidate.Name == pod.Name {
+			return true
+		}
+	}
+	return false
+}
+
 // resolvePodName returns the name of the pod associated with the given Sandbox.
 // If the sandbox has adopted a warm pool pod, the pod name is tracked in the
 // agents.x-k8s.io/pod-name annotation and may differ from sandbox.Name.
@@ -184,6 +222,7 @@ func init() {
 type SandboxReconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
+	Recorder      events.EventRecorder
 	Tracer        asmetrics.Instrumenter
 	ClusterDomain string
 
@@ -349,18 +388,22 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	nameHash := NameHash(sandbox.Name)
 
 	var allErrors error
+	var conditionErrors error
 
 	// Reconcile PVCs from volumeClaimTemplates
 	err := r.reconcilePVCs(ctx, sandbox, nameHash)
 	allErrors = errors.Join(allErrors, err)
+	conditionErrors = errors.Join(conditionErrors, err)
 
 	// Reconcile Pod
-	pod, err := r.reconcilePod(ctx, sandbox, nameHash, wd)
-	allErrors = errors.Join(allErrors, err)
-	// Keep the pod error: the Pod-derived conditions use it to tell a
-	// confirmed-absent Pod from one whose state could not be read, and the
-	// reconcileService call below reassigns err (its := only introduces svc).
-	podErr := err
+	pod, podErr := r.reconcilePod(ctx, sandbox, nameHash, wd)
+	conditionErrors = errors.Join(conditionErrors, podErr)
+	podMappingConflict := isMultipleSandboxPodsError(podErr)
+	if podMappingConflict {
+		r.recordMultiplePodsEvent(sandbox, podErr)
+	} else {
+		allErrors = errors.Join(allErrors, podErr)
+	}
 
 	if pod == nil {
 		sandbox.Status.PodIPs = nil
@@ -376,12 +419,17 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 		}
 	}
 
-	// Reconcile Service
-	svc, err := r.reconcileService(ctx, sandbox, nameHash)
-	allErrors = errors.Join(allErrors, err)
+	// Do not create or modify a routing Service while the backing Pod mapping is
+	// ambiguous. Existing Services are left untouched for an operator to inspect.
+	var svc *corev1.Service
+	if !podMappingConflict {
+		svc, err = r.reconcileService(ctx, sandbox, nameHash)
+		allErrors = errors.Join(allErrors, err)
+		conditionErrors = errors.Join(conditionErrors, err)
+	}
 
 	// compute and set overall conditions
-	conditions := r.computeConditions(sandbox, allErrors, svc, pod, podErr)
+	conditions := r.computeConditions(sandbox, conditionErrors, svc, pod, podErr)
 	// Conditions that are only present while they apply: Finished has no
 	// meaning without a terminal pod, PodScheduled none without a pod at
 	// all. Any of these not computed this pass is removed from status.
@@ -404,6 +452,17 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	}
 
 	return allErrors
+}
+
+func (r *SandboxReconciler) recordMultiplePodsEvent(sandbox *sandboxv1beta1.Sandbox, err error) {
+	if r.Recorder == nil {
+		return
+	}
+	ready := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	if ready != nil && ready.Reason == sandboxv1beta1.SandboxReasonMultiplePods {
+		return
+	}
+	r.Recorder.Eventf(sandbox, nil, corev1.EventTypeWarning, sandboxv1beta1.SandboxReasonMultiplePods, "Reconciling", "%s", err.Error())
 }
 
 func (r *SandboxReconciler) computeConditions(sandbox *sandboxv1beta1.Sandbox, err error, svc *corev1.Service, pod *corev1.Pod, podErr error) []metav1.Condition {
@@ -530,6 +589,11 @@ func (r *SandboxReconciler) computeReadyCondition(sandbox *sandboxv1beta1.Sandbo
 	}
 
 	if err != nil {
+		if isMultipleSandboxPodsError(err) {
+			readyCondition.Reason = sandboxv1beta1.SandboxReasonMultiplePods
+			readyCondition.Message = err.Error()
+			return readyCondition
+		}
 		readyCondition.Reason = "ReconcilerError"
 		readyCondition.Message = "Error seen: " + err.Error()
 		return readyCondition
@@ -1107,8 +1171,8 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 	defer end()
 
 	// List all pods carrying this sandbox's tracking label (sandboxLabel),
-	// via the cache field index registered in SetupWithManager.
-	// TODO: find a better way to make sure one sandbox has at most one pod
+	// via the cache field index registered in SetupWithManager. The label only
+	// identifies candidates; controller owner UID establishes the mapping.
 	podList := &corev1.PodList{}
 	if err := r.List(ctx, podList,
 		client.InNamespace(sandbox.Namespace),
@@ -1118,9 +1182,7 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 		return nil, fmt.Errorf("pod list failed: %w", err)
 	}
 
-	if len(podList.Items) > 1 {
-		logger.Info("Multiple pods found for sandbox, this should not happen", "Sandbox", sandbox.Name, "PodCount", len(podList.Items))
-	}
+	ownedPods := sandboxOwnedPods(podList.Items, sandbox)
 
 	// Determine the pod name to look up
 	podName := resolvePodName(sandbox)
@@ -1143,6 +1205,30 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			}
 		}
 		pod = nil
+	}
+
+	// A tracked Pod may temporarily be absent from the label index (for
+	// example, a legacy adopted Pod before its metadata patch is observed).
+	// Include it in the ownership classification without double counting it.
+	if pod != nil && isOwnedBySandbox(pod, sandbox) && !containsPod(ownedPods, pod) {
+		ownedPods = append(ownedPods, pod)
+	}
+	if len(ownedPods) > 1 {
+		return nil, &multipleSandboxPodsError{count: len(ownedPods)}
+	}
+
+	// Owner UID is authoritative over the compatibility annotation. If an
+	// owned Pod survives while the annotation is missing or stale, reconcile
+	// that Pod instead of adopting or creating another one.
+	if len(ownedPods) == 1 && (pod == nil || pod.Name != ownedPods[0].Name) {
+		if podNameAnnotationExists {
+			logger.Info("Tracked Pod differs from the owned Pod, repairing mapping",
+				"trackedPodName", podName, "ownedPodName", ownedPods[0].Name)
+			if err := r.clearPodNameAnnotation(ctx, sandbox); err != nil {
+				return nil, err
+			}
+		}
+		pod = ownedPods[0].DeepCopy()
 	}
 
 	if sandbox.Spec.OperatingMode == sandboxv1beta1.SandboxOperatingModeSuspended {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -3088,6 +3089,313 @@ func TestReconcilePod(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcilePodRecoversOwnedPodWhenTrackedPodIsMissing(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+		survivor    = "warm-pod-survivor"
+	)
+
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: sandboxNs,
+			UID:       sandboxUID,
+			Annotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: "warm-pod-missing",
+			},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+	ownedSurvivor := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            survivor,
+			Namespace:       sandboxNs,
+			Labels:          map[string]string{sandboxLabel: nameHash},
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+	}
+
+	r := &SandboxReconciler{
+		Client:        newFakeClient(sandbox, ownedSurvivor),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+	assert.Equal(t, survivor, pod.Name)
+
+	createdPod := &corev1.Pod{}
+	err = r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, createdPod)
+	require.True(t, k8serrors.IsNotFound(err), "must not create a second Pod when an owned survivor exists")
+
+	liveSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), client.ObjectKeyFromObject(sandbox), liveSandbox))
+	assert.Equal(t, survivor, liveSandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation])
+}
+
+func TestReconcilePodPrefersOwnedPodOverStaleAdoptionTarget(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+		survivor    = "owned-survivor"
+		staleTarget = "stale-adoption-target"
+	)
+
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sandboxName,
+			Namespace: sandboxNs,
+			UID:       sandboxUID,
+			Annotations: map[string]string{
+				sandboxv1beta1.SandboxPodNameAnnotation: staleTarget,
+			},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+	ownedSurvivor := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            survivor,
+			Namespace:       sandboxNs,
+			Labels:          map[string]string{sandboxLabel: nameHash},
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+	}
+	staleAdoptionTarget := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      staleTarget,
+			Namespace: sandboxNs,
+			Labels:    map[string]string{sandboxv1beta1.SandboxAdoptableLabel: "true"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+	}
+
+	r := &SandboxReconciler{
+		Client:        newFakeClient(sandbox, ownedSurvivor, staleAdoptionTarget),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+	assert.Equal(t, survivor, pod.Name)
+
+	liveTarget := &corev1.Pod{}
+	require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: staleTarget, Namespace: sandboxNs}, liveTarget))
+	assert.Empty(t, liveTarget.OwnerReferences, "stale target must not be adopted when an owned Pod already exists")
+
+	liveSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), client.ObjectKeyFromObject(sandbox), liveSandbox))
+	assert.Equal(t, survivor, liveSandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation])
+}
+
+func TestReconcilePodFailsClosedForMultipleOwnedPods(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+	)
+
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs, UID: sandboxUID},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+	ownedPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       sandboxNs,
+				Labels:          map[string]string{sandboxLabel: nameHash},
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		}
+	}
+	first := ownedPod("owned-pod-a")
+	second := ownedPod("owned-pod-b")
+	r := &SandboxReconciler{
+		Client:        newFakeClient(sandbox, first, second),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	require.Error(t, err)
+	assert.Nil(t, pod)
+	assert.Contains(t, err.Error(), "multiple Pods")
+
+	createdPod := &corev1.Pod{}
+	err = r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, createdPod)
+	require.True(t, k8serrors.IsNotFound(err), "must not create another Pod while ownership is ambiguous")
+	for _, name := range []string{first.Name, second.Name} {
+		livePod := &corev1.Pod{}
+		require.NoError(t, r.Get(t.Context(), types.NamespacedName{Name: name, Namespace: sandboxNs}, livePod))
+	}
+}
+
+func TestReconcileChildResourcesSurfacesMultipleOwnedPods(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+	)
+	nameHash := NameHash(sandboxName)
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       sandboxName,
+			Namespace:  sandboxNs,
+			UID:        sandboxUID,
+			Generation: 3,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+	ownedPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Namespace:       sandboxNs,
+				Labels:          map[string]string{sandboxLabel: nameHash},
+				OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			},
+		}
+	}
+	recorder := events.NewFakeRecorder(2)
+	r := &SandboxReconciler{
+		Client:        newFakeClient(sandbox, ownedPod("owned-pod-a"), ownedPod("owned-pod-b")),
+		Scheme:        Scheme,
+		Recorder:      recorder,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	require.NoError(t, r.reconcileChildResources(t.Context(), sandbox))
+	ready := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, sandboxv1beta1.SandboxReasonMultiplePods, ready.Reason)
+	assert.Contains(t, ready.Message, "multiple Pods (2)")
+	assert.Nil(t, sandbox.Status.PodIPs)
+	assert.Empty(t, sandbox.Status.NodeName)
+
+	service := &corev1.Service{}
+	err := r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, service)
+	require.True(t, k8serrors.IsNotFound(err), "must not create a routing Service for an ambiguous Pod mapping")
+
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, corev1.EventTypeWarning)
+		assert.Contains(t, event, sandboxv1beta1.SandboxReasonMultiplePods)
+	default:
+		t.Fatal("expected a warning Event for the Pod mapping conflict")
+	}
+
+	// The conflict is watch-driven and does not return an error or emit a new
+	// Event on every reconcile while the Ready condition already reports it.
+	require.NoError(t, r.reconcileChildResources(t.Context(), sandbox))
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("unexpected duplicate Event: %s", event)
+	default:
+	}
+}
+
+func TestSandboxOwnedPodsRequiresOwnerUID(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{ObjectMeta: metav1.ObjectMeta{UID: sandboxUID}}
+	pods := []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "owned", OwnerReferences: []metav1.OwnerReference{sandboxControllerRef("sandbox")}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "old-incarnation", OwnerReferences: []metav1.OwnerReference{{UID: "old-sandbox-uid", Controller: new(true)}}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "unowned"}},
+	}
+
+	owned := sandboxOwnedPods(pods, sandbox)
+	require.Len(t, owned, 1)
+	assert.Equal(t, "owned", owned[0].Name)
+}
+
+func TestReconcilePodWaitsForOwnedTerminatingPod(t *testing.T) {
+	const (
+		sandboxName = "sandbox-name"
+		sandboxNs   = "sandbox-ns"
+		nameHash    = "name-hash"
+	)
+
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: sandboxName, Namespace: sandboxNs, UID: sandboxUID},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				},
+			},
+			OperatingMode: sandboxv1beta1.SandboxOperatingModeRunning,
+		},
+	}
+	deletionTime := metav1.Now()
+	terminatingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "terminating-owned-pod",
+			Namespace:         sandboxNs,
+			Labels:            map[string]string{sandboxLabel: nameHash},
+			OwnerReferences:   []metav1.OwnerReference{sandboxControllerRef(sandboxName)},
+			Finalizers:        []string{"agents.x-k8s.io/test-hold"},
+			DeletionTimestamp: &deletionTime,
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+	}
+	r := &SandboxReconciler{
+		Client:        newFakeClient(sandbox, terminatingPod),
+		Scheme:        Scheme,
+		Tracer:        asmetrics.NewNoOp(),
+		ClusterDomain: "cluster.local",
+	}
+
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	require.NoError(t, err)
+	require.NotNil(t, pod)
+	assert.Equal(t, terminatingPod.Name, pod.Name)
+
+	createdPod := &corev1.Pod{}
+	err = r.Get(t.Context(), types.NamespacedName{Name: sandboxName, Namespace: sandboxNs}, createdPod)
+	require.True(t, k8serrors.IsNotFound(err), "must wait for the owned terminating Pod instead of overlapping it")
 }
 
 func TestServicePortsForSandboxReturnsNilWithoutContainerPorts(t *testing.T) {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -467,6 +467,18 @@ func TestComputeConditions(t *testing.T) {
 				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "DependenciesNotReady", Message: "Pod exists with phase: Pending; Service Exists"},
 			},
 		},
+		{
+			name:    "16. Multiple owned Pods message excludes joined transient errors",
+			sandbox: sbWithMode(sandboxv1beta1.SandboxOperatingModeRunning),
+			err: errors.Join(
+				errors.New("failed to reconcile PVC: temporary error"),
+				&multipleSandboxPodsError{count: 2},
+			),
+			expectedConditions: []metav1.Condition{
+				{Type: "Suspended", Status: "False", ObservedGeneration: gen, Reason: "NotSuspended", Message: "Sandbox is not suspended"},
+				{Type: "Ready", Status: "False", ObservedGeneration: gen, Reason: "MultiplePods", Message: "multiple Pods (2) are controlled by this Sandbox; refusing to choose or create a Pod"},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -3134,7 +3146,7 @@ func TestReconcilePodRecoversOwnedPodWhenTrackedPodIsMissing(t *testing.T) {
 		ClusterDomain: "cluster.local",
 	}
 
-	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pod)
 	assert.Equal(t, survivor, pod.Name)
@@ -3200,7 +3212,7 @@ func TestReconcilePodPrefersOwnedPodOverStaleAdoptionTarget(t *testing.T) {
 		ClusterDomain: "cluster.local",
 	}
 
-	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pod)
 	assert.Equal(t, survivor, pod.Name)
@@ -3252,7 +3264,7 @@ func TestReconcilePodFailsClosedForMultipleOwnedPods(t *testing.T) {
 		ClusterDomain: "cluster.local",
 	}
 
-	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash, nil)
 	require.Error(t, err)
 	assert.Nil(t, pod)
 	assert.Contains(t, err.Error(), "multiple Pods")
@@ -3307,7 +3319,7 @@ func TestReconcileChildResourcesSurfacesMultipleOwnedPods(t *testing.T) {
 		ClusterDomain: "cluster.local",
 	}
 
-	require.NoError(t, r.reconcileChildResources(t.Context(), sandbox))
+	require.NoError(t, r.reconcileChildResources(t.Context(), sandbox, nil))
 	ready := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
 	require.NotNil(t, ready)
 	assert.Equal(t, metav1.ConditionFalse, ready.Status)
@@ -3330,7 +3342,7 @@ func TestReconcileChildResourcesSurfacesMultipleOwnedPods(t *testing.T) {
 
 	// The conflict is watch-driven and does not return an error or emit a new
 	// Event on every reconcile while the Ready condition already reports it.
-	require.NoError(t, r.reconcileChildResources(t.Context(), sandbox))
+	require.NoError(t, r.reconcileChildResources(t.Context(), sandbox, nil))
 	select {
 	case event := <-recorder.Events:
 		t.Fatalf("unexpected duplicate Event: %s", event)
@@ -3388,7 +3400,7 @@ func TestReconcilePodWaitsForOwnedTerminatingPod(t *testing.T) {
 		ClusterDomain: "cluster.local",
 	}
 
-	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash)
+	pod, err := r.reconcilePod(t.Context(), sandbox.DeepCopy(), nameHash, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pod)
 	assert.Equal(t, terminatingPod.Name, pod.Name)


### PR DESCRIPTION
#### What this PR does / why we need it:
The Sandbox controller could create an additional Pod when the pod-name annotation was stale or missing even though a Pod controlled by the same Sandbox UID still existed.

This PR treats the tracking label as a candidate index and the controller owner-reference UID as the authoritative Sandbox-to-Pod mapping. It recovers a unique owned Pod instead of adopting or creating another Pod, and waits for an owned terminating Pod rather than overlapping it.

If multiple Pods are controlled by the same Sandbox UID, reconciliation now fails closed: it does not select, create, or delete a Pod; it does not create or modify the routing Service; and it reports Ready=False with reason MultiplePods plus a Warning Event. This preserves stateful Pods for operator inspection and avoids hot-loop retries while the conflict remains unchanged.

#### Which issue(s) this PR is related to:
Fixes #1332
Follow-up to #127.
Related to #1297.

#### Release Note

```release-note
Fixed Sandbox reconciliation to avoid creating an additional Pod when the pod-name annotation is stale or an owned Pod is terminating. Multiple owned Pods now fail closed and report Ready=False with reason MultiplePods.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox Pod selection using ownership information and repaired stale tracking metadata.
  * Prevented duplicate Pod creation when an owned Pod exists or is terminating.
  * Added safe handling for multiple owned Pods, including Ready status updates and warning events.
  * Prevented Service reconciliation when Pod ownership is ambiguous.

* **Tests**
  * Added coverage for Pod recovery, ownership filtering, duplicate prevention, termination handling, and conflict reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->