### PR TITLE
WIP: scaleup — one status write per launch + million-sandboxes-per-minute scenario

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -82,6 +82,7 @@ func main() {
 	var sandboxWarmPoolReplenishDelay time.Duration
 	var sandboxWarmPoolMaxRefillRate float64
 	var sandboxWriteBehindWindow time.Duration
+	var sandboxTransitionalStatusWindow time.Duration
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
@@ -174,6 +175,12 @@ func main() {
 			"by the previous process. Default false (annotations persisted).")
 	flag.DurationVar(&sandboxWriteBehindWindow, "sandbox-write-behind-window", 0,
 		"Coalescing window for the Sandbox controller's recoverable metadata-only writes. 0 disables coalescing.")
+	flag.DurationVar(&sandboxTransitionalStatusWindow, "sandbox-transitional-status-window", 0,
+		"Defer transitional Sandbox status writes (reason/message churn and field fills while no condition changes value) "+
+			"for sandboxes younger than this window: a launch that reaches Ready inside the window writes status exactly once, "+
+			"at the Ready flip, and a sandbox that is stuck still flushes an explanatory status once the window elapses. "+
+			"Material changes (condition value flips, terminal reasons like Expired/PodFailed) are always written immediately. "+
+			"0 disables deferral (every status change is written synchronously).")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -227,6 +234,11 @@ func main() {
 	if sandboxWriteBehindWindow < 0 {
 		setupLog.Error(nil, "sandbox-write-behind-window must be >= 0 (0 disables write-behind coalescing)",
 			"value", sandboxWriteBehindWindow)
+		os.Exit(1)
+	}
+	if sandboxTransitionalStatusWindow < 0 {
+		setupLog.Error(nil, "sandbox-transitional-status-window must be >= 0 (0 disables transitional-status deferral)",
+			"value", sandboxTransitionalStatusWindow)
 		os.Exit(1)
 	}
 	// A logical maximum (too much will create unnecessary load on the API server)
@@ -472,13 +484,18 @@ func main() {
 		setupLog.Info("Sandbox controller write deferral enabled (--sandbox-write-behind-window)",
 			"window", sandboxWriteBehindWindow, "podPatchBound", "1s")
 	}
+	if sandboxTransitionalStatusWindow > 0 {
+		setupLog.Info("Sandbox controller transitional-status deferral enabled (--sandbox-transitional-status-window)",
+			"window", sandboxTransitionalStatusWindow)
+	}
 
 	if err = (&controllers.SandboxReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Tracer:            instrumenter,
-		ClusterDomain:     clusterDomain,
-		WriteBehindWindow: sandboxWriteBehindWindow,
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		Tracer:                   instrumenter,
+		ClusterDomain:            clusterDomain,
+		WriteBehindWindow:        sandboxWriteBehindWindow,
+		TransitionalStatusWindow: sandboxTransitionalStatusWindow,
 	}).SetupWithManager(mgr, sandboxConcurrentWorkers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Sandbox")
 		os.Exit(1)

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -212,6 +212,22 @@ type SandboxReconciler struct {
 	// for why this one piece of in-memory state is unavoidable and why
 	// losing it is harmless.
 	deferralClock deferredWriteClock
+
+	// TransitionalStatusWindow, when > 0, defers TRANSITIONAL status writes
+	// (see materialStatusChange) for sandboxes younger than the window: the
+	// launch fast path then writes status once, at the Ready flip, while a
+	// sandbox that is stuck still flushes an explanatory status at age
+	// == window via RequeueAfter. Material changes (Ready flips, Suspended,
+	// Finished, terminal reasons) are always written immediately. 0 (the
+	// default) preserves the fully synchronous behavior. Gated by the
+	// --sandbox-transitional-status-window flag; anchored to
+	// metadata.creationTimestamp, so no in-memory clock is needed.
+	TransitionalStatusWindow time.Duration
+
+	// staleWrites suppresses reconcile passes that observe an informer copy
+	// older than this controller's own last write to the sandbox -- the
+	// source of no-op re-PATCHes under launch load; see staleCacheGuard.
+	staleWrites staleCacheGuard
 }
 
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
@@ -242,9 +258,19 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if k8serrors.IsNotFound(err) {
 			logger.Info("sandbox resource not found. Ignoring since object must be deleted")
 			r.deferralClock.clear(req.NamespacedName)
+			r.staleWrites.clear(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// The informer has not yet replayed this controller's own last write to
+	// this sandbox: every decision this pass could make would be re-derived
+	// from superseded state and every write it could issue would be a no-op
+	// the apiserver still has to serve. Skip the pass; the recorded write
+	// guarantees a watch event (hence a fresh reconcile) is on its way.
+	if r.staleWrites.stillStale(req.NamespacedName, sandbox.ResourceVersion) {
+		return ctrl.Result{}, nil
 	}
 
 	// Start Tracing Span
@@ -262,6 +288,7 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if !sandbox.DeletionTimestamp.IsZero() {
 		logger.Info("Sandbox is being deleted")
 		r.deferralClock.clear(req.NamespacedName)
+		r.staleWrites.clear(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
@@ -274,9 +301,11 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		sandbox.Annotations[asmetrics.TraceContextAnnotation] = tc
 
+		rvBefore := sandbox.ResourceVersion
 		if err := r.Patch(ctx, sandbox, patch); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.staleWrites.record(req.NamespacedName, rvBefore, sandbox.ResourceVersion)
 	}
 
 	oldStatus := sandbox.Status.DeepCopy()
@@ -288,7 +317,9 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if expired {
 		if !sandboxMarkedExpired(sandbox) {
 			setSandboxExpiredCondition(sandbox)
-			if statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
+			// The Expired mark is material (terminal reason), so it is never
+			// deferred; the returned wait is always zero here.
+			if _, statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
 				return ctrl.Result{}, statusUpdateErr
 			}
 			return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
@@ -334,10 +365,17 @@ func (r *SandboxReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if !sandboxDeleted {
-		// Update status
-		if statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox); statusUpdateErr != nil {
+		// Update status. A deferred transitional write (non-zero wait)
+		// requeues the request so a stuck sandbox still flushes its status
+		// once the transitional window elapses; the requeue dedups with any
+		// pending write-behind requeue via the workqueue.
+		statusWait, statusUpdateErr := r.updateStatus(ctx, oldStatus, sandbox)
+		if statusUpdateErr != nil {
 			// Surface update error
 			err = errors.Join(err, statusUpdateErr)
+		}
+		if statusWait > 0 && (result.RequeueAfter == 0 || statusWait < result.RequeueAfter) {
+			result.RequeueAfter = statusWait
 		}
 	}
 	// return errors seen
@@ -579,11 +617,17 @@ func podIPsFromStatus(podIPs []corev1.PodIP) []string {
 	return ips
 }
 
-func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1beta1.SandboxStatus, sandbox *sandboxv1beta1.Sandbox) error {
+// updateStatus persists sandbox.Status if it differs from oldStatus. The
+// returned duration is non-zero when a transitional change was deferred
+// under --sandbox-transitional-status-window: the caller must requeue the
+// request after that long so a stuck sandbox still flushes its status at
+// age == window (a sandbox that progresses sooner flushes earlier, riding
+// the material write its progress produces).
+func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandboxv1beta1.SandboxStatus, sandbox *sandboxv1beta1.Sandbox) (time.Duration, error) {
 	logger := log.FromContext(ctx)
 
 	if apiequality.Semantic.DeepEqual(oldStatus, &sandbox.Status) {
-		return nil
+		return 0, nil
 	}
 
 	// Pod scheduling produces a status change containing nothing but the
@@ -597,7 +641,22 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	// rather than leave a Ready sandbox with a wrong or missing node name.
 	if nodeNameOnlyChange(oldStatus, &sandbox.Status) &&
 		!meta.IsStatusConditionTrue(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady)) {
-		return nil
+		return 0, nil
+	}
+
+	// Transitional-status gating (--sandbox-transitional-status-window):
+	// on the launch fast path nothing reads the pre-Ready status fills, so
+	// while the sandbox is younger than the window, only material changes
+	// (Ready flips, Suspended, Finished, terminal reasons; see
+	// materialStatusChange) are written immediately. The generalization of
+	// the nodeName-only deferral above: the skipped write is recomputed from
+	// informer state whenever it eventually flushes, so nothing is lost on
+	// crash or failover. A zero creationTimestamp (never set by a real
+	// apiserver) yields a huge age and thus no deferral.
+	if r.TransitionalStatusWindow > 0 && !materialStatusChange(oldStatus, &sandbox.Status) {
+		if age := time.Since(sandbox.CreationTimestamp.Time); age < r.TransitionalStatusWindow {
+			return r.TransitionalStatusWindow - age, nil
+		}
 	}
 
 	// Merge-patch (no resourceVersion precondition) the status subresource.
@@ -613,17 +672,19 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 	//      pod state, so it self-heals on the next watch event and converges.
 	base := sandbox.DeepCopy()
 	base.Status = *oldStatus
+	rvBefore := sandbox.ResourceVersion
 	if err := r.Status().Patch(ctx, sandbox, client.MergeFrom(base)); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Sandbox was deleted mid-reconcile
-			return nil
+			return 0, nil
 		}
 		logger.Error(err, "Failed to patch sandbox status")
-		return err
+		return 0, err
 	}
+	r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 
 	// Surface error
-	return nil
+	return 0, nil
 }
 
 // nodeNameOnlyChange reports whether the node assignment is the only
@@ -1007,9 +1068,11 @@ func (r *SandboxReconciler) clearPodNameAnnotation(ctx context.Context, sandbox 
 	logger := log.FromContext(ctx)
 	patch := client.MergeFrom(sandbox.DeepCopy())
 	delete(sandbox.Annotations, sandboxv1beta1.SandboxPodNameAnnotation)
+	rvBefore := sandbox.ResourceVersion
 	if err := r.Patch(ctx, sandbox, patch); err != nil {
 		return fmt.Errorf("failed to clear pod name annotation: %w", err)
 	}
+	r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 	logger.Info("Removed pod name annotation from sandbox", "Sandbox.Name", sandbox.Name)
 	return nil
 }
@@ -1125,9 +1188,11 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			sandbox.Annotations = make(map[string]string)
 		}
 		sandbox.Annotations[sandboxv1beta1.SandboxPodNameAnnotation] = podName
+		rvBefore := sandbox.ResourceVersion
 		if err := r.Patch(ctx, sandbox, patch); err != nil {
 			return fmt.Errorf("failed to set pod name annotation: %w", err)
 		}
+		r.staleWrites.record(client.ObjectKeyFromObject(sandbox), rvBefore, sandbox.ResourceVersion)
 
 		return nil
 	}

--- a/controllers/status_writes.go
+++ b/controllers/status_writes.go
@@ -1,0 +1,186 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+// Status-write reduction for the Sandbox launch path.
+//
+// A healthy launch used to cost ~2.3 status writes (an initial "not Ready
+// yet" fill, sometimes an intermediate reason change, then the Ready flip)
+// plus ~0.8 no-op PATCH requests re-issued by reconciles racing the
+// controller's own informer (measured on a 100-node/50k-sandbox run:
+// 107k status PATCH requests and ~39k no-ops for 50k launches). Nothing
+// reads the transitional writes on the fast path -- consumers (the claim
+// controller, kubectl wait) act on Ready -- so this file provides:
+//
+//  1. materialStatusChange: an explicit classification of status changes
+//     into material (must write now) vs transitional (may ride along with
+//     the next material write).
+//  2. Creation-age gating (see updateStatus): with
+//     --sandbox-transitional-status-window=T, a transitional change on a
+//     sandbox younger than T is skipped and requeued to flush at age T. A
+//     launch that reaches Ready inside T writes status exactly once; a
+//     sandbox that is stuck still converges to an explanatory status at T.
+//     Like the write-behind window (writebehind_requeue.go), the deferred
+//     write is recomputed from informer state by the flushing pass, so a
+//     crash can never lose a mutation.
+//  3. staleCacheGuard: suppresses whole reconcile passes that run against
+//     an informer cache that has not yet caught up with this controller's
+//     own last sandbox write -- the source of the no-op PATCHes. The
+//     guard stores only resourceVersions, never payloads.
+
+import (
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+// terminalReadyReasons are Ready-condition reasons that carry terminal or
+// operator-actionable meaning even without a condition Status flip: a
+// never-Ready sandbox that expires stays Ready=False, but the expiry flow
+// (handleSandboxExpiry) only proceeds once the Expired mark is persisted,
+// and Succeeded/Failed are ends of the lifecycle, not launch progress.
+var terminalReadyReasons = map[string]bool{
+	sandboxv1beta1.SandboxReasonExpired:      true,
+	sandboxv1beta1.SandboxReasonPodFailed:    true,
+	sandboxv1beta1.SandboxReasonPodSucceeded: true,
+}
+
+// materialStatusChange reports whether the old->new status change must be
+// written immediately (material) rather than deferred (transitional).
+//
+// Material changes are the ones consumers act on:
+//   - any condition's Status VALUE changing (False->True, True->False,
+//     anything<->Unknown) -- this covers the Ready flip in both directions,
+//     Suspended taking effect, and Finished appearing (it is created with
+//     Status=True, so its very addition is material);
+//   - a condition disappearing (Finished is removed when the pod restarts);
+//   - a condition appearing with any Status other than False (the initial
+//     Ready=False / Suspended=False fill is launch progress, not news);
+//   - the Ready reason moving to or from a terminal reason (see
+//     terminalReadyReasons).
+//
+// Everything else is transitional: reason/message churn while the Status
+// value holds (Pending -> ContainerCreating), observedGeneration bumps, and
+// non-condition field fills (nodeName, podIPs, serviceFQDN, selector) --
+// all of which ride along with the next material write, where consumers
+// actually read them.
+func materialStatusChange(oldStatus, newStatus *sandboxv1beta1.SandboxStatus) bool {
+	oldConds := make(map[string]*metav1.Condition, len(oldStatus.Conditions))
+	for i := range oldStatus.Conditions {
+		oldConds[oldStatus.Conditions[i].Type] = &oldStatus.Conditions[i]
+	}
+	newSeen := make(map[string]bool, len(newStatus.Conditions))
+	for i := range newStatus.Conditions {
+		nc := &newStatus.Conditions[i]
+		newSeen[nc.Type] = true
+		oc, existed := oldConds[nc.Type]
+		if !existed {
+			if nc.Status != metav1.ConditionFalse {
+				return true
+			}
+			if nc.Type == string(sandboxv1beta1.SandboxConditionReady) && terminalReadyReasons[nc.Reason] {
+				return true
+			}
+			continue
+		}
+		if oc.Status != nc.Status {
+			return true
+		}
+		if nc.Type == string(sandboxv1beta1.SandboxConditionReady) && oc.Reason != nc.Reason &&
+			(terminalReadyReasons[oc.Reason] || terminalReadyReasons[nc.Reason]) {
+			return true
+		}
+	}
+	for condType := range oldConds {
+		if !newSeen[condType] {
+			return true
+		}
+	}
+	return false
+}
+
+// rvPair is one recorded sandbox write: the resourceVersion the write was
+// issued against and the resourceVersion it produced.
+type rvPair struct {
+	before, after string
+}
+
+// staleCacheGuard remembers, per sandbox, the resourceVersions bracketing
+// this controller's most recent write to that sandbox (main resource or
+// status). A reconcile pass whose informer copy still shows the pre-write
+// resourceVersion is running on state this controller has already
+// superseded: acting on it can only re-derive writes the apiserver will
+// no-op (measured: ~19% of all PATCH requests under launch load). Such a
+// pass is skipped outright -- no requeue is needed, because the recorded
+// write itself guarantees a future watch event (and therefore a fresh
+// reconcile) for the object.
+//
+// Correctness rests on resourceVersion EQUALITY only (never ordering): the
+// informer replays one object's versions in order, so observing the
+// pre-write version means the post-write event has not been delivered yet,
+// and observing anything else means it has (or a later writer has moved the
+// object on, which is equally fresh for our purposes). Writes that do not
+// change the resourceVersion (a patch the apiserver no-ops) are never
+// recorded -- recording before==after would classify every future pass as
+// stale with no event ever coming to clear it.
+//
+// Like deferredWriteClock, the map holds no mutation payload; losing it on
+// crash or failover costs at most one redundant no-op PATCH per object.
+type staleCacheGuard struct {
+	mu sync.Mutex
+	m  map[types.NamespacedName]rvPair
+}
+
+// record notes a successful write that moved key from rvBefore to rvAfter.
+// No-op writes (rvAfter empty or equal to rvBefore) are ignored.
+func (g *staleCacheGuard) record(key types.NamespacedName, rvBefore, rvAfter string) {
+	if rvAfter == "" || rvAfter == rvBefore {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.m == nil {
+		g.m = make(map[types.NamespacedName]rvPair)
+	}
+	g.m[key] = rvPair{before: rvBefore, after: rvAfter}
+}
+
+// stillStale reports whether a pass observing observedRV for key is running
+// behind this controller's own last write. Any observation other than the
+// recorded pre-write version proves the cache has caught up (or moved
+// further) and drops the record.
+func (g *staleCacheGuard) stillStale(key types.NamespacedName, observedRV string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	pair, ok := g.m[key]
+	if !ok {
+		return false
+	}
+	if observedRV == pair.before {
+		return true
+	}
+	delete(g.m, key)
+	return false
+}
+
+// clear drops the record for key, if any (object deleted or gone).
+func (g *staleCacheGuard) clear(key types.NamespacedName) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.m, key)
+}

--- a/controllers/status_writes_test.go
+++ b/controllers/status_writes_test.go
@@ -1,0 +1,312 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+)
+
+func condition(condType string, status metav1.ConditionStatus, reason string) metav1.Condition {
+	return metav1.Condition{Type: condType, Status: status, Reason: reason}
+}
+
+func statusWithConditions(conds ...metav1.Condition) *sandboxv1beta1.SandboxStatus {
+	return &sandboxv1beta1.SandboxStatus{Conditions: conds}
+}
+
+func TestMaterialStatusChange(t *testing.T) {
+	ready := string(sandboxv1beta1.SandboxConditionReady)
+	suspended := string(sandboxv1beta1.SandboxConditionSuspended)
+	finished := string(sandboxv1beta1.SandboxConditionFinished)
+
+	tests := []struct {
+		name     string
+		old, new *sandboxv1beta1.SandboxStatus
+		material bool
+	}{
+		{
+			name: "initial fill: empty -> Ready=False + Suspended=False is transitional",
+			old:  &sandboxv1beta1.SandboxStatus{},
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				condition(suspended, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonNotSuspended),
+			),
+			material: false,
+		},
+		{
+			name:     "Ready False -> True is material",
+			old:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonDependenciesReady)),
+			material: true,
+		},
+		{
+			name:     "Ready True -> False (regression) is material",
+			old:      statusWithConditions(condition(ready, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonDependenciesReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			material: true,
+		},
+		{
+			name:     "reason/message churn while Ready stays False is transitional",
+			old:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, "ReconcilerError")),
+			material: false,
+		},
+		{
+			name:     "Ready reason moving to Expired is material even without a value flip",
+			old:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonExpired)),
+			material: true,
+		},
+		{
+			name:     "Expired appearing on a status with no prior Ready condition is material",
+			old:      &sandboxv1beta1.SandboxStatus{},
+			new:      statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonExpired)),
+			material: true,
+		},
+		{
+			name: "Finished appearing (Status=True) is material",
+			old:  statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new: statusWithConditions(
+				condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonPodSucceeded),
+				condition(finished, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonPodSucceeded),
+			),
+			material: true,
+		},
+		{
+			name:     "condition removal is material",
+			old:      statusWithConditions(condition(finished, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonPodSucceeded)),
+			new:      &sandboxv1beta1.SandboxStatus{},
+			material: true,
+		},
+		{
+			name:     "Suspended False -> Unknown is material",
+			old:      statusWithConditions(condition(suspended, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonNotSuspended)),
+			new:      statusWithConditions(condition(suspended, metav1.ConditionUnknown, sandboxv1beta1.SandboxReasonSuspendedPodStateUnknown)),
+			material: true,
+		},
+		{
+			name: "field-only fill (nodeName, podIPs, selector) is transitional",
+			old:  statusWithConditions(condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)),
+			new: &sandboxv1beta1.SandboxStatus{
+				Conditions:    []metav1.Condition{condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady)},
+				NodeName:      "node-1",
+				PodIPs:        []string{"10.0.0.1"},
+				LabelSelector: "x=y",
+			},
+			material: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := materialStatusChange(tt.old, tt.new); got != tt.material {
+				t.Errorf("materialStatusChange() = %v, want %v", got, tt.material)
+			}
+		})
+	}
+}
+
+// TestUpdateStatusTransitionalWindow exercises the creation-age gating end
+// to end against the fake client: transitional changes on a young sandbox
+// are deferred (no write, positive requeue), material changes and old
+// sandboxes write through.
+func TestUpdateStatusTransitionalWindow(t *testing.T) {
+	ready := string(sandboxv1beta1.SandboxConditionReady)
+	const window = 15 * time.Second
+
+	newSandbox := func(age time.Duration) *sandboxv1beta1.Sandbox {
+		return &sandboxv1beta1.Sandbox{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "sb",
+				Namespace:         "default",
+				UID:               sandboxUID,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		age       time.Duration
+		mutate    func(*sandboxv1beta1.Sandbox)
+		wantWrite bool
+		wantDefer bool
+	}{
+		{
+			name: "transitional change on young sandbox is deferred",
+			age:  1 * time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.Conditions = []metav1.Condition{
+					condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				}
+				sb.Status.NodeName = "node-1"
+			},
+			wantWrite: false,
+			wantDefer: true,
+		},
+		{
+			name: "material change on young sandbox writes immediately",
+			age:  1 * time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.Conditions = []metav1.Condition{
+					condition(ready, metav1.ConditionTrue, sandboxv1beta1.SandboxReasonDependenciesReady),
+				}
+			},
+			wantWrite: true,
+			wantDefer: false,
+		},
+		{
+			name: "transitional change past the window writes through",
+			age:  window + time.Second,
+			mutate: func(sb *sandboxv1beta1.Sandbox) {
+				sb.Status.Conditions = []metav1.Condition{
+					condition(ready, metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+				}
+				sb.Status.PodIPs = []string{"10.0.0.1"}
+			},
+			wantWrite: true,
+			wantDefer: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := newSandbox(tt.age)
+			fakeClient := newFakeClient(sb)
+			r := &SandboxReconciler{Client: fakeClient, TransitionalStatusWindow: window}
+
+			oldStatus := sb.Status.DeepCopy()
+			tt.mutate(sb)
+
+			wait, err := r.updateStatus(context.Background(), oldStatus, sb)
+			if err != nil {
+				t.Fatalf("updateStatus() error: %v", err)
+			}
+			if tt.wantDefer && (wait <= 0 || wait > window) {
+				t.Errorf("updateStatus() wait = %v, want in (0, %v]", wait, window)
+			}
+			if !tt.wantDefer && wait != 0 {
+				t.Errorf("updateStatus() wait = %v, want 0", wait)
+			}
+
+			stored := &sandboxv1beta1.Sandbox{}
+			if err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "sb"}, stored); err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			wrote := len(stored.Status.Conditions) > 0 || stored.Status.NodeName != "" || len(stored.Status.PodIPs) > 0
+			if wrote != tt.wantWrite {
+				t.Errorf("status written = %v, want %v (stored status: %+v)", wrote, tt.wantWrite, stored.Status)
+			}
+		})
+	}
+}
+
+// TestUpdateStatusWindowDisabled verifies the default (window 0) keeps the
+// fully synchronous behavior for transitional changes.
+func TestUpdateStatusWindowDisabled(t *testing.T) {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "sb", Namespace: "default", UID: sandboxUID,
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+	fakeClient := newFakeClient(sb)
+	r := &SandboxReconciler{Client: fakeClient}
+
+	oldStatus := sb.Status.DeepCopy()
+	sb.Status.Conditions = []metav1.Condition{
+		condition(string(sandboxv1beta1.SandboxConditionReady), metav1.ConditionFalse, sandboxv1beta1.SandboxReasonDependenciesNotReady),
+	}
+	// Include a second field so the change is not nodeName-only.
+	sb.Status.LabelSelector = "x=y"
+
+	wait, err := r.updateStatus(context.Background(), oldStatus, sb)
+	if err != nil {
+		t.Fatalf("updateStatus() error: %v", err)
+	}
+	if wait != 0 {
+		t.Errorf("wait = %v, want 0 with window disabled", wait)
+	}
+	stored := &sandboxv1beta1.Sandbox{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: "sb"}, stored); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(stored.Status.Conditions) == 0 {
+		t.Error("status not written with window disabled")
+	}
+}
+
+func TestStaleCacheGuard(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "sb"}
+	other := types.NamespacedName{Namespace: "default", Name: "other"}
+
+	var g staleCacheGuard
+
+	// No record: never stale.
+	if g.stillStale(key, "5") {
+		t.Error("stillStale with no record = true, want false")
+	}
+
+	// Recorded write 5 -> 6: observing 5 is stale (event pending), and stays
+	// stale on repeat observation.
+	g.record(key, "5", "6")
+	if !g.stillStale(key, "5") {
+		t.Error("observing pre-write rv: stillStale = false, want true")
+	}
+	if !g.stillStale(key, "5") {
+		t.Error("repeat observation of pre-write rv: stillStale = false, want true")
+	}
+	// Observing the post-write rv clears the record.
+	if g.stillStale(key, "6") {
+		t.Error("observing post-write rv: stillStale = true, want false")
+	}
+	if g.stillStale(key, "5") {
+		t.Error("record should have been dropped after catch-up")
+	}
+
+	// A third-party write (any rv other than pre-write) also clears.
+	g.record(key, "6", "7")
+	if g.stillStale(key, "9") {
+		t.Error("observing newer third-party rv: stillStale = true, want false")
+	}
+
+	// No-op writes must not be recorded: they produce no event to clear them.
+	g.record(key, "7", "7")
+	if g.stillStale(key, "7") {
+		t.Error("no-op write recorded: every future pass would be stale forever")
+	}
+	g.record(key, "7", "")
+	if g.stillStale(key, "7") {
+		t.Error("empty rvAfter recorded")
+	}
+
+	// clear is per-key.
+	g.record(key, "7", "8")
+	g.record(other, "1", "2")
+	g.clear(key)
+	if g.stillStale(key, "7") {
+		t.Error("cleared key still stale")
+	}
+	if !g.stillStale(other, "1") {
+		t.Error("clear(key) affected other key")
+	}
+}

