### PR TITLE
Examples/sandboxd sdk quickstart

### DIFF
--- a/examples/sandboxd-sandbox/client/README.md
+++ b/examples/sandboxd-sandbox/client/README.md
@@ -1,0 +1,57 @@
+# sandboxd SDK example (Go)
+
+A minimal end-to-end program that uses the Go SDK against the **sandboxd**
+runtime. It:
+
+1. creates a sandbox from a warm pool,
+2. writes a file into `/workspace` over the REST filesystem,
+3. execs a command over the gRPC `ProcessService`,
+4. reads the file back and prints the command output,
+
+then deletes the sandbox on exit.
+
+## Prerequisites
+
+- A Kubernetes cluster you can reach with `kubectl` (a `kind` cluster is fine).
+- A sandboxd-backed `SandboxTemplate` **and** `SandboxWarmPool` applied to the
+  cluster. Use [`../sandbox-template.yaml`](../sandbox-template.yaml) as the
+  template (it runs the `sandboxd` image), and create a `SandboxWarmPool` that
+  references it.
+- Your kubeconfig must allow **port-forward to pods** in the target namespace —
+  the SDK reaches sandboxd via a pod port-forward.
+
+## Run
+
+```console
+$ go run ./examples/sandboxd-sandbox/client \
+    -warmpool sandboxd-warmpool \
+    -namespace default
+```
+
+Flags:
+
+| flag | default | description |
+|------|---------|-------------|
+| `-warmpool`  | `sandboxd-warmpool` | SandboxWarmPool to claim from |
+| `-namespace` | `default`           | Namespace of the warm pool / sandbox |
+| `-file`      | `greeting.txt`      | Path (relative to `/workspace`) to write and read back |
+| `-content`   | `hello from …`      | Content to write |
+
+## Expected output
+
+```
+created sandbox "sandboxd-xxxxx" (claim "sandboxd-warmpool-xxxxx")
+wrote 36 bytes to greeting.txt
+run: exit=0
+stdout: hello from the sandboxd SDK example
+read back 36 bytes, content matches
+```
+
+## Notes
+
+- Commands run through `ProcessService` execute **inside the `sandboxd`
+  container**, with `/workspace` as the working directory. Files written over
+  REST land in that same shared volume, which is why `cat greeting.txt` sees the
+  file the SDK just wrote.
+- The base `sandboxd` image ships a minimal (busybox) toolset. To run a language
+  runtime (e.g. `python3`), build a sandboxd image that includes it.

--- a/examples/sandboxd-sandbox/client/README.md
+++ b/examples/sandboxd-sandbox/client/README.md
@@ -36,11 +36,12 @@ Flags:
 | `-namespace` | `default`           | Namespace of the warm pool / sandbox |
 | `-file`      | `greeting.txt`      | Path (relative to `/workspace`) to write and read back |
 | `-content`   | `hello from …`      | Content to write |
