### PR TITLE
docs: add READMEs for clients, integrations, and generated k8s clientset

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -1,0 +1,19 @@
+# Agent Sandbox Clients & Integrations
+
+This directory contains client libraries, SDKs, and ecosystem adapters for interacting with the Kubernetes Agent Sandbox.
+
+## Directory Structure
+
+| Directory | Type | Language / Package | Description |
+| :--- | :--- | :--- | :--- |
+| [**`go/`**](./go) | High-Level SDK | Go (`sigs.k8s.io/agent-sandbox/clients/go/sandbox`) | Hand-written Go client wrapping `SandboxClaim` lifecycle, Gateway, port-forward, and direct connectivity. |
+| [**`python/agentic-sandbox-client/`**](./python/agentic-sandbox-client) | High-Level SDK | Python (`k8s-agent-sandbox`) | Hand-written Python client for sandbox provisioning, command execution, and file management (sync and async). |
+| [**`integrations/`**](./integrations) | Ecosystem Adapters | Python | Higher-level wrappers for AI agent frameworks (LangChain/DeepAgents, MCP Server). |
+| [**`k8s/`**](./k8s) | **Generated** Clientset | Go (`sigs.k8s.io/agent-sandbox/clients/k8s/...`) | Auto-generated Kubernetes `client-go` typed clientset, informers, and listers for custom Go controllers. **Do not hand-edit.** |
+
+## Choosing the Right Client
+
+* **Building an AI agent or script (Python)**: Use [`k8s-agent-sandbox`](./python/agentic-sandbox-client) or an adapter in [`integrations/`](./integrations).
+* **Building an AI agent or orchestration service (Go)**: Use the high-level Go SDK in [`go/`](./go).
+* **Connecting standard LLMs via Model Context Protocol**: Use [`integrations/mcp-server/`](./integrations/mcp-server).
+* **Building a custom Kubernetes controller (Go)**: Use the typed clientset/informers in [`k8s/`](./k8s).

--- a/clients/integrations/README.md
+++ b/clients/integrations/README.md
@@ -1,0 +1,18 @@
+# Agent Sandbox Integrations
+
+This directory contains specialized adapters and integration packages that bridge [`k8s-agent-sandbox`](../python/agentic-sandbox-client) with popular AI agent frameworks, protocols, and evaluation harnesses.
+
+## Available Integrations
+
+| Integration | Distribution Name | Framework / Protocol | Description |
+| :--- | :--- | :--- | :--- |
+| [**`deepagents/`**](./deepagents) | `deepagents-k8s-agent-sandbox` | [LangChain DeepAgents](https://github.com/langchain-ai/deepagents) | Plugs into LangChain agent graphs as a secure, sandboxed execution backend (`K8sAgentSandbox`). |
+| [**`mcp-server/`**](./mcp-server) | `k8s-agent-sandbox-mcp-server` | [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) | Exposes Sandbox provisioning and execution tools over MCP for Antigravity, Claude Desktop, Cursor, and other MCP hosts. |
+
+## Adding a New Integration
+
+1. Create a subdirectory under `clients/integrations/<name>/`.
+2. Match the `requires-python` version floor defined in [`clients/python/agentic-sandbox-client/pyproject.toml`](../python/agentic-sandbox-client/pyproject.toml) and depend on `k8s-agent-sandbox`.
+3. Include unit tests under `tests/unit/` using `pytest`.
+4. Register the test suite in [`dev/tools/test-unit`](../../dev/tools/test-unit) under `PYTHON_TEST_SUITES`.
+5. Exclude test packages from discovery (`[tool.setuptools.packages.find].exclude = ["tests*"]`) and configure `[tool.setuptools.exclude-package-data]` if using `setuptools_scm`.

--- a/clients/k8s/README.md
+++ b/clients/k8s/README.md
@@ -1,0 +1,27 @@
+# Generated Kubernetes Typed Clientset
+
+> [!WARNING]
+> **DO NOT EDIT CODE IN THIS DIRECTORY DIRECTLY.**
+> The files in this directory are auto-generated from API definitions in `api/` and `extensions/api/`.
+
+## Purpose
+
+This directory provides standard `client-go` typed machinery for custom Kubernetes controllers and operators:
+* `clientset/` — Versioned typed clientset for `agents.x-k8s.io` and `extensions.agents.x-k8s.io`.
+* `informers/` — Shared informer factories for caching and event handling.
+* `listers/` — Typed listers for cache lookups.
+
+If you are writing application code or an agent rather than a Kubernetes controller, use the high-level Go client in [`clients/go/`](../go) instead.
+
+## How to Regenerate
+
+After modifying API structs or kubebuilder markers in `api/` or `extensions/api/`, regenerate these packages:
+
+```bash
+make fix-go-generate
+```
+
+Direct script invocation:
+```bash
+dev/tools/client-gen-go.sh
+```


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds documentation and directory overview READMEs across `clients/`:
- `clients/README.md`: Top-level index explaining the directory layout, distinguishing high-level SDKs (Go, Python), ecosystem adapters, and generated client-go machinery.
- `clients/integrations/README.md`: Catalog of available framework adapters (MCP server, DeepAgents) and guidelines for contributing new integrations.
- `clients/k8s/README.md`: Notice clarifying that the directory contains generated `client-go` code (informers, listers, clientset), warning against direct manual edits, and providing regeneration instructions.

#### Which issue(s) this PR is related to:

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an overview of available Go and Python SDKs, ecosystem integrations, and the generated Kubernetes client.
  * Added guidance for selecting the appropriate client for different use cases.
  * Documented existing MCP and DeepAgents integrations.
  * Added instructions for creating, testing, registering, and packaging new integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->