--- a/dev/ci/periodics/scaleup
+++ b/dev/ci/periodics/scaleup
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Daily scale-up run: the full single-cluster leg of the
+# million-sandboxes-in-a-minute demonstration -- 200 nodes x 500
+# sandboxes/node = 100,000 sandboxes on kindnet, target window 60s
+# (~1,667/s). Ten of these clusters is the 1M/minute headline; this
+# periodic tracks the per-cluster number.
+#
+# All knobs default to the full target in the scenario itself; see
+# test/benchmarks/scenarios/scaleup-kops-gcp/run for sizing and tuning
+# rationale. Note the quota callout there: the full shape needs ~1,600
+# node vCPUs plus an 88-vCPU control plane in one zone.
+# SCALEUP_ENFORCE_TARGET flips red/green gating on the 60s window once the
+# target is consistently met.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+exec "${REPO_ROOT}/test/benchmarks/scenarios/scaleup-kops-gcp/run"

--- a/dev/ci/presubmits/scaleup
+++ b/dev/ci/presubmits/scaleup
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Scale-up prove-out leg: the same per-node shape as the full
+# million-sandboxes-in-a-minute periodic (500 sandboxes/node, maxPods=512,
+# /22 pod CIDRs, kindnet) at 1/10 the node count, so it fits a normal
+# boskos project: 20 nodes x 500 = 10,000 sandboxes, same 60s target
+# window (~167/s for this leg). See
+# test/benchmarks/scenarios/scaleup-kops-gcp/run for the full rationale.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+export SCALEUP_NODE_COUNT="${SCALEUP_NODE_COUNT:-20}"
+# Create burst width scaled with the leg: 400 in-flight creates is ample
+# for ~167/s and spares the smaller control plane the full-scale burst.
+export STRESS_CREATE_CONCURRENCY="${STRESS_CREATE_CONCURRENCY:-400}"
+# The benchmark-standard control plane is plenty at 1/10 scale.
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
+export STRESS_VALIDATE_WAIT="${STRESS_VALIDATE_WAIT:-10m}"
+
+exec "${REPO_ROOT}/test/benchmarks/scenarios/scaleup-kops-gcp/run"

