### PR TITLE
docs(sdk): point Python and Go client docs to Go sandbox-router

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -23,7 +23,7 @@ The client operates in three connectivity modes:
 
 - A running Kubernetes cluster with a valid kubeconfig (or in-cluster config). This is required even in Direct URL mode because the client creates Kubernetes clientsets for SandboxClaim lifecycle management.
 - The [**Agent Sandbox Controller**](https://github.com/kubernetes-sigs/agent-sandbox?tab=readme-ov-file#installation) installed.
-- The **Sandbox Router** deployed in the target namespace (see [sandbox-router](../../sandbox-router/README.md) and its [deployment manifests](../../sandbox-router/deploy)).
+- The **Sandbox Router** deployed in the target namespace (see [sandbox-router](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router/README.md) and its [deployment manifests](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router/deploy)). *(Note: If you are using a specific tagged release, replace `main` in these URLs with your version tag.)*
 - A `SandboxWarmPool` created in the target namespace.
 - Go 1.26+.
 

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -10,12 +10,12 @@ It supports three connectivity modes: **Gateway** (Kubernetes Gateway API), **Po
 
 ## Architecture
 
-The client operates in three modes:
+The client operates in three connectivity modes:
 
-1. **Production (Gateway Mode):** Traffic flows from the Client -> Cloud Load Balancer (Gateway)
+1. **Gateway Mode:** Traffic flows from the Client -> Cloud Load Balancer (Gateway)
    -> Router Service -> Sandbox Pod. The client watches the Gateway resource for an external IP.
-2. **Development (Port-Forward Mode):** Traffic flows from the Client -> SPDY tunnel -> Router
-   Service -> Sandbox Pod. Uses `client-go/tools/portforward` natively, no `kubectl` required.
+2. **Port-Forward Mode:** Traffic flows from the Client -> SPDY tunnel -> Router
+   Service -> Sandbox Pod. Uses `client-go/tools/portforward` natively, no `kubectl` required (ideal for local development and CI).
 3. **Advanced / Internal Mode:** The client connects directly to a provided `APIURL`, bypassing
    discovery. Useful for in-cluster agents or custom domains.
 
@@ -23,7 +23,7 @@ The client operates in three modes:
 
 - A running Kubernetes cluster with a valid kubeconfig (or in-cluster config). This is required even in Direct URL mode because the client creates Kubernetes clientsets for SandboxClaim lifecycle management.
 - The [**Agent Sandbox Controller**](https://github.com/kubernetes-sigs/agent-sandbox?tab=readme-ov-file#installation) installed.
-- The **Sandbox Router** deployed in the target namespace (`sandbox-router-svc`).
+- The **Sandbox Router** deployed in the target namespace (see [sandbox-router](../../sandbox-router/README.md) and its [deployment manifests](../../sandbox-router/deploy)).
 - A `SandboxWarmPool` created in the target namespace.
 - Go 1.26+.
 
@@ -50,7 +50,7 @@ go get sigs.k8s.io/agent-sandbox/clients/go/sandbox@latest
 
 ## Usage Examples
 
-### 1. Production Mode (Gateway)
+### 1. Gateway Mode
 
 Use this when running against a cluster with a public Gateway IP. The client automatically
 discovers the Gateway address.
@@ -71,7 +71,7 @@ if err != nil { log.Fatal(err) }
 fmt.Println(result.Stdout)
 ```
 
-### 2. Developer Mode (Port-Forward)
+### 2. Port-Forward Mode
 
 Use this for local development or CI. If you omit `GatewayName` and `APIURL`, the client
 automatically establishes an SPDY port-forward tunnel to the Router Service.

--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -16,7 +16,7 @@ The client operates in three connectivity modes:
    -> Router Service -> Sandbox Pod. The client watches the Gateway resource for an external IP.
 2. **Port-Forward Mode:** Traffic flows from the Client -> SPDY tunnel -> Router
    Service -> Sandbox Pod. Uses `client-go/tools/portforward` natively, no `kubectl` required (ideal for local development and CI).
-3. **Advanced / Internal Mode:** The client connects directly to a provided `APIURL`, bypassing
+3. **Direct URL Mode:** The client connects directly to a provided `APIURL`, bypassing
    discovery. Useful for in-cluster agents or custom domains.
 
 ## Prerequisites
@@ -89,7 +89,7 @@ if err != nil { log.Fatal(err) }
 fmt.Println(result.Stdout)
 ```
 
-### 3. Advanced / Internal Mode
+### 3. Direct URL Mode
 
 Use `APIURL` to bypass discovery entirely. Useful for:
 

--- a/clients/go/sandbox/integration_test.go
+++ b/clients/go/sandbox/integration_test.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	warmPoolName     = flag.String("warmpool-name", "python-sandbox-warmpool", "SandboxWarmPool name")
-	gatewayName      = flag.String("gateway-name", "", "Gateway name for production mode")
+	gatewayName      = flag.String("gateway-name", "", "Gateway name for Gateway mode")
 	gatewayNamespace = flag.String("gateway-namespace", "", "Gateway namespace (defaults to --namespace)")
 	apiURL           = flag.String("api-url", "", "Direct API URL")
 	namespace        = flag.String("namespace", "default", "Kubernetes namespace")

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -97,7 +97,7 @@ type Options struct {
 	// from the Gateway's address. Default: "http".
 	GatewayScheme string
 
-	// APIURL enables direct connection mode. The client connects directly to this URL,
+	// APIURL enables Direct URL mode. The client connects directly to this URL,
 	// bypassing gateway discovery. Takes precedence over GatewayName.
 	APIURL string
 

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -84,7 +84,7 @@ type Options struct {
 	// Must be a valid Kubernetes DNS label (lowercase, [a-z0-9-]).
 	Namespace string
 
-	// GatewayName enables production mode. The client watches this Gateway resource
+	// GatewayName enables Gateway mode. The client watches this Gateway resource
 	// for an external IP, then routes through the sandbox-router.
 	// Must be a valid Kubernetes DNS subdomain (lowercase, [a-z0-9.-]).
 	GatewayName string
@@ -97,7 +97,7 @@ type Options struct {
 	// from the Gateway's address. Default: "http".
 	GatewayScheme string
 
-	// APIURL enables advanced mode. The client connects directly to this URL,
+	// APIURL enables direct connection mode. The client connects directly to this URL,
 	// bypassing gateway discovery. Takes precedence over GatewayName.
 	APIURL string
 

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -5,16 +5,16 @@ sandboxes managed by the Agent Sandbox controller. It's designed to be used as a
 ensuring that sandbox resources are properly created and cleaned up.
 
 It supports a **scalable, cloud-native architecture** using Kubernetes Gateways and a specialized
-Router, while maintaining a convenient **Developer Mode** for local testing.
+Router, while maintaining a convenient **Tunnel Mode** for local testing.
 
 ## Architecture
 
-The client operates in four modes:
+The client operates in four connectivity modes:
 
-1.  **Production (Gateway Mode):** Traffic flows from the Client -> Cloud Load Balancer (Gateway)
-    -> Router Service -> Sandbox Pod. This supports high-scale deployments.
-2.  **Development (Tunnel Mode):** Traffic flows from Localhost -> `kubectl port-forward` -> Router
-    Service -> Sandbox Pod. This requires no public IP and works on Kind/Minikube.
+1.  **Gateway Mode:** Traffic flows from the Client -> Cloud Load Balancer (Gateway)
+    -> Router Service -> Sandbox Pod. This supports external ingress via Gateway API.
+2.  **Tunnel Mode:** Traffic flows from Localhost -> `kubectl port-forward` -> Router
+    Service -> Sandbox Pod. This requires no public IP and works on Kind/Minikube for local development.
 3.  **In-Cluster Mode:** The client connects **directly to the sandbox pod** (via pod IP or cluster
     DNS), bypassing the router. Intended for workloads running inside the cluster.
 4.  **Advanced / Internal Mode:** The client connects directly to a provided `api_url`, bypassing
@@ -28,12 +28,11 @@ The client operates in four modes:
 
 ## Setup: Deploying the Router
 
-Before using the client, you must deploy the `sandbox-router`. This is a one-time setup.
+Before using the client in Gateway Mode or Tunnel Mode, deploy the `sandbox-router` into your cluster.
 
-1.  **Build and Push the Router Image:**
+1.  **Deploy the Router:**
 
-    For both Gateway Mode and Tunnel Mode, follow the instructions in [sandbox-router](sandbox-router/README.md)
-    to build, push, and apply the router image and resources.
+    Follow the instructions in [sandbox-router](../../../sandbox-router/README.md) to deploy the router using the manifests in [sandbox-router/deploy](../../../sandbox-router/deploy).
 
 2.  **Create a Sandbox Warmpool:**
 
@@ -108,7 +107,7 @@ Before using the client, you must deploy the `sandbox-router`. This is a one-tim
 
 ## Usage Examples
 
-### 1. Production Mode (GKE Gateway)
+### 1. Gateway Mode (GKE Gateway)
 
 Use this when running against a real cluster with a public Gateway IP. The client automatically
 discovers the Gateway.
@@ -131,7 +130,7 @@ finally:
     sandbox.terminate()
 ```
 
-### 2. Developer Mode (Local Tunnel)
+### 2. Tunnel Mode (Local Port-Forward)
 
 Use this for local development or CI. The client automatically opens a secure tunnel to the
 Router Service using `kubectl`.
@@ -371,13 +370,13 @@ Latency guidance:
 
 A test script is included to verify the full lifecycle (Creation -> Execution -> File I/O -> Cleanup).
 
-### Run in Dev Mode:
+### Run in Tunnel Mode:
 
 ```bash
 python test_client.py --namespace default
 ```
 
-### Run in Production Mode:
+### Run in Gateway Mode:
 
 ```bash
 python test_client.py --gateway-name external-http-gateway

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -32,7 +32,7 @@ Before using the client in Gateway Mode or Tunnel Mode, deploy the `sandbox-rout
 
 1.  **Deploy the Router:**
 
-    Follow the instructions in [sandbox-router](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router) to deploy the router using the manifests in [sandbox-router/deploy](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router/deploy).
+    Follow the instructions in [sandbox-router](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router) to deploy the router using the manifests in [sandbox-router/deploy](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router/deploy). *(Note: If you installed a specific client release tag, replace `main` in these URLs with the corresponding tag.)*
 
 2.  **Create a Sandbox Warmpool:**
 

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -17,7 +17,7 @@ The client operates in four connectivity modes:
     Service -> Sandbox Pod. This requires no public IP and works on Kind/Minikube for local development.
 3.  **In-Cluster Mode:** The client connects **directly to the sandbox pod** (via pod IP or cluster
     DNS), bypassing the router. Intended for workloads running inside the cluster.
-4.  **Advanced / Internal Mode:** The client connects directly to a provided `api_url`, bypassing
+4.  **Direct URL Mode:** The client connects directly to a provided `api_url`, bypassing
     discovery. This is useful when connecting through a custom domain or a manually specified router URL.
 
 ## Prerequisites
@@ -32,12 +32,12 @@ Before using the client in Gateway Mode or Tunnel Mode, deploy the `sandbox-rout
 
 1.  **Deploy the Router:**
 
-    Follow the instructions in [sandbox-router](../../../sandbox-router/README.md) to deploy the router using the manifests in [sandbox-router/deploy](../../../sandbox-router/deploy).
+    Follow the instructions in [sandbox-router](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router) to deploy the router using the manifests in [sandbox-router/deploy](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/sandbox-router/deploy).
 
 2.  **Create a Sandbox Warmpool:**
 
     Ensure a `SandboxWarmPool` exists in your target namespace. The test_client.py
-    uses the [python-runtime-sandbox](../../../examples/python-runtime-sandbox/) image.
+    uses the [python-runtime-sandbox](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/examples/python-runtime-sandbox) image.
 
     ```bash
     kubectl apply -f python-sandbox-warmpool.yaml
@@ -176,7 +176,7 @@ finally:
     sandbox.terminate()
 ```
 
-### 4. Advanced / Internal Mode
+### 4. Direct URL Mode
 
 Use `SandboxDirectConnectionConfig` to bypass discovery entirely. Useful for:
 

--- a/clients/python/agentic-sandbox-client/sandbox-router/README.md
+++ b/clients/python/agentic-sandbox-client/sandbox-router/README.md
@@ -1,6 +1,6 @@
 # Sandbox Router (Python Reference Implementation)
 
-> **Note:** A production-ready [Go Sandbox Router](../../../../sandbox-router/README.md) is now the recommended deployment. It is a drop-in replacement that preserves the same HTTP header contract and adds TLS, metrics, tracing, retries, and graceful shutdown. This Python implementation is retained for reference until its deprecation is formalized.
+> **Note:** The [Go Sandbox Router](../../../../sandbox-router/README.md) is now the recommended deployment. It is a drop-in replacement that preserves the same HTTP header contract and adds TLS, metrics, tracing, retries, and graceful shutdown. This Python implementation is retained for reference until its deprecation is formalized.
 
 The Sandbox Router is a lightweight, asynchronous reverse proxy designed to provide scalable and
 dynamic access to thousands of ephemeral agent sandboxes running in a Kubernetes cluster. It acts as

--- a/clients/python/agentic-sandbox-client/sandbox-router/README.md
+++ b/clients/python/agentic-sandbox-client/sandbox-router/README.md
@@ -1,4 +1,6 @@
-# Sandbox Router
+# Sandbox Router (Python Reference Implementation)
+
+> **Note:** A production-ready [Go Sandbox Router](../../../../sandbox-router/README.md) is now the recommended deployment. It is a drop-in replacement that preserves the same HTTP header contract and adds TLS, metrics, tracing, retries, and graceful shutdown. This Python implementation is retained for reference until its deprecation is formalized.
 
 The Sandbox Router is a lightweight, asynchronous reverse proxy designed to provide scalable and
 dynamic access to thousands of ephemeral agent sandboxes running in a Kubernetes cluster. It acts as

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -549,7 +549,7 @@ type Options struct {
     // Must be a valid Kubernetes DNS label (lowercase, [a-z0-9-]).
     Namespace string
 
-    // GatewayName enables production mode. The client watches this Gateway resource
+    // GatewayName enables Gateway mode. The client watches this Gateway resource
     // for an external IP, then routes through the sandbox-router.
     // Must be a valid Kubernetes DNS subdomain (lowercase, [a-z0-9.-]).
     GatewayName string
@@ -562,7 +562,7 @@ type Options struct {
     // from the Gateway's address. Default: "http".
     GatewayScheme string
 
-    // APIURL enables advanced mode. The client connects directly to this URL,
+    // APIURL enables direct connection mode. The client connects directly to this URL,
     // bypassing gateway discovery. Takes precedence over GatewayName.
     APIURL string
 

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -562,7 +562,7 @@ type Options struct {
     // from the Gateway's address. Default: "http".
     GatewayScheme string
 
-    // APIURL enables direct connection mode. The client connects directly to this URL,
+    // APIURL enables Direct URL mode. The client connects directly to this URL,
     // bypassing gateway discovery. Takes precedence over GatewayName.
     APIURL string
 

--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -189,7 +189,12 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
 1.  **Deploy the Router (Required for All Modes):**
     ```bash
     # Deploys the Deployment and Service
-    kubectl apply -f ../../sandbox-router/deploy/
+    kubectl apply -f ../../sandbox-router/deploy/serviceaccount.yaml \
+      -f ../../sandbox-router/deploy/rbac.yaml \
+      -f ../../sandbox-router/deploy/deployment.yaml \
+      -f ../../sandbox-router/deploy/service.yaml \
+      -f ../../sandbox-router/deploy/pdb.yaml \
+      -f ../../sandbox-router/deploy/networkpolicy.yaml
     ```
 
 2.  **Deploy the Gateway (Production Only):**

--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -196,7 +196,7 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
     If you need external access via a Public IP (GKE), apply the Gateway configuration.
     ```bash
     # Deploys Gateway, HTTPRoute, and HealthCheckPolicy
-    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/gateway.yaml
+    kubectl apply -f ../../sandbox-router/deploy/examples/gateway-gke.yaml
     ```
 
 **Via Gateway**

--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -188,13 +188,11 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
 
 1.  **Deploy the Router (Required for All Modes):**
     ```bash
-    # Deploys the Deployment and Service
+    # Deploys the Deployment, Service, ServiceAccount, and RBAC
     kubectl apply -f ../../sandbox-router/deploy/serviceaccount.yaml \
       -f ../../sandbox-router/deploy/rbac.yaml \
       -f ../../sandbox-router/deploy/deployment.yaml \
-      -f ../../sandbox-router/deploy/service.yaml \
-      -f ../../sandbox-router/deploy/pdb.yaml \
-      -f ../../sandbox-router/deploy/networkpolicy.yaml
+      -f ../../sandbox-router/deploy/service.yaml
     ```
 
 2.  **Deploy the Gateway (Production Only):**

--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -189,7 +189,7 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
 1.  **Deploy the Router (Required for All Modes):**
     ```bash
     # Deploys the Deployment and Service
-    kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml
+    kubectl apply -f ../../sandbox-router/deploy/
     ```
 
 2.  **Deploy the Gateway (Production Only):**

--- a/examples/vscode-sandbox/README.md
+++ b/examples/vscode-sandbox/README.md
@@ -199,7 +199,7 @@ If you are using gVisor or Kata Containers, direct pod port-forwarding isn't com
     kubectl apply -f ../../clients/python/agentic-sandbox-client/sandbox-router/gateway.yaml
     ```
 
-**For Production (via Gateway)**
+**Via Gateway**
 
 1. Get the Gateway IP:
 ```bash
@@ -225,7 +225,7 @@ curl -v -H "X-Sandbox-ID: sandbox-example" \
 
     You should see the VSCode interface load immediately.
 
-**For Local Development (via Router Tunnel)**
+**Via Router Port-Forward Tunnel**
 
 For local development, port-forward to the **Router Service** (do not port-forward to the pod directly, as it's not compatible with secure runtimes like gVisor/kata).
 

--- a/sandbox-router/deploy/README.md
+++ b/sandbox-router/deploy/README.md
@@ -13,11 +13,16 @@ Drop-in starting point for running the Go sandbox-router in Kubernetes. These ma
 | `service.yaml` | Cluster-IP service named `sandbox-router-svc` (preserves the Python router's name — existing Gateway/HTTPRoute resources work unchanged). |
 | `pdb.yaml` | Prevents voluntary disruptions from taking the whole fleet offline. |
 | `networkpolicy.yaml` | Locks down ingress to proxy/metrics/probe ports; egress to DNS, sandbox port, OTel collector. **Tighten the selectors for your tenancy model.** |
+| `examples/gateway-gke.yaml` | Optional GKE Gateway, HTTPRoute, and HealthCheckPolicy for external ingress in front of `sandbox-router-svc`. |
 
 ## Apply
 
 ```sh
+# Core router components
 kubectl apply -f sandbox-router/deploy/
+
+# Optional: GKE Gateway API ingress
+kubectl apply -f sandbox-router/deploy/examples/gateway-gke.yaml
 ```
 
 ## Things to change before production

--- a/sandbox-router/deploy/README.md
+++ b/sandbox-router/deploy/README.md
@@ -21,7 +21,9 @@ Drop-in starting point for running the Go sandbox-router in Kubernetes. These ma
 # Core router components
 kubectl apply -f sandbox-router/deploy/
 
-# Optional: GKE Gateway API ingress
+# Optional: GKE Gateway API ingress.
+# Note: GKE Standard clusters require Gateway API to be explicitly enabled
+# using --gateway-api=standard. GKE Autopilot enables it by default.
 kubectl apply -f sandbox-router/deploy/examples/gateway-gke.yaml
 ```
 

--- a/sandbox-router/deploy/examples/gateway-gke.yaml
+++ b/sandbox-router/deploy/examples/gateway-gke.yaml
@@ -1,0 +1,51 @@
+# A Gateway to create an endpoint for external HTTP traffic on GKE.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-http-gateway
+  namespace: default
+spec:
+  gatewayClassName: gke-l7-global-external-managed # Specific to GKE; creates all necessary GatewayClass resources; choose a different gateway class to use other Gateway implementations
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+# The HTTPRoute to connect the Gateway to the router service.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: sandbox-router-route
+  namespace: default
+spec:
+  parentRefs:
+  - name: external-http-gateway # This must match the name of the Gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: sandbox-router-svc # Route all traffic to the router service
+      port: 8080
+---
+# HealthCheckPolicy tells the GKE Gateway to use the router app "/healthz" endpoint for its health
+# checks instead of the default "/".
+apiVersion: networking.gke.io/v1 # Specific to GKE
+kind: HealthCheckPolicy
+metadata:
+  name: router-health-check-policy
+  namespace: default
+spec:
+  targetRef:
+    group: ""
+    kind: Service
+    name: sandbox-router-svc # This must match the name of the router's service
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz # Tell the health checker to use this path

--- a/sandbox-router/deploy/examples/gateway-gke.yaml
+++ b/sandbox-router/deploy/examples/gateway-gke.yaml
@@ -1,4 +1,7 @@
 # A Gateway to create an endpoint for external HTTP traffic on GKE.
+# Note: This example uses `namespace: default` and limits routes to the `Same` namespace.
+# The sandbox-router Service must either be in this same namespace, or you must
+# configure cross-namespace Gateway API wiring (e.g. ReferenceGrant).
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/test/e2e/clients/python/test_e2e_python_sdk.py
+++ b/test/e2e/clients/python/test_e2e_python_sdk.py
@@ -255,7 +255,7 @@ def test_python_sdk_router_mode_warmpool(
 def test_python_sdk_gateway_mode(
     tc, temp_namespace, sandbox_template, deploy_router, deploy_gateway, sandbox_coldpool
 ):
-    """Tests the Python SDK in Production mode (with Gateway and Router) without warmpool."""
+    """Tests the Python SDK in Gateway mode (with Gateway and Router) without warmpool."""
     config = SandboxGatewayConnectionConfig(
         gateway_name=GATEWAY_NAME,
         gateway_namespace=temp_namespace,
@@ -284,7 +284,7 @@ def test_python_sdk_gateway_mode_warmpool(
     sandbox_warmpool,
     deploy_gateway,
 ):
-    """Tests the Python SDK in Production mode (with gateway and router) with warmpool."""
+    """Tests the Python SDK in Gateway mode (with gateway and router) with warmpool."""
     config = SandboxGatewayConnectionConfig(
         gateway_name=GATEWAY_NAME,
         gateway_namespace=temp_namespace,


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates both Python and Go SDK client READMEs to point to the canonical Go sandbox router in `sandbox-router/` and its deployment manifests in `sandbox-router/deploy/`.

Also clarifies the connectivity mode naming across the docs (`Gateway Mode`, `Tunnel Mode` / `Port-Forward Mode`, `In-Cluster Mode`) to avoid confusing network topologies with component maturity.

#### Which issue(s) this PR is related to:
Ref #1058

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized connectivity-mode terminology across Go and Python SDK documentation.
  * Clarified Gateway, Port-Forward, Tunnel, and Direct URL usage scenarios.
  * Expanded architecture, local development, CI, and secure-access guidance.
  * Updated Sandbox Router setup instructions, references, and usage headings.
  * Updated SDK option reference documentation and related testing descriptions.

* **New Features**
  * Added an optional GKE Gateway configuration for exposing Sandbox Router traffic with health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->