### PR TITLE
docs(examples): update Gemini model references to gemini-3.7-flash

### DIFF
--- a/examples/analytics-tool/jupyterlab.yaml
+++ b/examples/analytics-tool/jupyterlab.yaml
@@ -226,7 +226,7 @@ data:
         "        return f\"Execution successful:\\n[stdout]: {stdout}\"\n",
         "\n",
         "model = ChatGoogleGenerativeAI(\n",
-        "    model=\"gemini-2.5-flash\",\n",
+        "    model=\"gemini-3.7-flash\",\n",
         "    temperature=0,\n",
         "    max_tokens=None,\n",
         "    timeout=None,\n",

--- a/examples/code-interpreter-agent-on-adk/README.md
+++ b/examples/code-interpreter-agent-on-adk/README.md
@@ -45,7 +45,7 @@ The guide walks you through the process of creating a simple [ADK](https://googl
    
    
    root_agent = Agent(
-       model='gemini-2.5-flash',
+       model='gemini-3.7-flash',
        name='coding_agent',
        description="Writes Python code and executes it in a sandbox.",
        instruction="You are a helpful assistant that can write Python code and execute it in the sandbox. Use the 'execute_python' tool for this purpose.",
@@ -114,7 +114,7 @@ The guide walks you through the process of creating a simple [ADK](https://googl
    func main() {
    	ctx := context.Background()
 
-   	model, err := gemini.NewModel(ctx, "gemini-2.5-flash", &genai.ClientConfig{
+   	model, err := gemini.NewModel(ctx, "gemini-3.7-flash", &genai.ClientConfig{
    		APIKey: os.Getenv("GOOGLE_API_KEY"),
    	})
    	if err != nil {

--- a/site/content/docs/use-cases/code-execution/_index.md
+++ b/site/content/docs/use-cases/code-execution/_index.md
@@ -28,6 +28,6 @@ Agent Sandbox provides isolated Kubernetes pods where untrusted code runs safely
 
 ## Examples
 
-- [Code Interpreter Agent on ADK](/docs/use-cases/examples/code-interpreter-agent-on-adk/) — An ADK agent (using Gemini 2.5 Flash) that wraps `SandboxClient` as a tool. For each request, it creates a sandbox from a template, writes Python code to a file, executes it via `sandbox.commands.run("python3 run.py")`, returns stdout, and terminates the sandbox.
+- [Code Interpreter Agent on ADK](/docs/use-cases/examples/code-interpreter-agent-on-adk/) — An ADK agent (using Gemini 3.7 Flash) that wraps `SandboxClient` as a tool. For each request, it creates a sandbox from a template, writes Python code to a file, executes it via `sandbox.commands.run("python3 run.py")`, returns stdout, and terminates the sandbox.
 - [Analytics Tool](/docs/use-cases/examples/analytics-tool/) — A GKE-deployed analytics tool that uses LangChain with Google Generative AI to generate data analysis code (pandas, matplotlib). The generated code executes inside a sandbox pod and returns encoded chart images. Includes a JupyterLab frontend for interactive use.
 - [Python Runtime Sandbox](/docs/runtime-templates/python/) — A FastAPI-based Python runtime that accepts shell commands via a `/execute` endpoint and returns stdout, stderr, and exit code. Includes a `tester.py` client script and a `run-test-kind.sh` script for automated Kind cluster setup and testing.


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates Gemini model references in example code and documentation from deprecated `gemini-2.5-flash` (will be shutdown in Oct 2026) to `gemini-3.7-flash` across:
- `examples/analytics-tool/jupyterlab.yaml` (JupyterLab analytics demo)
- `examples/code-interpreter-agent-on-adk/README.md` (ADK Python and Go sample implementations)
- `site/content/docs/use-cases/code-execution/_index.md` (Code execution use-case docs)

#### Which issue(s) this PR is related to:

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example and guide references to use Gemini 3.7 Flash instead of Gemini 2.5 Flash.
  * Aligned the code execution and analytics examples with the newer model name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->