### PR TITLE
Add OpenAI integration

### DIFF
--- a/clients/integrations/openai/README.md
+++ b/clients/integrations/openai/README.md
@@ -4,9 +4,9 @@ Runs OpenAI Agents SDK `SandboxAgent` workloads on
 [Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox), as an
 out-of-tree sandbox provider.
 
-This is **Option A** from [k8s-agent-sandbox-integration-options.md](k8s-agent-sandbox-integration-options.md):
-a separate package rather than a PR to `openai-agents-python`, because OpenAI maintainers
-have [declined new in-tree third-party providers](https://github.com/openai/openai-agents-python/issues/3468).
+It ships as a separate package rather than as a PR to `openai-agents-python`, whose
+maintainers
+[do not currently accept in-tree third-party providers](https://github.com/openai/openai-agents-python/issues/3468).
 
 Status: prototype. Exercised end-to-end against an in-process fake pod; **not yet run
 against a live cluster** — see [Before trusting it](#before-trusting-it).
@@ -42,8 +42,6 @@ run_config = RunConfig(
 
 result = await Runner.run(agent, "summarize the repo", run_config=run_config)
 ```
-
-A runnable script is in [examples/k8s_runner.py](examples/k8s_runner.py).
 
 ## Cluster prerequisites
 

--- a/clients/integrations/openai/README.md
+++ b/clients/integrations/openai/README.md
@@ -1,0 +1,120 @@
+# openai-agents-k8s-sandbox (prototype)
+
+Runs OpenAI Agents SDK `SandboxAgent` workloads on
+[Kubernetes Agent Sandbox](https://github.com/kubernetes-sigs/agent-sandbox), as an
+out-of-tree sandbox provider.
+
+This is **Option A** from [k8s-agent-sandbox-integration-options.md](k8s-agent-sandbox-integration-options.md):
+a separate package rather than a PR to `openai-agents-python`, because OpenAI maintainers
+have [declined new in-tree third-party providers](https://github.com/openai/openai-agents-python/issues/3468).
+
+Status: prototype. Exercised end-to-end against an in-process fake pod; **not yet run
+against a live cluster** — see [Before trusting it](#before-trusting-it).
+
+## Usage
+
+The agent definition does not change; only the run config does.
+
+```python
+from agents import Runner
+from agents.run import RunConfig
+from agents.sandbox import SandboxRunConfig
+from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
+from k8s_agent_sandbox.models import SandboxInClusterConnectionConfig
+
+from openai_agents_k8s_sandbox import K8sSandboxClient, K8sSandboxClientOptions
+
+sandbox_client = AsyncSandboxClient(
+    connection_config=SandboxInClusterConnectionConfig(),
+    cleanup=False,  # see "Lifecycle ownership" below
+)
+
+run_config = RunConfig(
+    sandbox=SandboxRunConfig(
+        client=K8sSandboxClient(sandbox_client),
+        options=K8sSandboxClientOptions(
+            warm_pool="python-sandbox-pool",
+            namespace="agents",
+            shutdown_after_seconds=3600,
+        ),
+    ),
+)
+
+result = await Runner.run(agent, "summarize the repo", run_config=run_config)
+```
+
+A runnable script is in [examples/k8s_runner.py](examples/k8s_runner.py).
+
+## Cluster prerequisites
+
+- Agent Sandbox controller + extensions installed (`sandbox-with-extensions.yaml`).
+- A `SandboxTemplate` and a `SandboxWarmPool` whose image runs the in-pod sandbox server on
+  port 8888 (e.g. `python-runtime-sandbox`). A stock `python:3.14-slim` will **not** work.
+- The image needs a POSIX shell, `tar`, and `base64` on `PATH`, and a writable workspace root.
+- For manifest `users`/`groups`: `sudo` in the image, because the SDK prefixes `sudo -u`
+  itself when a tool runs as a non-default user.
+
+## How it maps
+
+| SDK contract | Implementation |
+| --- | --- |
+| `create` | `AsyncSandboxClient.create_sandbox(warm_pool, …)`, TTL via `shutdown_after_seconds` |
+| `resume` | `get_sandbox(claim, warmpool_name=…)`; if the claim is gone, provision a replacement and let `start()` restore from `state.snapshot` |
+| `delete` | `delete_sandbox(claim)` — deletes the `SandboxClaim`, cascading to pod and PVC |
+| `_exec_internal` | `commands.run()`; argv is `shlex.join`-ed and the pod's shell reconstructs it |
+| `read` / `write` | `files.read` / `files.write` (bytes-clean), or base64 over exec |
+| `persist_workspace` | `tar` inside the pod to a staging file, then download it |
+| `hydrate_workspace` | validate the tar locally, upload it, `tar -x` inside the pod |
+| `running` | `status()[0] == "SandboxReady"` |
+| `resolve_exposed_port` | the sandbox's stable in-cluster DNS name (`{sandbox}.{ns}.svc.cluster.local`) |
+| PTY | not supported — the HTTP API has no PTY channel |
+
+Mounts: no provider-specific mount strategy is needed. `InContainerMountStrategy` with
+`RcloneMountPattern` already works if the image ships `rclone` (S3, GCS, R2, Azure Blob, Box).
+
+## Design notes
+
+**Transport seam.** Everything the session needs from the pod is three operations
+(`exec_command`, `read_file`, `write_file`) behind `SandboxTransport`. Today's
+implementation is HTTP; when the [`sandboxd` gRPC `ProcessService`](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/packages/sandboxd/spec)
+lands (streaming, `WriteStdin`, `ResizeTTY`), it drops in without touching the session.
+
+**Binary safety.** `ExecutionResult.stdout` is `str`, so the exec endpoint is lossy for
+binary. File bytes and workspace tars never travel that path — they use the
+upload/download endpoints. When exec is the only option (`file_transfer="exec"`, or a read
+that must run as a specific user), the payload is base64-encoded.
+
+**Absolute paths.** The in-pod client's own sanitizer strips a leading `/`, which would
+silently relocate workspace writes. This provider passes `allow_unsafe_paths=True` and
+sends absolute paths. A test asserts absolute paths actually reach the endpoints.
+
+**Lifecycle ownership.** `AsyncSandboxClient` defaults to `cleanup=True`, registering an
+`atexit` hook that deletes every tracked sandbox. That destroys sandboxes a later process
+intends to `resume()`. Pass `cleanup=False` and rely on `shutdown_after_seconds`.
+
+**`timeout=None`.** The SDK's "no timeout" becomes `exec_timeout_default_s` (300s), since
+the HTTP API has no unbounded mode.
+
+## Tests
+
+```bash
+.venv/bin/python -m pytest tests -q
+```
+
+`tests/fake_k8s.py` stands in for `k8s_agent_sandbox`'s async client and backs it with the
+local machine — "the pod is this host". The real transport and session code run against
+it, including the shell probes the SDK issues during `start()`, so the tests cover the
+provider contract rather than mocks of it.
+
+## Before trusting it
+
+Unverified against a live cluster, in rough order of risk:
+
+1. **Absolute paths on the server.** Does the in-pod server resolve `/workspace/x` as an
+   absolute path, or relative to its own cwd? If the latter, set `file_transfer="exec"`.
+2. **Concurrency.** The SDK issues parallel `exec` calls. Confirm the in-pod server handles
+   concurrent `POST execute`.
+3. **`tar --exclude`.** Assumes GNU-style `--exclude` before the member list. Busybox tar
+   differs.
+4. **Warm-pool cold start** under the SDK's `sandbox_ready_timeout`.
+5. **Snapshot restore across pods** — the replacement-claim path in `resume()`.

--- a/clients/integrations/openai/pyproject.toml
+++ b/clients/integrations/openai/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "openai-agents-k8s-sandbox"
+version = "0.1.0.dev0"
+description = "Kubernetes Agent Sandbox provider for the OpenAI Agents SDK sandbox API (prototype)"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+dependencies = [
+    # The sandbox API is beta; pin to the minor we were built against.
+    "openai-agents>=0.19,<0.20",
+    "k8s-agent-sandbox[async]>=0.5.3,<0.6",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8", "pytest-asyncio>=0.24"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/openai_agents_k8s_sandbox"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/__init__.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Kubernetes Agent Sandbox provider for the OpenAI Agents SDK.
 
 Importing this package registers the ``"k8s"`` options and session-state discriminators

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/__init__.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/__init__.py
@@ -10,10 +10,10 @@ from .session import K8sSandboxSession
 from .transport import K8sHttpTransport, SandboxTransport
 
 __all__ = [
+    "K8sHttpTransport",
     "K8sSandboxClient",
     "K8sSandboxClientOptions",
     "K8sSandboxSession",
     "K8sSandboxSessionState",
-    "K8sHttpTransport",
     "SandboxTransport",
 ]

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/__init__.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/__init__.py
@@ -1,0 +1,19 @@
+"""Kubernetes Agent Sandbox provider for the OpenAI Agents SDK.
+
+Importing this package registers the ``"k8s"`` options and session-state discriminators
+with the SDK's registries, which is what lets a persisted session round-trip.
+"""
+
+from .client import K8sSandboxClient
+from .options import K8sSandboxClientOptions, K8sSandboxSessionState
+from .session import K8sSandboxSession
+from .transport import K8sHttpTransport, SandboxTransport
+
+__all__ = [
+    "K8sSandboxClient",
+    "K8sSandboxClientOptions",
+    "K8sSandboxSession",
+    "K8sSandboxSessionState",
+    "K8sHttpTransport",
+    "SandboxTransport",
+]

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -109,9 +109,17 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
             # the pod and its PVC.
             pass
 
-        await self._sandbox_client.delete_sandbox(
-            inner.state.claim_name, namespace=inner.state.namespace
-        )
+        # delete_sandbox() logs a failed deletion and returns normally, reporting a leaked
+        # pod and PVC as a clean delete. terminate() does the same work and raises.
+        try:
+            sandbox = await self._sandbox_client.get_sandbox(
+                inner.state.claim_name, namespace=inner.state.namespace
+            )
+        except SandboxNotFoundError:
+            # Claim already gone: nothing left to free. Anything else propagates.
+            return session
+
+        await sandbox.terminate()
         return session
 
     async def resume(self, state: SandboxSessionState) -> SandboxSession:

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -93,9 +93,14 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
         )
 
     async def delete(self, session: SandboxSession) -> SandboxSession:
-        inner = session._inner
+        # `_inner` belongs to the SDK's session wrapper, which only create()/resume() hand
+        # out. Reaching for it directly would raise AttributeError on anything else --
+        # including a bare K8sSandboxSession -- before the check below could say why.
+        inner = getattr(session, "_inner", None)
         if not isinstance(inner, K8sSandboxSession):
-            raise TypeError("K8sSandboxClient.delete expects a K8sSandboxSession")
+            raise TypeError(
+                "K8sSandboxClient.delete expects a K8sSandboxSession from create() or resume()"
+            )
 
         try:
             await inner.shutdown()

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """``BaseSandboxClient`` implementation for Kubernetes Agent Sandbox."""
 
 from __future__ import annotations

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -83,6 +83,7 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
             namespace=options.namespace,
             warm_pool=options.warm_pool,
             file_transfer=options.file_transfer,
+            read_fallback=options.read_fallback,
             exec_timeout_default_s=options.exec_timeout_default_s,
             exposed_port_host=_exposed_port_host(options, sandbox.sandbox_id),
             exposed_port_host_override=options.exposed_port_host,
@@ -209,6 +210,7 @@ def _options_from_state(state: K8sSandboxSessionState) -> K8sSandboxClientOption
         labels=state.labels,
         pod_labels=state.pod_labels,
         file_transfer=state.file_transfer,
+        read_fallback=state.read_fallback,
         exec_timeout_default_s=state.exec_timeout_default_s,
     )
 

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -11,6 +11,7 @@ from agents.sandbox.session.dependencies import Dependencies
 from agents.sandbox.session.manager import Instrumentation
 from agents.sandbox.session.sandbox_client import BaseSandboxClient
 from agents.sandbox.snapshot import SnapshotBase, SnapshotSpec, resolve_snapshot
+from k8s_agent_sandbox.exceptions import SandboxNotFoundError
 
 from .options import K8sSandboxClientOptions, K8sSandboxSessionState
 from .session import K8sSandboxSession
@@ -67,6 +68,11 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
             file_transfer=options.file_transfer,
             exec_timeout_default_s=options.exec_timeout_default_s,
             exposed_port_host=_exposed_port_host(options, sandbox.sandbox_id),
+            exposed_port_host_override=options.exposed_port_host,
+            sandbox_ready_timeout=options.sandbox_ready_timeout,
+            shutdown_after_seconds=options.shutdown_after_seconds,
+            labels=options.labels,
+            pod_labels=options.pod_labels,
         )
         return self._wrap_session(
             self._build_session(sandbox, state), instrumentation=self._instrumentation
@@ -100,20 +106,16 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
         if sandbox is None:
             # The claim is gone (TTL expiry, node loss, namespace cleanup). Provision a
             # replacement; start() hydrates its workspace from state.snapshot.
-            sandbox = await self._create_sandbox(
-                K8sSandboxClientOptions(
-                    warm_pool=state.warm_pool,
-                    namespace=state.namespace,
-                    exposed_ports=state.exposed_ports,
-                    file_transfer=state.file_transfer,
-                    exec_timeout_default_s=state.exec_timeout_default_s,
-                )
-            )
+            sandbox = await self._create_sandbox(_options_from_state(state))
             state.claim_name = sandbox.claim_name
             state.sandbox_id = sandbox.sandbox_id
             state.workspace_root_ready = False
             if state.exposed_port_host:
-                state.exposed_port_host = _in_cluster_host(sandbox.sandbox_id, state.namespace)
+                # A pinned host is the caller's routing decision and still holds. A derived
+                # one named the old sandbox, so it has to follow the new one.
+                state.exposed_port_host = state.exposed_port_host_override or _in_cluster_host(
+                    sandbox.sandbox_id, state.namespace
+                )
 
         inner = self._build_session(sandbox, state)
         inner._set_start_state_preserved(preserved)
@@ -145,7 +147,10 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
             # A warm-pool mismatch is a deliberate refusal by the client, not a missing
             # sandbox. Surface it rather than silently provisioning a replacement.
             raise
-        except Exception:
+        except SandboxNotFoundError:
+            # The only failure that justifies provisioning a replacement. Anything else —
+            # an unreachable API server, a bug in this provider — would orphan a sandbox
+            # that is still running, so it propagates.
             return None
 
     def _build_session(self, sandbox: Any, state: K8sSandboxSessionState) -> K8sSandboxSession:
@@ -155,6 +160,23 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
             default_timeout_s=state.exec_timeout_default_s,
         )
         return K8sSandboxSession(transport=transport, state=state)
+
+
+def _options_from_state(state: K8sSandboxSessionState) -> K8sSandboxClientOptions:
+    """Rebuild the creation options a replacement sandbox has to be provisioned with."""
+
+    return K8sSandboxClientOptions(
+        warm_pool=state.warm_pool,
+        namespace=state.namespace,
+        sandbox_ready_timeout=state.sandbox_ready_timeout,
+        shutdown_after_seconds=state.shutdown_after_seconds,
+        exposed_ports=state.exposed_ports,
+        exposed_port_host=state.exposed_port_host_override,
+        labels=state.labels,
+        pod_labels=state.pod_labels,
+        file_transfer=state.file_transfer,
+        exec_timeout_default_s=state.exec_timeout_default_s,
+    )
 
 
 def _exposed_port_host(options: K8sSandboxClientOptions, sandbox_id: str) -> str | None:

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -30,6 +31,8 @@ from k8s_agent_sandbox.exceptions import SandboxNotFoundError
 from .options import K8sSandboxClientOptions, K8sSandboxSessionState
 from .session import K8sSandboxSession
 from .transport import K8sHttpTransport
+
+logger = logging.getLogger(__name__)
 
 
 class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
@@ -107,7 +110,11 @@ class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
         except Exception:
             # Teardown is best-effort; the claim deletion below is what actually frees
             # the pod and its PVC.
-            pass
+            logger.warning(
+                "sandbox teardown failed during delete for %s; continuing",
+                inner.state.claim_name,
+                exc_info=True,
+            )
 
         # delete_sandbox() logs a failed deletion and returns normally, reporting a leaked
         # pod and PVC as a clean delete. terminate() does the same work and raises.

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/client.py
@@ -1,0 +1,169 @@
+"""``BaseSandboxClient`` implementation for Kubernetes Agent Sandbox."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from agents.sandbox.manifest import Manifest
+from agents.sandbox.session import SandboxSession, SandboxSessionState
+from agents.sandbox.session.dependencies import Dependencies
+from agents.sandbox.session.manager import Instrumentation
+from agents.sandbox.session.sandbox_client import BaseSandboxClient
+from agents.sandbox.snapshot import SnapshotBase, SnapshotSpec, resolve_snapshot
+
+from .options import K8sSandboxClientOptions, K8sSandboxSessionState
+from .session import K8sSandboxSession
+from .transport import K8sHttpTransport
+
+
+class K8sSandboxClient(BaseSandboxClient[K8sSandboxClientOptions]):
+    """Runs SandboxAgent workloads on Kubernetes Agent Sandbox.
+
+    Takes an already-configured ``AsyncSandboxClient`` — the same shape as
+    ``DockerSandboxClient(docker_from_env())`` — so cluster connectivity
+    (direct/gateway/in-cluster) stays the caller's decision.
+
+    Construct the underlying client with ``cleanup=False``: its default ``atexit`` hook
+    deletes every tracked sandbox on process exit, which would destroy sandboxes that a
+    later process still intends to ``resume()``. ``shutdown_after_seconds`` on the
+    options is the leak backstop instead.
+    """
+
+    backend_id = "k8s"
+
+    def __init__(
+        self,
+        sandbox_client: Any,
+        *,
+        instrumentation: Instrumentation | None = None,
+        dependencies: Dependencies | None = None,
+    ) -> None:
+        super().__init__()
+        self._sandbox_client = sandbox_client
+        self._instrumentation = instrumentation or Instrumentation()
+        self._dependencies = dependencies
+
+    async def create(
+        self,
+        *,
+        snapshot: SnapshotSpec | SnapshotBase | None = None,
+        manifest: Manifest | None = None,
+        options: K8sSandboxClientOptions,
+    ) -> SandboxSession:
+        manifest = manifest or Manifest()
+        session_id = uuid.uuid4()
+
+        sandbox = await self._create_sandbox(options)
+        state = K8sSandboxSessionState(
+            session_id=session_id,
+            manifest=manifest,
+            snapshot=resolve_snapshot(snapshot, str(session_id)),
+            exposed_ports=options.exposed_ports,
+            claim_name=sandbox.claim_name,
+            sandbox_id=sandbox.sandbox_id,
+            namespace=options.namespace,
+            warm_pool=options.warm_pool,
+            file_transfer=options.file_transfer,
+            exec_timeout_default_s=options.exec_timeout_default_s,
+            exposed_port_host=_exposed_port_host(options, sandbox.sandbox_id),
+        )
+        return self._wrap_session(
+            self._build_session(sandbox, state), instrumentation=self._instrumentation
+        )
+
+    async def delete(self, session: SandboxSession) -> SandboxSession:
+        inner = session._inner
+        if not isinstance(inner, K8sSandboxSession):
+            raise TypeError("K8sSandboxClient.delete expects a K8sSandboxSession")
+
+        try:
+            await inner.shutdown()
+        except Exception:
+            # Teardown is best-effort; the claim deletion below is what actually frees
+            # the pod and its PVC.
+            pass
+
+        await self._sandbox_client.delete_sandbox(
+            inner.state.claim_name, namespace=inner.state.namespace
+        )
+        return session
+
+    async def resume(self, state: SandboxSessionState) -> SandboxSession:
+        if not isinstance(state, K8sSandboxSessionState):
+            raise TypeError("K8sSandboxClient.resume expects a K8sSandboxSessionState")
+        state.assert_path_grants_rebound()
+
+        sandbox = await self._reattach(state)
+        preserved = sandbox is not None
+
+        if sandbox is None:
+            # The claim is gone (TTL expiry, node loss, namespace cleanup). Provision a
+            # replacement; start() hydrates its workspace from state.snapshot.
+            sandbox = await self._create_sandbox(
+                K8sSandboxClientOptions(
+                    warm_pool=state.warm_pool,
+                    namespace=state.namespace,
+                    exposed_ports=state.exposed_ports,
+                    file_transfer=state.file_transfer,
+                    exec_timeout_default_s=state.exec_timeout_default_s,
+                )
+            )
+            state.claim_name = sandbox.claim_name
+            state.sandbox_id = sandbox.sandbox_id
+            state.workspace_root_ready = False
+            if state.exposed_port_host:
+                state.exposed_port_host = _in_cluster_host(sandbox.sandbox_id, state.namespace)
+
+        inner = self._build_session(sandbox, state)
+        inner._set_start_state_preserved(preserved)
+        return self._wrap_session(inner, instrumentation=self._instrumentation)
+
+    def deserialize_session_state(self, payload: dict[str, object]) -> SandboxSessionState:
+        return self._deserialize_session_state_payload(payload, K8sSandboxSessionState)
+
+    # -- internals ---------------------------------------------------------------
+
+    async def _create_sandbox(self, options: K8sSandboxClientOptions) -> Any:
+        return await self._sandbox_client.create_sandbox(
+            options.warm_pool,
+            namespace=options.namespace,
+            sandbox_ready_timeout=options.sandbox_ready_timeout,
+            labels=options.labels,
+            shutdown_after_seconds=options.shutdown_after_seconds,
+            pod_labels=options.pod_labels,
+        )
+
+    async def _reattach(self, state: K8sSandboxSessionState) -> Any | None:
+        try:
+            return await self._sandbox_client.get_sandbox(
+                state.claim_name,
+                namespace=state.namespace,
+                warmpool_name=state.warm_pool,
+            )
+        except ValueError:
+            # A warm-pool mismatch is a deliberate refusal by the client, not a missing
+            # sandbox. Surface it rather than silently provisioning a replacement.
+            raise
+        except Exception:
+            return None
+
+    def _build_session(self, sandbox: Any, state: K8sSandboxSessionState) -> K8sSandboxSession:
+        transport = K8sHttpTransport(
+            sandbox,
+            file_transfer=state.file_transfer,
+            default_timeout_s=state.exec_timeout_default_s,
+        )
+        return K8sSandboxSession(transport=transport, state=state)
+
+
+def _exposed_port_host(options: K8sSandboxClientOptions, sandbox_id: str) -> str | None:
+    if not options.exposed_ports:
+        return None
+    if options.exposed_port_host:
+        return options.exposed_port_host
+    return _in_cluster_host(sandbox_id, options.namespace)
+
+
+def _in_cluster_host(sandbox_id: str, namespace: str) -> str:
+    return f"{sandbox_id}.{namespace}.svc.cluster.local"

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Options and session state for the Kubernetes Agent Sandbox provider.
 
 Both types are pydantic models with a ``type`` discriminator. The SDK registers

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
@@ -58,7 +58,13 @@ class K8sSandboxClientOptions(BaseSandboxClientOptions):
 
 
 class K8sSandboxSessionState(SandboxSessionState):
-    """Everything needed to reattach to a sandbox in a later process."""
+    """Everything needed to reattach to a sandbox in a later process.
+
+    Every field below the connection details exists because ``resume()`` may have to
+    provision a *replacement* sandbox, and that replacement has to be configured the way
+    the original was. Anything not recorded here is silently reset to a class default.
+    All of them are optional so payloads written by an earlier version still deserialize.
+    """
 
     type: Literal["k8s"] = "k8s"
 
@@ -69,3 +75,13 @@ class K8sSandboxSessionState(SandboxSessionState):
     file_transfer: FileTransfer = "http"
     exec_timeout_default_s: float = 300.0
     exposed_port_host: str | None = None
+    """Resolved host for :meth:`resolve_exposed_port`, derived unless pinned below."""
+
+    exposed_port_host_override: str | None = None
+    """The caller's explicit ``exposed_port_host``, if any. Survives a replacement; the
+    derived in-cluster name does not, because it names a sandbox that no longer exists."""
+
+    sandbox_ready_timeout: int = 180
+    shutdown_after_seconds: int | None = 3600
+    labels: dict[str, str] | None = None
+    pod_labels: dict[str, str] | None = None

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
@@ -1,0 +1,71 @@
+"""Options and session state for the Kubernetes Agent Sandbox provider.
+
+Both types are pydantic models with a ``type`` discriminator. The SDK registers
+subclasses in a global registry on import, which is how a persisted session state
+round-trips back to the right provider. That registry has no entry-point
+discovery: this package must be imported before
+``BaseSandboxClient.deserialize_session_state`` can resolve ``"k8s"``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from agents.sandbox.session import SandboxSessionState
+from agents.sandbox.session.sandbox_client import BaseSandboxClientOptions
+
+# How file bytes move in and out of the sandbox.
+#
+# "http" uses the in-pod server's upload/download endpoints, which are bytes-clean.
+# "exec" base64-encodes through the JSON ``execute`` endpoint: slower and bounded by
+# command-length limits, but it works when the in-pod server rejects absolute paths
+# (its client-side sanitizer strips a leading "/") or is not reachable for file I/O.
+FileTransfer = Literal["http", "exec"]
+
+
+class K8sSandboxClientOptions(BaseSandboxClientOptions):
+    """Per-run settings for :class:`~openai_agents_k8s_sandbox.client.K8sSandboxClient`."""
+
+    type: Literal["k8s"] = "k8s"
+
+    warm_pool: str
+    """Name of the ``SandboxWarmPool`` to claim from."""
+
+    namespace: str = "default"
+    sandbox_ready_timeout: int = 180
+
+    shutdown_after_seconds: int | None = 3600
+    """TTL backstop. Sets ``shutdownTime``/``shutdownPolicy: Delete`` on the claim so a
+    crashed run cannot leak a pod. ``None`` disables it."""
+
+    exposed_ports: tuple[int, ...] = ()
+
+    exposed_port_host: str | None = None
+    """Host that :meth:`resolve_exposed_port` reports. Defaults to the sandbox's stable
+    in-cluster DNS name, which is only reachable from inside the cluster."""
+
+    labels: dict[str, str] | None = None
+    """Labels on the ``SandboxClaim`` object."""
+
+    pod_labels: dict[str, str] | None = None
+    """Labels stamped onto the running pod (readable inside the sandbox via the Downward API)."""
+
+    file_transfer: FileTransfer = "http"
+
+    exec_timeout_default_s: float = 300.0
+    """Timeout applied when the SDK passes ``timeout=None``. The in-pod HTTP API has no
+    unbounded mode, so a finite default is required."""
+
+
+class K8sSandboxSessionState(SandboxSessionState):
+    """Everything needed to reattach to a sandbox in a later process."""
+
+    type: Literal["k8s"] = "k8s"
+
+    claim_name: str
+    sandbox_id: str
+    namespace: str
+    warm_pool: str
+    file_transfer: FileTransfer = "http"
+    exec_timeout_default_s: float = 300.0
+    exposed_port_host: str | None = None

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/options.py
@@ -66,6 +66,11 @@ class K8sSandboxClientOptions(BaseSandboxClientOptions):
 
     file_transfer: FileTransfer = "http"
 
+    read_fallback: bool = True
+    """Whether a failed download retries over exec. ``False`` surfaces the transport error
+    instead, for callers who would rather see a broken endpoint than silently read every
+    file over the slower, ARG_MAX-bounded path."""
+
     exec_timeout_default_s: float = 300.0
     """Timeout applied when the SDK passes ``timeout=None``. The in-pod HTTP API has no
     unbounded mode, so a finite default is required."""
@@ -87,6 +92,7 @@ class K8sSandboxSessionState(SandboxSessionState):
     namespace: str
     warm_pool: str
     file_transfer: FileTransfer = "http"
+    read_fallback: bool = True
     exec_timeout_default_s: float = 300.0
     exposed_port_host: str | None = None
     """Resolved host for :meth:`resolve_exposed_port`, derived unless pinned below."""

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -128,6 +128,8 @@ class K8sSandboxSession(BaseSandboxSession):
         try:
             data = await self._transport.read_file(sandbox_path_str(workspace_path))
         except Exception as e:
+            if not self.state.read_fallback:
+                raise
             # Fall back to exec so a missing file is reported as WorkspaceReadNotFoundError
             # rather than an opaque transport error. Log it: a download endpoint that
             # always fails would otherwise look like a merely slow sandbox.

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -35,7 +35,7 @@ from agents.sandbox.workspace_paths import (
 )
 
 from .options import K8sSandboxSessionState
-from .transport import SandboxTransport
+from .transport import _EXEC_CHUNK_CHARS, SandboxTransport
 
 logger = logging.getLogger(__name__)
 
@@ -185,18 +185,56 @@ class K8sSandboxSession(BaseSandboxSession):
     ) -> None:
         encoded = base64.b64encode(raw).decode("ascii")
         path_arg = sandbox_path_str(workspace_path)
-        script = 'mkdir -p "$(dirname "$1")" && printf %s "$2" | base64 -d > "$1"'
-        result = await self.exec(
-            "sh", "-lc", script, "sh", path_arg, encoded, shell=False, user=user
-        )
-        if not result.ok():
-            raise WorkspaceArchiveWriteError(
-                path=workspace_path,
-                context={
-                    "exit_code": result.exit_code,
-                    "stderr": result.stderr.decode("utf-8", errors="replace"),
-                },
+        staging_arg = f"{path_arg}.b64.part"
+
+        # The in-pod server splits the command and execs the argv directly, so the payload
+        # lands as a single execve argument — capped at MAX_ARG_STRLEN (128 KiB), which a
+        # base64 blob clears at roughly 96 KiB of input. Append it in chunks instead, the
+        # same way K8sHttpTransport does. Every chunk goes through self.exec so a `user`
+        # still gets its `sudo -u` prefix.
+        chunks = [
+            encoded[i : i + _EXEC_CHUNK_CHARS] for i in range(0, len(encoded), _EXEC_CHUNK_CHARS)
+        ] or [""]
+
+        try:
+            for index, chunk in enumerate(chunks):
+                script = (
+                    'mkdir -p "$(dirname "$1")" && printf %s "$2" > "$1"'
+                    if index == 0
+                    else 'printf %s "$2" >> "$1"'
+                )
+                result = await self.exec(
+                    "sh", "-lc", script, "sh", staging_arg, chunk, shell=False, user=user
+                )
+                if not result.ok():
+                    raise self._write_via_exec_error(workspace_path, result)
+
+            result = await self.exec(
+                "sh",
+                "-lc",
+                'base64 -d < "$1" > "$2"',
+                "sh",
+                staging_arg,
+                path_arg,
+                shell=False,
+                user=user,
             )
+            if not result.ok():
+                raise self._write_via_exec_error(workspace_path, result)
+        finally:
+            await self._rm_best_effort(Path(staging_arg))
+
+    @staticmethod
+    def _write_via_exec_error(
+        workspace_path: Path, result: ExecResult
+    ) -> WorkspaceArchiveWriteError:
+        return WorkspaceArchiveWriteError(
+            path=workspace_path,
+            context={
+                "exit_code": result.exit_code,
+                "stderr": result.stderr.decode("utf-8", errors="replace"),
+            },
+        )
 
     # -- workspace snapshots -----------------------------------------------------
 

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -300,8 +300,11 @@ class K8sSandboxSession(BaseSandboxSession):
 
         read = False
         try:
+            await self._reject_oversized_stage(staging_arg, error_root)
             data = await self._transport.read_file(staging_arg)
             read = True
+        except WorkspaceArchiveReadError:
+            raise
         except Exception as e:
             raise WorkspaceArchiveReadError(path=error_root, cause=e) from e
         finally:
@@ -371,6 +374,32 @@ class K8sSandboxSession(BaseSandboxSession):
 
     def _stage_path(self, name_hint: str) -> Path:
         return self._ARCHIVE_STAGING_DIR / f"{uuid.uuid4().hex}_{name_hint}"
+
+    async def _reject_oversized_stage(self, staging_arg: str, error_path: Path) -> None:
+        """Size the staged tar in the pod before it is pulled into this process.
+
+        `read_file()` has no streaming form, so the whole archive lands in memory; and an
+        archive above the input ceiling is one `hydrate_workspace()` would refuse anyway.
+        """
+
+        limit = self._max_archive_input_bytes()
+        if limit is None:
+            return
+
+        result = await self.exec("sh", "-lc", 'wc -c < "$1"', "sh", staging_arg, shell=False)
+        measured = result.stdout.decode("utf-8", errors="replace").strip()
+        if not result.ok() or not measured.isdigit():
+            raise WorkspaceArchiveReadError(
+                path=error_path,
+                context={"reason": "archive size probe failed", "exit_code": result.exit_code},
+            )
+
+        size = int(measured)
+        if size > limit:
+            raise WorkspaceArchiveReadError(
+                path=error_path,
+                context={"reason": "archive size exceeds limit", "limit": limit, "actual": size},
+            )
 
     def _max_archive_input_bytes(self) -> int | None:
         # None (the default until a run opts in via SandboxArchiveLimits) means unbounded,

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -1,0 +1,316 @@
+"""``BaseSandboxSession`` implementation backed by a Kubernetes sandbox pod.
+
+Only six methods are abstract on ``BaseSandboxSession``; the ~1300 lines above them
+(``ls``/``rm``/``mkdir``/``extract``/``apply_patch``, manifest materialization, snapshot
+fingerprinting) run unchanged on top of them.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import tarfile
+import uuid
+from pathlib import Path
+
+from agents.sandbox.errors import (
+    ExposedPortUnavailableError,
+    WorkspaceArchiveReadError,
+    WorkspaceArchiveWriteError,
+)
+from agents.sandbox.session.base_sandbox_session import BaseSandboxSession
+from agents.sandbox.session.runtime_helpers import (
+    RESOLVE_WORKSPACE_PATH_HELPER,
+    RuntimeHelperScript,
+)
+from agents.sandbox.session.workspace_payloads import coerce_write_payload
+from agents.sandbox.types import ExecResult, ExposedPortEndpoint, User
+from agents.sandbox.util.tar_utils import UnsafeTarMemberError, validate_tarfile
+from agents.sandbox.workspace_paths import (
+    coerce_posix_path,
+    posix_path_as_path,
+    posix_path_for_error,
+    sandbox_path_str,
+)
+
+from .options import K8sSandboxSessionState
+from .transport import SandboxTransport
+
+logger = logging.getLogger(__name__)
+
+
+class K8sSandboxSession(BaseSandboxSession):
+    state: K8sSandboxSessionState
+
+    # Staging area for workspace archives. Outside the workspace root so it is never
+    # swept into a snapshot.
+    _ARCHIVE_STAGING_DIR: Path = posix_path_as_path(coerce_posix_path("/tmp/agents-k8s-sandbox"))
+
+    def __init__(
+        self,
+        *,
+        transport: SandboxTransport,
+        state: K8sSandboxSessionState,
+    ) -> None:
+        self._transport = transport
+        self.state = state
+
+    # -- capabilities ------------------------------------------------------------
+
+    def supports_pty(self) -> bool:
+        # The in-pod HTTP API has no PTY channel. sandboxd's gRPC ProcessService
+        # (Start/WriteStdin/ResizeTTY) is the path to flipping this on.
+        return False
+
+    def supports_docker_volume_mounts(self) -> bool:
+        return False
+
+    def _runtime_helpers(self) -> tuple[RuntimeHelperScript, ...]:
+        return (RESOLVE_WORKSPACE_PATH_HELPER,)
+
+    def _current_runtime_helper_cache_key(self) -> object | None:
+        return self.state.sandbox_id
+
+    async def _validate_path_access(self, path: Path | str, *, for_write: bool = False) -> Path:
+        # Remote validation: the path checks run in the pod, not in this process.
+        return await self._validate_remote_path_access(path, for_write=for_write)
+
+    # -- exec --------------------------------------------------------------------
+
+    async def _exec_internal(
+        self, *command: str | Path, timeout: float | None = None
+    ) -> ExecResult:
+        return await self._transport.exec_command(
+            [str(part) for part in command], timeout=timeout
+        )
+
+    async def running(self) -> bool:
+        return await self._transport.is_ready()
+
+    async def _resolve_exposed_port(self, port: int) -> ExposedPortEndpoint:
+        host = self.state.exposed_port_host
+        if not host:
+            raise ExposedPortUnavailableError(
+                port=port,
+                exposed_ports=self.state.exposed_ports,
+                reason="backend_unavailable",
+                context={"backend": "k8s", "detail": "no_exposed_port_host"},
+            )
+        # The Sandbox CR gives the pod a stable hostname, so the container port is the
+        # published port — there is no host-side remapping as with Docker.
+        return ExposedPortEndpoint(host=host, port=port, tls=False)
+
+    # -- file I/O ----------------------------------------------------------------
+
+    async def read(self, path: Path, *, user: str | User | None = None) -> io.IOBase:
+        workspace_path = await self._validate_path_access(path)
+
+        # A `user` means the read must be subject to that user's permissions, which only
+        # the exec path can express (the SDK prefixes `sudo -u`).
+        if user is not None or self._uses_exec_file_transfer:
+            return await self._read_via_exec(path, workspace_path, user=user)
+
+        try:
+            data = await self._transport.read_file(sandbox_path_str(workspace_path))
+        except Exception as e:
+            # Fall back to exec so a missing file is reported as WorkspaceReadNotFoundError
+            # rather than an opaque transport error. Log it: a download endpoint that
+            # always fails would otherwise look like a merely slow sandbox.
+            logger.warning(
+                "sandbox file download failed, falling back to exec for %s: %s",
+                workspace_path,
+                e,
+            )
+            return await self._read_via_exec(path, workspace_path, user=user)
+        return io.BytesIO(data)
+
+    async def write(
+        self,
+        path: Path,
+        data: io.IOBase,
+        *,
+        user: str | User | None = None,
+    ) -> None:
+        payload = coerce_write_payload(path=path, data=data)
+        workspace_path = await self._validate_path_access(path, for_write=True)
+        # Prototype limitation: the whole payload is buffered. The HTTP upload endpoint
+        # takes a single body, so streaming would need the sandboxd filesystem service.
+        raw = payload.stream.read()
+
+        if user is not None or self._uses_exec_file_transfer:
+            await self._write_via_exec(workspace_path, raw, user=user)
+            return
+
+        await self.mkdir(workspace_path.parent, parents=True)
+        try:
+            await self._transport.write_file(sandbox_path_str(workspace_path), raw)
+        except Exception as e:
+            raise WorkspaceArchiveWriteError(path=workspace_path, cause=e) from e
+
+    async def _read_via_exec(
+        self,
+        path: Path,
+        workspace_path: Path,
+        *,
+        user: str | User | None,
+    ) -> io.IOBase:
+        # base64 keeps the bytes intact across an endpoint that returns JSON strings.
+        # Pass the file as an argument rather than redirecting into stdin: a failed
+        # redirect exits 2 under dash, and the SDK's not-found classifier keys on exit 1.
+        path_arg = sandbox_path_str(workspace_path)
+        command = ("base64", "--", path_arg)
+        result = await self.exec(*command, shell=False, user=user)
+        if not result.ok():
+            await self._raise_read_error_from_exec(
+                path=path,
+                workspace_path=workspace_path,
+                command=command,
+                result=result,
+                user=user,
+            )
+
+        try:
+            decoded = base64.b64decode(result.stdout)
+        except ValueError as e:
+            raise WorkspaceArchiveReadError(path=path, cause=e) from e
+        return io.BytesIO(decoded)
+
+    async def _write_via_exec(
+        self,
+        workspace_path: Path,
+        raw: bytes,
+        *,
+        user: str | User | None,
+    ) -> None:
+        encoded = base64.b64encode(raw).decode("ascii")
+        path_arg = sandbox_path_str(workspace_path)
+        script = 'mkdir -p "$(dirname "$1")" && printf %s "$2" | base64 -d > "$1"'
+        result = await self.exec(
+            "sh", "-lc", script, "sh", path_arg, encoded, shell=False, user=user
+        )
+        if not result.ok():
+            raise WorkspaceArchiveWriteError(
+                path=workspace_path,
+                context={
+                    "exit_code": result.exit_code,
+                    "stderr": result.stderr.decode("utf-8", errors="replace"),
+                },
+            )
+
+    # -- workspace snapshots -----------------------------------------------------
+
+    async def persist_workspace(self) -> io.IOBase:
+        root = self._workspace_root_path()
+        error_root = posix_path_for_error(root)
+        staging = self._stage_path("workspace.tar")
+        staging_arg = sandbox_path_str(staging)
+
+        await self._exec_checked_nonzero("mkdir", "-p", sandbox_path_str(self._ARCHIVE_STAGING_DIR))
+
+        # Tar inside the pod, then pull the archive over the bytes-clean file channel.
+        # Streaming a tar through the JSON exec endpoint would corrupt it.
+        excludes = [
+            f"--exclude=./{rel.as_posix()}" for rel in sorted(self._persist_workspace_skip_relpaths())
+        ]
+        result = await self.exec(
+            "tar",
+            "-c",
+            "-f",
+            staging_arg,
+            "-C",
+            sandbox_path_str(root),
+            *excludes,
+            ".",
+            shell=False,
+        )
+        if not result.ok():
+            raise WorkspaceArchiveReadError(
+                path=error_root,
+                context={
+                    "exit_code": result.exit_code,
+                    "stderr": result.stderr.decode("utf-8", errors="replace"),
+                },
+            )
+
+        try:
+            data = await self._transport.read_file(staging_arg)
+        except Exception as e:
+            raise WorkspaceArchiveReadError(path=error_root, cause=e) from e
+        finally:
+            await self._rm_best_effort(staging)
+
+        return io.BytesIO(data)
+
+    async def hydrate_workspace(self, data: io.IOBase) -> None:
+        root = self._workspace_root_path()
+        error_root = posix_path_for_error(root)
+
+        archive = _drain(data, error_path=error_root)
+        try:
+            with tarfile.open(fileobj=io.BytesIO(archive), mode="r:*") as tar:
+                validate_tarfile(tar, allow_external_symlink_targets=False)
+        except UnsafeTarMemberError as e:
+            raise WorkspaceArchiveWriteError(
+                path=error_root,
+                context={"reason": e.reason, "member": e.member},
+                cause=e,
+            ) from e
+        except (tarfile.TarError, OSError) as e:
+            raise WorkspaceArchiveWriteError(path=error_root, cause=e) from e
+
+        staging = self._stage_path("hydrate.tar")
+        staging_arg = sandbox_path_str(staging)
+        await self._exec_checked_nonzero("mkdir", "-p", sandbox_path_str(self._ARCHIVE_STAGING_DIR))
+        await self._exec_checked_nonzero("mkdir", "-p", sandbox_path_str(root))
+
+        try:
+            await self._transport.write_file(staging_arg, archive)
+        except Exception as e:
+            raise WorkspaceArchiveWriteError(path=error_root, cause=e) from e
+
+        try:
+            result = await self.exec(
+                "tar", "-x", "-f", staging_arg, "-C", sandbox_path_str(root), shell=False
+            )
+            if not result.ok():
+                raise WorkspaceArchiveWriteError(
+                    path=error_root,
+                    context={
+                        "exit_code": result.exit_code,
+                        "stderr": result.stderr.decode("utf-8", errors="replace"),
+                    },
+                )
+        finally:
+            await self._rm_best_effort(staging)
+
+    # -- helpers -----------------------------------------------------------------
+
+    @property
+    def _uses_exec_file_transfer(self) -> bool:
+        return self.state.file_transfer == "exec"
+
+    def _stage_path(self, name_hint: str) -> Path:
+        return self._ARCHIVE_STAGING_DIR / f"{uuid.uuid4().hex}_{name_hint}"
+
+    async def _rm_best_effort(self, path: Path) -> None:
+        try:
+            await self.exec("rm", "-f", "--", sandbox_path_str(path), shell=False)
+        except Exception:
+            pass
+
+
+def _drain(data: io.IOBase, *, error_path: Path) -> bytes:
+    buf = io.BytesIO()
+    while True:
+        chunk = data.read(io.DEFAULT_BUFFER_SIZE)
+        if chunk in ("", b"", None):
+            break
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8")
+        if not isinstance(chunk, (bytes, bytearray)):
+            raise WorkspaceArchiveWriteError(
+                path=error_path, context={"reason": "non_bytes_tar_payload"}
+            )
+        buf.write(chunk)
+    return buf.getvalue()

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -210,6 +210,7 @@ class K8sSandboxSession(BaseSandboxSession):
             encoded[i : i + _EXEC_CHUNK_CHARS] for i in range(0, len(encoded), _EXEC_CHUNK_CHARS)
         ] or [""]
 
+        written = False
         try:
             for index, chunk in enumerate(chunks):
                 script = (
@@ -235,8 +236,20 @@ class K8sSandboxSession(BaseSandboxSession):
             )
             if not result.ok():
                 raise self._write_via_exec_error(workspace_path, result)
+            written = True
         finally:
-            await self._rm_best_effort(Path(staging_arg))
+            # Staging sits next to the target, inside the workspace: leaving it behind
+            # after a write the caller believes succeeded would seed the next snapshot
+            # with it. `written` is the last statement above, so the checked branch can
+            # only raise with nothing else in flight to mask.
+            if written:
+                await self._rm_checked(
+                    Path(staging_arg),
+                    error=WorkspaceArchiveWriteError,
+                    error_path=workspace_path,
+                )
+            else:
+                await self._rm_best_effort(Path(staging_arg))
 
     @staticmethod
     def _write_via_exec_error(
@@ -285,12 +298,19 @@ class K8sSandboxSession(BaseSandboxSession):
                 },
             )
 
+        read = False
         try:
             data = await self._transport.read_file(staging_arg)
+            read = True
         except Exception as e:
             raise WorkspaceArchiveReadError(path=error_root, cause=e) from e
         finally:
-            await self._rm_best_effort(staging)
+            if read:
+                await self._rm_checked(
+                    staging, error=WorkspaceArchiveReadError, error_path=error_root
+                )
+            else:
+                await self._rm_best_effort(staging)
 
         return io.BytesIO(data)
 
@@ -321,6 +341,7 @@ class K8sSandboxSession(BaseSandboxSession):
         except Exception as e:
             raise WorkspaceArchiveWriteError(path=error_root, cause=e) from e
 
+        extracted = False
         try:
             result = await self.exec(
                 "tar", "-x", "-f", staging_arg, "-C", sandbox_path_str(root), shell=False
@@ -333,8 +354,14 @@ class K8sSandboxSession(BaseSandboxSession):
                         "stderr": result.stderr.decode("utf-8", errors="replace"),
                     },
                 )
+            extracted = True
         finally:
-            await self._rm_best_effort(staging)
+            if extracted:
+                await self._rm_checked(
+                    staging, error=WorkspaceArchiveWriteError, error_path=error_root
+                )
+            else:
+                await self._rm_best_effort(staging)
 
     # -- helpers -----------------------------------------------------------------
 
@@ -352,10 +379,52 @@ class K8sSandboxSession(BaseSandboxSession):
         return limits.max_input_bytes if limits is not None else None
 
     async def _rm_best_effort(self, path: Path) -> None:
+        """Remove staging while another failure is already propagating.
+
+        That failure is the one the caller needs, so a cleanup that fails too is logged
+        rather than raised: it must never take the original error's place.
+        """
+        context, cause = await self._rm(path)
+        if context is not None:
+            logger.warning(
+                "sandbox staging cleanup failed for %s: %s",
+                path,
+                cause if cause is not None else context,
+            )
+
+    async def _rm_checked(
+        self,
+        path: Path,
+        *,
+        error: type[WorkspaceArchiveReadError] | type[WorkspaceArchiveWriteError],
+        error_path: Path,
+    ) -> None:
+        """Remove staging on a path where nothing else failed.
+
+        No other error is on its way out to carry this one, so an archive that cannot be
+        cleaned up is reported in the error class the surrounding operation already uses.
+        """
+        context, cause = await self._rm(path)
+        if context is not None:
+            raise error(path=error_path, context=context, cause=cause)
+
+    async def _rm(self, path: Path) -> tuple[dict[str, object] | None, Exception | None]:
+        """Remove a file, describing a failure instead of raising it.
+
+        Returns ``(None, None)`` once the file is gone. Otherwise the context/cause pair
+        lets the caller decide whether this failure is worth raising.
+        """
         try:
-            await self.exec("rm", "-f", "--", sandbox_path_str(path), shell=False)
-        except Exception:
-            pass
+            result = await self.exec("rm", "-f", "--", sandbox_path_str(path), shell=False)
+        except Exception as e:
+            return {"reason": "staging cleanup failed"}, e
+        if result.ok():
+            return None, None
+        return {
+            "reason": "staging cleanup failed",
+            "exit_code": result.exit_code,
+            "stderr": result.stderr.decode("utf-8", errors="replace"),
+        }, None
 
 
 def _drain(data: io.IOBase, *, error_path: Path, max_bytes: int | None) -> bytes:

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -284,7 +284,7 @@ class K8sSandboxSession(BaseSandboxSession):
         root = self._workspace_root_path()
         error_root = posix_path_for_error(root)
 
-        archive = _drain(data, error_path=error_root)
+        archive = _drain(data, error_path=error_root, max_bytes=self._max_archive_input_bytes())
         try:
             with tarfile.open(fileobj=io.BytesIO(archive), mode="r:*") as tar:
                 validate_tarfile(tar, allow_external_symlink_targets=False)
@@ -331,6 +331,12 @@ class K8sSandboxSession(BaseSandboxSession):
     def _stage_path(self, name_hint: str) -> Path:
         return self._ARCHIVE_STAGING_DIR / f"{uuid.uuid4().hex}_{name_hint}"
 
+    def _max_archive_input_bytes(self) -> int | None:
+        # None (the default until a run opts in via SandboxArchiveLimits) means unbounded,
+        # which keeps this a no-op for callers that never configured limits.
+        limits = self._archive_limits
+        return limits.max_input_bytes if limits is not None else None
+
     async def _rm_best_effort(self, path: Path) -> None:
         try:
             await self.exec("rm", "-f", "--", sandbox_path_str(path), shell=False)
@@ -338,8 +344,16 @@ class K8sSandboxSession(BaseSandboxSession):
             pass
 
 
-def _drain(data: io.IOBase, *, error_path: Path) -> bytes:
+def _drain(data: io.IOBase, *, error_path: Path, max_bytes: int | None) -> bytes:
+    """Buffer a snapshot archive, refusing to grow past ``max_bytes``.
+
+    The whole archive is held in memory, so the ceiling is enforced per chunk rather than
+    after the fact — otherwise an oversized stream is already resident by the time anyone
+    could reject it.
+    """
+
     buf = io.BytesIO()
+    total = 0
     while True:
         chunk = data.read(io.DEFAULT_BUFFER_SIZE)
         if chunk in ("", b"", None):
@@ -349,6 +363,16 @@ def _drain(data: io.IOBase, *, error_path: Path) -> bytes:
         if not isinstance(chunk, (bytes, bytearray)):
             raise WorkspaceArchiveWriteError(
                 path=error_path, context={"reason": "non_bytes_tar_payload"}
+            )
+        total += len(chunk)
+        if max_bytes is not None and total > max_bytes:
+            raise WorkspaceArchiveWriteError(
+                path=error_path,
+                context={
+                    "reason": "archive input size exceeds limit",
+                    "limit": max_bytes,
+                    "actual": total,
+                },
             )
         buf.write(chunk)
     return buf.getvalue()

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -201,7 +201,8 @@ class K8sSandboxSession(BaseSandboxSession):
     ) -> None:
         encoded = base64.b64encode(raw).decode("ascii")
         path_arg = sandbox_path_str(workspace_path)
-        staging_arg = f"{path_arg}.b64.part"
+        # Unique per write, for the same reason K8sHttpTransport stages under a uuid.
+        staging_arg = f"{path_arg}.{uuid.uuid4().hex}.b64.part"
 
         # The in-pod server splits the command and execs the argv directly, so the payload
         # lands as a single execve argument — capped at MAX_ARG_STRLEN (128 KiB), which a

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/session.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """``BaseSandboxSession`` implementation backed by a Kubernetes sandbox pod.
 
 Only six methods are abstract on ``BaseSandboxSession``; the ~1300 lines above them

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -137,17 +137,19 @@ class K8sHttpTransport:
         # There is no unbounded mode on the HTTP API, so `None` becomes the configured
         # default rather than "wait forever". The endpoint takes whole seconds.
         effective = self._default_timeout_s if timeout is None else timeout
-        enforced_s = max(1, int(math.ceil(effective)))
+        client_timeout_s = max(1, int(math.ceil(effective)))
 
         try:
-            result = await self._sandbox.commands.run(command, timeout=enforced_s)
+            result = await self._sandbox.commands.run(command, timeout=client_timeout_s)
         except Exception as e:
             if self._is_timeout(e):
-                # Report the budget the pod actually enforced, not the caller's request:
-                # `None` would read as "no timeout" for something that just timed out.
+                # Bounds the HTTP request only: the execute payload carries no timeout, so
+                # the command runs on in the pod under the server's own limit. Reported as
+                # applied, since `None` would read as "no timeout".
                 raise ExecTimeoutError(
                     command=reported_command,
-                    timeout_s=float(enforced_s),
+                    timeout_s=float(client_timeout_s),
+                    context={"enforced_by": "client"},
                     cause=e,
                 ) from e
             raise ExecTransportError(command=reported_command, cause=e) from e

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 import math
 import shlex
 from collections.abc import Sequence
@@ -39,6 +40,8 @@ try:  # httpx ships with k8s-agent-sandbox[async]; keep the import soft anyway.
     import httpx
 except ImportError:  # pragma: no cover - exercised only in stripped installs
     httpx = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 # Base64 payloads are pushed through the JSON exec endpoint one chunk per command.
 # 32 KiB of base64 keeps each rendered command well under a typical ARG_MAX.
@@ -187,6 +190,7 @@ class K8sHttpTransport:
         # Cleanup lives in `finally` rather than on the decode command: a failed chunk
         # write or a failed decode would otherwise strand a half-written base64 file next
         # to the target, where nothing ever collects it.
+        written = False
         try:
             for index, chunk in enumerate(chunks):
                 redirect = ">" if index == 0 else ">>"
@@ -205,15 +209,58 @@ class K8sHttpTransport:
                     message="sandbox file write failed",
                     context={"exit_code": result.exit_code},
                 )
+            written = True
         finally:
-            await self._rm_staging_best_effort(staging)
+            # `written` is the last statement of the block above, so raising here can only
+            # happen with nothing else in flight to mask.
+            if written:
+                await self._rm_staging_checked(staging)
+            else:
+                await self._rm_staging_best_effort(staging)
+
+    async def _rm_staging_checked(self, staging: str) -> None:
+        """Remove staging on a write that otherwise succeeded.
+
+        No other error is on its way out to carry this one, and a stranded ".b64.part"
+        sits next to the file the caller believes was written cleanly — inside the
+        workspace a snapshot would sweep.
+        """
+        context, cause = await self._rm_staging(staging)
+        if context is not None:
+            raise ExecTransportError(
+                command=["rm", "-f", staging],
+                message="sandbox staging cleanup failed",
+                context=context,
+                cause=cause,
+            )
 
     async def _rm_staging_best_effort(self, staging: str) -> None:
+        """Remove staging while another failure is already on its way out.
+
+        That failure is the one the caller needs, so a cleanup that fails too is logged
+        rather than raised: it must never replace the write or decode error.
+        """
+        context, cause = await self._rm_staging(staging)
+        if context is not None:
+            logger.warning(
+                "sandbox staging cleanup failed for %s: %s",
+                staging,
+                cause if cause is not None else context,
+            )
+
+    async def _rm_staging(self, staging: str) -> tuple[dict[str, object] | None, Exception | None]:
+        """Remove the staging file, describing a failure instead of raising it.
+
+        Returns ``(None, None)`` once the file is gone. Otherwise the context/cause pair
+        lets the caller decide whether this failure is worth raising.
+        """
         try:
-            await self._run_script('rm -f "$1"', staging)
-        except Exception:
-            # Never let cleanup replace the failure that brought us here.
-            pass
+            result = await self._run_script('rm -f "$1"', staging)
+        except Exception as e:
+            return {"reason": "cleanup command failed"}, e
+        if result.ok():
+            return None, None
+        return {"exit_code": result.exit_code}, None
 
     @staticmethod
     def _is_timeout(exc: BaseException) -> bool:

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Transport seam between the SDK session and a running Kubernetes sandbox.
 
 Everything the session needs from the pod is expressed as three operations. Today the

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -28,6 +28,7 @@ import base64
 import logging
 import math
 import shlex
+import uuid
 from collections.abc import Sequence
 from typing import Any, Protocol, runtime_checkable
 
@@ -181,7 +182,9 @@ class K8sHttpTransport:
 
     async def _write_file_via_exec(self, path: str, data: bytes) -> None:
         encoded = base64.b64encode(data).decode("ascii")
-        staging = f"{path}.b64.part"
+        # Unique per write: a fixed suffix would clobber a real file of that name, and two
+        # writers to one path would interleave into the same staging file.
+        staging = f"{path}.{uuid.uuid4().hex}.b64.part"
 
         # Chunks and destinations both travel as argv, never as script text. Standard
         # base64 has no shell metacharacters, but that is a property of the alphabet in

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -169,23 +169,37 @@ class K8sHttpTransport:
         chunks = [
             encoded[i : i + _EXEC_CHUNK_CHARS] for i in range(0, len(encoded), _EXEC_CHUNK_CHARS)
         ] or [""]
-        for index, chunk in enumerate(chunks):
-            redirect = ">" if index == 0 else ">>"
-            result = await self._run_script(f'printf %s {chunk} {redirect} "$1"', staging)
+
+        # Cleanup lives in `finally` rather than on the decode command: a failed chunk
+        # write or a failed decode would otherwise strand a half-written base64 file next
+        # to the target, where nothing ever collects it.
+        try:
+            for index, chunk in enumerate(chunks):
+                redirect = ">" if index == 0 else ">>"
+                result = await self._run_script(f'printf %s {chunk} {redirect} "$1"', staging)
+                if not result.ok():
+                    raise ExecTransportError(
+                        command=["printf", staging],
+                        message="sandbox file write failed",
+                        context={"exit_code": result.exit_code, "chunk": index},
+                    )
+
+            result = await self._run_script('base64 -d < "$1" > "$2"', staging, path)
             if not result.ok():
                 raise ExecTransportError(
-                    command=["printf", staging],
+                    command=["base64", "-d", staging, path],
                     message="sandbox file write failed",
-                    context={"exit_code": result.exit_code, "chunk": index},
+                    context={"exit_code": result.exit_code},
                 )
+        finally:
+            await self._rm_staging_best_effort(staging)
 
-        result = await self._run_script('base64 -d < "$1" > "$2" && rm -f "$1"', staging, path)
-        if not result.ok():
-            raise ExecTransportError(
-                command=["base64", "-d", staging, path],
-                message="sandbox file write failed",
-                context={"exit_code": result.exit_code},
-            )
+    async def _rm_staging_best_effort(self, staging: str) -> None:
+        try:
+            await self._run_script('rm -f "$1"', staging)
+        except Exception:
+            # Never let cleanup replace the failure that brought us here.
+            pass
 
     @staticmethod
     def _is_timeout(exc: BaseException) -> bool:

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -181,8 +181,9 @@ class K8sHttpTransport:
         encoded = base64.b64encode(data).decode("ascii")
         staging = f"{path}.b64.part"
 
-        # base64's alphabet contains no shell metacharacters, so the chunks are safe to
-        # interpolate; the destination paths still go through argv.
+        # Chunks and destinations both travel as argv, never as script text. Standard
+        # base64 has no shell metacharacters, but that is a property of the alphabet in
+        # use today: switching to the URL-safe one would otherwise break this quietly.
         chunks = [
             encoded[i : i + _EXEC_CHUNK_CHARS] for i in range(0, len(encoded), _EXEC_CHUNK_CHARS)
         ] or [""]
@@ -193,8 +194,8 @@ class K8sHttpTransport:
         written = False
         try:
             for index, chunk in enumerate(chunks):
-                redirect = ">" if index == 0 else ">>"
-                result = await self._run_script(f'printf %s {chunk} {redirect} "$1"', staging)
+                script = 'printf %s "$2" > "$1"' if index == 0 else 'printf %s "$2" >> "$1"'
+                result = await self._run_script(script, staging, chunk)
                 if not result.ok():
                     raise ExecTransportError(
                         command=["printf", staging],

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -1,0 +1,202 @@
+"""Transport seam between the SDK session and a running Kubernetes sandbox.
+
+Everything the session needs from the pod is expressed as three operations. Today the
+only implementation talks to the in-pod HTTP server that ``k8s-agent-sandbox`` targets
+(``POST execute``, ``POST upload``, ``GET download/{path}``). When the ``sandboxd`` gRPC
+``ProcessService`` lands (streaming stdout/stderr, ``WriteStdin``, ``ResizeTTY``), it can
+be dropped in here without touching :mod:`openai_agents_k8s_sandbox.session`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import math
+import shlex
+from collections.abc import Sequence
+from typing import Any, Protocol, runtime_checkable
+
+from agents.sandbox.errors import ExecTimeoutError, ExecTransportError
+from agents.sandbox.types import ExecResult
+
+from .options import FileTransfer
+
+try:  # httpx ships with k8s-agent-sandbox[async]; keep the import soft anyway.
+    import httpx
+except ImportError:  # pragma: no cover - exercised only in stripped installs
+    httpx = None  # type: ignore[assignment]
+
+# Base64 payloads are pushed through the JSON exec endpoint one chunk per command.
+# 32 KiB of base64 keeps each rendered command well under a typical ARG_MAX.
+_EXEC_CHUNK_CHARS = 32 * 1024
+
+
+@runtime_checkable
+class SandboxTransport(Protocol):
+    """The pod-facing operations the session depends on."""
+
+    async def exec_command(
+        self, argv: Sequence[str], *, timeout: float | None = None
+    ) -> ExecResult: ...
+
+    async def read_file(self, path: str) -> bytes: ...
+
+    async def write_file(self, path: str, data: bytes) -> None: ...
+
+    async def is_ready(self) -> bool: ...
+
+
+class K8sHttpTransport:
+    """Talks to a sandbox pod through the ``k8s-agent-sandbox`` async client."""
+
+    def __init__(
+        self,
+        sandbox: Any,
+        *,
+        file_transfer: FileTransfer = "http",
+        default_timeout_s: float = 300.0,
+    ) -> None:
+        self._sandbox = sandbox
+        self._file_transfer: FileTransfer = file_transfer
+        self._default_timeout_s = default_timeout_s
+
+    @property
+    def file_transfer(self) -> FileTransfer:
+        return self._file_transfer
+
+    async def exec_command(
+        self, argv: Sequence[str], *, timeout: float | None = None
+    ) -> ExecResult:
+        # The SDK hands us an argv list that it has already shell-wrapped
+        # (``sh -lc "..."``). The in-pod API only accepts a command string, so join it
+        # back with shell quoting: the server's own shell reconstructs the same argv.
+        return await self._run(shlex.join(str(part) for part in argv), argv, timeout=timeout)
+
+    async def read_file(self, path: str) -> bytes:
+        if self._file_transfer == "exec":
+            return await self._read_file_via_exec(path)
+
+        try:
+            data = await self._sandbox.files.read(path, allow_unsafe_paths=True)
+        except Exception as e:
+            raise ExecTransportError(
+                command=["download", path],
+                message="sandbox file download failed",
+                cause=e,
+            ) from e
+        return bytes(data)
+
+    async def write_file(self, path: str, data: bytes) -> None:
+        if self._file_transfer == "exec":
+            await self._write_file_via_exec(path, data)
+            return
+
+        try:
+            await self._sandbox.files.write(path, data, allow_unsafe_paths=True)
+        except Exception as e:
+            raise ExecTransportError(
+                command=["upload", path],
+                message="sandbox file upload failed",
+                cause=e,
+            ) from e
+
+    async def is_ready(self) -> bool:
+        try:
+            status, _message = await self._sandbox.status()
+        except Exception:
+            return False
+        return status == "SandboxReady"
+
+    # -- internals ---------------------------------------------------------------
+
+    async def _run(
+        self,
+        command: str,
+        argv: Sequence[str] | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> ExecResult:
+        reported_command = list(argv) if argv is not None else [command]
+        # There is no unbounded mode on the HTTP API, so `None` becomes the configured
+        # default rather than "wait forever".
+        effective = self._default_timeout_s if timeout is None else timeout
+        timeout_s = max(1, int(math.ceil(effective)))
+
+        try:
+            result = await self._sandbox.commands.run(command, timeout=timeout_s)
+        except Exception as e:
+            if self._is_timeout(e):
+                raise ExecTimeoutError(
+                    command=reported_command,
+                    timeout_s=None if timeout is None else float(timeout),
+                    cause=e,
+                ) from e
+            raise ExecTransportError(command=reported_command, cause=e) from e
+
+        # ExecutionResult carries text, not bytes. Binary payloads must never travel
+        # this path — read_file()/write_file() exist for that.
+        return ExecResult(
+            stdout=_encode(result.stdout),
+            stderr=_encode(result.stderr),
+            exit_code=int(result.exit_code),
+        )
+
+    async def _run_script(
+        self, script: str, *args: str, timeout: float | None = None
+    ) -> ExecResult:
+        argv = ["sh", "-lc", script, "sh", *args]
+        return await self._run(shlex.join(argv), argv, timeout=timeout)
+
+    async def _read_file_via_exec(self, path: str) -> bytes:
+        argv = ["base64", "--", path]
+        result = await self._run(shlex.join(argv), argv)
+        if not result.ok():
+            raise ExecTransportError(
+                command=["base64", path],
+                message="sandbox file read failed",
+                context={"exit_code": result.exit_code},
+            )
+        return base64.b64decode(result.stdout)
+
+    async def _write_file_via_exec(self, path: str, data: bytes) -> None:
+        encoded = base64.b64encode(data).decode("ascii")
+        staging = f"{path}.b64.part"
+
+        # base64's alphabet contains no shell metacharacters, so the chunks are safe to
+        # interpolate; the destination paths still go through argv.
+        chunks = [
+            encoded[i : i + _EXEC_CHUNK_CHARS] for i in range(0, len(encoded), _EXEC_CHUNK_CHARS)
+        ] or [""]
+        for index, chunk in enumerate(chunks):
+            redirect = ">" if index == 0 else ">>"
+            result = await self._run_script(f'printf %s {chunk} {redirect} "$1"', staging)
+            if not result.ok():
+                raise ExecTransportError(
+                    command=["printf", staging],
+                    message="sandbox file write failed",
+                    context={"exit_code": result.exit_code, "chunk": index},
+                )
+
+        result = await self._run_script('base64 -d < "$1" > "$2" && rm -f "$1"', staging, path)
+        if not result.ok():
+            raise ExecTransportError(
+                command=["base64", "-d", staging, path],
+                message="sandbox file write failed",
+                context={"exit_code": result.exit_code},
+            )
+
+    @staticmethod
+    def _is_timeout(exc: BaseException) -> bool:
+        if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+            return True
+        if httpx is not None and isinstance(exc, httpx.TimeoutException):
+            return True
+        return False
+
+
+def _encode(value: str | bytes | None) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    return value.encode("utf-8", errors="replace")

--- a/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
+++ b/clients/integrations/openai/src/openai_agents_k8s_sandbox/transport.py
@@ -118,17 +118,19 @@ class K8sHttpTransport:
     ) -> ExecResult:
         reported_command = list(argv) if argv is not None else [command]
         # There is no unbounded mode on the HTTP API, so `None` becomes the configured
-        # default rather than "wait forever".
+        # default rather than "wait forever". The endpoint takes whole seconds.
         effective = self._default_timeout_s if timeout is None else timeout
-        timeout_s = max(1, int(math.ceil(effective)))
+        enforced_s = max(1, int(math.ceil(effective)))
 
         try:
-            result = await self._sandbox.commands.run(command, timeout=timeout_s)
+            result = await self._sandbox.commands.run(command, timeout=enforced_s)
         except Exception as e:
             if self._is_timeout(e):
+                # Report the budget the pod actually enforced, not the caller's request:
+                # `None` would read as "no timeout" for something that just timed out.
                 raise ExecTimeoutError(
                     command=reported_command,
-                    timeout_s=None if timeout is None else float(timeout),
+                    timeout_s=float(enforced_s),
                     cause=e,
                 ) from e
             raise ExecTransportError(command=reported_command, cause=e) from e

--- a/clients/integrations/openai/tests/conftest.py
+++ b/clients/integrations/openai/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Fixtures shared by the provider test modules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fake_k8s import FakeAsyncSandboxClient
+from openai_agents_k8s_sandbox import K8sSandboxClient
+
+
+@pytest.fixture
+def fake_client(tmp_path: Path) -> FakeAsyncSandboxClient:
+    return FakeAsyncSandboxClient(home=tmp_path / "home")
+
+
+@pytest.fixture
+def client(fake_client: FakeAsyncSandboxClient) -> K8sSandboxClient:
+    return K8sSandboxClient(fake_client)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    return tmp_path / "workspace"

--- a/clients/integrations/openai/tests/conftest.py
+++ b/clients/integrations/openai/tests/conftest.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Fixtures shared by the provider test modules."""
 
 from __future__ import annotations

--- a/clients/integrations/openai/tests/fake_k8s.py
+++ b/clients/integrations/openai/tests/fake_k8s.py
@@ -8,18 +8,27 @@ shell probes the SDK runs during ``start()``, without needing a cluster.
 
 Deliberate fidelity choices:
 
-* ``commands.run`` takes a command *string* and runs it through ``sh -c``, mirroring the
-  in-pod HTTP server, so the provider's ``shlex.join`` round-trip is exercised.
+* ``commands.run`` takes a command *string*, ``shlex.split``s it and execs the argv
+  **without a shell** — exactly what the in-pod server does
+  (``examples/python-runtime-sandbox/main.py``). The provider supplies its own ``sh -lc``
+  wrapper when it wants a shell, so this round-trips the provider's ``shlex.join``.
+* ``max_command_chars`` models ``MAX_ARG_STRLEN``: the kernel caps a *single* execve
+  argument at 128 KiB, which is why base64 payloads have to be chunked.
 * ``ExecutionResult`` carries ``str``, not ``bytes`` — the same lossiness as the JSON
   ``execute`` endpoint.
 * ``files.write`` does **not** create parent directories, so a provider that forgets to
   ``mkdir`` first fails here the way it would against a real server.
+* Failure injection (``fail_file_reads``, ``fail_file_writes``, ``fail_get_sandbox``,
+  ``status_value``) exists so error-mapping paths can be driven deterministically instead
+  of relying on incidental I/O failures.
 """
 
 from __future__ import annotations
 
 import asyncio
+import errno
 import os
+import shlex
 import uuid
 from pathlib import Path
 
@@ -34,11 +43,14 @@ class FakeCommands:
     async def run(self, command: str, timeout: int = 60) -> ExecutionResult:
         self._sandbox.assert_live()
         self._sandbox.commands_run.append(command)
+        self._sandbox.commands_timeouts.append(timeout)
+
+        # The in-pod server splits the command string and execs the argv directly.
+        argv = shlex.split(command)
+        self._sandbox.assert_argv_within_limits(argv)
 
         proc = await asyncio.create_subprocess_exec(
-            "sh",
-            "-c",
-            command,
+            *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd="/",
@@ -68,6 +80,8 @@ class FakeFilesystem:
         self._sandbox.assert_live()
         _reject_relative(path, allow_unsafe_paths)
         self._sandbox.files_read.append(path)
+        if self._sandbox.fail_file_reads is not None:
+            raise self._sandbox.fail_file_reads
         return Path(path).read_bytes()
 
     async def write(
@@ -80,6 +94,8 @@ class FakeFilesystem:
         self._sandbox.assert_live()
         _reject_relative(path, allow_unsafe_paths)
         self._sandbox.files_written.append(path)
+        if self._sandbox.fail_file_writes is not None:
+            raise self._sandbox.fail_file_writes
         if isinstance(content, str):
             content = content.encode("utf-8")
         target = Path(path)
@@ -100,8 +116,22 @@ class FakeAsyncSandbox:
         self.terminated = False
 
         self.commands_run: list[str] = []
+        self.commands_timeouts: list[int] = []
         self.files_read: list[str] = []
         self.files_written: list[str] = []
+
+        # -- knobs -------------------------------------------------------------
+        self.status_value = "SandboxReady"
+        """Reported by :meth:`status` while the sandbox is alive."""
+
+        self.status_error: BaseException | None = None
+        """When set, :meth:`status` raises it instead of returning."""
+
+        self.fail_file_reads: BaseException | None = None
+        self.fail_file_writes: BaseException | None = None
+
+        self.max_command_chars: int | None = None
+        """Per-argument ceiling, mirroring the kernel's ``MAX_ARG_STRLEN`` (128 KiB)."""
 
     @property
     def is_active(self) -> bool:
@@ -111,10 +141,27 @@ class FakeAsyncSandbox:
         if self.terminated:
             raise SandboxNotFoundError(f"sandbox '{self.sandbox_id}' has been terminated")
 
+    def assert_argv_within_limits(self, argv: list[str]) -> None:
+        if self.max_command_chars is None:
+            return
+        for arg in argv:
+            if len(arg) > self.max_command_chars:
+                raise OSError(errno.E2BIG, "Argument list too long")
+
+    def longest_command_argument(self) -> int:
+        """Longest single execve argument this sandbox has been asked to run."""
+
+        return max(
+            (len(arg) for command in self.commands_run for arg in shlex.split(command)),
+            default=0,
+        )
+
     async def status(self) -> tuple[str, str]:
+        if self.status_error is not None:
+            raise self.status_error
         if self.terminated:
             return "SandboxNotFound", "Sandbox object not found in Kubernetes."
-        return "SandboxReady", ""
+        return self.status_value, ""
 
     async def close_connection(self) -> None:
         return None
@@ -131,6 +178,8 @@ class FakeAsyncSandboxClient:
         self._sandboxes: dict[tuple[str, str], FakeAsyncSandbox] = {}
         self._warm_pools: dict[tuple[str, str], str] = {}
         self.created: list[dict[str, object]] = []
+        self.fail_get_sandbox: BaseException | None = None
+        """When set, :meth:`get_sandbox` raises it — models an API blip, not a deletion."""
 
     async def create_sandbox(
         self,
@@ -150,6 +199,7 @@ class FakeAsyncSandboxClient:
             {
                 "warmpool": warmpool,
                 "namespace": namespace,
+                "sandbox_ready_timeout": sandbox_ready_timeout,
                 "labels": labels,
                 "shutdown_after_seconds": shutdown_after_seconds,
                 "pod_labels": pod_labels,
@@ -167,6 +217,8 @@ class FakeAsyncSandboxClient:
         resolve_timeout: int = 30,
         warmpool_name: str | None = None,
     ) -> FakeAsyncSandbox:
+        if self.fail_get_sandbox is not None:
+            raise self.fail_get_sandbox
         sandbox = self._sandboxes.get((namespace, claim_name))
         if sandbox is None or sandbox.terminated:
             raise SandboxNotFoundError(f"claim '{claim_name}' not found in '{namespace}'")

--- a/clients/integrations/openai/tests/fake_k8s.py
+++ b/clients/integrations/openai/tests/fake_k8s.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """An in-process stand-in for ``k8s_agent_sandbox``'s async client.
 
 The fake speaks the same surface the provider actually uses — ``commands.run``,

--- a/clients/integrations/openai/tests/fake_k8s.py
+++ b/clients/integrations/openai/tests/fake_k8s.py
@@ -160,6 +160,9 @@ class FakeAsyncSandbox:
         self.max_command_chars: int | None = None
         """Per-argument ceiling, mirroring the kernel's ``MAX_ARG_STRLEN`` (128 KiB)."""
 
+        self.fail_terminate: BaseException | None = None
+        """When set, :meth:`terminate` raises it — models a refused claim deletion."""
+
     @property
     def is_active(self) -> bool:
         return not self.terminated
@@ -194,6 +197,8 @@ class FakeAsyncSandbox:
         return None
 
     async def terminate(self) -> None:
+        if self.fail_terminate is not None:
+            raise self.fail_terminate
         self.terminated = True
 
 
@@ -260,8 +265,14 @@ class FakeAsyncSandboxClient:
     async def delete_sandbox(self, claim_name: str, namespace: str = "default") -> None:
         sandbox = self._sandboxes.pop((namespace, claim_name), None)
         self._warm_pools.pop((namespace, claim_name), None)
-        if sandbox is not None:
+        if sandbox is None:
+            return
+        try:
             await sandbox.terminate()
+        except Exception:
+            # Modelled, not a bug: the real client logs deletion failures and returns
+            # normally, which is why the provider deletes via terminate() instead.
+            pass
 
     def drop_claim(self, claim_name: str, namespace: str = "default") -> None:
         """Simulate the claim disappearing underneath us (TTL expiry, node loss)."""

--- a/clients/integrations/openai/tests/fake_k8s.py
+++ b/clients/integrations/openai/tests/fake_k8s.py
@@ -78,7 +78,7 @@ class FakeFilesystem:
         self, path: str, timeout: int = 60, allow_unsafe_paths: bool = False
     ) -> bytes:
         self._sandbox.assert_live()
-        _reject_relative(path, allow_unsafe_paths)
+        _reject_absolute_without_allow_unsafe(path, allow_unsafe_paths)
         self._sandbox.files_read.append(path)
         if self._sandbox.fail_file_reads is not None:
             raise self._sandbox.fail_file_reads
@@ -92,7 +92,7 @@ class FakeFilesystem:
         allow_unsafe_paths: bool = False,
     ) -> None:
         self._sandbox.assert_live()
-        _reject_relative(path, allow_unsafe_paths)
+        _reject_absolute_without_allow_unsafe(path, allow_unsafe_paths)
         self._sandbox.files_written.append(path)
         if self._sandbox.fail_file_writes is not None:
             raise self._sandbox.fail_file_writes
@@ -242,7 +242,7 @@ class FakeAsyncSandboxClient:
         self._warm_pools.pop((namespace, claim_name), None)
 
 
-def _reject_relative(path: str, allow_unsafe_paths: bool) -> None:
+def _reject_absolute_without_allow_unsafe(path: str, allow_unsafe_paths: bool) -> None:
     # The real client's sanitizer strips a leading "/", so an absolute workspace path
     # only survives with allow_unsafe_paths=True. Enforce that here so the provider
     # cannot silently regress to server-relative paths.

--- a/clients/integrations/openai/tests/fake_k8s.py
+++ b/clients/integrations/openai/tests/fake_k8s.py
@@ -32,9 +32,9 @@ Deliberate fidelity choices:
   ``execute`` endpoint.
 * ``files.write`` does **not** create parent directories, so a provider that forgets to
   ``mkdir`` first fails here the way it would against a real server.
-* Failure injection (``fail_file_reads``, ``fail_file_writes``, ``fail_get_sandbox``,
-  ``status_value``) exists so error-mapping paths can be driven deterministically instead
-  of relying on incidental I/O failures.
+* Failure injection (``fail_file_reads``, ``fail_file_writes``, ``fail_commands_matching``,
+  ``fail_get_sandbox``, ``status_value``) exists so error-mapping paths can be driven
+  deterministically instead of relying on incidental I/O failures.
 """
 
 from __future__ import annotations
@@ -58,6 +58,11 @@ class FakeCommands:
         self._sandbox.assert_live()
         self._sandbox.commands_run.append(command)
         self._sandbox.commands_timeouts.append(timeout)
+
+        if self._sandbox.fail_commands_matching is not None and (
+            self._sandbox.fail_commands_matching in command
+        ):
+            return ExecutionResult(stdout="", stderr="injected command failure", exit_code=1)
 
         # The in-pod server splits the command string and execs the argv directly.
         argv = shlex.split(command)
@@ -143,6 +148,14 @@ class FakeAsyncSandbox:
 
         self.fail_file_reads: BaseException | None = None
         self.fail_file_writes: BaseException | None = None
+
+        self.fail_commands_matching: str | None = None
+        """Substring; matching commands report exit 1 instead of running.
+
+        A command that the pod runs but that fails — `rm` on a read-only mount, say — is
+        not reachable by arranging the local filesystem, since the fake runs the argv for
+        real.
+        """
 
         self.max_command_chars: int | None = None
         """Per-argument ceiling, mirroring the kernel's ``MAX_ARG_STRLEN`` (128 KiB)."""

--- a/clients/integrations/openai/tests/fake_k8s.py
+++ b/clients/integrations/openai/tests/fake_k8s.py
@@ -1,0 +1,198 @@
+"""An in-process stand-in for ``k8s_agent_sandbox``'s async client.
+
+The fake speaks the same surface the provider actually uses — ``commands.run``,
+``files.read``/``files.write``, ``status()``, plus the client's create/get/delete — and
+backs it with the local machine: "the pod is this host". That keeps the real
+:class:`K8sHttpTransport` and :class:`K8sSandboxSession` code under test, including the
+shell probes the SDK runs during ``start()``, without needing a cluster.
+
+Deliberate fidelity choices:
+
+* ``commands.run`` takes a command *string* and runs it through ``sh -c``, mirroring the
+  in-pod HTTP server, so the provider's ``shlex.join`` round-trip is exercised.
+* ``ExecutionResult`` carries ``str``, not ``bytes`` — the same lossiness as the JSON
+  ``execute`` endpoint.
+* ``files.write`` does **not** create parent directories, so a provider that forgets to
+  ``mkdir`` first fails here the way it would against a real server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+
+from k8s_agent_sandbox.exceptions import SandboxNotFoundError
+from k8s_agent_sandbox.models import ExecutionResult
+
+
+class FakeCommands:
+    def __init__(self, sandbox: "FakeAsyncSandbox") -> None:
+        self._sandbox = sandbox
+
+    async def run(self, command: str, timeout: int = 60) -> ExecutionResult:
+        self._sandbox.assert_live()
+        self._sandbox.commands_run.append(command)
+
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd="/",
+            env={**os.environ, "HOME": str(self._sandbox.home)},
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except (asyncio.TimeoutError, TimeoutError):
+            proc.kill()
+            await proc.wait()
+            raise
+
+        return ExecutionResult(
+            stdout=stdout.decode("utf-8", errors="replace"),
+            stderr=stderr.decode("utf-8", errors="replace"),
+            exit_code=proc.returncode if proc.returncode is not None else -1,
+        )
+
+
+class FakeFilesystem:
+    def __init__(self, sandbox: "FakeAsyncSandbox") -> None:
+        self._sandbox = sandbox
+
+    async def read(
+        self, path: str, timeout: int = 60, allow_unsafe_paths: bool = False
+    ) -> bytes:
+        self._sandbox.assert_live()
+        _reject_relative(path, allow_unsafe_paths)
+        self._sandbox.files_read.append(path)
+        return Path(path).read_bytes()
+
+    async def write(
+        self,
+        path: str,
+        content: bytes | str,
+        timeout: int = 60,
+        allow_unsafe_paths: bool = False,
+    ) -> None:
+        self._sandbox.assert_live()
+        _reject_relative(path, allow_unsafe_paths)
+        self._sandbox.files_written.append(path)
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        target = Path(path)
+        if not target.parent.is_dir():
+            # Matches a server that will not implicitly create directories.
+            raise FileNotFoundError(f"no such directory: {target.parent}")
+        target.write_bytes(content)
+
+
+class FakeAsyncSandbox:
+    def __init__(self, claim_name: str, sandbox_id: str, namespace: str, home: Path) -> None:
+        self.claim_name: str | None = claim_name
+        self.sandbox_id = sandbox_id
+        self.namespace = namespace
+        self.home = home
+        self.commands = FakeCommands(self)
+        self.files = FakeFilesystem(self)
+        self.terminated = False
+
+        self.commands_run: list[str] = []
+        self.files_read: list[str] = []
+        self.files_written: list[str] = []
+
+    @property
+    def is_active(self) -> bool:
+        return not self.terminated
+
+    def assert_live(self) -> None:
+        if self.terminated:
+            raise SandboxNotFoundError(f"sandbox '{self.sandbox_id}' has been terminated")
+
+    async def status(self) -> tuple[str, str]:
+        if self.terminated:
+            return "SandboxNotFound", "Sandbox object not found in Kubernetes."
+        return "SandboxReady", ""
+
+    async def close_connection(self) -> None:
+        return None
+
+    async def terminate(self) -> None:
+        self.terminated = True
+
+
+class FakeAsyncSandboxClient:
+    """Stands in for ``AsyncSandboxClient``."""
+
+    def __init__(self, home: Path) -> None:
+        self._home = home
+        self._sandboxes: dict[tuple[str, str], FakeAsyncSandbox] = {}
+        self._warm_pools: dict[tuple[str, str], str] = {}
+        self.created: list[dict[str, object]] = []
+
+    async def create_sandbox(
+        self,
+        warmpool: str,
+        namespace: str = "default",
+        sandbox_ready_timeout: int = 180,
+        labels: dict[str, str] | None = None,
+        *,
+        shutdown_after_seconds: int | None = None,
+        volume_claim_templates: list[dict] | None = None,
+        pod_labels: dict[str, str] | None = None,
+        pod_annotations: dict[str, str] | None = None,
+    ) -> FakeAsyncSandbox:
+        claim_name = f"sandbox-claim-{uuid.uuid4().hex[:8]}"
+        sandbox_id = f"{warmpool}-{uuid.uuid4().hex[:5]}"
+        self.created.append(
+            {
+                "warmpool": warmpool,
+                "namespace": namespace,
+                "labels": labels,
+                "shutdown_after_seconds": shutdown_after_seconds,
+                "pod_labels": pod_labels,
+            }
+        )
+        sandbox = FakeAsyncSandbox(claim_name, sandbox_id, namespace, self._home)
+        self._sandboxes[(namespace, claim_name)] = sandbox
+        self._warm_pools[(namespace, claim_name)] = warmpool
+        return sandbox
+
+    async def get_sandbox(
+        self,
+        claim_name: str,
+        namespace: str = "default",
+        resolve_timeout: int = 30,
+        warmpool_name: str | None = None,
+    ) -> FakeAsyncSandbox:
+        sandbox = self._sandboxes.get((namespace, claim_name))
+        if sandbox is None or sandbox.terminated:
+            raise SandboxNotFoundError(f"claim '{claim_name}' not found in '{namespace}'")
+        existing_pool = self._warm_pools.get((namespace, claim_name))
+        if warmpool_name is not None and existing_pool != warmpool_name:
+            raise ValueError(
+                f"SandboxClaim '{claim_name}' references warmpool '{existing_pool}', "
+                f"not '{warmpool_name}'. Refusing to reattach."
+            )
+        return sandbox
+
+    async def delete_sandbox(self, claim_name: str, namespace: str = "default") -> None:
+        sandbox = self._sandboxes.pop((namespace, claim_name), None)
+        self._warm_pools.pop((namespace, claim_name), None)
+        if sandbox is not None:
+            await sandbox.terminate()
+
+    def drop_claim(self, claim_name: str, namespace: str = "default") -> None:
+        """Simulate the claim disappearing underneath us (TTL expiry, node loss)."""
+        self._sandboxes.pop((namespace, claim_name), None)
+        self._warm_pools.pop((namespace, claim_name), None)
+
+
+def _reject_relative(path: str, allow_unsafe_paths: bool) -> None:
+    # The real client's sanitizer strips a leading "/", so an absolute workspace path
+    # only survives with allow_unsafe_paths=True. Enforce that here so the provider
+    # cannot silently regress to server-relative paths.
+    if not allow_unsafe_paths and path.startswith("/"):
+        raise ValueError(f"absolute path requires allow_unsafe_paths: {path}")

--- a/clients/integrations/openai/tests/support.py
+++ b/clients/integrations/openai/tests/support.py
@@ -1,0 +1,38 @@
+"""Helpers shared by the provider test modules."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+from openai_agents_k8s_sandbox import K8sSandboxClientOptions
+
+WARM_POOL = "python-sandbox-pool"
+NAMESPACE = "agents"
+
+# The kernel's MAX_ARG_STRLEN: a single execve argument above this fails with E2BIG,
+# which is what forces base64 payloads to be chunked.
+MAX_ARG_STRLEN = 128 * 1024
+
+
+def make_options(**overrides: object) -> K8sSandboxClientOptions:
+    base: dict[str, object] = {"warm_pool": WARM_POOL, "namespace": NAMESPACE}
+    base.update(overrides)
+    return K8sSandboxClientOptions(**base)  # type: ignore[arg-type]
+
+
+def make_tar(members: dict[str, bytes], *, symlinks: dict[str, str] | None = None) -> bytes:
+    """Build a tar in memory. Member names are used verbatim, traversal included."""
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        for name, target in (symlinks or {}).items():
+            info = tarfile.TarInfo(name=name)
+            info.type = tarfile.SYMTYPE
+            info.linkname = target
+            tar.addfile(info)
+    return buf.getvalue()

--- a/clients/integrations/openai/tests/support.py
+++ b/clients/integrations/openai/tests/support.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Helpers shared by the provider test modules."""
 
 from __future__ import annotations

--- a/clients/integrations/openai/tests/test_exposed_ports.py
+++ b/clients/integrations/openai/tests/test_exposed_ports.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Exposed-port resolution.
 
 The Sandbox CR gives the pod a stable in-cluster hostname, so there is no host-side port

--- a/clients/integrations/openai/tests/test_exposed_ports.py
+++ b/clients/integrations/openai/tests/test_exposed_ports.py
@@ -1,0 +1,95 @@
+"""Exposed-port resolution.
+
+The Sandbox CR gives the pod a stable in-cluster hostname, so there is no host-side port
+remapping as with Docker: the container port *is* the published port. What varies is the
+host, and getting it wrong points callers at something unreachable rather than failing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agents.sandbox.errors import ExposedPortUnavailableError
+from agents.sandbox.manifest import Manifest
+
+from openai_agents_k8s_sandbox import K8sSandboxClient
+from support import NAMESPACE, make_options
+
+
+async def test_resolves_to_the_in_cluster_dns_name(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(exposed_ports=(8080, 9090)),
+    )
+
+    endpoint = await session.resolve_exposed_port(8080)
+
+    assert endpoint.host == f"{session.state.sandbox_id}.{NAMESPACE}.svc.cluster.local"
+    assert endpoint.port == 8080
+    assert endpoint.tls is False
+
+    await client.delete(session)
+
+
+async def test_explicit_host_overrides_the_derived_one(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(exposed_ports=(8080,), exposed_port_host="gateway.example.test"),
+    )
+
+    endpoint = await session.resolve_exposed_port(8080)
+    assert endpoint.host == "gateway.example.test"
+
+    await client.delete(session)
+
+
+async def test_unconfigured_port_is_refused(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(exposed_ports=(8080,)),
+    )
+
+    with pytest.raises(ExposedPortUnavailableError) as excinfo:
+        await session.resolve_exposed_port(9999)
+
+    assert excinfo.value.context["reason"] == "not_configured"
+
+    await client.delete(session)
+
+
+async def test_no_exposed_ports_means_no_host(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    assert session.state.exposed_port_host is None
+
+    await client.delete(session)
+
+
+async def test_configured_port_without_a_host_reports_backend_unavailable(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    """Reachable from a hand-edited or older persisted payload, where the host is unset."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(exposed_ports=(8080,)),
+    )
+    session.state.exposed_port_host = None
+
+    with pytest.raises(ExposedPortUnavailableError) as excinfo:
+        await session.resolve_exposed_port(8080)
+
+    assert excinfo.value.context["reason"] == "backend_unavailable"
+
+    await client.delete(session)

--- a/clients/integrations/openai/tests/test_file_transfer.py
+++ b/clients/integrations/openai/tests/test_file_transfer.py
@@ -110,6 +110,34 @@ async def test_exec_write_cleans_up_its_staging_file(
     await client.delete(session)
 
 
+async def test_exec_write_reports_a_staging_cleanup_failure(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Staging that survives the write is inside the workspace the next snapshot sweeps."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        sandbox = await _sandbox_for(fake_client, session)
+        # Set after the first write so the SDK's own helper installation is unaffected.
+        await session.write(workspace / "warm.txt", io.BytesIO(b"warm"))
+        sandbox.fail_commands_matching = f"rm -f -- {workspace}"
+
+        with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+            await session.write(workspace / "kept.txt", io.BytesIO(b"kept"))
+        sandbox.fail_commands_matching = None
+
+        assert excinfo.value.context["reason"] == "staging cleanup failed"
+        # The payload landed; what failed is the sweep of the base64 staging file.
+        assert (workspace / "kept.txt").read_bytes() == b"kept"
+        assert (workspace / "kept.txt.b64.part").exists()
+
+    await client.delete(session)
+
+
 async def test_persist_and_hydrate_over_exec_transfer(
     client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
 ) -> None:

--- a/clients/integrations/openai/tests/test_file_transfer.py
+++ b/clients/integrations/openai/tests/test_file_transfer.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """How file bytes actually move, and what happens when that channel breaks.
 
 Two independent paths carry bytes: the bytes-clean upload/download endpoints, and base64

--- a/clients/integrations/openai/tests/test_file_transfer.py
+++ b/clients/integrations/openai/tests/test_file_transfer.py
@@ -28,7 +28,7 @@ import shutil
 from pathlib import Path
 
 import pytest
-from agents.sandbox.errors import WorkspaceArchiveWriteError
+from agents.sandbox.errors import ExecTransportError, WorkspaceArchiveWriteError
 from agents.sandbox.manifest import Manifest
 
 from fake_k8s import FakeAsyncSandbox, FakeAsyncSandboxClient
@@ -134,6 +134,29 @@ async def test_exec_write_reports_a_staging_cleanup_failure(
         # The payload landed; what failed is the sweep of the base64 staging file.
         assert (workspace / "kept.txt").read_bytes() == b"kept"
         assert (workspace / "kept.txt.b64.part").exists()
+
+    await client.delete(session)
+
+
+async def test_read_fallback_can_be_turned_off(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Opting out means a broken download endpoint is visible, not silently routed."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(read_fallback=False),
+    )
+
+    async with session:
+        target = workspace / "payload.txt"
+        await session.write(target, io.BytesIO(b"unreadable over http"))
+
+        sandbox = await _sandbox_for(fake_client, session)
+        sandbox.fail_file_reads = RuntimeError("download endpoint exploded")
+
+        with pytest.raises(ExecTransportError):
+            await session.read(target)
 
     await client.delete(session)
 

--- a/clients/integrations/openai/tests/test_file_transfer.py
+++ b/clients/integrations/openai/tests/test_file_transfer.py
@@ -1,0 +1,192 @@
+"""How file bytes actually move, and what happens when that channel breaks.
+
+Two independent paths carry bytes: the bytes-clean upload/download endpoints, and base64
+over the JSON ``execute`` endpoint. The exec path is bounded by how long a single command
+argument may be, which is the constraint these tests pin down.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from agents.sandbox.errors import WorkspaceArchiveWriteError
+from agents.sandbox.manifest import Manifest
+
+from fake_k8s import FakeAsyncSandbox, FakeAsyncSandboxClient
+from openai_agents_k8s_sandbox import K8sSandboxClient
+from support import MAX_ARG_STRLEN, NAMESPACE, make_options
+
+
+async def _sandbox_for(
+    fake_client: FakeAsyncSandboxClient, session: object
+) -> FakeAsyncSandbox:
+    return await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+
+
+async def test_exec_write_stays_within_the_argument_limit(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """A single execve argument is capped at 128 KiB, so base64 payloads must be chunked.
+
+    The in-pod server ``shlex.split``s the command and execs the argv directly, so an
+    unchunked base64 blob lands as one argument and fails with E2BIG well before any
+    realistic file size.
+    """
+
+    payload = os.urandom(256 * 1024)
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        sandbox = await _sandbox_for(fake_client, session)
+        # Applied after start() so the SDK's own probes are unaffected.
+        sandbox.max_command_chars = MAX_ARG_STRLEN
+
+        target = workspace / "big.bin"
+        await session.write(target, io.BytesIO(payload))
+
+        assert (await session.read(target)).read() == payload
+        assert sandbox.longest_command_argument() <= MAX_ARG_STRLEN
+
+    await client.delete(session)
+
+
+@pytest.mark.parametrize("size", [0, 1, 32 * 1024 - 1, 128 * 1024])
+async def test_exec_write_roundtrips_across_chunk_boundaries(
+    client: K8sSandboxClient, workspace: Path, size: int
+) -> None:
+    """An empty file has no chunks to send, and the boundary sizes are easy to fencepost."""
+
+    payload = os.urandom(size)
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        target = workspace / "payload.bin"
+        await session.write(target, io.BytesIO(payload))
+        assert (await session.read(target)).read() == payload
+
+    await client.delete(session)
+
+
+async def test_exec_write_cleans_up_its_staging_file(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    """Chunked writes stage base64 next to the target; that must not survive the write."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        await session.write(workspace / "kept.txt", io.BytesIO(os.urandom(64 * 1024)))
+
+        assert sorted(p.name for p in workspace.iterdir()) == ["kept.txt"]
+
+    await client.delete(session)
+
+
+async def test_persist_and_hydrate_over_exec_transfer(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Snapshots must work when the upload/download endpoints are unusable."""
+
+    payload = os.urandom(96 * 1024)
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        sandbox = await _sandbox_for(fake_client, session)
+        sandbox.max_command_chars = MAX_ARG_STRLEN
+
+        await session.write(workspace / "keep" / "blob.bin", io.BytesIO(payload))
+        archive = await session.persist_workspace()
+
+        shutil.rmtree(workspace)
+        workspace.mkdir(parents=True)
+
+        await session.hydrate_workspace(archive)
+        assert (await session.read(workspace / "keep" / "blob.bin")).read() == payload
+
+        # Nothing went through the http file endpoints.
+        assert sandbox.files_read == []
+        assert sandbox.files_written == []
+
+    await client.delete(session)
+
+
+async def test_read_falls_back_to_exec_when_download_fails(
+    client: K8sSandboxClient,
+    fake_client: FakeAsyncSandboxClient,
+    workspace: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A download endpoint that always fails must not look like a merely slow sandbox."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        target = workspace / "payload.txt"
+        await session.write(target, io.BytesIO(b"still readable"))
+
+        sandbox = await _sandbox_for(fake_client, session)
+        sandbox.fail_file_reads = RuntimeError("download endpoint exploded")
+
+        with caplog.at_level(logging.WARNING, logger="openai_agents_k8s_sandbox.session"):
+            data = await session.read(target)
+
+        assert data.read() == b"still readable"
+        assert "falling back to exec" in caplog.text
+
+    await client.delete(session)
+
+
+async def test_upload_failure_surfaces_as_a_workspace_write_error(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Writes have no fallback, so the transport error must be mapped, not leaked raw."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        sandbox = await _sandbox_for(fake_client, session)
+        sandbox.fail_file_writes = RuntimeError("upload endpoint exploded")
+
+        with pytest.raises(WorkspaceArchiveWriteError):
+            await session.write(workspace / "doomed.txt", io.BytesIO(b"x"))
+
+    await client.delete(session)
+
+
+async def test_exec_write_failure_surfaces_as_a_workspace_write_error(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        # A directory cannot be overwritten by a file redirect, so the shell exits non-zero.
+        (workspace / "adirectory").mkdir(parents=True)
+
+        with pytest.raises(WorkspaceArchiveWriteError):
+            await session.write(workspace / "adirectory", io.BytesIO(b"x"))
+
+    await client.delete(session)

--- a/clients/integrations/openai/tests/test_file_transfer.py
+++ b/clients/integrations/openai/tests/test_file_transfer.py
@@ -133,7 +133,27 @@ async def test_exec_write_reports_a_staging_cleanup_failure(
         assert excinfo.value.context["reason"] == "staging cleanup failed"
         # The payload landed; what failed is the sweep of the base64 staging file.
         assert (workspace / "kept.txt").read_bytes() == b"kept"
-        assert (workspace / "kept.txt.b64.part").exists()
+        assert list(workspace.glob("kept.txt.*.b64.part"))
+
+    await client.delete(session)
+
+
+async def test_exec_write_spares_a_file_named_like_staging(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    """A real file whose name looks like staging is not this write's scratch space."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer="exec"),
+    )
+
+    async with session:
+        await session.write(workspace / "payload.bin.b64.part", io.BytesIO(b"not staging"))
+        await session.write(workspace / "payload.bin", io.BytesIO(b"payload"))
+
+        assert (workspace / "payload.bin").read_bytes() == b"payload"
+        assert (workspace / "payload.bin.b64.part").read_bytes() == b"not staging"
 
     await client.delete(session)
 

--- a/clients/integrations/openai/tests/test_prototype.py
+++ b/clients/integrations/openai/tests/test_prototype.py
@@ -12,35 +12,17 @@ import shutil
 from pathlib import Path
 
 import pytest
-from agents.sandbox.errors import ExecTimeoutError, WorkspaceReadNotFoundError
+from agents.sandbox.errors import (
+    ExecTimeoutError,
+    InvalidManifestPathError,
+    WorkspaceReadNotFoundError,
+)
 from agents.sandbox.manifest import Manifest
 from agents.sandbox.snapshot import LocalSnapshotSpec
 
 from fake_k8s import FakeAsyncSandboxClient
-from openai_agents_k8s_sandbox import K8sSandboxClient, K8sSandboxClientOptions
-
-WARM_POOL = "python-sandbox-pool"
-
-
-@pytest.fixture
-def fake_client(tmp_path: Path) -> FakeAsyncSandboxClient:
-    return FakeAsyncSandboxClient(home=tmp_path / "home")
-
-
-@pytest.fixture
-def client(fake_client: FakeAsyncSandboxClient) -> K8sSandboxClient:
-    return K8sSandboxClient(fake_client)
-
-
-@pytest.fixture
-def workspace(tmp_path: Path) -> Path:
-    return tmp_path / "workspace"
-
-
-def make_options(**overrides: object) -> K8sSandboxClientOptions:
-    base: dict[str, object] = {"warm_pool": WARM_POOL, "namespace": "agents"}
-    base.update(overrides)
-    return K8sSandboxClientOptions(**base)  # type: ignore[arg-type]
+from openai_agents_k8s_sandbox import K8sSandboxClient
+from support import WARM_POOL, make_options
 
 
 async def test_start_and_exec(client: K8sSandboxClient, workspace: Path) -> None:
@@ -67,6 +49,7 @@ async def test_create_passes_lifecycle_settings(
         {
             "warmpool": WARM_POOL,
             "namespace": "agents",
+            "sandbox_ready_timeout": 180,
             "labels": None,
             "shutdown_after_seconds": 120,
             "pod_labels": {"team": "agents"},
@@ -232,5 +215,38 @@ async def test_absolute_paths_reach_the_file_endpoints(
         await session.write(workspace / "abs.txt", io.BytesIO(b"x"))
         sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace="agents")
         assert any(p.startswith("/") for p in sandbox.files_written)
+
+    await client.delete(session)
+
+
+async def test_capability_contract(client: K8sSandboxClient, workspace: Path) -> None:
+    """Both are advertised as unsupported; the SDK branches on them during start()."""
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+
+    async with session:
+        assert session.supports_pty() is False
+        assert session._inner.supports_docker_volume_mounts() is False
+
+    await client.delete(session)
+
+
+async def test_workspace_root_is_manifest_driven(
+    client: K8sSandboxClient, tmp_path: Path
+) -> None:
+    """Nothing hardcodes /workspace: relative paths resolve under whatever root is set."""
+    root = tmp_path / "srv" / "app"  # deliberately not named "workspace"
+    session = await client.create(manifest=Manifest(root=str(root)), options=make_options())
+
+    async with session:
+        assert session._inner._workspace_root_path() == root
+        assert root.is_dir()
+
+        await session.write(Path("notes.txt"), io.BytesIO(b"relative"))
+        assert (root / "notes.txt").read_bytes() == b"relative"
+        assert (await session.read(Path("notes.txt"))).read() == b"relative"
+
+        # A path outside the configured root is refused, /workspace included.
+        with pytest.raises(InvalidManifestPathError):
+            await session.write(Path("/workspace/escape.txt"), io.BytesIO(b"x"))
 
     await client.delete(session)

--- a/clients/integrations/openai/tests/test_prototype.py
+++ b/clients/integrations/openai/tests/test_prototype.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """End-to-end exercise of the provider against a fake pod.
 
 These run the real ``SandboxSession`` machinery — ``start()``, manifest materialization,

--- a/clients/integrations/openai/tests/test_prototype.py
+++ b/clients/integrations/openai/tests/test_prototype.py
@@ -1,0 +1,236 @@
+"""End-to-end exercise of the provider against a fake pod.
+
+These run the real ``SandboxSession`` machinery — ``start()``, manifest materialization,
+the remote path probes, snapshot persist/restore — so a contract break in the SDK shows
+up here rather than against a live cluster.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+from pathlib import Path
+
+import pytest
+from agents.sandbox.errors import ExecTimeoutError, WorkspaceReadNotFoundError
+from agents.sandbox.manifest import Manifest
+from agents.sandbox.snapshot import LocalSnapshotSpec
+
+from fake_k8s import FakeAsyncSandboxClient
+from openai_agents_k8s_sandbox import K8sSandboxClient, K8sSandboxClientOptions
+
+WARM_POOL = "python-sandbox-pool"
+
+
+@pytest.fixture
+def fake_client(tmp_path: Path) -> FakeAsyncSandboxClient:
+    return FakeAsyncSandboxClient(home=tmp_path / "home")
+
+
+@pytest.fixture
+def client(fake_client: FakeAsyncSandboxClient) -> K8sSandboxClient:
+    return K8sSandboxClient(fake_client)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    return tmp_path / "workspace"
+
+
+def make_options(**overrides: object) -> K8sSandboxClientOptions:
+    base: dict[str, object] = {"warm_pool": WARM_POOL, "namespace": "agents"}
+    base.update(overrides)
+    return K8sSandboxClientOptions(**base)  # type: ignore[arg-type]
+
+
+async def test_start_and_exec(client: K8sSandboxClient, workspace: Path) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+
+    async with session:
+        result = await session.exec("echo hello")
+        assert result.ok()
+        assert result.stdout.strip() == b"hello"
+
+        # The workspace root is materialized by start().
+        assert workspace.is_dir()
+
+    await client.delete(session)
+
+
+async def test_create_passes_lifecycle_settings(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    options = make_options(shutdown_after_seconds=120, pod_labels={"team": "agents"})
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=options)
+
+    assert fake_client.created == [
+        {
+            "warmpool": WARM_POOL,
+            "namespace": "agents",
+            "labels": None,
+            "shutdown_after_seconds": 120,
+            "pod_labels": {"team": "agents"},
+        }
+    ]
+    await client.delete(session)
+
+
+@pytest.mark.parametrize("file_transfer", ["http", "exec"])
+async def test_binary_file_roundtrip(
+    client: K8sSandboxClient,
+    fake_client: FakeAsyncSandboxClient,
+    workspace: Path,
+    file_transfer: str,
+) -> None:
+    payload = bytes(range(256)) * 8  # NULs, high bytes, invalid UTF-8
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(file_transfer=file_transfer),
+    )
+
+    async with session:
+        target = workspace / "nested" / "blob.bin"
+        await session.write(target, io.BytesIO(payload))
+        assert (await session.read(target)).read() == payload
+
+        # Pin which path actually carried the bytes: `read` falls back to exec when the
+        # download endpoint errors, which would otherwise let a broken http path pass.
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace="agents")
+        used_http = bool(sandbox.files_read) and bool(sandbox.files_written)
+        assert used_http is (file_transfer == "http")
+
+    await client.delete(session)
+
+
+async def test_read_missing_file_is_classified(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+
+    async with session:
+        with pytest.raises(WorkspaceReadNotFoundError):
+            await session.read(workspace / "does-not-exist.txt")
+
+    await client.delete(session)
+
+
+async def test_persist_and_hydrate_workspace(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+
+    async with session:
+        await session.write(workspace / "keep" / "a.txt", io.BytesIO(b"kept"))
+        archive = await session.persist_workspace()
+
+        shutil.rmtree(workspace)
+        workspace.mkdir(parents=True)
+
+        await session.hydrate_workspace(archive)
+        assert (await session.read(workspace / "keep" / "a.txt")).read() == b"kept"
+
+    await client.delete(session)
+
+
+async def test_resume_reattaches_to_live_claim(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+    async with session:
+        await session.write(workspace / "state.txt", io.BytesIO(b"before"))
+        claim_name = session.state.claim_name
+        payload = client.serialize_session_state(session.state)
+
+    # A different process would rebuild the state from JSON.
+    state = client.deserialize_session_state(payload)
+    assert state.claim_name == claim_name
+
+    resumed = await client.resume(state)
+    async with resumed:
+        assert (await resumed.read(workspace / "state.txt")).read() == b"before"
+        assert resumed.state.claim_name == claim_name
+
+    await client.delete(resumed)
+
+
+async def test_resume_replaces_lost_claim_and_restores_snapshot(
+    client: K8sSandboxClient,
+    fake_client: FakeAsyncSandboxClient,
+    workspace: Path,
+    tmp_path: Path,
+) -> None:
+    snapshots = tmp_path / "snapshots"
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        snapshot=LocalSnapshotSpec(base_path=snapshots),
+        options=make_options(),
+    )
+    async with session:
+        await session.write(workspace / "durable.txt", io.BytesIO(b"survives"))
+        claim_name = session.state.claim_name
+        state = session.state
+    # Leaving the context persisted the workspace into the local snapshot.
+    assert list(snapshots.glob("*.tar"))
+
+    # The pod and its PVC are gone: TTL expiry, node loss, namespace cleanup.
+    fake_client.drop_claim(claim_name, namespace="agents")
+    shutil.rmtree(workspace)
+
+    resumed = await client.resume(state)
+    async with resumed:
+        assert resumed.state.claim_name != claim_name
+        assert (await resumed.read(workspace / "durable.txt")).read() == b"survives"
+
+    await client.delete(resumed)
+
+
+async def test_resume_refuses_warm_pool_mismatch(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+    async with session:
+        state = session.state
+
+    state.warm_pool = "some-other-pool"
+    with pytest.raises(ValueError, match="Refusing to reattach"):
+        await client.resume(state)
+
+    await client.delete(session)
+
+
+async def test_delete_terminates_the_claim(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+    claim_name = session.state.claim_name
+
+    await client.delete(session)
+
+    from k8s_agent_sandbox.exceptions import SandboxNotFoundError
+
+    with pytest.raises(SandboxNotFoundError):
+        await fake_client.get_sandbox(claim_name, namespace="agents")
+
+
+async def test_exec_timeout_is_mapped(client: K8sSandboxClient, workspace: Path) -> None:
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+
+    async with session:
+        with pytest.raises(ExecTimeoutError):
+            await session.exec("sleep 5", timeout=1)
+
+    await client.delete(session)
+
+
+async def test_absolute_paths_reach_the_file_endpoints(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """The in-pod client strips a leading '/' unless allow_unsafe_paths is set."""
+    session = await client.create(manifest=Manifest(root=str(workspace)), options=make_options())
+
+    async with session:
+        await session.write(workspace / "abs.txt", io.BytesIO(b"x"))
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace="agents")
+        assert any(p.startswith("/") for p in sandbox.files_written)
+
+    await client.delete(session)

--- a/clients/integrations/openai/tests/test_resume_options.py
+++ b/clients/integrations/openai/tests/test_resume_options.py
@@ -219,6 +219,37 @@ async def test_delete_refuses_foreign_session(client: K8sSandboxClient) -> None:
         await client.delete(foreign)  # type: ignore[arg-type]
 
 
+async def test_delete_surfaces_a_failed_claim_deletion(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """A claim the API server refused to delete leaves a pod and a PVC running."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+    sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+    sandbox.fail_terminate = RuntimeError("claim deletion refused")
+
+    with pytest.raises(RuntimeError, match="claim deletion refused"):
+        await client.delete(session)
+
+    sandbox.fail_terminate = None
+    await client.delete(session)
+
+
+async def test_delete_accepts_an_already_deleted_claim(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Nothing is left to free, so deleting twice is not an error."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+    fake_client.drop_claim(session.state.claim_name, namespace=NAMESPACE)
+
+    await client.delete(session)
+
+
 async def test_delete_refuses_an_unwrapped_session(
     client: K8sSandboxClient, workspace: Path
 ) -> None:

--- a/clients/integrations/openai/tests/test_resume_options.py
+++ b/clients/integrations/openai/tests/test_resume_options.py
@@ -21,6 +21,7 @@ supposed to be a continuation, not a fresh sandbox with default settings.
 
 from __future__ import annotations
 
+import logging
 import types
 import uuid
 from pathlib import Path
@@ -235,6 +236,27 @@ async def test_delete_surfaces_a_failed_claim_deletion(
 
     sandbox.fail_terminate = None
     await client.delete(session)
+
+
+async def test_delete_logs_a_failed_teardown(
+    client: K8sSandboxClient, workspace: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Deletion carries on, but a crash in shutdown() must not vanish."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async def broken_shutdown() -> None:
+        raise RuntimeError("transport gone")
+
+    session._inner.shutdown = broken_shutdown  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="openai_agents_k8s_sandbox.client"):
+        await client.delete(session)
+
+    assert "teardown failed" in caplog.text
+    assert "transport gone" in caplog.text
 
 
 async def test_delete_accepts_an_already_deleted_claim(

--- a/clients/integrations/openai/tests/test_resume_options.py
+++ b/clients/integrations/openai/tests/test_resume_options.py
@@ -1,0 +1,205 @@
+"""What survives ``resume()`` when the original claim is gone.
+
+When the claim has expired the provider provisions a replacement. Everything the caller
+configured on the original ``create()`` has to come back with it — the replacement is
+supposed to be a continuation, not a fresh sandbox with default settings.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+
+import pytest
+from agents.sandbox.manifest import Manifest
+from agents.sandbox.session import SandboxSessionState
+from agents.sandbox.snapshot import resolve_snapshot
+from k8s_agent_sandbox.exceptions import SandboxNotFoundError
+
+from fake_k8s import FakeAsyncSandboxClient
+from openai_agents_k8s_sandbox import K8sSandboxClient
+from support import NAMESPACE, make_options
+
+
+async def _create_then_lose_claim(
+    client: K8sSandboxClient,
+    fake_client: FakeAsyncSandboxClient,
+    workspace: Path,
+    **option_overrides: object,
+) -> SandboxSessionState:
+    """Create a session, close it, then make its claim vanish (TTL expiry, node loss)."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(**option_overrides),
+    )
+    async with session:
+        state = session.state
+
+    fake_client.drop_claim(state.claim_name, namespace=NAMESPACE)
+    return state
+
+
+async def test_replacement_preserves_lifecycle_options(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    state = await _create_then_lose_claim(
+        client,
+        fake_client,
+        workspace,
+        shutdown_after_seconds=120,
+        sandbox_ready_timeout=600,
+        labels={"owner": "platform"},
+        pod_labels={"team": "agents"},
+    )
+
+    resumed = await client.resume(state)
+
+    assert len(fake_client.created) == 2
+    original, replacement = fake_client.created
+    assert replacement == original
+
+    await client.delete(resumed)
+
+
+async def test_replacement_preserves_disabled_ttl(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """``None`` means "no TTL backstop" — it must not silently become the 3600s default."""
+
+    state = await _create_then_lose_claim(
+        client, fake_client, workspace, shutdown_after_seconds=None
+    )
+
+    resumed = await client.resume(state)
+
+    assert fake_client.created[1]["shutdown_after_seconds"] is None
+
+    await client.delete(resumed)
+
+
+async def test_replacement_keeps_pinned_exposed_port_host(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """A caller-supplied host is a deliberate override; the replacement must keep it."""
+
+    state = await _create_then_lose_claim(
+        client,
+        fake_client,
+        workspace,
+        exposed_ports=(8080,),
+        exposed_port_host="gateway.example.test",
+    )
+    assert state.exposed_port_host == "gateway.example.test"
+
+    resumed = await client.resume(state)
+
+    endpoint = await resumed.resolve_exposed_port(8080)
+    assert endpoint.host == "gateway.example.test"
+
+    await client.delete(resumed)
+
+
+async def test_replacement_refreshes_unpinned_host_to_new_sandbox(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Without an override the host is derived, so it has to follow the new sandbox."""
+
+    state = await _create_then_lose_claim(client, fake_client, workspace, exposed_ports=(8080,))
+    original_host = state.exposed_port_host
+    assert original_host == f"{state.sandbox_id}.{NAMESPACE}.svc.cluster.local"
+
+    resumed = await client.resume(state)
+
+    expected = f"{resumed.state.sandbox_id}.{NAMESPACE}.svc.cluster.local"
+    assert resumed.state.exposed_port_host == expected
+    assert resumed.state.exposed_port_host != original_host
+
+    await client.delete(resumed)
+
+
+async def test_missing_claim_provisions_a_replacement(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    state = await _create_then_lose_claim(client, fake_client, workspace)
+    original_claim = state.claim_name
+
+    fake_client.fail_get_sandbox = SandboxNotFoundError("claim is gone")
+    resumed = await client.resume(state)
+
+    assert resumed.state.claim_name != original_claim
+    assert len(fake_client.created) == 2
+
+    await client.delete(resumed)
+
+
+async def test_unexpected_reattach_failure_is_not_swallowed(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """An API blip is not proof the sandbox died. Replacing it would orphan a live pod."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+    async with session:
+        state = session.state
+
+    fake_client.fail_get_sandbox = RuntimeError("kube-apiserver unavailable")
+
+    with pytest.raises(RuntimeError, match="kube-apiserver"):
+        await client.resume(state)
+
+    # The original sandbox is still live and must not have been abandoned.
+    assert len(fake_client.created) == 1
+
+    fake_client.fail_get_sandbox = None
+    await client.delete(session)
+
+
+async def test_state_written_by_an_older_version_still_deserializes(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Session state is persisted JSON, so a payload missing the newer keys must load."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+    payload = client.serialize_session_state(session.state)
+    for added_later in (
+        "exposed_port_host_override",
+        "sandbox_ready_timeout",
+        "shutdown_after_seconds",
+        "labels",
+        "pod_labels",
+    ):
+        payload.pop(added_later, None)
+
+    state = client.deserialize_session_state(payload)
+
+    assert state.sandbox_ready_timeout == 180
+    assert state.shutdown_after_seconds == 3600
+    assert state.labels is None
+    assert state.pod_labels is None
+    assert state.exposed_port_host_override is None
+
+    await client.delete(session)
+
+
+async def test_resume_refuses_foreign_state(client: K8sSandboxClient) -> None:
+    foreign = SandboxSessionState(
+        type="not-k8s",
+        session_id=uuid.uuid4(),
+        manifest=Manifest(),
+        snapshot=resolve_snapshot(None, "foreign"),
+    )
+
+    with pytest.raises(TypeError, match="K8sSandboxSessionState"):
+        await client.resume(foreign)
+
+
+async def test_delete_refuses_foreign_session(client: K8sSandboxClient) -> None:
+    foreign = types.SimpleNamespace(_inner=object())
+
+    with pytest.raises(TypeError, match="K8sSandboxSession"):
+        await client.delete(foreign)  # type: ignore[arg-type]

--- a/clients/integrations/openai/tests/test_resume_options.py
+++ b/clients/integrations/openai/tests/test_resume_options.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """What survives ``resume()`` when the original claim is gone.
 
 When the claim has expired the provider provisions a replacement. Everything the caller

--- a/clients/integrations/openai/tests/test_resume_options.py
+++ b/clients/integrations/openai/tests/test_resume_options.py
@@ -217,3 +217,18 @@ async def test_delete_refuses_foreign_session(client: K8sSandboxClient) -> None:
 
     with pytest.raises(TypeError, match="K8sSandboxSession"):
         await client.delete(foreign)  # type: ignore[arg-type]
+
+
+async def test_delete_refuses_an_unwrapped_session(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    """`_inner` is the wrapper's attribute; the session it wraps has none of its own."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    with pytest.raises(TypeError, match="K8sSandboxSession"):
+        await client.delete(session._inner)
+
+    await client.delete(session)

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -293,7 +293,7 @@ async def test_timeout_error_reports_the_requested_budget(
 async def test_timeout_error_marks_the_budget_as_client_side(
     client: K8sSandboxClient, workspace: Path
 ) -> None:
-    """The execute payload carries no timeout, so the pod keeps running the command."""
+    """The error records which side enforced the budget."""
 
     session = await client.create(
         manifest=Manifest(root=str(workspace)), options=make_options()

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -137,3 +137,22 @@ async def test_timeout_error_reports_the_requested_budget(
         assert excinfo.value.context["timeout_s"] == 1.0
 
     await client.delete(session)
+
+
+async def test_timeout_error_reports_the_default_when_none_was_requested(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    """Reporting None for something that just timed out would read as "no timeout"."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(exec_timeout_default_s=1.0),
+    )
+
+    async with session:
+        with pytest.raises(ExecTimeoutError) as excinfo:
+            await session.exec("sleep 5", timeout=None)
+
+        assert excinfo.value.context["timeout_s"] == 1.0
+
+    await client.delete(session)

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Transport-level behaviour: readiness reporting, timeouts, and error classification.
 
 ``ExecTimeoutError`` and ``ExecTransportError`` mean different things to a caller — one is

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -1,0 +1,139 @@
+"""Transport-level behaviour: readiness reporting, timeouts, and error classification.
+
+``ExecTimeoutError`` and ``ExecTransportError`` mean different things to a caller — one is
+worth retrying with a longer budget, the other is not — so the boundary between them
+matters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from agents.sandbox.errors import ExecTimeoutError, ExecTransportError
+from agents.sandbox.manifest import Manifest
+
+from fake_k8s import FakeAsyncSandboxClient
+from openai_agents_k8s_sandbox import K8sSandboxClient
+from support import NAMESPACE, make_options
+
+
+async def test_running_is_true_for_a_ready_sandbox(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        assert await session.running() is True
+
+    await client.delete(session)
+
+
+async def test_running_is_false_while_the_sandbox_is_not_ready(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Alive but still pending is not ready — only "SandboxReady" counts."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+        sandbox.status_value = "SandboxPending"
+
+        assert await session.running() is False
+
+    await client.delete(session)
+
+
+async def test_running_is_false_when_the_status_call_fails(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+        sandbox.status_error = RuntimeError("status endpoint unreachable")
+
+        assert await session.running() is False
+
+    await client.delete(session)
+
+
+async def test_unbounded_timeout_becomes_the_configured_default(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """The in-pod API has no "wait forever" mode, so None must map to a finite budget."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)),
+        options=make_options(exec_timeout_default_s=42.0),
+    )
+
+    async with session:
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+        sandbox.commands_timeouts.clear()
+
+        await session.exec("true", timeout=None)
+
+        assert sandbox.commands_timeouts == [42]
+
+    await client.delete(session)
+
+
+async def test_subsecond_timeout_floors_to_one_second(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """The endpoint takes whole seconds; rounding to 0 would mean "no time at all"."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+        sandbox.commands_timeouts.clear()
+
+        await session.exec("true", timeout=0.2)
+
+        assert sandbox.commands_timeouts == [1]
+
+    await client.delete(session)
+
+
+async def test_backend_failure_is_a_transport_error_not_a_timeout(
+    client: K8sSandboxClient, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+        await sandbox.terminate()
+
+        with pytest.raises(ExecTransportError):
+            await session.exec("true")
+
+    await client.delete(session)
+
+
+async def test_timeout_error_reports_the_requested_budget(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        with pytest.raises(ExecTimeoutError) as excinfo:
+            await session.exec("sleep 5", timeout=1)
+
+        assert excinfo.value.context["timeout_s"] == 1.0
+
+    await client.delete(session)

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -186,6 +186,40 @@ async def test_exec_write_preserves_the_original_error_when_staging_fails(
     assert list(tmp_path.glob("*.b64.part")) == []
 
 
+async def test_exec_write_reports_a_staging_cleanup_failure(
+    fake_client: FakeAsyncSandboxClient, tmp_path: Path
+) -> None:
+    """A write nobody can see failed is worse than one that reports its leftover."""
+
+    sandbox = await fake_client.create_sandbox("python-sandbox-pool", namespace=NAMESPACE)
+    transport = K8sHttpTransport(sandbox, file_transfer="exec")
+    sandbox.fail_commands_matching = "rm -f"
+    target = tmp_path / "payload.bin"
+
+    with pytest.raises(ExecTransportError) as excinfo:
+        await transport.write_file(str(target), b"payload")
+
+    assert "cleanup" in excinfo.value.message
+    assert excinfo.value.context["exit_code"] == 1
+    # The payload itself did land; only the staging file could not be swept.
+    assert target.read_bytes() == b"payload"
+
+
+async def test_exec_write_cleanup_failure_never_masks_the_write_failure(
+    fake_client: FakeAsyncSandboxClient, tmp_path: Path
+) -> None:
+    sandbox = await fake_client.create_sandbox("python-sandbox-pool", namespace=NAMESPACE)
+    transport = K8sHttpTransport(sandbox, file_transfer="exec")
+    sandbox.fail_commands_matching = "rm -f"
+    target = tmp_path / "target"
+    target.mkdir()  # a directory cannot be overwritten by the decode's redirect
+
+    with pytest.raises(ExecTransportError) as excinfo:
+        await transport.write_file(str(target), b"payload")
+
+    assert excinfo.value.message == "sandbox file write failed"
+
+
 async def test_timeout_error_reports_the_requested_budget(
     client: K8sSandboxClient, workspace: Path
 ) -> None:

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -182,6 +182,21 @@ async def test_exec_write_passes_chunks_as_arguments(
     assert all(encoded[:64] not in argv[2] for argv in writes)
 
 
+async def test_exec_write_spares_a_file_named_like_staging(
+    exec_transport: K8sHttpTransport, tmp_path: Path
+) -> None:
+    """A fixed suffix would overwrite this file and then delete it during cleanup."""
+
+    target = tmp_path / "payload.bin"
+    lookalike = tmp_path / "payload.bin.b64.part"
+    lookalike.write_bytes(b"not staging")
+
+    await exec_transport.write_file(str(target), b"payload")
+
+    assert target.read_bytes() == b"payload"
+    assert lookalike.read_bytes() == b"not staging"
+
+
 async def test_exec_write_handles_an_empty_payload(
     exec_transport: K8sHttpTransport, tmp_path: Path
 ) -> None:

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -21,6 +21,9 @@ matters.
 
 from __future__ import annotations
 
+import base64
+import os
+import shlex
 from pathlib import Path
 
 import pytest
@@ -29,6 +32,7 @@ from agents.sandbox.manifest import Manifest
 
 from fake_k8s import FakeAsyncSandboxClient
 from openai_agents_k8s_sandbox import K8sHttpTransport, K8sSandboxClient
+from openai_agents_k8s_sandbox.transport import _EXEC_CHUNK_CHARS
 from support import NAMESPACE, make_options
 
 
@@ -153,6 +157,41 @@ async def test_exec_write_removes_staging_on_success(
     await exec_transport.write_file(str(target), b"x" * (64 * 1024))
 
     assert target.read_bytes() == b"x" * (64 * 1024)
+    assert list(tmp_path.glob("*.b64.part")) == []
+
+
+async def test_exec_write_passes_chunks_as_arguments(
+    fake_client: FakeAsyncSandboxClient, tmp_path: Path
+) -> None:
+    """Chunks ride argv, not the script text: today's alphabet is not a guarantee."""
+
+    sandbox = await fake_client.create_sandbox("python-sandbox-pool", namespace=NAMESPACE)
+    transport = K8sHttpTransport(sandbox, file_transfer="exec")
+    payload = os.urandom(64 * 1024)
+    encoded = base64.b64encode(payload).decode("ascii")
+
+    await transport.write_file(str(tmp_path / "payload.bin"), payload)
+
+    # Each chunk write renders as ["sh", "-lc", <script>, "sh", <staging>, <chunk>], so
+    # the tail of the argv is the chunk itself and the script never carries base64.
+    writes = [shlex.split(command) for command in sandbox.commands_run if "printf" in command]
+    assert [argv[5:] for argv in writes] == [
+        [encoded[i : i + _EXEC_CHUNK_CHARS]]
+        for i in range(0, len(encoded), _EXEC_CHUNK_CHARS)
+    ]
+    assert all(encoded[:64] not in argv[2] for argv in writes)
+
+
+async def test_exec_write_handles_an_empty_payload(
+    exec_transport: K8sHttpTransport, tmp_path: Path
+) -> None:
+    """No chunks to send: the staging file still has to be created and decoded."""
+
+    target = tmp_path / "empty.bin"
+
+    await exec_transport.write_file(str(target), b"")
+
+    assert target.read_bytes() == b""
     assert list(tmp_path.glob("*.b64.part")) == []
 
 

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -275,6 +275,24 @@ async def test_timeout_error_reports_the_requested_budget(
     await client.delete(session)
 
 
+async def test_timeout_error_marks_the_budget_as_client_side(
+    client: K8sSandboxClient, workspace: Path
+) -> None:
+    """The execute payload carries no timeout, so the pod keeps running the command."""
+
+    session = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+
+    async with session:
+        with pytest.raises(ExecTimeoutError) as excinfo:
+            await session.exec("sleep 5", timeout=1)
+
+        assert excinfo.value.context["enforced_by"] == "client"
+
+    await client.delete(session)
+
+
 async def test_timeout_error_reports_the_default_when_none_was_requested(
     client: K8sSandboxClient, workspace: Path
 ) -> None:

--- a/clients/integrations/openai/tests/test_transport.py
+++ b/clients/integrations/openai/tests/test_transport.py
@@ -14,8 +14,16 @@ from agents.sandbox.errors import ExecTimeoutError, ExecTransportError
 from agents.sandbox.manifest import Manifest
 
 from fake_k8s import FakeAsyncSandboxClient
-from openai_agents_k8s_sandbox import K8sSandboxClient
+from openai_agents_k8s_sandbox import K8sHttpTransport, K8sSandboxClient
 from support import NAMESPACE, make_options
+
+
+@pytest.fixture
+async def exec_transport(fake_client: FakeAsyncSandboxClient) -> K8sHttpTransport:
+    """A transport wired straight to a sandbox, bypassing the session."""
+
+    sandbox = await fake_client.create_sandbox("python-sandbox-pool", namespace=NAMESPACE)
+    return K8sHttpTransport(sandbox, file_transfer="exec")
 
 
 async def test_running_is_true_for_a_ready_sandbox(
@@ -121,6 +129,47 @@ async def test_backend_failure_is_a_transport_error_not_a_timeout(
             await session.exec("true")
 
     await client.delete(session)
+
+
+async def test_exec_write_removes_staging_on_success(
+    exec_transport: K8sHttpTransport, tmp_path: Path
+) -> None:
+    target = tmp_path / "payload.bin"
+
+    await exec_transport.write_file(str(target), b"x" * (64 * 1024))
+
+    assert target.read_bytes() == b"x" * (64 * 1024)
+    assert list(tmp_path.glob("*.b64.part")) == []
+
+
+async def test_exec_write_removes_staging_when_the_decode_fails(
+    exec_transport: K8sHttpTransport, tmp_path: Path
+) -> None:
+    """The chunks land, then the decode cannot write its output — staging must not leak."""
+
+    target = tmp_path / "target"
+    target.mkdir()  # a directory cannot be overwritten by a redirect
+
+    with pytest.raises(ExecTransportError) as excinfo:
+        await exec_transport.write_file(str(target), b"payload")
+
+    assert excinfo.value.context["exit_code"] != 0
+    assert list(tmp_path.glob("*.b64.part")) == []
+
+
+async def test_exec_write_preserves_the_original_error_when_staging_fails(
+    exec_transport: K8sHttpTransport, tmp_path: Path
+) -> None:
+    """A chunk write that cannot even create staging must still report the chunk failure."""
+
+    target = tmp_path / "no-such-dir" / "payload.bin"
+
+    with pytest.raises(ExecTransportError) as excinfo:
+        await exec_transport.write_file(str(target), b"payload")
+
+    # The chunk-write failure, not something raised by the cleanup that follows it.
+    assert excinfo.value.context["chunk"] == 0
+    assert list(tmp_path.glob("*.b64.part")) == []
 
 
 async def test_timeout_error_reports_the_requested_budget(

--- a/clients/integrations/openai/tests/test_workspace_archives.py
+++ b/clients/integrations/openai/tests/test_workspace_archives.py
@@ -1,0 +1,107 @@
+"""Snapshot archives, including the ones that are trying to escape the workspace.
+
+``hydrate_workspace`` extracts an archive inside the pod with ``tar -x``. The archive may
+come from a snapshot store the caller does not fully control, so it is validated locally
+first — before any bytes are uploaded — and that guard is the security boundary here.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+from pathlib import Path
+
+import pytest
+from agents.sandbox.errors import WorkspaceArchiveReadError, WorkspaceArchiveWriteError
+from agents.sandbox.manifest import Manifest
+
+from openai_agents_k8s_sandbox import K8sSandboxClient
+from support import make_options, make_tar
+
+
+@pytest.fixture
+async def session(client: K8sSandboxClient, workspace: Path):
+    started = await client.create(
+        manifest=Manifest(root=str(workspace)), options=make_options()
+    )
+    async with started:
+        yield started
+    await client.delete(started)
+
+
+async def test_rejects_parent_traversal_members(session, workspace: Path) -> None:
+    archive = make_tar({"../escape.txt": b"pwned"})
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.hydrate_workspace(io.BytesIO(archive))
+
+    assert excinfo.value.context["reason"] == "parent traversal"
+    assert not (workspace.parent / "escape.txt").exists()
+
+
+async def test_rejects_absolute_members(session, workspace: Path) -> None:
+    archive = make_tar({"/etc/pwned.txt": b"pwned"})
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.hydrate_workspace(io.BytesIO(archive))
+
+    assert excinfo.value.context["reason"] == "absolute path"
+
+
+async def test_rejects_symlinks_pointing_outside_the_archive(session) -> None:
+    archive = make_tar({}, symlinks={"./link": "/etc/passwd"})
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.hydrate_workspace(io.BytesIO(archive))
+
+    assert "absolute symlink target" in excinfo.value.context["reason"]
+
+
+async def test_rejects_a_corrupt_archive(session) -> None:
+    with pytest.raises(WorkspaceArchiveWriteError):
+        await session.hydrate_workspace(io.BytesIO(b"this is not a tar archive"))
+
+
+async def test_rejects_a_non_bytes_payload(session) -> None:
+    class BadStream(io.IOBase):
+        def read(self, size: int = -1) -> object:  # type: ignore[override]
+            return 12345
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.hydrate_workspace(BadStream())
+
+    assert excinfo.value.context["reason"] == "non_bytes_tar_payload"
+
+
+async def test_accepts_a_clean_archive(session, workspace: Path) -> None:
+    archive = make_tar({"./nested/ok.txt": b"safe"})
+
+    await session.hydrate_workspace(io.BytesIO(archive))
+
+    assert (workspace / "nested" / "ok.txt").read_bytes() == b"safe"
+
+
+async def test_persist_maps_a_failing_tar(session, workspace: Path) -> None:
+    """No workspace root means ``tar -c -C`` exits non-zero; that must be mapped."""
+
+    shutil.rmtree(workspace)
+
+    with pytest.raises(WorkspaceArchiveReadError) as excinfo:
+        await session.persist_workspace()
+
+    assert excinfo.value.context["exit_code"] != 0
+
+
+async def test_persist_excludes_the_archive_staging_area(session, workspace: Path) -> None:
+    """Staging lives outside the root precisely so it never lands in a snapshot."""
+
+    import tarfile
+
+    await session.write(workspace / "kept.txt", io.BytesIO(b"kept"))
+    archive = await session.persist_workspace()
+
+    with tarfile.open(fileobj=io.BytesIO(archive.read()), mode="r:*") as tar:
+        names = {member.name for member in tar.getmembers()}
+
+    assert "./kept.txt" in names
+    assert not any("agents-k8s-sandbox" in name for name in names)

--- a/clients/integrations/openai/tests/test_workspace_archives.py
+++ b/clients/integrations/openai/tests/test_workspace_archives.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Snapshot archives, including the ones that are trying to escape the workspace.
 
 ``hydrate_workspace`` extracts an archive inside the pod with ``tar -x``. The archive may

--- a/clients/integrations/openai/tests/test_workspace_archives.py
+++ b/clients/integrations/openai/tests/test_workspace_archives.py
@@ -12,6 +12,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+from agents.run_config import SandboxArchiveLimits
 from agents.sandbox.errors import WorkspaceArchiveReadError, WorkspaceArchiveWriteError
 from agents.sandbox.manifest import Manifest
 
@@ -71,6 +72,51 @@ async def test_rejects_a_non_bytes_payload(session) -> None:
         await session.hydrate_workspace(BadStream())
 
     assert excinfo.value.context["reason"] == "non_bytes_tar_payload"
+
+
+class _CountingStream(io.IOBase):
+    """Hands out a fixed chunk on demand and records how much has been consumed."""
+
+    def __init__(self, chunk: bytes, chunks: int) -> None:
+        self.chunk = chunk
+        self.remaining = chunks
+        self.served = 0
+
+    def read(self, size: int = -1) -> bytes:  # type: ignore[override]
+        if self.remaining <= 0:
+            return b""
+        self.remaining -= 1
+        self.served += len(self.chunk)
+        return self.chunk
+
+
+async def test_rejects_an_oversized_archive_before_buffering_it_all(session) -> None:
+    """The archive is held in memory, so the ceiling has to bite mid-stream."""
+
+    limit = 64 * 1024
+    chunk = b"\0" * io.DEFAULT_BUFFER_SIZE
+    # Far more than the limit: draining all of it is exactly the failure mode.
+    stream = _CountingStream(chunk, chunks=4096)
+    session._set_archive_limits(SandboxArchiveLimits(max_input_bytes=limit))
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.hydrate_workspace(stream)
+
+    assert excinfo.value.context["reason"] == "archive input size exceeds limit"
+    assert excinfo.value.context["limit"] == limit
+
+    # It stopped as soon as the limit was crossed rather than reading the whole stream.
+    assert stream.served <= limit + len(chunk)
+    assert stream.remaining > 0
+
+
+async def test_unlimited_by_default(session, workspace: Path) -> None:
+    """Limits are opt-in; without them hydration behaves as it always did."""
+
+    assert session._inner._max_archive_input_bytes() is None
+
+    await session.hydrate_workspace(io.BytesIO(make_tar({"./ok.txt": b"safe"})))
+    assert (workspace / "ok.txt").read_bytes() == b"safe"
 
 
 async def test_accepts_a_clean_archive(session, workspace: Path) -> None:

--- a/clients/integrations/openai/tests/test_workspace_archives.py
+++ b/clients/integrations/openai/tests/test_workspace_archives.py
@@ -125,6 +125,28 @@ async def test_rejects_an_oversized_archive_before_buffering_it_all(session) -> 
     assert stream.remaining > 0
 
 
+async def test_persist_rejects_an_oversized_workspace(session, workspace: Path) -> None:
+    """The snapshot is buffered whole, and hydrate would refuse it on the way back in."""
+
+    limit = 4 * 1024
+    await session.write(workspace / "big.bin", io.BytesIO(b"x" * (64 * 1024)))
+    session._set_archive_limits(SandboxArchiveLimits(max_input_bytes=limit))
+
+    with pytest.raises(WorkspaceArchiveReadError) as excinfo:
+        await session.persist_workspace()
+
+    assert excinfo.value.context["reason"] == "archive size exceeds limit"
+    assert excinfo.value.context["limit"] == limit
+    assert excinfo.value.context["actual"] > limit
+
+
+async def test_persist_stays_within_a_generous_limit(session, workspace: Path) -> None:
+    session._set_archive_limits(SandboxArchiveLimits(max_input_bytes=8 * 1024 * 1024))
+    await session.write(workspace / "kept.txt", io.BytesIO(b"kept"))
+
+    assert (await session.persist_workspace()).read()
+
+
 async def test_unlimited_by_default(session, workspace: Path) -> None:
     """Limits are opt-in; without them hydration behaves as it always did."""
 

--- a/clients/integrations/openai/tests/test_workspace_archives.py
+++ b/clients/integrations/openai/tests/test_workspace_archives.py
@@ -30,8 +30,9 @@ from agents.run_config import SandboxArchiveLimits
 from agents.sandbox.errors import WorkspaceArchiveReadError, WorkspaceArchiveWriteError
 from agents.sandbox.manifest import Manifest
 
+from fake_k8s import FakeAsyncSandboxClient
 from openai_agents_k8s_sandbox import K8sSandboxClient
-from support import make_options, make_tar
+from support import NAMESPACE, make_options, make_tar
 
 
 @pytest.fixture
@@ -150,6 +151,36 @@ async def test_persist_maps_a_failing_tar(session, workspace: Path) -> None:
         await session.persist_workspace()
 
     assert excinfo.value.context["exit_code"] != 0
+
+
+async def test_hydrate_reports_a_staging_cleanup_failure(
+    session, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    """Staging is shared state in the pod's /tmp, so a leak there just accumulates."""
+
+    sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+    sandbox.fail_commands_matching = f"rm -f -- {session._inner._ARCHIVE_STAGING_DIR}"
+
+    with pytest.raises(WorkspaceArchiveWriteError) as excinfo:
+        await session.hydrate_workspace(io.BytesIO(make_tar({"./ok.txt": b"safe"})))
+    sandbox.fail_commands_matching = None
+
+    assert excinfo.value.context["reason"] == "staging cleanup failed"
+    # The extraction itself went through; only its staging tar could not be swept.
+    assert (workspace / "ok.txt").read_bytes() == b"safe"
+
+
+async def test_persist_reports_a_staging_cleanup_failure(
+    session, fake_client: FakeAsyncSandboxClient, workspace: Path
+) -> None:
+    sandbox = await fake_client.get_sandbox(session.state.claim_name, namespace=NAMESPACE)
+    sandbox.fail_commands_matching = f"rm -f -- {session._inner._ARCHIVE_STAGING_DIR}"
+
+    with pytest.raises(WorkspaceArchiveReadError) as excinfo:
+        await session.persist_workspace()
+    sandbox.fail_commands_matching = None
+
+    assert excinfo.value.context["reason"] == "staging cleanup failed"
 
 
 async def test_persist_excludes_the_archive_staging_area(session, workspace: Path) -> None:


### PR DESCRIPTION
This pull request adds support for running OpenAI Agents SDK agents inside Agent Sandbox. It ships as its own package in a separate `clients/integrations/openai` folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes sandbox integration for OpenAI Agents SDK workloads.
  * Supports sandbox creation, deletion, resumption, replacement, and session persistence.
  * Enables command execution, HTTP or exec-based file transfers, exposed ports, and workspace snapshots.
  * Adds configurable lifecycle, networking, timeout, labeling, and transfer settings.
  * Provides archive protections and clear handling for transport, timeout, and file errors.

* **Documentation**
  * Added setup, usage, prerequisites, operation mappings, and verification guidance.

* **Tests**
  * Added comprehensive coverage for lifecycle, transport, file transfer, archives, security, ports, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->