### PR TITLE
feat(mcp): add /healthz and /readyz probe endpoints

### DIFF
--- a/clients/integrations/mcp-server/README.md
+++ b/clients/integrations/mcp-server/README.md
@@ -89,7 +89,11 @@ The server exposes two endpoints for Kubernetes probes:
 | Endpoint | Meaning |
 |---|---|
 | `GET /healthz` | **Liveness.** The process is up and routing HTTP. Never contacts the Kubernetes API. |
-| `GET /readyz` | **Readiness.** Lists SandboxClaims in `K8S_SANDBOX_PROBE_NAMESPACE` to confirm the Kubernetes API is reachable. Returns `503` with `{"ready": false}` while starting or when the API is unreachable. |
+| `GET /readyz` | **Readiness.** Lists SandboxClaims in `K8S_SANDBOX_PROBE_NAMESPACE` to confirm the Kubernetes API is reachable. Returns `200` with `{"ready": true}`, or `503` with `{"ready": false, "reason": "..."}`. |
+
+`/readyz` failure reasons are `"starting"` (the server has not finished initializing) and
+`"kubernetes API unavailable"`. The reason is deliberately generic — the endpoint is
+unauthenticated, so the underlying exception is logged rather than returned.
 
 `/healthz` is deliberately independent of the Kubernetes API: wiring a liveness probe to an
 external dependency turns a transient control-plane blip into a rolling restart of every replica.

