### PR TITLE
feat: add NeMo Gym sandbox provider integration (agent_sandbox)

### DIFF
--- a/clients/integrations/README.md
+++ b/clients/integrations/README.md
@@ -8,6 +8,7 @@ This directory contains specialized adapters and integration packages that bridg
 | :--- | :--- | :--- | :--- |
 | [**`deepagents/`**](./deepagents) | `deepagents-k8s-agent-sandbox` | [LangChain DeepAgents](https://github.com/langchain-ai/deepagents) | Plugs into LangChain agent graphs as a secure, sandboxed execution backend (`K8sAgentSandbox`). |
 | [**`mcp-server/`**](./mcp-server) | `k8s-agent-sandbox-mcp-server` | [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) | Exposes Sandbox provisioning and execution tools over MCP for Antigravity, Claude Desktop, Cursor, and other MCP hosts. |
+| [**`nemo-gym/`**](./nemo-gym) | `nemo-gym-k8s-agent-sandbox` | [NVIDIA NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) | Registers Agent Sandbox warm pools as the `agent_sandbox` sandbox provider for NeMo Gym RL training environments. |
 
 ## Adding a New Integration
 

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -1,0 +1,117 @@
+# Agent Sandbox provider for NVIDIA NeMo Gym
+
+This package makes [Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox) a
+sandbox backend for [NVIDIA NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) RL training
+environments, alongside NeMo Gym's built-in providers (Docker, Daytona, ECS Fargate,
+Enroot, OpenShell, OpenSandbox, Apptainer).
+
+NeMo Gym environments get their isolated execution sandboxes as **SandboxClaims against
+SandboxWarmPools**, so per-rollout sandbox acquisition is claim-bind latency (typically
+sub-second on a warm pool hit) instead of pod scheduling + image pull. Claim TTLs
+(`ttl_s`) map to the claim lifecycle's `shutdownTime`, so the controller garbage-collects
+expired sandboxes even if the training process dies.
+
+## How it plugs in
+
+NeMo Gym discovers providers through the `nemo_gym.sandbox_providers` entry-point group
+(see NeMo Gym's `nemo_gym/sandbox/providers/registry.py`). This package publishes
+`agent_sandbox` in that group, so:
+
+```bash
+pip install nemo-gym-k8s-agent-sandbox   # alongside nemo-gym
+```
+
+is all it takes for `agent_sandbox` to become a valid provider name — no registration
+code, no NeMo Gym fork.
+
+## Cluster prerequisites
+
+- The agent-sandbox controller **and extensions** (SandboxClaim / SandboxTemplate /
+  SandboxWarmPool CRDs and controllers) installed.
+- At least one `SandboxWarmPool` whose `SandboxTemplate` runs an image serving the
+  sandbox runtime REST API (`/execute`, `/upload`, `/download`, ...) on
+  `connection.server_port` (default 8888). See
+  [`examples/python-runtime-sandbox`](../../../examples/python-runtime-sandbox) for the
+  reference runtime image.
+- For clients running **outside** the cluster: the sandbox router plus either a Gateway
+  (`connection.mode: gateway`) or a directly reachable router URL
+  (`connection.mode: direct`). Inside the cluster, `in_cluster` mode talks straight to
+  sandbox pod IPs and needs neither.
+
+## Usage
+
+Add the provider config to a NeMo Gym run (the shipped config binds the standard
+instance name `sandbox`, so it drops in wherever an openshell/opensandbox config would):
+
+```bash
+AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+ng_run "+config_paths=[$AGENT, /path/to/configs/agent_sandbox.yaml, $MODEL]"
+```
+
+See [`configs/agent_sandbox.yaml`](configs/agent_sandbox.yaml) for the annotated config.
+Kubernetes API access uses standard kubeconfig / in-cluster service account resolution.
+
+### Image -> warm pool routing
+
+Warm pools pre-bake their image in the pool's SandboxTemplate, so `sandbox_spec.image`
+cannot be pulled per-create. Instead, images route to pools:
+
+```yaml
+create:
+  warmpool: nemo-gym-pool          # default pool
+  image_warmpools:                 # exact image string -> pool name
+    my-registry/swebench-runtime:latest: swebench-pool
+```
+
+Resolution order per sandbox: `provider_options.warmpool` >
+`image_warmpools[spec.image]` > `create.warmpool`. An image that only resolves via the
+default pool logs a warning (the pool's template decides the real image).
+
+### Per-sandbox `provider_options`
+
+| Key | Meaning |
+| --- | --- |
+| `warmpool` | Claim from this pool (overrides all routing) |
+| `namespace` | Claim namespace (overrides `create.namespace`) |
+| `pod_labels` / `pod_annotations` | Stamped on the sandbox Pod via `additionalPodMetadata` |
+| `volume_claim_templates` | Volume claim templates merged into the sandbox |
+
+## Semantics and limitations
+
+| NeMo Gym spec field | Mapping |
+| --- | --- |
+| `image` | Routed to a warm pool via `image_warmpools` (not pulled per-create) |
+| `ttl_s` | Claim lifecycle `shutdownTime` + `Delete` policy (enforced server-side) |
+| `env` | Exported inside every wrapped exec script |
+| `workdir` | Default `cd` for every exec (falls back to the runtime's own cwd) |
+| `files` | Uploaded by NeMo Gym's sandbox API via `upload_file` after `create` returns |
+| `metadata` | SandboxClaim labels (must satisfy Kubernetes label syntax) |
+| `resources` | **Ignored with a warning** — resources come from the SandboxTemplate |
+| `entrypoint` | **Unsupported** (create error) — the template owns the pod command |
+| `ports` | **Ignored with a warning** — no `SupportsSandboxEndpoint` yet |
+| `exec(user=...)` | **Ignored with a warning** — the runtime API runs as the pod user |
+
+Implementation notes:
+
+- The runtime's `/execute` tokenizes with `shlex.split` and runs **without a shell**, so
+  every command is sent as `<exec_shell> -c '<script>'` with `cwd`/`env` folded in.
+- The file API only accepts `..`-free **relative** paths rooted at the runtime server's
+  working directory. Absolute `upload_file`/`download_file` paths are honored by staging
+  through a relative temp name and copying via exec — this assumes the file-API root and
+  the exec working directory are the same directory, which holds for the reference
+  runtime image (both `/app`).
+- An exec that exceeds its timeout abandons the HTTP request, but the process may keep
+  running inside the pod (the runtime API has no server-side kill); the result carries
+  `error_type="timeout"` and return code 125.
+
+## Development
+
+```bash
+pip install -e '../../python/agentic-sandbox-client[async]'
+pip install -e '.[test]'
+pytest tests/unit
+```
+
+Tests are pure unit tests against fakes — no cluster, no NeMo Gym run required (only the
+`nemo-gym` package for its provider base types).

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -24,12 +24,17 @@ pip install nemo-gym-k8s-agent-sandbox   # alongside nemo-gym
 is all it takes for `agent_sandbox` to become a valid provider name — no registration
 code, no NeMo Gym fork.
 
-> **Python version**: this package declares `requires-python >=3.13.14`, matching the
-> floor that nemo-gym itself publishes on PyPI. pip/uv enforce that floor at resolve
-> time, so installs on earlier interpreters (including 3.13.x patch releases below
-> 3.13.14) are rejected with a nemo-gym resolution error. If nemo-gym relaxes its
-> floor, this package's floor (and the `min_python` gate in `dev/tools/test-unit`)
-> should be relaxed to match.
+> **Python version**: this package requires Python >= 3.13. nemo-gym itself currently
+> publishes `requires-python >=3.13.14` — a floor no released 3.13.x satisfies (3.14+
+> does) — so on a 3.13.x interpreter pip rejects the nemo-gym resolution. Either use
+> Python 3.14+, or pre-install nemo-gym past its floor first:
+>
+> ```bash
+> pip install --ignore-requires-python 'nemo-gym>=0.5.0'
+> ```
+>
+> Once nemo-gym relaxes its floor, the workaround (and the matching one in
+> `dev/tools/test-unit`) goes away — this package's own metadata already works.
 
 ## Cluster prerequisites
 
@@ -114,6 +119,8 @@ Implementation notes:
 ## Development
 
 ```bash
+# Only needed on 3.13.x interpreters (see the Python version note above):
+pip install --ignore-requires-python 'nemo-gym>=0.5.0'
 pip install -e '../../python/agentic-sandbox-client[async]'
 pip install -e '.[test]'
 pytest tests/unit

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -96,7 +96,6 @@ default pool logs a warning (the pool's template decides the real image).
 | `metadata` | SandboxClaim labels (must satisfy Kubernetes label syntax) |
 | `resources` | **Ignored with a warning** — resources come from the SandboxTemplate |
 | `entrypoint` | **Unsupported** (create error) — the template owns the pod command |
-| `ports` | **Ignored with a warning** — no `SupportsSandboxEndpoint` yet |
 | `exec(user=...)` | **Ignored with a warning** — the runtime API runs as the pod user |
 
 Implementation notes:

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -24,6 +24,13 @@ pip install nemo-gym-k8s-agent-sandbox   # alongside nemo-gym
 is all it takes for `agent_sandbox` to become a valid provider name — no registration
 code, no NeMo Gym fork.
 
+> **Python version**: this package declares `requires-python >=3.13.14`, mirroring the
+> floor that nemo-gym itself publishes on PyPI (pip/uv enforce it at resolve time, so
+> every current 3.13.x is rejected and Python 3.14+ is required in practice). The
+> upstream floor looks like a typo for `>=3.13.1`; if nemo-gym relaxes it, this
+> package's floor (and the `min_python` gate in `dev/tools/test-unit`) can be relaxed
+> to match.
+
 ## Cluster prerequisites
 
 - The agent-sandbox controller **and extensions** (SandboxClaim / SandboxTemplate /

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -24,12 +24,12 @@ pip install nemo-gym-k8s-agent-sandbox   # alongside nemo-gym
 is all it takes for `agent_sandbox` to become a valid provider name — no registration
 code, no NeMo Gym fork.
 
-> **Python version**: this package declares `requires-python >=3.13.14`, mirroring the
-> floor that nemo-gym itself publishes on PyPI (pip/uv enforce it at resolve time, so
-> every current 3.13.x is rejected and Python 3.14+ is required in practice). The
-> upstream floor looks like a typo for `>=3.13.1`; if nemo-gym relaxes it, this
-> package's floor (and the `min_python` gate in `dev/tools/test-unit`) can be relaxed
-> to match.
+> **Python version**: this package declares `requires-python >=3.13.14`, matching the
+> floor that nemo-gym itself publishes on PyPI. pip/uv enforce that floor at resolve
+> time, so installs on earlier interpreters (including 3.13.x patch releases below
+> 3.13.14) are rejected with a nemo-gym resolution error. If nemo-gym relaxes its
+> floor, this package's floor (and the `min_python` gate in `dev/tools/test-unit`)
+> should be relaxed to match.
 
 ## Cluster prerequisites
 

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -38,7 +38,7 @@ code, no NeMo Gym fork.
 - At least one `SandboxWarmPool` whose `SandboxTemplate` runs an image serving the
   sandbox runtime REST API (`/execute`, `/upload`, `/download`, ...) on
   `connection.server_port` (default 8888). See
-  [`examples/python-runtime-sandbox`](../../../examples/python-runtime-sandbox) for the
+  [`examples/python-runtime-sandbox`](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/examples/python-runtime-sandbox) for the
   reference runtime image.
 - For clients running **outside** the cluster: the sandbox router plus either a Gateway
   (`connection.mode: gateway`) or a directly reachable router URL
@@ -56,7 +56,7 @@ MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
 ng_run "+config_paths=[$AGENT, /path/to/configs/agent_sandbox.yaml, $MODEL]"
 ```
 
-See [`configs/agent_sandbox.yaml`](configs/agent_sandbox.yaml) for the annotated config.
+See [`configs/agent_sandbox.yaml`](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/integrations/nemo-gym/configs/agent_sandbox.yaml) for the annotated config.
 Kubernetes API access uses standard kubeconfig / in-cluster service account resolution.
 
 ### Image -> warm pool routing

--- a/clients/integrations/nemo-gym/README.md
+++ b/clients/integrations/nemo-gym/README.md
@@ -106,7 +106,7 @@ Implementation notes:
   working directory. Absolute `upload_file`/`download_file` paths are honored by staging
   through a relative temp name and copying via exec — this assumes the file-API root and
   the exec working directory are the same directory, which holds for the reference
-  runtime image (both `/app`).
+  runtime image (both come from its `SANDBOX_BASE_DIR`, default `/app`).
 - An exec that exceeds its timeout abandons the HTTP request, but the process may keep
   running inside the pod (the runtime API has no server-side kill); the result carries
   `error_type="timeout"` and return code 125.

--- a/clients/integrations/nemo-gym/configs/agent_sandbox.yaml
+++ b/clients/integrations/nemo-gym/configs/agent_sandbox.yaml
@@ -59,6 +59,7 @@ sandbox:
       command: printf agent-sandbox-ready
       expected_stdout: agent-sandbox-ready
       timeout_s: 30
+      # null = poll without a time limit (until stable_count consecutive passes).
       deadline_s: 60
       stable_count: 1
       stable_delay_s: 1.0

--- a/clients/integrations/nemo-gym/configs/agent_sandbox.yaml
+++ b/clients/integrations/nemo-gym/configs/agent_sandbox.yaml
@@ -1,0 +1,73 @@
+# Agent Sandbox provider config for NVIDIA NeMo Gym.
+#
+# `sandbox` is the instance name an agent references via `sandbox_provider: sandbox`;
+# the child key `agent_sandbox` selects the provider class (published through the
+# `nemo_gym.sandbox_providers` entry-point group by nemo-gym-k8s-agent-sandbox) and
+# its value is passed to the provider constructor.
+#
+# Every shipped NeMo Gym provider config binds the same name `sandbox`, so swapping
+# providers is swapping this config path in `+config_paths` (no agent edit):
+#
+#   AGENT=responses_api_agents/mini_swe_agent_2/configs/mini_swe_agent_2.yaml
+#   MODEL=responses_api_models/vllm_model/configs/vllm_model.yaml
+#   ng_run "+config_paths=[$AGENT, /path/to/configs/agent_sandbox.yaml, $MODEL]"
+#
+# Requires a cluster with the agent-sandbox controller + extensions (SandboxClaim /
+# SandboxWarmPool CRDs) installed, and at least one SandboxWarmPool whose
+# SandboxTemplate image serves the sandbox runtime REST API (see ../README.md).
+sandbox:
+  default_metadata:
+    sandbox-api: agent-sandbox-k8s
+  agent_sandbox:
+    connection:
+      # in_cluster: exec/file traffic goes straight to sandbox pod IPs (run the NeMo
+      # Gym resource servers inside the same cluster — the recommended RL setup).
+      # gateway: route through a Gateway API resource fronting the sandbox router.
+      # direct: fixed URL to an already-reachable sandbox router.
+      mode: ${oc.env:AGENT_SANDBOX_CONNECTION_MODE,in_cluster}
+      # Port the runtime server inside the sandbox container listens on.
+      server_port: 8888
+      # gateway mode only:
+      # gateway_name: sandbox-gateway
+      # gateway_namespace: default
+      # gateway_ready_timeout_s: 180
+      # direct mode only:
+      # api_url: http://localhost:8000
+    create:
+      # Default SandboxWarmPool to claim from when the agent's sandbox_spec names no
+      # image (or names one with no image_warmpools entry).
+      warmpool: ${oc.env:AGENT_SANDBOX_WARMPOOL,nemo-gym-pool}
+      namespace: ${oc.env:AGENT_SANDBOX_NAMESPACE,default}
+      # Images are baked into each pool's SandboxTemplate, so per-create images are
+      # routed to pools rather than pulled: exact `sandbox_spec.image` string -> pool.
+      image_warmpools: {}
+      #   docker.io/library/python:3.12: python-pool
+      #   my-registry/swebench-runtime:latest: swebench-pool
+      # Claim-bind wait. Warm pool hits bind in seconds; a miss falls back to a cold
+      # pod start, so leave headroom for an image pull.
+      ready_timeout_s: 180
+    exec:
+      default_timeout_s: 180
+      # File staging execs and file API transfers use this instead of default_timeout_s.
+      transfer_timeout_s: 300
+      # Commands run as `<exec_shell> -c <script>`; cwd/env are folded into the script
+      # because the runtime API executes without a shell.
+      exec_shell: /bin/sh
+    probe:
+      # A bound claim proves the pod is Ready, not that the runtime HTTP server (or a
+      # gateway route) is reachable yet — poll a cheap exec before handing the sandbox out.
+      command: printf agent-sandbox-ready
+      expected_stdout: agent-sandbox-ready
+      timeout_s: 30
+      deadline_s: 60
+      stable_count: 1
+      stable_delay_s: 1.0
+    operations:
+      # Claim deletion returns once accepted; pod teardown and warm pool backfill
+      # continue asynchronously. Keep false for RL churn; true for deterministic tests.
+      close_wait_deleted: false
+      close_timeout_s: 60
+      poll_interval_s: 1.0
+      # Off: NeMo Gym owns the lifecycle, and claim TTLs (sandbox_spec.ttl_s ->
+      # lifecycle shutdownTime) are the crash-safety net.
+      atexit_cleanup: false

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/__init__.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Agent Sandbox provider for NVIDIA NeMo Gym."""
+
+from nemo_gym_k8s_agent_sandbox.provider import (
+    AgentSandboxConnectionConfig,
+    AgentSandboxCreateConfig,
+    AgentSandboxCreateError,
+    AgentSandboxCreateVerificationError,
+    AgentSandboxExecConfig,
+    AgentSandboxOperationsConfig,
+    AgentSandboxProbeConfig,
+    AgentSandboxProvider,
+    AgentSandboxProviderOptions,
+)
+
+__all__ = [
+    "AgentSandboxConnectionConfig",
+    "AgentSandboxCreateConfig",
+    "AgentSandboxCreateError",
+    "AgentSandboxCreateVerificationError",
+    "AgentSandboxExecConfig",
+    "AgentSandboxOperationsConfig",
+    "AgentSandboxProbeConfig",
+    "AgentSandboxProvider",
+    "AgentSandboxProviderOptions",
+]

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -346,6 +346,10 @@ class AgentSandboxProvider:
         self._client: Any = None
         self._client_lock = asyncio.Lock()
         self._closed = False
+        # RL runs call create() once per rollout with near-identical specs; these
+        # dedup the advisory warnings below to once per distinct cause.
+        self._warned_default_pool_images: set[str] = set()
+        self._warned_ignored_resources: set[tuple[str, ...]] = set()
 
     async def _get_client(self) -> Any:
         if self._closed:
@@ -356,22 +360,15 @@ class AgentSandboxProvider:
             if self._closed:
                 raise RuntimeError("agent_sandbox provider is closed")
             if self._client is None:
-                import inspect
-
                 from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
 
-                kwargs: dict[str, Any] = {"connection_config": self._connection.build()}
-                # The `cleanup` parameter landed after v0.5.4 (#859). Released clients
-                # without it never register the atexit hook, which is exactly the
-                # atexit_cleanup=False behavior; only an explicit opt-in needs it.
-                if "cleanup" in inspect.signature(AsyncSandboxClient.__init__).parameters:
-                    kwargs["cleanup"] = self._operations.atexit_cleanup
-                elif self._operations.atexit_cleanup:
-                    raise RuntimeError(
-                        "operations.atexit_cleanup=true requires a k8s-agent-sandbox release "
-                        "with AsyncSandboxClient(cleanup=...) support"
-                    )
-                self._client = AsyncSandboxClient(**kwargs)
+                self._client = AsyncSandboxClient(
+                    connection_config=self._connection.build(),
+                    # Always pass explicitly: the client's own default flipped from
+                    # False (0.5.0) to True (0.5.1), and the provider's contract is
+                    # atexit_cleanup regardless of the installed client version.
+                    cleanup=self._operations.atexit_cleanup,
+                )
             return self._client
 
     # ------------------------------------------------------------------ create
@@ -384,7 +381,8 @@ class AgentSandboxProvider:
             if pool:
                 return pool
         if self._create_config.warmpool:
-            if spec.image:
+            if spec.image and spec.image not in self._warned_default_pool_images:
+                self._warned_default_pool_images.add(spec.image)
                 LOGGER.warning(
                     "spec.image=%r has no create.image_warmpools entry; using the default warm pool "
                     "%r, whose SandboxTemplate decides the actual image.",
@@ -410,7 +408,8 @@ class AgentSandboxProvider:
             )
             if value is not None
         ]
-        if ignored:
+        if ignored and tuple(ignored) not in self._warned_ignored_resources:
+            self._warned_ignored_resources.add(tuple(ignored))
             LOGGER.warning(
                 "%s resource requests are not mapped by the agent_sandbox provider; resources come "
                 "from the warm pool's SandboxTemplate.",

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -113,14 +113,17 @@ def _is_runtime_failure(exc: BaseException) -> bool:
     """Whether an exception came from the transport/cluster rather than caller code.
 
     Covers the HTTP path to the in-sandbox runtime (httpx), the Kubernetes API
-    (kubernetes_asyncio), and the client's SandboxError hierarchy. Bare RuntimeError
-    is included because the command executor raises it for malformed runtime
-    responses (SandboxError itself subclasses RuntimeError).
+    (kubernetes_asyncio), and the client's SandboxError hierarchy. Deliberately
+    does NOT match bare RuntimeError: a programming bug must propagate, not be
+    misclassified as a sandbox failure. The one known producer of bare
+    RuntimeError (the command executor's malformed-response error) is handled at
+    its call site in ``_run_wrapped``.
     """
     import httpx
+    from k8s_agent_sandbox.exceptions import SandboxError
     from kubernetes_asyncio.client.rest import ApiException
 
-    return isinstance(exc, (httpx.HTTPError, ApiException, ConnectionError, TimeoutError, RuntimeError))
+    return isinstance(exc, (httpx.HTTPError, ApiException, SandboxError, ConnectionError, TimeoutError))
 
 
 @dataclass(frozen=True)
@@ -582,7 +585,10 @@ class AgentSandboxProvider:
                 return SandboxExecResult(
                     stdout=None, stderr=str(e), return_code=SANDBOX_RUNTIME_RETURN_CODE, error_type="timeout"
                 )
-            if _is_runtime_failure(e):
+            # type(e) is checked exactly: the executor raises bare RuntimeError for
+            # malformed runtime responses, which is a sandbox failure at this call
+            # site only — RuntimeError subclasses from elsewhere still propagate.
+            if _is_runtime_failure(e) or type(e) is RuntimeError:
                 return SandboxExecResult(
                     stdout=None, stderr=str(e), return_code=SANDBOX_RUNTIME_RETURN_CODE, error_type="sandbox"
                 )

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -1,0 +1,735 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Agent Sandbox provider for NVIDIA NeMo Gym (kubernetes-sigs/agent-sandbox).
+
+Sandboxes are checked out of a SandboxWarmPool through a SandboxClaim, so create
+latency is claim-bind latency rather than pod-start latency. The pool's
+SandboxTemplate — not ``SandboxSpec.image`` — decides the image; images are routed
+to pools through ``create.image_warmpools`` (see ``AgentSandboxCreateConfig``).
+
+The provider wraps the async ``k8s-agent-sandbox`` client. Two properties of the
+in-sandbox runtime API shape everything here:
+
+- The runtime's ``/execute`` endpoint tokenizes the command with ``shlex.split``
+  and runs it WITHOUT a shell, so every command is sent as
+  ``<exec_shell> -c '<script>'``; ``cwd``/``env`` are folded into the script.
+- The file API only accepts ``..``-free relative paths, rooted at the runtime
+  server's working directory (the same directory ``/execute`` runs in). Absolute
+  ``upload_file``/``download_file`` paths are honored by staging through a
+  relative temp name and copying with ``exec``.
+"""
+
+import asyncio
+import logging
+import math
+import posixpath
+import re
+import shlex
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from nemo_gym.sandbox.providers.base import (
+    SandboxCreateError,
+    SandboxCreateVerificationError,
+    SandboxExecResult,
+    SandboxHandle,
+    SandboxSpec,
+    SandboxStatus,
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+MANAGED_BY_VALUE = "nemo-gym"
+READY_PROBE_COMMAND = "printf agent-sandbox-ready"
+READY_PROBE_EXPECTED = "agent-sandbox-ready"
+# Non-process sentinel for runtime failures (transport errors, timeouts), mirroring
+# the convention of the other NeMo Gym providers. Also used as the `cd` guard exit
+# code inside wrapped scripts so a bad cwd cannot fall through to the command.
+SANDBOX_RUNTIME_RETURN_CODE = 125
+# Staging names are flat (no subdirectory): the reference runtime's upload handler
+# does not create parent directories, so a nested staging path would 500.
+STAGING_PREFIX = ".nemo-gym-"
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+_CONNECTION_MODES = ("in_cluster", "gateway", "direct")
+
+
+class AgentSandboxCreateError(SandboxCreateError):
+    """Raised when a SandboxClaim cannot be created or bound."""
+
+
+class AgentSandboxCreateVerificationError(SandboxCreateVerificationError):
+    """Raised when a claimed sandbox fails its exec readiness probe."""
+
+
+def _require_client() -> None:
+    try:
+        import k8s_agent_sandbox.async_sandbox_client  # noqa: F401
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "The k8s-agent-sandbox async client is required for the agent_sandbox "
+            "sandbox provider. Install k8s-agent-sandbox[async] (it ships with the "
+            "nemo-gym-k8s-agent-sandbox distribution) before using "
+            "sandbox provider name agent_sandbox."
+        ) from e
+
+
+def _coerce_config(value: Any, config_cls: type[Any]) -> Any:
+    if value is None:
+        return config_cls()
+    if isinstance(value, config_cls):
+        return value
+    if isinstance(value, Mapping):
+        return config_cls(**value)
+    raise TypeError(f"{config_cls.__name__} must be a mapping or {config_cls.__name__} instance")
+
+
+def _is_timeout_failure(exc: BaseException) -> bool:
+    import httpx
+
+    return isinstance(exc, (httpx.TimeoutException, TimeoutError))
+
+
+def _is_runtime_failure(exc: BaseException) -> bool:
+    """Whether an exception came from the transport/cluster rather than caller code.
+
+    Covers the HTTP path to the in-sandbox runtime (httpx), the Kubernetes API
+    (kubernetes_asyncio), and the client's SandboxError hierarchy. Bare RuntimeError
+    is included because the command executor raises it for malformed runtime
+    responses (SandboxError itself subclasses RuntimeError).
+    """
+    import httpx
+    from kubernetes_asyncio.client.rest import ApiException
+
+    return isinstance(exc, (httpx.HTTPError, ApiException, ConnectionError, TimeoutError, RuntimeError))
+
+
+@dataclass(frozen=True)
+class AgentSandboxConnectionConfig:
+    """How to reach the Kubernetes API and the runtime server inside each sandbox.
+
+    ``mode`` selects the client's connection config class:
+
+    - ``in_cluster``: talk to the sandbox pod IP directly (NeMo Gym resource
+      servers running inside the same cluster — the recommended RL setup).
+    - ``gateway``: route through a Gateway API resource fronting the sandbox
+      router (out-of-cluster clients).
+    - ``direct``: a fixed URL to an already-reachable sandbox router.
+
+    Kubernetes API credentials come from the standard kubeconfig / in-cluster
+    service account resolution done by the client's K8s helper.
+    """
+
+    mode: str = "in_cluster"
+    server_port: int = 8888
+    api_url: str | None = None
+    gateway_name: str | None = None
+    gateway_namespace: str = "default"
+    gateway_ready_timeout_s: int = 180
+
+    def __post_init__(self) -> None:
+        if self.mode not in _CONNECTION_MODES:
+            raise ValueError(f"connection.mode must be one of {_CONNECTION_MODES}, got {self.mode!r}")
+        if self.server_port < 1 or self.server_port > 65535:
+            raise ValueError("connection.server_port must be a valid TCP port")
+        if self.mode == "direct" and not self.api_url:
+            raise ValueError("connection.api_url is required when connection.mode is 'direct'")
+        if self.mode == "gateway" and not self.gateway_name:
+            raise ValueError("connection.gateway_name is required when connection.mode is 'gateway'")
+
+    def build(self) -> Any:
+        from k8s_agent_sandbox.models import (
+            SandboxDirectConnectionConfig,
+            SandboxGatewayConnectionConfig,
+            SandboxInClusterConnectionConfig,
+        )
+
+        if self.mode == "direct":
+            return SandboxDirectConnectionConfig(api_url=self.api_url, server_port=self.server_port)
+        if self.mode == "gateway":
+            return SandboxGatewayConnectionConfig(
+                gateway_name=self.gateway_name,
+                gateway_namespace=self.gateway_namespace,
+                gateway_ready_timeout=self.gateway_ready_timeout_s,
+                server_port=self.server_port,
+            )
+        return SandboxInClusterConnectionConfig(server_port=self.server_port)
+
+
+@dataclass(frozen=True)
+class AgentSandboxCreateConfig:
+    """Claim creation settings.
+
+    Warm pool resolution order for each sandbox: ``provider_options.warmpool`` >
+    ``image_warmpools[spec.image]`` > ``warmpool``. ``image_warmpools`` keys are
+    exact image references as agents request them (the pool's SandboxTemplate must
+    actually run that image — the provider cannot verify this).
+    """
+
+    warmpool: str | None = None
+    namespace: str = "default"
+    image_warmpools: dict[str, str] = field(default_factory=dict)
+    ready_timeout_s: float = 180
+
+    def __post_init__(self) -> None:
+        if self.ready_timeout_s <= 0:
+            raise ValueError("create.ready_timeout_s must be > 0")
+        if not isinstance(self.image_warmpools, Mapping):
+            raise TypeError("create.image_warmpools must be a mapping of image -> warmpool name")
+        object.__setattr__(
+            self,
+            "image_warmpools",
+            {str(k): str(v) for k, v in self.image_warmpools.items()},
+        )
+
+
+@dataclass(frozen=True)
+class AgentSandboxExecConfig:
+    default_timeout_s: float | None = 180
+    # File staging execs (mkdir/cp/rm) and file API reads/writes use this timeout
+    # instead of default_timeout_s so large artifacts are not capped by the exec default.
+    transfer_timeout_s: float = 300
+    exec_shell: str = "/bin/sh"
+
+    def __post_init__(self) -> None:
+        if self.default_timeout_s is not None and self.default_timeout_s <= 0:
+            raise ValueError("exec.default_timeout_s must be > 0")
+        if self.transfer_timeout_s <= 0:
+            raise ValueError("exec.transfer_timeout_s must be > 0")
+        if not self.exec_shell:
+            raise ValueError("exec.exec_shell must be a non-empty shell name/path")
+
+
+@dataclass(frozen=True)
+class AgentSandboxProbeConfig:
+    """Exec readiness probe run after the claim binds.
+
+    A bound claim means the pod is Ready, not that the runtime HTTP server is
+    accepting requests (or that a gateway route has propagated), so the provider
+    polls a cheap exec until it succeeds ``stable_count`` times.
+    """
+
+    command: str | None = READY_PROBE_COMMAND
+    expected_stdout: str | None = READY_PROBE_EXPECTED
+    timeout_s: int = 30
+    deadline_s: float | None = 60
+    stable_count: int = 1
+    stable_delay_s: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.command is not None and self.timeout_s <= 0:
+            raise ValueError("probe.timeout_s must be > 0")
+        if self.deadline_s is not None and self.deadline_s <= 0:
+            raise ValueError("probe.deadline_s must be > 0")
+        if self.stable_count < 1:
+            raise ValueError("probe.stable_count must be >= 1")
+        if self.stable_delay_s < 0:
+            raise ValueError("probe.stable_delay_s must be >= 0")
+
+
+@dataclass(frozen=True)
+class AgentSandboxOperationsConfig:
+    # Deleting a claim returns once the apiserver accepts it; pod teardown (and the
+    # warm pool backfilling the freed slot) continues asynchronously. Waiting is off
+    # by default to keep RL rollout churn fast — enable it when tests need
+    # deterministic teardown.
+    close_wait_deleted: bool = False
+    close_timeout_s: float = 60
+    poll_interval_s: float = 1.0
+    # When True, the underlying client registers an atexit hook that deletes any
+    # still-tracked claims on interpreter exit. Off by default: NeMo Gym owns the
+    # sandbox lifecycle, and claim TTLs (spec.ttl_s) are the crash-safety net.
+    atexit_cleanup: bool = False
+
+    def __post_init__(self) -> None:
+        if self.close_timeout_s <= 0:
+            raise ValueError("operations.close_timeout_s must be > 0")
+        if self.poll_interval_s <= 0:
+            raise ValueError("operations.poll_interval_s must be > 0")
+
+
+@dataclass(frozen=True)
+class AgentSandboxProviderOptions:
+    """Validated per-sandbox options carried in ``SandboxSpec.provider_options``."""
+
+    warmpool: str | None = None
+    namespace: str | None = None
+    pod_labels: dict[str, str] = field(default_factory=dict)
+    pod_annotations: dict[str, str] = field(default_factory=dict)
+    volume_claim_templates: list[dict] = field(default_factory=list)
+
+    @classmethod
+    def from_mapping(cls, options: Mapping[str, Any]) -> "AgentSandboxProviderOptions":
+        allowed = set(cls.__dataclass_fields__)
+        unknown = set(options) - allowed
+        if unknown:
+            raise ValueError(
+                f"Unknown agent_sandbox provider_options keys: {sorted(unknown)}. Allowed keys: {sorted(allowed)}"
+            )
+        for key in ("pod_labels", "pod_annotations"):
+            value = options.get(key)
+            if value is not None and not isinstance(value, Mapping):
+                raise TypeError(f"provider_options[{key!r}] must be a mapping, got {type(value).__name__}")
+        vcts = options.get("volume_claim_templates") or []
+        if not isinstance(vcts, (list, tuple)):
+            raise TypeError(
+                f"provider_options['volume_claim_templates'] must be a list, got {type(vcts).__name__}"
+            )
+        return cls(
+            warmpool=str(options["warmpool"]) if options.get("warmpool") else None,
+            namespace=str(options["namespace"]) if options.get("namespace") else None,
+            pod_labels={str(k): str(v) for k, v in (options.get("pod_labels") or {}).items()},
+            pod_annotations={str(k): str(v) for k, v in (options.get("pod_annotations") or {}).items()},
+            volume_claim_templates=[dict(v) for v in vcts],
+        )
+
+
+@dataclass
+class _AgentSandboxInstance:
+    claim_name: str
+    sandbox_name: str
+    namespace: str
+    sandbox: Any  # k8s_agent_sandbox.async_sandbox.AsyncSandbox
+    env: dict[str, str] = field(default_factory=dict)
+    workdir: str | None = None
+
+
+class AgentSandboxProvider:
+    """Sandbox provider backed by kubernetes-sigs/agent-sandbox warm pools."""
+
+    name = "agent_sandbox"
+
+    def __init__(
+        self,
+        *,
+        connection: AgentSandboxConnectionConfig | Mapping[str, Any] | None = None,
+        create: AgentSandboxCreateConfig | Mapping[str, Any] | None = None,
+        exec: AgentSandboxExecConfig | Mapping[str, Any] | None = None,
+        probe: AgentSandboxProbeConfig | Mapping[str, Any] | None = None,
+        operations: AgentSandboxOperationsConfig | Mapping[str, Any] | None = None,
+    ) -> None:
+        self._connection = _coerce_config(connection, AgentSandboxConnectionConfig)
+        self._create_config = _coerce_config(create, AgentSandboxCreateConfig)
+        self._exec_config = _coerce_config(exec, AgentSandboxExecConfig)
+        self._probe = _coerce_config(probe, AgentSandboxProbeConfig)
+        self._operations = _coerce_config(operations, AgentSandboxOperationsConfig)
+        _require_client()
+        # Built lazily on first use: AsyncSandboxClient owns kubernetes_asyncio
+        # resources that bind to the running event loop, so it cannot be shared at
+        # module scope the way providers with loop-free SDK clients share theirs.
+        self._client: Any = None
+        self._client_lock = asyncio.Lock()
+        self._closed = False
+
+    async def _get_client(self) -> Any:
+        if self._closed:
+            raise RuntimeError("agent_sandbox provider is closed")
+        async with self._client_lock:
+            # Re-check under the lock: aclose() may have run while we waited, and
+            # building a client past that point would leak it.
+            if self._closed:
+                raise RuntimeError("agent_sandbox provider is closed")
+            if self._client is None:
+                import inspect
+
+                from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
+
+                kwargs: dict[str, Any] = {"connection_config": self._connection.build()}
+                # The `cleanup` parameter landed after v0.5.4 (#859). Released clients
+                # without it never register the atexit hook, which is exactly the
+                # atexit_cleanup=False behavior; only an explicit opt-in needs it.
+                if "cleanup" in inspect.signature(AsyncSandboxClient.__init__).parameters:
+                    kwargs["cleanup"] = self._operations.atexit_cleanup
+                elif self._operations.atexit_cleanup:
+                    raise RuntimeError(
+                        "operations.atexit_cleanup=true requires a k8s-agent-sandbox release "
+                        "with AsyncSandboxClient(cleanup=...) support"
+                    )
+                self._client = AsyncSandboxClient(**kwargs)
+            return self._client
+
+    # ------------------------------------------------------------------ create
+
+    def _resolve_warmpool(self, spec: SandboxSpec, options: AgentSandboxProviderOptions) -> str:
+        if options.warmpool:
+            return options.warmpool
+        if spec.image:
+            pool = self._create_config.image_warmpools.get(spec.image)
+            if pool:
+                return pool
+        if self._create_config.warmpool:
+            if spec.image:
+                LOGGER.warning(
+                    "spec.image=%r has no create.image_warmpools entry; using the default warm pool "
+                    "%r, whose SandboxTemplate decides the actual image.",
+                    spec.image,
+                    self._create_config.warmpool,
+                )
+            return self._create_config.warmpool
+        raise AgentSandboxCreateError(
+            f"No warm pool for image={spec.image!r}: set provider_options.warmpool, add the image to "
+            "create.image_warmpools, or configure create.warmpool as a default."
+        )
+
+    def _warn_unmapped_spec_fields(self, spec: SandboxSpec) -> None:
+        resources = spec.resources
+        ignored = [
+            key
+            for key, value in (
+                ("cpu", resources.cpu),
+                ("memory_mib", resources.memory_mib),
+                ("disk_gib", resources.disk_gib),
+                ("gpu", resources.gpu),
+                ("gpu_type", resources.gpu_type),
+            )
+            if value is not None
+        ]
+        if ignored:
+            LOGGER.warning(
+                "%s resource requests are not mapped by the agent_sandbox provider; resources come "
+                "from the warm pool's SandboxTemplate.",
+                ", ".join(ignored),
+            )
+        if spec.ports:
+            LOGGER.warning(
+                "spec.ports=%s is ignored: the agent_sandbox provider does not resolve service "
+                "endpoints yet (SupportsSandboxEndpoint is not implemented).",
+                list(spec.ports),
+            )
+
+    async def create(self, spec: SandboxSpec) -> SandboxHandle:
+        """Claim a sandbox from a warm pool, wait for the bind, then probe exec readiness.
+
+        ``spec.ttl_s`` maps to the claim's lifecycle ``shutdownTime`` (ceil to whole
+        seconds), so the controller deletes expired sandboxes even if this process
+        dies. ``spec.metadata`` becomes SandboxClaim labels and must satisfy
+        Kubernetes label syntax. ``spec.entrypoint`` is unsupported: the pool's
+        SandboxTemplate owns the pod command. ``spec.files`` are not handled here —
+        NeMo Gym's sandbox API uploads them via ``upload_file`` after ``create``
+        returns. A claim that binds but fails verification is deleted before the
+        error propagates.
+        """
+        if spec.entrypoint:
+            raise AgentSandboxCreateError(
+                "spec.entrypoint is not supported by the agent_sandbox provider; the warm pool's "
+                "SandboxTemplate owns the pod command"
+            )
+        self._warn_unmapped_spec_fields(spec)
+        options = AgentSandboxProviderOptions.from_mapping(spec.provider_options)
+        warmpool = self._resolve_warmpool(spec, options)
+        namespace = options.namespace or self._create_config.namespace
+        ready_timeout_s = spec.ready_timeout_s or self._create_config.ready_timeout_s
+        shutdown_after_seconds = max(1, math.ceil(spec.ttl_s)) if spec.ttl_s is not None else None
+        # Marker label goes last so user metadata cannot clobber it.
+        labels = {**{str(k): str(v) for k, v in spec.metadata.items()}, MANAGED_BY_LABEL: MANAGED_BY_VALUE}
+
+        client = await self._get_client()
+        try:
+            sandbox = await client.create_sandbox(
+                warmpool,
+                namespace=namespace,
+                sandbox_ready_timeout=max(1, math.ceil(ready_timeout_s)),
+                labels=labels,
+                shutdown_after_seconds=shutdown_after_seconds,
+                volume_claim_templates=options.volume_claim_templates or None,
+                pod_labels=options.pod_labels or None,
+                pod_annotations=options.pod_annotations or None,
+            )
+        except ValueError as e:
+            # Bad warm pool name / label syntax — caller error, keep it precise.
+            raise AgentSandboxCreateError(f"invalid sandbox claim for warm pool {warmpool!r}: {e}") from e
+        except Exception as e:
+            if not _is_runtime_failure(e):
+                raise
+            raise AgentSandboxCreateError(
+                f"SandboxClaim against warm pool {warmpool!r} in namespace {namespace!r} failed: {e}"
+            ) from e
+
+        handle = SandboxHandle(
+            sandbox_id=sandbox.claim_name,
+            provider_name=self.name,
+            raw=_AgentSandboxInstance(
+                claim_name=sandbox.claim_name,
+                sandbox_name=sandbox.sandbox_id,
+                namespace=namespace,
+                sandbox=sandbox,
+                env=dict(spec.env),
+                workdir=spec.workdir,
+            ),
+        )
+        try:
+            # spec.files is NOT seeded here: NeMo Gym's sandbox API uploads them
+            # through provider.upload_file() after create() returns.
+            await self._verify_created_handle(handle)
+        except (Exception, asyncio.CancelledError):
+            await asyncio.shield(self._cleanup_failed_create_handle(handle))
+            raise
+        return handle
+
+    async def _verify_created_handle(self, handle: SandboxHandle) -> None:
+        """Poll the readiness probe until it passes ``stable_count`` times or the deadline elapses."""
+        probe = self._probe
+        if probe.command is None:
+            return
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + probe.deadline_s if probe.deadline_s is not None else None
+        consecutive = 0
+        last_detail = "no probe attempt completed"
+        while True:
+            result = await self.exec(handle, probe.command, timeout_s=probe.timeout_s)
+            passed = result.return_code == 0 and (
+                probe.expected_stdout is None or probe.expected_stdout in (result.stdout or "")
+            )
+            if passed:
+                consecutive += 1
+                if consecutive >= probe.stable_count:
+                    return
+            else:
+                consecutive = 0
+                last_detail = f"return_code={result.return_code}, stderr={(result.stderr or '').strip()!r}"
+                if deadline is None:
+                    raise AgentSandboxCreateVerificationError(
+                        f"sandbox {handle.sandbox_id!r} failed readiness probe: {last_detail}"
+                    )
+            if deadline is not None and loop.time() >= deadline:
+                raise AgentSandboxCreateVerificationError(
+                    f"sandbox {handle.sandbox_id!r} did not pass readiness probe within "
+                    f"{probe.deadline_s:g}s: {last_detail}"
+                )
+            if probe.stable_delay_s > 0:
+                await asyncio.sleep(probe.stable_delay_s)
+
+    async def _cleanup_failed_create_handle(self, handle: SandboxHandle) -> None:
+        inst: _AgentSandboxInstance = handle.raw
+        try:
+            await inst.sandbox.terminate()
+        except Exception as e:
+            LOGGER.warning(
+                f"Failed to delete half-created sandbox claim {inst.claim_name!r} in namespace "
+                f"{inst.namespace!r}; the claim TTL (if set) is the remaining safety net: {e}"
+            )
+
+    # -------------------------------------------------------------------- exec
+
+    def _wrap_command(self, command: str, *, cwd: str | None, env: Mapping[str, str]) -> str:
+        """Fold cwd/env into a shell script and wrap it for the runtime's shlex+no-shell exec."""
+        lines = []
+        for key, value in env.items():
+            if not _ENV_NAME_RE.match(key):
+                raise ValueError(f"Invalid environment variable name for sandbox exec: {key!r}")
+            lines.append(f"export {key}={shlex.quote(str(value))}")
+        if cwd:
+            lines.append(f"cd {shlex.quote(cwd)} || exit {SANDBOX_RUNTIME_RETURN_CODE}")
+        lines.append(command)
+        return f"{self._exec_config.exec_shell} -c {shlex.quote('\n'.join(lines))}"
+
+    async def _run_wrapped(
+        self, inst: _AgentSandboxInstance, wrapped_command: str, timeout_s: int | float | None
+    ) -> SandboxExecResult:
+        commands = inst.sandbox.commands
+        if commands is None:
+            return SandboxExecResult(
+                stdout=None,
+                stderr=f"sandbox connection for claim {inst.claim_name!r} is closed",
+                return_code=SANDBOX_RUNTIME_RETURN_CODE,
+                error_type="sandbox",
+            )
+        effective_timeout = timeout_s if timeout_s is not None else self._exec_config.default_timeout_s
+        timeout = max(1, math.ceil(effective_timeout)) if effective_timeout is not None else None
+        try:
+            result = await commands.run(wrapped_command, timeout=timeout)
+        except Exception as e:
+            # The runtime server has no server-side timeout: a timed-out HTTP request
+            # abandons the request but the process may keep running in the pod.
+            if _is_timeout_failure(e):
+                return SandboxExecResult(
+                    stdout=None, stderr=str(e), return_code=SANDBOX_RUNTIME_RETURN_CODE, error_type="timeout"
+                )
+            if _is_runtime_failure(e):
+                return SandboxExecResult(
+                    stdout=None, stderr=str(e), return_code=SANDBOX_RUNTIME_RETURN_CODE, error_type="sandbox"
+                )
+            raise
+        return SandboxExecResult(stdout=result.stdout, stderr=result.stderr, return_code=result.exit_code)
+
+    async def exec(
+        self,
+        handle: SandboxHandle,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_s: int | float | None = None,
+        user: str | int | None = None,
+    ) -> SandboxExecResult:
+        """Run ``<exec_shell> -c <script>`` in the sandbox; never raises for command failure.
+
+        ``cwd`` falls back to the sandbox spec's ``workdir``; a failing ``cd`` exits
+        with the runtime sentinel code before the command runs. ``user`` is ignored
+        with a warning — the runtime API always executes as the pod's user.
+        """
+        inst: _AgentSandboxInstance = handle.raw
+        if user is not None:
+            LOGGER.warning(
+                f"The agent_sandbox provider cannot run commands as user={user!r}; the sandbox "
+                "runtime API has no user field. Running as the pod's user."
+            )
+        merged_env = {str(k): str(v) for k, v in inst.env.items()}
+        if env:
+            merged_env.update({str(k): str(v) for k, v in env.items()})
+        workdir = cwd if cwd is not None else inst.workdir
+        wrapped = self._wrap_command(command, cwd=workdir, env=merged_env)
+        return await self._run_wrapped(inst, wrapped, timeout_s)
+
+    # ------------------------------------------------------------------- files
+
+    async def _transfer_exec(self, inst: _AgentSandboxInstance, script: str) -> SandboxExecResult:
+        # Staging paths are relative to the runtime server's working directory, which
+        # is also where /execute runs — so no cd/env wrapping here, only shell quoting.
+        wrapped = f"{self._exec_config.exec_shell} -c {shlex.quote(script)}"
+        return await self._run_wrapped(inst, wrapped, self._exec_config.transfer_timeout_s)
+
+    async def _put_bytes(self, handle: SandboxHandle, data: bytes, target_path: str) -> None:
+        inst: _AgentSandboxInstance = handle.raw
+        files = inst.sandbox.files
+        if files is None:
+            raise RuntimeError(f"sandbox connection for claim {inst.claim_name!r} is closed")
+        staging = STAGING_PREFIX + uuid.uuid4().hex
+        await files.write(staging, data, timeout=max(1, math.ceil(self._exec_config.transfer_timeout_s)))
+        quoted_target = shlex.quote(target_path)
+        parent = posixpath.dirname(target_path)
+        script_parts = []
+        if parent:
+            script_parts.append(f"mkdir -p {shlex.quote(parent)}")
+        # cp+rm rather than mv: the target may live on a different mount (e.g. a
+        # volumeClaimTemplate volume), where rename(2) fails cross-device.
+        script_parts.append(f"cp {shlex.quote(staging)} {quoted_target}")
+        script_parts.append(f"rm -f {shlex.quote(staging)}")
+        result = await self._transfer_exec(inst, " && ".join(script_parts))
+        if result.return_code != 0:
+            await self._transfer_exec(inst, f"rm -f {shlex.quote(staging)}")
+            raise RuntimeError(
+                f"agent_sandbox upload to {target_path!r} failed (code={result.return_code}): "
+                f"{(result.stderr or '').strip()}"
+            )
+
+    async def upload_file(self, handle: SandboxHandle, source_path: Path, target_path: str) -> None:
+        """Upload one local file, staging through a relative temp name to allow absolute targets."""
+        data = await asyncio.to_thread(Path(source_path).read_bytes)
+        await self._put_bytes(handle, data, target_path)
+
+    async def download_file(self, handle: SandboxHandle, source_path: str, target_path: Path) -> None:
+        """Download one sandbox file (staged copy first, so absolute source paths work)."""
+        inst: _AgentSandboxInstance = handle.raw
+        files = inst.sandbox.files
+        if files is None:
+            raise RuntimeError(f"sandbox connection for claim {inst.claim_name!r} is closed")
+        staging = STAGING_PREFIX + uuid.uuid4().hex
+        result = await self._transfer_exec(inst, f"cp {shlex.quote(source_path)} {shlex.quote(staging)}")
+        if result.return_code != 0:
+            raise RuntimeError(
+                f"agent_sandbox download from {source_path!r} failed (code={result.return_code}): "
+                f"{(result.stderr or '').strip()}"
+            )
+        try:
+            data = await files.read(staging, timeout=max(1, math.ceil(self._exec_config.transfer_timeout_s)))
+        finally:
+            cleanup = await self._transfer_exec(inst, f"rm -f {shlex.quote(staging)}")
+            if cleanup.return_code != 0:
+                LOGGER.warning(
+                    f"Failed to remove staging file {staging!r} in sandbox {inst.claim_name!r}: "
+                    f"{(cleanup.stderr or '').strip()}"
+                )
+        target_path = Path(target_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(target_path.write_bytes, data)
+
+    # --------------------------------------------------------------- lifecycle
+
+    async def status(self, handle: SandboxHandle) -> SandboxStatus:
+        """Sandbox Ready condition via the Kubernetes API (missing -> STOPPED; API failure -> UNKNOWN)."""
+        inst: _AgentSandboxInstance = handle.raw
+        try:
+            state, _message = await inst.sandbox.status()
+        except Exception as e:
+            if _is_runtime_failure(e):
+                return SandboxStatus.UNKNOWN
+            raise
+        if state == "SandboxReady":
+            return SandboxStatus.RUNNING
+        if state == "SandboxNotFound":
+            return SandboxStatus.STOPPED
+        # "SandboxNotReady" covers both warm-up and degradation; the Ready condition
+        # does not distinguish them, so report the optimistic phase.
+        return SandboxStatus.STARTING
+
+    async def close(self, handle: SandboxHandle) -> None:
+        """Delete the SandboxClaim (already-gone counts as success)."""
+        inst: _AgentSandboxInstance = handle.raw
+        try:
+            await inst.sandbox.terminate()
+        except Exception as e:
+            if not _is_runtime_failure(e):
+                raise
+            raise RuntimeError(
+                f"agent_sandbox delete failed for claim {inst.claim_name!r} in namespace "
+                f"{inst.namespace!r}: {e}"
+            ) from e
+        # terminate() deletes the claim, but the client keeps tracking the handle in
+        # its active-sandbox registry; delete_sandbox pops that entry (its internal
+        # second terminate is an idempotent no-op), keeping the registry bounded
+        # across long RL runs. Guarded on the raw attribute so a close() racing
+        # aclose() cannot resurrect the client.
+        if self._client is not None:
+            await self._client.delete_sandbox(inst.claim_name, inst.namespace)
+        if self._operations.close_wait_deleted:
+            await self._wait_deleted(inst)
+
+    async def _wait_deleted(self, inst: _AgentSandboxInstance) -> None:
+        client = await self._get_client()
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._operations.close_timeout_s
+        while True:
+            gone = False
+            try:
+                gone = await client.k8s_helper.get_sandbox_claim(inst.claim_name, inst.namespace) is None
+            except Exception as e:
+                # Transient API failure: keep polling until the deadline.
+                if not _is_runtime_failure(e):
+                    raise
+                LOGGER.debug(f"get_sandbox_claim failed while waiting for {inst.claim_name!r} deletion: {e}")
+            if gone:
+                return
+            if loop.time() >= deadline:
+                raise RuntimeError(
+                    f"agent_sandbox claim {inst.claim_name!r} was not deleted within "
+                    f"{self._operations.close_timeout_s:g}s"
+                )
+            await asyncio.sleep(self._operations.poll_interval_s)
+
+    async def aclose(self) -> None:
+        """Close the Kubernetes client and all tracked sandbox connections (sandboxes keep running)."""
+        if self._closed:
+            return
+        self._closed = True
+        async with self._client_lock:
+            if self._client is not None:
+                await self._client.close()
+                self._client = None

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -82,8 +82,10 @@ class AgentSandboxCreateVerificationError(SandboxCreateVerificationError):
 def _require_client() -> None:
     try:
         import k8s_agent_sandbox.async_sandbox_client  # noqa: F401
-    except ModuleNotFoundError as e:
-        raise ModuleNotFoundError(
+    except ImportError as e:
+        # ImportError, not just ModuleNotFoundError: a failed `from ... import`
+        # inside the async client module (missing [async] extras) raises the former.
+        raise ImportError(
             "The k8s-agent-sandbox async client is required for the agent_sandbox "
             "sandbox provider. Install k8s-agent-sandbox[async] (it ships with the "
             "nemo-gym-k8s-agent-sandbox distribution) before using "
@@ -321,7 +323,10 @@ class AgentSandboxProvider:
         *,
         connection: AgentSandboxConnectionConfig | Mapping[str, Any] | None = None,
         create: AgentSandboxCreateConfig | Mapping[str, Any] | None = None,
-        exec: AgentSandboxExecConfig | Mapping[str, Any] | None = None,
+        # `exec` shadows the builtin, but the parameter name IS the provider config
+        # contract: NeMo Gym passes the YAML `exec:` block by keyword, and NeMo
+        # Gym's own providers (e.g. openshell) use the same name.
+        exec: AgentSandboxExecConfig | Mapping[str, Any] | None = None,  # noqa: A002
         probe: AgentSandboxProbeConfig | Mapping[str, Any] | None = None,
         operations: AgentSandboxOperationsConfig | Mapping[str, Any] | None = None,
     ) -> None:
@@ -432,11 +437,15 @@ class AgentSandboxProvider:
                 "SandboxTemplate owns the pod command"
             )
         self._warn_unmapped_spec_fields(spec)
+        if spec.ttl_s is not None and spec.ttl_s <= 0:
+            raise AgentSandboxCreateError(f"spec.ttl_s must be > 0, got {spec.ttl_s!r}")
+        if spec.ready_timeout_s is not None and spec.ready_timeout_s <= 0:
+            raise AgentSandboxCreateError(f"spec.ready_timeout_s must be > 0, got {spec.ready_timeout_s!r}")
         options = AgentSandboxProviderOptions.from_mapping(spec.provider_options)
         warmpool = self._resolve_warmpool(spec, options)
         namespace = options.namespace or self._create_config.namespace
         ready_timeout_s = spec.ready_timeout_s or self._create_config.ready_timeout_s
-        shutdown_after_seconds = max(1, math.ceil(spec.ttl_s)) if spec.ttl_s is not None else None
+        shutdown_after_seconds = math.ceil(spec.ttl_s) if spec.ttl_s is not None else None
         # Marker label goes last so user metadata cannot clobber it.
         labels = {**{str(k): str(v) for k, v in spec.metadata.items()}, MANAGED_BY_LABEL: MANAGED_BY_VALUE}
 
@@ -445,7 +454,7 @@ class AgentSandboxProvider:
             sandbox = await client.create_sandbox(
                 warmpool,
                 namespace=namespace,
-                sandbox_ready_timeout=max(1, math.ceil(ready_timeout_s)),
+                sandbox_ready_timeout=math.ceil(ready_timeout_s),
                 labels=labels,
                 shutdown_after_seconds=shutdown_after_seconds,
                 volume_claim_templates=options.volume_claim_templates or None,
@@ -484,21 +493,29 @@ class AgentSandboxProvider:
         return handle
 
     async def _verify_created_handle(self, handle: SandboxHandle) -> None:
-        """Poll the readiness probe until it passes ``stable_count`` times or the deadline elapses."""
+        """Poll the readiness probe until it passes ``stable_count`` times or the deadline elapses.
+
+        The probe runs WITHOUT the cwd/env wrapping that ``exec`` applies: it tests
+        runtime reachability only, and a ``spec.workdir`` that does not exist until
+        the agent creates it must not fail an otherwise healthy sandbox.
+        """
         probe = self._probe
         if probe.command is None:
             return
+        inst: _AgentSandboxInstance = handle.raw
+        wrapped = f"{self._exec_config.exec_shell} -c {shlex.quote(probe.command)}"
         loop = asyncio.get_running_loop()
         deadline = loop.time() + probe.deadline_s if probe.deadline_s is not None else None
         consecutive = 0
         last_detail = "no probe attempt completed"
         while True:
-            result = await self.exec(handle, probe.command, timeout_s=probe.timeout_s)
+            result = await self._run_wrapped(inst, wrapped, probe.timeout_s)
             passed = result.return_code == 0 and (
                 probe.expected_stdout is None or probe.expected_stdout in (result.stdout or "")
             )
             if passed:
                 consecutive += 1
+                last_detail = f"probe passed {consecutive}/{probe.stable_count} consecutive times"
                 if consecutive >= probe.stable_count:
                     return
             else:
@@ -522,8 +539,11 @@ class AgentSandboxProvider:
             await inst.sandbox.terminate()
         except Exception as e:
             LOGGER.warning(
-                f"Failed to delete half-created sandbox claim {inst.claim_name!r} in namespace "
-                f"{inst.namespace!r}; the claim TTL (if set) is the remaining safety net: {e}"
+                "Failed to delete half-created sandbox claim %r in namespace %r; "
+                "the claim TTL (if set) is the remaining safety net: %s",
+                inst.claim_name,
+                inst.namespace,
+                e,
             )
 
     # -------------------------------------------------------------------- exec
@@ -588,8 +608,9 @@ class AgentSandboxProvider:
         inst: _AgentSandboxInstance = handle.raw
         if user is not None:
             LOGGER.warning(
-                f"The agent_sandbox provider cannot run commands as user={user!r}; the sandbox "
-                "runtime API has no user field. Running as the pod's user."
+                "The agent_sandbox provider cannot run commands as user=%r; the sandbox "
+                "runtime API has no user field. Running as the pod's user.",
+                user,
             )
         merged_env = {str(k): str(v) for k, v in inst.env.items()}
         if env:
@@ -654,8 +675,10 @@ class AgentSandboxProvider:
             cleanup = await self._transfer_exec(inst, f"rm -f {shlex.quote(staging)}")
             if cleanup.return_code != 0:
                 LOGGER.warning(
-                    f"Failed to remove staging file {staging!r} in sandbox {inst.claim_name!r}: "
-                    f"{(cleanup.stderr or '').strip()}"
+                    "Failed to remove staging file %r in sandbox %r: %s",
+                    staging,
+                    inst.claim_name,
+                    (cleanup.stderr or "").strip(),
                 )
         target_path = Path(target_path)
         target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -714,7 +737,7 @@ class AgentSandboxProvider:
                 # Transient API failure: keep polling until the deadline.
                 if not _is_runtime_failure(e):
                     raise
-                LOGGER.debug(f"get_sandbox_claim failed while waiting for {inst.claim_name!r} deletion: {e}")
+                LOGGER.debug("get_sandbox_claim failed while waiting for %r deletion: %s", inst.claim_name, e)
             if gone:
                 return
             if loop.time() >= deadline:

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -416,12 +416,6 @@ class AgentSandboxProvider:
                 "from the warm pool's SandboxTemplate.",
                 ", ".join(ignored),
             )
-        if spec.ports:
-            LOGGER.warning(
-                "spec.ports=%s is ignored: the agent_sandbox provider does not resolve service "
-                "endpoints yet (SupportsSandboxEndpoint is not implemented).",
-                list(spec.ports),
-            )
 
     async def create(self, spec: SandboxSpec) -> SandboxHandle:
         """Claim a sandbox from a warm pool, wait for the bind, then probe exec readiness.

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -438,7 +438,12 @@ class AgentSandboxProvider:
             raise AgentSandboxCreateError(f"spec.ttl_s must be > 0, got {spec.ttl_s!r}")
         if spec.ready_timeout_s is not None and spec.ready_timeout_s <= 0:
             raise AgentSandboxCreateError(f"spec.ready_timeout_s must be > 0, got {spec.ready_timeout_s!r}")
-        options = AgentSandboxProviderOptions.from_mapping(spec.provider_options)
+        try:
+            options = AgentSandboxProviderOptions.from_mapping(spec.provider_options)
+        except (ValueError, TypeError) as e:
+            # Caller error, same contract as the create_sandbox wrap below —
+            # callers catching SandboxCreateError must see bad provider_options.
+            raise AgentSandboxCreateError(f"invalid provider_options: {e}") from e
         warmpool = self._resolve_warmpool(spec, options)
         namespace = options.namespace or self._create_config.namespace
         ready_timeout_s = spec.ready_timeout_s or self._create_config.ready_timeout_s

--- a/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
+++ b/clients/integrations/nemo-gym/nemo_gym_k8s_agent_sandbox/provider.py
@@ -228,7 +228,8 @@ class AgentSandboxProbeConfig:
 
     A bound claim means the pod is Ready, not that the runtime HTTP server is
     accepting requests (or that a gateway route has propagated), so the provider
-    polls a cheap exec until it succeeds ``stable_count`` times.
+    polls a cheap exec until it succeeds ``stable_count`` times. ``deadline_s``
+    bounds the whole poll; ``None`` polls without a time limit.
     """
 
     command: str | None = READY_PROBE_COMMAND
@@ -510,9 +511,11 @@ class AgentSandboxProvider:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + probe.deadline_s if probe.deadline_s is not None else None
         consecutive = 0
+        attempts = 0
         last_detail = "no probe attempt completed"
         while True:
             result = await self._run_wrapped(inst, wrapped, probe.timeout_s)
+            attempts += 1
             passed = result.return_code == 0 and (
                 probe.expected_stdout is None or probe.expected_stdout in (result.stdout or "")
             )
@@ -524,9 +527,14 @@ class AgentSandboxProvider:
             else:
                 consecutive = 0
                 last_detail = f"return_code={result.return_code}, stderr={(result.stderr or '').strip()!r}"
-                if deadline is None:
-                    raise AgentSandboxCreateVerificationError(
-                        f"sandbox {handle.sandbox_id!r} failed readiness probe: {last_detail}"
+                # Without a deadline the poll can run forever; surface progress so a
+                # never-ready sandbox does not block create() silently.
+                if deadline is None and attempts % 30 == 0:
+                    LOGGER.warning(
+                        "sandbox %r readiness probe still failing after %d attempts (no deadline configured): %s",
+                        handle.sandbox_id,
+                        attempts,
+                        last_detail,
                     )
             if deadline is not None and loop.time() >= deadline:
                 raise AgentSandboxCreateVerificationError(

--- a/clients/integrations/nemo-gym/pyproject.toml
+++ b/clients/integrations/nemo-gym/pyproject.toml
@@ -13,7 +13,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
-# Inherited floor: nemo-gym itself requires >=3.13.14.
+# Inherited floor: this mirrors nemo-gym's PUBLISHED metadata verbatim —
+# nemo-gym 0.5.1 on PyPI declares requires-python >=3.13.14 (pip/uv reject
+# 3.13.x below that micro version at resolve time). That is likely an upstream
+# typo for >=3.13.1, but declaring a looser floor here would only trade our
+# clear error for a confusing nemo-gym resolution failure. Relax this (and the
+# min_python gate in dev/tools/test-unit) when nemo-gym relaxes theirs.
 requires-python = ">=3.13.14"
 dependencies = [
     # The provider instantiates NeMo Gym's provider-neutral types (SandboxHandle,

--- a/clients/integrations/nemo-gym/pyproject.toml
+++ b/clients/integrations/nemo-gym/pyproject.toml
@@ -24,9 +24,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/kubernetes-sigs/agent-sandbox/clients/integrations/nemo-gym"
+Homepage = "https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/nemo-gym"
 Repository = "https://github.com/kubernetes-sigs/agent-sandbox"
-Documentation = "https://github.com/kubernetes-sigs/agent-sandbox/clients/integrations/nemo-gym"
+Documentation = "https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/nemo-gym"
 
 # NeMo Gym discovers third-party sandbox providers through this entry-point group
 # (see nemo_gym/sandbox/providers/registry.py). Installing this package next to

--- a/clients/integrations/nemo-gym/pyproject.toml
+++ b/clients/integrations/nemo-gym/pyproject.toml
@@ -13,19 +13,21 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
-# Inherited floor: this mirrors nemo-gym's PUBLISHED metadata verbatim —
-# nemo-gym 0.5.0 on PyPI declares requires-python >=3.13.14 (pip/uv reject
-# 3.13.x below that micro version at resolve time). That is likely an upstream
-# typo for >=3.13.1, but declaring a looser floor here would only trade our
-# clear error for a confusing nemo-gym resolution failure. Relax this (and the
-# min_python gate in dev/tools/test-unit) when nemo-gym relaxes theirs.
-requires-python = ">=3.13.14"
+# This package's own floor. nemo-gym publishes requires-python >=3.13.14 —
+# no released 3.13.x satisfies that (3.14+ does), and it appears in upstream's
+# source pyproject too, so it is likely a typo for >=3.13.1 that only they can
+# fix. We deliberately do NOT mirror it: on 3.13.x pip surfaces the rejection
+# from nemo-gym's own metadata, and this wheel starts working the moment
+# upstream relaxes theirs — no re-release needed here.
+requires-python = ">=3.13"
 dependencies = [
     # The provider instantiates NeMo Gym's provider-neutral types (SandboxHandle,
     # SandboxExecResult, ...) and error classes; the SandboxProvider protocol and the
     # entry-point registry both ship in nemo-gym 0.5.0.
     "nemo-gym>=0.5.0",
-    "k8s-agent-sandbox[async]~=0.5.0",
+    # ~=0.5.1: create_sandbox(volume_claim_templates=...) landed in 0.5.1 and the
+    # provider passes it unconditionally.
+    "k8s-agent-sandbox[async]~=0.5.1",
 ]
 
 [project.urls]

--- a/clients/integrations/nemo-gym/pyproject.toml
+++ b/clients/integrations/nemo-gym/pyproject.toml
@@ -1,0 +1,62 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nemo-gym-k8s-agent-sandbox"
+description = "NVIDIA NeMo Gym sandbox provider backed by Kubernetes agent-sandbox warm pools."
+readme = "README.md"
+
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dynamic = ["version"]
+# Inherited floor: nemo-gym itself requires >=3.13.14.
+requires-python = ">=3.13.14"
+dependencies = [
+    # The provider instantiates NeMo Gym's provider-neutral types (SandboxHandle,
+    # SandboxExecResult, ...) and error classes; the SandboxProvider protocol and the
+    # entry-point registry both ship in nemo-gym 0.5.0.
+    "nemo-gym>=0.5.0",
+    "k8s-agent-sandbox[async]~=0.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/kubernetes-sigs/agent-sandbox/clients/integrations/nemo-gym"
+Repository = "https://github.com/kubernetes-sigs/agent-sandbox"
+Documentation = "https://github.com/kubernetes-sigs/agent-sandbox/clients/integrations/nemo-gym"
+
+# NeMo Gym discovers third-party sandbox providers through this entry-point group
+# (see nemo_gym/sandbox/providers/registry.py). Installing this package next to
+# nemo-gym makes `agent_sandbox` a valid provider name with no registration code.
+[project.entry-points."nemo_gym.sandbox_providers"]
+agent_sandbox = "nemo_gym_k8s_agent_sandbox.provider:AgentSandboxProvider"
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["nemo_gym_k8s_agent_sandbox*"]
+exclude = ["tests*"]
+
+[tool.setuptools.exclude-package-data]
+# setuptools_scm automatically bundles tracked files as package data.
+# We need to explicitly exclude test directories and files from being bundled.
+"*" = ["test/*", "tests/*", "*/test/*", "*/tests/*", "test_*.py", "*_test.py"]
+
+[tool.setuptools_scm]
+root = "../../.."
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/clients/integrations/nemo-gym/pyproject.toml
+++ b/clients/integrations/nemo-gym/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 # Inherited floor: this mirrors nemo-gym's PUBLISHED metadata verbatim —
-# nemo-gym 0.5.1 on PyPI declares requires-python >=3.13.14 (pip/uv reject
+# nemo-gym 0.5.0 on PyPI declares requires-python >=3.13.14 (pip/uv reject
 # 3.13.x below that micro version at resolve time). That is likely an upstream
 # typo for >=3.13.1, but declaring a looser floor here would only trade our
 # clear error for a confusing nemo-gym resolution failure. Relax this (and the

--- a/clients/integrations/nemo-gym/tests/unit/test_provider.py
+++ b/clients/integrations/nemo-gym/tests/unit/test_provider.py
@@ -1,0 +1,479 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the NeMo Gym agent_sandbox provider (fakes only — no cluster)."""
+
+import logging
+import shlex
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("nemo_gym", reason="nemo-gym is required for the provider's base types")
+pytest.importorskip("k8s_agent_sandbox", reason="k8s-agent-sandbox[async] is required")
+httpx = pytest.importorskip("httpx")
+
+from nemo_gym.sandbox.providers.base import SandboxHandle, SandboxSpec, SandboxStatus  # noqa: E402
+
+from k8s_agent_sandbox.exceptions import SandboxNotReadyError  # noqa: E402
+
+from nemo_gym_k8s_agent_sandbox.provider import (  # noqa: E402
+    MANAGED_BY_LABEL,
+    MANAGED_BY_VALUE,
+    SANDBOX_RUNTIME_RETURN_CODE,
+    STAGING_PREFIX,
+    AgentSandboxCreateError,
+    AgentSandboxCreateVerificationError,
+    AgentSandboxProvider,
+    AgentSandboxProviderOptions,
+    _AgentSandboxInstance,
+)
+
+
+def exec_result(stdout: str = "", stderr: str = "", exit_code: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+
+class FakeCommands:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int | None]] = []
+        self.results: deque = deque()
+        self.default = exec_result()
+        self.error: BaseException | None = None
+
+    async def run(self, command: str, timeout: int = 60):
+        self.calls.append((command, timeout))
+        if self.error is not None:
+            raise self.error
+        return self.results.popleft() if self.results else self.default
+
+    def scripts(self) -> list[str]:
+        """The inner `sh -c` script of every wrapped command sent to the runtime."""
+        return [shlex.split(command)[-1] for command, _ in self.calls]
+
+
+class FakeFiles:
+    def __init__(self) -> None:
+        self.written: list[tuple[str, bytes]] = []
+        self.contents: dict[str, bytes] = {}
+        self.write_error: BaseException | None = None
+
+    async def write(self, path: str, content, timeout: int = 60, allow_unsafe_paths: bool = False):
+        if self.write_error is not None:
+            raise self.write_error
+        data = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        self.written.append((path, data))
+        self.contents[path] = data
+
+    async def read(self, path: str, timeout: int = 60, allow_unsafe_paths: bool = False) -> bytes:
+        return self.contents[path]
+
+
+class FakeAsyncSandbox:
+    def __init__(self, claim_name: str = "sandbox-claim-test", sandbox_id: str = "sandbox-abc") -> None:
+        self.claim_name = claim_name
+        self.sandbox_id = sandbox_id
+        self._commands = FakeCommands()
+        self._files = FakeFiles()
+        self.status_result: tuple[str, str] = ("SandboxReady", "")
+        self.status_error: BaseException | None = None
+        self.terminated = 0
+
+    @property
+    def commands(self):
+        return self._commands
+
+    @property
+    def files(self):
+        return self._files
+
+    async def status(self) -> tuple[str, str]:
+        if self.status_error is not None:
+            raise self.status_error
+        return self.status_result
+
+    async def terminate(self) -> None:
+        self.terminated += 1
+
+
+class FakeK8sHelper:
+    def __init__(self) -> None:
+        self.claims: deque = deque()
+
+    async def get_sandbox_claim(self, name: str, namespace: str):
+        return self.claims.popleft() if self.claims else None
+
+
+class FakeClient:
+    def __init__(self, sandbox: FakeAsyncSandbox | None = None) -> None:
+        self.sandbox = sandbox or FakeAsyncSandbox()
+        self.create_error: BaseException | None = None
+        self.create_calls: list[tuple[tuple, dict]] = []
+        self.delete_calls: list[tuple[str, str]] = []
+        self.k8s_helper = FakeK8sHelper()
+        self.closed = 0
+
+    async def create_sandbox(self, *args, **kwargs):
+        self.create_calls.append((args, kwargs))
+        if self.create_error is not None:
+            raise self.create_error
+        return self.sandbox
+
+    async def delete_sandbox(self, claim_name: str, namespace: str = "default") -> None:
+        self.delete_calls.append((claim_name, namespace))
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+NO_PROBE = {"command": None}
+
+
+def make_provider(client: FakeClient | None = None, **kwargs) -> AgentSandboxProvider:
+    kwargs.setdefault("probe", NO_PROBE)
+    provider = AgentSandboxProvider(**kwargs)
+    provider._client = client or FakeClient()
+    return provider
+
+
+def make_handle(sandbox: FakeAsyncSandbox | None = None, **inst_kwargs) -> SandboxHandle:
+    sandbox = sandbox or FakeAsyncSandbox()
+    inst = _AgentSandboxInstance(
+        claim_name=sandbox.claim_name,
+        sandbox_name=sandbox.sandbox_id,
+        namespace=inst_kwargs.pop("namespace", "default"),
+        sandbox=sandbox,
+        **inst_kwargs,
+    )
+    return SandboxHandle(sandbox_id=inst.claim_name, provider_name="agent_sandbox", raw=inst)
+
+
+# ------------------------------------------------------------------------ create
+
+
+async def test_create_uses_default_warmpool_and_maps_spec():
+    client = FakeClient()
+    provider = make_provider(client, create={"warmpool": "default-pool", "namespace": "rl"})
+    spec = SandboxSpec(ttl_s=12.3, ready_timeout_s=90.5, metadata={"run": "rollout-7"})
+
+    handle = await provider.create(spec)
+
+    assert handle.provider_name == "agent_sandbox"
+    assert handle.sandbox_id == client.sandbox.claim_name
+    (args, kwargs) = client.create_calls[0]
+    assert args == ("default-pool",)
+    assert kwargs["namespace"] == "rl"
+    assert kwargs["sandbox_ready_timeout"] == 91
+    assert kwargs["shutdown_after_seconds"] == 13
+    assert kwargs["labels"] == {"run": "rollout-7", MANAGED_BY_LABEL: MANAGED_BY_VALUE}
+
+
+async def test_create_warmpool_resolution_precedence():
+    client = FakeClient()
+    provider = make_provider(
+        client,
+        create={"warmpool": "default-pool", "image_warmpools": {"img:1": "image-pool"}},
+    )
+
+    await provider.create(SandboxSpec(image="img:1"))
+    assert client.create_calls[-1][0] == ("image-pool",)
+
+    await provider.create(SandboxSpec(image="img:1", provider_options={"warmpool": "explicit-pool"}))
+    assert client.create_calls[-1][0] == ("explicit-pool",)
+
+    await provider.create(SandboxSpec(image="unmapped:latest"))
+    assert client.create_calls[-1][0] == ("default-pool",)
+
+
+async def test_create_without_any_warmpool_raises():
+    provider = make_provider()
+    with pytest.raises(AgentSandboxCreateError, match="No warm pool"):
+        await provider.create(SandboxSpec(image="img:1"))
+
+
+async def test_create_rejects_entrypoint():
+    provider = make_provider(create={"warmpool": "pool"})
+    with pytest.raises(AgentSandboxCreateError, match="entrypoint"):
+        await provider.create(SandboxSpec(entrypoint=["/bin/init"]))
+
+
+async def test_create_wraps_runtime_failure():
+    client = FakeClient()
+    client.create_error = SandboxNotReadyError("pool empty and pod never came up")
+    provider = make_provider(client, create={"warmpool": "pool"})
+    with pytest.raises(AgentSandboxCreateError, match="pool"):
+        await provider.create(SandboxSpec())
+
+
+async def test_create_does_not_seed_files():
+    # NeMo Gym's sandbox API uploads spec.files through provider.upload_file()
+    # after create() returns; seeding in create() too would double-write every file.
+    client = FakeClient()
+    provider = make_provider(client, create={"warmpool": "pool"})
+
+    await provider.create(SandboxSpec(files={"/data/task/input.json": '{"k": 1}'}))
+
+    assert client.sandbox._files.written == []
+    assert client.sandbox._commands.calls == []
+
+
+async def test_create_probe_failure_terminates_claim():
+    client = FakeClient()
+    client.sandbox._commands.default = exec_result(stderr="connection refused", exit_code=7)
+    provider = make_provider(
+        client,
+        create={"warmpool": "pool"},
+        probe={"command": "printf ok", "expected_stdout": "ok", "deadline_s": 0.05, "stable_delay_s": 0},
+    )
+
+    with pytest.raises(AgentSandboxCreateVerificationError, match="readiness probe"):
+        await provider.create(SandboxSpec())
+    assert client.sandbox.terminated == 1
+
+
+async def test_create_probe_waits_for_stable_count():
+    client = FakeClient()
+    commands = client.sandbox._commands
+    commands.results.extend([exec_result(exit_code=1), exec_result(stdout="ok"), exec_result(stdout="ok")])
+    provider = make_provider(
+        client,
+        create={"warmpool": "pool"},
+        probe={
+            "command": "printf ok",
+            "expected_stdout": "ok",
+            "deadline_s": 5,
+            "stable_count": 2,
+            "stable_delay_s": 0,
+        },
+    )
+
+    await provider.create(SandboxSpec())
+    assert len(commands.calls) == 3
+
+
+# -------------------------------------------------------------------------- exec
+
+
+async def test_exec_wraps_env_cwd_and_maps_result():
+    sandbox = FakeAsyncSandbox()
+    sandbox._commands.default = exec_result(stdout="out", stderr="err", exit_code=3)
+    provider = make_provider()
+    handle = make_handle(sandbox, env={"BASE": "1"}, workdir="/work")
+
+    result = await provider.exec(handle, "echo hi; false", env={"EXTRA": "a b"}, timeout_s=9.2)
+
+    command, timeout = sandbox._commands.calls[0]
+    shell, dash_c, script = shlex.split(command)
+    assert (shell, dash_c) == ("/bin/sh", "-c")
+    assert script.splitlines() == [
+        "export BASE=1",
+        "export EXTRA='a b'",
+        f"cd /work || exit {SANDBOX_RUNTIME_RETURN_CODE}",
+        "echo hi; false",
+    ]
+    assert timeout == 10
+    assert (result.stdout, result.stderr, result.return_code) == ("out", "err", 3)
+    assert result.error_type is None
+
+
+async def test_exec_cwd_overrides_spec_workdir():
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    handle = make_handle(sandbox, workdir="/work")
+
+    await provider.exec(handle, "pwd", cwd="/elsewhere")
+    assert "cd /elsewhere" in sandbox._commands.scripts()[0]
+
+
+async def test_exec_rejects_invalid_env_name():
+    provider = make_provider()
+    handle = make_handle()
+    with pytest.raises(ValueError, match="environment variable name"):
+        await provider.exec(handle, "true", env={"BAD-NAME": "x"})
+
+
+async def test_exec_timeout_and_runtime_failures_return_sentinel():
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    handle = make_handle(sandbox)
+
+    sandbox._commands.error = httpx.ConnectTimeout("deadline")
+    result = await provider.exec(handle, "sleep 999")
+    assert (result.return_code, result.error_type) == (SANDBOX_RUNTIME_RETURN_CODE, "timeout")
+
+    sandbox._commands.error = httpx.ConnectError("boom")
+    result = await provider.exec(handle, "true")
+    assert (result.return_code, result.error_type) == (SANDBOX_RUNTIME_RETURN_CODE, "sandbox")
+
+    sandbox._commands.error = ZeroDivisionError("bug in caller land")
+    with pytest.raises(ZeroDivisionError):
+        await provider.exec(handle, "true")
+
+
+async def test_exec_warns_and_ignores_user(caplog):
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    handle = make_handle(sandbox)
+
+    with caplog.at_level(logging.WARNING, logger="nemo_gym_k8s_agent_sandbox.provider"):
+        result = await provider.exec(handle, "id", user="root")
+
+    assert result.return_code == 0
+    assert any("user" in record.message for record in caplog.records)
+
+
+# ------------------------------------------------------------------------- files
+
+
+async def test_upload_file_stages_then_copies(tmp_path):
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    # workdir must NOT leak into staging execs: staging names resolve against the
+    # runtime server's own cwd, where the file API drops uploads.
+    handle = make_handle(sandbox, workdir="/work")
+    source = tmp_path / "artifact.bin"
+    source.write_bytes(b"\x00\x01binary")
+
+    await provider.upload_file(handle, source, "/data/out/artifact.bin")
+
+    staging, data = sandbox._files.written[0]
+    assert staging.startswith(STAGING_PREFIX) and "/" not in staging
+    assert data == b"\x00\x01binary"
+    script = sandbox._commands.scripts()[0]
+    assert script == f"mkdir -p /data/out && cp {staging} /data/out/artifact.bin && rm -f {staging}"
+    assert "cd " not in script
+
+
+async def test_upload_file_failure_raises_and_cleans_staging(tmp_path):
+    sandbox = FakeAsyncSandbox()
+    sandbox._commands.results.append(exec_result(stderr="cp: no space", exit_code=1))
+    provider = make_provider()
+    handle = make_handle(sandbox)
+    source = tmp_path / "f"
+    source.write_text("x")
+
+    with pytest.raises(RuntimeError, match="no space"):
+        await provider.upload_file(handle, source, "/data/f")
+
+    # Second exec is the best-effort staging cleanup.
+    assert sandbox._commands.scripts()[1].startswith("rm -f ")
+
+
+async def test_download_file_stages_reads_and_cleans(tmp_path):
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    handle = make_handle(sandbox, workdir="/work")
+    target = tmp_path / "nested" / "result.tar"
+
+    async def fake_read(path, timeout=60, allow_unsafe_paths=False):
+        return b"tarball-bytes"
+
+    sandbox._files.read = fake_read
+
+    await provider.download_file(handle, "/data/result.tar", target)
+
+    scripts = sandbox._commands.scripts()
+    assert scripts[0].startswith("cp /data/result.tar " + STAGING_PREFIX)
+    assert scripts[1].startswith("rm -f " + STAGING_PREFIX)
+    assert target.read_bytes() == b"tarball-bytes"
+
+
+async def test_download_file_missing_source_raises():
+    sandbox = FakeAsyncSandbox()
+    sandbox._commands.results.append(exec_result(stderr="cp: not found", exit_code=1))
+    provider = make_provider()
+    handle = make_handle(sandbox)
+
+    with pytest.raises(RuntimeError, match="not found"):
+        await provider.download_file(handle, "/data/missing", "/tmp/out")
+
+
+# --------------------------------------------------------------------- lifecycle
+
+
+async def test_status_mapping():
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    handle = make_handle(sandbox)
+
+    sandbox.status_result = ("SandboxReady", "")
+    assert await provider.status(handle) == SandboxStatus.RUNNING
+
+    sandbox.status_result = ("SandboxNotReady", "warming up")
+    assert await provider.status(handle) == SandboxStatus.STARTING
+
+    sandbox.status_result = ("SandboxNotFound", "")
+    assert await provider.status(handle) == SandboxStatus.STOPPED
+
+    sandbox.status_error = httpx.ConnectError("apiserver flake")
+    assert await provider.status(handle) == SandboxStatus.UNKNOWN
+
+
+async def test_close_terminates_claim_and_untracks_from_client():
+    client = FakeClient()
+    provider = make_provider(client)
+    handle = make_handle(client.sandbox, namespace="rl")
+
+    await provider.close(handle)
+    assert client.sandbox.terminated == 1
+    # The client's active-sandbox registry entry must be released too, or a long
+    # RL run accumulates one dead handle per rollout.
+    assert client.delete_calls == [(client.sandbox.claim_name, "rl")]
+
+
+async def test_close_wait_deleted_polls_until_gone():
+    client = FakeClient()
+    client.k8s_helper.claims.append({"metadata": {"name": "still-there"}})
+    provider = make_provider(
+        client,
+        operations={"close_wait_deleted": True, "close_timeout_s": 5, "poll_interval_s": 0.01},
+    )
+    handle = make_handle(client.sandbox)
+
+    await provider.close(handle)
+    assert client.sandbox.terminated == 1
+    assert not client.k8s_helper.claims
+
+
+async def test_aclose_closes_client_and_blocks_reuse():
+    client = FakeClient()
+    provider = make_provider(client, create={"warmpool": "pool"})
+
+    await provider.aclose()
+    await provider.aclose()  # idempotent
+
+    assert client.closed == 1
+    with pytest.raises(RuntimeError, match="closed"):
+        await provider.create(SandboxSpec())
+
+
+# ----------------------------------------------------------------------- options
+
+
+def test_provider_options_reject_unknown_keys():
+    with pytest.raises(ValueError, match="Unknown agent_sandbox provider_options"):
+        AgentSandboxProviderOptions.from_mapping({"warmpool": "p", "policy": {}})
+
+
+def test_provider_name_matches_entry_point():
+    assert AgentSandboxProvider.name == "agent_sandbox"
+
+
+def test_connection_config_validation():
+    with pytest.raises(ValueError, match="connection.mode"):
+        make_provider(connection={"mode": "carrier-pigeon"})
+    with pytest.raises(ValueError, match="api_url"):
+        make_provider(connection={"mode": "direct"})
+    with pytest.raises(ValueError, match="gateway_name"):
+        make_provider(connection={"mode": "gateway"})

--- a/clients/integrations/nemo-gym/tests/unit/test_provider.py
+++ b/clients/integrations/nemo-gym/tests/unit/test_provider.py
@@ -228,6 +228,17 @@ async def test_create_rejects_entrypoint():
         await provider.create(SandboxSpec(entrypoint=["/bin/init"]))
 
 
+async def test_create_wraps_bad_provider_options():
+    # Both the ValueError (unknown key) and TypeError (wrong shape) paths out of
+    # from_mapping must surface as AgentSandboxCreateError, so callers catching
+    # SandboxCreateError see bad provider_options like every other caller error.
+    provider = make_provider(create={"warmpool": "pool"})
+    with pytest.raises(AgentSandboxCreateError, match="invalid provider_options.*bogus"):
+        await provider.create(SandboxSpec(provider_options={"bogus": 1}))
+    with pytest.raises(AgentSandboxCreateError, match="invalid provider_options.*pod_labels"):
+        await provider.create(SandboxSpec(provider_options={"pod_labels": "not-a-mapping"}))
+
+
 async def test_create_wraps_runtime_failure():
     client = FakeClient()
     client.create_error = SandboxNotReadyError("pool empty and pod never came up")

--- a/clients/integrations/nemo-gym/tests/unit/test_provider.py
+++ b/clients/integrations/nemo-gym/tests/unit/test_provider.py
@@ -242,6 +242,31 @@ async def test_create_probe_failure_terminates_claim():
     assert client.sandbox.terminated == 1
 
 
+async def test_create_rejects_non_positive_ttl_and_ready_timeout():
+    provider = make_provider(create={"warmpool": "pool"})
+    with pytest.raises(AgentSandboxCreateError, match="ttl_s"):
+        await provider.create(SandboxSpec(ttl_s=0))
+    with pytest.raises(AgentSandboxCreateError, match="ready_timeout_s"):
+        await provider.create(SandboxSpec(ready_timeout_s=-1))
+
+
+async def test_probe_runs_without_cwd_env_wrapping():
+    # The probe must test runtime reachability only: a spec.workdir that the agent
+    # has not created yet (or a spec.env export) must not fail a healthy sandbox.
+    client = FakeClient()
+    client.sandbox._commands.default = exec_result(stdout="ok")
+    provider = make_provider(
+        client,
+        create={"warmpool": "pool"},
+        probe={"command": "printf ok", "expected_stdout": "ok", "deadline_s": 5, "stable_delay_s": 0},
+    )
+
+    await provider.create(SandboxSpec(workdir="/not-created-yet", env={"FOO": "bar"}))
+
+    probe_script = client.sandbox._commands.scripts()[0]
+    assert probe_script == "printf ok"
+
+
 async def test_create_probe_waits_for_stable_count():
     client = FakeClient()
     commands = client.sandbox._commands
@@ -389,14 +414,14 @@ async def test_download_file_stages_reads_and_cleans(tmp_path):
     assert target.read_bytes() == b"tarball-bytes"
 
 
-async def test_download_file_missing_source_raises():
+async def test_download_file_missing_source_raises(tmp_path):
     sandbox = FakeAsyncSandbox()
     sandbox._commands.results.append(exec_result(stderr="cp: not found", exit_code=1))
     provider = make_provider()
     handle = make_handle(sandbox)
 
     with pytest.raises(RuntimeError, match="not found"):
-        await provider.download_file(handle, "/data/missing", "/tmp/out")
+        await provider.download_file(handle, "/data/missing", tmp_path / "out")
 
 
 # --------------------------------------------------------------------- lifecycle
@@ -471,7 +496,7 @@ def test_provider_name_matches_entry_point():
 
 
 def test_connection_config_validation():
-    with pytest.raises(ValueError, match="connection.mode"):
+    with pytest.raises(ValueError, match=r"connection\.mode"):
         make_provider(connection={"mode": "carrier-pigeon"})
     with pytest.raises(ValueError, match="api_url"):
         make_provider(connection={"mode": "direct"})

--- a/clients/integrations/nemo-gym/tests/unit/test_provider.py
+++ b/clients/integrations/nemo-gym/tests/unit/test_provider.py
@@ -287,6 +287,25 @@ async def test_create_probe_waits_for_stable_count():
     assert len(commands.calls) == 3
 
 
+async def test_create_probe_without_deadline_retries_failures():
+    # deadline_s=None means no time bound, not single-attempt: a probe that fails
+    # while the runtime server is still starting must keep polling until it
+    # accumulates stable_count consecutive passes.
+    client = FakeClient()
+    commands = client.sandbox._commands
+    commands.results.extend(
+        [exec_result(exit_code=1), exec_result(stderr="connection refused", exit_code=7), exec_result(stdout="ok")]
+    )
+    provider = make_provider(
+        client,
+        create={"warmpool": "pool"},
+        probe={"command": "printf ok", "expected_stdout": "ok", "deadline_s": None, "stable_delay_s": 0},
+    )
+
+    await provider.create(SandboxSpec())
+    assert len(commands.calls) == 3
+
+
 # -------------------------------------------------------------------------- exec
 
 

--- a/clients/integrations/nemo-gym/tests/unit/test_provider.py
+++ b/clients/integrations/nemo-gym/tests/unit/test_provider.py
@@ -346,6 +346,26 @@ async def test_exec_timeout_and_runtime_failures_return_sentinel():
         await provider.exec(handle, "true")
 
 
+async def test_exec_runtime_error_scoping():
+    # Bare RuntimeError from the command executor (malformed runtime response)
+    # is a sandbox failure at the exec call site only...
+    sandbox = FakeAsyncSandbox()
+    provider = make_provider()
+    handle = make_handle(sandbox)
+
+    sandbox._commands.error = RuntimeError("Failed to decode JSON response from sandbox")
+    result = await provider.exec(handle, "true")
+    assert (result.return_code, result.error_type) == (SANDBOX_RUNTIME_RETURN_CODE, "sandbox")
+
+    # ...but RuntimeError *subclasses* from unrelated code are not swallowed.
+    class NotASandboxProblem(RuntimeError):
+        pass
+
+    sandbox._commands.error = NotASandboxProblem("programming bug")
+    with pytest.raises(NotASandboxProblem):
+        await provider.exec(handle, "true")
+
+
 async def test_exec_warns_and_ignores_user(caplog):
     sandbox = FakeAsyncSandbox()
     provider = make_provider()
@@ -443,6 +463,12 @@ async def test_status_mapping():
 
     sandbox.status_error = httpx.ConnectError("apiserver flake")
     assert await provider.status(handle) == SandboxStatus.UNKNOWN
+
+    # A bare RuntimeError outside the exec path is a programming bug: propagate,
+    # don't misreport the sandbox as UNKNOWN.
+    sandbox.status_error = RuntimeError("bug in status handling")
+    with pytest.raises(RuntimeError, match="bug in status handling"):
+        await provider.status(handle)
 
 
 async def test_close_terminates_claim_and_untracks_from_client():

--- a/clients/integrations/nemo-gym/tests/unit/test_provider.py
+++ b/clients/integrations/nemo-gym/tests/unit/test_provider.py
@@ -202,6 +202,26 @@ async def test_create_without_any_warmpool_raises():
         await provider.create(SandboxSpec(image="img:1"))
 
 
+async def test_create_advisory_warnings_dedup_across_rollouts(caplog):
+    # An RL run calls create() once per rollout with near-identical specs; the
+    # default-pool and ignored-resources warnings must fire once per distinct
+    # cause, not once per create.
+    client = FakeClient()
+    provider = make_provider(client, create={"warmpool": "default-pool"})
+    spec = SandboxSpec(image="unmapped:latest", resources={"cpu": 2})
+
+    with caplog.at_level(logging.WARNING, logger="nemo_gym_k8s_agent_sandbox.provider"):
+        await provider.create(spec)
+        await provider.create(spec)
+        await provider.create(SandboxSpec(image="other:latest", resources={"gpu": 1}))
+
+    pool_warnings = [r for r in caplog.records if "image_warmpools" in r.message]
+    resource_warnings = [r for r in caplog.records if "resource requests" in r.message]
+    # Once per distinct image / distinct ignored-resource set, not per create.
+    assert len(pool_warnings) == 2
+    assert len(resource_warnings) == 2
+
+
 async def test_create_rejects_entrypoint():
     provider = make_provider(create={"warmpool": "pool"})
     with pytest.raises(AgentSandboxCreateError, match="entrypoint"):

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -101,7 +101,19 @@ PYTHON_TEST_SUITES = [
             (os.path.join("clients", "python", "agentic-sandbox-client"), ""),
             (os.path.join("clients", "integrations", "gymnasium"), "[test]"),
         ]
-    }
+    },
+    {
+        "name": "integrations-nemo-gym",
+        "dir": os.path.join("clients", "integrations", "nemo-gym"),
+        # The nemo-gym PyPI package (a hard dependency of this integration)
+        # requires Python >= 3.13.14, so the suite skips on older interpreters
+        # instead of failing the venv install.
+        "min_python": (3, 13, 14),
+        "editable_installs": [
+            (os.path.join("clients", "python", "agentic-sandbox-client"), "[async]"),
+            (os.path.join("clients", "integrations", "nemo-gym"), "[test]"),
+        ],
+    },
 ]
 
 
@@ -132,6 +144,13 @@ def run_python_tests(repo_root, artifact_dir):
         test_dir = os.path.join(repo_root, suite["dir"])
         if not os.path.isdir(test_dir):
             print(f"WARNING: Python test directory not found, skipping: {test_dir}")
+            continue
+
+        min_python = suite.get("min_python")
+        if min_python and sys.version_info < min_python:
+            wanted = ".".join(str(part) for part in min_python)
+            running = ".".join(str(part) for part in sys.version_info[:3])
+            print(f"WARNING: Skipping {suite['name']} tests: requires Python >= {wanted}, running {running}")
             continue
 
         venv_dir = os.path.join(repo_root, "bin", f"python-venv-{suite['name']}")

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -105,10 +105,13 @@ PYTHON_TEST_SUITES = [
     {
         "name": "integrations-nemo-gym",
         "dir": os.path.join("clients", "integrations", "nemo-gym"),
-        # The nemo-gym PyPI package (a hard dependency of this integration)
-        # requires Python >= 3.13.14, so the suite skips on older interpreters
-        # instead of failing the venv install.
-        "min_python": (3, 13, 14),
+        # The integration itself needs Python >= 3.13. nemo-gym publishes
+        # requires-python >=3.13.14 — no released 3.13.x satisfies that (3.14+
+        # does) — so pre-install it past its floor; the editable install below
+        # then sees the requirement already satisfied. Drop the pre_install
+        # when nemo-gym relaxes its floor.
+        "min_python": (3, 13),
+        "pre_installs": [["--ignore-requires-python", "nemo-gym>=0.5.0"]],
         "editable_installs": [
             (os.path.join("clients", "python", "agentic-sandbox-client"), "[async]"),
             (os.path.join("clients", "integrations", "nemo-gym"), "[test]"),
@@ -169,6 +172,13 @@ def run_python_tests(repo_root, artifact_dir):
         env = os.environ.copy()
         if not os.environ.get("PIP_EXTRA_INDEX_URL"):
             env.pop("PIP_EXTRA_INDEX_URL", None)
+
+        # Pre-installs run before editable installs so the resolver sees these
+        # requirements as already satisfied (e.g. forcing a package past a broken
+        # published requires-python floor).
+        for pre_install_args in suite.get("pre_installs", []):
+            subprocess.check_call(
+                [venv_pip, "install", "--quiet", *pre_install_args], env=env)
 
         req_name = suite.get("requirements")
         req_file = os.path.join(test_dir, req_name) if req_name else None

--- a/site/content/docs/use-cases/examples/nemo-gym/_index.md
+++ b/site/content/docs/use-cases/examples/nemo-gym/_index.md
@@ -1,0 +1,8 @@
+---
+title: "NVIDIA NeMo Gym Sandbox Provider"
+linkTitle: "NVIDIA NeMo Gym Sandbox Provider"
+weight: 2
+description: >
+  Run NVIDIA NeMo Gym RL training environments on Agent Sandbox warm pools. Installing the nemo-gym-k8s-agent-sandbox package registers the agent_sandbox sandbox provider through NeMo Gym's entry-point registry — no NeMo Gym fork required.
+---
+{{% include-file file="additional/integrations-nemo-gym/README.md" %}}

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -159,6 +159,10 @@ module:
     target: assets/additional/go-client
     files: ["README.md"]
   - disableWatch: true
+    source: ../clients/integrations/nemo-gym
+    target: assets/additional/integrations-nemo-gym
+    files: ["README.md"]
+  - disableWatch: true
     source: ../docs
     target: assets/additional/docs
     files: ["testing.md", "api.md", "api-migration-guide.md", "python_sdk_reference.md", "go_sdk_reference.md"]


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `clients/integrations/nemo-gym`, a Python package (`nemo-gym-k8s-agent-sandbox`) that makes Agent Sandbox a sandbox backend for [NVIDIA NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) RL training environments, alongside NeMo Gym's built-in providers (Docker, Daytona, ECS Fargate, Enroot, OpenShell, OpenSandbox, Apptainer).

NeMo Gym discovers third-party providers through its `nemo_gym.sandbox_providers` entry-point group, so installing this package next to `nemo-gym` makes `agent_sandbox` a valid provider name with no registration code and no NeMo Gym fork.

Design highlights:
- **Warm-pool claims**: sandboxes are checked out via SandboxClaim -> SandboxWarmPool, so per-rollout acquisition is claim-bind latency rather than pod start. Images route to pools through a `create.image_warmpools` mapping (claims are `warmPoolRef`-only in v1beta1).
- **TTL safety net**: NeMo Gym's `ttl_s` maps to the claim lifecycle `shutdownTime` with `Delete` policy, so the controller GCs sandboxes even if the training process dies.
- **Runtime API adaptation**: the in-sandbox runtime execs via `shlex.split` with no shell, and its file API only accepts relative paths — commands are wrapped in `sh -c` scripts (cwd/env folded in, all user input shell-quoted), and absolute-path file transfers stage through flat temp names.
- **Readiness probe**: a bound claim proves the pod is Ready, not that the runtime HTTP server (or a gateway route) is reachable, so create polls a cheap exec before handing the sandbox out.

Layout, naming, and packaging follow `clients/integrations/deepagents`. Includes 29 unit tests (fakes only, no cluster), an annotated NeMo Gym provider config, and a README documenting the spec-field mapping and limitations (no endpoint resolution / `ConnectableProvider` support yet; `entrypoint`/`user`/`resources` are template-owned).

**Note for reviewers**: the provider requires `k8s-agent-sandbox~=0.5.1` — `create_sandbox(volume_claim_templates=...)` landed in 0.5.1 — and always passes `AsyncSandboxClient(cleanup=...)` explicitly, since the client's own default flipped from `False` (0.5.0) to `True` (0.5.1).

#### Which issue(s) this PR is related to:

<!-- none -->

#### Release Note

```release-note
Added a NeMo Gym integration (`clients/integrations/nemo-gym`): installing the `nemo-gym-k8s-agent-sandbox` package registers Agent Sandbox warm pools as the `agent_sandbox` sandbox provider in NVIDIA NeMo Gym.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an NVIDIA NeMo Gym provider for Kubernetes-based agent sandboxes.
  * Supports sandbox creation, readiness checks, command execution, file transfers, status reporting, and cleanup.
  * Added configurable connection modes, warm pools, namespaces, images, timeouts, probes, and lifecycle options.
  * Added packaging and installation support.

* **Documentation**
  * Added setup, usage, configuration, runtime behavior, limitations, and development guidance.

* **Tests**
  * Added comprehensive coverage for sandbox lifecycle, execution, file operations, validation, errors, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
