### PR TITLE
owners: add aditya-shantanu and shruti6991 to extensions/controllers/OWNERS

### DIFF
--- a/extensions/controllers/OWNERS
+++ b/extensions/controllers/OWNERS
@@ -1,8 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - aditya-shantanu
+  - igooch
+  - barney-s
   - janetkuo
   - justinsb
-  - barney-s
+  - shruti6991
   - vicentefb
-  - igooch


### PR DESCRIPTION
Add `aditya-shantanu` and `shruti6991` (Shruti Nair) as approvers for the `extensions/controllers/` subtree. List is kept alphabetical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the approval list for controller extension changes.
  * Added two new approvers and reordered the existing list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->