### PR TITLE
feat: add SKIP_BUILD to deploy published images without a local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,17 +78,20 @@ build-sandboxd:
 	go build -ldflags "$(LD_FLAGS)" -o bin/sandboxd ./packages/sandboxd/cmd/sandboxd
 
 KIND_CLUSTER=agent-sandbox
-CONTAINER_ENGINE ?= docker
 
+# `make deploy-kind` delegates to dev/tools/deploy-kind, which reads its
+# configuration from environment variables (GNU make exports command-line
+# variables to recipe subprocesses):
+#   SKIP_BUILD=true       deploy published images instead of building locally
+#   IMAGE_TAG=vX.Y.Z      pin the published image tag (with SKIP_BUILD=true)
+#   EXTENSIONS=true       deploy the extensions controller and CRDs
+#   CONTROLLER_ONLY=true  build and push only the controller image
+#   CONTROLLER_ARGS=...   extra controller flags
+#   CONTAINER_ENGINE=...  docker or podman
+#   KIND_CLUSTER_NAME=... cluster name (default: agent-sandbox)
 .PHONY: deploy-kind
-# `EXTENSIONS=true make deploy-kind` to deploy with Extensions enabled.
-# `CONTROLLER_ARGS="--enable-pprof-debug --zap-log-level=debug" make deploy-kind` to deploy with custom controller flags.
-# `CONTROLLER_ONLY=true make deploy-kind` to build and push only the controller image.
-# `CONTAINER_ENGINE=podman make deploy-kind` to use podman instead of docker.
 deploy-kind:
-	./dev/tools/create-kind-cluster --recreate ${KIND_CLUSTER} --kubeconfig bin/KUBECONFIG --container-engine=${CONTAINER_ENGINE}
-	./dev/tools/push-images --image-prefix=kind.local/ --kind-cluster-name=${KIND_CLUSTER} --container-engine=${CONTAINER_ENGINE} $(if $(filter true,$(CONTROLLER_ONLY)),--controller-only)
-	./dev/tools/deploy-to-kube --image-prefix=kind.local/ $(if $(filter true,$(EXTENSIONS)),--extensions) $(if $(CONTROLLER_ARGS),--controller-args="$(CONTROLLER_ARGS)")
+	KIND_CLUSTER_NAME="$${KIND_CLUSTER_NAME:-$(KIND_CLUSTER)}" ./dev/tools/deploy-kind
 
 .PHONY: deploy-cloud-provider-kind
 deploy-cloud-provider-kind:

