### PR TITLE
fix(router): fence stale Pod cache events by UID

### DIFF
--- a/sandbox-router/cache/cache.go
+++ b/sandbox-router/cache/cache.go
@@ -76,6 +76,11 @@ const (
 // (e.g. ready timestamp, ownership labels for authz) can be added without
 // breaking call sites.
 type Entry struct {
+	// PodUID identifies the Pod that supplied PodIP. It fences delayed
+	// delete and NotReady events from an older Pod after the Sandbox has
+	// been recreated with the same owner UID.
+	PodUID types.UID
+
 	// PodIP is the IPv4/IPv6 address of the sandbox Pod. The ext_proc
 	// handler combines this with the inbound X-Sandbox-Port to build the
 	// upstream target.
@@ -244,7 +249,7 @@ func (c *Cache) onAddOrUpdate(obj any) {
 		return
 	}
 	if !podReady(pod) || pod.Status.PodIP == "" {
-		c.remove(uid)
+		c.removePod(uid, pod.UID)
 		return
 	}
 	// Unclaimed warm-pool Pods stay out of the name index: before the
@@ -255,6 +260,7 @@ func (c *Cache) onAddOrUpdate(obj any) {
 	// label, and the resulting Pod update indexes the entry.
 	_, unclaimed := pod.Labels[PodWarmPoolLabel]
 	c.upsert(uid, Entry{
+		PodUID:      pod.UID,
 		PodIP:       pod.Status.PodIP,
 		SandboxName: pod.Name,
 		Namespace:   pod.Namespace,
@@ -272,7 +278,7 @@ func (c *Cache) onDelete(obj any) {
 		return
 	}
 	if uid, ok := sandboxUIDOf(pod); ok {
-		c.remove(uid)
+		c.removePod(uid, pod.UID)
 	}
 }
 
@@ -305,7 +311,21 @@ func (c *Cache) upsert(uid types.UID, e Entry, indexName bool) {
 }
 
 func (c *Cache) remove(uid types.UID) {
+	c.removePod(uid, "")
+}
+
+// removePod removes the entry for uid only when podUID is empty (an internal
+// unconditional eviction) or matches the Pod that currently supplies the
+// entry. Matching the Pod UID prevents a delayed delete or NotReady event for
+// an older Pod from evicting a replacement Pod with the same Sandbox owner.
+func (c *Cache) removePod(uid, podUID types.UID) {
 	c.mu.Lock()
+	if podUID != "" {
+		if entry, ok := c.entries[uid]; !ok || entry.PodUID != podUID {
+			c.mu.Unlock()
+			return
+		}
+	}
 	existed := c.removeLocked(uid)
 	c.mu.Unlock()
 	if existed {

--- a/sandbox-router/cache/cache_test.go
+++ b/sandbox-router/cache/cache_test.go
@@ -460,6 +460,92 @@ func TestCache_PodRecreationNewUIDSameName(t *testing.T) {
 	}
 }
 
+func TestCache_StaleDeleteDoesNotEvictReplacementForSameSandbox(t *testing.T) {
+	const sandboxUID = types.UID("sandbox-recreated")
+	c := &Cache{
+		log:     logr.Discard(),
+		entries: make(map[types.UID]Entry),
+		byName:  make(map[string]types.UID),
+	}
+
+	oldPod := makePod(testPodName, testPodNS, sandboxUID, testPodIP, true)
+	oldPod.UID = types.UID("old-pod")
+	replacementPod := makePod(testPodName, testPodNS, sandboxUID, testPodIP2, true)
+	replacementPod.UID = types.UID("replacement-pod")
+
+	c.onAddOrUpdate(oldPod)
+	c.onAddOrUpdate(replacementPod)
+	c.onDelete(oldPod)
+
+	e, ok := c.Get(sandboxUID)
+	if !ok || e.PodUID != replacementPod.UID || e.PodIP != testPodIP2 {
+		t.Fatalf("stale delete evicted replacement entry: %+v, found=%v", e, ok)
+	}
+}
+
+func TestCache_StaleNotReadyDoesNotEvictReplacementForSameSandbox(t *testing.T) {
+	const sandboxUID = types.UID("sandbox-recreated")
+	c := &Cache{
+		log:     logr.Discard(),
+		entries: make(map[types.UID]Entry),
+		byName:  make(map[string]types.UID),
+	}
+
+	oldPod := makePod(testPodName, testPodNS, sandboxUID, testPodIP, true)
+	oldPod.UID = types.UID("old-pod")
+	replacementPod := makePod(testPodName, testPodNS, sandboxUID, testPodIP2, true)
+	replacementPod.UID = types.UID("replacement-pod")
+
+	c.onAddOrUpdate(oldPod)
+	c.onAddOrUpdate(replacementPod)
+	oldPodNotReady := oldPod.DeepCopy()
+	oldPodNotReady.Status.Conditions[0].Status = corev1.ConditionFalse
+	c.onAddOrUpdate(oldPodNotReady)
+
+	e, ok := c.Get(sandboxUID)
+	if !ok || e.PodUID != replacementPod.UID || e.PodIP != testPodIP2 {
+		t.Fatalf("stale NotReady event evicted replacement entry: %+v, found=%v", e, ok)
+	}
+}
+
+func TestCache_CurrentPodDeleteEvictsEntry(t *testing.T) {
+	const sandboxUID = types.UID("sandbox-current")
+	c := &Cache{
+		log:     logr.Discard(),
+		entries: make(map[types.UID]Entry),
+		byName:  make(map[string]types.UID),
+	}
+
+	pod := makePod(testPodName, testPodNS, sandboxUID, testPodIP, true)
+	pod.UID = types.UID("current-pod")
+	c.onAddOrUpdate(pod)
+	c.onDelete(pod)
+
+	if _, ok := c.Get(sandboxUID); ok {
+		t.Fatal("current Pod delete must evict the cache entry")
+	}
+}
+
+func TestCache_CurrentPodNotReadyEvictsEntry(t *testing.T) {
+	const sandboxUID = types.UID("sandbox-current")
+	c := &Cache{
+		log:     logr.Discard(),
+		entries: make(map[types.UID]Entry),
+		byName:  make(map[string]types.UID),
+	}
+
+	pod := makePod(testPodName, testPodNS, sandboxUID, testPodIP, true)
+	pod.UID = types.UID("current-pod")
+	c.onAddOrUpdate(pod)
+	podNotReady := pod.DeepCopy()
+	podNotReady.Status.Conditions[0].Status = corev1.ConditionFalse
+	c.onAddOrUpdate(podNotReady)
+
+	if _, ok := c.Get(sandboxUID); ok {
+		t.Fatal("current Pod NotReady update must evict the cache entry")
+	}
+}
+
 func TestCache_InvalidateByName(t *testing.T) {
 	pod := makePod(testPodName, testPodNS, testUID, testPodIP, true)
 	c, _, cancel := newCache(t, pod)


### PR DESCRIPTION
#### What this PR does / why we need it:

The sandbox-router cache previously keyed entries by Sandbox UID without retaining the backing Pod UID. During Pod recreation, a delayed Delete or NotReady event from the old Pod could evict the replacement Pod entry, temporarily making a Ready Sandbox unroutable.

This change:

- Stores the backing Pod UID in `cache.Entry`.
- Fences informer Delete and NotReady removals by both Sandbox UID and Pod UID.
- Preserves unconditional eviction for the router’s explicit `Invalidate` path.
- Adds regression tests for stale Delete and NotReady events, plus tests confirming current-Pod events still evict entries.

#### Which issue(s) this PR is related to:

Fixes #1397

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale Pod deletion or NotReady events from removing active replacement entries.
  * Ensured cache entries are removed when the currently associated Pod is deleted or becomes NotReady.
* **Tests**
  * Added coverage for replacement Pods and current Pod lifecycle events to verify correct cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->