+| `-cmd`       | *(empty)*           | Optional extra command to exec — e.g. `'npm --version'` to [verify which deployment topology you're on](../deploy/README.md#verify-which-topology-you-have) |
 
 ## Expected output
 
 ```
-created sandbox "sandboxd-xxxxx" (claim "sandboxd-warmpool-xxxxx")
+created sandbox "sandboxd-warmpool-xxxxx" (claim "sandbox-claim-xxxxx")
 wrote 36 bytes to greeting.txt
 run: exit=0
 stdout: hello from the sandboxd SDK example
@@ -49,9 +50,12 @@ read back 36 bytes, content matches
 
 ## Notes
 
-- Commands run through `ProcessService` execute **inside the `sandboxd`
-  container**, with `/workspace` as the working directory. Files written over
-  REST land in that same shared volume, which is why `cat greeting.txt` sees the
-  file the SDK just wrote.
-- The base `sandboxd` image ships a minimal (busybox) toolset. To run a language
-  runtime (e.g. `python3`), build a sandboxd image that includes it.
+- Commands run through `ProcessService` execute **inside the container running
+  `sandboxd`** (see [deployment topologies](../deploy/README.md)), with
+  `/workspace` as the working directory. Files written over REST land in that
+  same volume, which is why `cat greeting.txt` sees the file the SDK just
+  wrote.
+- The base `sandboxd` image (`debian:bookworm-slim`) ships a shell and
+  coreutils but no language runtimes. To run one (e.g. `python3`), build a
+  sandboxd image that includes it, or use the binary-injection topology
+  (`../deploy/b-inject-binary.yaml`).

--- a/examples/sandboxd-sandbox/client/README.md
+++ b/examples/sandboxd-sandbox/client/README.md
@@ -14,9 +14,9 @@ then deletes the sandbox on exit.
 
 - A Kubernetes cluster you can reach with `kubectl` (a `kind` cluster is fine).
 - A sandboxd-backed `SandboxTemplate` **and** `SandboxWarmPool` applied to the
-  cluster. Use [`../sandbox-template.yaml`](../sandbox-template.yaml) as the
-  template (it runs the `sandboxd` image), and create a `SandboxWarmPool` that
-  references it.
+  cluster. Apply one of the ready-to-use deployment topologies in
+  [`../deploy/`](../deploy/) — each file defines both the template and a
+  `sandboxd-warmpool` (see its README for choosing between them).
 - Your kubeconfig must allow **port-forward to pods** in the target namespace —
   the SDK reaches sandboxd via a pod port-forward.
 

--- a/examples/sandboxd-sandbox/client/main.go
+++ b/examples/sandboxd-sandbox/client/main.go
@@ -48,14 +48,15 @@ func main() {
 	namespace := flag.String("namespace", "default", "Namespace of the warm pool / sandbox.")
 	path := flag.String("file", "greeting.txt", "File path (relative to /workspace) to write and read back.")
 	content := flag.String("content", "hello from the sandboxd SDK example\n", "Content to write to the file.")
+	extraCmd := flag.String("cmd", "", "Optional extra command to exec in the sandbox (e.g. 'npm --version' to check which topology you're on).")
 	flag.Parse()
 
-	if err := run(*warmPool, *namespace, *path, *content); err != nil {
+	if err := run(*warmPool, *namespace, *path, *content, *extraCmd); err != nil {
 		log.Fatalf("example failed: %v", err)
 	}
 }
 
-func run(warmPool, namespace, path, content string) error {
+func run(warmPool, namespace, path, content, extraCmd string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -89,13 +90,28 @@ func run(warmPool, namespace, path, content string) error {
 	fmt.Printf("wrote %d bytes to %s\n", len(content), path)
 
 	// 3. Exec a command over the gRPC ProcessService and grab its output.
-	result, err := sb.Run(ctx, "cat "+path)
+	// Run passes the command through `sh -c`, so quote anything interpolated.
+	result, err := sb.Run(ctx, fmt.Sprintf("cat %q", path))
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
 	fmt.Printf("run: exit=%d\nstdout: %s", result.ExitCode, result.Stdout)
 	if result.Stderr != "" {
 		fmt.Printf("stderr: %s", result.Stderr)
+	}
+
+	// 3b. Optionally exec an extra command — handy for checking which
+	// topology you're on (e.g. -cmd 'npm --version' succeeds under the
+	// binary-injection topology, fails in the base runtime image).
+	if extraCmd != "" {
+		extra, err := sb.Run(ctx, extraCmd)
+		if err != nil {
+			return fmt.Errorf("run %q: %w", extraCmd, err)
+		}
+		fmt.Printf("cmd %q: exit=%d\nstdout: %s", extraCmd, extra.ExitCode, extra.Stdout)
+		if extra.Stderr != "" {
+			fmt.Printf("stderr: %s", extra.Stderr)
+		}
 	}
 
 	// 4. Read the file back over REST to confirm the round trip.

--- a/examples/sandboxd-sandbox/client/main.go
+++ b/examples/sandboxd-sandbox/client/main.go
@@ -76,9 +76,13 @@ func run(warmPool, namespace, path, content, extraCmd string) error {
 	}
 	fmt.Printf("created sandbox %q (claim %q)\n", sb.SandboxName(), sb.ClaimName())
 
-	// Always tear the sandbox down on exit so the example leaves nothing behind.
+	// Always tear the sandbox down on exit so the example leaves nothing
+	// behind. Cleanup is detached from ctx (which may already be cancelled)
+	// but bounded so a stalled deletion cannot block process exit forever.
 	defer func() {
-		if err := client.DeleteSandbox(context.Background(), sb.ClaimName(), namespace); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		if err := client.DeleteSandbox(cleanupCtx, sb.ClaimName(), namespace); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to delete sandbox %q: %v\n", sb.ClaimName(), err)
 		}
 	}()
@@ -94,6 +98,12 @@ func run(warmPool, namespace, path, content, extraCmd string) error {
 	result, err := sb.Run(ctx, fmt.Sprintf("cat %q", path))
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("cat %q exited with code %d: %s", path, result.ExitCode, result.Stderr)
+	}
+	if result.Stdout != content {
+		return fmt.Errorf("command output mismatch: got %q, want %q", result.Stdout, content)
 	}
 	fmt.Printf("run: exit=%d\nstdout: %s", result.ExitCode, result.Stdout)
 	if result.Stderr != "" {

--- a/examples/sandboxd-sandbox/client/main.go
+++ b/examples/sandboxd-sandbox/client/main.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end example of the Go SDK talking to the sandboxd runtime.
+//
+// It exercises the full round trip against a sandboxd-backed sandbox:
+//
+//  1. create a sandbox from a warm pool,
+//  2. write a file into /workspace over the REST filesystem,
+//  3. exec a command over the gRPC ProcessService,
+//  4. read the file back and print the command output.
+//
+// Prerequisites: a cluster with a sandboxd SandboxTemplate + SandboxWarmPool
+// applied (see ../sandbox-template.yaml and the README in this directory).
+// The SDK reaches sandboxd via a pod port-forward, so your kubeconfig must
+// be able to port-forward to pods in the target namespace.
+//
+// Usage:
+//
+//	go run ./examples/sandboxd-sandbox/client \
+//	    -warmpool sandboxd-warmpool -namespace default
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+func main() {
+	warmPool := flag.String("warmpool", "sandboxd-warmpool", "SandboxWarmPool to claim a sandbox from.")
+	namespace := flag.String("namespace", "default", "Namespace of the warm pool / sandbox.")
+	path := flag.String("file", "greeting.txt", "File path (relative to /workspace) to write and read back.")
+	content := flag.String("content", "hello from the sandboxd SDK example\n", "Content to write to the file.")
+	flag.Parse()
+
+	if err := run(*warmPool, *namespace, *path, *content); err != nil {
+		log.Fatalf("example failed: %v", err)
+	}
+}
+
+func run(warmPool, namespace, path, content string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Select the sandboxd runtime. RestConfig is left nil so the SDK loads the
+	// default kubeconfig (or in-cluster config when running inside a pod).
+	client, err := sandbox.NewClient(ctx, sandbox.Options{
+		Runtime: sandbox.RuntimeSandboxd,
+	})
+	if err != nil {
+		return fmt.Errorf("new client: %w", err)
+	}
+
+	// 1. Create (claim) a sandbox. The returned handle is already connected.
+	sb, err := client.CreateSandbox(ctx, warmPool, namespace)
+	if err != nil {
+		return fmt.Errorf("create sandbox: %w", err)
+	}
+	fmt.Printf("created sandbox %q (claim %q)\n", sb.SandboxName(), sb.ClaimName())
+
+	// Always tear the sandbox down on exit so the example leaves nothing behind.
+	defer func() {
+		if err := client.DeleteSandbox(context.Background(), sb.ClaimName(), namespace); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to delete sandbox %q: %v\n", sb.ClaimName(), err)
+		}
+	}()
+
+	// 2. Write a file into /workspace over the REST filesystem.
+	if err := sb.Write(ctx, path, []byte(content)); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+	fmt.Printf("wrote %d bytes to %s\n", len(content), path)
+
+	// 3. Exec a command over the gRPC ProcessService and grab its output.
+	result, err := sb.Run(ctx, "cat "+path)
+	if err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+	fmt.Printf("run: exit=%d\nstdout: %s", result.ExitCode, result.Stdout)
+	if result.Stderr != "" {
+		fmt.Printf("stderr: %s", result.Stderr)
+	}
+
+	// 4. Read the file back over REST to confirm the round trip.
+	got, err := sb.Read(ctx, path)
+	if err != nil {
+		return fmt.Errorf("read %q: %w", path, err)
+	}
+	if string(got) != content {
+		return fmt.Errorf("round-trip mismatch: wrote %q, read %q", content, got)
+	}
+	fmt.Printf("read back %d bytes, content matches\n", len(got))
+
+	return nil
+}

--- a/examples/sandboxd-sandbox/client/main.go
+++ b/examples/sandboxd-sandbox/client/main.go
@@ -38,6 +38,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/agent-sandbox/clients/go/sandbox"
@@ -94,8 +95,10 @@ func run(warmPool, namespace, path, content, extraCmd string) error {
 	fmt.Printf("wrote %d bytes to %s\n", len(content), path)
 
 	// 3. Exec a command over the gRPC ProcessService and grab its output.
-	// Run passes the command through `sh -c`, so quote anything interpolated.
-	result, err := sb.Run(ctx, fmt.Sprintf("cat %q", path))
+	// Run passes the command through `sh -c`, so single-quote the path
+	// (escaping embedded single quotes) to prevent shell expansion.
+	quotedPath := "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+	result, err := sb.Run(ctx, "cat "+quotedPath)
 	if err != nil {
 		return fmt.Errorf("run: %w", err)
 	}
@@ -105,10 +108,9 @@ func run(warmPool, namespace, path, content, extraCmd string) error {
 	if result.Stdout != content {
 		return fmt.Errorf("command output mismatch: got %q, want %q", result.Stdout, content)
 	}
-	fmt.Printf("run: exit=%d\nstdout: %s", result.ExitCode, result.Stdout)
-	if result.Stderr != "" {
-		fmt.Printf("stderr: %s", result.Stderr)
-	}
+	fmt.Printf("run: exit=%d\n", result.ExitCode)
+	printStream("stdout", result.Stdout)
+	printStream("stderr", result.Stderr)
 
 	// 3b. Optionally exec an extra command — handy for checking which
 	// topology you're on (e.g. -cmd 'npm --version' succeeds under the
@@ -118,10 +120,9 @@ func run(warmPool, namespace, path, content, extraCmd string) error {
 		if err != nil {
 			return fmt.Errorf("run %q: %w", extraCmd, err)
 		}
-		fmt.Printf("cmd %q: exit=%d\nstdout: %s", extraCmd, extra.ExitCode, extra.Stdout)
-		if extra.Stderr != "" {
-			fmt.Printf("stderr: %s", extra.Stderr)
-		}
+		fmt.Printf("cmd %q: exit=%d\n", extraCmd, extra.ExitCode)
+		printStream("stdout", extra.Stdout)
+		printStream("stderr", extra.Stderr)
 	}
 
 	// 4. Read the file back over REST to confirm the round trip.
@@ -135,4 +136,16 @@ func run(warmPool, namespace, path, content, extraCmd string) error {
 	fmt.Printf("read back %d bytes, content matches\n", len(got))
 
 	return nil
+}
+
+// printStream prints a labeled output stream, skipping empty streams and
+// ensuring a trailing newline so following lines never concatenate onto it.
+func printStream(label, s string) {
+	if s == "" {
+		return
+	}
+	if !strings.HasSuffix(s, "\n") {
+		s += "\n"
+	}
+	fmt.Printf("%s: %s", label, s)
 }

--- a/examples/sandboxd-sandbox/deploy/README.md
+++ b/examples/sandboxd-sandbox/deploy/README.md
@@ -1,0 +1,64 @@
+# Deploying sandboxd: two topologies
+
+The SDK talks to sandboxd the same way regardless of how it's deployed — but
+**where the sandboxd process runs decides where your commands execute and which
+binaries are available.**
+
+## Mental model (read this first)
+
+- A **shared volume** (`/workspace`) shares *files/bytes* between containers.
+- It does **not** share *binaries* — each container has its own root filesystem
+  (its own overlayfs). `python3`, `npm`, and the dynamic linker come from a
+  container's **image**, not from the volume.
+- `ProcessService.Execute` runs a command in **whatever container the sandboxd
+  process lives in**. So the tools your agent invokes must exist in *that*
+  container's image.
+
+That single fact is why there are two topologies.
+
+## The two options
+
+| | **A — runtime image** (default) | **B — inject binary** (no-rebuild) |
+|---|---|---|
+| File | [`a-runtime-image.yaml`](a-runtime-image.yaml) | [`b-inject-binary.yaml`](b-inject-binary.yaml) |
+| Where sandboxd runs | dedicated `sandboxd` container | inside your existing app container |
+| Commands execute in | the sandboxd image | your app image |
+| Tools (npm, python…) come from | the sandboxd image (bake them in) | your app image (already there) |
+| Needs an image rebuild? | yes — `FROM sandboxd` + your tools | **no** |
+| Isolation | stronger (locked-down runtime) | weaker (full app image) |
+| Use when | you can build/control the runtime image | you must reuse an existing image untouched |
+
+**Recommendation:** use **A** by default — it's the isolation-first model. Reach
+for **B** only when you can't rebuild the execution image.
+
+### A — runtime image (default)
+sandboxd is a dedicated container and *is* the execution environment. To give the
+agent tools, build your own image `FROM` the sandboxd image and add them. Untrusted
+code runs in that controlled image, not your application.
+
+### B — inject the binary (no rebuild)
+An initContainer copies the sandboxd **binary** into a shared volume, and your
+existing, tool-rich app image runs it as its command. Because sandboxd now runs
+inside the app image's filesystem, `npm install` finds `npm` there — with **no
+change to the app image**. Trade-off: agent code runs in your full app image, and
+sandboxd runs as the container's main process (PID 1).
+
+## Try it
+
+Apply **one** of the two (both define a `sandboxd-warmpool` in `default`):
+
+```console
+# Option A (default)
+$ kubectl apply -f a-runtime-image.yaml
+
+# ...or Option B (no-rebuild)
+$ kubectl apply -f b-inject-binary.yaml
+```
+
+Then run the SDK example against it — the client code is identical either way:
+
+```console
+$ go run ./examples/sandboxd-sandbox/client -warmpool sandboxd-warmpool -namespace default
+```
+
+See [`../client/README.md`](../client/README.md) for the client walkthrough.

--- a/examples/sandboxd-sandbox/deploy/README.md
+++ b/examples/sandboxd-sandbox/deploy/README.md
@@ -45,14 +45,15 @@ sandboxd runs as the container's main process (PID 1).
 
 ## Try it
 
-Apply **one** of the two (both define a `sandboxd-warmpool` in `default`):
+From the repository root, apply **one** of the two (both define a
+`sandboxd-warmpool` in `default`):
 
 ```console
 # Option A (default)
-$ kubectl apply -f a-runtime-image.yaml
+$ kubectl apply -f examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
 
 # ...or Option B (no-rebuild)
-$ kubectl apply -f b-inject-binary.yaml
+$ kubectl apply -f examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
 ```
 
 Then run the SDK example against it — the client code is identical either way:

--- a/examples/sandboxd-sandbox/deploy/README.md
+++ b/examples/sandboxd-sandbox/deploy/README.md
@@ -61,4 +61,22 @@ Then run the SDK example against it — the client code is identical either way:
 $ go run ./examples/sandboxd-sandbox/client -warmpool sandboxd-warmpool -namespace default
 ```
 
+## Verify which topology you have
+
+The litmus test is a tool that exists in the app image but not in the base
+sandboxd image — e.g. `npm` with B's `node:22-slim`:
+
+```console
+$ go run ./examples/sandboxd-sandbox/client -warmpool sandboxd-warmpool \
+    -namespace default -cmd 'npm --version'
+```
+
+- Under **B**, this prints the npm version with `exit=0`: the command executed
+  inside the app image, whose tools are all available — with no image rebuild.
+- Under **A**, it reports `exit=127` with `npm: not found` on stderr: the
+  shared `/workspace` volume carries files, not the neighboring image's
+  binaries, so only tools baked into the runtime image are reachable.
+
+That pair of results *is* the mental model above, observed live.
+
 See [`../client/README.md`](../client/README.md) for the client walkthrough.

--- a/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
+++ b/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
@@ -1,0 +1,85 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Topology A (recommended default): the sandboxd runtime image.
+#
+# sandboxd runs as a dedicated container and IS the execution environment:
+# ProcessService commands run inside THIS container's filesystem. Whatever
+# tools the agent invokes (python3, node, git, ...) must exist in this image.
+#
+# The base sandboxd image ships a minimal (busybox) toolset. To add tools,
+# build your own image FROM the sandboxd image, e.g.:
+#
+#     FROM us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandboxd:latest-main
+#     USER root
+#     RUN apt-get update && apt-get install -y nodejs npm python3
+#     USER 1000
+#
+# Use this topology when you can build/control the runtime image and want the
+# strongest isolation (untrusted code runs in a locked-down image, not your app).
+#
+# Apply this file, then run the client example:
+#   go run ./examples/sandboxd-sandbox/client -warmpool sandboxd-warmpool -namespace default
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: sandboxd-runtime-template
+  namespace: default
+spec:
+  podTemplate:
+    spec:
+      # The sandbox runs untrusted agent code; it needs no API access.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        # Ensure the shared emptyDir is writable by the non-root runtime user.
+        fsGroup: 1000
+      containers:
+        - name: sandboxd
+          # Replace with your own "FROM sandboxd" image to add tools.
+          image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandboxd:latest-main
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080  # REST filesystem + probes
+            - containerPort: 9090  # gRPC ProcessService
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: 8080
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: workspace
+          emptyDir: {}
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: sandboxd-warmpool
+  namespace: default
+spec:
+  updateStrategy:
+    type: Recreate
+  replicas: 1
+  sandboxTemplateRef:
+    name: sandboxd-runtime-template

--- a/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
+++ b/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
@@ -59,6 +59,13 @@ spec:
             capabilities:
               drop:
                 - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 8080  # REST filesystem + probes
             - containerPort: 9090  # gRPC ProcessService

--- a/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
+++ b/examples/sandboxd-sandbox/deploy/a-runtime-image.yaml
@@ -18,8 +18,9 @@
 # ProcessService commands run inside THIS container's filesystem. Whatever
 # tools the agent invokes (python3, node, git, ...) must exist in this image.
 #
-# The base sandboxd image ships a minimal (busybox) toolset. To add tools,
-# build your own image FROM the sandboxd image, e.g.:
+# The base sandboxd image (debian:bookworm-slim) ships a shell and coreutils
+# but no language runtimes. To add tools, build your own image FROM the
+# sandboxd image, e.g.:
 #
 #     FROM us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandboxd:latest-main
 #     USER root

--- a/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
+++ b/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
@@ -28,6 +28,13 @@
 # image) and sandboxd runs as the container's main process (PID 1). Prefer A
 # when you can build a runtime image.
 #
+# PID 1 caveat: sandboxd reaps the processes it starts, but as PID 1 it also
+# inherits any orphaned grandchildren (e.g. daemons forked by a command), and
+# it does not run a general zombie reaper. For long-lived sandboxes whose
+# commands fork background processes, prefer topology A, or use an image
+# that ships a minimal init (e.g. tini) and set it as the command with
+# sandboxd as its child.
+#
 # Apply this file, then run the client example:
 #   go run ./examples/sandboxd-sandbox/client -warmpool sandboxd-warmpool -namespace default
 apiVersion: extensions.agents.x-k8s.io/v1beta1

--- a/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
+++ b/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
@@ -1,0 +1,112 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Topology B (no-rebuild alternative): inject the sandboxd binary into an
+# existing, tool-rich image.
+#
+# Use this when you already have an application image with the tools your agent
+# needs (npm, python, ...) and you CANNOT rebuild it. Instead of baking sandboxd
+# into a runtime image, an initContainer copies the sandboxd *binary* into a
+# shared volume, and the (unmodified) app image runs it as its command.
+#
+# Because sandboxd now runs INSIDE the app image's filesystem, ProcessService
+# commands execute there — so `npm install` finds npm in the app image. No image
+# rebuild required.
+#
+# Trade-off vs topology A: weaker isolation (agent code runs in your full app
+# image) and sandboxd runs as the container's main process (PID 1). Prefer A
+# when you can build a runtime image.
+#
+# Apply this file, then run the client example:
+#   go run ./examples/sandboxd-sandbox/client -warmpool sandboxd-warmpool -namespace default
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: sandboxd-inject-template
+  namespace: default
+spec:
+  podTemplate:
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      initContainers:
+        # Copy the sandboxd binary out of the runtime image into a shared
+        # volume. This is the only place the sandboxd image is referenced;
+        # the app image below is never modified.
+        - name: install-sandboxd
+          image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandboxd:latest-main
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "cp /usr/local/bin/sandboxd /sandboxd-bin/sandboxd"]
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: sandboxd-bin
+              mountPath: /sandboxd-bin
+      containers:
+        # Your existing, unmodified application image — the one that already
+        # has the tools the agent will invoke. Only the command is overridden
+        # to launch the injected sandboxd binary.
+        - name: app
+          image: node:22-slim  # example: an image that already ships npm/node
+          imagePullPolicy: IfNotPresent
+          command:
+            - /sandboxd-bin/sandboxd
+            - --root-dir=/workspace
+            - --rest-port=8080
+            - --grpc-port=9090
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080  # REST filesystem + probes
+            - containerPort: 9090  # gRPC ProcessService
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: 8080
+          volumeMounts:
+            - name: sandboxd-bin
+              mountPath: /sandboxd-bin
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: sandboxd-bin
+          emptyDir: {}
+        - name: workspace
+          emptyDir: {}
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: sandboxd-warmpool
+  namespace: default
+spec:
+  updateStrategy:
+    type: Recreate
+  replicas: 1
+  sandboxTemplateRef:
+    name: sandboxd-inject-template