--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -78,8 +78,14 @@ fi
 export IMAGE_TAG
 echo "Using image tag: ${IMAGE_TAG}"
 
-# Push images
-for image in "agent-sandbox-controller" "chrome-sandbox"; do
+# Push images. chrome-sandbox is only exercised by the e2e benchmark suite,
+# and its image build is expensive (a full chromium dependency tree, ~5
+# minutes emulated on an arm64 laptop) -- skip it when the suite is skipped.
+IMAGES_TO_PUSH=("agent-sandbox-controller")
+if [[ "${RUN_BENCHMARK_SUITE:-true}" == "true" ]]; then
+  IMAGES_TO_PUSH+=("chrome-sandbox")
+fi
+for image in "${IMAGES_TO_PUSH[@]}"; do
   echo "Pushing ${image} to ${IMAGE_PREFIX}..."
   dev/tools/push-images --image-prefix="${IMAGE_PREFIX}" --images "${image}"
 done
@@ -100,7 +106,10 @@ export KOPS_STATE_STORE="gs://${BUCKET_NAME}"
 
 # Compute a relatively unique identifier for this run to allow concurrent runs
 CLUSTER_NAME="sandbox-${UNIQUE_SUFFIX}"
-ZONE="us-central1-a"
+# Overridable because zones stock out (observed: ZONE_RESOURCE_POOL_EXHAUSTED
+# for c3 in us-central1-a); pick another zone rather than another machine type
+# so results stay comparable.
+ZONE="${STRESS_ZONE:-us-central1-a}"
 
 cleanup() {
   echo "Cleaning up..."
@@ -163,6 +172,12 @@ echo "Using node count: ${STRESS_NODE_COUNT}"
 STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-22}"
 echo "Using control-plane size: ${STRESS_CONTROL_PLANE_SIZE}"
 
