### PR TITLE
docs: fix some typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ fix-api:
 # Location of your local k8s.io repo (can be overridden: make release-promote TAG=v0.1.0 K8S_IO_DIR=../other/k8s.io)
 K8S_IO_DIR ?= ../../kubernetes/k8s.io
 
-# Default remote (can be overriden: make release-publish REMOTE=upstream ...)
+# Default remote (can be overridden: make release-publish REMOTE=upstream ...)
 REMOTE_UPSTREAM ?= upstream
 REMOTE_FORK ?= origin
 

--- a/examples/composing-sandbox-nw-policies/README.md
+++ b/examples/composing-sandbox-nw-policies/README.md
@@ -111,7 +111,7 @@ The KRO reconciler reconciles `AgenticSandbox` instance and creates the followin
 * Sandbox
 * Service
 * NetworkPolicy (if enabled)
-* Ingress (if enbled)
+* Ingress (if enabled)
 
 The user/agent can access the Sandbox via the Ingress or the Service as appropriate.
 

--- a/examples/policy/vap/README.md
+++ b/examples/policy/vap/README.md
@@ -23,7 +23,8 @@ This policy **rejects** any `Sandbox` resource that attempts to bypass the follo
 | **DoS Protection** | `resources.limits` (CPU & Memory) | **Prevents Noisy Neighbors.** <br> Requires all containers to set resource limits, preventing a single compromised or buggy sandbox from starving the underlying node of resources. |
 | **User Isolation** | `runAsNonRoot: true` | **Defense in Depth.** <br> Enforces that the process cannot run as root. The policy checks both the Pod-level `securityContext` and the individual Container-level `securityContext` to ensure proper inheritance. |
 | **GKE Specific: Scheduling** | `nodeSelector: sandbox.gke.io/runtime: gvisor` | **Guarantees Runtime Target.** <br> Ensures the Kubernetes scheduler only places the Sandbox on node pools that have gVisor installed and configured. |
-| **GKE Specfic: Scheduling** | `tolerations: sandbox.gke.io/runtime=gvisor` | **Permits Runtime Target.** <br> Ensures the Sandbox is authorized to land on the dedicated, tainted gVisor node pool. |
+| **GKE Specific: Scheduling** | `tolerations: sandbox.gke.io/runtime=gvisor` | **Permits Runtime Target.** <br> Ensures the Sandbox is authorized to land on the dedicated, tainted gVisor node pool. |
+
 ## Deployment
 
 This policy requires **Kubernetes v1.30+** (Standard on GKE Autopilot).


### PR DESCRIPTION
Fixes three trivial typos. Each has the correct spelling on an adjacent line in the same file, so the intended wording is unambiguous:

- `Makefile`: `overriden` → `overridden` (line 131 of the same file already spells it `overridden`)
- `examples/policy/vap/README.md`: `Specfic` → `Specific` (the preceding table row uses `GKE Specific`)
- `examples/composing-sandbox-nw-policies/README.md`: `enbled` → `enabled` (the preceding list item uses `(if enabled)`)

Comment/documentation only — no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling and grammar errors in build instructions and example documentation.
  - Fixed the description of the default remote.
  - Corrected resource and scheduling-control terminology in policy examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->