### PR TITLE
fix: align default NetworkPolicy with Go sandbox-router

### DIFF
--- a/examples/policy/network-policy-management/README.md
+++ b/examples/policy/network-policy-management/README.md
@@ -37,17 +37,15 @@ To make discovery straightforward, the generated policy is predictably named `<t
 
 ## The "Secure by Default" Posture
 
-If you create a `SandboxTemplate` and set `networkPolicyManagement: Managed` (or leave it blank, as this is the default) without specifying custom rules, the controller applies a highly restrictive **Secure Default** policy.
+If you create a `SandboxTemplate` with `networkPolicyManagement: Managed` (or leave it unset, which is the default) and omit `spec.networkPolicy`, the controller applies a highly restrictive **Secure Default** policy.
 
 This is designed for running untrusted code safely:
 
 **Ingress (Incoming Traffic)**
 
-- **Allowed:** Traffic is only allowed from the project's supported [Sandbox Router](../../../clients/python/agentic-sandbox-client/sandbox-router) deployments:
-  - the Python router (`app: sandbox-router`) in the `"agent-sandbox-system"` namespace;
-  - the Go router (`app.kubernetes.io/name: sandbox-router` and `app.kubernetes.io/component: sandbox-router`) in the `"default"` namespace.
+- **Allowed:** Traffic is only allowed from the project's supported Sandbox Router deployments: the [Python router](../../../clients/python/agentic-sandbox-client/sandbox-router) (`app: sandbox-router`) in the `"agent-sandbox-system"` namespace, or the [Go router](../../../sandbox-router/deploy/README.md) (`app.kubernetes.io/name: sandbox-router` and `app.kubernetes.io/component: sandbox-router`) in the `"default"` namespace.
 
-  Routers deployed in another namespace or with different labels must be allowed through an explicit `spec.networkPolicy`.
+  These built-in identities assume that Pod creation is restricted in the router namespaces. In a shared `default` namespace or another multi-tenant environment, deploy the router in a dedicated namespace and allow it with an explicit `spec.networkPolicy` instead. Routers deployed in another namespace or with different labels must also be allowed through an explicit `spec.networkPolicy`.
 
 - **Blocked:** All other internal cluster traffic and external ingress is explicitly denied.
 
@@ -129,7 +127,7 @@ spec:
           - protocol: TCP
             port: 8080
 
-      # 2. Re-allow the standard Sandbox Router (required if you override defaults)
+      # 2. Re-allow the standard Sandbox Routers (required if you override defaults)
       - from:
         - namespaceSelector:
             matchLabels:
@@ -137,6 +135,14 @@ spec:
           podSelector:
             matchLabels:
               app: sandbox-router
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: sandbox-router
+              app.kubernetes.io/component: sandbox-router
 
     egress:
       # 1. Allow outbound traffic to a specific internal Vector Database
@@ -193,7 +199,7 @@ spec:
   networkPolicyManagement: Managed
   networkPolicy:
     ingress:
-      # Re-allow the standard Sandbox Router
+      # Re-allow the standard Sandbox Routers
       - from:
         - namespaceSelector:
             matchLabels:
@@ -201,6 +207,14 @@ spec:
           podSelector:
             matchLabels:
               app: sandbox-router
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: default
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: sandbox-router
+              app.kubernetes.io/component: sandbox-router
     egress:
       # 1. Allow outbound IPv4 to the public internet (excluding private subnets and link-local)
       - to:

--- a/examples/policy/network-policy-management/README.md
+++ b/examples/policy/network-policy-management/README.md
@@ -43,7 +43,11 @@ This is designed for running untrusted code safely:
 
 **Ingress (Incoming Traffic)**
 
-- **Allowed:**  Traffic is only allowed from the designated [Sandbox Router](../../../clients/python/agentic-sandbox-client/sandbox-router) (`app: sandbox-router`) residing in the `"agent-sandbox-system"` system namespace.
+- **Allowed:** Traffic is only allowed from the project's supported [Sandbox Router](../../../clients/python/agentic-sandbox-client/sandbox-router) deployments:
+  - the Python router (`app: sandbox-router`) in the `"agent-sandbox-system"` namespace;
+  - the Go router (`app.kubernetes.io/name: sandbox-router` and `app.kubernetes.io/component: sandbox-router`) in the `"default"` namespace.
+
+  Routers deployed in another namespace or with different labels must be allowed through an explicit `spec.networkPolicy`.
 
 - **Blocked:** All other internal cluster traffic and external ingress is explicitly denied.
 

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -192,6 +192,7 @@ func (r *SandboxTemplateReconciler) ensureTemplateRefHashLabel(ctx context.Conte
 func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPolicySpec {
 	peers := []networkingv1.NetworkPolicyPeer{
 		{
+			// Python router deployment in the agent-sandbox-system namespace.
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"kubernetes.io/metadata.name": "agent-sandbox-system",
@@ -200,6 +201,20 @@ func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPoli
 			PodSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": "sandbox-router",
+				},
+			},
+		},
+		{
+			// Go router deployment shipped in sandbox-router/deploy.
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": "default",
+				},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/name":      "sandbox-router",
+					"app.kubernetes.io/component": "sandbox-router",
 				},
 			},
 		},

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -205,7 +205,9 @@ func buildDefaultNetworkPolicySpec(templateName string) networkingv1.NetworkPoli
 			},
 		},
 		{
-			// Go router deployment shipped in sandbox-router/deploy.
+			// Go router deployment shipped in sandbox-router/deploy. This reference
+			// identity assumes Pod creation is restricted in the default namespace;
+			// shared or multi-tenant clusters should use an explicit policy instead.
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"kubernetes.io/metadata.name": "default",

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -61,8 +61,12 @@ func assertManagedNetworkPolicySelectsTemplateBackedPod(t *testing.T, templateNa
 	}
 }
 
+// networkPolicyHasIngressPeer reports whether the policy allows the given pod labels in a namespace.
 func networkPolicyHasIngressPeer(t *testing.T, np *networkingv1.NetworkPolicy, namespace string, podLabels labels.Set) bool {
 	t.Helper()
+	if len(np.Spec.Ingress) == 0 {
+		return false
+	}
 
 	namespaceLabels := labels.Set{"kubernetes.io/metadata.name": namespace}
 	for _, peer := range np.Spec.Ingress[0].From {
@@ -86,6 +90,8 @@ func networkPolicyHasIngressPeer(t *testing.T, np *networkingv1.NetworkPolicy, n
 	return false
 }
 
+// TestSandboxTemplateReconcileNetworkPolicy verifies managed and unmanaged
+// NetworkPolicy reconciliation, including both supported router identities.
 func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	templateDefault := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
@@ -181,8 +187,11 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 				if len(np.Spec.PolicyTypes) != 2 {
 					t.Errorf("Expected 2 PolicyTypes, got %d", len(np.Spec.PolicyTypes))
 				}
-				if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].From) != 2 {
-					t.Fatalf("Expected Default Ingress rule to contain exactly 2 peer sources, got %d", len(np.Spec.Ingress[0].From))
+				if len(np.Spec.Ingress) != 1 {
+					t.Fatalf("Expected exactly 1 default ingress rule, got %d", len(np.Spec.Ingress))
+				}
+				if len(np.Spec.Ingress[0].From) != 2 {
+					t.Fatalf("Expected default ingress rule to contain exactly 2 peer sources, got %d", len(np.Spec.Ingress[0].From))
 				}
 				if !networkPolicyHasIngressPeer(t, np, "agent-sandbox-system", labels.Set{
 					"app": "sandbox-router",

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -61,6 +61,31 @@ func assertManagedNetworkPolicySelectsTemplateBackedPod(t *testing.T, templateNa
 	}
 }
 
+func networkPolicyHasIngressPeer(t *testing.T, np *networkingv1.NetworkPolicy, namespace string, podLabels labels.Set) bool {
+	t.Helper()
+
+	namespaceLabels := labels.Set{"kubernetes.io/metadata.name": namespace}
+	for _, peer := range np.Spec.Ingress[0].From {
+		if peer.NamespaceSelector == nil || peer.PodSelector == nil {
+			continue
+		}
+
+		namespaceSelector, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+		if err != nil {
+			t.Fatalf("namespace selector: %v", err)
+		}
+		podSelector, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
+		if err != nil {
+			t.Fatalf("pod selector: %v", err)
+		}
+
+		if namespaceSelector.Matches(namespaceLabels) && podSelector.Matches(podLabels) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 	templateDefault := &extensionsv1beta1.SandboxTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
@@ -156,16 +181,19 @@ func TestSandboxTemplateReconcileNetworkPolicy(t *testing.T) {
 				if len(np.Spec.PolicyTypes) != 2 {
 					t.Errorf("Expected 2 PolicyTypes, got %d", len(np.Spec.PolicyTypes))
 				}
-				if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].From) != 1 {
-					t.Fatalf("Expected Default Ingress rule to contain exactly 1 peer source, got %d", len(np.Spec.Ingress[0].From))
+				if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].From) != 2 {
+					t.Fatalf("Expected Default Ingress rule to contain exactly 2 peer sources, got %d", len(np.Spec.Ingress[0].From))
 				}
-				peer1 := np.Spec.Ingress[0].From[0]
-				if peer1.PodSelector == nil || peer1.NamespaceSelector == nil {
-					t.Fatalf("Expected both PodSelector and NamespaceSelector to be non-nil")
+				if !networkPolicyHasIngressPeer(t, np, "agent-sandbox-system", labels.Set{
+					"app": "sandbox-router",
+				}) {
+					t.Errorf("Expected default ingress to allow the Python router in agent-sandbox-system")
 				}
-				if peer1.PodSelector.MatchLabels["app"] != "sandbox-router" ||
-					peer1.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "agent-sandbox-system" {
-					t.Errorf("Expected first Ingress peer to target sandbox-router in agent-sandbox-system namespace")
+				if !networkPolicyHasIngressPeer(t, np, "default", labels.Set{
+					"app.kubernetes.io/name":      "sandbox-router",
+					"app.kubernetes.io/component": "sandbox-router",
+				}) {
+					t.Errorf("Expected default ingress to allow the Go router in default")
 				}
 				if len(np.Spec.Egress) != 1 {
 					t.Fatalf("Expected 1 Default Egress rule, got %d", len(np.Spec.Egress))

--- a/extensions/controllers/sandboxtemplate_controller_test.go
+++ b/extensions/controllers/sandboxtemplate_controller_test.go
@@ -64,27 +64,26 @@ func assertManagedNetworkPolicySelectsTemplateBackedPod(t *testing.T, templateNa
 // networkPolicyHasIngressPeer reports whether the policy allows the given pod labels in a namespace.
 func networkPolicyHasIngressPeer(t *testing.T, np *networkingv1.NetworkPolicy, namespace string, podLabels labels.Set) bool {
 	t.Helper()
-	if len(np.Spec.Ingress) == 0 {
-		return false
-	}
 
 	namespaceLabels := labels.Set{"kubernetes.io/metadata.name": namespace}
-	for _, peer := range np.Spec.Ingress[0].From {
-		if peer.NamespaceSelector == nil || peer.PodSelector == nil {
-			continue
-		}
+	for _, ingressRule := range np.Spec.Ingress {
+		for _, peer := range ingressRule.From {
+			if peer.NamespaceSelector == nil || peer.PodSelector == nil {
+				continue
+			}
 
-		namespaceSelector, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
-		if err != nil {
-			t.Fatalf("namespace selector: %v", err)
-		}
-		podSelector, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
-		if err != nil {
-			t.Fatalf("pod selector: %v", err)
-		}
+			namespaceSelector, err := metav1.LabelSelectorAsSelector(peer.NamespaceSelector)
+			if err != nil {
+				t.Fatalf("namespace selector: %v", err)
+			}
+			podSelector, err := metav1.LabelSelectorAsSelector(peer.PodSelector)
+			if err != nil {
+				t.Fatalf("pod selector: %v", err)
+			}
 
-		if namespaceSelector.Matches(namespaceLabels) && podSelector.Matches(podLabels) {
-			return true
+			if namespaceSelector.Matches(namespaceLabels) && podSelector.Matches(podLabels) {
+				return true
+			}
 		}
 	}
 	return false

--- a/sandbox-router/deploy/README.md
+++ b/sandbox-router/deploy/README.md
@@ -2,6 +2,13 @@
 
 Drop-in starting point for running the Go sandbox-router in Kubernetes. These manifests prioritize sensible defaults over completeness — read each one and tune for your environment.
 
+The manifests deploy the router into the `default` namespace and label its Pods
+with `app.kubernetes.io/name: sandbox-router` and
+`app.kubernetes.io/component: sandbox-router`. The default `SandboxTemplate`
+NetworkPolicy allows this router identity. If you deploy the router elsewhere or
+change these labels, add a matching ingress peer to the template's explicit
+`spec.networkPolicy`.
+
 ## Files
 
 | File | What it does |

--- a/sandbox-router/deploy/README.md
+++ b/sandbox-router/deploy/README.md
@@ -4,10 +4,14 @@ Drop-in starting point for running the Go sandbox-router in Kubernetes. These ma
 
 The manifests deploy the router into the `default` namespace and label its Pods
 with `app.kubernetes.io/name: sandbox-router` and
-`app.kubernetes.io/component: sandbox-router`. The default `SandboxTemplate`
-NetworkPolicy allows this router identity. If you deploy the router elsewhere or
-change these labels, add a matching ingress peer to the template's explicit
-`spec.networkPolicy`.
+`app.kubernetes.io/component: sandbox-router`. The controller-generated
+`SandboxTemplate` NetworkPolicy allows this identity only when
+`networkPolicyManagement` is `Managed` and `spec.networkPolicy` is unset. This
+default identity assumes that Pod creation is restricted in `default`; in a
+shared or multi-tenant cluster, deploy the router in a dedicated namespace and
+add a matching ingress peer to the template's explicit `spec.networkPolicy`.
+If you deploy the router elsewhere or change these labels, the explicit policy
+must likewise include the new namespace and labels.
 
 ## Files
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The default SandboxTemplate NetworkPolicy now allows both supported sandbox-router deployments. The existing policy allowed only `app=sandbox-router` in `agent-sandbox-system`, while the Go router manifests deploy to `default` with `app.kubernetes.io/name` and `app.kubernetes.io/component` labels. This mismatch caused documented Go router setups to time out when connecting to Sandbox pods.

This change adds the Go router namespace and label selector, preserves the existing Python router rule, adds regression coverage for both selectors, and updates the related documentation. Custom router namespaces or labels still require an explicit `spec.networkPolicy`.

#### Which issue(s) this PR is related to:

Fixes #1409
Ref #1058

#### Release Note

```release-note
Fix the default SandboxTemplate NetworkPolicy so the Go sandbox-router can reach Sandbox pods.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Default network policies now allow traffic from both Python and Go sandbox routers.
  - Router access is supported across the `agent-sandbox-system` and `default` namespaces using standard labels.

- **Documentation**
  - Added deployment guidance covering namespaces, required labels, and custom network policy configuration.
  - Clarified that shared environments or nonstandard router settings require explicit policy rules.

- **Tests**
  - Expanded coverage to verify access for both supported router types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->