+# Worker node size. n2-standard-8 is the benchmark baseline; scenarios that
+# trade per-node CPU for node count (or fight vCPU quota at high node
+# counts) can override.
+STRESS_NODE_SIZE="${STRESS_NODE_SIZE:-n2-standard-8}"
+echo "Using node size: ${STRESS_NODE_SIZE}"
+
 echo "Creating kOps cluster configuration..."
 # --gce-service-account=default: needed because boskos doesn't let us configure IAM permissions on the project.
 kops create cluster \
@@ -175,7 +190,7 @@ kops create cluster \
   --control-plane-count=1 \
   --control-plane-size="${STRESS_CONTROL_PLANE_SIZE}" \
   --node-count="${STRESS_NODE_COUNT}" \
-  --node-size=n2-standard-8
+  --node-size="${STRESS_NODE_SIZE}"
 
 # Spec tuning is applied as separate `kops edit cluster --set` blocks rather
 # than as flags on `kops create` above. Each knob keeps its rationale next to
@@ -266,9 +281,15 @@ kops edit cluster --name "${CLUSTER_NAME}" \
 # scheduler's kubeAPIQPS/kubeAPIBurst spec fields map to the legacy
 # --kube-api-qps/--kube-api-burst flags, which current kube-schedulers no
 # longer accept).
