### PR TITLE
chore(site): add website pages for 18 examples missing site entries

### DIFF
--- a/site/content/docs/use-cases/examples/agent-sandbox-rl/_index.md
+++ b/site/content/docs/use-cases/examples/agent-sandbox-rl/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Agent Sandbox RL"
+linkTitle: "Agent Sandbox RL"
+weight: 2
+description: >
+  Generic, multi-cluster batch orchestration for running SWE-bench-style RL and evaluation workloads on Agent Sandbox.
+---
+{{% include-file file="additional/examples/agent-sandbox-rl/README.md" %}}

--- a/site/content/docs/use-cases/examples/apf-insulation/_index.md
+++ b/site/content/docs/use-cases/examples/apf-insulation/_index.md
@@ -1,0 +1,8 @@
+---
+title: "APF Insulation for the Agent Sandbox Controller"
+linkTitle: "APF Insulation"
+weight: 2
+description: >
+  An opt-in API Priority and Fairness overlay that gives the agent-sandbox controller dedicated apiserver concurrency, insulating high-rate SandboxClaim workloads from other apiserver load.
+---
+{{% include-file file="additional/examples/apf-insulation/README.md" %}}

--- a/site/content/docs/use-cases/examples/containarium-ssh-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/containarium-ssh-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Containarium SSH Sandbox Example"
+linkTitle: "Containarium SSH Sandbox"
+weight: 2
+description: >
+  Demonstrates an SSH-reachable, MCP-native access pattern for the Sandbox CRD where the agent holds only an SSH key and every SSH session is pinned by a forced command.
+---
+{{% include-file file="additional/examples/containarium-ssh-sandbox/README.md" %}}

--- a/site/content/docs/use-cases/examples/demo-cilium-egress/_index.md
+++ b/site/content/docs/use-cases/examples/demo-cilium-egress/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Per-Identity Egress Allowlisting with Cilium FQDN Policy"
+linkTitle: "Cilium Egress Policy"
+weight: 2
+description: >
+  A self-contained example demonstrating on GKE that a network policy bound to a workload identity controls which external domains a sandbox can reach.
+---
+{{% include-file file="additional/examples/demo-cilium-egress/README.md" %}}

--- a/site/content/docs/use-cases/examples/gke-swap/_index.md
+++ b/site/content/docs/use-cases/examples/gke-swap/_index.md
@@ -1,0 +1,8 @@
+---
+title: "High-Density Agent Sandbox on GKE with Local SSD Swap"
+linkTitle: "GKE Local SSD Swap"
+weight: 2
+description: >
+  Demonstrates how to configure GKE Memory Swap using dedicated Local SSDs to drastically increase the density of agent-sandbox workloads on a single node.
+---
+{{% include-file file="additional/examples/gke-swap/README.md" %}}

--- a/site/content/docs/use-cases/examples/hermes-agent/_index.md
+++ b/site/content/docs/use-cases/examples/hermes-agent/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Hermes Agent in Kubernetes Sandbox Example"
+linkTitle: "Hermes Agent"
+weight: 2
+description: >
+  A complete, informational example of how to run Hermes Agent inside a Kubernetes cluster using the Sandbox CRD from agent-sandbox.
+---
+{{% include-file file="additional/examples/hermes-agent/README.md" %}}

--- a/site/content/docs/use-cases/examples/hpa-swp-scaling/_index.md
+++ b/site/content/docs/use-cases/examples/hpa-swp-scaling/_index.md
@@ -1,0 +1,8 @@
+---
+title: "SandboxWarmPool Scaling with HPA (GKE Specific)"
+linkTitle: "HPA Warm Pool Scaling"
+weight: 2
+description: >
+  Demonstrates how to use the Kubernetes Horizontal Pod Autoscaler (HPA) to scale a SandboxWarmPool based on custom metrics emitted by the agent sandbox controller.
+---
+{{% include-file file="additional/examples/hpa-swp-scaling/README.md" %}}

--- a/site/content/docs/use-cases/examples/irsa-simulation-localstack/_index.md
+++ b/site/content/docs/use-cases/examples/irsa-simulation-localstack/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Simulating AWS IRSA Locally with LocalStack"
+linkTitle: "IRSA Simulation (LocalStack)"
+weight: 2
+description: >
+  Shows how to validate an AWS IRSA credential-loading code path against a sandbox pod entirely on a local or non-EKS cluster — no real AWS account required.
+---
+{{% include-file file="additional/examples/irsa-simulation-localstack/README.md" %}}