--- a/clients/integrations/mcp-server/README.md
+++ b/clients/integrations/mcp-server/README.md
@@ -80,6 +80,37 @@ Connects directly to the sandbox pod from within the cluster (bypassing the rout
 ### General Settings
 
 * `K8S_SANDBOX_SESSION_ID_LABEL_KEY`: The Kubernetes label key to apply for tracking session IDs on the sandboxes. (Default: `"mcp.k8s-agent-sandbox/session-id"`)
+* `K8S_SANDBOX_PROBE_NAMESPACE`: Namespace the `/readyz` probe lists SandboxClaims in to confirm the Kubernetes API is reachable. Must be a namespace the server's service account can list claims in. (Default: `"default"`)
+
+## Health checks
+
+The server exposes two endpoints for Kubernetes probes:
+
+| Endpoint | Meaning |
+|---|---|
+| `GET /healthz` | **Liveness.** The process is up and routing HTTP. Never contacts the Kubernetes API. |
+| `GET /readyz` | **Readiness.** Lists SandboxClaims in `K8S_SANDBOX_PROBE_NAMESPACE` to confirm the Kubernetes API is reachable. Returns `503` with `{"ready": false}` while starting or when the API is unreachable. |
+
+`/healthz` is deliberately independent of the Kubernetes API: wiring a liveness probe to an
+external dependency turns a transient control-plane blip into a rolling restart of every replica.
+Use `/readyz` — which does check — to pull a pod out of the Service instead.
+
+Because `/readyz` makes a real API call, keep `periodSeconds` modest rather than polling it
+aggressively:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8000
+  initialDelaySeconds: 5
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8000
+  initialDelaySeconds: 5
+  periodSeconds: 15
+```
 
 ## Security
 

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/probes.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/probes.py
@@ -1,0 +1,80 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kubernetes liveness and readiness endpoints.
+
+The two probes answer deliberately different questions, following the split
+`sandbox-router` uses (`sandbox-router/server/server.go`):
+
+* ``/healthz`` — is the process alive and serving HTTP? Never touches the
+  Kubernetes API, so an apiserver outage cannot cause a restart loop. If this
+  fails the process is wedged and restarting is the right response.
+* ``/readyz`` — can this replica actually serve tool calls? Every tool resolves
+  a SandboxClaim first, so this checks the Kubernetes API is reachable. If it
+  fails the pod is pulled from the Service while the process keeps running.
+
+Keeping ``/healthz`` free of the apiserver is the important part: wiring the
+liveness probe to an external dependency turns a transient control-plane blip
+into a rolling restart of every replica, which is strictly worse than briefly
+serving no traffic.
+"""
+
+import logging
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse
+
+
+logger = logging.getLogger(__name__)
+
+
+async def healthz(request: Request) -> PlainTextResponse:
+    """Liveness: the process is up and the ASGI app is routing requests.
+
+    Deliberately dependency-free -- reaching this handler at all is the signal.
+    """
+    return PlainTextResponse("ok")
+
+
+async def readyz(request: Request) -> JSONResponse:
+    """Readiness: the Kubernetes client is usable, so tool calls can be served.
+
+    Probes ``list_sandbox_claims`` in the configured probe namespace. That is
+    a public SDK call (the private ``_ensure_initialized`` was avoided
+    deliberately -- nothing else in the repo depends on SDK internals) and it
+    exercises the whole path a tool call needs: credential loading, client
+    construction, and one real apiserver request.
+
+    A LIST bounded to a single namespace is the cheapest call that proves all
+    three. It is not free, so keep the probe's ``periodSeconds`` modest rather
+    than polling it aggressively.
+    """
+    server = getattr(request.app.state, "fastmcp_server", None)
+    client = getattr(server, "sandbox_client", None)
+    settings = getattr(server, "probe_settings", None)
+    if client is None or settings is None:
+        # The lifespan has not run yet: still starting, so not ready -- but not
+        # unhealthy, which is why /healthz stays independent of this.
+        return JSONResponse({"ready": False, "reason": "starting"}, status_code=503)
+
+    try:
+        await client.k8s_helper.list_sandbox_claims(settings.probe_namespace)
+    except Exception as e:
+        logger.warning("readiness check failed: %s", e)
+        return JSONResponse(
+            {"ready": False, "reason": "kubernetes API unavailable"},
+            status_code=503,
+        )
+
+    return JSONResponse({"ready": True})

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/server.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/server.py
@@ -32,6 +32,8 @@ from .resources import (
     get_sandboxes,
 )
 
+from .probes import healthz, readyz
+
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +45,18 @@ def create_mcp_server(settings: Settings | None = None):
 
     @asynccontextmanager
     async def lifespan(server: FastMCP):
-     
+
         client = AsyncSandboxClient(
             connection_config=settings.connection,
             cleanup=False,
         )
+        # The yielded mapping reaches tools via ctx.lifespan_context but is not
+        # published on the ASGI app, so probe routes cannot read it. Stash what
+        # they need on the server object, which routes reach as
+        # request.app.state.fastmcp_server. Before this runs, /readyz correctly
+        # reports "starting".
+        server.sandbox_client = client
+        server.probe_settings = settings
         try:
             yield {"client": client, "settings": settings}
         finally:
@@ -56,12 +65,15 @@ def create_mcp_server(settings: Settings | None = None):
     mcp = FastMCP("K8sAgentSandbox", lifespan=lifespan)
 
     mcp.add_resource(get_sandboxes)
-    
+
     mcp.add_tool(create_sandbox)
     mcp.add_tool(delete_sandbox)
     mcp.add_tool(execute_command)
     mcp.add_tool(upload_file)
     mcp.add_tool(download_file)
+
+    mcp.custom_route("/healthz", methods=["GET"])(healthz)
+    mcp.custom_route("/readyz", methods=["GET"])(readyz)
 
     return mcp
 

--- a/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/settings.py
+++ b/clients/integrations/mcp-server/k8s_agent_sandbox_mcp_server/settings.py
@@ -41,9 +41,15 @@ class InClusterConnectionConfig(SandboxInClusterConnectionConfig):
 ConnectionType = Union[GatewayConnectionConfig, DirectConnectionConfig, InClusterConnectionConfig]
 
 class Settings(BaseSettings):
-    connection: ConnectionType = Field(default=..., discriminator='type')  
+    connection: ConnectionType = Field(default=..., discriminator='type')
     session_id_label_key: str = Field(
         default="mcp.k8s-agent-sandbox/session-id",
+    )
+    probe_namespace: str = Field(
+        default="default",
+        description="Namespace the /readyz probe lists SandboxClaims in to confirm "
+                    "the Kubernetes API is reachable. Must be a namespace the "
+                    "server's service account can list claims in.",
     )
 
     model_config = SettingsConfigDict(

--- a/clients/integrations/mcp-server/pyproject.toml
+++ b/clients/integrations/mcp-server/pyproject.toml
@@ -32,5 +32,9 @@ test = [
     "pytest",
     "pytest-xdist",
     "anyio",
+    # Used by the probe tests to drive the ASGI app. It is currently pulled in
+    # transitively by fastmcp, but declare it so the suite does not silently
+    # depend on another package's dependency tree.
+    "httpx",
 ]
 

--- a/clients/integrations/mcp-server/tests/unit/test_probes.py
+++ b/clients/integrations/mcp-server/tests/unit/test_probes.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from k8s_agent_sandbox_mcp_server.server import create_mcp_server
+
+
+async def probe(settings, sandbox_client, path, run_lifespan=True):
+    """GET path against a fresh app, optionally skipping the lifespan.
+
+    The patch must stay active while the lifespan runs: the client is
+    constructed inside it, not at create_mcp_server() time. Patching only
+    around construction lets the real AsyncSandboxClient be built, which then
+    talks to whatever cluster the ambient kubeconfig points at -- these tests
+    hit a live apiserver and got a 401 before this was fixed.
+    """
+    with patch(
+        "k8s_agent_sandbox_mcp_server.server.AsyncSandboxClient"
+    ) as client_class:
+        client_class.return_value = sandbox_client
+        app = create_mcp_server(settings=settings).http_app()
+        transport = httpx.ASGITransport(app=app)
+
+        if not run_lifespan:
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://t"
+            ) as c:
+                return await c.get(path)
+
+        async with app.router.lifespan_context(app):
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://t"
+            ) as c:
+                return await c.get(path)
+
+
+@pytest.fixture
+def k8s_client():
+    client = AsyncMock()
+    client.k8s_helper = MagicMock()
+    client.k8s_helper.list_sandbox_claims = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.mark.anyio
+async def test_healthz_is_ok(mcp_server_settings, k8s_client):
+    response = await probe(mcp_server_settings, k8s_client, "/healthz")
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+@pytest.mark.anyio
+async def test_healthz_does_not_touch_kubernetes(mcp_server_settings, k8s_client):
+    """Liveness must not depend on the apiserver.
+
+    Wiring it to an external dependency would turn a control-plane blip into a
+    rolling restart of every replica.
+    """
+    response = await probe(mcp_server_settings, k8s_client, "/healthz")
+
+    assert response.status_code == 200
+    k8s_client.k8s_helper.list_sandbox_claims.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_readyz_is_ready_when_kubernetes_reachable(
+    mcp_server_settings, k8s_client
+):
+    response = await probe(mcp_server_settings, k8s_client, "/readyz")
+
+    assert response.status_code == 200
+    assert response.json() == {"ready": True}
+    k8s_client.k8s_helper.list_sandbox_claims.assert_awaited_once_with(
+        mcp_server_settings.probe_namespace
+    )
+
+
+@pytest.mark.anyio
+async def test_readyz_is_not_ready_when_kubernetes_unreachable(
+    mcp_server_settings, k8s_client
+):
+    k8s_client.k8s_helper.list_sandbox_claims = AsyncMock(
+        side_effect=RuntimeError("connection refused")
+    )
+    response = await probe(mcp_server_settings, k8s_client, "/readyz")
+
+    assert response.status_code == 503
+    assert response.json()["ready"] is False
+    # The reason must not leak the underlying exception text to an
+    # unauthenticated caller.
+    assert "connection refused" not in response.text
+
+
+@pytest.mark.anyio
+async def test_readyz_reports_starting_before_lifespan_runs(
+    mcp_server_settings, k8s_client
+):
+    response = await probe(
+        mcp_server_settings, k8s_client, "/readyz", run_lifespan=False
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {"ready": False, "reason": "starting"}
+
+
+@pytest.mark.anyio
+async def test_readyz_uses_the_configured_probe_namespace(k8s_client):
+    from k8s_agent_sandbox_mcp_server.settings import (
+        DirectConnectionConfig,
+        Settings,
+    )
+
+    settings = Settings(
+        connection=DirectConnectionConfig(api_url="http://some-url"),
+        probe_namespace="sandboxes",
+    )
+    response = await probe(settings, k8s_client, "/readyz")
+
+    assert response.status_code == 200
+    k8s_client.k8s_helper.list_sandbox_claims.assert_awaited_once_with("sandboxes")

--- a/clients/integrations/mcp-server/tests/unit/test_probes.py
+++ b/clients/integrations/mcp-server/tests/unit/test_probes.py
@@ -101,7 +101,12 @@ async def test_readyz_is_not_ready_when_kubernetes_unreachable(
     response = await probe(mcp_server_settings, k8s_client, "/readyz")
 
     assert response.status_code == 503
-    assert response.json()["ready"] is False
+    # Pin the documented body shape: README promises {"ready": ..., "reason": ...}
+    # and drifted from the implementation once already.
+    assert response.json() == {
+        "ready": False,
+        "reason": "kubernetes API unavailable",
+    }
     # The reason must not leak the underlying exception text to an
     # unauthenticated caller.
     assert "connection refused" not in response.text


### PR DESCRIPTION
#### What this PR does / why we need it:

The MCP server ships a Dockerfile that serves streamable HTTP on `0.0.0.0:8000`, so it is
deployed as a long-running network service — but it exposes no probe endpoints. A Deployment
has no way to tell a wedged replica from a healthy one, or to keep traffic off one that cannot
reach the Kubernetes API.

Adds the two-endpoint split `sandbox-router` already uses (`sandbox-router/server/server.go:41`):

| Endpoint | Meaning |
|---|---|
| `GET /healthz` | **Liveness.** 200 once the ASGI app routes the request. Never contacts the Kubernetes API. |
| `GET /readyz` | **Readiness.** Lists SandboxClaims in a configurable `probe_namespace`. `503` while starting or when the API is unreachable. |

Keeping liveness independent of the Kubernetes API is the deliberate part: wiring it to an
external dependency would turn a transient control-plane blip into a rolling restart of every
replica, which is worse than briefly serving no traffic. A test asserts `/healthz` makes no
Kubernetes call.

`/readyz` returns a generic reason string rather than the underlying exception, since the
endpoint is unauthenticated.

Two implementation notes for reviewers:

* **`/readyz` calls the public `list_sandbox_claims`, not `_ensure_initialized`.** The latter only
  loads credentials and builds API objects without contacting the apiserver, so it would report
  ready while the cluster was unreachable. It is also private, and nothing else in the repo
  depends on SDK internals.
* **The client is stashed on the `FastMCP` server object.** The lifespan's yielded mapping reaches
  tools via `ctx.lifespan_context` but is not published on the ASGI app, so routes read it as
  `request.app.state.fastmcp_server`.

`httpx` is now declared in the `test` extra — the probe tests drive the ASGI app with it, and it
was previously only available transitively through `fastmcp`.

#### Testing

Six new tests: `/healthz` 200, `/healthz` makes no Kubernetes call, `/readyz` ready,
`/readyz` 503 when the API fails (asserting the exception text is not leaked), `/readyz`
reports `starting` before the lifespan runs, and the configured namespace is honoured.
Suite 19 → 25. `dev/tools/test-unit` green across all suites locally.

Suggested probe config is documented in the README; because `/readyz` makes a real API call,
it recommends a modest `periodSeconds` rather than aggressive polling.

#### Which issue(s) this PR is related to:

Follow-up hardening for the MCP server added in https://github.com/kubernetes-sigs/agent-sandbox/pull/1141

#### Release Note
```release-note
Added `/healthz` and `/readyz` endpoints to the Agent Sandbox MCP server for Kubernetes liveness and readiness probes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/healthz` liveness and `/readyz` readiness endpoints.
  * Readiness checks server startup status and Kubernetes API availability.
  * Added configurable namespace selection for readiness checks.
* **Documentation**
  * Documented health endpoints, response behavior, and recommended Kubernetes probe configuration.
* **Tests**
  * Added coverage for successful, unavailable, and not-yet-started readiness states.
  * Verified liveness checks avoid backend access and responses exclude internal error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->