--- a/dev/tools/deploy-kind
+++ b/dev/tools/deploy-kind
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Orchestrate the local kind deployment (invoked by `make deploy-kind`).
+
+Reads its configuration from environment variables — GNU make exports
+command-line variables to recipe subprocesses, so `SKIP_BUILD=true make
+deploy-kind` reaches this script with SKIP_BUILD=true — which keeps the
+Makefile completely declarative. The workflow:
+
+  1. create-kind-cluster   (always recreates the cluster)
+  2. push-images           (skipped when SKIP_BUILD=true)
+  3. deploy-to-kube        (published images when SKIP_BUILD=true)
+
+Environment:
+  SKIP_BUILD=true       deploy the latest published images from
+                        registry.k8s.io/agent-sandbox/ instead of building
+                        them locally
+  IMAGE_TAG=vX.Y.Z      pin the published image tag (SKIP_BUILD mode)
+  EXTENSIONS=true       also deploy the extensions controller and CRDs
+  CONTROLLER_ONLY=true  build and push only the controller image
+  CONTROLLER_ARGS=...   extra controller flags
+  CONTAINER_ENGINE      docker or podman (default: docker)
+  KIND_CLUSTER_NAME     cluster name (default: agent-sandbox)
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+from importlib.machinery import SourceFileLoader
+
+from shared import utils
+
+_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# latest-published-tag is a small side-effect-free module; load it in-process
+# instead of spawning a subprocess (the repo's established pattern for
+# importing extensionless dev/tools scripts, see push_images_test.py).
+_loader = SourceFileLoader("latest_published_tag",
+                           os.path.join(_TOOLS_DIR, "latest-published-tag"))
+_spec = importlib.util.spec_from_loader("latest_published_tag", _loader)
+_latest_published_tag = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_latest_published_tag)
+
+
+def _env_flag(name):
+    """Treat an env var as true when it is literally "true"."""
+    return os.environ.get(name, "") == "true"
+
+
+def _run_tool(tool, *args):
+    """Run a dev/tools script from the repo root with the current interpreter."""
+    subprocess.run(
+        [sys.executable, os.path.join(_TOOLS_DIR, tool), *args],
+        cwd=utils.get_repo_root(), check=True)
+
+
+def _resolve_published_tag():
+    """Return the newest stable published tag from registry.k8s.io."""
+    try:
+        tag = _latest_published_tag.pick_latest_stable(
+            _latest_published_tag.fetch_all_tags())
+    except Exception as e:  # network or parse failures
+        sys.exit(f"error: cannot resolve the latest published image tag from "
+                 f"registry.k8s.io: {e}; pin one with IMAGE_TAG=vX.Y.Z")
+    if not tag:
+        sys.exit("error: no stable vX.Y.Z tag found on registry.k8s.io; "
+                 "pin one with IMAGE_TAG=vX.Y.Z")
+    return tag
+
+
+def main():
+    cluster = os.environ.get("KIND_CLUSTER_NAME") or "agent-sandbox"
+    container_engine = os.environ.get("CONTAINER_ENGINE", "docker")
+    skip_build = _env_flag("SKIP_BUILD")
+    extensions = _env_flag("EXTENSIONS")
+    controller_only = _env_flag("CONTROLLER_ONLY")
+    controller_args = os.environ.get("CONTROLLER_ARGS", "")
+    kubeconfig = os.path.join(utils.get_repo_root(), "bin", "KUBECONFIG")
+
+    # 1. create (recreate) the kind cluster
+    _run_tool("create-kind-cluster", "--recreate", cluster,
+              "--kubeconfig", kubeconfig, "--container-engine", container_engine)
+
+    # 2. build and load images (skipped when deploying published images)
+    if not skip_build:
+        args = ["--image-prefix=kind.local/",
+                f"--kind-cluster-name={cluster}",
+                f"--container-engine={container_engine}"]
+        if controller_only:
+            args.append("--controller-only")
+        _run_tool("push-images", *args)
+    else:
+        print("SKIP_BUILD=true: skipping image build")
+
+    # 3. deploy the manifests
+    if skip_build:
+        image_prefix = utils.PUBLISHED_IMAGE_PREFIX
+        image_tag = os.environ.get("IMAGE_TAG") or _resolve_published_tag()
+        print(f"deploying published images from {image_prefix} (tag {image_tag})")
+    else:
+        image_prefix = "kind.local/"
+        image_tag = ""
+    args = [f"--image-prefix={image_prefix}", f"--image-tag={image_tag}"]
+    if extensions:
+        args.append("--extensions")
+    if controller_args:
+        args.append(f"--controller-args={controller_args}")
+    _run_tool("deploy-to-kube", *args)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/tools/deploy_kind_test.py
+++ b/dev/tools/deploy_kind_test.py
@@ -1,0 +1,103 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for deploy-kind — orchestration and env-based configuration."""
+
+import importlib.util
+import os
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+# Load the extensionless deploy-kind script via importlib (same pattern as
+# dev/tools/push_images_test.py).
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _SCRIPT_DIR)
+_REPO_ROOT = os.path.dirname(os.path.dirname(_SCRIPT_DIR))
+
+_SCRIPT_PATH = os.path.join(_SCRIPT_DIR, "deploy-kind")
+_loader = SourceFileLoader("deploy_kind", _SCRIPT_PATH)
+_spec = importlib.util.spec_from_loader("deploy_kind", _loader)
+deploy_kind = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_kind)
+
+
+class DeployKindTest(unittest.TestCase):
+    def _run_with(self, **env):
+        with mock.patch.dict(os.environ, {"PATH": os.environ.get("PATH", ""), **env},
+                             clear=True), \
+             mock.patch.object(deploy_kind, "_run_tool") as run_tool:
+            deploy_kind.main()
+        return [call.args for call in run_tool.call_args_list]
+
+    def _find_call(self, calls, tool):
+        match = next((args for args in calls if args[0] == tool), None)
+        return None if match is None else list(match[1:])
+
+    def _assert_create_call(self, calls, cluster, engine):
+        self.assertEqual(
+            self._find_call(calls, "create-kind-cluster"),
+            ["--recreate", cluster, "--kubeconfig",
+             os.path.join(_REPO_ROOT, "bin", "KUBECONFIG"),
+             "--container-engine", engine])
+
+    def test_default_flow(self):
+        calls = self._run_with()
+        self._assert_create_call(calls, "agent-sandbox", "docker")
+        self.assertEqual(self._find_call(calls, "push-images"),
+                         ["--image-prefix=kind.local/",
+                          "--kind-cluster-name=agent-sandbox",
+                          "--container-engine=docker"])
+        self.assertEqual(self._find_call(calls, "deploy-to-kube"),
+                         ["--image-prefix=kind.local/", "--image-tag="])
+
+    def test_skip_build_deploys_published_images(self):
+        with mock.patch.object(deploy_kind, "_resolve_published_tag",
+                               return_value="v0.5.5"):
+            calls = self._run_with(SKIP_BUILD="true")
+        self.assertIsNone(self._find_call(calls, "push-images"))
+        self.assertEqual(self._find_call(calls, "deploy-to-kube"),
+                         ["--image-prefix=registry.k8s.io/agent-sandbox/",
+                          "--image-tag=v0.5.5"])
+
+    def test_skip_build_with_pinned_image_tag(self):
+        with mock.patch.object(deploy_kind, "_resolve_published_tag") as resolve:
+            calls = self._run_with(SKIP_BUILD="true", IMAGE_TAG="v0.5.4")
+        resolve.assert_not_called()
+        self.assertEqual(self._find_call(calls, "deploy-to-kube"),
+                         ["--image-prefix=registry.k8s.io/agent-sandbox/",
+                          "--image-tag=v0.5.4"])
+
+    def test_extensions_and_controller_flags(self):
+        calls = self._run_with(EXTENSIONS="true",
+                               CONTROLLER_ARGS="--zap-log-level=debug")
+        self.assertEqual(self._find_call(calls, "deploy-to-kube"),
+                         ["--image-prefix=kind.local/", "--image-tag=",
+                          "--extensions", "--controller-args=--zap-log-level=debug"])
+
+    def test_controller_only_builds_just_the_controller(self):
+        calls = self._run_with(CONTROLLER_ONLY="true")
+        self.assertEqual(self._find_call(calls, "push-images")[-1],
+                         "--controller-only")
+
+    def test_custom_engine_and_cluster(self):
+        calls = self._run_with(CONTAINER_ENGINE="podman", KIND_CLUSTER_NAME="other")
+        self._assert_create_call(calls, "other", "podman")
+        self.assertIn("--container-engine=podman",
+                      self._find_call(calls, "push-images"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dev/tools/latest-published-tag
+++ b/dev/tools/latest-published-tag
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Print the latest stable published tag of the agent-sandbox controller image.
+
+Queries the tag list of registry.k8s.io/agent-sandbox/agent-sandbox-controller
+and prints the newest stable vX.Y.Z tag, so `make deploy-kind SKIP_BUILD=true`
+never needs a hardcoded tag bumped per release. Pre-release tags (vX.Y.ZrcN,
+vX.Y.Z-rc.N) and signature/attestation tags are ignored. Pin a specific
+release instead by passing IMAGE_TAG to make, e.g. IMAGE_TAG=v0.5.5.
+"""
+
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+_TAGS_URL = "https://registry.k8s.io/v2/agent-sandbox/agent-sandbox-controller/tags/list"
+_STABLE_RE = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+_NEXT_LINK_RE = re.compile(r'\s*<([^>]+)>\s*;\s*rel\s*=\s*"?next"?', re.IGNORECASE)
+
+
+def pick_latest_stable(tags):
+    """Return the newest stable vX.Y.Z tag from *tags*, or None if there is none."""
+    stable = [t for t in tags if _STABLE_RE.match(t)]
+    return max(stable, key=lambda t: tuple(int(x) for x in t.lstrip("v").split(".")),
+               default=None)
+
+
+def _next_link(headers):
+    """Return the next-page URL advertised in a Link header, or None if there is none.
+
+    The registry may paginate the tags list (OCI Distribution Spec): each page
+    carries a ``Link: <url>; rel="next"`` header pointing at the next page.
+    """
+    for part in (headers.get("Link") or "").split(","):
+        match = _NEXT_LINK_RE.match(part)
+        if match:
+            return urllib.parse.urljoin(_TAGS_URL, match.group(1))
+    return None
+
+
+def fetch_all_tags():
+    """Fetch tags from every page of the registry tags/list endpoint."""
+    tags = []
+    url = _TAGS_URL
+    while url:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            tags.extend(json.load(resp).get("tags") or [])
+            url = _next_link(resp.headers)
+    return tags
+
+
+def main():
+    try:
+        tags = fetch_all_tags()
+    except Exception as e:  # network or parse failures
+        print(f"error: failed to list tags from {_TAGS_URL}: {e}", file=sys.stderr)
+        sys.exit(1)
+    tag = pick_latest_stable(tags)
+    if not tag:
+        print("error: no stable vX.Y.Z tag found on registry.k8s.io", file=sys.stderr)
+        sys.exit(1)
+    print(tag)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/dev/tools/latest_published_tag_test.py
+++ b/dev/tools/latest_published_tag_test.py
@@ -1,0 +1,124 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for latest-published-tag — stable tag selection and pagination."""
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+from unittest import mock
+
+# Load the extensionless latest-published-tag script via importlib (same
+# pattern as dev/tools/push_images_test.py).
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _SCRIPT_DIR)
+
+_SCRIPT_PATH = os.path.join(_SCRIPT_DIR, "latest-published-tag")
+_loader = SourceFileLoader("latest_published_tag", _SCRIPT_PATH)
+_spec = importlib.util.spec_from_loader("latest_published_tag", _loader)
+latest_published_tag = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(latest_published_tag)
+
+
+class PickLatestStableTest(unittest.TestCase):
+    def test_picks_newest_stable(self):
+        tags = ["v0.4.5", "v0.5.3", "v0.1.1", "v0.5.5", "v0.5.0"]
+        self.assertEqual(latest_published_tag.pick_latest_stable(tags), "v0.5.5")
+
+    def test_ignores_prerelease_and_signature_tags(self):
+        tags = [
+            "v0.5.0rc1", "v0.5.0rc5", "v0.1.0-rc.2",
+            "sha256-027a33ae4a4608ea26761978b8d14a0e1b03804b625f2d0a92b0cbddcb1536ef.sig",
+            "sha256-4405ad751517c9f490fe7e4c6c419e8b565d98ee7583f0ad76c606ab18266b9b.att",
+            "v0.4.6",
+        ]
+        self.assertEqual(latest_published_tag.pick_latest_stable(tags), "v0.4.6")
+
+    def test_numeric_ordering_not_lexicographic(self):
+        tags = ["v0.10.0", "v0.9.0", "v0.5.5"]
+        self.assertEqual(latest_published_tag.pick_latest_stable(tags), "v0.10.0")
+
+    def test_returns_none_when_no_stable_tags(self):
+        self.assertIsNone(latest_published_tag.pick_latest_stable([]))
+        self.assertIsNone(latest_published_tag.pick_latest_stable(["v0.5.0rc1", "v0.1.0-rc.2"]))
+
+
+class _FakeResponse:
+    """Minimal stand-in for urllib.request.urlopen responses."""
+
+    def __init__(self, payload, headers=None):
+        self._payload = payload
+        self.headers = headers or {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def read(self):
+        return self._payload
+
+
+def _page(tags, next_url=None):
+    """Build a fake tags/list page, optionally advertising a next page."""
+    headers = {"Link": f'<{next_url}>; rel="next"'} if next_url else {}
+    return _FakeResponse(json.dumps({"tags": tags}).encode(), headers)
+
+
+class FetchAllTagsTest(unittest.TestCase):
+    def test_follows_next_links_across_pages(self):
+        next_url = ("https://registry.k8s.io/v2/agent-sandbox/agent-sandbox-controller/"
+                    "tags/list?n=2&last=v0.4.5")
+        pages = [
+            _page(["v0.4.5", "v0.5.0rc1"], next_url),
+            _page(["v0.5.5"]),
+        ]
+        with mock.patch("urllib.request.urlopen", side_effect=pages) as urlopen:
+            tags = latest_published_tag.fetch_all_tags()
+        self.assertEqual(tags, ["v0.4.5", "v0.5.0rc1", "v0.5.5"])
+        self.assertEqual(urlopen.call_count, 2)
+
+    def test_picks_newest_stable_from_later_page(self):
+        next_url = ("https://registry.k8s.io/v2/agent-sandbox/agent-sandbox-controller/"
+                    "tags/list?n=2&last=v0.5.0")
+        pages = [
+            _page(["v0.4.5", "v0.5.0"], next_url),
+            _page(["v0.6.0"]),
+        ]
+        with mock.patch("urllib.request.urlopen", side_effect=pages):
+            tags = latest_published_tag.fetch_all_tags()
+        self.assertEqual(latest_published_tag.pick_latest_stable(tags), "v0.6.0")
+
+    def test_single_page_without_link_header(self):
+        with mock.patch("urllib.request.urlopen", side_effect=[_page(["v0.5.5"])]) as urlopen:
+            tags = latest_published_tag.fetch_all_tags()
+        self.assertEqual(tags, ["v0.5.5"])
+        self.assertEqual(urlopen.call_count, 1)
+
+    def test_null_tags_are_ignored(self):
+        # A valid OCI response may carry "tags": null; it must not crash.
+        response = _FakeResponse(json.dumps({"tags": None}).encode())
+        with mock.patch("urllib.request.urlopen", side_effect=[response]):
+            tags = latest_published_tag.fetch_all_tags()
+        self.assertEqual(tags, [])
+        self.assertIsNone(latest_published_tag.pick_latest_stable(tags))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/dev/tools/shared/utils.py
+++ b/dev/tools/shared/utils.py
@@ -19,6 +19,10 @@ import re
 import subprocess
 
 
+# Where published agent-sandbox images live (see dev/tools/release).
+PUBLISHED_IMAGE_PREFIX = "registry.k8s.io/agent-sandbox/"
+
+
 # Version strings derived from git refs are interpolated unquoted into the
 # Dockerfile's `RUN go build -ldflags="...${GIT_VERSION}..."` instruction. A
 # git tag or branch containing shell metacharacters could therefore break out

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,6 +65,26 @@ This command will:
 3.  Push the image to the `kind` cluster.
 4.  Deploy the controller to the `kind` cluster.
 
+To deploy the latest **published** images from `registry.k8s.io/agent-sandbox/`
+instead of building them locally (no container build required):
+
+```sh
+make deploy-kind SKIP_BUILD=true
+```
+
+The published image tag is resolved automatically from `registry.k8s.io` at
+deploy time (the newest stable `vX.Y.Z`, so no per-release bump is needed);
+pin a specific release with `IMAGE_TAG`:
+
+```sh
+make deploy-kind SKIP_BUILD=true IMAGE_TAG=v0.5.4
+```
+
+Note that only `agent-sandbox-controller` is deployed by `deploy-kind` itself;
+any runtime images referenced by your Sandbox resources (e.g. `chrome-sandbox`,
+`python-runtime-sandbox`) must be pullable from a registry the cluster can
+reach.
+
 You can verify that the controller is running by checking the pods in the `agent-sandbox-system` namespace:
 
 ```sh


### PR DESCRIPTION
#### What this PR does / why we need it:

`make deploy-kind SKIP_BUILD=true` now skips the local image build and
   deploys the latest published images from registry.k8s.io instead. The
   published tag is resolved automatically at deploy time by the new
   dev/tools/latest-published-tag helper (newest stable vX.Y.Z, so no
   per-release bump is needed); IMAGE_TAG pins a specific release.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes-sigs/agent-sandbox/issues/1383

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Local Kind deployments can use published controller images without building or pushing locally.
* The latest stable image tag is selected automatically, with support for pinning a specific release.
* Deployment options support custom cluster names, container engines, extensions, and controller settings.
* Local image builds remain supported, including controller-only builds.

## Documentation
* Added guidance for published images and required runtime image access.

## Tests
* Added coverage for tag selection, pagination, version ordering, and deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->