--- a/site/content/docs/use-cases/examples/kata-aks/_index.md
+++ b/site/content/docs/use-cases/examples/kata-aks/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Kata-Isolated Per-Owner Agent Warm Pool on AKS"
+linkTitle: "Kata on AKS"
+weight: 2
+description: >
+  Shows how to combine the agent-sandbox extension CRDs with the AKS Pod Sandboxing feature (Kata Containers on Microsoft Hyper-V) to run a fleet of owner-aware AI agents on Azure Kubernetes Service.
+---
+{{% include-file file="additional/examples/kata-aks/README.md" %}}

--- a/site/content/docs/use-cases/examples/keda-scale-to-zero/_index.md
+++ b/site/content/docs/use-cases/examples/keda-scale-to-zero/_index.md
@@ -1,0 +1,8 @@
+---
+title: "SandboxWarmPool Scale-to-Zero with KEDA on GKE"
+linkTitle: "KEDA Scale-to-Zero"
+weight: 2
+description: >
+  Uses KEDA to scale a SandboxWarmPool down to zero (and back up) based on the rate of sandbox claims, using the KEDA Prometheus scaler against GKE Managed Service for Prometheus.
+---
+{{% include-file file="additional/examples/keda-scale-to-zero/README.md" %}}

--- a/site/content/docs/use-cases/examples/kueue-agent-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/kueue-agent-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Using Kueue with Agent Sandbox"
+linkTitle: "Kueue Integration"
+weight: 2
+description: >
+  Shows how to use Kueue to control the admission of Agent Sandbox workloads and defines a default ResourceFlavor required by the ClusterQueue.
+---
+{{% include-file file="additional/examples/kueue-agent-sandbox/README.md" %}}

--- a/site/content/docs/use-cases/examples/latebind-storage-gke-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/latebind-storage-gke-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Dynamic Storage Late-Binding for GKE Sandbox Warm Pools"
+linkTitle: "GKE Storage Late-Binding"
+weight: 2
+description: >
+  Demonstrates dynamic storage late-binding for GKE Sandbox warm pools, covering private isolated workspaces, shared read-only datasets, and writable scratch storage.
+---
+{{% include-file file="additional/examples/latebind-storage-gke-sandbox/README.md" %}}

--- a/site/content/docs/use-cases/examples/mcp-server-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/mcp-server-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "MCP Sandbox"
+linkTitle: "MCP Sandbox"
+weight: 2
+description: >
+  A self-contained example of running a Model Context Protocol (MCP) server inside an Agent Sandbox using nothing but kubectl.
+---
+{{% include-file file="additional/examples/mcp-server-sandbox/README.md" %}}

--- a/site/content/docs/use-cases/examples/nono-sandbox/_index.md
+++ b/site/content/docs/use-cases/examples/nono-sandbox/_index.md
@@ -1,0 +1,8 @@
+---
+title: "nono with Kubernetes Agent Sandbox"
+linkTitle: "nono Sandbox"
+weight: 2
+description: >
+  Runs nono inside a Kubernetes Sandbox, demonstrating defense in depth for an AI agent with layered isolation and tool execution.
+---
+{{% include-file file="additional/examples/nono-sandbox/README.md" %}}

--- a/site/content/docs/use-cases/examples/quickstart/_index.md
+++ b/site/content/docs/use-cases/examples/quickstart/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Secure Agent Sandbox Quickstart"
+linkTitle: "Sandbox Quickstart"
+weight: 2
+description: >
+  A comprehensive guide to setting up Agent Sandbox from scratch, with optional gVisor or Kata Containers runtime isolation for stronger security.
+---
+{{% include-file file="additional/examples/quickstart/README.md" %}}

--- a/site/content/docs/use-cases/examples/ray-integration/_index.md
+++ b/site/content/docs/use-cases/examples/ray-integration/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Agentic Reinforcement Learning with Ray and Agent Sandbox"
+linkTitle: "Ray Integration"
+weight: 2
+description: >
+  Demonstrates how to integrate the Ray framework with agent-sandbox to securely execute AI-generated code during Agentic Reinforcement Learning training.
+---
+{{% include-file file="additional/examples/ray-integration/README.md" %}}

