### PR TITLE
chore: update default release notes model to gemini-3.7-flash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
           GCP_LOCATION: "global"
           GEMINI_MODEL: gemini-3.7-flash
         run: |
-          pip install "google-genai>=1.51.0" pyopenssl==25.1.0 pyyaml==6.0.2
+          pip install google-genai==1.51.0 pyopenssl==25.1.0 pyyaml==6.0.2
 
           # This finally publishes the draft for your review
           make release-publish TAG="${{ needs.promote-images.outputs.new_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,10 +236,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_LOCATION: "us-central1"
+          GCP_LOCATION: "global"
           GEMINI_MODEL: gemini-3.7-flash
         run: |
-          pip install google-genai==1.30.0 pyopenssl==25.1.0 pyyaml==6.0.2
+          pip install "google-genai>=1.51.0" pyopenssl==25.1.0 pyyaml==6.0.2
 
           # This finally publishes the draft for your review
           make release-publish TAG="${{ needs.promote-images.outputs.new_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GCP_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
           GCP_LOCATION: "us-central1"
-          GEMINI_MODEL: gemini-2.5-flash
+          GEMINI_MODEL: gemini-3.7-flash
         run: |
           pip install google-genai==1.30.0 pyopenssl==25.1.0 pyyaml==6.0.2
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ REMOTE_UPSTREAM ?= upstream
 REMOTE_FORK ?= origin
 
 # Gemini model for release notes generation
-GEMINI_MODEL ?= gemini-2.5-flash
+GEMINI_MODEL ?= gemini-3.7-flash
 
 # Promote all staging images to registry.k8s.io
 # Usage: make release-promote TAG=vX.Y.Z
@@ -156,7 +156,7 @@ release-promote:
 	./dev/tools/tag-promote-images --tag=${TAG} --k8s-io-dir=${K8S_IO_DIR} --upstream-remote=${REMOTE_UPSTREAM} --fork-remote=${REMOTE_FORK} $(if $(filter true,$(SKIP_TAGGING)),--skip-tagging) $(if $(filter true,$(ONLY_TAGGING)),--only-tagging)
 
 # Publish a draft release to GitHub
-# Usage: make release-publish TAG=vX.Y.Z GEMINI_MODEL=gemini-2.5-flash
+# Usage: make release-publish TAG=vX.Y.Z GEMINI_MODEL=gemini-3.7-flash
 .PHONY: release-publish
 release-publish: install-gen-tools
 	@if [ -z "$(TAG)" ]; then echo "TAG is required (e.g., make release-publish TAG=vX.Y.Z)"; exit 1; fi

--- a/dev/tools/generate-release-notes
+++ b/dev/tools/generate-release-notes
@@ -157,7 +157,7 @@ def generate_release_notes(commits, breaking_changes, pr_descriptions, contribut
         return None
 
     project_id = os.getenv("GCP_PROJECT", "").strip()
-    location = os.getenv("GCP_LOCATION", "us-central1").strip()
+    location = os.getenv("GCP_LOCATION", "global").strip()
 
     if not project_id:
         print("⚠️ GCP_PROJECT environment variable not set. Skipping Gemini release notes.")

--- a/dev/tools/generate-release-notes
+++ b/dev/tools/generate-release-notes
@@ -146,7 +146,7 @@ def get_pr_descriptions(prs_data):
     return pr_descriptions
 
 
-def generate_release_notes(commits, breaking_changes, pr_descriptions, contributors, tag, installation_notes, model="gemini-2.5-flash"):
+def generate_release_notes(commits, breaking_changes, pr_descriptions, contributors, tag, installation_notes, model="gemini-3.7-flash"):
     """Generates curated release notes using Gemini via the Vertex AI API platform."""
     # Try importing the modern SDK
     try:
@@ -273,7 +273,7 @@ def main():
         "--output", default="release_notes_preview.md", help="File to save notes to."
     )
     parser.add_argument(
-        "--model", default=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"), help="The Gemini model to use."
+        "--model", default=os.getenv("GEMINI_MODEL", "gemini-3.7-flash"), help="The Gemini model to use."
     )
     args = parser.parse_args()
 

--- a/dev/tools/release
+++ b/dev/tools/release
@@ -145,7 +145,7 @@ def main():
     parser.add_argument("--publish", action="store_true", help="Publish the release to GitHub.")
     parser.add_argument(
         "--model",
-        default=os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
+        default=os.getenv("GEMINI_MODEL", "gemini-3.7-flash"),
         help="Gemini model to use for generating release notes.",
     )
     args = parser.parse_args()


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates the default Gemini model used for automated release notes generation from `gemini-2.5-flash` to `gemini-3.7-flash` across the Makefile, release tooling (`dev/tools/release`, `dev/tools/generate-release-notes`), and GitHub release workflow (`.github/workflows/release.yml`).

In addition:
- Sets the default Vertex AI location to `"global"` in `generate-release-notes` and `release.yml` (since `gemini-3.7-flash` is served from global/multi-region endpoints rather than regional endpoints like `us-central1`).
- Pins `google-genai==1.51.0` in the release workflow for deterministic builds and compatibility with Gemini 3.x.

#### Which issue(s) this PR is related to:

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Release note generation now uses the Gemini 3.7 Flash model by default.
  * Vertex AI requests now default to the global location, improving availability across regions.
  * Existing configuration overrides remain supported.

* **Maintenance**
  * Release automation now uses a consistent, fixed model configuration for more predictable publishing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->