### PR TITLE
fix(python): do not replay POST requests after a server error

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -32,6 +32,9 @@ from .models import (
 )
 
 RETRYABLE_STATUS_CODES = {500, 502, 503, 504}
+# POST endpoints include command execution, so replaying them can duplicate
+# side effects after the server handled a request but returned a 5xx response.
+RETRYABLE_METHODS = {"GET", "PUT", "DELETE"}
 MAX_RETRIES = 5
 BACKOFF_FACTOR = 0.5
 
@@ -212,7 +215,11 @@ class AsyncSandboxConnector:
                 response = await self.client.request(
                     method, url, headers=headers, follow_redirects=False, **kwargs
                 )
-                if response.status_code in RETRYABLE_STATUS_CODES and attempt < MAX_RETRIES:
+                if (
+                    method.upper() in RETRYABLE_METHODS
+                    and response.status_code in RETRYABLE_STATUS_CODES
+                    and attempt < MAX_RETRIES
+                ):
                     delay = BACKOFF_FACTOR * (2 ** attempt)
                     logger.warning(
                         f"Retryable status {response.status_code} from {url}, "

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -37,6 +37,9 @@ from .exceptions import (
 )
 
 ROUTER_SERVICE_NAME = "svc/sandbox-router-svc"
+# POST endpoints include command execution, so replaying them can duplicate
+# side effects after the server handled a request but returned a 5xx response.
+RETRYABLE_METHODS = frozenset({"GET", "PUT", "DELETE"})
 
 
 def _router_timeout_header_value(timeout) -> str | None:
@@ -310,7 +313,7 @@ class SandboxConnector:
             total=5,
             backoff_factor=0.5,
             status_forcelist=[500, 502, 503, 504],
-            allowed_methods=["GET", "POST", "PUT", "DELETE"]
+            allowed_methods=RETRYABLE_METHODS,
         )
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
         self.session.mount("https://", HTTPAdapter(max_retries=retries))

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -509,6 +509,37 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
             )
         self.assertIn("does not support SandboxLocalTunnelConnectionConfig", str(ctx.exception))
 
+    async def test_post_requests_are_not_retried_on_server_error(self):
+        connector = AsyncSandboxConnector(
+            sandbox_id="test",
+            namespace="default",
+            connection_config=SandboxDirectConnectionConfig(
+                api_url="http://router"
+            ),
+            k8s_helper=MagicMock(),
+        )
+        response = MagicMock()
+        response.status_code = 503
+        response.is_redirect = False
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=response,
+        )
+        connector.client.request = AsyncMock(return_value=response)
+
+        try:
+            with patch(
+                "k8s_agent_sandbox.async_connector.asyncio.sleep",
+                new=AsyncMock(),
+            ):
+                with self.assertRaises(SandboxRequestError):
+                    await connector.send_request("POST", "execute")
+
+            self.assertEqual(connector.client.request.await_count, 1)
+        finally:
+            await connector.close()
+
     async def test_in_cluster_resolves_dns_by_default(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)
         connector = AsyncSandboxConnector(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -540,6 +540,40 @@ class TestAsyncConnector(unittest.IsolatedAsyncioTestCase):
         finally:
             await connector.close()
 
+    async def test_idempotent_methods_are_retried_on_server_error(self):
+        for method in ("GET", "PUT", "DELETE"):
+            with self.subTest(method=method):
+                connector = AsyncSandboxConnector(
+                    sandbox_id="test",
+                    namespace="default",
+                    connection_config=SandboxDirectConnectionConfig(
+                        api_url="http://router"
+                    ),
+                    k8s_helper=MagicMock(),
+                )
+                error_response = MagicMock()
+                error_response.status_code = 503
+                error_response.is_redirect = False
+                ok_response = MagicMock()
+                ok_response.status_code = 200
+                ok_response.is_redirect = False
+                ok_response.raise_for_status.return_value = None
+                connector.client.request = AsyncMock(
+                    side_effect=[error_response, ok_response]
+                )
+
+                try:
+                    with patch(
+                        "k8s_agent_sandbox.async_connector.asyncio.sleep",
+                        new=AsyncMock(),
+                    ):
+                        result = await connector.send_request(method, "path")
+
+                    self.assertIs(result, ok_response)
+                    self.assertEqual(connector.client.request.await_count, 2)
+                finally:
+                    await connector.close()
+
     async def test_in_cluster_resolves_dns_by_default(self):
         config = SandboxInClusterConnectionConfig(server_port=8888)
         connector = AsyncSandboxConnector(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -160,8 +160,9 @@ class TestSandboxConnectorStrategySelection(unittest.TestCase):
         )
         retry_policy = connector.session.get_adapter("http://").max_retries
 
-        self.assertNotIn("POST", retry_policy.allowed_methods)
-        self.assertIn("GET", retry_policy.allowed_methods)
+        self.assertEqual(
+            set(retry_policy.allowed_methods), {"GET", "PUT", "DELETE"}
+        )
 
     def test_selects_in_cluster_strategy(self):
         config = SandboxInClusterConnectionConfig()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -154,6 +154,15 @@ class TestSandboxConnectorStrategySelection(unittest.TestCase):
             k8s_helper=MagicMock(),
         )
 
