### PR TITLE
fix(controllers): pass correct pod error to computeSuspendedCondition

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -355,8 +355,8 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	allErrors = errors.Join(allErrors, err)
 
 	// Reconcile Pod
-	pod, err := r.reconcilePod(ctx, sandbox, nameHash, wd)
-	allErrors = errors.Join(allErrors, err)
+	pod, podErr := r.reconcilePod(ctx, sandbox, nameHash, wd)
+	allErrors = errors.Join(allErrors, podErr)
 
 	if pod == nil {
 		sandbox.Status.PodIPs = nil
@@ -373,11 +373,11 @@ func (r *SandboxReconciler) reconcileChildResources(ctx context.Context, sandbox
 	}
 
 	// Reconcile Service
-	svc, err := r.reconcileService(ctx, sandbox, nameHash)
-	allErrors = errors.Join(allErrors, err)
+	svc, svcErr := r.reconcileService(ctx, sandbox, nameHash)
+	allErrors = errors.Join(allErrors, svcErr)
 
 	// compute and set overall conditions
-	conditions := r.computeConditions(sandbox, allErrors, svc, pod, err)
+	conditions := r.computeConditions(sandbox, allErrors, svc, pod, podErr)
 	hasFinished := false
 	for _, condition := range conditions {
 		meta.SetStatusCondition(&sandbox.Status.Conditions, condition)


### PR DESCRIPTION
#### What this PR does / why we need it:

In `reconcileChildResources`, the `err` variable was reused for both `reconcilePod` and `reconcileService` return values. By the time `computeConditions` was called, `err` held the service error, which was then passed as the `podErr` parameter.

This caused `computeSuspendedCondition` to receive a service reconciliation error instead of the pod error. When `reconcileService` failed on a cleanly-suspended sandbox (pod == nil), the Suspended condition incorrectly flipped to `Unknown` with "Pod state is unknown" — even though the pod state was fully known (absent).

Fix: capture pod and service errors in separate variables (`podErr`, `svcErr`) and pass the correct one to `computeConditions`.

#### Which issue(s) this PR is related to:
N/A

#### Release Note
```release-note
Fixed Suspended condition incorrectly reporting Unknown when service reconciliation failed on a suspended sandbox.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for sandbox resources by preserving distinct Pod and Service reconciliation errors.
  * Sandbox conditions now accurately reflect Pod-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->