### PR TITLE
docs: add reinforcement learning (RL) use case to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [Website](https://agent-sandbox.sigs.k8s.io) · [Docs](https://agent-sandbox.sigs.k8s.io/docs/) · [DeepWiki](https://deepwiki.com/kubernetes-sigs/agent-sandbox) · [Getting Started](https://agent-sandbox.sigs.k8s.io/docs/getting_started/) · [Examples](examples/) · [Roadmap](roadmap.md)
 
-**agent-sandbox enables easy management of isolated, stateful, singleton workloads, ideal for use cases like AI agent runtimes.**
+**agent-sandbox enables easy management of isolated, stateful, singleton workloads, ideal for use cases like AI agent runtimes and reinforcement learning.**
 
 This project is developing a `Sandbox` Custom Resource Definition (CRD) and controller for Kubernetes, under the umbrella of [SIG Apps](https://github.com/kubernetes/community/tree/master/sig-apps). The goal is to provide a declarative, standardized API for managing workloads that require the characteristics of a long-running, stateful, singleton container with a stable identity, much like a lightweight, single-container VM experience built on Kubernetes primitives.
 
@@ -205,6 +205,7 @@ Kubernetes excels at managing stateless, replicated applications (Deployments) a
 
 *   **Development Environments:** Isolated, persistent, network-accessible cloud environments for developers.
 *   **AI Agent Runtimes:** Isolated environments for executing untrusted, LLM-generated code.
+*   **Reinforcement Learning (RL) & Evaluation:** High-throughput, isolated execution sandboxes for training and evaluation loops (e.g., SWE-bench, R2E-Gym, Ray/RLlib) with low-latency warm-pool claims.
 *   **Notebooks and Research Tools:** Persistent, single-container sessions for tools like Jupyter Notebooks.
 *   **Stateful Single-Pod Services:** Hosting single-instance applications (e.g., build agents, small databases) needing a stable identity without StatefulSet overhead.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**playwright-sandbox**](./playwright-sandbox): An example of running Playwright with Chromium in a sandbox for web scraping and screenshots.
 - [**policy**](./policy): Examples of using different policies with sandboxes.
 - [**python-runtime-sandbox**](./python-runtime-sandbox): An example of a Python runtime sandbox.
+- [**ray-integration**](./ray-integration): An example of integrating Ray with agent-sandbox for secure Proxy Execution during Agentic Reinforcement Learning (RL) training.
 - [**sandbox-ksa**](./sandbox-ksa): Examples of a sandbox with a service account, namespace, and a basic sandbox.
 - [**vscode-sandbox**](./vscode-sandbox): An example of running VSCode in a sandbox.
 - [**warmpool-quickstart**](./warmpool-quickstart): Reference YAML for the three extension CRDs — SandboxTemplate, SandboxWarmPool, and SandboxClaim — including a secure template and an LLM-scoped network policy example.


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Reinforcement Learning (RL) and evaluation rollouts to the repository's primary `README.md` (top summary tagline and `Motivation` section) and includes the `ray-integration` example in `examples/README.md`.

Reinforcement learning (e.g. SWE-bench, R2E-Gym, Ray/RLlib training loops) is a prominent workload for `agent-sandbox` that benefits from sub-second warm-pool claims, kernel-level isolation (gVisor/Kata), and multi-cluster fleet orchestration. Surfacing RL in `README.md` also updates the public documentation site at `/docs/overview/`.

#### Which issue(s) this PR is related to:

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the project overview to include reinforcement learning as a target use case.
  - Added details about high-throughput isolated execution, training and evaluation workloads, and warm-pool performance.
  - Added the Ray integration example to the examples index for secure proxy execution during reinforcement learning training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->