### PR TITLE
doc: Mention the need for storage class

### DIFF
--- a/site/content/docs/volumes/volume-claim-template/_index.md
+++ b/site/content/docs/volumes/volume-claim-template/_index.md
@@ -24,6 +24,19 @@ The introduction of **`volumeClaimTemplates`** into the `SandboxTemplate` API so
 
 ---
 
+{{% alert title="Prerequisite: StorageClass" color="warning" %}}
+`volumeClaimTemplates` rely on a working [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) in your cluster. If no `storageClassName` is specified in the template, Kubernetes uses the cluster's **default StorageClass**. Most managed Kubernetes distributions (GKE, EKS, AKS) and local development environments like KIND (which ships with the `standard` StorageClass backed by `rancher.io/local-path`) provide one out of the box.
+
+If your cluster does not have a default StorageClass, PVCs created from `volumeClaimTemplates` will remain in a `Pending` state. The PVC events will show:
+`no persistent volumes available for this claim and no storage class is set`.
+
+To check your cluster's StorageClasses, run:
+```bash
+kubectl get storageclass
+```
+The default StorageClass is marked with `(default)` in the output. If none is set, either annotate an existing StorageClass as default or explicitly set `storageClassName` in your `volumeClaimTemplates` spec.
+{{% /alert %}}
+
 ### Create a SandboxTemplate with Volume Claims
 To use a volume, you need to add the `volumeClaimTemplates` array to your `SandboxTemplate` specification and reference it in the `volumeMounts` of your container.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
In environments like Single Node OpenShift cluster there is no default storage class. The feature `volumeClaimTemplates ` is dependent on a storage class already present and configured correctly. Its best to call it out in the docs. It also gives a hint to the reader where to debug the issues.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the `StorageClass` prerequisite for `volumeClaimTemplates`.
  * Documented default behavior and the failure that occurs when no default `StorageClass` is configured.
  * Included commands and configuration options for checking or setting a default `StorageClass`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->