### PR TITLE
sandbox-router: add opt-in path-based routing for browser-facing traffic

### DIFF
--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -108,6 +108,8 @@ Set `--path-routing-prefix` to give such traffic a second way in: a request whos
 
 This is strictly additive: the default is `""` (disabled), and a request whose path does not match the configured prefix falls straight through to `X-Sandbox-*` header parsing, unchanged. `X-Sandbox-Pod-IP` and `X-Sandbox-UID` have no path equivalent — both are dial-target overrides meant for SDKs that already hold cluster-internal knowledge, never for a browser tab, so path-routed requests always resolve through the DNS form or the namespace/name cache index, same as a header-routed request carrying only `X-Sandbox-ID`.
 
+Everything after `<port>` is forwarded byte-for-byte, escaping included — an encoded separator inside a single upstream path segment (e.g. a filename containing `/`, sent as `%2F`) survives the hop unchanged rather than being silently decoded into an extra segment. `sandbox_router_requests_total` labels, the access log's `sandbox_id`/`sandbox_namespace` fields, and the `sandbox.id`/`sandbox.namespace` trace attributes all reflect the resolved target regardless of whether it came from a header or from the path.
+
 ```sh
 curl -i --http1.1 -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
   -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \

--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -98,6 +98,23 @@ The router also sets `X-Forwarded-Host` / `X-Forwarded-Proto` / `X-Forwarded-For
 
 Metrics for upgraded requests record `code="101"` once the handshake completes; the duration histogram records the full lifetime of the upgraded connection.
 
