### PR TITLE
fix(examples): switch chrome-sandbox to debian 12 and re-add --no-first-run flag

### DIFF
--- a/examples/chrome-sandbox/Dockerfile
+++ b/examples/chrome-sandbox/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /chrome-sand
 
 #----------------------
 # Use a base image with a minimal set of packages.
-FROM debian:13-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
+FROM debian:12-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 #----------------------
 # Install general prerequisite packages.

--- a/examples/chrome-sandbox/scripts/start-chrome
+++ b/examples/chrome-sandbox/scripts/start-chrome
@@ -26,6 +26,7 @@ flags+=(--disable-gpu) # We don't (normally) have a GPU
 flags+=(--disable-dev-shm-usage) # We don't (normally) have a shared memory filesystem
 
 flags+=(--no-default-browser-check) # Avoids hanging with a "set chrome as default browser" dialog
+flags+=(--no-first-run) # Skips the first run onboarding wizard
 
 flags+=(--start-maximized) # We're the only thing running, use the whole screen
 


### PR DESCRIPTION
#### What this PR does / why we need it:
1. **Re-adds `--no-first-run` in `examples/chrome-sandbox/scripts/start-chrome`**:
   Bypasses Chromium's First-Run Experience (FRE) onboarding wizard so DevTools remote debugging on port 9222 binds immediately upon startup, allowing the readiness probe to pass cleanly.
2. **Switches base image to `debian:12-slim` (Bookworm)** in `examples/chrome-sandbox/Dockerfile`:
   Aligns `chrome-sandbox` with the rest of the examples in the repository and uses Debian Stable instead of Debian 13 (*Trixie*, testing) to prevent rolling package drift from breaking CI builds.

#### Which issue(s) this PR is related to:
Fixes #1410

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Chrome sandbox environments now start without displaying the first-run onboarding wizard.
  - Updated the underlying runtime image to improve compatibility and provide a more consistent development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->