### PR TITLE
python-runtime-sandbox: make the base directory configurable

### DIFF
--- a/examples/python-runtime-sandbox/README.md
+++ b/examples/python-runtime-sandbox/README.md
@@ -32,6 +32,11 @@ This class models the response body for the `/execute` endpoint.
   spawned) are killed and the request reports a failed execution. Defaults
   to `300`. If set to a value that isn't a finite number greater than `0`,
   the default is used instead and a warning is logged.
+- **`SANDBOX_BASE_DIR`**: Directory that commands run from and that file
+  operations (`/upload`, `/download`, `/list`, `/exists`) are confined to.
+  Defaults to `/app`. Pointing it at a writable volume (e.g. an `emptyDir`
+  mounted at `/workspace`) keeps the runtime's own code out of the working
+  area and lets the container run with `readOnlyRootFilesystem: true`.
 
 ## Testing on a local kind cluster using agent-sandbox
 

--- a/examples/python-runtime-sandbox/main.py
+++ b/examples/python-runtime-sandbox/main.py
@@ -35,16 +35,26 @@ class ExecuteResponse(BaseModel):
     stderr: str
     exit_code: int
 
+def get_base_dir() -> str:
+    """Reads SANDBOX_BASE_DIR, falling back to /app when it's unset or blank.
+
+    Making the base directory configurable lets the sandbox run with a
+    read-only root filesystem: the runtime code stays wherever the image put
+    it, while commands and file operations are confined to a writable volume
+    (e.g. an emptyDir) mounted at SANDBOX_BASE_DIR.
+    """
+    return os.environ.get("SANDBOX_BASE_DIR", "").strip() or "/app"
+
 def get_safe_path(file_path: str) -> str:
-    """Sanitizes the file path to ensure it stays within /app."""
-    base_dir = os.path.realpath("/app")
+    """Sanitizes the file path to ensure it stays within the base directory."""
+    base_dir = os.path.realpath(get_base_dir())
     # Remove leading slashes to ensure path is relative
     clean_path = file_path.lstrip("/")
     full_path = os.path.realpath(os.path.join(base_dir, clean_path))
 
     if os.path.commonpath([base_dir, full_path]) != base_dir:
-        raise ValueError("Access denied: Path must be within /app")
-    
+        raise ValueError("Access denied: Path must be within the sandbox base directory")
+
     return full_path
 
 app = FastAPI(
@@ -82,7 +92,7 @@ def _run_command(args: list, timeout: float) -> subprocess.CompletedProcess:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
-        cwd="/app",
+        cwd=get_base_dir(),
         start_new_session=True,
     ) as process:
         try:
@@ -111,7 +121,7 @@ async def execute_command(request: ExecuteRequest):
         # Split the command string into a list to safely pass to subprocess
         args = shlex.split(request.command)
         
-        # Execute the command, always from the /app directory. Run it in a
+        # Execute the command, always from the base directory. Run it in a
         # worker thread so a long-running or hung command doesn't block the
         # event loop (and with it, the health check and file endpoints), and
         # enforce a timeout so a runaway command can't wedge the sandbox
@@ -136,11 +146,11 @@ async def execute_command(request: ExecuteRequest):
 @app.post("/upload", summary="Upload a file to the sandbox")
 async def upload_file(file: UploadFile = File(...)):
     """
-    Receives a file and saves it to the /app directory in the sandbox.
+    Receives a file and saves it to the base directory in the sandbox.
     """
     try:
         logging.info(f"--- UPLOAD_FILE CALLED: Attempting to save '{file.filename}' ---")
-        
+
         try:
             file_path = get_safe_path(file.filename)
         except ValueError:
@@ -148,7 +158,13 @@ async def upload_file(file: UploadFile = File(...)):
                 status_code=403,
                 content={"message": "Access denied"}
             )
-        
+
+        # The filename may carry a relative destination path (e.g.
+        # "data/input.csv"); create the intermediate directories so such
+        # uploads don't fail. file_path is already confined to the base
+        # directory by get_safe_path, so its parents are too.
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
         with open(file_path, "wb") as f:
             f.write(await file.read())
             
@@ -166,7 +182,7 @@ async def upload_file(file: UploadFile = File(...)):
 @app.get("/download/{encoded_file_path:path}", summary="Download a file from the sandbox")
 async def download_file(encoded_file_path: str):
     """
-    Downloads a specified file from the /app directory in the sandbox.
+    Downloads a specified file from the base directory in the sandbox.
     """
     decoded_path = urllib.parse.unquote(encoded_file_path)
     try:
@@ -181,7 +197,7 @@ async def download_file(encoded_file_path: str):
 @app.get("/list/{encoded_file_path:path}", summary="List files in a directory")
 async def list_files(encoded_file_path: str):
     """
-    Lists the contents of a directory under the /app directory in the sandbox.
+    Lists the contents of a directory under the base directory in the sandbox.
     """
     decoded_path = urllib.parse.unquote(encoded_file_path)
     try:
@@ -210,7 +226,7 @@ async def list_files(encoded_file_path: str):
 @app.get("/exists/{encoded_file_path:path}", summary="Check if the relative path exists")
 async def exists(encoded_file_path: str):
     """
-    Checks if a specified file or directory exists under the /app directory in the sandbox.
+    Checks if a specified file or directory exists under the base directory in the sandbox.
     """
     decoded_path = urllib.parse.unquote(encoded_file_path)
     try:

--- a/examples/python-runtime-sandbox/test_main.py
+++ b/examples/python-runtime-sandbox/test_main.py
@@ -49,6 +49,21 @@ class TestGetSafePath:
         with pytest.raises(ValueError):
             get_safe_path("foo/../../bar")
 
+    def test_respects_configured_base_dir(self, tmp_path):
+        with patch.dict(os.environ, {"SANDBOX_BASE_DIR": str(tmp_path)}):
+            expected = os.path.join(os.path.realpath(str(tmp_path)), "foo.txt")
+            assert get_safe_path("foo.txt") == expected
+
+    def test_rejects_traversal_from_configured_base_dir(self, tmp_path):
+        with patch.dict(os.environ, {"SANDBOX_BASE_DIR": str(tmp_path)}):
+            with pytest.raises(ValueError):
+                get_safe_path("../escape.txt")
+
+    def test_blank_base_dir_falls_back_to_default(self):
+        with patch.dict(os.environ, {"SANDBOX_BASE_DIR": "   "}):
+            base_dir = os.path.realpath("/app")
+            assert get_safe_path("foo.txt") == os.path.join(base_dir, "foo.txt")
+
 
 def _mock_process(mock_popen, stdout="", stderr="", returncode=0, pid=1234):
     """Configures mock_popen (a patched main.subprocess.Popen) to behave like
@@ -103,6 +118,17 @@ def test_execute_command_falls_back_to_default_on_invalid_timeout(mock_popen):
     mock_process.communicate.assert_called_once_with(timeout=300.0)
 
 
+@patch('main.subprocess.Popen')
+def test_execute_command_runs_from_configured_base_dir(mock_popen, tmp_path):
+    _mock_process(mock_popen)
+
+    with patch.dict(os.environ, {"SANDBOX_BASE_DIR": str(tmp_path)}):
+        response = client.post("/execute", json={"command": "pwd"})
+
+    assert response.status_code == 200
+    assert mock_popen.call_args.kwargs["cwd"] == str(tmp_path)
+
+
 @patch('main.os.killpg')
 @patch('main.os.getpgid', return_value=4321)
 @patch('main.subprocess.Popen')
@@ -143,6 +169,16 @@ def test_upload_file_writes_to_safe_path(tmp_path):
 
     assert response.status_code == 200
     assert target.read_bytes() == b"hello world"
+
+
+def test_upload_file_creates_parent_directories(tmp_path):
+    target = tmp_path / "nested" / "dir" / "uploaded.txt"
+
+    with patch('main.get_safe_path', return_value=str(target)):
+        response = client.post("/upload", files={"file": ("nested/dir/uploaded.txt", b"hello")})
+
+    assert response.status_code == 200
+    assert target.read_bytes() == b"hello"
 
 
 def test_upload_file_rejects_path_traversal():


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR makes the working directory of the python-runtime-sandbox configurable through a new `SANDBOX_BASE_DIR` env var.

Running the sandbox with `readOnlyRootFilesystem: true` is not possible today: `/app` is both where the code lives and where `/execute` and the file endpoints work, so uploads fail on the read-only rootfs and mounting a writable volume at `/app` shadows `main.py`. With `SANDBOX_BASE_DIR` pointing at a writable mount (e.g. an emptyDir at `/workspace`) the code stays on the read-only image and the file API keeps working. It defaults to `/app`, so existing deployments are not affected. Same pattern already used for `SANDBOX_EXEC_TIMEOUT_SECONDS`.

It also fixes `/upload` to create the parent directories, otherwise a filename like `data/input.csv` returns a 500 because `open()` does not create them. The path is already confined by `get_safe_path`.

Tested on a kind cluster with the pod locked down (restricted PSA, non-root, seccomp RuntimeDefault, caps dropped, read-only rootfs). 5 new tests added, full suite passes (26).

BR

#### Which issue(s) this PR is related to:
NONE

#### Release Note
```release-note
python-runtime-sandbox: the working directory is now configurable via the `SANDBOX_BASE_DIR` environment variable (default `/app`), allowing the sandbox to run with a read-only root filesystem.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the sandbox base directory with `SANDBOX_BASE_DIR`.
  * Sandbox operations now work with custom writable volumes and read-only root filesystems.
  * Uploads automatically create missing parent directories for nested paths.

* **Bug Fixes**
  * Improved path validation to prevent traversal outside the configured sandbox directory.
  * Added fallback behavior when the configuration is blank.

* **Documentation**
  * Documented the new configuration option, default value, filesystem scope, and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->