--- a/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
+++ b/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
@@ -96,8 +96,11 @@ spec:
               path: /v1/health
               port: 8080
           volumeMounts:
+            # Read-only: sandboxed commands must not be able to replace the
+            # injected binary (it would run on the next container restart).
             - name: sandboxd-bin
               mountPath: /sandboxd-bin
+              readOnly: true
             - name: workspace
               mountPath: /workspace
       volumes:

--- a/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
+++ b/examples/sandboxd-sandbox/deploy/b-inject-binary.yaml
@@ -65,6 +65,13 @@ spec:
             capabilities:
               drop:
                 - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: sandboxd-bin
               mountPath: /sandboxd-bin
@@ -88,6 +95,13 @@ spec:
             capabilities:
               drop:
                 - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 8080  # REST filesystem + probes
             - containerPort: 9090  # gRPC ProcessService

--- a/examples/sandboxd-sandbox/sandbox-template.yaml
+++ b/examples/sandboxd-sandbox/sandbox-template.yaml
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 # SandboxTemplate running the sandboxd portable runtime daemon (KEP-539.2)
-# as a sidecar next to an (unmodified) workload container. The two share the
-# /workspace volume; a co-located workload reaches sandboxd over pod-local
-# networking.
+# as the pod's runtime container (topology A). Commands sent over
+# ProcessService execute in THIS container's filesystem, so any tools they
+# need must be in this image; see deploy/README.md for the topology choice
+# (including topology B: injecting sandboxd into an existing tool-rich image).
 #
 # SDK access: sandboxd binds 0.0.0.0 by default, so it is reachable on the
 # pod network like any other in-pod service (via a Service or the