+# Overridable: 500/500 is comfortable at benchmark scale (20 nodes), but the
+# 100-node scaleup run pinned this exact limiter -- ~102k scheduler requests
+# queued a mean of 11.4s each in the client rate limiter while every other
+# component idled, capping cluster ready-throughput at ~470/s (the scheduler
+# spends ~2 requests per pod placed). scaleup-kops-gcp raises it via
+# STRESS_SCHEDULER_QPS/BURST.
 kops edit cluster --name "${CLUSTER_NAME}" \
-  --set cluster.spec.kubeScheduler.qps=500 \
-  --set cluster.spec.kubeScheduler.burst=500
+  --set "cluster.spec.kubeScheduler.qps=${STRESS_SCHEDULER_QPS:-500}" \
+  --set "cluster.spec.kubeScheduler.burst=${STRESS_SCHEDULER_BURST:-500}"
 
 # kubelet.kubeAPIQPS (default 50): the kubelets make multiple pod
 # status updates per pod.
@@ -285,6 +306,42 @@ kops edit cluster --name "${CLUSTER_NAME}" \
   --set cluster.spec.kubelet.eventQPS=5 \
   --set cluster.spec.kubelet.eventBurst=50
 
+# kubeAPIServer.maxRequestsInflight/maxMutatingRequestsInflight (defaults
+# 400/200): APF's total seat budget is derived from these two flags and
+# scales with NOTHING else - not CPU, not node count. First seen on the
+# stress-40-nodes hero run (80 nodes: the system level's kubelet traffic
+# queued while the apiserver sat at 35% CPU); the 100-node scaleup run
+# reproduced it on the launch path (scheduler bindings in workload-high
+# accumulated 338k queued seconds against the default 600-seat pool while
+# the apiserver had 50 idle cores). 1600/800 is the baseline; scaleup
+# raises further via STRESS_MAX_REQUESTS_INFLIGHT/STRESS_MAX_MUTATING_INFLIGHT.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set "cluster.spec.kubeAPIServer.maxRequestsInflight=${STRESS_MAX_REQUESTS_INFLIGHT:-1600}" \
+  --set "cluster.spec.kubeAPIServer.maxMutatingRequestsInflight=${STRESS_MAX_MUTATING_INFLIGHT:-800}"
+
+# kubelet.maxPods (default 110): pod-density scenarios (scaleup-kops-gcp
+# packs 500 sandboxes onto every node) need the kubelet cap raised.
+# Anything past ~250 pods/node also needs a wider per-node pod CIDR --
+# see STRESS_NODE_CIDR_MASK_SIZE right below; the two travel together.
+if [[ -n "${STRESS_MAX_PODS:-}" ]]; then
+  echo "Setting kubelet maxPods=${STRESS_MAX_PODS}"
+  kops edit cluster --name "${CLUSTER_NAME}" \
+    --set "cluster.spec.kubelet.maxPods=${STRESS_MAX_PODS}"
+fi
+
+# kubeControllerManager.nodeCIDRMaskSize: the per-node pod CIDR carved out
+# of the 100.64.0.0/10 cluster CIDR. The default /24 (256 addresses) caps a
+# node at ~250 pods; /22 gives 1,024 addresses per node -- enough for
+# maxPods=512 -- while still leaving room for 4,096 nodes. kindnet routes
+# node-to-node on the VMs themselves (no GCP route-table entries), so a
+# wider mask does not eat cloud route quota. (IPv6 would remove the
+# per-node address math entirely, but kOps only supports IPv6 on AWS, so
+# on GCE a wider IPv4 mask is the tool.)
+if [[ -n "${STRESS_NODE_CIDR_MASK_SIZE:-}" ]]; then
+  echo "Setting nodeCIDRMaskSize=${STRESS_NODE_CIDR_MASK_SIZE}"
+  kops edit cluster --name "${CLUSTER_NAME}" \
+    --set "cluster.spec.kubeControllerManager.nodeCIDRMaskSize=${STRESS_NODE_CIDR_MASK_SIZE}"
+fi
 
 if [[ "${CNI}" == "cilium" ]]; then
   # cilium.enablePrometheusMetrics: serve cilium-agent metrics on :9090 so the
