### PR TITLE
examples(pi-code-agent): add Pi coding agent sandbox example

### DIFF
--- a/examples/pi-code-agent/Dockerfile
+++ b/examples/pi-code-agent/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:24-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates git ripgrep \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.84.1
+
+WORKDIR /workspace
+ENTRYPOINT ["pi"]

--- a/examples/pi-code-agent/README.md
+++ b/examples/pi-code-agent/README.md
@@ -1,0 +1,92 @@
+# Pi Code Agent in Kubernetes Sandbox Example
+
+This example demonstrates how to run [Pi](https://github.com/earendil-works/pi) — a terminal-based coding agent from Earendil Works — inside a Kubernetes cluster using the `Sandbox` CRD from [agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox).
+
+It mirrors Pi's [Plain Docker](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/containerization.md#plain-docker) containerization pattern, adapted to the Sandbox CRD.
+
+## Prerequisites
+
+1. A Kubernetes cluster (Kind, Minikube, GKE, etc.).
+2. `agent-sandbox` controller and CRDs installed in the cluster.
+3. `kubectl` configured to access your cluster.
+4. Docker (for building the Pi image locally).
+5. (If using Kind) [Kind](https://kind.sigs.k8s.io/) installed.
+6. An Anthropic API key.
+
+## Files
+
+- `Dockerfile`: Builds `pi-sandbox:local` from `node:24-bookworm-slim`, installing `@earendil-works/pi-coding-agent@0.84.1`.
+- `sandbox.yaml`: The `Sandbox` manifest. Two PVCs (`/workspace` for code, `/root/.pi/agent` for Pi's own settings/sessions), `ANTHROPIC_API_KEY` injected from a Secret, `stdin`/`tty` enabled so you can attach to the Pi TUI.
+- `run-test-kind.sh`: Build, load into Kind, apply, and wait — one command end-to-end.
+
+## How to Use
+
+### 1. Create the API key Secret
+
+```bash
+kubectl create secret generic pi-code-agent-api-keys \
+  --from-literal=ANTHROPIC_API_KEY="your_anthropic_key"
+```
+
+### 2. Deploy the Sandbox
+
+#### Option A: Quick path (Kind)
+
+```bash
+./run-test-kind.sh
+```
+
+This builds the image, loads it into the Kind cluster (default name `agent-sandbox`, override with `KIND_CLUSTER_NAME=...`), applies `sandbox.yaml`, and waits for the pod to become Ready.
+
+#### Option B: Manual path
+
+```bash
+# Build the image
+docker build -t pi-sandbox:local .
+
+# (Kind only) Load the image into the cluster
+kind load docker-image pi-sandbox:local --name agent-sandbox
+
+# Apply the Sandbox manifest
+kubectl apply -f sandbox.yaml
+```
+
+### 3. Verify the Deployment
+
+```bash
+kubectl get sandboxes
+kubectl get pods -l sandbox=pi-code-agent
+```
+
+You should see a pod named `pi-code-agent` (matching `Sandbox.metadata.name`).
+
+### 4. Interact with Pi
+
+Pi is a terminal TUI; attach to the running container:
+
+```bash
+POD_NAME="$(kubectl get pods -l sandbox=pi-code-agent -o jsonpath='{.items[0].metadata.name}')"
+kubectl attach -it "${POD_NAME}"
+```
+
+Detach without killing Pi: press `Ctrl+P`, then `Ctrl+Q`.
+
+## Cleanup
+
+```bash
+kubectl delete -f sandbox.yaml
+kubectl delete secret pi-code-agent-api-keys
+```
+
+The PVCs are retained by default. To delete them as well:
+
+```bash
+kubectl delete pvc -l sandbox=pi-code-agent
+```
+
+## Configuration
+
+- **Different API provider:** Pi supports multiple providers. Add additional env vars (e.g., `OPENAI_API_KEY`) to `sandbox.yaml` and create corresponding entries in the Secret.
+- **Different PVC sizes:** edit `volumeClaimTemplates` in `sandbox.yaml`.
+- **Tighter security:** add a `securityContext` to the container spec (see `examples/nullclaw-sandbox/nullclaw-sandbox.yaml` for an example).
+- **Newer Pi version:** bump the version in `Dockerfile` (`@earendil-works/pi-coding-agent@<new-version>`) and rebuild.

--- a/examples/pi-code-agent/README.md
+++ b/examples/pi-code-agent/README.md
@@ -51,7 +51,7 @@ kubectl apply -f sandbox.yaml
 **Kind users** — load the image into the cluster before applying the manifest (or use `./run-test-kind.sh`, which does this for you):
 
 ```bash
-kind load docker-image pi-sandbox:local --name agent-sandbox
+kind load docker-image pi-sandbox:local --name "${KIND_CLUSTER_NAME:-agent-sandbox}"
 ```
 
 **Non-Kind clusters (Minikube, GKE, EKS, ...)** — `sandbox.yaml` references `pi-sandbox:local`, which is a node-local image. For clusters that cannot see your local Docker daemon, push the image to a registry and update the `image:` field in `sandbox.yaml` before applying:

--- a/examples/pi-code-agent/README.md
+++ b/examples/pi-code-agent/README.md
@@ -44,10 +44,24 @@ This builds the image, loads it into the Kind cluster (default name `agent-sandb
 # Build the image
 docker build -t pi-sandbox:local .
 
-# (Kind only) Load the image into the cluster
-kind load docker-image pi-sandbox:local --name agent-sandbox
-
 # Apply the Sandbox manifest
+kubectl apply -f sandbox.yaml
+```
+
+**Kind users** — load the image into the cluster before applying the manifest (or use `./run-test-kind.sh`, which does this for you):
+
+```bash
+kind load docker-image pi-sandbox:local --name agent-sandbox
+```
+
+**Non-Kind clusters (Minikube, GKE, EKS, ...)** — `sandbox.yaml` references `pi-sandbox:local`, which is a node-local image. For clusters that cannot see your local Docker daemon, push the image to a registry and update the `image:` field in `sandbox.yaml` before applying:
+
+```bash
+# Example: push to a registry you control
+docker tag pi-sandbox:local REGISTRY/pi-sandbox:0.84.1
+docker push REGISTRY/pi-sandbox:0.84.1
+
+# Edit sandbox.yaml: replace `image: pi-sandbox:local` with `image: REGISTRY/pi-sandbox:0.84.1`
 kubectl apply -f sandbox.yaml
 ```
 

--- a/examples/pi-code-agent/run-test-kind.sh
+++ b/examples/pi-code-agent/run-test-kind.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-agent-sandbox}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "${SCRIPT_DIR}"
+
+echo "Building pi-sandbox:local..."
+docker build -t pi-sandbox:local .
+
+echo "Loading pi-sandbox:local into kind cluster '${KIND_CLUSTER_NAME}'..."
+kind load docker-image pi-sandbox:local --name "${KIND_CLUSTER_NAME}"
+
+echo "Applying sandbox manifest..."
+kubectl apply -f sandbox.yaml
+
+echo "Waiting for sandbox pod to be ready..."
+kubectl wait --for=condition=ready pod -l sandbox=pi-code-agent --timeout=120s
+
+POD_NAME="$(kubectl get pods -l sandbox=pi-code-agent -o jsonpath='{.items[0].metadata.name}')"
+
+echo ""
+echo "Pi sandbox is running (pod: ${POD_NAME})."
+echo "Attach with:"
+echo "  kubectl attach -it ${POD_NAME}"
+echo "Detach without killing Pi: Ctrl+P, then Ctrl+Q"

--- a/examples/pi-code-agent/sandbox.yaml
+++ b/examples/pi-code-agent/sandbox.yaml
@@ -8,6 +8,7 @@ spec:
       labels:
         sandbox: pi-code-agent
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: pi
           image: pi-sandbox:local
@@ -25,7 +26,6 @@ spec:
               mountPath: /workspace
             - name: agent-state
               mountPath: /root/.pi/agent
-      volumes: []
   volumeClaimTemplates:
     - metadata:
         name: workspace

--- a/examples/pi-code-agent/sandbox.yaml
+++ b/examples/pi-code-agent/sandbox.yaml
@@ -1,0 +1,49 @@
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: pi-code-agent
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: pi-code-agent
+    spec:
+      containers:
+        - name: pi
+          image: pi-sandbox:local
+          imagePullPolicy: IfNotPresent
+          stdin: true
+          tty: true
+          env:
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pi-code-agent-api-keys
+                  key: ANTHROPIC_API_KEY
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+            - name: agent-state
+              mountPath: /root/.pi/agent
+      volumes: []
+  volumeClaimTemplates:
+    - metadata:
+        name: workspace
+        labels:
+          sandbox: pi-code-agent
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+    - metadata:
+        name: agent-state
+        labels:
+          sandbox: pi-code-agent
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/site/content/docs/use-cases/examples/pi-code-agent/_index.md
+++ b/site/content/docs/use-cases/examples/pi-code-agent/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Pi Code Agent Sandbox Example"
+linkTitle: "Pi Code Agent"
+weight: 2
+description: >
+  This example demonstrates how to run Pi, a terminal-based coding agent from Earendil Works, inside the Agent Sandbox using Pi's Plain Docker containerization pattern.
+---
+{{% include-file file="additional/examples/pi-code-agent/README.md" %}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a new example that runs the [Pi coding agent](https://github.com/earendil-works/pi) — a terminal-based coding agent from Earendil Works — inside the `Sandbox` CRD. The example mirrors Pi's [Plain Docker](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/containerization.md#plain-docker) containerization pattern, adapted to the Sandbox CRD, so users familiar with Pi's docs can quickly get it running in Kubernetes.

Files added:

- `examples/pi-code-agent/Dockerfile` — `node:24-bookworm-slim` base, installs `@earendil-works/pi-coding-agent@0.84.1`, entrypoint `pi` (literal copy of the upstream Plain Docker Dockerfile with the version pinned to the current npm latest).
- `examples/pi-code-agent/sandbox.yaml` — `Sandbox` manifest with two PVCs (`/workspace` 5Gi for code, `/root/.pi/agent` 1Gi for Pi's own settings/sessions), `ANTHROPIC_API_KEY` injected from a pre-created Secret, `stdin`/`tty` enabled so users can attach to the Pi TUI via `kubectl attach -it`.
- `examples/pi-code-agent/run-test-kind.sh` — one-command helper that builds the image, loads it into a Kind cluster, applies the manifest, and waits for the pod to be Ready.
- `examples/pi-code-agent/README.md` — prerequisites, two deployment paths (quick via the helper script, manual), attach instructions (including detach keystrokes), cleanup, and configuration knobs.
- `site/content/docs/use-cases/examples/pi-code-agent/_index.md` — Hugo content page that renders the example's README via the `include-file` shortcode, matching the pattern used by other examples such as `nullclaw-sandbox`.

The style and structure follow the existing `hermes-agent` and `nullclaw-sandbox` examples.

#### Which issue(s) this PR is related to:

N/A — new example contribution.

#### Release Note

```release-note
Add pi code agent example
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes Sandbox example for running the Pi terminal coding agent.
  * Includes container setup, interactive terminal access, persistent workspace and agent-state storage, and API key configuration.
  * Added a script to build, deploy, verify, and provide connection instructions for the example on a Kind cluster.

* **Documentation**
  * Added setup, usage, cleanup, verification, and customization instructions.
  * Added guidance for image management, provider configuration, security settings, storage, and Pi version selection.
  * Added the example to the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->