### PR TITLE
Add loading of images with extra tags to kind load docker-image

### DIFF
--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -86,28 +86,34 @@ def build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfi
     # Inject version info into Go binaries
     build_cmd.extend(_get_version_build_args())
     subprocess.run(build_cmd, cwd=srcdir, check=True)
-    print(f"pushed image {image_name}")
+
+    if args.docker_build_output_type == "registry":
+        print(f"pushed image {image_name}")
 
 
 def load_kind_image(args, cluster_name, service_name, srcdir, image_tag):
-    image_name = utils.get_full_image_name(args, service_name, tag=image_tag)
+    all_image_names = [utils.get_full_image_name(args, service_name, tag=image_tag)]
+    if args.extra_image_tags:
+        for tag in args.extra_image_tags:
+            extra_image_name = utils.get_full_image_name(args, service_name, tag=tag)
+            all_image_names.append(extra_image_name)
+
     build_cmd = [
         "kind",
         "load",
         "docker-image",
         f"--name={cluster_name}",
-        image_name,
+        *all_image_names,
     ]
 
     subprocess.run(build_cmd, cwd=srcdir, check=True)
-    print(f"loaded image {image_name} into kind cluster {args.kind_cluster_name}")
+    print(f"loaded image(s) {', '.join(all_image_names)} into kind cluster {args.kind_cluster_name}")
 
 
 def build_and_push_image(args, service_name, srcdir, dockerfile_path, image_tag):
     build_and_push_image_with_docker_buildx(args, service_name, srcdir, dockerfile_path, image_tag)
     if args.kind_cluster_name:
         load_kind_image(args, args.kind_cluster_name, service_name, srcdir, image_tag)
-
 
 def main(args):
     """Builds and pushes all discovered Docker images."""

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -107,7 +107,7 @@ def load_kind_image(args, cluster_name, service_name, srcdir, image_tag):
     ]
 
     subprocess.run(build_cmd, cwd=srcdir, check=True)
-    print(f"loaded image(s) {', '.join(all_image_names)} into kind cluster {args.kind_cluster_name}")
+    print(f"loaded image(s) {', '.join(all_image_names)} into kind cluster {cluster_name}")
 
 
 def build_and_push_image(args, service_name, srcdir, dockerfile_path, image_tag):

--- a/dev/tools/push_images_test.py
+++ b/dev/tools/push_images_test.py
@@ -191,6 +191,42 @@ class ControllerOnlySelectionTest(unittest.TestCase):
             "testtag",
         )
 
+class KindLoadImagesExtraTagsTest(unittest.TestCase):
+    """kind load docker-images should include extra tags as well."""
+
+    def test_all_images_loaded_when_extra_image_tags_exist(self):
+
+        all_image_names = []
+        def fake_run(cmd, **kwargs):
+            # Collect last three arguments which should be the image names
+            all_image_names.extend(cmd[4:])
+
+        # Moke the subprocess run for kind load docker-images
+        with (
+            mock.patch.object(
+                push_images.subprocess, "run", side_effect=fake_run
+            )
+        ):
+            push_images.load_kind_image(
+                args=argparse.Namespace(
+                    image_prefix="test/",
+                    kind_cluster_name="test-cluster",
+                    extra_image_tags=["extra-tag-1", "extra-tag-2"]
+                ),
+                cluster_name="test-cluster",
+                service_name="test-service",
+                srcdir=".",
+                image_tag="testtag",
+            )
+
+        self.assertEqual(
+            all_image_names,
+            [
+                "test/test-service:testtag",
+                "test/test-service:extra-tag-1",
+                "test/test-service:extra-tag-2",
+            ]
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/dev/tools/push_images_test.py
+++ b/dev/tools/push_images_test.py
@@ -201,7 +201,7 @@ class KindLoadImagesExtraTagsTest(unittest.TestCase):
             # Collect last three arguments which should be the image names
             all_image_names.extend(cmd[4:])
 
-        # Moke the subprocess run for kind load docker-images
+        # Mock the subprocess run for kind load docker-images
         with (
             mock.patch.object(
                 push_images.subprocess, "run", side_effect=fake_run


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently `--extra-image-tag` arguments are ignored when invoking the tooling script `push-images` for kind (`--kind-cluster-name` argument passed). The changes in this PR fix this by adding the additional image names to the `kind load` invocation in `push-images`.
A (very) small additional change: The message `pushed image ...` was logged even for kind clusters, where it is actually not really true.
Thanks for reviewing this.

#### Which issue(s) this PR is related to:
Fixes #1357

#### Release Note
NONE
