### PR TITLE
Add the router into the operator too

### DIFF
--- a/olm/Makefile
+++ b/olm/Makefile
@@ -55,6 +55,9 @@ OPM_VERSION ?= v1.55.0
 # Image URL for the agent-sandbox-controller (built from the repo root Dockerfile).
 IMG ?= registry.k8s.io/agent-sandbox/agent-sandbox-controller:v$(VERSION)
 
+# Image URL for the sandbox-router (built from sandbox-router/Dockerfile).
+ROUTER_IMG ?= registry.k8s.io/agent-sandbox/sandbox-router-go:v$(VERSION)
+
 # Parent repo root (one level above this module); holds the controller Dockerfile and source.
 REPO_ROOT ?= ..
 
@@ -108,14 +111,19 @@ copy-k8s-config: ## Copy ../k8s into config/ (CRDs, RBAC .generated.yaml → rol
 	mkdir -p $(CONFIG_DIR)/crd/bases
 	rm -rf $(CONFIG_DIR)/crd/bases/*
 	cp $(K8S_ROOT)/crds/*.yaml $(CONFIG_DIR)/crd/bases/
-	@{ \
-		echo 'resources:'; \
-		for f in $(CONFIG_DIR)/crd/bases/*.yaml; do echo "- bases/$$(basename "$$f")"; done; \
-	} > $(CONFIG_DIR)/crd/kustomization.yaml
 	cp $(K8S_ROOT)/rbac.generated.yaml $(CONFIG_DIR)/rbac/role.yaml
 	cp $(K8S_ROOT)/extensions-rbac.generated.yaml $(CONFIG_DIR)/rbac/extensions_role.yaml
 	cp $(K8S_ROOT)/extensions.yaml $(CONFIG_DIR)/rbac/extensions_role_binding.yaml
-	go run ./hack/sync-k8s-manifests -controller $(K8S_ROOT)/controller.yaml -extensions $(K8S_ROOT)/extensions.controller.yaml -support-out $(CONFIG_DIR)/rbac/support.yaml -manager-out $(CONFIG_DIR)/manager/manager.yaml
+	mkdir -p $(CONFIG_DIR)/sandbox-router
+	rm -rf $(CONFIG_DIR)/sandbox-router/*
+	cp $(REPO_ROOT)/sandbox-router/deploy/*.yaml $(CONFIG_DIR)/sandbox-router/
+	go run ./hack/sync-k8s-manifests \
+		-controller $(K8S_ROOT)/controller.yaml \
+		-extensions $(K8S_ROOT)/extensions.controller.yaml \
+		-support-out $(CONFIG_DIR)/rbac/support.yaml \
+		-manager-out $(CONFIG_DIR)/manager/manager.yaml \
+		-router-dir $(CONFIG_DIR)/sandbox-router \
+		-crd-dir $(CONFIG_DIR)/crd/bases
 
 .PHONY: manifests
 manifests: copy-k8s-config ## Refresh config/ YAML from $(K8S_ROOT) (same layout as manual copy from k8s/).
@@ -300,6 +308,7 @@ endif
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
+	cd config/default && $(KUSTOMIZE) edit set image registry.k8s.io/agent-sandbox/sandbox-router-go=$(ROUTER_IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
 	sed -i.bak 's|containerImage: .*|containerImage: $(IMG)|' bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml && rm -f bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml.bak
 	$(OPERATOR_SDK) bundle validate ./bundle

--- a/olm/README.md
+++ b/olm/README.md
@@ -71,6 +71,7 @@ Contributors should **not** hand-edit the synced paths below. Change the upstrea
 - `k8s/extensions-rbac.generated.yaml` → `config/rbac/extensions_role.yaml`
 - `k8s/extensions.yaml` → `config/rbac/extensions_role_binding.yaml`
 - `k8s/controller.yaml` and `k8s/extensions.controller.yaml` → `config/rbac/support.yaml` and `config/manager/manager.yaml` via [`hack/sync-k8s-manifests`](hack/sync-k8s-manifests/) (Namespace, ServiceAccount, bindings, Service, extensions Deployment; image placeholder rewritten for the operator image)
+- `sandbox-router/deploy/*.yaml` → `config/sandbox-router/` (copied, then `hack/sync-k8s-manifests -router-dir` rewrites `metadata.namespace` and `subjects[].namespace` to `agent-sandbox-system` and regenerates `kustomization.yaml` as a resource list). The router image is remapped in `config/default/kustomization.yaml`, so `make bundle` can `kustomize edit set image` without breaking `verify-olm`. **Note:** `networkpolicy.yaml` and `rbac-tokenreview.yaml` are copied for reference but excluded from the generated `kustomization.yaml` resources. The upstream NetworkPolicy example is not yet suitable for OLM defaults; `rbac-tokenreview.yaml` grants `system:auth-delegator` which is only needed when `--authz-mode=tokenreview` is enabled (the default is `allow-all`). Both will be included when proper defaults are established.
 
 Run from `olm/`:
 

--- a/olm/bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml
+++ b/olm/bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml
@@ -287,6 +287,16 @@ spec:
           - update
           - watch
         serviceAccountName: agent-sandbox-controller
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: sandbox-router
       deployments:
       - label:
           app: agent-sandbox-controller
@@ -326,6 +336,94 @@ spec:
                   name: agent-sandbox-config
                   optional: true
                 name: config-volume
+      - label:
+          app.kubernetes.io/component: sandbox-router
+          app.kubernetes.io/name: sandbox-router
+        name: sandbox-router
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: sandbox-router
+              app.kubernetes.io/name: sandbox-router
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                prometheus.io/path: /metrics
+                prometheus.io/port: "9090"
+                prometheus.io/scrape: "true"
+              labels:
+                app.kubernetes.io/component: sandbox-router
+                app.kubernetes.io/name: sandbox-router
+            spec:
+              containers:
+              - args:
+                - --http-bind-address=:8080
+                - --metrics-bind-address=:9090
+                - --health-probe-bind-address=:8081
+                - --cluster-domain=cluster.local
+                - --proxy-timeout=180s
+                - --upstream-max-retries=3
+                - --cache-enabled=true
+                image: registry.k8s.io/agent-sandbox/sandbox-router-go:v1.0.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: healthz
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                name: sandbox-router
+                ports:
+                - containerPort: 8080
+                  name: proxy
+                  protocol: TCP
+                - containerPort: 9090
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8081
+                  name: healthz
+                  protocol: TCP
+                readinessProbe:
+                  failureThreshold: 2
+                  httpGet:
+                    path: /readyz
+                    port: healthz
+                  initialDelaySeconds: 1
+                  periodSeconds: 5
+                resources:
+                  limits:
+                    cpu: "2"
+                    memory: 1Gi
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+              serviceAccountName: sandbox-router
+              terminationGracePeriodSeconds: 45
+              topologySpreadConstraints:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: sandbox-router
+                maxSkew: 1
+                topologyKey: topology.kubernetes.io/zone
+                whenUnsatisfiable: ScheduleAnyway
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: sandbox-router
+                maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
     strategy: deployment
   installModes:
   - supported: false

--- a/olm/bundle/manifests/sandbox-router-svc_v1_service.yaml
+++ b/olm/bundle/manifests/sandbox-router-svc_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: sandbox-router
+    app.kubernetes.io/name: sandbox-router
+  name: sandbox-router-svc
+spec:
+  ports:
+  - name: proxy
+    port: 8080
+    protocol: TCP
+    targetPort: proxy
+  selector:
+    app.kubernetes.io/component: sandbox-router
+    app.kubernetes.io/name: sandbox-router
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/olm/bundle/manifests/sandbox-router_policy_v1_poddisruptionbudget.yaml
+++ b/olm/bundle/manifests/sandbox-router_policy_v1_poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: sandbox-router
+    app.kubernetes.io/name: sandbox-router
+  name: sandbox-router
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: sandbox-router
+      app.kubernetes.io/name: sandbox-router

--- a/olm/config/default/kustomization.yaml
+++ b/olm/config/default/kustomization.yaml
@@ -1,7 +1,14 @@
 # Standard operator-sdk layout; content is derived from parent k8s/ (see Makefile manifests).
+# Router image remap lives here so `kustomize edit set image`
+# during `make bundle` does not fight verify-olm.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../sandbox-router
+images:
+- name: registry.k8s.io/agent-sandbox/sandbox-router-go
+  newName: registry.k8s.io/agent-sandbox/sandbox-router-go
+  newTag: v1.0.0

--- a/olm/config/sandbox-router/deployment.yaml
+++ b/olm/config/sandbox-router/deployment.yaml
@@ -1,0 +1,113 @@
+# Example Deployment for the Go sandbox-router. Tune the replica count and
+# resource requests for your tenant count and request rate — see the
+# "Scaling guidance" section of the package README.
+#
+# This example shows the plain-HTTP setup. For TLS, set --https-bind-address
+# and mount a Secret at /tls (see networkpolicy.yaml + the README's TLS section).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sandbox-router
+  namespace: agent-sandbox-system
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  # Minimum 2 for HA; tune up based on load test numbers.
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sandbox-router
+      app.kubernetes.io/component: sandbox-router
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sandbox-router
+        app.kubernetes.io/component: sandbox-router
+      annotations:
+        # Tell Prometheus to scrape the metrics port if you don't use a
+        # ServiceMonitor. Adjust or remove for your environment.
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: sandbox-router
+      # Spread replicas across nodes/zones so a single failure doesn't take
+      # the router fleet offline.
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: sandbox-router
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: sandbox-router
+      containers:
+      - name: sandbox-router
+        # Replace with the published image. The Go router image is
+        # `sandbox-router-go` to avoid colliding with the Python router's
+        # `sandbox-router` image — see sandbox-router/README.md.
+        image: registry.k8s.io/agent-sandbox/sandbox-router-go:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --http-bind-address=:8080
+        - --metrics-bind-address=:9090
+        - --health-probe-bind-address=:8081
+        - --cluster-domain=cluster.local
+        - --proxy-timeout=180s
+        # Retry budget for upstream dial failures; see README "Behavior on
+        # missing sandboxes".
+        - --upstream-max-retries=3
+        # KEP-NNNN: enable the Pod-IP cache so requests carrying
+        # X-Sandbox-UID dial the live PodIP and bypass DNS. Requires
+        # the ClusterRole granted in rbac.yaml. Set to false (and skip
+        # rbac.yaml) to fall back to DNS-only routing.
+        - --cache-enabled=true
+        ports:
+        - name: proxy
+          containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 9090
+          protocol: TCP
+        - name: healthz
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          failureThreshold: 2
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: "2"
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+      # Give in-flight requests a chance to finish before the kubelet
+      # delivers SIGKILL. The router's own --shutdown-timeout defaults to
+      # 30s; keep this slightly larger.
+      terminationGracePeriodSeconds: 45

--- a/olm/config/sandbox-router/kustomization.yaml
+++ b/olm/config/sandbox-router/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- deployment.yaml
+- pdb.yaml
+- rbac.yaml
+- service.yaml
+- serviceaccount.yaml

--- a/olm/config/sandbox-router/networkpolicy.yaml
+++ b/olm/config/sandbox-router/networkpolicy.yaml
@@ -1,0 +1,88 @@
+# Example NetworkPolicy. Adjust the ingress source — most deployments have
+# the router behind a Gateway in a specific namespace; tighten the from:
+# selector to that namespace + labels to prevent direct cluster-wide ingress.
+#
+# Egress is intentionally broad because the router dials arbitrary sandbox
+# pods in tenant namespaces — narrow it via labels if your tenancy model
+# constrains which pods/namespaces are valid targets.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-router
+  namespace: agent-sandbox-system
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: sandbox-router
+      app.kubernetes.io/component: sandbox-router
+  policyTypes: ["Ingress", "Egress"]
+  ingress:
+  # Proxy traffic — replace this from: clause with your Gateway namespace.
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8080
+    # Uncomment when TLS is enabled:
+    # - protocol: TCP
+    #   port: 8443
+  # Metrics scrape — restrict to your monitoring namespace.
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9090
+  # Kubelet probes hit the pod IP directly; allow all.
+  - ports:
+    - protocol: TCP
+      port: 8081
+  egress:
+  # DNS for resolving sandbox FQDNs.
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow forwarding to sandbox pods on the agreed sandbox port. Tighten
+  # via namespaceSelector/podSelector if your tenancy model permits.
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 8888
+  # OTel collector (if --enable-tracing or --enable-otel-metrics). Tighten
+  # to your collector's namespace/pod selector.
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 4317
+  # Kubernetes API server — required when --cache-enabled or
+  # --authz-mode=tokenreview. The cache informer LIST/WATCHes Pods and
+  # the TokenReview authorizer POSTs to authentication.k8s.io. Without
+  # this rule, cache sync hangs and tokenreview every-request fails
+  # closed. The apiserver lives at the cluster-wide kubernetes service;
+  # NetworkPolicy can't name it directly, so we allow egress to the
+  # default namespace on the standard API port. Many clusters also
+  # accept apiserver traffic over the public LB IP — if your cluster
+  # routes that way, add an ipBlock for the LB CIDR alongside this
+  # rule. Skip this rule entirely when running with --cache-enabled=false
+  # AND --authz-mode=allow-all.
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: default
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443

--- a/olm/config/sandbox-router/pdb.yaml
+++ b/olm/config/sandbox-router/pdb.yaml
@@ -1,0 +1,18 @@
+# Prevent voluntary disruptions (drain, autoscaler eviction) from taking
+# the entire router fleet offline. Tune for your replica count: with N
+# replicas, minAvailable: max(1, N-1) keeps you served during single-node
+# events while still allowing node drains.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sandbox-router
+  namespace: agent-sandbox-system
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sandbox-router
+      app.kubernetes.io/component: sandbox-router

--- a/olm/config/sandbox-router/rbac-tokenreview.yaml
+++ b/olm/config/sandbox-router/rbac-tokenreview.yaml
@@ -1,0 +1,29 @@
+# Extra RBAC for --authz-mode=tokenreview. system:auth-delegator is the
+# stock ClusterRole granted to kubelet / metrics-server / kube-state-
+# metrics and other components that validate caller-supplied tokens;
+# it gives `create` on tokenreviews.authentication.k8s.io and `create`
+# on subjectaccessreviews.authorization.k8s.io.
+#
+# Apply this file alongside rbac.yaml ONLY when running the router
+# with --authz-mode=tokenreview. The default (--authz-mode=allow-all)
+# does not need it, and shipping it by default would unnecessarily
+# grant tokenreview / SAR creation rights to a ServiceAccount that
+# never uses them.
+#
+#   kubectl apply -f sandbox-router/deploy/rbac.yaml
+#   kubectl apply -f sandbox-router/deploy/rbac-tokenreview.yaml  # only when tokenreview is on
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sandbox-router-auth-delegator
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: sandbox-router
+  namespace: agent-sandbox-system

--- a/olm/config/sandbox-router/rbac.yaml
+++ b/olm/config/sandbox-router/rbac.yaml
@@ -1,0 +1,74 @@
+# RBAC for the sandbox-router's Pod-IP cache (KEP-NNNN fast path).
+#
+# The router watches sandbox-owned Pods so it can dial the live PodIP
+# instead of hitting cluster DNS on every request. Sandboxes can land
+# in any user namespace, so the informer needs get/list/watch on Pods
+# cluster-wide. If your deployment pins sandboxes to a single namespace,
+# narrow this to a Role + RoleBinding in that namespace and set
+# --cache-namespace=<ns> on the router.
+#
+# Skip these manifests entirely when running the router with
+# --cache-enabled=false (the DNS-only default).
+#
+# A note for auditors reading this grant:
+#
+#   The grant is "get/list/watch on Pods in every namespace", which on
+#   paper includes kube-system / kube-public / kube-node-lease. K8s RBAC
+#   has no negative-namespace primitive, so the grant cannot be
+#   expressed as "everywhere except the system namespaces."
+#
+#   At runtime, however, the informer issues its LIST/WATCH with the
+#   server-side label selector
+#
+#       agents.x-k8s.io/sandbox-name-hash
+#
+#   which the sandbox controller stamps on every sandbox-owned Pod (and
+#   nothing else). System-namespace Pods do not carry this label, so the
+#   apiserver never returns them and the router's cache never stores
+#   them. The grant is the upper bound on what the SA *could* read; the
+#   informer filter is what it actually does read.
+#
+#   If you need the grant itself to match the runtime behavior, the only
+#   options today are (a) per-namespace RoleBindings enumerated from
+#   your allow-list of tenant namespaces, or (b) a Kyverno / OPA
+#   admission policy that rejects list/watch on Pods from this SA in
+#   namespaces matching a deny pattern.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sandbox-router
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+rules:
+# Pod read access for the informer cache. The cache uses a server-side
+# label selector to narrow the actual watch to sandbox-owned Pods (see
+# the header comment); the API permission grant itself cannot be
+# label-scoped.
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sandbox-router
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sandbox-router
+subjects:
+- kind: ServiceAccount
+  name: sandbox-router
+  namespace: agent-sandbox-system
+#
+# The ClusterRoleBinding granting system:auth-delegator (needed for
+# --authz-mode=tokenreview) lives in a separate file —
+# rbac-tokenreview.yaml — so the default-mode deployment (which is
+# --authz-mode=allow-all) doesn't carry the broader create permissions
+# on tokenreviews.authentication.k8s.io and
+# subjectaccessreviews.authorization.k8s.io. Apply that file in
+# addition to this one only when you enable --authz-mode=tokenreview.

--- a/olm/config/sandbox-router/service.yaml
+++ b/olm/config/sandbox-router/service.yaml
@@ -1,0 +1,27 @@
+# Service name matches the Python router's: existing Gateway/HTTPRoute
+# resources that point at `sandbox-router-svc` keep working when the Go
+# router is the backing deployment. See the package README for the
+# header contract clients use.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-router-svc
+  namespace: agent-sandbox-system
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router
+  ports:
+  - name: proxy
+    port: 8080
+    targetPort: proxy
+    protocol: TCP
+  # Uncomment when --https-bind-address=:8443 is set on the router.
+  # - name: proxy-tls
+  #   port: 8443
+  #   targetPort: 8443
+  #   protocol: TCP

--- a/olm/config/sandbox-router/serviceaccount.yaml
+++ b/olm/config/sandbox-router/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sandbox-router
+  namespace: agent-sandbox-system
+  labels:
+    app.kubernetes.io/name: sandbox-router
+    app.kubernetes.io/component: sandbox-router

--- a/olm/hack/sync-k8s-manifests/main.go
+++ b/olm/hack/sync-k8s-manifests/main.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
 
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
@@ -45,11 +47,34 @@ func main() {
 		"write Namespace from controller + Deployment from extensions",
 	)
 	image := flag.String("image", "controller:latest", "container image for the extensions Deployment")
+	routerDir := flag.String(
+		"router-dir",
+		"",
+		"directory of copied sandbox-router manifests to rewrite namespace in-place (optional)",
+	)
+	routerNS := flag.String("router-namespace", "agent-sandbox-system", "target namespace for router manifests")
+	crdDir := flag.String(
+		"crd-dir",
+		"",
+		"directory of copied CRD bases; generates kustomization.yaml in the parent (optional)",
+	)
 	flag.Parse()
 
 	if err := run(*controllerPath, *extensionsPath, *supportOut, *managerOut, *image); err != nil {
 		fmt.Fprintf(os.Stderr, "sync-k8s-manifests: %v\n", err)
 		os.Exit(1)
+	}
+	if *routerDir != "" {
+		if err := rewriteRouterNamespace(*routerDir, *routerNS); err != nil {
+			fmt.Fprintf(os.Stderr, "sync-k8s-manifests: %v\n", err)
+			os.Exit(1)
+		}
+	}
+	if *crdDir != "" {
+		if err := writeCRDKustomization(*crdDir); err != nil {
+			fmt.Fprintf(os.Stderr, "sync-k8s-manifests: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 
@@ -171,6 +196,70 @@ func replaceControllerImage(dep map[string]interface{}, replacement string) erro
 		}
 	}
 	return fmt.Errorf("extensions deployment: no container image matching %q", koControllerImage)
+}
+
+func writeCRDKustomization(basesDir string) error {
+	entries, err := os.ReadDir(basesDir)
+	if err != nil {
+		return fmt.Errorf("read CRD dir %s: %w", basesDir, err)
+	}
+	resources := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		resources = append(resources, "bases/"+e.Name())
+	}
+	out := filepath.Join(filepath.Dir(filepath.Clean(basesDir)), "kustomization.yaml")
+	return writeResourcesKustomization(out, resources)
+}
+
+// writeResourcesKustomization writes a kustomization that only lists resources,
+// matching config/crd/kustomization.yaml. Image remaps belong on a parent
+// overlay that copy-k8s-config does not regenerate (config/default).
+func writeResourcesKustomization(path string, resources []string) error {
+	var buf bytes.Buffer
+	buf.WriteString("resources:\n")
+	for _, r := range resources {
+		fmt.Fprintf(&buf, "- %s\n", r)
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}
+
+// nsDefaultRe matches "namespace: default" with any surrounding whitespace,
+// preserving indentation. This avoids a full YAML parse-marshal round-trip
+// that would drop comments and reorder keys.
+var nsDefaultRe = regexp.MustCompile(`(?m)^(\s*namespace:\s+)default\s*$`)
+
+func rewriteRouterNamespace(dir, namespace string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read router dir %s: %w", dir, err)
+	}
+	excludeFromResources := map[string]bool{
+		"kustomization.yaml":    true,
+		"networkpolicy.yaml":    true,
+		"rbac-tokenreview.yaml": true,
+	}
+	resources := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", e.Name(), err)
+		}
+		data = nsDefaultRe.ReplaceAll(data, []byte("${1}"+namespace))
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", e.Name(), err)
+		}
+		if !excludeFromResources[e.Name()] {
+			resources = append(resources, e.Name())
+		}
+	}
+	return writeResourcesKustomization(filepath.Join(dir, "kustomization.yaml"), resources)
 }
 
 func writeMultiDoc(path string, docs []map[string]interface{}) error {

--- a/olm/hack/sync-k8s-manifests/main_test.go
+++ b/olm/hack/sync-k8s-manifests/main_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteResourcesKustomization(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kustomization.yaml")
+	resources := []string{"deployment.yaml", "service.yaml"}
+	if err := writeResourcesKustomization(path, resources); err != nil {
+		t.Fatalf("writeResourcesKustomization: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read kustomization.yaml: %v", err)
+	}
+	want := "resources:\n- deployment.yaml\n- service.yaml\n"
+	if string(got) != want {
+		t.Fatalf("kustomization.yaml mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestRewriteRouterNamespaceResourceList(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{
+		"deployment.yaml",
+		"service.yaml",
+		"networkpolicy.yaml",
+		"rbac-tokenreview.yaml",
+	} {
+		body := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: x\n  namespace: default\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if err := rewriteRouterNamespace(dir, "agent-sandbox-system"); err != nil {
+		t.Fatalf("rewriteRouterNamespace: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("read kustomization.yaml: %v", err)
+	}
+	text := string(got)
+	if !strings.HasPrefix(text, "resources:\n") {
+		t.Fatalf("kustomization.yaml should be a resources list, got:\n%s", text)
+	}
+	if !strings.Contains(text, "- deployment.yaml\n") || !strings.Contains(text, "- service.yaml\n") {
+		t.Fatalf("kustomization.yaml missing included resources:\n%s", text)
+	}
+	if strings.Contains(text, "networkpolicy.yaml") || strings.Contains(text, "rbac-tokenreview.yaml") {
+		t.Fatalf("kustomization.yaml included excluded resources:\n%s", text)
+	}
+	if strings.Contains(text, "images:") {
+		t.Fatalf("generated kustomization.yaml must not pin images:\n%s", text)
+	}
+	rewritten, err := os.ReadFile(filepath.Join(dir, "deployment.yaml"))
+	if err != nil {
+		t.Fatalf("read deployment.yaml: %v", err)
+	}
+	if !strings.Contains(string(rewritten), "namespace: agent-sandbox-system") {
+		t.Fatalf("deployment.yaml namespace not rewritten:\n%s", rewritten)
+	}
+}
+
+func TestWriteCRDKustomization(t *testing.T) {
+	dir := t.TempDir()
+	basesDir := filepath.Join(dir, "bases")
+	if err := os.Mkdir(basesDir, 0o755); err != nil {
+		t.Fatalf("mkdir bases: %v", err)
+	}
+	crdStub := []byte("apiVersion: apiextensions.k8s.io/v1\n")
+	for _, name := range []string{
+		"agents.x-k8s.io_sandboxes.yaml",
+		"extensions.agents.x-k8s.io_sandboxclaims.yaml",
+	} {
+		if err := os.WriteFile(filepath.Join(basesDir, name), crdStub, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(basesDir, "README.md"), []byte("skip me\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(basesDir, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(basesDir, "nested", "ignored.yaml"), []byte("kind: X\n"), 0o644); err != nil {
+		t.Fatalf("write nested yaml: %v", err)
+	}
+
+	if err := writeCRDKustomization(basesDir); err != nil {
+		t.Fatalf("writeCRDKustomization: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "kustomization.yaml"))
+	if err != nil {
+		t.Fatalf("read kustomization.yaml: %v", err)
+	}
+	want := "resources:\n- bases/agents.x-k8s.io_sandboxes.yaml\n- bases/extensions.agents.x-k8s.io_sandboxclaims.yaml\n"
+	if string(got) != want {
+		t.Fatalf("kustomization.yaml mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(basesDir, "kustomization.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("kustomization.yaml should be written next to bases/, not inside it: %v", err)
+	}
+}
+
+func TestRewriteRouterNamespaceBindings(t *testing.T) {
+	dir := t.TempDir()
+	// ClusterRoleBinding has only subjects[].namespace; RoleBinding has both
+	// metadata.namespace and subjects[].namespace. Both must be rewritten.
+	binding := `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sandbox-router
+subjects:
+- kind: ServiceAccount
+  name: sandbox-router
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-router
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: sandbox-router
+  namespace: default
+`
+	if err := os.WriteFile(filepath.Join(dir, "rbac.yaml"), []byte(binding), 0o644); err != nil {
+		t.Fatalf("write rbac.yaml: %v", err)
+	}
+	if err := rewriteRouterNamespace(dir, "agent-sandbox-system"); err != nil {
+		t.Fatalf("rewriteRouterNamespace: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "rbac.yaml"))
+	if err != nil {
+		t.Fatalf("read rbac.yaml: %v", err)
+	}
+	text := string(got)
+	if strings.Contains(text, "namespace: default") {
+		t.Fatalf("leftover namespace: default in binding:\n%s", text)
+	}
+	wantCRB := `kind: ClusterRoleBinding
+metadata:
+  name: sandbox-router
+subjects:
+- kind: ServiceAccount
+  name: sandbox-router
+  namespace: agent-sandbox-system`
+	if !strings.Contains(text, wantCRB) {
+		t.Fatalf("ClusterRoleBinding subjects[].namespace not rewritten:\n%s", text)
+	}
+	wantRB := `kind: RoleBinding
+metadata:
+  name: sandbox-router
+  namespace: agent-sandbox-system`
+	if !strings.Contains(text, wantRB) {
+		t.Fatalf("RoleBinding metadata.namespace not rewritten:\n%s", text)
+	}
+	wantSubject := `kind: ServiceAccount
+  name: sandbox-router
+  namespace: agent-sandbox-system`
+	if n := strings.Count(text, wantSubject); n != 2 {
+		t.Fatalf("want 2 rewritten subjects[].namespace fields, got %d:\n%s", n, text)
+	}
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Add the router deployment to the olm operator.

Note that networkpolicy and rbac-tokenreview.yaml is explicitly NOT added as it is an example one and it won't properly work without customization

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
The OLM operator now includes the router component
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the sandbox router to the Kubernetes operator bundle.
  * Added a proxy service for routing sandbox traffic.
  * Added health checks, metrics endpoints, resource settings, and availability protections.
  * Added required access controls and network policies for router operation.
  * Added configurable sandbox-router image selection during bundle creation.

* **Documentation**
  * Documented sandbox-router manifest synchronization and optional token-review authorization configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->