### PR TITLE
fix(sandboxd): kill process group on context cancellation to prevent orphan leaks

### DIFF
--- a/packages/sandboxd/pkg/server/process.go
+++ b/packages/sandboxd/pkg/server/process.go
@@ -23,11 +23,14 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -39,20 +42,19 @@ import (
 // mapCommandError converts command execution errors (e.g. missing binary or
 // permission denied) into appropriate gRPC status codes (NOT_FOUND,
 // PERMISSION_DENIED) instead of generic INTERNAL error codes.
-func mapCommandError(err error, defaultCode codes.Code, msg string) error {
+func mapCommandError(err error, msg string) error {
 	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
 		return status.Errorf(codes.NotFound, "%s: command or path not found: %v", msg, err)
 	}
 	if errors.Is(err, fs.ErrPermission) {
 		return status.Errorf(codes.PermissionDenied, "%s: permission denied: %v", msg, err)
 	}
-	return status.Errorf(defaultCode, "%s: %v", msg, err)
+	return status.Errorf(codes.Internal, "%s: %v", msg, err)
 }
 
 // defaultStreamChunkSize is the default read buffer size for stdout/stderr
 // streaming, overridable via the --stream-chunk-size daemon flag. Timing
-// constants (waitDelay, pipeDrainGrace, ...) are collected in one block in
-// server.go.
+// constants (pipeDrainGrace, ...) are collected in one block in server.go.
 const defaultStreamChunkSize = 4096
 
 // ProcessServer implements the ProcessService gRPC API defined in
@@ -62,35 +64,47 @@ type ProcessServer struct {
 	rootDir         string
 	registry        *processmanager.ProcessRegistry
 	streamChunkSize int
+	log             logr.Logger
 }
 
 // NewProcessServer builds a ProcessServer rooted at rootDir. rootDir must be
 // non-empty. A nil registry gets a fresh one, but callers normally share the
 // daemon-wide registry so shutdown can signal every child. A non-positive
 // streamChunkSize selects the default.
-func NewProcessServer(rootDir string, registry *processmanager.ProcessRegistry, streamChunkSize int) *ProcessServer {
+func NewProcessServer(rootDir string, registry *processmanager.ProcessRegistry, streamChunkSize int, log logr.Logger) *ProcessServer {
 	if registry == nil {
 		registry = processmanager.NewProcessRegistry()
 	}
 	if streamChunkSize <= 0 {
 		streamChunkSize = defaultStreamChunkSize
 	}
+	// Default a nil/zero-value logger to Discard so that s.log.Error
+	// calls in killProcessGroupOnContextDone never panic.
+	if log.GetSink() == nil {
+		log = logr.Discard()
+	}
 	return &ProcessServer{
 		rootDir:         rootDir,
 		registry:        registry,
 		streamChunkSize: streamChunkSize,
+		log:             log,
 	}
 }
 
-// buildCommand translates a ProcessConfig into an exec.Cmd bound to ctx,
-// with env merged over the daemon environment and cwd confined to rootDir.
-func (s *ProcessServer) buildCommand(ctx context.Context, config *processv1.ProcessConfig) (*exec.Cmd, error) {
+// buildCommand translates a ProcessConfig into an exec.Cmd with env merged
+// over the daemon environment and cwd confined to rootDir.
+//
+// Unlike exec.CommandContext, this does NOT install Go's default context
+// cancellation handler (which only sends SIGKILL to the child PID). Callers
+// are responsible for killing the process group on context cancellation —
+// see killProcessGroupOnContextDone — so that grandchildren are reaped too.
+func (s *ProcessServer) buildCommand(_ context.Context, config *processv1.ProcessConfig) (*exec.Cmd, error) {
 	if config == nil || len(config.GetCommand()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "command is required")
 	}
 
 	command := config.GetCommand()
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	cmd := exec.Command(command[0], command[1:]...)
 
 	// A nil cmd.Env inherits the daemon environment automatically, so it is
 	// only materialized when the request adds vars. Request vars are
@@ -143,13 +157,18 @@ func (s *ProcessServer) Start(req *processv1.StartRequest, stream processv1.Proc
 
 	usePTY := req.GetPty() != nil
 	if usePTY {
+		// Bail out early if the client already disconnected — no point
+		// forking a process we would immediately have to kill.
+		if err := stream.Context().Err(); err != nil {
+			return status.FromContextError(err).Err()
+		}
 		// creack/pty sets Setsid on the child, which already places it in
 		// its own process group (pgid == pid), so process-group signalling
 		// works without Setpgid. Setting both would make fork fail with
 		// EPERM (setpgid is illegal on a session leader).
 		ptyFile, err = pty.Start(cmd)
 		if err != nil {
-			return mapCommandError(err, codes.Internal, "failed to start command with PTY")
+			return mapCommandError(err, "failed to start command with PTY")
 		}
 		proc.PTY = ptyFile
 		proc.Stdin = ptyFile
@@ -175,9 +194,15 @@ func (s *ProcessServer) Start(req *processv1.StartRequest, stream processv1.Proc
 		cmd.Stdout, cmd.Stderr, cmd.Stdin = stdoutW, stderrW, stdinR
 		proc.Stdin = stdinW
 
+		// Bail out early if the client already disconnected.
+		if err := stream.Context().Err(); err != nil {
+			closeAll(stdoutR, stdoutW, stderrR, stderrW, stdinR, stdinW)
+			return status.FromContextError(err).Err()
+		}
+
 		if err := cmd.Start(); err != nil {
 			closeAll(stdoutR, stdoutW, stderrR, stderrW, stdinR, stdinW)
-			return mapCommandError(err, codes.Internal, "failed to start command")
+			return mapCommandError(err, "failed to start command")
 		}
 		// Process owns its write end copies; close ours so readers get EOF.
 		closeAll(stdoutW, stderrW, stdinR)
@@ -188,6 +213,11 @@ func (s *ProcessServer) Start(req *processv1.StartRequest, stream processv1.Proc
 	// registry.
 	s.registry.Register(proc)
 	defer s.registry.Remove(pid)
+
+	// Kill the entire process group (not just the child PID) when the
+	// stream context is cancelled (client disconnects). This prevents
+	// grandchildren from becoming orphan processes.
+	s.killProcessGroupOnContextDone(stream.Context(), cmd, proc.Done)
 
 	// Set initial TTY size if requested.
 	if usePTY && req.GetPty().GetCols() > 0 && req.GetPty().GetRows() > 0 {
@@ -207,6 +237,7 @@ func (s *ProcessServer) Start(req *processv1.StartRequest, stream processv1.Proc
 		go func() {
 			_ = cmd.Wait()
 			_ = proc.ClosePTY()
+			close(proc.Done) // release the cancellation watcher so it doesn't leak
 		}()
 		return status.Errorf(codes.Internal, "failed to send InitEvent: %v", err)
 	}
@@ -284,6 +315,7 @@ func (s *ProcessServer) Start(req *processv1.StartRequest, stream processv1.Proc
 	}
 
 	proc.SetExitCode(exitCode)
+	closeAll(stdinW) // close stdin pipe; safe no-op if nil (PTY path)
 	close(proc.Done)
 
 	if err := stream.Send(&processv1.StartResponse{
@@ -309,15 +341,38 @@ func (s *ProcessServer) Execute(ctx context.Context, req *processv1.ExecuteReque
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 
-	runErr := cmd.Run()
+	// Bail out early if the caller's context is already cancelled.
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, mapCommandError(err, "failed to execute command")
+	}
+
+	// Kill the entire process group on context cancellation. Use a local
+	// done channel since Execute does not register in the process registry.
+	execDone := make(chan struct{})
+	defer close(execDone)
+	s.killProcessGroupOnContextDone(ctx, cmd, execDone)
+
+	runErr := cmd.Wait()
 	exitCode := int32(0)
 	if runErr != nil {
 		var exitErr *exec.ExitError
 		if errors.As(runErr, &exitErr) {
 			exitCode = int32(exitErr.ExitCode())
 		} else {
-			return nil, mapCommandError(runErr, codes.Internal, "failed to execute command")
+			return nil, mapCommandError(runErr, "failed to execute command")
 		}
+	}
+
+	// The command may have been killed by killProcessGroupOnContextDone
+	// because the caller's context was cancelled. Surface that as a gRPC
+	// cancellation rather than a normal (successful) response with a
+	// non-zero exit code.
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
 	}
 
 	return &processv1.ExecuteResponse{
@@ -399,4 +454,108 @@ func closeAll(files ...*os.File) {
 			_ = f.Close()
 		}
 	}
+}
+
+// killProcessGroupOnContextDone starts a goroutine that terminates the
+// command's entire process tree when ctx is cancelled. This replaces the
+// default exec.CommandContext behaviour (which only sends SIGKILL to the
+// child PID) so that grandchildren are reaped as well. The goroutine exits
+// when ctx is done OR when the process exits (done closed), whichever comes
+// first.
+//
+// The kill strategy is layered to work across container runtimes:
+//
+//  1. syscall.Kill(-PGID, SIGKILL) — signals the whole process group in one
+//     shot. Works on real Linux where Setpgid/Setsid places the child and
+//     its descendants in the same process group.
+//  2. /proc descendant scan — walks /proc to find children of the command
+//     PID and kills each recursively. This is the fallback for runtimes
+//     like gVisor (runsc) where process-group signalling does not reliably
+//     propagate to grandchildren.
+//  3. Direct PID kill — last-resort kill of the child PID itself, in case
+//     both of the above failed to reach it.
+//
+// The caller must have set Setpgid (or Setsid via PTY) on the command so
+// that the child and its descendants share a process group.
+func (s *ProcessServer) killProcessGroupOnContextDone(ctx context.Context, cmd *exec.Cmd, done <-chan struct{}) {
+	go func() {
+		select {
+		case <-ctx.Done():
+			// Skip the kill if the child has already been reaped by Wait;
+			// its PID/PGID may have been reused by an unrelated process.
+			select {
+			case <-done:
+				return
+			default:
+			}
+			pid := cmd.Process.Pid
+
+			// Strategy 1: process-group kill (real Linux; reaches all
+			// descendants in one syscall when the runtime honours PGIDs).
+			if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				s.log.Error(err, "failed to kill process group on context cancellation", "pgid", pid)
+			}
+
+			// Strategy 2: walk /proc to find and kill descendants. This
+			// is the fallback for runtimes where negative-PID signalling
+			// does not reach the whole tree (e.g. gVisor). On real Linux
+			// this is mostly a no-op — strategy 1 already killed them —
+			// and any remaining Kill calls return ESRCH which we ignore.
+			s.killDescendants(pid)
+
+			// Strategy 3: direct PID kill as last resort.
+			if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+				s.log.Error(err, "failed to kill child process on context cancellation", "pid", pid)
+			}
+		case <-done:
+		}
+	}()
+}
+
+// killDescendants recursively kills all descendant processes of rootPID by
+// walking /proc. On real Linux, killProcessGroupOnContextDone's strategy 1
+// already killed the tree, so the Kill calls below return ESRCH and are
+// silently skipped. In runtimes like gVisor where PGID kill does not
+// propagate, this ensures grandchildren do not outlive the parent.
+func (s *ProcessServer) killDescendants(rootPID int) {
+	for _, cpid := range readProcChildren(rootPID) {
+		// Recurse first so we kill leaves before their parents — otherwise
+		// a child reaped mid-walk could reparent its children to init
+		// before we get a chance to signal them.
+		s.killDescendants(cpid)
+		if err := syscall.Kill(cpid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			s.log.V(1).Info("failed to kill descendant process", "pid", cpid, "error", err)
+		}
+	}
+}
+
+// readProcChildren returns the direct children of pid by iterating every
+// thread's /proc/<pid>/task/<tid>/children (a Linux-specific interface
+// enabled by CONFIG_PROC_CHILDREN). Children forked by a non-main thread
+// only appear under that thread's TID, so scanning only the main PID
+// would miss grandchildren of multithreaded parents. Returns nil when the
+// directory is unavailable.
+func readProcChildren(pid int) []int {
+	taskDir := fmt.Sprintf("/proc/%d/task", pid)
+	entries, err := os.ReadDir(taskDir)
+	if err != nil {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	var children []int
+	for _, entry := range entries {
+		data, err := os.ReadFile(fmt.Sprintf("%s/%s/children", taskDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		for f := range strings.FieldsSeq(string(data)) {
+			if cpid, err := strconv.Atoi(f); err == nil && cpid > 0 {
+				if _, ok := seen[cpid]; !ok {
+					seen[cpid] = struct{}{}
+					children = append(children, cpid)
+				}
+			}
+		}
+	}
+	return children
 }

--- a/packages/sandboxd/pkg/server/process_test.go
+++ b/packages/sandboxd/pkg/server/process_test.go
@@ -17,14 +17,18 @@ package server
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -45,7 +49,7 @@ func newProcessClient(t *testing.T, rootDir string) processv1.ProcessServiceClie
 	lis := bufconn.Listen(1024 * 1024)
 	grpcServer := grpc.NewServer()
 	processv1.RegisterProcessServiceServer(grpcServer,
-		NewProcessServer(rootDir, processmanager.NewProcessRegistry(), 0))
+		NewProcessServer(rootDir, processmanager.NewProcessRegistry(), 0, logr.Discard()))
 	go func() { _ = grpcServer.Serve(lis) }()
 
 	conn, err := grpc.NewClient("passthrough:///bufnet",
@@ -118,6 +122,57 @@ func testCtx(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+// skipIfGVisor skips the test when running under gVisor (runsc). gVisor does
+// not faithfully reproduce all Linux process-group semantics — negative-PID
+// signalling may not propagate to grandchildren — so tests that assert on
+// grandchild termination cannot pass reliably there. Production uses a
+// layered kill strategy (PGID kill + /proc descendant scan + direct PID
+// kill) to compensate, but the regression tests still need a real kernel
+// to validate the PGID path.
+func skipIfGVisor(t *testing.T) {
+	t.Helper()
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return
+	}
+	if strings.Contains(string(data), "gvisor") || strings.Contains(string(data), "runsc") {
+		t.Skip("process-group semantics unreliable under gVisor; skipping")
+	}
+}
+
+// isProcessDead returns true if the process no longer exists (ESRCH) or is a
+// zombie (state 'Z' in /proc/<pid>/stat). In containers without a proper init
+// process, killed processes may become zombies if their parent doesn't reap
+// them. We treat zombies as "dead" for the purposes of these tests since they
+// are no longer executing and cannot cause harm.
+func isProcessDead(pid int) bool {
+	// First check if process exists at all
+	if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+		return true
+	}
+
+	// On Linux, check if it's a zombie by reading /proc/<pid>/stat
+	// Format: pid (comm) state ...
+	// where state is 'Z' for zombie
+	statPath := fmt.Sprintf("/proc/%d/stat", pid)
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		// If we can't read /proc, assume process is dead (might not exist)
+		return true
+	}
+
+	// Find the state field: it's after the closing paren of comm
+	// comm can contain spaces and parens, so we find the last ')'
+	statStr := string(data)
+	lastParen := strings.LastIndex(statStr, ")")
+	if lastParen < 0 || lastParen+2 >= len(statStr) {
+		return false
+	}
+
+	state := statStr[lastParen+2]
+	return state == 'Z'
 }
 
 func TestExecuteEcho(t *testing.T) {
@@ -352,4 +407,128 @@ func TestResizeTTYWithPTY(t *testing.T) {
 	})
 	require.NoError(t, err)
 	drainStart(t, stream)
+}
+
+// TestStart_KillsGrandchildrenOnCancel verifies that cancelling the stream
+// context terminates not just the child process but also any grandchildren,
+// preventing orphan process leaks.
+func TestStart_KillsGrandchildrenOnCancel(t *testing.T) {
+	skipIfGVisor(t)
+	client := newProcessClient(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Capture the grandchild PID via a temp file rather than stdout, so
+	// that parsing cannot be skipped and the PID is available regardless
+	// of when stdout events are delivered.
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	// Disable job control (set +m) to ensure the backgrounded sleep stays
+	// in the same process group as the parent shell. Background the sleep
+	// so it becomes a grandchild of cmd, then write its PID ($!) to pidFile.
+	// When we SIGKILL -PGID, both the sh process and the backgrounded sleep
+	// must terminate.
+	stream, err := client.Start(ctx, &processv1.StartRequest{
+		Config: &processv1.ProcessConfig{
+			Command: []string{"sh", "-c", "set +m; sleep 86400 & echo $! > " + pidFile + "; wait"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Receive InitEvent to ensure the process is running.
+	_ = recvInit(t, stream)
+
+	// Wait for the PID file to appear (the shell writes it immediately on
+	// entry). Polling is robust to CI scheduling delays.
+	var grandchildPID int
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return false
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || pid <= 0 {
+			return false
+		}
+		grandchildPID = pid
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "grandchild PID file %q never populated", pidFile)
+
+	// Cancel the context to trigger process group kill.
+	cancel()
+
+	// Wait for the stream to end. It may return EOF or a Canceled error.
+	_, err = stream.Recv()
+	require.Error(t, err)
+
+	// Wait for the grandchild to die. The kill goroutine runs asynchronously
+	// after ctx cancellation, so polling is needed to avoid a race between
+	// the client observing the stream error and the server delivering SIGKILL
+	// to the process group. 10s timeout accommodates slow CI runners.
+	require.Eventually(t, func() bool {
+		return isProcessDead(grandchildPID)
+	}, 10*time.Second, 50*time.Millisecond, "grandchild process %d should have been killed", grandchildPID)
+}
+
+// TestExecute_KillsGrandchildrenOnCancel verifies that cancelling the context
+// during Execute terminates the entire process group including grandchildren.
+func TestExecute_KillsGrandchildrenOnCancel(t *testing.T) {
+	skipIfGVisor(t)
+	client := newProcessClient(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Capture the grandchild PID via a temp file rather than stdout.
+	// Execute returns a Canceled error (and resp == nil) on cancellation,
+	// so any stdout-based PID assertion would be vacuously skipped.
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	// Disable job control (set +m) to ensure the backgrounded sleep stays
+	// in the same process group as the parent shell. Background the sleep
+	// so it becomes a grandchild, then write its PID ($!) to pidFile.
+	// When we SIGKILL -PGID, both the sh process and the backgrounded sleep
+	// must terminate.
+	cmd := "set +m; sleep 86400 & echo $! > " + pidFile + "; wait"
+
+	// Start Execute in a goroutine so we can cancel mid-execution.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = client.Execute(ctx, &processv1.ExecuteRequest{
+			Config: &processv1.ProcessConfig{
+				Command: []string{"sh", "-c", cmd},
+			},
+		})
+	}()
+
+	// Wait for the PID file to appear (the shell writes it immediately on
+	// entry, well before we need to cancel). Polling avoids the race that
+	// a fixed time.Sleep introduces on loaded CI runners.
+	var grandchildPID int
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return false
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || pid <= 0 {
+			return false
+		}
+		grandchildPID = pid
+		return true
+	}, 10*time.Second, 50*time.Millisecond, "grandchild PID file %q never populated", pidFile)
+
+	// Cancel the context to trigger process group kill.
+	cancel()
+
+	// Wait for Execute to return.
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute did not return after context cancellation")
+	}
+
+	// Wait for the grandchild to die. Polling avoids a race between
+	// Execute returning and SIGKILL propagating to the grandchild.
+	require.Eventually(t, func() bool {
+		return isProcessDead(grandchildPID)
+	}, 10*time.Second, 50*time.Millisecond, "grandchild process %d should have been killed", grandchildPID)
 }

--- a/packages/sandboxd/pkg/server/server.go
+++ b/packages/sandboxd/pkg/server/server.go
@@ -42,8 +42,9 @@ const (
 	// pipe readers to reach EOF after cmd.Wait has reaped the child process
 	// (a grandchild may still hold the write end).
 	pipeDrainGrace = 5 * time.Second
-	// waitDelay bounds cmd.Wait on I/O drain in Execute and on unkillable
-	// children in Start.
+	// waitDelay bounds how long cmd.Wait blocks on I/O drain after the
+	// child exits. Without it, a grandchild holding the stdout/stderr
+	// write ends keeps Wait blocked indefinitely.
 	waitDelay = 10 * time.Second
 )
 
@@ -78,7 +79,7 @@ func New(opts Options) (*Server, error) {
 	registry := processmanager.NewProcessRegistry()
 	return &Server{
 		registry:      registry,
-		processServer: NewProcessServer(opts.RootDir, registry, opts.StreamChunkSize),
+		processServer: NewProcessServer(opts.RootDir, registry, opts.StreamChunkSize, opts.Log),
 		restServer:    NewRESTServer(opts.RootDir, opts.MetadataEnvPrefix, opts.Log),
 	}, nil
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

`exec.CommandContext` only sends SIGKILL to the child PID on context cancellation, not its process group. Since Start/Execute use `Setpgid: true`, grandchildren survive as orphans when the parent is killed (e.g. client disconnect).

**Fix:** Replace `exec.CommandContext` with `exec.Command`, add `killProcessGroupOnContextDone` helper that signals `-PGID` (whole process group) on context cancellation. Also check context before forking to avoid starting commands we'd immediately kill.

#### Which issue(s) this PR is related to:
N/A

#### Release Note
```release-note
Fixed orphan process leak in sandboxd when clients disconnect from long-running commands with grandchildren.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for started and executed commands.
  * Cancelling a command now also terminates spawned child processes.
  * Added safeguards for requests cancelled before command execution begins.
  * Improved cleanup of command input streams after completion.
  * Improved error reporting for cancelled commands and unexpected failures.
  * Added safer handling for process termination errors.
* **Tests**
  * Added coverage verifying cancellation terminates descendant processes and returns the expected cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->