+    def test_post_requests_are_not_retried(self):
+        connector = self._make_connector(
+            SandboxDirectConnectionConfig(api_url="http://router")
+        )
+        retry_policy = connector.session.get_adapter("http://").max_retries
+
+        self.assertNotIn("POST", retry_policy.allowed_methods)
+        self.assertIn("GET", retry_policy.allowed_methods)
+
     def test_selects_in_cluster_strategy(self):
         config = SandboxInClusterConnectionConfig()
         connector = self._make_connector(config)

--- a/test/e2e/clients/python/test_e2e_python_sdk.py
+++ b/test/e2e/clients/python/test_e2e_python_sdk.py
@@ -134,8 +134,18 @@ spec:
     return "python-sdk-coldpool"
 
 
+def wait_until_sandbox_routable(sandbox):
+    """Probe the data path with GET before the first POST /execute.
+
+    Claim Ready does not mean the router can dial the runtime yet. GET is
+    still retried on 5xx; POST /execute is not.
+    """
+    sandbox.files.exists(".")
+
+
 def run_sdk_tests(sandbox):
     """Runs basic SDK operations to validate functionality"""
+    wait_until_sandbox_routable(sandbox)
     # Test execution
     result = sandbox.commands.run("echo 'Hello from SDK'")
     print(f"Run result: {result}")
@@ -362,6 +372,7 @@ def test_python_sdk_volume_claim_templates(
             assert pvc_res.spec.storage_class_name == storage_class, "PVC storageClassName mismatch in cluster"
 
         print("Running command to verify sandbox is operational...")
+        wait_until_sandbox_routable(sandbox)
         res = sandbox.commands.run("df -h")
         print(f"Disk space output:\n{res.stdout}")
         assert res.exit_code == 0, f"Command df -h failed with exit code {res.exit_code}: {res.stderr}"


### PR DESCRIPTION
#### What this PR does / why we need it:

`commands.run()` sends `POST /execute`, which runs a shell command inside the
sandbox. Both Python connectors retried that request on 500/502/503/504, so a
command whose response failed after the runtime had already run it was executed
again — six attempts in total. The caller saw a single `SandboxRequestError`
with no indication that the command had run more than once.

A retryable status code means the connection succeeded and the request body
reached the server, so the work it describes may already be done. This change
limits transport-level replay to `GET`, `PUT` and `DELETE`: the sync connector
drops `POST` from the urllib3 `Retry(allowed_methods=...)`, and the async
connector checks the method alongside the status code.

Concretely, for a `POST`:

| Failure mode | Before | After |
|---|---|---|
| Server answers 5xx | replayed | not replayed |
| Body sent, no response (read error, sync connector) | replayed | not replayed |
| Never connected (dial error) | unchanged | unchanged |

The read-error row changes for the same reason as the 5xx row: the body reached
the server, so the command may already be running. Dial-time failures are
untouched — urllib3's `allowed_methods` does not gate connect-error retries, and
the async connector never retried transport errors to begin with.

This matches how the rest of the project draws the line. `Run()` in the Go SDK
defaults to a single attempt, and the router retries dial-class failures only
because replaying a body that may already have been sent could duplicate side
effects.

Testing: two regression tests were added, both failing before this change and
passing after — `test_connector.py::TestSandboxConnectorStrategySelection::test_post_requests_are_not_retried`
and `test_async_sandboxclient.py::TestAsyncConnector::test_post_requests_are_not_retried_on_server_error`.
`make test-unit` passes. The behaviour was also verified end to end against a
stub runtime that performs a side effect and then answers 503: it records the
command executed 6 times on `main` and once with this change, for both the sync
and async connectors.

#### Which issue(s) this PR is related to:

Fixes #1352

#### Release Note

```release-note
Fixed the Python SDK re-executing sandbox commands after a transient server error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failed `POST` requests from being automatically retried, avoiding duplicate command executions.
  * Continued retrying eligible `GET`, `PUT`, and `DELETE` requests after temporary server errors.
  * Improved sandbox readiness checks before executing commands.

* **Tests**
  * Added coverage confirming `POST` requests fail immediately after a server error.
  * Verified retry behavior for supported request methods.
  * Added end-to-end coverage for sandbox connectivity before command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->