### PR TITLE
feat(helm): add support for image pull secrets

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters and their defaults.
 | `image.tag` | Controller image tag — **required** | `""` |
 | `image.repository` | Controller image repository | `registry.k8s.io/agent-sandbox/agent-sandbox-controller` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | List of image pull secrets to add to the Deployment | `[]` |
 | `replicaCount` | Number of controller replicas | `1` |
 | `namespace.create` | Create the namespace as part of the release | `true` |
 | `namespace.name` | Namespace to deploy into | `agent-sandbox-system` |

--- a/helm/README.md
+++ b/helm/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters and their defaults.
 | `image.tag` | Controller image tag — **required** | `""` |
 | `image.repository` | Controller image repository | `registry.k8s.io/agent-sandbox/agent-sandbox-controller` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
-| `imagePullSecrets` | List of image pull secrets to add to the Deployment | `[]` |
+| `imagePullSecrets` | List of image pull secrets (e.g. `[{name: my-secret}]`) to add to the Deployment | `[]` |
 | `replicaCount` | Number of controller replicas | `1` |
 | `namespace.create` | Create the namespace as part of the release | `true` |
 | `namespace.name` | Namespace to deploy into | `agent-sandbox-system` |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: agent-sandbox-controller
         image: {{ include "agent-sandbox.image" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,6 +8,8 @@ image:
   tag: ""  # required, eg. v0.3.10
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 replicaCount: 1
 
 # podAnnotations are added to the controller pod template.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,8 +8,11 @@ image:
   tag: ""  # required, eg. v0.3.10
   pullPolicy: IfNotPresent
 
+# imagePullSecrets adds image pull secrets to the controller PodSpec (spec.template.spec.imagePullSecrets).
+# Example:
+# imagePullSecrets:
+#   - name: my-registry-creds
 imagePullSecrets: []
-
 replicaCount: 1
 
 # podAnnotations are added to the controller pod template.


### PR DESCRIPTION
Add Helm values, templates, and docs for using image pull secrets.

#### What this PR does / why we need it:
This change adds chart values, templates, and docs for:

- `imagePullSecrets` to be added on the `Deployment`

#### Which issue(s) this PR is related to:
Fixes #1369

#### Release Note
```release-note
Added support for using `imagePullSecrets` in the Helm chart.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm configuration for specifying image pull secrets.
  * Deployments now use the configured image pull secrets when provided.

* **Documentation**
  * Documented the new `imagePullSecrets` setting and its default empty value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->