### PR TITLE
fix(examples/python-runtime-sandbox): run /execute off the event loop with a timeout

### DIFF
--- a/examples/python-runtime-sandbox/README.md
+++ b/examples/python-runtime-sandbox/README.md
@@ -25,6 +25,12 @@ This class models the response body for the `/execute` endpoint.
 - **`stderr: str`**: The standard error from the executed command.
 - **`exit_code: int`**: The exit code of the executed command.
 
+### Configuration
+
+- **`SANDBOX_EXEC_TIMEOUT_SECONDS`**: Maximum time, in seconds, a command
+  submitted to `/execute` is allowed to run before it is killed and the
+  request reports a failed execution. Defaults to `300`.
+
 ## Testing on a local kind cluster using agent-sandbox
 
 To test the sandbox on a local [kind](https://kind.sigs.k8s.io/) cluster, you can use the `run-test-kind.sh` script.

--- a/examples/python-runtime-sandbox/README.md
+++ b/examples/python-runtime-sandbox/README.md
@@ -28,8 +28,10 @@ This class models the response body for the `/execute` endpoint.
 ### Configuration
 
 - **`SANDBOX_EXEC_TIMEOUT_SECONDS`**: Maximum time, in seconds, a command
-  submitted to `/execute` is allowed to run before it is killed and the
-  request reports a failed execution. Defaults to `300`.
+  submitted to `/execute` is allowed to run before it (and any processes it
+  spawned) are killed and the request reports a failed execution. Defaults
+  to `300`. If set to a value that isn't a finite number greater than `0`,
+  the default is used instead and a warning is logged.
 
 ## Testing on a local kind cluster using agent-sandbox
 

--- a/examples/python-runtime-sandbox/main.py
+++ b/examples/python-runtime-sandbox/main.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import subprocess
 import os
 import shlex
@@ -65,12 +66,18 @@ async def execute_command(request: ExecuteRequest):
         # Split the command string into a list to safely pass to subprocess
         args = shlex.split(request.command)
         
-        # Execute the command, always from the /app directory
-        process = subprocess.run(
+        # Execute the command, always from the /app directory. Run it in a
+        # worker thread so a long-running or hung command doesn't block the
+        # event loop (and with it, the health check and file endpoints), and
+        # enforce a timeout so a runaway command can't wedge the sandbox
+        # forever.
+        process = await asyncio.to_thread(
+            subprocess.run,
             args,
             capture_output=True,
             text=True,
-            cwd="/app" 
+            cwd="/app",
+            timeout=float(os.environ.get("SANDBOX_EXEC_TIMEOUT_SECONDS", "300")),
         )
         return ExecuteResponse(
             stdout=process.stdout,

--- a/examples/python-runtime-sandbox/main.py
+++ b/examples/python-runtime-sandbox/main.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import asyncio
+import math
+import signal
 import subprocess
 import os
 import shlex
@@ -51,6 +53,49 @@ app = FastAPI(
     version="1.0.0",
 )
 
+def _get_exec_timeout_seconds() -> float:
+    """Reads SANDBOX_EXEC_TIMEOUT_SECONDS, falling back to the 300s default
+    (with a warning) if it's unset or not a finite number greater than 0, so
+    a misconfigured value doesn't fail every /execute request.
+    """
+    raw = os.environ.get("SANDBOX_EXEC_TIMEOUT_SECONDS", "300")
+    try:
+        value = float(raw)
+    except ValueError:
+        value = float("nan")
+
+    if not (math.isfinite(value) and value > 0):
+        logging.warning(
+            "Ignoring invalid SANDBOX_EXEC_TIMEOUT_SECONDS=%r; using default of 300 seconds",
+            raw,
+        )
+        return 300.0
+    return value
+
+def _run_command(args: list, timeout: float) -> subprocess.CompletedProcess:
+    """Runs args as the leader of a new process group so that on timeout the
+    entire process tree can be killed, not just the direct child (matching
+    the pattern used in examples/firecracker-sandbox/main.py).
+    """
+    with subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd="/app",
+        start_new_session=True,
+    ) as process:
+        try:
+            stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+            process.communicate()
+            raise
+        return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
 @app.get("/", summary="Health Check")
 async def health_check():
     """A simple health check endpoint to confirm the server is running."""
@@ -72,12 +117,9 @@ async def execute_command(request: ExecuteRequest):
         # enforce a timeout so a runaway command can't wedge the sandbox
         # forever.
         process = await asyncio.to_thread(
-            subprocess.run,
+            _run_command,
             args,
-            capture_output=True,
-            text=True,
-            cwd="/app",
-            timeout=float(os.environ.get("SANDBOX_EXEC_TIMEOUT_SECONDS", "300")),
+            _get_exec_timeout_seconds(),
         )
         return ExecuteResponse(
             stdout=process.stdout,

--- a/examples/python-runtime-sandbox/test_main.py
+++ b/examples/python-runtime-sandbox/test_main.py
@@ -14,6 +14,7 @@
 
 import os
 import shlex
+import signal
 import subprocess
 from unittest.mock import patch, MagicMock
 
@@ -49,37 +50,68 @@ class TestGetSafePath:
             get_safe_path("foo/../../bar")
 
 
-@patch('main.subprocess.run')
-def test_execute_command_success(mock_run):
-    mock_run.return_value = MagicMock(stdout="hello\n", stderr="", returncode=0)
+def _mock_process(mock_popen, stdout="", stderr="", returncode=0, pid=1234):
+    """Configures mock_popen (a patched main.subprocess.Popen) to behave like
+    a Popen used as a context manager, and returns the inner process mock.
+    """
+    mock_process = MagicMock()
+    mock_process.communicate.return_value = (stdout, stderr)
+    mock_process.returncode = returncode
+    mock_process.pid = pid
+    mock_popen.return_value.__enter__.return_value = mock_process
+    return mock_process
 
-    response = client.post("/execute", json={"command": "echo hello"})
+
+@patch('main.subprocess.Popen')
+def test_execute_command_success(mock_popen):
+    _mock_process(mock_popen, stdout="hello\n", stderr="", returncode=0)
+
+    with patch.dict(os.environ):
+        os.environ.pop("SANDBOX_EXEC_TIMEOUT_SECONDS", None)
+        response = client.post("/execute", json={"command": "echo hello"})
 
     assert response.status_code == 200
     assert response.json() == {"stdout": "hello\n", "stderr": "", "exit_code": 0}
 
-    mock_run.assert_called_once()
-    called_args, called_kwargs = mock_run.call_args
+    mock_popen.assert_called_once()
+    called_args, called_kwargs = mock_popen.call_args
     assert called_args[0] == shlex.split("echo hello")
     assert called_kwargs["cwd"] == "/app"
-    assert called_kwargs["timeout"] == 300.0
+    assert called_kwargs["start_new_session"] is True
+    mock_popen.return_value.__enter__.return_value.communicate.assert_called_once_with(timeout=300.0)
 
 
-@patch('main.subprocess.run')
-def test_execute_command_uses_configured_timeout(mock_run):
-    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+@patch('main.subprocess.Popen')
+def test_execute_command_uses_configured_timeout(mock_popen):
+    mock_process = _mock_process(mock_popen)
 
     with patch.dict(os.environ, {"SANDBOX_EXEC_TIMEOUT_SECONDS": "5"}):
         response = client.post("/execute", json={"command": "echo hello"})
 
     assert response.status_code == 200
-    called_kwargs = mock_run.call_args.kwargs
-    assert called_kwargs["timeout"] == 5.0
+    mock_process.communicate.assert_called_once_with(timeout=5.0)
 
 
-@patch('main.subprocess.run')
-def test_execute_command_timeout_returns_failed_execution(mock_run):
-    mock_run.side_effect = subprocess.TimeoutExpired(cmd="sleep infinity", timeout=300)
+@patch('main.subprocess.Popen')
+def test_execute_command_falls_back_to_default_on_invalid_timeout(mock_popen):
+    mock_process = _mock_process(mock_popen)
+
+    with patch.dict(os.environ, {"SANDBOX_EXEC_TIMEOUT_SECONDS": "not-a-number"}):
+        response = client.post("/execute", json={"command": "echo hello"})
+
+    assert response.status_code == 200
+    mock_process.communicate.assert_called_once_with(timeout=300.0)
+
+
+@patch('main.os.killpg')
+@patch('main.os.getpgid', return_value=4321)
+@patch('main.subprocess.Popen')
+def test_execute_command_timeout_returns_failed_execution(mock_popen, mock_getpgid, mock_killpg):
+    mock_process = _mock_process(mock_popen, pid=4321)
+    mock_process.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="sleep infinity", timeout=300),
+        ("", ""),
+    ]
 
     response = client.post("/execute", json={"command": "sleep infinity"})
 
@@ -87,6 +119,9 @@ def test_execute_command_timeout_returns_failed_execution(mock_run):
     body = response.json()
     assert body["exit_code"] == 1
     assert "Failed to execute command" in body["stderr"]
+    assert "timed out" in body["stderr"]
+    mock_getpgid.assert_called_once_with(4321)
+    mock_killpg.assert_called_once_with(4321, signal.SIGKILL)
 
 
 def test_execute_command_invalid_syntax_returns_error():

--- a/examples/python-runtime-sandbox/test_main.py
+++ b/examples/python-runtime-sandbox/test_main.py
@@ -14,6 +14,7 @@
 
 import os
 import shlex
+import subprocess
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -61,6 +62,31 @@ def test_execute_command_success(mock_run):
     called_args, called_kwargs = mock_run.call_args
     assert called_args[0] == shlex.split("echo hello")
     assert called_kwargs["cwd"] == "/app"
+    assert called_kwargs["timeout"] == 300.0
+
+
+@patch('main.subprocess.run')
+def test_execute_command_uses_configured_timeout(mock_run):
+    mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+
+    with patch.dict(os.environ, {"SANDBOX_EXEC_TIMEOUT_SECONDS": "5"}):
+        response = client.post("/execute", json={"command": "echo hello"})
+
+    assert response.status_code == 200
+    called_kwargs = mock_run.call_args.kwargs
+    assert called_kwargs["timeout"] == 5.0
+
+
+@patch('main.subprocess.run')
+def test_execute_command_timeout_returns_failed_execution(mock_run):
+    mock_run.side_effect = subprocess.TimeoutExpired(cmd="sleep infinity", timeout=300)
+
+    response = client.post("/execute", json={"command": "sleep infinity"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exit_code"] == 1
+    assert "Failed to execute command" in body["stderr"]
 
 
 def test_execute_command_invalid_syntax_returns_error():


### PR DESCRIPTION
#### What this PR does / why we need it:
In `examples/python-runtime-sandbox/main.py`, the `/execute` handler is `async def` but called blocking `subprocess.run(...)` directly on the event loop, with no timeout. Two consequences:

1. Any exec (even a legitimate 30s command) starved the event loop, so the health-check endpoint (`GET /`) and all file endpoints stopped answering for the duration of the exec.
2. A command that never exits (`sleep infinity`, a process waiting on stdin, a crashed-but-not-exited child) blocked the loop forever with no timeout to recover it — the sandbox stayed up but stopped responding to everything, indefinitely.

This PR wraps the `subprocess.run` call in `asyncio.to_thread(...)` so it runs off the event loop (health check and file endpoints keep responding while a command executes), and adds a `timeout=` argument sourced from a new `SANDBOX_EXEC_TIMEOUT_SECONDS` env var (default `300`). `subprocess.TimeoutExpired` falls into the handler's existing `except Exception` clause and is reported as a normal failed execution (`exit_code=1`, descriptive `stderr`), matching the shape of every other error path in this handler — no new failure mode is introduced.

Note: this fixes the event loop being starved / the server becoming unresponsive to other endpoints — it does not change behavior around process crashes, and normal `/execute` responses for successful commands are unchanged.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1375

#### Release Note
```release-note
Fixed `/execute` in the python-runtime-sandbox example blocking the event loop (and the health check with it) for the duration of every command, and added a `SANDBOX_EXEC_TIMEOUT_SECONDS` (default 300s) timeout so a runaway or hung command no longer wedges the sandbox indefinitely.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

---
AI assistance: this change was drafted with Claude Code.

Fixes #1375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable command execution timeouts through `SANDBOX_EXEC_TIMEOUT_SECONDS`.
  * Commands now use a 300-second timeout by default.
  * Timed-out commands return a clear failure response instead of blocking indefinitely.
  * Command execution no longer blocks other sandbox operations.

* **Documentation**
  * Added configuration guidance, timeout behavior, and the default value to the sandbox documentation.

* **Tests**
  * Added coverage for default and custom timeout settings, including timeout error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->