+### Browser-facing traffic: path-based routing
+
+Everything above assumes the caller can set `X-Sandbox-*` headers. A browser tab, an `<iframe>`, and — critically — a WebSocket handshake cannot: there is no web API for attaching custom headers to a top-level navigation, a subresource document load, or `new WebSocket(url, protocols)` (`protocols` only negotiates a subprotocol, it is not a headers map). This is a platform limitation, not something a Service Worker can work around either — WebSocket handshakes are explicitly not exposed to the `fetch` event, which is exactly why tools that need to intercept WebSocket traffic client-side (e.g. Mock Service Worker) have to patch the global `WebSocket` constructor instead of using a Service Worker at all. See [w3c/ServiceWorker#947](https://github.com/w3c/ServiceWorker/issues/947), still open.
+
+This bites concretely for any browser-facing dev tool proxied through this router — a web IDE whose terminal is a WebSocket (code-server is the common case), or a dev server whose hot-reload client opens one (Vite/webpack HMR). Both work fine once a request reaches the router with the right headers; the problem is entirely upstream of that, in getting the browser's own request there in the first place.
+
+Set `--path-routing-prefix` to give such traffic a second way in: a request whose path starts with the configured prefix is routed by `<prefix>/<namespace>/<id>/<port>/<rest...>` instead of headers — plain URL segments, which a browser can put in any navigation, `<iframe src>`, or `new WebSocket(...)` call with zero client-side code. Concretely, once a page is loaded at a URL under this prefix, any *relative* WebSocket URL that page's own JavaScript opens (which is how code-server and most dev-server HMR clients behave) automatically carries the same prefix along — the routing identity travels for free.
+
+This is strictly additive: the default is `""` (disabled), and a request whose path does not match the configured prefix falls straight through to `X-Sandbox-*` header parsing, unchanged. `X-Sandbox-Pod-IP` and `X-Sandbox-UID` have no path equivalent — both are dial-target overrides meant for SDKs that already hold cluster-internal knowledge, never for a browser tab, so path-routed requests always resolve through the DNS form or the namespace/name cache index, same as a header-routed request carrying only `X-Sandbox-ID`.
+
+```sh
+curl -i --http1.1 -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  'http://sandbox-router-svc:8080/router/default/my-sandbox/8080/'
+# -> 101 Switching Protocols, no X-Sandbox-* header sent anywhere in this request
+```
+
 ## Flags
 
 Run `sandbox-router --help` for the full list. The most relevant:
@@ -116,6 +133,7 @@ Run `sandbox-router --help` for the full list. The most relevant:
 | `--upstream-max-retries` | `3` | Dial retries. `0` disables. |
 | `--max-request-body-bytes` | `0` (unlimited) | Optional cap on inbound body size. |
 | `--allow-loopback-pod-ip` | `false` | Permit loopback addresses in `X-Sandbox-Pod-IP`. Default-off rejects the router's own loopback as an SSRF target. Enable only when the sandbox runs as a sidecar in the router's Pod, or for integration tests against a localhost backend. Link-local / multicast / unspecified stay rejected regardless. |
+| `--path-routing-prefix` | `""` (disabled) | Optional path prefix (`<prefix>/<namespace>/<id>/<port>/...`) for callers that cannot set `X-Sandbox-*` headers — see [Browser-facing traffic](#browser-facing-traffic-path-based-routing). Falls through to header-based routing for any path that doesn't match. |
 | `--cache-enabled` | `false` | Enable the Pod-IP cache (KEP-NNNN fast path). Requires the RBAC in `deploy/rbac.yaml`. |
 | `--cache-namespace` | `""` (cluster-wide) | Restrict the Pod informer to a single namespace. |
 | `--kubeconfig` | `""` (in-cluster) | Kubeconfig for the cache's informer client. Honors `KUBECONFIG`. |

--- a/sandbox-router/config/config.go
+++ b/sandbox-router/config/config.go
@@ -18,6 +18,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -119,6 +120,33 @@ type Config struct {
 	// localhost. Link-local, multicast, and unspecified addresses
 	// stay rejected even when this flag is on.
 	AllowLoopbackPodIP bool
+
+	// PathRoutingPrefix, when non-empty, additionally lets a caller address
+	// a sandbox via a URL path segment instead of X-Sandbox-* headers:
+	// <PathRoutingPrefix>/<namespace>/<id>/<port>/<rest...>. This is the
+	// only way a browser can reach a WebSocket-dependent backend inside a
+	// sandbox (a web IDE's terminal, a dev server's HMR socket) through
+	// this router: a page or an iframe cannot set custom request headers
+	// at all, and the WebSocket handshake specifically has no API for
+	// them either (see the "Browser-facing traffic" section of the
+	// package README for why — it is a platform limitation, not
+	// something a client-side workaround like a Service Worker can paper
+	// over, since WebSocket handshakes are not exposed to the fetch
+	// event). A page loaded under this prefix carries the same prefix
+	// into any relative WebSocket URL it opens, so the routing identity
+	// travels with zero client-side code.
+	//
+	// Off by default (""), so header-only behavior is completely
+	// unchanged unless an operator opts in. When set, a request path
+	// starting with this prefix is parsed for routing information
+	// FIRST; a path that does not match falls straight through to
+	// X-Sandbox-* header parsing, unmodified.
+	//
+	// X-Sandbox-Pod-IP and X-Sandbox-UID have no path equivalent, by
+	// design: both are trust-sensitive dial-target overrides meant for
+	// SDKs that already hold cluster-internal knowledge, never for a
+	// browser tab.
+	PathRoutingPrefix string
 
 	// EnableTracing enables OTel tracing via the OTLP gRPC exporter. The
 	// exporter endpoint is read from OTEL_EXPORTER_OTLP_ENDPOINT.
@@ -252,6 +280,14 @@ func (c *Config) Validate() error {
 	}
 	if c.ClusterDomain == "" {
 		return errors.New("--cluster-domain must not be empty")
+	}
+	if c.PathRoutingPrefix != "" {
+		if !strings.HasPrefix(c.PathRoutingPrefix, "/") {
+			return fmt.Errorf("--path-routing-prefix must start with \"/\", got %q", c.PathRoutingPrefix)
+		}
+		if strings.HasSuffix(c.PathRoutingPrefix, "/") {
+			return fmt.Errorf("--path-routing-prefix must not end with \"/\", got %q", c.PathRoutingPrefix)
+		}
 	}
 	if c.UpstreamMaxRetries < 0 {
 		return fmt.Errorf("--upstream-max-retries must be non-negative, got %d", c.UpstreamMaxRetries)

--- a/sandbox-router/config/config_test.go
+++ b/sandbox-router/config/config_test.go
@@ -364,6 +364,26 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		{
+			name:    "empty path routing prefix is valid (disabled)",
+			mut:     func(c *Config) { c.PathRoutingPrefix = "" },
+			wantErr: "",
+		},
+		{
+			name:    "path routing prefix without leading slash rejected",
+			mut:     func(c *Config) { c.PathRoutingPrefix = "router" },
+			wantErr: "path-routing-prefix must start with",
+		},
+		{
+			name:    "path routing prefix with trailing slash rejected",
+			mut:     func(c *Config) { c.PathRoutingPrefix = "/router/" },
+			wantErr: "path-routing-prefix must not end with",
+		},
+		{
+			name:    "valid path routing prefix accepted",
+			mut:     func(c *Config) { c.PathRoutingPrefix = "/router" },
+			wantErr: "",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sandbox-router/config/flags.go
+++ b/sandbox-router/config/flags.go
@@ -92,6 +92,17 @@ func RegisterFlags(fs *flag.FlagSet, c *Config, lookup LookupEnvFunc) {
 			"deployments where the sandbox shares a Pod with the router, or for "+
 			"integration tests using a localhost backend. Link-local, multicast, "+
 			"and unspecified addresses stay rejected regardless of this flag.")
+	fs.StringVar(&c.PathRoutingPrefix, "path-routing-prefix", c.PathRoutingPrefix,
+		"Optional URL path prefix that additionally lets a caller address a "+
+			"sandbox via <prefix>/<namespace>/<id>/<port>/<rest...>, instead of "+
+			"X-Sandbox-* headers. Off by default (headers only, unchanged). "+
+			"Enable this for browser-facing traffic: a WebSocket handshake has "+
+			"no API for custom headers, so a browser can only reach a "+
+			"WebSocket-dependent backend inside a sandbox (a web IDE's "+
+			"terminal, a dev server's HMR socket) through this router via a "+
+			"path it can put in a plain URL. A request whose path does not "+
+			"match this prefix falls straight through to header-based "+
+			"routing.")
 	fs.IntVar(&c.UpstreamMaxRetries, "upstream-max-retries", c.UpstreamMaxRetries,
 		"Number of additional dial attempts before returning 502. Only dial-class "+
 			"failures (DNS, connection refused) are retried. Smooths the case "+

--- a/sandbox-router/observability/access_log.go
+++ b/sandbox-router/observability/access_log.go
@@ -98,6 +98,14 @@ func (r *accessLogRecorder) Unwrap() http.ResponseWriter {
 // attached upstream, e.g. by TracingMiddleware with the trace_id baked in)
 // and falls back to base.
 //
+// sandbox_id and sandbox_namespace are read from Labels (via
+// LabelsForRequest) rather than the X-Sandbox-* request headers directly:
+// the proxy handler is what resolves the actual Target, from headers or,
+// when path-based routing is enabled, from the URL path instead — see
+// ParsePathRoute. Reading headers here, as an earlier version of this
+// middleware did, silently logged an empty sandbox identity for every
+// path-routed request, making exactly that traffic unsearchable.
+//
 // skip returns true for requests that should not be logged. Pass nil to log
 // every request; the typical caller passes a function that ignores
 // frequently-polled health endpoints so they don't drown the logs.
@@ -109,8 +117,9 @@ func AccessLogMiddleware(base logr.Logger, skip func(*http.Request) bool) func(h
 				return
 			}
 			start := time.Now()
+			ctx, labels := LabelsForRequest(r.Context())
 			rec := &accessLogRecorder{ResponseWriter: w, status: http.StatusOK}
-			next.ServeHTTP(rec, r)
+			next.ServeHTTP(rec, r.WithContext(ctx))
 
 			log := LoggerFromContext(r.Context(), base)
 			log.Info("request",
@@ -119,8 +128,8 @@ func AccessLogMiddleware(base logr.Logger, skip func(*http.Request) bool) func(h
 				"status", rec.status,
 				"duration_ms", time.Since(start).Milliseconds(),
 				"client_ip", clientIP(r),
-				"sandbox_id", r.Header.Get("X-Sandbox-Id"),
-				"sandbox_namespace", r.Header.Get("X-Sandbox-Namespace"),
+				"sandbox_id", labels.SandboxID,
+				"sandbox_namespace", labels.SandboxNamespace,
 				"bytes_out", rec.bytes,
 				"user_agent", r.UserAgent(),
 			)

--- a/sandbox-router/observability/access_log_test.go
+++ b/sandbox-router/observability/access_log_test.go
@@ -25,10 +25,10 @@ import (
 // capturedLine is the last "request" log line recorded by capturingSink.
 type capturedLine struct {
 	msg        string
-	keyAndVals []interface{}
+	keyAndVals []any
 }
 
-func (c *capturedLine) value(key string) (interface{}, bool) {
+func (c *capturedLine) value(key string) (any, bool) {
 	for i := 0; i+1 < len(c.keyAndVals); i += 2 {
 		if k, ok := c.keyAndVals[i].(string); ok && k == key {
 			return c.keyAndVals[i+1], true
@@ -48,12 +48,12 @@ type capturingSink struct {
 	dst *capturedLine
 }
 
-func (s *capturingSink) Init(logr.RuntimeInfo)                  {}
-func (s *capturingSink) Enabled(int) bool                       { return true }
-func (s *capturingSink) WithName(string) logr.LogSink           { return s }
-func (s *capturingSink) WithValues(...interface{}) logr.LogSink { return s }
-func (s *capturingSink) Error(error, string, ...interface{})    {}
-func (s *capturingSink) Info(_ int, msg string, kv ...interface{}) {
+func (s *capturingSink) Init(logr.RuntimeInfo)          {}
+func (s *capturingSink) Enabled(int) bool               { return true }
+func (s *capturingSink) WithName(string) logr.LogSink   { return s }
+func (s *capturingSink) WithValues(...any) logr.LogSink { return s }
+func (s *capturingSink) Error(error, string, ...any)    {}
+func (s *capturingSink) Info(_ int, msg string, kv ...any) {
 	*s.dst = capturedLine{msg: msg, keyAndVals: kv}
 }
 

--- a/sandbox-router/observability/access_log_test.go
+++ b/sandbox-router/observability/access_log_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// capturedLine is the last "request" log line recorded by capturingSink.
+type capturedLine struct {
+	msg        string
+	keyAndVals []interface{}
+}
+
+func (c *capturedLine) value(key string) (interface{}, bool) {
+	for i := 0; i+1 < len(c.keyAndVals); i += 2 {
+		if k, ok := c.keyAndVals[i].(string); ok && k == key {
+			return c.keyAndVals[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func newCapturingLogger(dst *capturedLine) logr.Logger {
+	return logr.New(&capturingSink{dst: dst})
+}
+
+// capturingSink is a minimal logr.LogSink that records the last Info()
+// call, so the test can assert on individual structured fields directly
+// instead of parsing a formatted log line back apart.
+type capturingSink struct {
+	dst *capturedLine
+}
+
+func (s *capturingSink) Init(logr.RuntimeInfo)                  {}
+func (s *capturingSink) Enabled(int) bool                       { return true }
+func (s *capturingSink) WithName(string) logr.LogSink           { return s }
+func (s *capturingSink) WithValues(...interface{}) logr.LogSink { return s }
+func (s *capturingSink) Error(error, string, ...interface{})    {}
+func (s *capturingSink) Info(_ int, msg string, kv ...interface{}) {
+	*s.dst = capturedLine{msg: msg, keyAndVals: kv}
+}
+
+// TestAccessLogMiddleware_UsesResolvedIdentityNotHeaders is the regression
+// test for the bug caught in review: sandbox_id/sandbox_namespace log
+// fields used to be read straight from the X-Sandbox-* request headers,
+// which a path-routed request (browser traffic reaching the router via
+// --path-routing-prefix, see ParsePathRoute) never sets at all — so every
+// such request was logged with an empty sandbox identity, making exactly
+// that traffic unsearchable. The inner handler here sets Labels directly
+// (exactly what the proxy Handler's ServeHTTP does once it resolves a
+// Target, from either input) with NO X-Sandbox-* header on the request at
+// all, simulating a path-routed request end to end.
+func TestAccessLogMiddleware_UsesResolvedIdentityNotHeaders(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labels := LabelsFromContext(r.Context())
+		if labels == nil {
+			t.Fatal("inner handler: no *Labels attached by AccessLogMiddleware")
+		}
+		labels.SandboxID = "path-routed-box"
+		labels.SandboxNamespace = "poc-agent-sandbox"
+		w.WriteHeader(http.StatusOK)
+	})
+
+	var line capturedLine
+	mw := AccessLogMiddleware(newCapturingLogger(&line), nil)
+	req := httptest.NewRequest(http.MethodGet, "/router/poc-agent-sandbox/path-routed-box/8080/", nil)
+	rec := httptest.NewRecorder()
+	mw(inner).ServeHTTP(rec, req)
+
+	if line.msg != "request" {
+		t.Fatalf("expected a logged \"request\" line, got %+v", line)
+	}
+	if v, ok := line.value("sandbox_id"); !ok || v != "path-routed-box" {
+		t.Errorf("sandbox_id field: got %v (present=%v), want %q", v, ok, "path-routed-box")
+	}
+	if v, ok := line.value("sandbox_namespace"); !ok || v != "poc-agent-sandbox" {
+		t.Errorf("sandbox_namespace field: got %v (present=%v), want %q", v, ok, "poc-agent-sandbox")
+	}
+}

--- a/sandbox-router/observability/context.go
+++ b/sandbox-router/observability/context.go
@@ -31,11 +31,20 @@ import (
 // packages and risks divergent default values), or type-asserting the
 // ResponseWriter to a custom setter interface (fragile under wrapping).
 type Labels struct {
-	// SandboxNamespace is the parsed and validated namespace from
-	// X-Sandbox-Namespace. The default sentinel "-" is used when no
-	// proxy handler has populated it (e.g. for /healthz, /metrics, or
-	// requests rejected at header-parse time).
+	// SandboxNamespace is the resolved namespace of the request's routing
+	// Target — from X-Sandbox-Namespace, or, when path-based routing is
+	// enabled, the corresponding path segment (see ParsePathRoute). The
+	// default sentinel "-" is used when no proxy handler has populated it
+	// (e.g. for /healthz, /metrics, or requests rejected at parse time).
 	SandboxNamespace string
+	// SandboxID is the resolved sandbox ID of the same Target, from
+	// whichever input actually produced it. Deliberately NOT read
+	// straight from the X-Sandbox-Id header by consumers (tracing,
+	// access logging): a path-routed request never sets that header at
+	// all, and doing so would silently show an empty sandbox identity
+	// for every browser-facing request. Empty when unset, same as
+	// SandboxNamespace before the "-" sentinel is applied.
+	SandboxID string
 }
 
 type labelsKey struct{}
@@ -49,6 +58,31 @@ func WithLabels(ctx context.Context, l *Labels) context.Context {
 func LabelsFromContext(ctx context.Context) *Labels {
 	l, _ := ctx.Value(labelsKey{}).(*Labels)
 	return l
+}
+
+// LabelsForRequest returns the *Labels already attached to ctx by an outer
+// middleware, alongside ctx unchanged — or, if none is attached yet,
+// allocates a fresh *Labels and returns the context it should be attached
+// to for inner handlers.
+//
+// Every middleware that wants to observe the routing identity the proxy
+// handler resolves (tracing, access logging, metrics) should call this
+// once, rather than unconditionally allocating its own Labels: context
+// values only propagate inward, so if two nested middleware layers each
+// call WithLabels independently, only the innermost allocation is ever
+// visible to the proxy handler that actually mutates it — the outer
+// layer's own pointer is never touched and stays permanently empty. In the
+// real middleware chain (TracingMiddleware, the outermost layer,
+// allocating first) this makes every layer share one Labels instance;
+// called standalone in a test with no outer layer present, it falls back
+// to allocating its own, so each middleware still works correctly in
+// isolation.
+func LabelsForRequest(ctx context.Context) (context.Context, *Labels) {
+	if l := LabelsFromContext(ctx); l != nil {
+		return ctx, l
+	}
+	l := &Labels{}
+	return WithLabels(ctx, l), l
 }
 
 // SandboxNamespaceFromContext returns the SandboxNamespace set on the Labels

--- a/sandbox-router/observability/context_test.go
+++ b/sandbox-router/observability/context_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLabelsForRequest_AllocatesWhenNoneAttached(t *testing.T) {
+	ctx, labels := LabelsForRequest(context.Background())
+	if labels == nil {
+		t.Fatal("expected a non-nil *Labels")
+	}
+	if got := LabelsFromContext(ctx); got != labels {
+		t.Fatalf("LabelsFromContext(ctx) = %p, want the same pointer %p returned by LabelsForRequest", got, labels)
+	}
+}
+
+// TestLabelsForRequest_ReusesOuterLabels is the regression test for the bug
+// this helper exists to prevent: if every middleware in the chain
+// unconditionally allocated its own *Labels, an outer layer (e.g.
+// TracingMiddleware) would end up with a *Labels the proxy handler never
+// sees or mutates — only the innermost allocation would ever be populated.
+func TestLabelsForRequest_ReusesOuterLabels(t *testing.T) {
+	outerCtx, outerLabels := LabelsForRequest(context.Background())
+
+	innerCtx, innerLabels := LabelsForRequest(outerCtx)
+	if innerLabels != outerLabels {
+		t.Fatalf("inner call allocated a new *Labels (%p) instead of reusing the outer one (%p)", innerLabels, outerLabels)
+	}
+	if innerCtx != outerCtx {
+		t.Fatal("expected the context to be returned unchanged when Labels was already attached")
+	}
+
+	// Whatever the innermost handler sets must be visible through the
+	// outer reference — same pointer, same struct.
+	innerLabels.SandboxID = "my-box"
+	innerLabels.SandboxNamespace = "test"
+	if outerLabels.SandboxID != "my-box" || outerLabels.SandboxNamespace != "test" {
+		t.Fatalf("mutation via inner reference not visible via outer: %+v", *outerLabels)
+	}
+}

--- a/sandbox-router/observability/metrics.go
+++ b/sandbox-router/observability/metrics.go
@@ -130,15 +130,21 @@ func buildInfoCollector() prometheus.Collector {
 
 // Middleware records inflight count, total requests, and request duration
 // for every handled request. The sandbox_namespace label is read from the
-// per-request *Labels attached to the request context — the proxy handler
-// populates Labels.SandboxNamespace once header parsing succeeds.
+// per-request *Labels attached to the request context via LabelsForRequest
+// — the proxy handler populates Labels.SandboxNamespace once routing
+// resolves, regardless of whether that came from headers or (with
+// path-based routing enabled) the URL path. LabelsForRequest reuses an
+// outer middleware's Labels when one is already attached (as
+// TracingMiddleware's is, in the real chain) rather than shadowing it with
+// a second, disconnected instance the proxy handler would never see —
+// see its doc comment — and falls back to allocating its own when none is
+// attached, so this middleware still works correctly wired up standalone.
 func (m *Metrics) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		m.InflightRequests.Inc()
 		defer m.InflightRequests.Dec()
 
-		labels := &Labels{}
-		ctx := WithLabels(r.Context(), labels)
+		ctx, labels := LabelsForRequest(r.Context())
 		ww := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 		start := time.Now()
 		next.ServeHTTP(ww, r.WithContext(ctx))

--- a/sandbox-router/observability/tracing.go
+++ b/sandbox-router/observability/tracing.go
@@ -24,8 +24,19 @@ import (
 )
 
 // TracingMiddleware opens a server span for every inbound request, extracts
-// trace context from inbound headers using prop, and decorates the span with
-// the routing headers so per-sandbox traces are searchable.
+// trace context from inbound headers using prop, and decorates the span
+// with the resolved sandbox identity so per-sandbox traces are searchable.
+//
+// That identity is read from Labels — via LabelsForRequest, allocated here
+// since this is the outermost layer in the real middleware chain — and
+// applied to the span only AFTER next.ServeHTTP returns, alongside the
+// existing http.status_code attribute: the proxy handler is what resolves
+// the Target (from X-Sandbox-* headers, or, when path-based routing is
+// enabled, from the URL path instead — see ParsePathRoute), and that
+// resolution hasn't happened yet at span-start time. Reading
+// X-Sandbox-Id/-Namespace straight from the request headers here, as an
+// earlier version of this middleware did, silently produced empty
+// sandbox.id/sandbox.namespace attributes for every path-routed request.
 //
 // When base is non-zero, a per-request logger is derived from it with the
 // trace_id and span_id baked in as fields, and stashed in the request
@@ -39,13 +50,12 @@ func TracingMiddleware(tracer trace.Tracer, prop propagation.TextMapPropagator, 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := prop.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+			ctx, labels := LabelsForRequest(ctx)
 			ctx, span := tracer.Start(ctx, "HTTP "+r.Method,
 				trace.WithSpanKind(trace.SpanKindServer),
 				trace.WithAttributes(
 					attribute.String("http.method", r.Method),
 					attribute.String("http.target", r.URL.Path),
-					attribute.String("sandbox.id", r.Header.Get("X-Sandbox-Id")),
-					attribute.String("sandbox.namespace", r.Header.Get("X-Sandbox-Namespace")),
 				))
 			defer span.End()
 
@@ -65,7 +75,11 @@ func TracingMiddleware(tracer trace.Tracer, prop propagation.TextMapPropagator, 
 
 			ww := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(ww, r.WithContext(ctx))
-			span.SetAttributes(attribute.Int("http.status_code", ww.status))
+			span.SetAttributes(
+				attribute.Int("http.status_code", ww.status),
+				attribute.String("sandbox.id", labels.SandboxID),
+				attribute.String("sandbox.namespace", labels.SandboxNamespace),
+			)
 		})
 	}
 }

--- a/sandbox-router/observability/tracing_test.go
+++ b/sandbox-router/observability/tracing_test.go
@@ -86,7 +86,7 @@ func TestTracingMiddleware_EmptyIdentityWhenUnresolved(t *testing.T) {
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
 	tracer := tp.Tracer("test")
 
-	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 

--- a/sandbox-router/observability/tracing_test.go
+++ b/sandbox-router/observability/tracing_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestTracingMiddleware_UsesResolvedIdentityNotHeaders is the regression
+// test for the bug caught in review: sandbox.id/sandbox.namespace span
+// attributes used to be read straight from the X-Sandbox-* request
+// headers, which a path-routed request (browser traffic reaching the
+// router via --path-routing-prefix, see ParsePathRoute) never sets at
+// all — so every such request traced with an empty sandbox identity, no
+// matter which sandbox it actually reached. The inner handler here sets
+// Labels directly (exactly what the proxy Handler's ServeHTTP does once
+// it resolves a Target, from either input) with NO X-Sandbox-* header on
+// the request at all, simulating a path-routed request end to end.
+func TestTracingMiddleware_UsesResolvedIdentityNotHeaders(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := tp.Tracer("test")
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labels := LabelsFromContext(r.Context())
+		if labels == nil {
+			t.Fatal("inner handler: no *Labels attached by TracingMiddleware")
+		}
+		labels.SandboxID = "path-routed-box"
+		labels.SandboxNamespace = "poc-agent-sandbox"
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := TracingMiddleware(tracer, propagation.TraceContext{}, logr.Discard())
+	// No X-Sandbox-Id / X-Sandbox-Namespace header anywhere on this
+	// request — that's the whole point.
+	req := httptest.NewRequest(http.MethodGet, "/router/poc-agent-sandbox/path-routed-box/8080/", nil)
+	rec := httptest.NewRecorder()
+	mw(inner).ServeHTTP(rec, req)
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d ended spans, want 1", len(spans))
+	}
+	attrs := attribute.NewSet(spans[0].Attributes()...)
+
+	wantID, ok := attrs.Value("sandbox.id")
+	if !ok || wantID.AsString() != "path-routed-box" {
+		t.Errorf("sandbox.id attribute: got %v (present=%v), want %q", wantID, ok, "path-routed-box")
+	}
+	wantNS, ok := attrs.Value("sandbox.namespace")
+	if !ok || wantNS.AsString() != "poc-agent-sandbox" {
+		t.Errorf("sandbox.namespace attribute: got %v (present=%v), want %q", wantNS, ok, "poc-agent-sandbox")
+	}
+	if status, ok := attrs.Value("http.status_code"); !ok || status.AsInt64() != http.StatusOK {
+		t.Errorf("http.status_code attribute: got %v (present=%v), want %d", status, ok, http.StatusOK)
+	}
+}
+
+// TestTracingMiddleware_EmptyIdentityWhenUnresolved makes sure a request
+// that never reaches routing resolution (e.g. rejected before the inner
+// handler runs) doesn't crash and simply reports an empty identity, rather
+// than something stale or panicking on a nil Labels.
+func TestTracingMiddleware_EmptyIdentityWhenUnresolved(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := tp.Tracer("test")
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	mw := TracingMiddleware(tracer, propagation.TraceContext{}, logr.Discard())
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	mw(inner).ServeHTTP(rec, req)
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("got %d ended spans, want 1", len(spans))
+	}
+	attrs := attribute.NewSet(spans[0].Attributes()...)
+	if v, ok := attrs.Value("sandbox.id"); !ok || v.AsString() != "" {
+		t.Errorf("sandbox.id attribute: got %v (present=%v), want empty string", v, ok)
+	}
+}

--- a/sandbox-router/proxy/helpers_test.go
+++ b/sandbox-router/proxy/helpers_test.go
@@ -21,7 +21,12 @@ package proxy
 import (
 	"net"
 	"strconv"
+	"sync"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/agent-sandbox/sandbox-router/cache"
 )
 
 // pickFreePort reserves an ephemeral port and immediately closes the
@@ -54,4 +59,57 @@ func pickFreePort(t *testing.T) int {
 func pickFreePortStr(t *testing.T) string {
 	t.Helper()
 	return strconv.Itoa(pickFreePort(t))
+}
+
+// stubLookup is a minimal Lookup for tests of cache wiring, both plain
+// unit tests and `-tags=integration` ones. No build tag on this file, so
+// it's visible from either. GetByName scans entries so tests only have to
+// populate one map. A mutex guards the maps/slices because the handler
+// mutates them from the httptest server goroutine while assertions read
+// from the test goroutine.
+type stubLookup struct {
+	mu                sync.Mutex
+	entries           map[types.UID]cache.Entry
+	invalidated       []types.UID
+	invalidatedByName []string
+}
+
+func (s *stubLookup) Get(uid types.UID) (cache.Entry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[uid]
+	return e, ok
+}
+
+func (s *stubLookup) GetByName(namespace, name string) (cache.Entry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.Namespace == namespace && e.SandboxName == name {
+			return e, true
+		}
+	}
+	return cache.Entry{}, false
+}
+
+func (s *stubLookup) Invalidate(uid types.UID) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.entries[uid]
+	delete(s.entries, uid)
+	s.invalidated = append(s.invalidated, uid)
+	return ok
+}
+
+func (s *stubLookup) InvalidateByName(namespace, name, podIP string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.invalidatedByName = append(s.invalidatedByName, namespace+"/"+name+"="+podIP)
+	for uid, e := range s.entries {
+		if e.Namespace == namespace && e.SandboxName == name && e.PodIP == podIP {
+			delete(s.entries, uid)
+			return true
+		}
+	}
+	return false
 }

--- a/sandbox-router/proxy/pathroute.go
+++ b/sandbox-router/proxy/pathroute.go
@@ -128,12 +128,14 @@ func ParsePathRoute(prefix, escapedPath string) (route PathRoute, matched bool, 
 	decodedRemainder, err := url.PathUnescape(rawRemainder)
 	if err != nil {
 		// Malformed escaping this deep in the path isn't this router's
-		// business to reject — forward it as-is and let the upstream
-		// sandbox decide. RawPath stays authoritative regardless: per
-		// net/url's EscapedPath doc, RawPath is only honored when it is
-		// a valid encoding of Path, so a mismatched Path here (the raw
-		// text instead of a real decode) never actually gets used for
-		// serialization — it's best-effort only, not load-bearing.
+		// business to reject — let the upstream sandbox see it and decide.
+		// This is NOT a byte-for-byte passthrough, though: rawRemainder
+		// isn't validly encoded, so url.URL.EscapedPath() can't use
+		// UpstreamRawPath as-is (per its own doc, RawPath is only honored
+		// when it decodes back to Path) and falls back to re-escaping
+		// UpstreamPath from scratch instead — so a literal "%" the client
+		// sent gets percent-encoded itself. A client-sent ".../my-box%ZZ"
+		// reaches the upstream as ".../my-box%25ZZ", not "%ZZ" unchanged.
 		decodedRemainder = rawRemainder
 	}
 

--- a/sandbox-router/proxy/pathroute.go
+++ b/sandbox-router/proxy/pathroute.go
@@ -16,73 +16,130 @@ package proxy
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
 
+// PathRoute is the result of successfully parsing a path-routed request.
+type PathRoute struct {
+	// Target is the resolved routing target — same type and same
+	// validation ParseSandboxHeaders produces, regardless of which input
+	// carried it.
+	Target Target
+	// UpstreamPath is the decoded remainder: the part of the path the
+	// upstream sandbox should actually see, with
+	// prefix/namespace/id/port stripped. Suitable for url.URL.Path.
+	UpstreamPath string
+	// UpstreamRawPath is the same remainder in the exact escaped form it
+	// arrived in, preserving encoded separators like "%2F" that decoding
+	// would otherwise silently collapse into a literal "/". Suitable for
+	// url.URL.RawPath, set ALONGSIDE UpstreamPath — url.URL only honors
+	// RawPath when it is a valid encoding of Path (see net/url's own
+	// EscapedPath doc), so the two must be assigned as a pair, never
+	// RawPath alone.
+	UpstreamRawPath string
+}
+
 // ParsePathRoute extracts routing information from a request path shaped as
 // <prefix>/<namespace>/<id>/<port>/<rest...>, where prefix is the operator's
-// configured --path-routing-prefix.
+// configured --path-routing-prefix and escapedPath is the request path
+// exactly as it arrived on the wire (r.URL.EscapedPath(), NOT r.URL.Path —
+// the latter is already percent-decoded, which would silently collapse an
+// encoded separator like "%2F" inside the upstream remainder into a literal
+// "/", changing which path segment a browser resource request actually
+// names).
 //
-// matched reports whether path even starts with prefix — the caller is
-// expected to fall through to header-based ParseSandboxHeaders when it is
-// false, which is not an error, just "this is not a path-routed request".
-// A perr is only ever returned alongside matched=true: the path opted in to
-// this routing mode but is otherwise malformed (missing segments, bad
-// namespace/id/port).
-//
-// On success, upstreamPath is what the upstream sandbox should actually
-// see — prefix/namespace/id/port stripped, everything after preserved
-// verbatim (matching the "verbatim remainder" contract header-routed
-// requests already get for free, since they carry no prefix to strip).
+// matched reports whether escapedPath even starts with prefix — the caller
+// is expected to fall through to header-based ParseSandboxHeaders when it
+// is false, which is not an error, just "this is not a path-routed
+// request". A perr is only ever returned alongside matched=true: the path
+// opted in to this routing mode but is otherwise malformed (missing
+// segments, bad namespace/id/port).
 //
 // The same validation as ParseSandboxHeaders applies to namespace and id
 // (validDNSLabel) and to port ([1, 65535]) — one shape for a Target
-// regardless of which input carried it. Port has no default here (unlike
-// the header form's DefaultSandboxPort): a browser-facing path with no
-// port is an authoring mistake worth surfacing immediately, not silently
-// guessing.
+// regardless of which input carried it. Those three segments are decoded
+// before validation: a client is free to percent-encode a character that
+// didn't strictly need it, and decoding first is the conventional way a
+// server honors that — a DNS label or a decimal port never legitimately
+// contains an encoded "/" in the first place, so this can't reintroduce
+// the ambiguity splitting on the still-escaped string was written to
+// avoid. Port has no default here (unlike the header form's
+// DefaultSandboxPort): a browser-facing path with no port is an authoring
+// mistake worth surfacing immediately, not silently guessing.
 //
 // X-Sandbox-Pod-IP and X-Sandbox-UID have no path equivalent, by design:
 // see the PathRoutingPrefix doc comment in package config for why.
-func ParsePathRoute(prefix, path string) (target Target, upstreamPath string, matched bool, perr *Error) {
-	if prefix == "" || !strings.HasPrefix(path, prefix) {
-		return Target{}, "", false, nil
+func ParsePathRoute(prefix, escapedPath string) (route PathRoute, matched bool, perr *Error) {
+	if prefix == "" || !strings.HasPrefix(escapedPath, prefix) {
+		return PathRoute{}, false, nil
 	}
-	rest := path[len(prefix):]
+	rest := escapedPath[len(prefix):]
 	// Require the leading slash explicitly, rather than accepting
 	// "<prefix>something" as a match just because it happens to share a
 	// string prefix with a sibling route the operator also serves.
 	if !strings.HasPrefix(rest, "/") {
-		return Target{}, "", false, nil
+		return PathRoute{}, false, nil
 	}
 
 	// At most 4 parts: namespace, id, port, and everything after the
-	// port — which may itself contain slashes and must be preserved
-	// verbatim.
+	// port. Splitting on literal "/" bytes in the STILL-ESCAPED string is
+	// safe and unambiguous: an encoded separator ("%2F") is three ASCII
+	// characters, never a literal "/", so it can't be mistaken for a
+	// path-segment boundary here even if it showed up inside one of the
+	// first three segments.
 	parts := strings.SplitN(rest[1:], "/", 4)
 	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-		return Target{}, "", true, &Error{
+		return PathRoute{}, true, &Error{
 			Status: http.StatusBadRequest,
 			Detail: "Path-routed request must have the form <prefix>/<namespace>/<id>/<port>/...",
 		}
 	}
-	ns, id, rawPort := parts[0], parts[1], parts[2]
+
+	ns, nsErr := url.PathUnescape(parts[0])
+	id, idErr := url.PathUnescape(parts[1])
+	rawPort, portErr := url.PathUnescape(parts[2])
+	if nsErr != nil || idErr != nil || portErr != nil {
+		return PathRoute{}, true, &Error{Status: http.StatusBadRequest, Detail: "Invalid percent-encoding in path."}
+	}
 
 	if !validDNSLabel(ns) {
-		return Target{}, "", true, &Error{Status: http.StatusBadRequest, Detail: "Invalid namespace format."}
+		return PathRoute{}, true, &Error{Status: http.StatusBadRequest, Detail: "Invalid namespace format."}
 	}
 	if !validDNSLabel(id) {
-		return Target{}, "", true, &Error{Status: http.StatusBadRequest, Detail: "Invalid sandbox ID format."}
+		return PathRoute{}, true, &Error{Status: http.StatusBadRequest, Detail: "Invalid sandbox ID format."}
 	}
 	port, err := strconv.Atoi(rawPort)
 	if err != nil || port < 1 || port > 65535 {
-		return Target{}, "", true, &Error{Status: http.StatusBadRequest, Detail: "Invalid port format."}
+		return PathRoute{}, true, &Error{Status: http.StatusBadRequest, Detail: "Invalid port format."}
 	}
 
-	upstreamPath = "/"
+	// Everything after the port is opaque to this router — NOT decoded,
+	// preserved byte-for-byte, escaping included. That's what lets an
+	// encoded separator inside a single upstream path segment (e.g. a
+	// filename containing "/", sent as "%2F") survive the hop unchanged,
+	// matching the same verbatim-remainder guarantee header-routed
+	// requests already get simply by never touching r.URL.Path at all.
+	rawRemainder := ""
 	if len(parts) == 4 {
-		upstreamPath += parts[3]
+		rawRemainder = parts[3]
 	}
-	return Target{ID: id, Namespace: ns, Port: port}, upstreamPath, true, nil
+	decodedRemainder, err := url.PathUnescape(rawRemainder)
+	if err != nil {
+		// Malformed escaping this deep in the path isn't this router's
+		// business to reject — forward it as-is and let the upstream
+		// sandbox decide. RawPath stays authoritative regardless: per
+		// net/url's EscapedPath doc, RawPath is only honored when it is
+		// a valid encoding of Path, so a mismatched Path here (the raw
+		// text instead of a real decode) never actually gets used for
+		// serialization — it's best-effort only, not load-bearing.
+		decodedRemainder = rawRemainder
+	}
+
+	return PathRoute{
+		Target:          Target{ID: id, Namespace: ns, Port: port},
+		UpstreamPath:    "/" + decodedRemainder,
+		UpstreamRawPath: "/" + rawRemainder,
+	}, true, nil
 }

--- a/sandbox-router/proxy/pathroute.go
+++ b/sandbox-router/proxy/pathroute.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ParsePathRoute extracts routing information from a request path shaped as
+// <prefix>/<namespace>/<id>/<port>/<rest...>, where prefix is the operator's
+// configured --path-routing-prefix.
+//
+// matched reports whether path even starts with prefix — the caller is
+// expected to fall through to header-based ParseSandboxHeaders when it is
+// false, which is not an error, just "this is not a path-routed request".
+// A perr is only ever returned alongside matched=true: the path opted in to
+// this routing mode but is otherwise malformed (missing segments, bad
+// namespace/id/port).
+//
+// On success, upstreamPath is what the upstream sandbox should actually
+// see — prefix/namespace/id/port stripped, everything after preserved
+// verbatim (matching the "verbatim remainder" contract header-routed
+// requests already get for free, since they carry no prefix to strip).
+//
+// The same validation as ParseSandboxHeaders applies to namespace and id
+// (validDNSLabel) and to port ([1, 65535]) — one shape for a Target
+// regardless of which input carried it. Port has no default here (unlike
+// the header form's DefaultSandboxPort): a browser-facing path with no
+// port is an authoring mistake worth surfacing immediately, not silently
+// guessing.
+//
+// X-Sandbox-Pod-IP and X-Sandbox-UID have no path equivalent, by design:
+// see the PathRoutingPrefix doc comment in package config for why.
+func ParsePathRoute(prefix, path string) (target Target, upstreamPath string, matched bool, perr *Error) {
+	if prefix == "" || !strings.HasPrefix(path, prefix) {
+		return Target{}, "", false, nil
+	}
+	rest := path[len(prefix):]
+	// Require the leading slash explicitly, rather than accepting
+	// "<prefix>something" as a match just because it happens to share a
+	// string prefix with a sibling route the operator also serves.
+	if !strings.HasPrefix(rest, "/") {
+		return Target{}, "", false, nil
+	}
+
+	// At most 4 parts: namespace, id, port, and everything after the
+	// port — which may itself contain slashes and must be preserved
+	// verbatim.
+	parts := strings.SplitN(rest[1:], "/", 4)
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return Target{}, "", true, &Error{
+			Status: http.StatusBadRequest,
+			Detail: "Path-routed request must have the form <prefix>/<namespace>/<id>/<port>/...",
+		}
+	}
+	ns, id, rawPort := parts[0], parts[1], parts[2]
+
+	if !validDNSLabel(ns) {
+		return Target{}, "", true, &Error{Status: http.StatusBadRequest, Detail: "Invalid namespace format."}
+	}
+	if !validDNSLabel(id) {
+		return Target{}, "", true, &Error{Status: http.StatusBadRequest, Detail: "Invalid sandbox ID format."}
+	}
+	port, err := strconv.Atoi(rawPort)
+	if err != nil || port < 1 || port > 65535 {
+		return Target{}, "", true, &Error{Status: http.StatusBadRequest, Detail: "Invalid port format."}
+	}
+
+	upstreamPath = "/"
+	if len(parts) == 4 {
+		upstreamPath += parts[3]
+	}
+	return Target{ID: id, Namespace: ns, Port: port}, upstreamPath, true, nil
+}

--- a/sandbox-router/proxy/pathroute_encoding_test.go
+++ b/sandbox-router/proxy/pathroute_encoding_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build integration
-
 package proxy
 
 import (
@@ -30,11 +28,11 @@ import (
 	"sigs.k8s.io/agent-sandbox/sandbox-router/config"
 )
 
-// TestIntegration_PathRoutingPreservesEncodedSlash is the end-to-end
-// regression test for the escaping bug caught in review: r.URL.Path is
-// already percent-decoded, so naively deriving the upstream remainder from
-// it would turn a request for "/router/test/my-box/8080/some%2Ffile" into
-// an upstream request for "/some/file" — two segments instead of one,
+// TestPathRoutingPreservesEncodedSlash is the end-to-end regression test
+// for the escaping bug caught in review: r.URL.Path is already
+// percent-decoded, so naively deriving the upstream remainder from it
+// would turn a request for "/router/test/my-box/8080/some%2Ffile" into an
+// upstream request for "/some/file" — two segments instead of one,
 // silently renaming whatever resource "some%2Ffile" actually named (a
 // filename containing "/", URL-encoded to keep it within a single path
 // segment, is exactly the kind of thing a browser-facing tool like
@@ -43,7 +41,15 @@ import (
 // RawPath alongside Path; this test proves the fix holds through the
 // actual httputil.ReverseProxy hop, not just the parser in isolation
 // (which pathroute_test.go already covers).
-func TestIntegration_PathRoutingPreservesEncodedSlash(t *testing.T) {
+//
+// Deliberately NOT behind the "integration" build tag, unlike its
+// siblings in this package: it needs nothing beyond two in-process
+// httptest servers, same as pathroute_test.go's table tests, and
+// dev/tools/test-unit (the only Go test job wired into CI here — there is
+// no separate integration presubmit) runs without -tags=integration. A
+// regression this specific is worth keeping under the suite that
+// actually runs.
+func TestPathRoutingPreservesEncodedSlash(t *testing.T) {
 	var (
 		mu             sync.Mutex
 		gotEscapedPath string

--- a/sandbox-router/proxy/pathroute_integration_test.go
+++ b/sandbox-router/proxy/pathroute_integration_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build integration
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/agent-sandbox/sandbox-router/cache"
+	"sigs.k8s.io/agent-sandbox/sandbox-router/config"
+)
+
+// TestIntegration_PathRoutingPreservesEncodedSlash is the end-to-end
+// regression test for the escaping bug caught in review: r.URL.Path is
+// already percent-decoded, so naively deriving the upstream remainder from
+// it would turn a request for "/router/test/my-box/8080/some%2Ffile" into
+// an upstream request for "/some/file" — two segments instead of one,
+// silently renaming whatever resource "some%2Ffile" actually named (a
+// filename containing "/", URL-encoded to keep it within a single path
+// segment, is exactly the kind of thing a browser-facing tool like
+// code-server can be asked to serve). ParsePathRoute/resolveTarget fix
+// this by working from r.URL.EscapedPath() and setting the outbound URL's
+// RawPath alongside Path; this test proves the fix holds through the
+// actual httputil.ReverseProxy hop, not just the parser in isolation
+// (which pathroute_test.go already covers).
+func TestIntegration_PathRoutingPreservesEncodedSlash(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		gotEscapedPath string
+	)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotEscapedPath = r.URL.EscapedPath()
+		mu.Unlock()
+		w.WriteHeader(204)
+	}))
+	defer backend.Close()
+	bu, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.PathRoutingPrefix = "/router"
+	lookup := &stubLookup{entries: map[types.UID]cache.Entry{
+		"path-routed-uid": {PodIP: bu.Hostname(), SandboxName: "my-box", Namespace: "test"},
+	}}
+	router := httptest.NewServer(NewHandler(Options{
+		Config: &cfg,
+		Cache:  lookup,
+		Logger: logr.Discard(),
+	}))
+	defer router.Close()
+
+	resp, err := http.Get(router.URL + "/router/test/my-box/" + bu.Port() + "/some%2Ffile")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Fatalf("status: got %d want 204", resp.StatusCode)
+	}
+
+	mu.Lock()
+	got := gotEscapedPath
+	mu.Unlock()
+	const want = "/some%2Ffile"
+	if got != want {
+		t.Fatalf("backend saw escaped path %q, want %q (the encoded slash must survive the hop)", got, want)
+	}
+}

--- a/sandbox-router/proxy/pathroute_test.go
+++ b/sandbox-router/proxy/pathroute_test.go
@@ -149,6 +149,18 @@ func TestParsePathRoute(t *testing.T) {
 			wantCode:    http.StatusBadRequest,
 		},
 		{
+			// url.PathUnescape fails on a malformed escape ("%ZZ" is not
+			// valid hex) — exercises the id branch of that error path.
+			// namespace and port share the same handling, so one case
+			// covering the mechanism is enough; this isn't a per-field
+			// property to re-verify three times over.
+			name:        "malformed percent-encoding rejected",
+			prefix:      "/router",
+			path:        "/router/test/my-box%ZZ/8080/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
 			name:        "non-numeric port rejected",
 			prefix:      "/router",
 			path:        "/router/test/my-box/abc/",

--- a/sandbox-router/proxy/pathroute_test.go
+++ b/sandbox-router/proxy/pathroute_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestParsePathRoute(t *testing.T) {
+	cases := []struct {
+		name         string
+		prefix       string
+		path         string
+		wantMatched  bool
+		wantCode     int // 0 means success (or "not matched", see wantMatched)
+		wantTarget   Target
+		wantUpstream string
+	}{
+		{
+			name:        "prefix disabled never matches",
+			prefix:      "",
+			path:        "/router/test/my-box/8080/",
+			wantMatched: false,
+		},
+		{
+			name:        "path outside the prefix does not match",
+			prefix:      "/router",
+			path:        "/other/test/my-box/8080/",
+			wantMatched: false,
+		},
+		{
+			name:        "prefix as bare string-prefix of a sibling path does not match",
+			prefix:      "/router",
+			path:        "/routerish/test/my-box/8080/",
+			wantMatched: false,
+		},
+		{
+			name:         "happy path, no trailing content",
+			prefix:       "/router",
+			path:         "/router/test/my-box/8080",
+			wantMatched:  true,
+			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream: "/",
+		},
+		{
+			name:         "happy path, trailing slash only",
+			prefix:       "/router",
+			path:         "/router/test/my-box/8080/",
+			wantMatched:  true,
+			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream: "/",
+		},
+		{
+			name:         "happy path, nested remainder preserved verbatim",
+			prefix:       "/router",
+			path:         "/router/test/my-box/8080/stable-abc/static/out/vs/code.js",
+			wantMatched:  true,
+			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream: "/stable-abc/static/out/vs/code.js",
+		},
+		{
+			name:        "empty prefix means root-mounted routing",
+			prefix:      "",
+			path:        "",
+			wantMatched: false, // prefix=="" is always "disabled", see first case
+		},
+		{
+			name:        "missing namespace and id rejected",
+			prefix:      "/router",
+			path:        "/router/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "missing port rejected",
+			prefix:      "/router",
+			path:        "/router/test/my-box",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "missing port with trailing slash rejected",
+			prefix:      "/router",
+			path:        "/router/test/my-box/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "invalid namespace rejected",
+			prefix:      "/router",
+			path:        "/router/BAD_NS/my-box/8080/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "invalid id rejected (dot would inject a DNS component)",
+			prefix:      "/router",
+			path:        "/router/test/foo.evil.com/8080/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "non-numeric port rejected",
+			prefix:      "/router",
+			path:        "/router/test/my-box/abc/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "zero port rejected",
+			prefix:      "/router",
+			path:        "/router/test/my-box/0/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:        "port above 65535 rejected",
+			prefix:      "/router",
+			path:        "/router/test/my-box/65536/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
+			name:         "port 1 accepted",
+			prefix:       "/router",
+			path:         "/router/test/my-box/1/",
+			wantMatched:  true,
+			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 1},
+			wantUpstream: "/",
+		},
+		{
+			name:         "port 65535 accepted",
+			prefix:       "/router",
+			path:         "/router/test/my-box/65535/",
+			wantMatched:  true,
+			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 65535},
+			wantUpstream: "/",
+		},
+		{
+			name:         "root-mounted prefix",
+			prefix:       "/sandboxes",
+			path:         "/sandboxes/poc-agent-sandbox/sandbox-abc123/4200/",
+			wantMatched:  true,
+			wantTarget:   Target{ID: "sandbox-abc123", Namespace: "poc-agent-sandbox", Port: 4200},
+			wantUpstream: "/",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target, upstream, matched, perr := ParsePathRoute(tc.prefix, tc.path)
+			if matched != tc.wantMatched {
+				t.Fatalf("matched: got %v, want %v (target=%+v, upstream=%q, perr=%v)",
+					matched, tc.wantMatched, target, upstream, perr)
+			}
+			if !matched {
+				return // nothing else to check — caller falls through to headers
+			}
+			if tc.wantCode != 0 {
+				if perr == nil {
+					t.Fatalf("expected error, got target=%+v upstream=%q", target, upstream)
+				}
+				if perr.Status != tc.wantCode {
+					t.Fatalf("status: got %d, want %d (detail=%q)", perr.Status, tc.wantCode, perr.Detail)
+				}
+				return
+			}
+			if perr != nil {
+				t.Fatalf("unexpected error: %v", perr)
+			}
+			if target != tc.wantTarget {
+				t.Fatalf("target: got %+v, want %+v", target, tc.wantTarget)
+			}
+			if upstream != tc.wantUpstream {
+				t.Fatalf("upstreamPath: got %q, want %q", upstream, tc.wantUpstream)
+			}
+		})
+	}
+}

--- a/sandbox-router/proxy/pathroute_test.go
+++ b/sandbox-router/proxy/pathroute_test.go
@@ -21,13 +21,14 @@ import (
 
 func TestParsePathRoute(t *testing.T) {
 	cases := []struct {
-		name         string
-		prefix       string
-		path         string
-		wantMatched  bool
-		wantCode     int // 0 means success (or "not matched", see wantMatched)
-		wantTarget   Target
-		wantUpstream string
+		name            string
+		prefix          string
+		path            string
+		wantMatched     bool
+		wantCode        int // 0 means success (or "not matched", see wantMatched)
+		wantTarget      Target
+		wantUpstream    string
+		wantUpstreamRaw string
 	}{
 		{
 			name:        "prefix disabled never matches",
@@ -48,34 +49,59 @@ func TestParsePathRoute(t *testing.T) {
 			wantMatched: false,
 		},
 		{
-			name:         "happy path, no trailing content",
-			prefix:       "/router",
-			path:         "/router/test/my-box/8080",
-			wantMatched:  true,
-			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 8080},
-			wantUpstream: "/",
+			name:            "happy path, no trailing content",
+			prefix:          "/router",
+			path:            "/router/test/my-box/8080",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream:    "/",
+			wantUpstreamRaw: "/",
 		},
 		{
-			name:         "happy path, trailing slash only",
-			prefix:       "/router",
-			path:         "/router/test/my-box/8080/",
-			wantMatched:  true,
-			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 8080},
-			wantUpstream: "/",
+			name:            "happy path, trailing slash only",
+			prefix:          "/router",
+			path:            "/router/test/my-box/8080/",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream:    "/",
+			wantUpstreamRaw: "/",
 		},
 		{
-			name:         "happy path, nested remainder preserved verbatim",
-			prefix:       "/router",
-			path:         "/router/test/my-box/8080/stable-abc/static/out/vs/code.js",
-			wantMatched:  true,
-			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 8080},
-			wantUpstream: "/stable-abc/static/out/vs/code.js",
+			name:            "happy path, nested remainder preserved verbatim",
+			prefix:          "/router",
+			path:            "/router/test/my-box/8080/stable-abc/static/out/vs/code.js",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream:    "/stable-abc/static/out/vs/code.js",
+			wantUpstreamRaw: "/stable-abc/static/out/vs/code.js",
 		},
 		{
-			name:        "empty prefix means root-mounted routing",
-			prefix:      "",
-			path:        "",
-			wantMatched: false, // prefix=="" is always "disabled", see first case
+			// Regression test for the escaping bug CodeRabbit's review
+			// caught: r.URL.Path decodes "%2F" to a literal "/" before
+			// ParsePathRoute ever sees it, which would silently turn one
+			// path segment (e.g. a filename containing "/") into two.
+			// Operating on the still-escaped path (r.URL.EscapedPath())
+			// keeps "%2F" as three literal characters, not a delimiter.
+			name:            "encoded slash in the remainder is preserved, not split on",
+			prefix:          "/router",
+			path:            "/router/test/my-box/8080/some%2Ffile",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream:    "/some/file",   // decoded form, for url.URL.Path
+			wantUpstreamRaw: "/some%2Ffile", // escaped form, for url.URL.RawPath — this is the one that actually reaches the wire
+		},
+		{
+			// A client is free to percent-encode a namespace/id character
+			// that didn't strictly need it (RFC 3986 allows this) — the
+			// router decodes before validating, same as it would for any
+			// other path segment it interprets rather than forwards.
+			name:            "harmlessly over-escaped namespace and id still validate",
+			prefix:          "/router",
+			path:            "/router/te%73t/my%2Dbox/8080/",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 8080},
+			wantUpstream:    "/",
+			wantUpstreamRaw: "/",
 		},
 		{
 			name:        "missing namespace and id rejected",
@@ -113,6 +139,16 @@ func TestParsePathRoute(t *testing.T) {
 			wantCode:    http.StatusBadRequest,
 		},
 		{
+			// Decoding "foo%2Eevil%2Ecom" produces "foo.evil.com", which
+			// validDNSLabel rejects exactly like the unescaped case above
+			// — decoding before validating must not open a bypass.
+			name:        "percent-encoded dot in id still rejected after decoding",
+			prefix:      "/router",
+			path:        "/router/test/foo%2Eevil%2Ecom/8080/",
+			wantMatched: true,
+			wantCode:    http.StatusBadRequest,
+		},
+		{
 			name:        "non-numeric port rejected",
 			prefix:      "/router",
 			path:        "/router/test/my-box/abc/",
@@ -134,44 +170,46 @@ func TestParsePathRoute(t *testing.T) {
 			wantCode:    http.StatusBadRequest,
 		},
 		{
-			name:         "port 1 accepted",
-			prefix:       "/router",
-			path:         "/router/test/my-box/1/",
-			wantMatched:  true,
-			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 1},
-			wantUpstream: "/",
+			name:            "port 1 accepted",
+			prefix:          "/router",
+			path:            "/router/test/my-box/1/",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 1},
+			wantUpstream:    "/",
+			wantUpstreamRaw: "/",
 		},
 		{
-			name:         "port 65535 accepted",
-			prefix:       "/router",
-			path:         "/router/test/my-box/65535/",
-			wantMatched:  true,
-			wantTarget:   Target{ID: "my-box", Namespace: "test", Port: 65535},
-			wantUpstream: "/",
+			name:            "port 65535 accepted",
+			prefix:          "/router",
+			path:            "/router/test/my-box/65535/",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "my-box", Namespace: "test", Port: 65535},
+			wantUpstream:    "/",
+			wantUpstreamRaw: "/",
 		},
 		{
-			name:         "root-mounted prefix",
-			prefix:       "/sandboxes",
-			path:         "/sandboxes/poc-agent-sandbox/sandbox-abc123/4200/",
-			wantMatched:  true,
-			wantTarget:   Target{ID: "sandbox-abc123", Namespace: "poc-agent-sandbox", Port: 4200},
-			wantUpstream: "/",
+			name:            "root-mounted prefix",
+			prefix:          "/sandboxes",
+			path:            "/sandboxes/poc-agent-sandbox/sandbox-abc123/4200/",
+			wantMatched:     true,
+			wantTarget:      Target{ID: "sandbox-abc123", Namespace: "poc-agent-sandbox", Port: 4200},
+			wantUpstream:    "/",
+			wantUpstreamRaw: "/",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			target, upstream, matched, perr := ParsePathRoute(tc.prefix, tc.path)
+			route, matched, perr := ParsePathRoute(tc.prefix, tc.path)
 			if matched != tc.wantMatched {
-				t.Fatalf("matched: got %v, want %v (target=%+v, upstream=%q, perr=%v)",
-					matched, tc.wantMatched, target, upstream, perr)
+				t.Fatalf("matched: got %v, want %v (route=%+v, perr=%v)", matched, tc.wantMatched, route, perr)
 			}
 			if !matched {
 				return // nothing else to check — caller falls through to headers
 			}
 			if tc.wantCode != 0 {
 				if perr == nil {
-					t.Fatalf("expected error, got target=%+v upstream=%q", target, upstream)
+					t.Fatalf("expected error, got route=%+v", route)
 				}
 				if perr.Status != tc.wantCode {
 					t.Fatalf("status: got %d, want %d (detail=%q)", perr.Status, tc.wantCode, perr.Detail)
@@ -181,11 +219,14 @@ func TestParsePathRoute(t *testing.T) {
 			if perr != nil {
 				t.Fatalf("unexpected error: %v", perr)
 			}
-			if target != tc.wantTarget {
-				t.Fatalf("target: got %+v, want %+v", target, tc.wantTarget)
+			if route.Target != tc.wantTarget {
+				t.Fatalf("target: got %+v, want %+v", route.Target, tc.wantTarget)
 			}
-			if upstream != tc.wantUpstream {
-				t.Fatalf("upstreamPath: got %q, want %q", upstream, tc.wantUpstream)
+			if route.UpstreamPath != tc.wantUpstream {
+				t.Fatalf("UpstreamPath: got %q, want %q", route.UpstreamPath, tc.wantUpstream)
+			}
+			if route.UpstreamRawPath != tc.wantUpstreamRaw {
+				t.Fatalf("UpstreamRawPath: got %q, want %q", route.UpstreamRawPath, tc.wantUpstreamRaw)
 			}
 		})
 	}

--- a/sandbox-router/proxy/proxy.go
+++ b/sandbox-router/proxy/proxy.go
@@ -112,16 +112,22 @@ func NewHandler(o Options) *Handler {
 
 // ServeHTTP implements http.Handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	upstreamPath := r.URL.Path
-	target, perr := h.resolveTarget(r, &upstreamPath)
+	upstreamPath, upstreamRawPath := r.URL.Path, ""
+	target, perr := h.resolveTarget(r, &upstreamPath, &upstreamRawPath)
 	if perr != nil {
 		WriteJSONError(w, perr)
 		return
 	}
 
-	// Make the parsed namespace visible to the observability middleware.
+	// Make the resolved identity visible to the observability middleware.
+	// Tracing and access logging read it back from Labels rather than the
+	// request headers directly, because a path-routed request (see
+	// resolveTarget) never sets X-Sandbox-* at all — reading headers
+	// there would silently show an empty sandbox identity for every
+	// browser-facing request.
 	if labels := observability.LabelsFromContext(r.Context()); labels != nil {
 		labels.SandboxNamespace = target.Namespace
+		labels.SandboxID = target.ID
 	}
 
 	// Authorization. Implementations are expected to pull whatever
@@ -153,6 +159,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// produced the IP (cache vs DNS vs override) and invalidate the cache
 	// entry on dial-class failures. The Rewrite callback re-uses the URL.
 	upstreamURL, src := target0.Resolve("http", h.cfg.ClusterDomain, upstreamPath, r.URL.RawQuery, h.cache)
+	if upstreamRawPath != "" {
+		// Only ever set for a path-routed request (see resolveTarget).
+		// Target.Resolve only assigns URL.Path, so without this a path-
+		// routed request carrying an encoded separator in its upstream
+		// portion (e.g. a filename containing "/", sent as "%2F") would
+		// reach the sandbox already decoded, silently renaming the
+		// resource it addresses. net/url only honors RawPath when it is
+		// a valid encoding of Path (see url.URL.EscapedPath's doc) —
+		// resolveTarget/ParsePathRoute guarantee that pairing holds.
+		upstreamURL.RawPath = upstreamRawPath
+	}
 	// Detect Upgrade once and reuse: the Rewrite callback uses it to
 	// decide whether to strip Origin, the timeout block below uses it
 	// to skip the per-request deadline. Same predicate, same source of
@@ -278,21 +295,29 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // resolveTarget parses the routing Target for r, preferring the path-based
-// form when --path-routing-prefix is configured and r.URL.Path matches it,
-// and falling through to X-Sandbox-* headers otherwise — byte-identical to
-// the header parsing this replaced when the prefix is unset (the default),
-// so header-only deployments are unaffected. On a path match, *upstreamPath
-// is rewritten to the portion of the path the upstream sandbox should
-// actually see (prefix/namespace/id/port stripped); left untouched for
-// header-routed requests, which carry no routing prefix to strip.
-func (h *Handler) resolveTarget(r *http.Request, upstreamPath *string) (Target, *Error) {
+// form when --path-routing-prefix is configured and r.URL.EscapedPath()
+// matches it, and falling through to X-Sandbox-* headers otherwise —
+// byte-identical to the header parsing this replaced when the prefix is
+// unset (the default), so header-only deployments are unaffected.
+//
+// On a path match, *upstreamPath and *upstreamRawPath are rewritten to the
+// portion of the path the upstream sandbox should actually see
+// (prefix/namespace/id/port stripped) in, respectively, decoded and
+// originally-escaped form — both are needed together to preserve an
+// encoded separator (e.g. "%2F") through to the outbound request, see
+// ParsePathRoute. Both are left untouched for header-routed requests,
+// which carry no routing prefix to strip; *upstreamRawPath in particular
+// stays "" there, exactly matching pre-path-routing behavior of never
+// setting Resolve's outbound URL.RawPath at all.
+func (h *Handler) resolveTarget(r *http.Request, upstreamPath, upstreamRawPath *string) (Target, *Error) {
 	if h.cfg.PathRoutingPrefix != "" {
-		if target, rem, matched, perr := ParsePathRoute(h.cfg.PathRoutingPrefix, r.URL.Path); matched {
+		if route, matched, perr := ParsePathRoute(h.cfg.PathRoutingPrefix, r.URL.EscapedPath()); matched {
 			if perr != nil {
 				return Target{}, perr
 			}
-			*upstreamPath = rem
-			return target, nil
+			*upstreamPath = route.UpstreamPath
+			*upstreamRawPath = route.UpstreamRawPath
+			return route.Target, nil
 		}
 	}
 	return ParseSandboxHeaders(r.Header, ParseOptions{AllowLoopbackPodIP: h.cfg.AllowLoopbackPodIP})

--- a/sandbox-router/proxy/proxy.go
+++ b/sandbox-router/proxy/proxy.go
@@ -112,9 +112,8 @@ func NewHandler(o Options) *Handler {
 
 // ServeHTTP implements http.Handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	target, perr := ParseSandboxHeaders(r.Header, ParseOptions{
-		AllowLoopbackPodIP: h.cfg.AllowLoopbackPodIP,
-	})
+	upstreamPath := r.URL.Path
+	target, perr := h.resolveTarget(r, &upstreamPath)
 	if perr != nil {
 		WriteJSONError(w, perr)
 		return
@@ -153,7 +152,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Resolve once per request so the ErrorHandler can see which path
 	// produced the IP (cache vs DNS vs override) and invalidate the cache
 	// entry on dial-class failures. The Rewrite callback re-uses the URL.
-	upstreamURL, src := target0.Resolve("http", h.cfg.ClusterDomain, r.URL.Path, r.URL.RawQuery, h.cache)
+	upstreamURL, src := target0.Resolve("http", h.cfg.ClusterDomain, upstreamPath, r.URL.RawQuery, h.cache)
 	// Detect Upgrade once and reuse: the Rewrite callback uses it to
 	// decide whether to strip Origin, the timeout block below uses it
 	// to skip the per-request deadline. Same predicate, same source of
@@ -276,6 +275,27 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		defer cancel()
 	}
 	rp.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// resolveTarget parses the routing Target for r, preferring the path-based
+// form when --path-routing-prefix is configured and r.URL.Path matches it,
+// and falling through to X-Sandbox-* headers otherwise — byte-identical to
+// the header parsing this replaced when the prefix is unset (the default),
+// so header-only deployments are unaffected. On a path match, *upstreamPath
+// is rewritten to the portion of the path the upstream sandbox should
+// actually see (prefix/namespace/id/port stripped); left untouched for
+// header-routed requests, which carry no routing prefix to strip.
+func (h *Handler) resolveTarget(r *http.Request, upstreamPath *string) (Target, *Error) {
+	if h.cfg.PathRoutingPrefix != "" {
+		if target, rem, matched, perr := ParsePathRoute(h.cfg.PathRoutingPrefix, r.URL.Path); matched {
+			if perr != nil {
+				return Target{}, perr
+			}
+			*upstreamPath = rem
+			return target, nil
+		}
+	}
+	return ParseSandboxHeaders(r.Header, ParseOptions{AllowLoopbackPodIP: h.cfg.AllowLoopbackPodIP})
 }
 
 // isUpgradeRequest reports whether r is asking the server to switch

--- a/sandbox-router/proxy/proxy_integration_test.go
+++ b/sandbox-router/proxy/proxy_integration_test.go
@@ -259,58 +259,6 @@ func TestIntegration_UpstreamConnectErrorReturns502(t *testing.T) {
 	}
 }
 
-// stubLookup is a minimal Lookup for integration tests of cache wiring.
-// GetByName scans entries so tests only have to populate one map. A
-// mutex guards the maps/slices because the handler mutates them from
-// the httptest server goroutine while assertions read from the test
-// goroutine.
-type stubLookup struct {
-	mu                sync.Mutex
-	entries           map[types.UID]cache.Entry
-	invalidated       []types.UID
-	invalidatedByName []string
-}
-
-func (s *stubLookup) Get(uid types.UID) (cache.Entry, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	e, ok := s.entries[uid]
-	return e, ok
-}
-
-func (s *stubLookup) GetByName(namespace, name string) (cache.Entry, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, e := range s.entries {
-		if e.Namespace == namespace && e.SandboxName == name {
-			return e, true
-		}
-	}
-	return cache.Entry{}, false
-}
-
-func (s *stubLookup) Invalidate(uid types.UID) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	_, ok := s.entries[uid]
-	delete(s.entries, uid)
-	s.invalidated = append(s.invalidated, uid)
-	return ok
-}
-
-func (s *stubLookup) InvalidateByName(namespace, name, podIP string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.invalidatedByName = append(s.invalidatedByName, namespace+"/"+name+"="+podIP)
-	for uid, e := range s.entries {
-		if e.Namespace == namespace && e.SandboxName == name && e.PodIP == podIP {
-			delete(s.entries, uid)
-			return true
-		}
-	}
-	return false
-}
-
 // TestIntegration_CacheInvalidationOnDialError exercises the KEP-NNNN
 // active invalidation: when the proxy dials a cached IP and the dial
 // fails because the host is unreachable, the cache entry is evicted so

--- a/sandbox-router/proxy/websocket_integration_test.go
+++ b/sandbox-router/proxy/websocket_integration_test.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -28,7 +29,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/websocket"
+	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/agent-sandbox/sandbox-router/cache"
 	"sigs.k8s.io/agent-sandbox/sandbox-router/config"
 )
 
@@ -215,6 +218,98 @@ func TestIntegration_NonUpgradeStillRespectsProxyTimeout(t *testing.T) {
 	// backend's 3s hold.
 	if elapsed > 1500*time.Millisecond {
 		t.Fatalf("ProxyTimeout did not bound the request: %s elapsed", elapsed)
+	}
+}
+
+// TestIntegration_WebSocketRoundTripsViaPathRouting is the regression test
+// for the whole point of --path-routing-prefix: a caller that cannot set
+// X-Sandbox-* headers at all — a browser opening a WebSocket, which has no
+// API for custom headers on the handshake — must still be able to reach a
+// WebSocket-dependent backend (a web IDE's terminal, a dev server's HMR
+// socket) purely through the URL path. No X-Sandbox-* header is set on this
+// request; if the router fell back to header parsing it would 400 on a
+// missing X-Sandbox-Id, so a 101 here proves the path alone carried routing.
+func TestIntegration_WebSocketRoundTripsViaPathRouting(t *testing.T) {
+	backend := startEchoBackend(t)
+	defer backend.Close()
+	bu, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.PathRoutingPrefix = "/router"
+	lookup := &stubLookup{entries: map[types.UID]cache.Entry{
+		"path-routed-uid": {PodIP: bu.Hostname(), SandboxName: "ws-sandbox", Namespace: "test"},
+	}}
+	router := httptest.NewServer(NewHandler(Options{
+		Config: &cfg,
+		Cache:  lookup,
+		Logger: logr.Discard(),
+	}))
+	defer router.Close()
+
+	wsURL := strings.Replace(router.URL, "http://", "ws://", 1) +
+		fmt.Sprintf("/router/test/ws-sandbox/%s/", bu.Port())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// No X-Sandbox-* headers anywhere in this dial — the path is the only
+	// routing information present.
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		status := -1
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Fatalf("ws dial: %v (status=%d)", err, status)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("path-routed")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, got, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "path-routed" {
+		t.Fatalf("echo: got %q want %q", got, "path-routed")
+	}
+}
+
+// TestIntegration_PathRoutingFallsThroughToHeaders makes sure enabling
+// --path-routing-prefix does not disable header-based routing for requests
+// whose path does not match the prefix — the two mechanisms are additive,
+// not exclusive.
+func TestIntegration_PathRoutingFallsThroughToHeaders(t *testing.T) {
+	backend := startEchoBackend(t)
+	defer backend.Close()
+
+	cfg := config.Defaults()
+	cfg.PathRoutingPrefix = "/router"
+	cfg.AllowLoopbackPodIP = true // httptest binds to 127.0.0.1
+	router := httptest.NewServer(NewHandler(Options{
+		Config: &cfg,
+		Logger: logr.Discard(),
+	}))
+	defer router.Close()
+
+	// Header-routed dial against a path that does NOT start with the
+	// configured prefix — must still work exactly as it does with path
+	// routing disabled.
+	conn := dialThroughRouter(t, router.URL, backend.URL)
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("still-header-routed")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, got, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "still-header-routed" {
+		t.Fatalf("echo: got %q want %q", got, "still-header-routed")
 	}
 }
 


### PR DESCRIPTION
Fixes #1412

## What

Adds `--path-routing-prefix` (default `""`, disabled): an opt-in, additive routing mode
that lets a caller address a sandbox via `<prefix>/<namespace>/<id>/<port>/<rest...>` in
the request path, instead of `X-Sandbox-*` headers.

## Why

See #1412 for the full writeup. Short version: a browser cannot set custom headers on a
top-level navigation, an `<iframe>` load, or (the case that actually matters here) a
WebSocket handshake — `new WebSocket(url, protocols)` has no headers parameter, and this
is not something a Service Worker can intercept either (WebSocket handshakes are not
exposed to the `fetch` event). That makes any browser-facing tool proxied through this
router whose UI depends on a WebSocket — a web IDE's terminal (code-server), a dev
server's HMR client (Vite/webpack) — unreachable without a separate, bespoke,
WebSocket-capable header-injecting proxy standing in front of the router.

## How

- `config.Config.PathRoutingPrefix` (new field) + `--path-routing-prefix` flag +
  `Validate()` sanity check (must start with `/`, must not end with `/`).
- `proxy.ParsePathRoute(prefix, path)` (new file, `pathroute.go`): parses
  `<prefix>/<namespace>/<id>/<port>/<rest...>`, reusing the exact same `Target` type and
  the exact same validation (`validDNSLabel`, port range `[1, 65535]`) that
  `ParseSandboxHeaders` already uses — one shape for a routing target, two ways to fill
  it in. Returns `(target, upstreamPath, matched, *Error)`: `matched=false` means "this
  path isn't path-routed, fall through to headers" and is not an error; `matched=true`
  with a non-nil `*Error` means the path opted in but is malformed.
- `Handler.ServeHTTP` now calls a small `resolveTarget` helper that tries path-routing
  first (only when the prefix is configured) and falls through to
  `ParseSandboxHeaders` otherwise — byte-identical to the previous behavior when the
  flag is unset, which is the default.
- No path equivalent for `X-Sandbox-Pod-IP` / `X-Sandbox-UID` — both are trust-sensitive
  dial-target overrides for SDKs that already hold cluster-internal knowledge, never
  appropriate input from a browser tab. Path-routed requests always resolve through the
  DNS form or the namespace/name cache index, same as a header-routed request that only
  sends `X-Sandbox-ID`.
- README: new "Browser-facing traffic: path-based routing" section (linked from the
  existing WebSocket section) + flag table entry.

## Compatibility

Strictly additive. Default is disabled (`""`), and every existing test, every existing
deployment, and every request whose path doesn't match a configured prefix goes through
the exact same `ParseSandboxHeaders` call as before — I didn't touch that function or
its tests.

## Testing

- `proxy/pathroute_test.go` (new): table-driven unit tests for the parser — happy path,
  trailing-slash variants, nested remainder preservation, every validation failure mode
  mirrored from `headers_test.go`'s coverage of the header form, prefix-is-a-string-
  prefix-of-a-sibling-path (must NOT match).
- `proxy/websocket_integration_test.go`: two new integration tests —
  `TestIntegration_WebSocketRoundTripsViaPathRouting` dials a real WebSocket through the
  router with **zero** `X-Sandbox-*` headers set, purely via path, and proves a full
  frame round-trip (this is the one that actually proves the motivating case);
  `TestIntegration_PathRoutingFallsThroughToHeaders` proves enabling the prefix doesn't
  regress header-based routing for a path that doesn't match it.
- `go build ./sandbox-router/...`, `go vet ./sandbox-router/...`, `gofmt -l`, and the
  full existing test suite (`go test ./sandbox-router/...` and
  `go test -tags=integration ./sandbox-router/...`) all pass locally.

## Not in scope for this PR

- Any change to how `X-Sandbox-Pod-IP` / `X-Sandbox-UID` are handled.
- Any change to the router's default no-authentication model — happy to discuss whether
  `--authz-mode=scoped-token` should interact with path-routed requests the same way it
  already restricts `X-Sandbox-Pod-IP`/`X-Sandbox-UID`, if that's a concern; I didn't
  wire path-routing through the authorizer any differently than headers are today
  (`Authorize` still runs against the resolved `Target.Namespace`/`Target.ID`
  regardless of which input produced them).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional browser-compatible path-based routing with `--path-routing-prefix`.
  * Supports HTTP and WebSocket requests without routing headers.
  * Preserves encoded URL path content during forwarding.
  * Unmatched paths continue using header-based routing.

* **Observability**
  * Access logs, metrics, and traces now report resolved sandbox identity for path-routed requests.

* **Documentation**
  * Added configuration guidance and WebSocket routing examples.

* **Bug Fixes**
  * Corrected handling of encoded separators and resolved sandbox identity in logs and traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->