### PR TITLE
test(benchmarks): extend kops cluster validation timeout to 15m

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -302,7 +302,7 @@ echo "Exporting kubeconfig..."
 kops export kubeconfig --name "${CLUSTER_NAME}" --admin
 
 echo "Waiting for cluster to be ready..."
-kops validate cluster --wait 10m
+kops validate cluster --wait 15m
 
 if [[ "${CNI}" == "cilium" ]]; then
   # Raise Cilium's endpoint-create API rate limit. The agent rate-limits


### PR DESCRIPTION
#### What this PR does / why we need it:
The kOps GCP benchmark suite (`test/benchmarks/scenarios/benchmarks-kops-gcp/run`) provisions a 20-worker-node cluster (`n2-standard-8`) alongside a 22-core control plane (`c3-standard-22`).

Under Boskos shared GCE resource pool conditions, allocating 21 VMs, configuring GCP external load balancer forwarding rules, and waiting for all 20 worker nodes and the control plane to reach `Ready` state and respond to validation calls often takes 11–13 minutes. 

The previous hardcoded `kops validate cluster --wait 10m` timeout frequently causes presubmit jobs (`presubmit-agent-sandbox-benchmarks-kops-gcp-*`) to flake with `wait time exceeded during validation` before benchmark executions begin.

This PR extends the validation timeout from `10m` to `15m` to ensure sufficient buffer for 20-node GCP cluster convergence and eliminate presubmit flakes.

block: https://github.com/kubernetes-sigs/agent-sandbox/pull/1314


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the cluster readiness validation timeout to 15 minutes to better accommodate longer startup times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->