--- a/site/content/docs/use-cases/examples/sandboxed-tools/_index.md
+++ b/site/content/docs/use-cases/examples/sandboxed-tools/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Sandboxed Tools Example (Go)"
+linkTitle: "Sandboxed Tools (Go)"
+weight: 2
+description: >
+  Demonstrates an architectural pattern for AI agents: launching an Agent Sandbox for tool execution, keeping the agentic loop outside, and reusing a sandbox across multiple tool calls.
+---
+{{% include-file file="additional/examples/sandboxed-tools/README.md" %}}

--- a/site/content/docs/use-cases/examples/warmpool-quickstart/_index.md
+++ b/site/content/docs/use-cases/examples/warmpool-quickstart/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Warm Pool Quickstart"
+linkTitle: "Warm Pool Quickstart"
+weight: 2
+description: >
+  Reference YAML for the three extension CRDs that power the warm-pool workflow: SandboxTemplate, SandboxWarmPool, and SandboxClaim.
+---
+{{% include-file file="additional/examples/warmpool-quickstart/README.md" %}}


### PR DESCRIPTION
#### What this PR does / why we need it:

The top-level `examples/` directory contains ~40 example projects with READMEs, but only about half of them had corresponding pages under `site/content/docs/use-cases/examples/`. Visitors to the Agent Sandbox documentation site were therefore missing discoverable entries for many officially maintained examples.

This PR adds a `_index.md` page for each of the 18 examples that were previously absent from the website:

- `agent-sandbox-rl` — Multi-cluster batch orchestration for SWE-bench-style RL workloads
- `apf-insulation` — API Priority and Fairness overlay for the agent-sandbox controller
- `containarium-ssh-sandbox` — SSH-reachable, MCP-native access pattern for the Sandbox CRD
- `demo-cilium-egress` — Per-identity egress allowlisting with Cilium FQDN policy on GKE
- `gke-swap` — High-density Agent Sandbox on GKE with Local SSD swap
- `hermes-agent` — Hermes Agent running inside a Kubernetes Sandbox
- `hpa-swp-scaling` — SandboxWarmPool scaling with HPA (GKE specific)
- `irsa-simulation-localstack` — Simulating AWS IRSA locally with LocalStack
- `kata-aks` — Kata-isolated per-owner agent warm pool on AKS
- `keda-scale-to-zero` — SandboxWarmPool scale-to-zero with KEDA on GKE
- `kueue-agent-sandbox` — Using Kueue to control Agent Sandbox workload admission
- `latebind-storage-gke-sandbox` — Dynamic storage late-binding for GKE Sandbox warm pools
- `mcp-server-sandbox` — Running an MCP server inside an Agent Sandbox via kubectl
- `nono-sandbox` — nono agent running inside a Kubernetes Sandbox
- `quickstart` — Secure Agent Sandbox quickstart with optional gVisor/Kata isolation
- `ray-integration` — Agentic RL with Ray and Agent Sandbox
- `sandboxed-tools` — Go-based pattern for launching an Agent Sandbox for tool execution
- `warmpool-quickstart` — Reference YAML for SandboxTemplate / SandboxWarmPool / SandboxClaim

Each page follows the existing pattern used by other example pages:
- Frontmatter with `title`, `linkTitle`, `weight`, and `description`.
- A single `{{% include-file file="additional/examples/<name>/README.md" %}}` shortcode that pulls content from the corresponding top-level `examples/<name>/README.md` via the existing Hugo assets mount (`../examples` → `assets/additional/examples`).

All 18 include-file targets have been verified to resolve correctly.

#### Which issue(s) this PR is related to:

N/A — documentation gap identified while reviewing the examples index.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation pages and quickstarts for Agent Sandbox examples, including reinforcement learning, Ray integration, secure execution, MCP, Hermes, Nono, Containarium, and sandboxed tools.
  * Added guides for GKE sandbox operations, including memory swap, warm-pool scaling, storage late binding, KEDA scale-to-zero, and Kata on AKS.
  * Added integration guidance for APF insulation, Kueue workload admission, Cilium egress policies, and simulated AWS IRSA credentials.
  * Added Agent Sandbox and Warm Pool quickstarts with setup details and reference configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->