@@ -302,7 +359,9 @@ echo "Exporting kubeconfig..."
 kops export kubeconfig --name "${CLUSTER_NAME}" --admin
 
 echo "Waiting for cluster to be ready..."
-kops validate cluster --wait 15m
+# High node counts take longer to converge; scenarios override the wait
+# (upstream #1377 raised the default to 15m).
+kops validate cluster --wait "${STRESS_VALIDATE_WAIT:-15m}"
 
 if [[ "${CNI}" == "cilium" ]]; then
   # Raise Cilium's endpoint-create API rate limit. The agent rate-limits
@@ -352,6 +411,13 @@ dev/tools/deploy-to-kube --image-prefix="${IMAGE_PREFIX}" --extensions \
 echo "Waiting for controller to be ready..."
 kubectl rollout status deployment agent-sandbox-controller --namespace agent-sandbox-system --timeout=10m
 
+# Optional extra manifests (space-separated paths), applied after the
+# controller is up. Used by scaleup-kops-gcp for its APF FlowSchema.
+for manifest in ${STRESS_EXTRA_MANIFESTS:-}; do
+  echo "Applying extra manifest ${manifest}..."
+  kubectl apply -f "${manifest}"
+done
+
 # Serve only the beta API: the mere presence of a v1alpha1 version
 # causes the kube-apiserver to build a v1alpha1 version for every resource,
 # in the informer cache, even if v1alpha1 is never used, adding unnecessary
@@ -370,10 +436,16 @@ for crd in sandboxes.agents.x-k8s.io \
   done
 done
 
-# Run the benchmarks
-echo "Running benchmarks..."
-dev/tools/test-e2e --suite=benchmarks --image-prefix="${IMAGE_PREFIX}"
-echo "Benchmark completed successfully."
+# Run the benchmarks. Scenarios whose signal is the stress test alone
+# (e.g. scaleup-kops-gcp, where the cluster is 10x the usual size and the
+# e2e suite would just burn wall-clock on it) set RUN_BENCHMARK_SUITE=false.
+if [[ "${RUN_BENCHMARK_SUITE:-true}" == "true" ]]; then
+  echo "Running benchmarks..."
+  dev/tools/test-e2e --suite=benchmarks --image-prefix="${IMAGE_PREFIX}"
+  echo "Benchmark completed successfully."
+else
+  echo "Skipping benchmark e2e suite (RUN_BENCHMARK_SUITE=${RUN_BENCHMARK_SUITE})."
+fi
 
 
 # Run the stress test.

--- a/test/benchmarks/scenarios/scaleup-kops-gcp/apf-flowschema.yaml
+++ b/test/benchmarks/scenarios/scaleup-kops-gcp/apf-flowschema.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Classify the agent-sandbox-controller's API traffic into workload-high --
+# the same APF priority level the kube-scheduler and kube-controller-manager
+# ride -- instead of the catch-all service-accounts FlowSchema (workload-low).
+#
+# Why: with client-side rate limiting off (the controller's default,
+# --kube-api-qps=-1), APF is the intended backpressure. But workload-low is
+# the wrong lane for a controller that sits on the pod-launch critical path:
+# in the 100-node scaleup run the controller's requests accumulated 3,533
+# queued seconds in service-accounts while it was the last component holding
+# up Sandbox readiness. matchingPrecedence 800 wins against the built-in
+# service-accounts FlowSchema (9000; lower wins).
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: agent-sandbox-controller
+spec:
+  matchingPrecedence: 800
+  priorityLevelConfiguration:
+    name: workload-high
+  distinguisherMethod:
+    type: ByUser
+  rules:
+  - subjects:
+    - kind: ServiceAccount
+      serviceAccount:
+        name: agent-sandbox-controller
+        namespace: agent-sandbox-system
+    resourceRules:
+    - verbs: ["*"]
+      apiGroups: ["*"]
+      resources: ["*"]
+      clusterScope: true
+      namespaces: ["*"]