@@ -66,11 +67,11 @@ spec:
           volumeMounts:
             - name: workspace
               mountPath: /workspace
-      # In practice sandboxd runs as a sidecar next to your workload container,
-      # sharing the /workspace volume; the workload reaches it on the pod
-      # network (e.g. via a Service) or an SDK connects from outside. The
-      # workload container is omitted here to keep the example focused on
-      # deploying sandboxd itself.
+      # A co-located workload container may be added as a CLIENT of the
+      # sandboxd API (reaching it over pod-local networking) — but note that
+      # a shared volume shares files, not binaries: exec'd commands still run
+      # in the sandboxd container above and cannot see a neighboring
+      # container's tools. See deploy/README.md.
       volumes:
         - name: workspace
           emptyDir: {}

--- a/packages/sandboxd/USER_GUIDE.md
+++ b/packages/sandboxd/USER_GUIDE.md
@@ -5,9 +5,9 @@
 inside a sandbox pod and exposes the hybrid runtime API:
 
 ```text
-sandboxd (sidecar)
-├── gRPC  127.0.0.1:9090  →  ProcessService    (streaming process I/O)
-└── HTTP  127.0.0.1:8080  →  FilesystemService (stateless file operations & runtime probes)
+sandboxd (runtime daemon)
+├── gRPC  :9090  →  ProcessService    (streaming process I/O)
+└── HTTP  :8080  →  FilesystemService (stateless file operations & runtime probes)
 ```
 
 - **Process execution** is served over **gRPC** because `Start` is a
