### PR TITLE
owners: remove extensions/OWNERS

### DIFF
--- a/extensions/OWNERS
+++ b/extensions/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-  - janetkuo
-  - justinsb
-  - barney-s


### PR DESCRIPTION
The `extensions/OWNERS` file duplicates ownership that is already covered by `extensions/controllers/OWNERS` (which was recently updated to include `aditya-shantanu` and `shruti6991`). Removing the redundant file to avoid split/conflicting ownership definitions for the extensions subtree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the extension ownership and approver list configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->