--- a/test/benchmarks/scenarios/scaleup-kops-gcp/run
+++ b/test/benchmarks/scenarios/scaleup-kops-gcp/run
@@ -1,0 +1,220 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# scaleup-kops-gcp: the single-cluster leg of the million-sandboxes-in-a-
+# minute demonstration.
+#
+# The end goal is 1,000,000 sandboxes launched in one minute across 10
+# clusters: 100,000 sandboxes per cluster in 60s, ~1,667 sustained
+# launches/s per cluster. This scenario builds ONE cluster shaped for that
+# density and launches SCALEUP_NODE_COUNT * SCALEUP_PODS_PER_NODE sandboxes
+# as fast as the pipeline allows (the test/stress fill phase: closed-loop
+# creates, then wait for every sandbox to become Ready), then reports the
+# achieved rate against the target window. Multi-cluster aggregation comes
+# later; this proves the per-cluster shape.
+#
+# Cluster shape (defaults): 200 worker nodes x maxPods=512 = 102,400 pod
+# slots, filled with 100,000 sandboxes (500 per node). Per-node pod
+# addressing comes from nodeCIDRMaskSize=22 (1,024 IPv4 addresses per node
+# out of the 100.64.0.0/10 cluster CIDR) -- kOps does not support IPv6 on
+# GCE, and the wider IPv4 mask serves the same purpose.
+#
+# CNI is kindnet: the benchmarks-kops-gcp CNI comparison showed kindnet
+# outperforming cilium on the launch path (cilium's endpoint-create rate
+# limiting and agent client QPS sit directly on pod-sandbox creation).
+#
+# The rate math that sizes this: the kindnet benchmark legs sustained
+# ~7.5 launches/s per node once node root disks moved to pd-ssd, so 200
+# nodes puts the node fleet's aggregate right at the ~1,600/s target --
+# making the control plane (apiserver/etcd/scheduler/controller) the
+# component this scenario actually interrogates. Expect the first runs to
+# find its wall well below target; that is the point of the periodic.
+#
+# Quota note: 200 x n2-standard-8 is 1,600 vCPUs (plus the control plane)
+# in us-central1 -- more than the usual boskos project allowance. Downsized
+# legs (the scaleup presubmit) fit; the full periodic needs a project with
+# raised CPU and in-use-IP quota.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# ---------------------------------------------------------------------------
+# Scale shape.
+# ---------------------------------------------------------------------------
+SCALEUP_NODE_COUNT="${SCALEUP_NODE_COUNT:-200}"
+SCALEUP_PODS_PER_NODE="${SCALEUP_PODS_PER_NODE:-500}"
+SCALEUP_MAX_PODS="${SCALEUP_MAX_PODS:-512}"
+
+# The window the whole launch must fit in for the 1M/minute story.
+SCALEUP_TARGET_SECONDS="${SCALEUP_TARGET_SECONDS:-60}"
+
+# Report-only vs gating: while we bring the number up, missing the target
+# window prints NOT MET but does not fail the job (an incomplete launch --
+# any create failed, any sandbox never Ready -- always fails). Flip to true
+# once the target is consistently met so regressions go red.
+SCALEUP_ENFORCE_TARGET="${SCALEUP_ENFORCE_TARGET:-false}"
+
+TOTAL_SANDBOXES=$(( SCALEUP_NODE_COUNT * SCALEUP_PODS_PER_NODE ))
+
+if (( SCALEUP_PODS_PER_NODE > SCALEUP_MAX_PODS - 8 )); then
+  # kindnet, kube-proxy and node-exporter live on every node too.
+  echo "SCALEUP_PODS_PER_NODE=${SCALEUP_PODS_PER_NODE} leaves no headroom under maxPods=${SCALEUP_MAX_PODS} for system daemonsets"
+  exit 1
+fi
+
+echo "======================================================="
+echo "scaleup-kops-gcp: ${TOTAL_SANDBOXES} sandboxes on 1 cluster"
+echo "  nodes:         ${SCALEUP_NODE_COUNT} x ${SCALEUP_PODS_PER_NODE} sandboxes (maxPods=${SCALEUP_MAX_PODS})"
+echo "  target window: ${SCALEUP_TARGET_SECONDS}s (~$(( TOTAL_SANDBOXES / SCALEUP_TARGET_SECONDS ))/s)"
+echo "  enforce:       ${SCALEUP_ENFORCE_TARGET}"
+echo "======================================================="
+
+# ---------------------------------------------------------------------------
+# Cluster + harness configuration, handed to the shared kops-gcp runner.
+# ---------------------------------------------------------------------------
+export CNI="${CNI:-kindnet}"
+export STRESS_NODE_COUNT="${SCALEUP_NODE_COUNT}"
+export STRESS_MAX_PODS="${SCALEUP_MAX_PODS}"
+export STRESS_NODE_CIDR_MASK_SIZE="${STRESS_NODE_CIDR_MASK_SIZE:-22}"
+
+# The 22-core control plane saturated near ~150 launches/s in the kindnet
+# benchmark era; this scenario asks for 10x that, so start from the largest
+# same-family box and let the runs tell us where the next wall is.
+export STRESS_CONTROL_PLANE_SIZE="${STRESS_CONTROL_PLANE_SIZE:-c3-standard-88}"
+
+# 200 nodes converge slower than the benchmark's 20.
+export STRESS_VALIDATE_WAIT="${STRESS_VALIDATE_WAIT:-25m}"
+
+# Scheduler client QPS: the proven wall at this scale. The 100-node run at
+# the benchmark's 500/500 pinned the scheduler's client rate limiter (11.4s
+# mean queued wait per request) and capped ready-throughput at ~470/s.
+# ~2 scheduler requests per pod placed means the 1,667/s target needs
+# ~3,400 req/s; 4000 keeps the limiter out of the measurement.
+export STRESS_SCHEDULER_QPS="${STRESS_SCHEDULER_QPS:-4000}"
+export STRESS_SCHEDULER_BURST="${STRESS_SCHEDULER_BURST:-4000}"
+
+# APF seat budget: with the scheduler's client limiter removed, its bindings
+# queued server-side in workload-high (338k queued seconds on the 100-node
+# run at the 1600/800 baseline-to-be; the run actually ran at the 400/200
+# kubeadm defaults). 3200/1600 gives workload-high roughly 4x the seats of
+# the kubeadm defaults while apiserver CPU (38 of 88 cores at peak) has
+# room to serve them.
+export STRESS_MAX_REQUESTS_INFLIGHT="${STRESS_MAX_REQUESTS_INFLIGHT:-3200}"
+export STRESS_MAX_MUTATING_INFLIGHT="${STRESS_MAX_MUTATING_INFLIGHT:-1600}"
+
+# The e2e benchmark suite adds nothing to this scenario's signal and would
+# run against a 10x-sized cluster; skip it.
+export RUN_BENCHMARK_SUITE=false
+
+# One phase: fill = create everything closed-loop, wait for all Ready.
+export STRESS_PHASES="fill"
+export STRESS_FILL_PER_NODE="${SCALEUP_PODS_PER_NODE}"
+
+# 1,600 concurrent create workers covers the target rate even at ~1s
+# create-ack; sharded over 16 HTTP/2 connections to stay under the
+# apiserver's ~100-streams-per-connection cap (test/stress clientconns.go).
+export STRESS_CREATE_CONCURRENCY="${STRESS_CREATE_CONCURRENCY:-1600}"
+CLIENT_CONNECTIONS=$(( (STRESS_CREATE_CONCURRENCY + 99) / 100 ))
+
+# --per-sandbox-timeout is the fill stall detector (no NEW Ready for that
+#   long aborts the run) -- generous because the Ready wave trails the
+#   create wave at this scale.
+# --cleanup=false: tearing down a 100k-sandbox namespace would add many
+#   minutes; the whole cluster is deleted on exit anyway.
+export STRESS_EXTRA_ARGS="${STRESS_EXTRA_ARGS:---client-connections=${CLIENT_CONNECTIONS} --per-sandbox-timeout=15m --cleanup=false}"
+export STRESS_TIMEOUT="${STRESS_TIMEOUT:-60m}"
+
+# Controller tuning: qps=2000 + 400 workers is the empirical optimum from
+# the 100-node campaign (runs 3/4/5), and NOT for the obvious reason.
+# The client-side limiter is not (only) protecting the apiserver -- it
+# paces the reconcile loop so workqueue events coalesce: at qps=2000 a
+# sandbox launch costs ~4.3 status PATCHes; uncapped (qps=-1) it costs
+# ~7.6, with or without more workers, and the extra intermediate-state
+# PATCHes queue in APF ahead of the Ready-marking PATCH (run 4: -18%
+# throughput). Reclassifying the controller into workload-high
+# (apf-flowschema.yaml, applied via STRESS_EXTRA_MANIFESTS) helped the
+# controller's own APF wait but crowded the scheduler's lane and slowed
+# pod-ready p50 55.9s -> 68.6s (run 5: worse still). The durable fix is
+# fewer status writes per launch in the controller itself, not tuning --
+# which is what the two write-reduction windows below turn on.
+#
+# --sandbox-transitional-status-window=180s: transitional status changes
+#   (pre-Ready fills, reason churn, field fills) defer until the Ready flip,
+#   so the fast path writes status once per launch. 180s comfortably
+#   exceeds the worst observed launch tail (run 5 max e2e 148.7s), so no
+#   transitional flush fires mid-burst; shrink it as the wave compresses
+#   toward the 60s target. Material changes (Ready flips, Finished,
+#   Expired, failures) always write immediately.
+# --sandbox-write-behind-window=1s: coalesces the recoverable pod
+#   label/annotation patch (~13k requests on the 50k run).
+export CONTROLLER_ARGS="${CONTROLLER_ARGS:---kube-api-qps=2000 --kube-api-burst=4000 --sandbox-concurrent-workers=400 --sandbox-transitional-status-window=180s --sandbox-write-behind-window=1s}"
+
+"${REPO_ROOT}/test/benchmarks/scenarios/benchmarks-kops-gcp/run"
+
+# ---------------------------------------------------------------------------
+# Verdict: did the launch fit the target window? Runs only when the stress
+# run itself succeeded (set -e above). An incomplete launch always fails;
+# missing the window fails only under SCALEUP_ENFORCE_TARGET=true.
+# ---------------------------------------------------------------------------
+# The shared runner cds to REPO_ROOT, so its ARTIFACTS fallback of "." is
+# the repo root; mirror that here where we have not cd'd.
+python3 - "${ARTIFACTS:-${REPO_ROOT}}/stress-test/summary.json" "${TOTAL_SANDBOXES}" \
+  "${SCALEUP_TARGET_SECONDS}" "${SCALEUP_ENFORCE_TARGET}" <<'PYEOF'
+import json
+import sys
+
+summary_path, total, target_seconds, enforce = sys.argv[1], int(sys.argv[2]), float(sys.argv[3]), sys.argv[4] == "true"
+
+with open(summary_path) as f:
+    summary = json.load(f)
+
+fills = [p for p in summary["phases"] if p.get("kind") == "fill"]
+if not fills:
+    print("SCALEUP FAILED: no fill phase found in summary.json")
+    sys.exit(1)
+phase = fills[0]
+
+requested = phase["requested"]
+ready = phase["ready"]
+failed = phase["failed"]
+time_to_all_ready = phase.get("timeToAllReadySeconds")
+ready_throughput = phase.get("readyThroughput") or {}
+
+print("==================== SCALEUP RESULT ====================")
+print(f"sandboxes: requested={requested} ready={ready} failed={failed}")
+if ready_throughput:
+    print("ready throughput: overall={overallPerSecond:.1f}/s best10s={best10sPerSecond:.1f}/s best60s={best60sPerSecond:.1f}/s".format(**ready_throughput))
+
+if ready < requested or failed > 0 or time_to_all_ready is None:
+    print(f"SCALEUP FAILED: launch incomplete ({ready}/{requested} Ready, {failed} failed)")
+    sys.exit(1)
+
+rate = ready / time_to_all_ready
+target_rate = total / target_seconds
+met = time_to_all_ready <= target_seconds
+print(f"launched {ready:,} sandboxes to Ready in {time_to_all_ready:.1f}s = {rate:,.0f}/s")
+print(f"target: {total:,} in {target_seconds:.0f}s ({target_rate:,.0f}/s) -> {'MET' if met else 'NOT MET'}")
+print(f"projection across 10 clusters: {int(rate * 60 * 10):,} sandboxes/minute")
+print("=========================================================")
+
+if enforce and not met:
+    print("SCALEUP FAILED: target window not met (SCALEUP_ENFORCE_TARGET=true)")
+    sys.exit(1)
+PYEOF
+
+echo "scaleup-kops-gcp completed."