@@ -17,9 +17,17 @@ sandboxd (sidecar)
   `application/octet-stream` payloads with no protobuf wrapping, and any
   plain HTTP client works without generated stubs.
 
-Both listeners bind strictly to `localhost` inside the pod network namespace.
-They are never reachable from outside the pod without explicit proxying
-(`sandbox-router`).
+Both listeners bind to `--listen-host` (default `0.0.0.0`), so the daemon is
+reachable on the pod network — via a Kubernetes Service, the `sandbox-router`,
+or an SDK pod port-forward. Containment is provided by pod isolation and
+NetworkPolicy, not loopback binding; pass `--listen-host=127.0.0.1` to
+restrict to loopback (e.g. local development).
+
+**Where commands execute:** `ProcessService` runs commands inside whichever
+container hosts the `sandboxd` process, using that container's root
+filesystem. A shared volume (`/workspace`) shares *files* between containers —
+it does **not** share binaries. This is the single most important fact for
+choosing a [deployment topology](#deployment-topologies).
 
 The specifications live in [`spec/`](spec/):
 
@@ -89,61 +97,50 @@ not need their own locking for correctness:
 There is no cross-request transaction or compare-and-swap; agents that need
 coordination on shared paths must layer it themselves.
 
-## Deploying as a sidecar
+## Deployment topologies
 
-`sandboxd` runs as a sidecar next to your (unmodified) workload container.
-The two share the workspace volume; a co-located workload reaches `sandboxd`
-over pod-local networking (it binds `0.0.0.0` by default), and external
-clients reach it via a Service or the sandbox-router.
+The SDK and API are identical regardless of how `sandboxd` is deployed — but
+**which container runs the `sandboxd` process decides where your commands
+execute and which binaries they can see.** Pick the topology from that:
 
-```yaml
-apiVersion: extensions.agents.x-k8s.io/v1beta1
-kind: SandboxTemplate
-metadata:
-  name: sandboxd-template
-spec:
-  podTemplate:
-    spec:
-      securityContext:
-        fsGroup: 1000
-      containers:
-        - name: sandboxd
-          image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandboxd:latest-main
-          ports:
-            - containerPort: 8080   # REST (localhost-only; port documented for probes)
-            - containerPort: 9090   # gRPC
-          readinessProbe:
-            httpGet:
-              path: /v1/health
-              port: 8080
-          volumeMounts:
-            - name: workspace
-              mountPath: /workspace
-        - name: workload
-          image: your-agent-image:latest
-          env:
-            - name: SANDBOXD_GRPC_ADDR
-              value: "localhost:9090"
-            - name: SANDBOXD_REST_ADDR
-              value: "localhost:8080"
-          volumeMounts:
-            - name: workspace
-              mountPath: /workspace
-      volumes:
-        - name: workspace
-          emptyDir: {}
-```
+| | A — dedicated runtime container | B — inject into an existing image |
+|---|---|---|
+| Commands run in | sandboxd's own container rootfs | your app image's rootfs |
+| Tools available | what's baked into the runtime image | everything already in your image |
+| Needs image rebuild | yes (to add tools) | no (initContainer injects the binary) |
+| Isolation | stronger (dedicated, minimal runtime) | weaker (daemon runs in your full image) |
+| Use when | you can build the execution image | you cannot rebuild your image |
 
-> **Note:** commands launched through `ProcessService` execute inside the
-> `sandboxd` container, with the shared `/workspace` volume as their working
-> directory — so files written by either container are visible to both.
+**A (default):** `sandboxd` runs as the pod's runtime container. Commands
+execute in that container, so tools must be baked into its image (the base
+image is minimal — a shell + coreutils; build `FROM sandboxd` to add `npm`,
+`python3`, …). Strongest isolation: untrusted agent code runs in a
+controlled runtime image.
+
+**B (no-rebuild alternative):** an initContainer copies the statically-linked
+`sandboxd` binary into a shared `emptyDir`, and your existing, unmodified
+tool-rich image runs it as its command. Commands now execute inside *your*
+image, so e.g. `npm install` finds `npm` — no rebuild required.
+
+Complete, runnable manifests for both (plus an end-to-end SDK client) live in
+[`examples/sandboxd-sandbox/`](../../examples/sandboxd-sandbox/).
+
+> **A common pitfall:** running `sandboxd` as a *sidecar* — a separate
+> container next to an (unmodified) workload container, sharing `/workspace`.
+> This looks like topology B but behaves like topology A: the shared volume
+> shares files, **not** the workload's binaries, so commands exec'd through
+> `ProcessService` still run in the sandboxd container and cannot see the
+> workload image's tools. A co-located workload container is useful only as a
+> *client* of the sandboxd API (reaching it over pod-local networking), not
+> as a source of tools.
 
 ## Flags
 
 | Flag | Default | Description |
 |---|---|---|
-| `--grpc-port` | `9090` | Port for the gRPC ProcessService. Always binds to `127.0.0.1`. |
-| `--rest-port` | `8080` | Port for the REST API. Always binds to `127.0.0.1`. |
+| `--listen-host` | `0.0.0.0` | Interface for both listeners. Default is reachable on the pod network; set `127.0.0.1` to restrict to loopback. |
+| `--grpc-port` | `9090` | Port for the gRPC ProcessService. |
+| `--rest-port` | `8080` | Port for the REST API. |
 | `--root-dir` | `/workspace` | Sandbox root confining all file operations and working directories. Created if missing. |
 | `--metadata-env-prefix` | `SANDBOX_` | Env var prefix exposed on `/v1/metadata`. |
 | `--shutdown-timeout` | `10s` | Grace period for in-flight requests and child processes. |
@@ -238,12 +235,14 @@ any other in-pod service — via a Kubernetes **Service** or the
 pod (both `:8080` and `:9090`): filesystem calls go over REST, `Run` goes over
 gRPC.
 
-> **Where commands run:** `ProcessService` executes commands **inside the
-> `sandboxd` container**, not the workload container. The base `sandboxd`
-> image is minimal (a shell + coreutils), so `Run` can use `sh`, `cat`,
-> `ls`, etc. out of the box; to run a language runtime (e.g. `python3`),
-> build a sandboxd image that includes it. Files written over REST land in
-> the shared `/workspace` volume, visible to both containers.
+> **Where commands run:** `ProcessService` executes commands inside the
+> container that hosts `sandboxd` (see
+> [Deployment topologies](#deployment-topologies)). With topology A the base
+> `sandboxd` image is minimal (a shell + coreutils), so `Run` can use `sh`,
+> `cat`, `ls`, etc. out of the box; for a language runtime, either build a
+> sandboxd image that includes it (A) or inject sandboxd into an image that
+> already has it (B). Files written over REST land in the `/workspace`
+> volume.
 
 **Go** — select the runtime via `Options`:
 

--- a/test/e2e/extensions/sandboxd_test.go
+++ b/test/e2e/extensions/sandboxd_test.go
@@ -36,8 +36,10 @@ import (
 
 // sandboxdManifest runs sandboxd as the sole container. It binds 0.0.0.0
 // (the daemon default), so the kubelet httpGet readiness probe reaches
-// /v1/health and the test reaches both ports via port-forward. Real
-// deployments run it as a sidecar next to the workload; behavior is identical.
+// /v1/health and the test reaches both ports via port-forward. The API
+// behaves the same in any deployment topology; note that exec'd commands
+// always run in the container hosting sandboxd, regardless of what other
+// containers share the pod.
 const sandboxdManifest = `
 apiVersion: agents.x-k8s.io/v1beta1
 kind: Sandbox


### PR DESCRIPTION
### What type of PR is this?

/kind documentation

### What this PR does / why we need it:

Follow-up from #1347. Adds a runnable end-to-end example for the Go SDK against the `sandboxd` runtime, plus two deployment topologies that answer the most common consumer question: *"Where do my commands execute, and which binaries can they see?"*

#### SDK client example (`examples/sandboxd-sandbox/client/`)
A single program that exercises the full round trip:
1. Creates a sandbox from a warm pool (`NewClient` → `CreateSandbox`),
2. Writes a file into `/workspace` over the REST filesystem API,
3. Execs a command over the gRPC `ProcessService` and captures stdout/exit code,
4. Reads the file back and verifies the content,
5. Deletes the sandbox on exit.

#### Deployment topologies (`examples/sandboxd-sandbox/deploy/`)
The client is topology-agnostic — the SDK talks to `sandboxd` the same way regardless of where the daemon runs. But the deployment choice decides which binaries commands can reach, so two variants are provided with a decision-table README:

- **A — Dedicated runtime container (`a-runtime-image.yaml`, default):** `sandboxd` runs in its own container; commands execute in its rootfs. Tools must be baked into the runtime image. Isolation-first.
- **B — Binary injection (`b-inject-binary.yaml`):** An `initContainer` copies the static `sandboxd` binary into an `emptyDir` and an existing, unmodified tool-rich image (e.g. `node:22-slim`) runs it as its entrypoint. Commands execute inside that image — e.g. `npm install` works with no image rebuild.

`deploy/README.md` leads with the mental model (a shared volume shares files, not binaries — each container has its own rootfs) and a table for choosing between A and B.

### Verification:

- `go build`, `go vet`, `gofmt`, `lint-go`: clean.
- Verified end-to-end on a live GKE cluster: both topologies deployed, warm pool pods reached `Ready`, and the client completed `create` → `write` → `exec` → `read-back` → `cleanup` successfully against each.

### Which issue(s) this PR fixes:

Follow-up from #1347.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a complete Go SDK example for creating sandboxes, managing files, executing commands, validating results, and cleaning up.
  - Added Kubernetes deployment examples for dedicated runtime images and binary injection into existing application containers.
  - Added secure runtime settings, readiness checks, workspace storage, and warm-pool configuration examples.

- **Documentation**
  - Expanded setup, execution, deployment, networking, and command-visibility guidance.
  - Clarified sandbox behavior across deployment topologies and documented the `--listen-host` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->