### PR TITLE
Add example: simulating AWS IRSA locally with LocalStack

### DIFF
--- a/examples/irsa-simulation-localstack/README.md
+++ b/examples/irsa-simulation-localstack/README.md
@@ -53,14 +53,17 @@ Install `amazon-eks-pod-identity-webhook` (real, unmodified upstream — not
 vendored here):
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/deployment-base.yaml
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/auth.yaml
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/service.yaml
-kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/mutatingwebhook.yaml
+# Pinned to the same release tag as the image below, not the moving `master`
+# branch, so this doesn't break if upstream manifests change incompatibly.
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/v0.6.17/deploy/deployment-base.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/v0.6.17/deploy/auth.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/v0.6.17/deploy/service.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/v0.6.17/deploy/mutatingwebhook.yaml
 
 # deployment-base.yaml ships with an unresolved IMAGE placeholder in the
-# container spec — point it at a real released image tag:
-kubectl set image deployment/pod-identity-webhook \
+# container spec — point it at a real released image tag (deploys into the
+# `default` namespace; see deployment-base.yaml):
+kubectl set image deployment/pod-identity-webhook -n default \
   pod-identity-webhook=public.ecr.aws/eks/amazon-eks-pod-identity-webhook:v0.6.17
 ```
 
@@ -101,9 +104,16 @@ The container runs as a non-root user whose home directory isn't writable, so
 override `HOME` for the install and the script:
 
 ```sh
-kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- sh -c 'HOME=/tmp pip install --user --quiet boto3'
+kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- sh -c 'HOME=/tmp python3 -m pip install --user --quiet "boto3>=1.29"'
 kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- sh -c 'HOME=/tmp python3 /irsa-sim/check_irsa.py'
 ```
+
+`python3 -m pip` (rather than a bare `pip`) guarantees the package installs
+for the same interpreter that runs the script, regardless of what else is on
+`PATH` in the container. The `boto3>=1.29` floor matters functionally, not
+just stylistically: `AWS_ENDPOINT_URL_STS` is only honored automatically
+starting around that botocore release — on an older version the check would
+silently fall through to calling real AWS STS instead of LocalStack.
 
 Expected output:
 

--- a/examples/irsa-simulation-localstack/README.md
+++ b/examples/irsa-simulation-localstack/README.md
@@ -1,0 +1,144 @@
+# Simulating AWS IRSA locally with LocalStack
+
+This example shows how to validate an AWS IRSA (IAM Roles for Service Accounts)
+credential-loading code path against a sandbox pod, entirely on a local or
+non-EKS cluster — no real AWS account, IAM role, or OIDC provider required.
+
+## Overview
+
+Real IRSA on Amazon EKS depends on the cluster's OIDC identity provider being
+registered with AWS IAM, which only exists on real EKS clusters (and requires
+IAM permissions many developers don't have on a shared/locked-down account).
+That makes it hard to validate "does my sandboxed workload correctly pick up
+and use IRSA-style credentials?" on a local kind/EKS Anywhere cluster, or in
+CI.
+
+This example combines two pieces that need no AWS IAM permissions at all:
+
+1. **[`amazon-eks-pod-identity-webhook`](https://github.com/aws/amazon-eks-pod-identity-webhook)**
+   (unmodified upstream project) — a mutating webhook that, for any pod whose
+   ServiceAccount carries an `eks.amazonaws.com/role-arn` annotation, injects
+   `AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE` env vars and mounts a
+   projected ServiceAccount token — identical to what real EKS does.
+2. **[LocalStack](https://github.com/localstack/localstack)**, running
+   in-cluster with only the `sts` service enabled, standing in for real AWS
+   STS.
+
+With both in place, the AWS SDK's default credential chain
+(`WebIdentityRoleCredentialFetcher` in boto3) picks up the injected env vars
+automatically and exchanges the token for credentials via LocalStack's mocked
+`AssumeRoleWithWebIdentity` — no application code changes needed.
+
+**Important caveat:** LocalStack accepts the web identity token without
+verifying its signature against a real OIDC issuer's JWKS. This proves the
+pod correctly *discovers and uses* IRSA-style credentials — it does **not**
+prove that a real AWS account would trust the token, or that an IRSA trust
+policy is configured correctly. Treat this as a code-path smoke test, not a
+security validation of the trust boundary.
+
+## Files
+
+- `namespace.yaml` — namespace for this example
+- `serviceaccount.yaml` — ServiceAccount annotated with a (non-existent, mock)
+  IAM role ARN
+- `localstack.yaml` — LocalStack Deployment + Service, `SERVICES=sts` only
+- `check-script-configmap.yaml` — the boto3 smoke-test script, mounted into
+  the sandbox pod
+- `sandbox.yaml` — a Sandbox using the annotated ServiceAccount, with
+  `AWS_ENDPOINT_URL_STS` pointed at the in-cluster LocalStack Service
+
+## Prerequisites
+
+Install `amazon-eks-pod-identity-webhook` (real, unmodified upstream — not
+vendored here):
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/deployment-base.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/auth.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/service.yaml
+kubectl apply -f https://raw.githubusercontent.com/aws/amazon-eks-pod-identity-webhook/master/deploy/mutatingwebhook.yaml
+
+# deployment-base.yaml ships with an unresolved IMAGE placeholder in the
+# container spec — point it at a real released image tag:
+kubectl set image deployment/pod-identity-webhook \
+  pod-identity-webhook=public.ecr.aws/eks/amazon-eks-pod-identity-webhook:v0.6.17
+```
+
+This requires `cert-manager` to already be installed on the cluster (used to
+issue the webhook's TLS certificate).
+
+## Usage
+
+### 1. Apply the resources
+
+```sh
+kubectl apply -f namespace.yaml
+kubectl apply -f serviceaccount.yaml
+kubectl apply -f localstack.yaml
+kubectl apply -f check-script-configmap.yaml
+kubectl apply -f sandbox.yaml
+```
+
+### 2. Wait for both to be ready
+
+```sh
+kubectl -n irsa-sim-ns wait --for=condition=Ready pod -l app=localstack --timeout=120s
+kubectl -n irsa-sim-ns get sandbox irsa-sim-sandbox
+```
+
+### 3. Confirm the webhook injected IRSA env vars
+
+```sh
+kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- printenv AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
+```
+
+### 4. Run the credential check
+
+The base sandbox image doesn't ship `boto3`, so install it once inside the
+pod before running the script (a real deployment would bake this into a
+custom image layered on top of the base — see `examples/python-runtime-sandbox`).
+The container runs as a non-root user whose home directory isn't writable, so
+override `HOME` for the install and the script:
+
+```sh
+kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- sh -c 'HOME=/tmp pip install --user --quiet boto3'
+kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- sh -c 'HOME=/tmp python3 /irsa-sim/check_irsa.py'
+```
+
+Expected output:
+
+```
+AccessKeyId: ASIA...
+SecretKey present: True
+SessionToken present: True
+Assumed identity ARN: arn:aws:sts::000000000000:assumed-role/irsa-sim-role/botocore-session-...
+```
+
+This confirms the sandbox pod correctly discovered the webhook-injected
+credentials and exchanged them via LocalStack's mocked STS — with no
+application code aware that it isn't talking to real AWS.
+
+## Cleanup
+
+```sh
+kubectl delete -f sandbox.yaml
+kubectl delete -f check-script-configmap.yaml
+kubectl delete -f localstack.yaml
+kubectl delete -f serviceaccount.yaml
+kubectl delete -f namespace.yaml
+```
+
+## Customization
+
+- **Using a `SandboxTemplate` instead of a bare `Sandbox`:** the controller's
+  auto-generated per-template `NetworkPolicy` restricts egress to the public
+  internet and blocks other in-cluster services by default (see
+  [`docs/security/threat_model.md`](../../docs/security/threat_model.md)).
+  Reaching LocalStack from a `SandboxTemplate`-managed pod needs a
+  supplemental, additive `NetworkPolicy` scoped to the LocalStack
+  Service/namespace — additional `NetworkPolicy` objects selecting the same
+  pods are unioned, not overridden.
+- **Moving to real EKS:** swap the mock `eks.amazonaws.com/role-arn` for a
+  real IAM role ARN, remove `AWS_ENDPOINT_URL_STS` so the SDK talks to real
+  AWS STS, and register the cluster's actual OIDC provider with that role's
+  trust policy.

--- a/examples/irsa-simulation-localstack/README.md
+++ b/examples/irsa-simulation-localstack/README.md
@@ -108,6 +108,7 @@ kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- sh -c 'HOME=/tmp python3 /irsa-s
 Expected output:
 
 ```
+Credential provider: assume-role-with-web-identity
 AccessKeyId: ASIA...
 SecretKey present: True
 SessionToken present: True

--- a/examples/irsa-simulation-localstack/check-script-configmap.yaml
+++ b/examples/irsa-simulation-localstack/check-script-configmap.yaml
@@ -31,8 +31,18 @@ data:
         if not f.read().strip():
             sys.exit(f"{token_file} is empty -- projected ServiceAccount token was not mounted")
 
+    # Read explicitly and pass to the client below rather than relying on
+    # boto3 picking up AWS_ENDPOINT_URL_STS implicitly -- older botocore
+    # versions don't honor that env var at all and would silently call real
+    # AWS STS instead of LocalStack (see README's boto3 version note).
+    sts_endpoint = os.environ.get("AWS_ENDPOINT_URL_STS")
+    if not sts_endpoint:
+        sys.exit("AWS_ENDPOINT_URL_STS not set -- refusing to guess whether this would hit real AWS")
+
     session = boto3.Session(region_name="us-east-1")
     resolved_creds = session.get_credentials()
+    if resolved_creds is None:
+        sys.exit("session.get_credentials() returned None -- no credential provider in the chain found anything usable")
     if resolved_creds.method != "assume-role-with-web-identity":
         sys.exit(f"boto3 used credential provider {resolved_creds.method!r}, not IRSA -- check is not testing what it claims to")
 
@@ -42,6 +52,6 @@ data:
     print(f"SecretKey present: {bool(creds.secret_key)}")
     print(f"SessionToken present: {bool(creds.token)}")
 
-    sts = session.client("sts")
+    sts = session.client("sts", endpoint_url=sts_endpoint)
     identity = sts.get_caller_identity()
     print(f"Assumed identity ARN: {identity['Arn']}")

--- a/examples/irsa-simulation-localstack/check-script-configmap.yaml
+++ b/examples/irsa-simulation-localstack/check-script-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: irsa-sim-check-script
+  namespace: irsa-sim-ns
+data:
+  check_irsa.py: |
+    """Validates the IRSA credential-loading code path against a
+    LocalStack-mocked STS. Does NOT validate the real AWS OIDC trust
+    boundary (issuer/JWKS signature checks) -- LocalStack accepts any web
+    identity token without verifying it. This only proves the pod correctly
+    discovers AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE (injected by
+    amazon-eks-pod-identity-webhook) and can exchange the projected token
+    for credentials via the standard boto3 credential chain -- no
+    application code changes needed.
+    """
+    import boto3
+
+    session = boto3.Session(region_name="us-east-1")
+    creds = session.get_credentials().get_frozen_credentials()
+
+    print(f"AccessKeyId: {creds.access_key}")
+    print(f"SecretKey present: {bool(creds.secret_key)}")
+    print(f"SessionToken present: {bool(creds.token)}")
+
+    sts = session.client("sts")
+    identity = sts.get_caller_identity()
+    print(f"Assumed identity ARN: {identity['Arn']}")

--- a/examples/irsa-simulation-localstack/check-script-configmap.yaml
+++ b/examples/irsa-simulation-localstack/check-script-configmap.yaml
@@ -14,11 +14,30 @@ data:
     for credentials via the standard boto3 credential chain -- no
     application code changes needed.
     """
+    import os
+    import sys
+
     import boto3
 
-    session = boto3.Session(region_name="us-east-1")
-    creds = session.get_credentials().get_frozen_credentials()
+    # Assert the webhook actually did its job before trusting any credentials
+    # boto3 hands back -- otherwise a stray static/env credential elsewhere in
+    # the pod could make this smoke test pass even if webhook injection is
+    # broken, defeating the point of the check.
+    role_arn = os.environ.get("AWS_ROLE_ARN")
+    token_file = os.environ.get("AWS_WEB_IDENTITY_TOKEN_FILE")
+    if not role_arn or not token_file:
+        sys.exit("AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE not set -- webhook did not inject IRSA env vars")
+    with open(token_file) as f:
+        if not f.read().strip():
+            sys.exit(f"{token_file} is empty -- projected ServiceAccount token was not mounted")
 
+    session = boto3.Session(region_name="us-east-1")
+    resolved_creds = session.get_credentials()
+    if resolved_creds.method != "assume-role-with-web-identity":
+        sys.exit(f"boto3 used credential provider {resolved_creds.method!r}, not IRSA -- check is not testing what it claims to")
+
+    creds = resolved_creds.get_frozen_credentials()
+    print(f"Credential provider: {resolved_creds.method}")
     print(f"AccessKeyId: {creds.access_key}")
     print(f"SecretKey present: {bool(creds.secret_key)}")
     print(f"SessionToken present: {bool(creds.token)}")

--- a/examples/irsa-simulation-localstack/localstack.yaml
+++ b/examples/irsa-simulation-localstack/localstack.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         app: localstack
     spec:
+      # Plain emptyDir volumes are created world-writable (0777) by kubelet
+      # regardless of security context, so UID 1000 can already write to both
+      # mounts below without this -- fsGroup is set anyway for explicitness
+      # and so ownership isn't left to an implementation detail of emptyDir.
+      securityContext:
+        fsGroup: 1000
       containers:
       - name: localstack
         image: localstack/localstack:3.8
@@ -29,6 +35,7 @@ spec:
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]

--- a/examples/irsa-simulation-localstack/localstack.yaml
+++ b/examples/irsa-simulation-localstack/localstack.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localstack
+  namespace: irsa-sim-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: localstack
+  template:
+    metadata:
+      labels:
+        app: localstack
+    spec:
+      containers:
+      - name: localstack
+        image: localstack/localstack:3.8
+        ports:
+        - containerPort: 4566
+        env:
+        - name: SERVICES
+          value: "sts"
+        readinessProbe:
+          httpGet:
+            path: /_localstack/health
+            port: 4566
+          initialDelaySeconds: 5
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: localstack
+  namespace: irsa-sim-ns
+spec:
+  selector:
+    app: localstack
+  ports:
+  - port: 4566
+    targetPort: 4566

--- a/examples/irsa-simulation-localstack/localstack.yaml
+++ b/examples/irsa-simulation-localstack/localstack.yaml
@@ -21,12 +21,33 @@ spec:
         env:
         - name: SERVICES
           value: "sts"
+        # The image runs as root by default and writes to /tmp/localstack and
+        # /var/lib/localstack/cache at startup; without the emptyDir mounts
+        # below, running as non-root fails with repeated PermissionErrors on
+        # those paths (verified: the container still becomes Ready, but logs
+        # are full of write failures and its on-disk cache never persists).
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: localstack-var
+          mountPath: /var/lib/localstack
         readinessProbe:
           httpGet:
             path: /_localstack/health
             port: 4566
           initialDelaySeconds: 5
           periodSeconds: 5
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: localstack-var
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/examples/irsa-simulation-localstack/namespace.yaml
+++ b/examples/irsa-simulation-localstack/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: irsa-sim-ns

--- a/examples/irsa-simulation-localstack/sandbox.yaml
+++ b/examples/irsa-simulation-localstack/sandbox.yaml
@@ -1,0 +1,24 @@
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: irsa-sim-sandbox
+  namespace: irsa-sim-ns
+spec:
+  podTemplate:
+    spec:
+      serviceAccountName: irsa-sim-sa
+      containers:
+      - name: sandbox
+        image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/python-runtime-sandbox:latest-main
+        env:
+        - name: AWS_ENDPOINT_URL_STS
+          value: "http://localstack.irsa-sim-ns.svc.cluster.local:4566"
+        - name: AWS_REGION
+          value: "us-east-1"
+        volumeMounts:
+        - name: check-script
+          mountPath: /irsa-sim
+      volumes:
+      - name: check-script
+        configMap:
+          name: irsa-sim-check-script

--- a/examples/irsa-simulation-localstack/serviceaccount.yaml
+++ b/examples/irsa-simulation-localstack/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: irsa-sim-sa
+  namespace: irsa-sim-ns
+  annotations:
+    # amazon-eks-pod-identity-webhook mutates any pod using this ServiceAccount
+    # to inject AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE, plus a projected
+    # ServiceAccount token volume — identical to real EKS IRSA. The role
+    # doesn't need to exist anywhere: on a non-EKS cluster nothing validates it.
+    eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/irsa-sim-role


### PR DESCRIPTION
## Summary
- Adds `examples/irsa-simulation-localstack/`, showing how to validate a sandbox pod's AWS IRSA credential-loading code path on a local/non-EKS cluster (kind, EKS Anywhere, CI), without a real AWS account or IAM permissions.
- Combines the real, unmodified `amazon-eks-pod-identity-webhook` (injects `AWS_ROLE_ARN`/`AWS_WEB_IDENTITY_TOKEN_FILE` for an annotated ServiceAccount, exactly like real EKS) with LocalStack running in-cluster with only `sts` enabled, standing in for real AWS STS.
- README explicitly caveats that this validates the credential-loading *code path* only — LocalStack doesn't verify the web identity token's signature against a real OIDC issuer, so this is not a substitute for validating the actual AWS trust boundary.
- Also documents, under "Customization", that the controller's auto-generated per-`SandboxTemplate` `NetworkPolicy` blocks in-cluster egress by default (matching `docs/security/threat_model.md`), and that reaching a service like LocalStack from a `SandboxTemplate`-managed pod needs an additive `NetworkPolicy`.

This PR was written with the assistance of generative AI.

## Test plan
- [x] Applied all manifests to a live cluster (EKS Anywhere, Docker provider) with `amazon-eks-pod-identity-webhook` installed.
- [x] Confirmed the webhook injects `AWS_ROLE_ARN`/`AWS_WEB_IDENTITY_TOKEN_FILE` into the `Sandbox` pod via the annotated ServiceAccount.
- [x] Confirmed cluster DNS resolves the in-cluster LocalStack Service name from the sandbox pod (standard `ClusterFirst` policy, no special-casing needed).
- [x] Ran the credential check script inside the pod — boto3's default credential chain automatically picked up the injected env vars and exchanged them for mock credentials via LocalStack's `AssumeRoleWithWebIdentity`, confirmed via `sts.get_caller_identity()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete local IRSA simulation example using Kubernetes and LocalStack.
  * Included deployment resources for the simulation environment, including namespace, service account, LocalStack service, and sandbox.
  * Added a validation script that checks credential availability and displays the assumed identity.
* **Documentation**
  * Added setup, deployment, validation, cleanup, limitations, and customization instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