### PR DESCRIPTION
## What

Two pieces, working toward launching 1M sandboxes/minute across 10 clusters (100k/cluster in 60s, ~1,667/s each):

1. **Controller: one status write per launch** (`--sandbox-transitional-status-window`, default off)
   - `materialStatusChange`: explicit material-vs-transitional classification of status changes (condition value flips, Finished add/removal, and terminal Ready reasons are material; reason/message churn and field fills are transitional).
   - Transitional writes on sandboxes younger than the window defer and ride the Ready flip; stuck sandboxes flush an explanatory status at age == window via RequeueAfter. Crash-safe: deferred writes are recomputed from informer state (same argument as #1252).
   - `staleCacheGuard`: skips reconcile passes running against an informer copy that predates the controller's own last write (rv-equality only; the write's own watch event guarantees a fresh pass) — these passes produced ~39k no-op PATCHes per 50k launches.

2. **`scaleup-kops-gcp` scenario + `scaleup` presubmit/periodic**: kindnet, maxPods=512, /22 node pod CIDRs, fill-phase launch with a rate-vs-target verdict; shared runner gains backward-compatible knobs (node size/zone, maxPods, node CIDR mask, scheduler QPS, APF inflight, validate wait, benchmark-suite skip).

## Measured (100 nodes × 500 sandboxes = 50k, n2-standard-64 CP, 6-run campaign)

| run | change | best-60s ready | all 50k Ready |
|---|---|---|---|
| 1 | baseline | 496/s | 164s |
| 2 | scheduler client QPS 500→4000 | 602/s | 146s |
| 3 | APF inflight 400/200→3200/1600 | 679/s | 114s |
| 6 | **this PR's controller change** | **757/s** | **99.5s** |

Run 6 mechanics: sandbox status PATCHes 107,333 → 48,446 (0.97/launch), stale no-ops eliminated, pod-ready p50 55.9s → 40.5s (freed APF seats accelerate the pod path), zero failed launches.

Negative results are encoded as comments where the knobs live: uncapping the controller client without this PR's write gating inflated transitional writes 76% and lost throughput in both APF lanes tried (runs 4–5); the controller-in-workload-high FlowSchema ships unapplied for experiments.

## WIP

- [ ] Rerun with controller client QPS uncapped now that transitional writes are structurally gated (expected to close the ~30s pod-ready→sandbox-Ready gap)
- [ ] 200-node full leg (needs ~1,700 vCPUs quota) and target-enforcement flip
- [ ] Possibly retire the pod-name annotation write (derivable pod names?)