### PR TITLE
Drop v1alpha1 docs

### DIFF
--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -1,338 +1,58 @@
 # v1alpha1 → v1beta1 API migration guide
 
-This document covers the operational side of migrating `Sandbox`, `SandboxClaim`, `SandboxTemplate`, and `SandboxWarmPool` resources from the `v1alpha1` API to the `v1beta1` API.
+The `v1alpha1` API was removed in `v1.0.0`.
 
-If you install the chart fresh with the v1beta1-storage version, there is nothing to migrate — read this only when **upgrading** an existing installation that holds v1alpha1-serialized resources in etcd.
+If your cluster still has `v1alpha1`-serialized resources in etcd or if you are upgrading from `v0.4.x` / early `v0.5.x` releases, you cannot upgrade directly to `v1.0.0` or later.
 
-## What changes between versions
+## Migration Steps
 
-Most CRDs are schema-compatible across the two versions; the migration matters mainly for **two reasons**:
+1. **Upgrade to `v0.5.x` first**: Upgrade your installation to the latest `v0.5.x` release.
+2. **Run the v0.5 migration**: Follow the [v0.5.x API migration guide](https://github.com/kubernetes-sigs/agent-sandbox/blob/v0.5.2/docs/api-migration-guide.md) to migrate all existing resources to `v1beta1` and prune legacy `storedVersions`.
+3. **Pre-upgrade check**: Before upgrading from `v0.5.x` to `v1.0.0`, verify that every agent-sandbox CustomResourceDefinition reports only `v1beta1` in `status.storedVersions`:
+   ```bash
+   for crd in \
+       sandboxes.agents.x-k8s.io \
+       sandboxclaims.extensions.agents.x-k8s.io \
+       sandboxtemplates.extensions.agents.x-k8s.io \
+       sandboxwarmpools.extensions.agents.x-k8s.io; do
+     printf '%s: ' "${crd}"
+     kubectl get crd "${crd}" -o jsonpath='{.status.storedVersions}'
+     printf '\n'
+   done
+   ```
+   If `v1alpha1` is still listed on any CRD, complete the v0.5 storage migration and CRD status prune first—otherwise the Kubernetes apiserver will reject the upgrade.
+4. **Upgrade to `v1.0.0`**: Once all four CRDs report only `["v1beta1"]`, proceed with upgrading to `v1.0.0` or later.
 
-1. **`SandboxClaim` is not field-compatible.** v1alpha1 has `spec.sandboxTemplateRef` plus an optional `spec.warmpool` string policy (`"none"` / `"default"` / a specific pool name). v1beta1 requires `spec.warmPoolRef.name`. The conversion webhook (in `extensions/api/v1alpha1/sandboxclaim_conversion.go`) handles the rewrite via three branches:
-   - **Specific pool name** (`warmpool: my-pool`) → webhook uses that name verbatim. If the pool doesn't exist, the converted claim points at a missing pool — operator must create it.
-   - **`""` / `"default"`, warm-started** (claim has a bound `Sandbox` whose name differs from the claim's name) → webhook derives the pool name from the existing `Sandbox` via `stripRandomSuffix(sandboxName)`. The source pool already exists; nothing to do at migration time. (`"none"` never falls into this branch — `"none"` always cold-starts.)
-   - **`""` / `"none"` / `"default"`, cold-start** (no bound `Sandbox`, or `Sandbox.name == claim.name`) → webhook redirects to `shadow-pool-<template-name>`. The bootstrap phase ensures one such shadow pool exists per `(namespace, template)` combination.
-2. **`Sandbox.spec.replicas` becomes `Sandbox.spec.operatingMode`.** `replicas: 0` → `Suspended`, `replicas: 1` (or unset) → `Running`. The webhook handles this automatically.
+## Helm Upgrade Ordering
 
-The other two CRDs (`SandboxTemplate`, `SandboxWarmPool`) are structurally identical between versions but still need a storage rewrite so etcd holds them in v1beta1 form.
+Helm does not upgrade CRDs in `crds/` (see [helm/README.md](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/helm/README.md)), so the order matters. Apply the CRDs **before** `helm upgrade`, otherwise the chart removes the webhook Service while the old CRDs still reference it for conversion.
 
-## Two phases
+After completing Migration Steps 1–3 above:
 
-The migration script executes in two distinct phases. **Neither phase can happen in an arbitrary order**, and if you have existing cold-start claims, skipping the bootstrap phase will immediately break them upon upgrading to `v0.5.2`.
+1. `kubectl apply -f helm/crds/` — installs the v1beta1-only CRDs and drops the conversion config.
+2. `helm upgrade` — now safe; removes the webhook Service, Role, and RoleBinding.
+3. Delete the orphaned cert Secret (see Post-Upgrade Cleanup below).
 
-> [!IMPORTANT]
-> When migrating from `v0.4.x`, always upgrade directly to **`v0.5.2`** (or later) rather than earlier `0.5.x` releases. Release `v0.5.2` includes a critical fix for a controller race condition that caused warm-started claims to undergo pod cold restarts during initial upgrade reconciliation.
+## Post-Upgrade Cleanup
 
-### Phase 1: `--phase=bootstrap` (Conditionally Mandatory, Pre-Upgrade)
+When upgrading via `kubectl apply -f k8s/` or sequential manifest application, Kubernetes does not automatically delete resources that have been removed from the newest release manifests. After upgrading to `v1.0.0`, four legacy webhook infrastructure objects from `v0.5.x` will remain in your cluster as orphans:
+- `Service/agent-sandbox-webhook-service`
+- `Secret/agent-sandbox-webhook-certs`
+- `Role/agent-sandbox-controller` (namespaced in `agent-sandbox-system`)
+- `RoleBinding/agent-sandbox-controller` (namespaced in `agent-sandbox-system`)
 
-- **Mandatory for `v0.5.2`:** Yes, if you have existing cold-start `v1alpha1` claims (claims where `spec.warmpool` is empty/`"none"`/`"default"` AND `status.sandbox.name` matches the claim name or is empty). Note: The script automatically detects whether cold-start claims exist. If none exist, it safely exits without creating anything, so it is recommended to always run it (or use `--dry-run` to inspect) rather than skipping it manually.
-- **Timing:** Strictly **before** upgrading to `v0.5.2` (while `v1alpha1` is still active).
-- **What it does:** Scans existing `v1alpha1` claims and pre-creates `shadow-pool-<template>` warm pools. The `v0.5.2` controller reconciler is written purely against `v1beta1.SandboxClaim`, which requires a valid `spec.warmPoolRef.name`. If you do not pre-create the shadow pools, the conversion webhook will point converted claims to non-existent infrastructure, leaving converted claims stuck with a `WarmPoolNotFound` condition while the controller repeatedly requeues them.
-- **Why it cannot run after upgrade:** Bootstrap relies on `v1alpha1` field inspection. Once `v0.5.2` is installed, `kubectl get sandboxclaims` defaults to returning `v1beta1` objects (which lack `spec.sandboxTemplateRef`). The script will see empty template names, log errors for every claim, and fail to create any shadow pools.
-
-### Phase 2: `--phase=migrate` (Optional for `v0.5.2`, Post-Upgrade)
-
-- **Optional for `v0.5.2`** (but mandatory before upgrading to a future release that drops `v1alpha1`).
-- **Timing:** Strictly **after** upgrading to `v0.5.2` (when `v1beta1` is established as the storage version and the conversion webhook is live).
-- **What it does:** Patches every existing resource with a benign annotation (`agents.x-k8s.io/storage-migrated-at`). This forces the API server to read the `v1alpha1` etcd record, pass it through the conversion webhook, and rewrite it to etcd in `v1beta1` storage format. While the kube-apiserver can translate older records on the fly for `v0.5.2`, running this phase ensures all objects are re-serialized in `v1beta1` format in etcd, which is required before `v1alpha1` can be safely removed from the CRD definition in a future release.
-- **Why it cannot run before upgrade:** Before upgrading, `v1alpha1` is still the storage version in etcd. Patching the resources will merely write an annotation onto `v1alpha1` etcd records, accomplishing zero storage migration.
-
-Both phases are idempotent — safe to re-run.
-
-## Before you start: back up your data
-
-Before running either phase, dump every CR the migration will touch so you have a known-good snapshot to fall back to if anything goes wrong:
-
+To clean up these orphaned webhook resources, run:
 ```bash
-kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools \
-  -A -o yaml > agent-sandbox-backup-$(date -u +%Y%m%dT%H%M%SZ).yaml
+kubectl delete -n agent-sandbox-system \
+  svc/agent-sandbox-webhook-service \
+  secret/agent-sandbox-webhook-certs \
+  role/agent-sandbox-controller \
+  rolebinding/agent-sandbox-controller \
+  --ignore-not-found
 ```
 
-Keep the file somewhere durable (not on a worker pod that may get rescheduled). Useful for:
-
-- Inspecting the original v1alpha1 shape if a converted v1beta1 record looks wrong.
-- Comparing pre- vs post-migration to confirm only the expected fields changed.
-- Re-creating individual mangled resources by hand without restoring the whole namespace.
-
-See [Recovery from backup](#recovery-from-backup) in the Troubleshooting section if you need to roll back.
-
-## Migration flows
-
-Pick one of the two flows depending on how you manage installs.
-
-### Flow A — Manual via kubectl (default)
-
-The official agent-sandbox installation path is `kubectl apply -f` against the release manifests (see the project README and release notes), so this is the default migration flow. Run the script directly from `dev/tools/migrate.sh` (a thin wrapper around `helm/files/migrate.sh`):
-
-```bash
-# 1. Pre-create the shadow pools BEFORE applying the new CRDs.
-#    Operates on v1alpha1 - this is the last step that does.
-bash dev/tools/migrate.sh --phase=bootstrap
-
-# 2. Install the new controller + CRDs (which include the conversion webhook).
-#    The release ships two manifests: sandbox.yaml (core controller + base
-#    CRDs + webhook Service) and extensions.yaml (the extensions API group
-#    CRDs: SandboxClaim, SandboxTemplate, SandboxWarmPool). Apply both.
-#    Wait until the controller pod is Ready and the webhook Service has
-#    endpoints before proceeding.
-#    Note: Starting from v0.5.2, the core manifest is named `sandbox.yaml`. 
-#    If upgrading to an older release (like v0.5.0 or v0.5.1), apply `manifest.yaml` instead of `sandbox.yaml`:
-#    kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/manifest.yaml
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/sandbox.yaml
-kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<new-version>/extensions.yaml
-kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system
-kubectl wait --for=condition=Ready pods -l app=agent-sandbox-controller -n agent-sandbox-system
-
-# Wait until the conversion webhook is responsive (this may take a few seconds after the pod starts)
-until kubectl get sandboxwarmpools.extensions.agents.x-k8s.io -A >/dev/null 2>&1; do
-  echo "Waiting for conversion webhook to be responsive..."
-  sleep 2
-done
-
-# 3. Force-rewrite every resource in v1beta1 storage format.
-bash dev/tools/migrate.sh --phase=migrate
-```
-
-If the cluster is large, scope the rewrite to one namespace at a time:
-
-```bash
-bash dev/tools/migrate.sh --phase=migrate --namespace=team-alpha
-```
-
-### Flow B — Helm-managed, manual script
-
-For installs managed by the Helm chart, the migration is driven manually by the operator using `dev/tools/migrate.sh`.
-
-```bash
-# 1. Pre-create shadow pools while v1alpha1 is still the storage version.
-bash dev/tools/migrate.sh --phase=bootstrap --dry-run   # inspect first
-bash dev/tools/migrate.sh --phase=bootstrap
-
-# 2. Manually apply the upgraded CRD manifests using Server-Side Apply.
-#    Since Helm does not upgrade CRDs on upgrade, they must be applied manually:
-kubectl apply --server-side --force-conflicts -f path/to/chart/crds/
-
-# 3. Upgrade the chart.
-# (If you are using extension resources like claims, templates, or pools, make sure --set controller.extensions=true is set or enabled in values)
-helm upgrade agent-sandbox ./helm/ \
-  --namespace agent-sandbox-system \
-  --reuse-values \
-  --set image.tag=<new-version> \
-  --set controller.extensions=true
-
-# 4. Wait for the new controller + webhook to be Ready, then rewrite storage.
-kubectl rollout status deploy/agent-sandbox-controller -n agent-sandbox-system
-
-# Wait until the conversion webhook is responsive (this may take a few seconds after the pod starts)
-until kubectl get sandboxwarmpools.extensions.agents.x-k8s.io -A >/dev/null 2>&1; do
-  echo "Waiting for conversion webhook to be responsive..."
-  sleep 2
-done
-bash dev/tools/migrate.sh --phase=migrate
-```
-
-
-
-## Dry-runs
-
-Both phases support `--dry-run`. The script prints what it would do without writing anything:
-
-```bash
-bash dev/tools/migrate.sh --phase=bootstrap --dry-run
-bash dev/tools/migrate.sh --phase=migrate --dry-run
-```
-
-The `bootstrap` dry-run also prints the "operator action required" summary (claims referencing missing specific pools), which is useful to inspect even when you intend to apply.
-
-## After migration completes
-
-### Shadow pools
-
-The bootstrap phase creates one `shadow-pool-<template>` per `(namespace, template)` combination referenced by cold-start v1alpha1 claims. They're marked with two annotations:
-
-- `agents.x-k8s.io/migration-shadow: "true"`
-- `agents.x-k8s.io/migration-source-template: <template-name>`
-
-List them:
-
-```bash
-kubectl get sandboxwarmpools -A -o json \
-  | jq -r '.items[]
-      | select(.metadata.annotations["agents.x-k8s.io/migration-shadow"]=="true")
-      | "\(.metadata.namespace)/\(.metadata.name) (for template: \(.metadata.annotations["agents.x-k8s.io/migration-source-template"]))"'
-```
-
-Do **not** delete these pools while any v1beta1 `SandboxClaim` still references them via `warmPoolRef`. While `v1alpha1` definitions remain in the codebase for webhook conversion, the `v1beta1` controller reconciler has no `v1alpha1` fallback logic for claims pointing to missing pools. Once you've manually re-pointed any remaining claims to real warm pools, the shadow pools can be cleaned up.
-
-### Re-pointing warm-started claims
-
-The bootstrap phase intentionally **skips** warm-started v1alpha1 claims (those with `warmpool: ""`/`"none"`/`"default"` AND a bound `Sandbox` whose name differs from the claim's). The webhook redirects those claims' `warmPoolRef` to the pool that produced their current `Sandbox` (via `stripRandomSuffix(sandboxName)`), so they end up pointing at a real, existing pool — no shadow needed.
-
-That said, after migration completes you may want to re-point such claims at a different pool (e.g., consolidate, or move to a shadow). The `warmPoolRef.name` is editable on the v1beta1 claim:
-
-```bash
-kubectl patch sandboxclaim <name> -n <ns> --type=merge \
-  -p '{"spec":{"warmPoolRef":{"name":"my-preferred-pool"}}}'
-```
-
-### Operator-action items from the bootstrap summary
-
-If `bootstrap` printed an `OPERATOR ACTION REQUIRED` section listing claims that reference specific pools which don't currently exist, the conversion webhook will still rewrite those claims to point at those exact (missing) pool names. To make those claims work, either:
-
-1. Create the missing pools manually, OR
-2. Re-point the claims to existing pools via the `kubectl patch` above.
-
-## Verifying the migration worked
-
-After the post-upgrade Job completes:
-
-```bash
-# Every resource should now have the storage-migrated-at annotation.
-# jq handles annotation keys with "." and "/" correctly; kubectl jsonpath
-# dot-escaping cannot reliably read keys containing "/".
-kubectl get sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A -o json \
-  | jq -r '.items[]
-      | "\(.kind) \(.metadata.namespace)/\(.metadata.name) -> \(.metadata.annotations["agents.x-k8s.io/storage-migrated-at"] // "<missing>")"'
-```
-
-To verify the actual etcd storage version, check each CRD's `status.storedVersions`. The kube-apiserver records every version that has ever been used to write any record there; after the rewrite Job touches every resource, you can manually prune `v1alpha1` from the list to confirm nothing v1alpha1 is left:
-
-```bash
-for crd in \
-    sandboxes.agents.x-k8s.io \
-    sandboxclaims.extensions.agents.x-k8s.io \
-    sandboxtemplates.extensions.agents.x-k8s.io \
-    sandboxwarmpools.extensions.agents.x-k8s.io; do
-  printf '%s: ' "${crd}"
-  kubectl get crd "${crd}" -o jsonpath='{.status.storedVersions}'
-  printf '\n'
-done
-```
-
-If a CRD still lists `["v1alpha1","v1beta1"]` after the rewrite Job succeeded, every existing record has been rewritten in v1beta1 form, but the `storedVersions` array is not auto-pruned. To finalize:
-
-```bash
-# Confirm no v1alpha1-only records remain, then prune storedVersions.
-kubectl patch crd <crd-name> --subresource=status --type=merge \
-  -p '{"status":{"storedVersions":["v1beta1"]}}'
-```
-
-Only do this after you've confirmed every existing record carries `agents.x-k8s.io/storage-migrated-at` from the rewrite Job's run.
-
-## Troubleshooting
-
-**Migrate phase reports failures on specific resources**: re-run the script (`bash dev/tools/migrate.sh --phase=migrate`). It's idempotent — already-migrated resources just get the annotation timestamp updated. If a specific resource keeps failing, fetch it (`kubectl get -o yaml`) and inspect what's wrong — usually it's a conversion-webhook error tied to a bad field combination that needs manual cleanup.
-
-**Bootstrap printed `OPERATOR ACTION REQUIRED` for some claims**: those claims reference specific pool names that don't currently exist. The conversion webhook will still rewrite them to point at those names — you must create the pools manually post-migration, or re-point the claims (see "Re-pointing warm-started claims" above).
-
-**Webhook connection timeouts in managed/private clusters (e.g., GKE)**: If you see `dial tcp ... connect: connection refused` or connection timeouts from the API server during the `migrate` phase, it is likely that the control plane VPC cannot reach the webhook target port (`9443`) on the worker nodes.
-* By default, GKE private clusters block master-to-worker node traffic on ports other than standard ones like `443` and `10250`.
-* **Fix**: Create a firewall rule in your GCP console allowing ingress from your GKE master node IP range to your worker nodes on TCP port `9443`.
-
-
-## Emergency Rollback Procedure (Reverting to v1alpha1)
-
-If the migration fails critically (e.g., the new controller fails to start, the webhook causes severe issues, or you encounter unresolvable errors) and you need to completely revert to the `v1alpha1` version:
-
-### Step 1: Disable Conversion Webhooks
-First, stop the API server from attempting version conversion to prevent blockages on custom resource writes and deletions:
-```bash
-for crd in \
-    sandboxes.agents.x-k8s.io \
-    sandboxclaims.extensions.agents.x-k8s.io \
-    sandboxtemplates.extensions.agents.x-k8s.io \
-    sandboxwarmpools.extensions.agents.x-k8s.io; do
-  kubectl patch crd "${crd}" --type=merge -p '{"spec":{"conversion":{"strategy":"None","webhook":null}}}'
-done
-```
-### Step 2: Scale down the controller deployment
-Scale down the `agent-sandbox-controller` deployment to `0` replicas, and wait for the pods to terminate completely. This stops the controller manager from reconciling resources or creating new Sandboxes to replace deleted ones while you are cleaning up the resources:
-```bash
-kubectl scale deploy/agent-sandbox-controller -n agent-sandbox-system --replicas=0
-kubectl wait --for=delete pod -l app=agent-sandbox-controller -n agent-sandbox-system --timeout=60s
-```
-
-### Step 3: Delete upgraded resources
-While the upgraded CRDs (supporting both `v1alpha1` and `v1beta1` versions) are still installed, delete all custom resources so etcd is completely emptied of `v1beta1` records:
-```bash
-kubectl delete sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A --all
-```
-
-### Step 4: Delete shadow pools (optional)
-If the bootstrap phase created shadow warm pools, delete them:
-```bash
-kubectl get sandboxwarmpools -A -o json \
-  | jq -r '.items[] | select(.metadata.annotations["agents.x-k8s.io/migration-shadow"]=="true") | "\(.metadata.namespace)/\(.metadata.name)"' \
-  | xargs -I {} sh -c 'kubectl delete sandboxwarmpool $(echo {} | cut -d/ -f2) -n $(echo {} | cut -d/ -f1)'
-```
-
-### Step 5: Reset CRD storedVersions to v1alpha1
-Because the API server enforces that any version in `status.storedVersions` must be present in `spec.versions`, you must patch the CRDs to list only `v1alpha1` in their stored versions before downgrading the CRD definitions:
-```bash
-for crd in \
-    sandboxes.agents.x-k8s.io \
-    sandboxclaims.extensions.agents.x-k8s.io \
-    sandboxtemplates.extensions.agents.x-k8s.io \
-    sandboxwarmpools.extensions.agents.x-k8s.io; do
-  kubectl patch crd "${crd}" --subresource=status --type=merge -p '{"status":{"storedVersions":["v1alpha1"]}}'
-done
-```
-
-### Step 6: Revert the CRD manifests and Controller
-Downgrade the installed components back to the old version:
-
-* **For Flow A (kubectl):** Re-apply the old version's manifests (substitute `<old-version>` with your previous version, e.g., `v0.4.6`):
-  ```bash
-  kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<old-version>/manifest.yaml
-  kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/<old-version>/extensions.yaml
-  ```
-* **For Flow B (Helm):** Roll back the Helm release to the pre-migration revision (find the revision number using `helm history agent-sandbox`):
-  ```bash
-  helm rollback agent-sandbox <previous-revision-number> -n agent-sandbox-system
-  # Re-apply the old CRD versions manually:
-  kubectl apply --server-side --force-conflicts -f path/to/old-chart/crds/
-  ```
-
-### Step 7: Restore Data from Backup
-Apply the backup file to restore your original `v1alpha1` resources:
-```bash
-# Re-apply the backup (stripping status fields is recommended to allow the old controller to re-initialize them)
-yq 'del(.items[].status)' backup.yaml | kubectl apply -f -
-```
-
----
-
-## Recovery from Backup (Remaining on v1beta1)
-
-If you intend to stay on `v1beta1` but need to restore specific broken or corrupt objects from your backup:
-
-If migration produces broken or unexpected v1beta1 resources, use the backup file from [Before you start: back up your data](#before-you-start-back-up-your-data) to restore.
-
-**Per-resource restore** (preferred — only touches what's actually broken):
-
-```bash
-# Inspect a specific resource against the backup to confirm it's wrong.
-kubectl get <kind> <name> -n <namespace> -o yaml \
-  | diff - <(yq '.items[] | select(.kind=="<kind>" and .metadata.name=="<name>")' backup.yaml)
-
-# Delete the broken record and re-apply the v1alpha1 spec from the backup.
-# The conversion webhook re-converts it on apply.
-kubectl delete <kind> <name> -n <namespace>
-yq '.items[] | select(.kind=="<kind>" and .metadata.name=="<name>")' backup.yaml \
-  | kubectl apply -f -
-```
-
-**Bulk restore** (last resort — only when many resources are broken AND the conversion webhook is functioning):
-
-```bash
-# CAUTION: deletes every Sandbox/SandboxClaim/SandboxTemplate/SandboxWarmPool
-# across all namespaces, then re-creates them from the backup.
-kubectl delete sandboxes,sandboxclaims,sandboxtemplates,sandboxwarmpools -A --all
-kubectl apply -f backup.yaml
-```
-
-Caveats:
-
-- Restoration depends on a functioning conversion webhook. If the webhook itself is broken, fix that first (typically: roll the controller image back to the pre-migration version, then re-apply the backup), or restore in two phases by first re-installing the old chart and then re-applying the backup against the old CRDs.
-- The backup captures `status` subresources too. Strip them before re-apply so the controllers re-derive status from spec rather than racing your stale snapshot: `yq 'del(.items[].status)' backup.yaml | kubectl apply -f -`.
-- Backups don't capture cluster-scoped state like `SandboxWarmPool` controller progress; freshly-applied pools will repopulate themselves from the template.
+> [!WARNING]
+> The cluster-scoped `ClusterRole` and `ClusterRoleBinding` named `agent-sandbox-controller` are still actively required by the running controller. Do **not** delete cluster-scoped roles; ensure the cleanup snippet above uses namespaced `role`/`rolebinding` within `-n agent-sandbox-system`.
+
+> [!NOTE]
+> **Helm and OLM Users**: Helm and OLM automatically prune the 3 manifest-managed resources (`Service/agent-sandbox-webhook-service`, `Role/agent-sandbox-controller`, and `RoleBinding/agent-sandbox-controller`) during upgrade. However, the runtime-generated `Secret/agent-sandbox-webhook-certs` is not tracked in release manifests—all users (kubectl, Helm, and OLM) should run `kubectl delete -n agent-sandbox-system secret/agent-sandbox-webhook-certs --ignore-not-found` to clean up the legacy certificate secret. Verify the three were pruned with `kubectl get -n agent-sandbox-system svc/agent-sandbox-webhook-service role/agent-sandbox-controller rolebinding/agent-sandbox-controller --ignore-not-found` — empty output means all three are gone. If anything remains, use the full cleanup command above. (See [OLM Installation Guide](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/olm/README.md#upgrading-from-v05x-to-v100) for OLM-specific pre-upgrade `storedVersions` instructions).

--- a/docs/api-migration-guide.md
+++ b/docs/api-migration-guide.md
@@ -6,7 +6,7 @@ If your cluster still has `v1alpha1`-serialized resources in etcd or if you are 
 
 ## Migration Steps
 
-1. **Upgrade to `v0.5.x` first**: Upgrade your installation to the latest `v0.5.x` release.
+1. **Upgrade to `v0.5.x` first**: Upgrade your installation to a `v0.5.x` release.
 2. **Run the v0.5 migration**: Follow the [v0.5.x API migration guide](https://github.com/kubernetes-sigs/agent-sandbox/blob/v0.5.2/docs/api-migration-guide.md) to migrate all existing resources to `v1beta1` and prune legacy `storedVersions`.
 3. **Pre-upgrade check**: Before upgrading from `v0.5.x` to `v1.0.0`, verify that every agent-sandbox CustomResourceDefinition reports only `v1beta1` in `status.storedVersions`:
    ```bash

--- a/docs/keps/694-kep-for-suspend-and-resume-for-beta/README.md
+++ b/docs/keps/694-kep-for-suspend-and-resume-for-beta/README.md
@@ -55,7 +55,7 @@ This approach introduces a strongly-typed Enum (`spec.operatingMode: Running | S
 To implement Suspend and Resume, the following alternatives were considered:
 
 #### 1. API Aggregation Server (True Custom Subresources) - *Rejected*
-Instead of using standard CRDs, we could build and deploy a custom API Aggregation Server (using the `apiregistration.k8s.io` API) to support native HTTP endpoints like `POST /apis/agents.x-k8s.io/v1alpha1/namespaces/default/sandboxes/dev-42/suspend`.
+Instead of using standard CRDs, we could build and deploy a custom API Aggregation Server (using the `apiregistration.k8s.io` API) to support native HTTP endpoints like `POST /apis/agents.x-k8s.io/v1beta1/namespaces/default/sandboxes/dev-42/suspend`.
 * **Pros:** Offers a completely native, secure, and clean API. Enables fine-grained RBAC specifically for the `/suspend` action.
 * **Cons:** Introduces massive operational complexity. Requires maintaining an active API Aggregator Pod, managing custom TLS certificates, and handling etcd storage manually.
 

--- a/examples/latebind-storage-gke-sandbox/README.md
+++ b/examples/latebind-storage-gke-sandbox/README.md
@@ -65,7 +65,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/lates
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/latest/download/extensions.yaml
 ```
 
-**Note on API Versions**: The OSS controller serves the `v1beta1` API. If you use this installation, you must update the apiVersion in the YAML examples throughout this guide from `extensions.agents.x-k8s.io/v1alpha1` to `extensions.agents.x-k8s.io/v1beta1`.
+**Note on API Versions**: The OSS controller serves the `v1beta1` API. The examples throughout this guide use `v1beta1`.
 
 ### GKE Agent Sandbox Add-on (Cloud-Specific Alternative)
 
@@ -77,7 +77,10 @@ gcloud beta container clusters update ${CLUSTER_NAME} \
 --enable-agent-sandbox
 ```
 
-**Note**: The GKE add-on currently serves the `v1alpha1` API. The examples in this guide use `v1alpha1` for compatibility with this managed service.
+**Note**: The GKE add-on currently serves `v1alpha1`. If using the add-on, adapt the manifests as follows:
+
+- `SandboxTemplate` and `SandboxWarmPool`: change `apiVersion` to `extensions.agents.x-k8s.io/v1alpha1`. All field names are unchanged.
+- `SandboxClaim`: change `apiVersion`, and replace `spec.warmPoolRef.name: late-bind-warmpool` with `spec.sandboxTemplateRef.name: late-bind-template`. In `v1alpha1` a claim references the *template*; in `v1beta1` it references the *warm pool*.
 
 
 # Infrastructure Deployment
@@ -179,15 +182,15 @@ Apply the following `SandboxClaim`:
 
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
- name: user-111-claim
- finalizers:
-  - agent.sandbox/storage-cleanup
+  name: user-111-claim
+  finalizers:
+    - agent.sandbox/storage-cleanup
 spec:
- sandboxTemplateRef:
-  name: late-bind-template
+  warmPoolRef:
+    name: late-bind-warmpool
 EOF
 ```
 
@@ -278,7 +281,7 @@ Success: Bound Filestore folder user-111 to mount path inside of agent container
 
 ### Securing the Running Pod with a Dynamic Finalizer
 
-While we statically declared a finalizer on the SandboxClaim in [Submit a SandboxClaim](#submit-a-sandbox-claim), we must also place a finalizer on the `SandboxWarmPool` Pods that are bound to `SandboxClaim`s. [Kubernetes does not support](https://github.com/kubernetes-sigs/agent-sandbox/blob/aae8e6272688daaf45a4a890f813da29aa73de7e/api/v1alpha1/sandbox_types.go#L124-L127) defining static finalizers inside a `SandboxTemplate`'s `podTemplate.spec` block. Therefore, the orchestrator must dynamically apply the finalizer to the running Pod immediately after the storage is successfully bound. This establishes a secure 1:1 mapping between the bound storage and the pod lifecycle, ensuring that the pod cannot be deleted until the host-level mount is safely decoupled.
+While we statically declared a finalizer on the SandboxClaim in [Submit a SandboxClaim](#submit-a-sandbox-claim), we must also place a finalizer on the `SandboxWarmPool` Pods that are bound to `SandboxClaim`s. [Kubernetes does not support](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/api/v1beta1/sandbox_types.go#L124-L127) defining static finalizers inside a `SandboxTemplate`'s `podTemplate.spec` block. Therefore, the orchestrator must dynamically apply the finalizer to the running Pod immediately after the storage is successfully bound. This establishes a secure 1:1 mapping between the bound storage and the pod lifecycle, ensuring that the pod cannot be deleted until the host-level mount is safely decoupled.
 
 Execute the following commands to dynamically patch the pod-level finalizer:
 
@@ -424,15 +427,15 @@ kubectl patch pod $POD_NAME --type=merge -p '{"metadata":{"finalizers":[]}}'
 To resume the session, a new claim is created, which automatically assigns a fresh pre-warmed pod from the background warm pool.
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
- name: user-111-resume
- finalizers:
-  - agent.sandbox/storage-cleanup
+  name: user-111-resume
+  finalizers:
+    - agent.sandbox/storage-cleanup
 spec:
- sandboxTemplateRef:
-  name: late-bind-template
+  warmPoolRef:
+    name: late-bind-warmpool
 EOF
 ```
 
@@ -583,15 +586,15 @@ When the user requests a restoration, the orchestrator issues a new claim and in
 ```shell
 # 1. Create a new SandboxClaim for the restoration session
 kubectl apply -f - <<EOF
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
- name: user-111-snapshot-restore
- finalizers:
-  - agent.sandbox/storage-cleanup
+  name: user-111-snapshot-restore
+  finalizers:
+    - agent.sandbox/storage-cleanup
 spec:
- sandboxTemplateRef:
-  name: late-bind-template
+  warmPoolRef:
+    name: late-bind-warmpool
 EOF
 
 # 2. Capture metadata for the newly assigned warm pod
@@ -645,15 +648,15 @@ This step demonstrates that even when multiple tenants are active on the same Fi
 ### 1. Create the SandboxClaim for user-222
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxClaim
 metadata:
- name: user-222-claim
- finalizers:
-  - agent.sandbox/storage-cleanup
+  name: user-222-claim
+  finalizers:
+    - agent.sandbox/storage-cleanup
 spec:
- sandboxTemplateRef:
-  name: late-bind-template
+  warmPoolRef:
+    name: late-bind-warmpool
 EOF
 ```
 

--- a/examples/latebind-storage-gke-sandbox/README.md
+++ b/examples/latebind-storage-gke-sandbox/README.md
@@ -281,7 +281,7 @@ Success: Bound Filestore folder user-111 to mount path inside of agent container
 
 ### Securing the Running Pod with a Dynamic Finalizer
 
-While we statically declared a finalizer on the SandboxClaim in [Submit a SandboxClaim](#submit-a-sandbox-claim), we must also place a finalizer on the `SandboxWarmPool` Pods that are bound to `SandboxClaim`s. [Kubernetes does not support](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/api/v1beta1/sandbox_types.go#L124-L127) defining static finalizers inside a `SandboxTemplate`'s `podTemplate.spec` block. Therefore, the orchestrator must dynamically apply the finalizer to the running Pod immediately after the storage is successfully bound. This establishes a secure 1:1 mapping between the bound storage and the pod lifecycle, ensuring that the pod cannot be deleted until the host-level mount is safely decoupled.
+While we statically declared a finalizer on the SandboxClaim in [Submit a SandboxClaim](#submit-a-sandbox-claim), we must also place a finalizer on the `SandboxWarmPool` Pods that are bound to `SandboxClaim`s. [Kubernetes does not support](https://github.com/kubernetes-sigs/agent-sandbox/blob/v0.5.4/api/v1beta1/sandbox_types.go#L136-L144) defining static finalizers inside a `SandboxTemplate`'s `podTemplate.spec` block. Therefore, the orchestrator must dynamically apply the finalizer to the running Pod immediately after the storage is successfully bound. This establishes a secure 1:1 mapping between the bound storage and the pod lifecycle, ensuring that the pod cannot be deleted until the host-level mount is safely decoupled.
 
 Execute the following commands to dynamically patch the pod-level finalizer:
 

--- a/examples/latebind-storage-gke-sandbox/sandbox-warmpool.yaml
+++ b/examples/latebind-storage-gke-sandbox/sandbox-warmpool.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxTemplate
 metadata:
   name: late-bind-template
@@ -77,7 +77,7 @@ spec:
       - name: workspace-volume
         emptyDir: {}
 ---
-apiVersion: extensions.agents.x-k8s.io/v1alpha1
+apiVersion: extensions.agents.x-k8s.io/v1beta1
 kind: SandboxWarmPool
 metadata:
   name: late-bind-warmpool

--- a/helm/README.md
+++ b/helm/README.md
@@ -51,11 +51,9 @@ helm upgrade agent-sandbox ./helm/ \
 > kubectl apply -f helm/crds/
 > ```
 
-### v1alpha1 → v1beta1 storage migration
+### Upgrading from v1alpha1
 
-Upgrades to chart versions that move CRDs from `v1alpha1` to `v1beta1` require a manual storage migration using the `dev/tools/migrate.sh` script.
-
-See [`docs/api-migration-guide.md`](../docs/api-migration-guide.md) for full details, sequence of steps, and operational guidelines.
+Support for the `v1alpha1` API has been removed. If you are upgrading from an older release that uses `v1alpha1`, you must upgrade to a `v0.5.x` release and run the storage migration first. See [`docs/api-migration-guide.md`](../docs/api-migration-guide.md) for details.
 
 ## Uninstallation
 
@@ -109,4 +107,3 @@ The following table lists the configurable parameters and their defaults.
 | `containerSecurityContext` | Container `securityContext` for the controller; only rendered when set | `null` |
 | `podAnnotations` | Annotations added to the controller pod template (e.g. service-mesh sidecar toggles, Prometheus scrape autodiscovery) | `{}` |
 | `podLabels` | Extra labels added to the controller pod template alongside the chart's selector labels (selector labels take precedence on conflict) | `{}` |
-| `webhookServiceName` | Name of the conversion webhook Service | `agent-sandbox-webhook-service` |

--- a/helm/README.md
+++ b/helm/README.md
@@ -53,7 +53,7 @@ helm upgrade agent-sandbox ./helm/ \
 
 ### Upgrading from v1alpha1
 
-Support for the `v1alpha1` API has been removed. If you are upgrading from an older release that uses `v1alpha1`, you must upgrade to a `v0.5.x` release and run the storage migration first. See [`docs/api-migration-guide.md`](../docs/api-migration-guide.md) for details.
+Support for the `v1alpha1` API has been removed. If you are upgrading from an older release that uses `v1alpha1`, you must upgrade to a `v0.5.x` release and run the storage migration first. Note that this upgrade inverts the general order above: you must apply the `v1beta1` CRDs **before** running `helm upgrade` to prevent conversion errors during webhook service teardown. See the [Helm Upgrade Ordering section in `docs/api-migration-guide.md`](../docs/api-migration-guide.md#helm-upgrade-ordering) for the full sequence.
 
 ## Uninstallation
 

--- a/olm/README.md
+++ b/olm/README.md
@@ -19,6 +19,32 @@ This directory packages Agent Sandbox for **OLM** (OperatorHub, OpenShift, and o
 
 For controller development (local kind cluster, image build), see [docs/development.md](../docs/development.md).
 
+### Upgrading from v0.5.x to v1.0.0+
+
+Starting in **v1.0.0**, `v1alpha1` support and conversion webhooks are removed. If upgrading an existing OLM-managed cluster from `v0.5.x`:
+
+1. **Migrate existing resources**: Follow the [v1alpha1 → v1beta1 API migration guide](../docs/api-migration-guide.md) to migrate all existing resources to `v1beta1`.
+2. **Prune `storedVersions` before upgrading**: Every agent-sandbox CustomResourceDefinition must report only `v1beta1` in `status.storedVersions`. Run:
+   ```bash
+   for crd in \
+       sandboxes.agents.x-k8s.io \
+       sandboxclaims.extensions.agents.x-k8s.io \
+       sandboxtemplates.extensions.agents.x-k8s.io \
+       sandboxwarmpools.extensions.agents.x-k8s.io; do
+     kubectl patch crd "${crd}" --type=json -p='[{"op":"replace","path":"/status/storedVersions","value":["v1beta1"]}]' --subresource=status
+   done
+   ```
+
+> [!WARNING]
+> **InstallPlan Failure Behavior**: If an OLM upgrade is attempted before `storedVersions` is pruned, the Kubernetes apiserver rejects the CRD update and the upgrade does not proceed. In OperatorHub UI, this may appear generically as "install failed" (with the root rejection message visible in the `Subscription` status conditions). Once you patch `storedVersions`, re-trigger or approve the `InstallPlan` if it does not converge on its own.
+
+> [!NOTE]
+> **Automatic Cleanup**: Unlike standard `kubectl apply` upgrades, OLM automatically garbage-collects legacy webhook `Service` and namespaced `Role`/`RoleBinding` objects when the previous CSV is replaced. `Secret/agent-sandbox-webhook-certs` is the exception — the controller created it at runtime with no owner reference, so OLM has no ownership link to it. Delete it manually:
+>
+> ```bash
+> kubectl delete -n agent-sandbox-system secret/agent-sandbox-webhook-certs --ignore-not-found
+> ```
+
 ## Maintaining operator manifests
 
 CRDs, ClusterRoles, and the controller Deployment in this module are **copies** of the main Agent Sandbox tree. They are not authored separately under `olm/config/`.
@@ -95,8 +121,6 @@ operator-sdk run bundle ${BUNDLE_IMG}
 ```
 
 `operator-sdk run bundle` installs the bundle into the cluster’s OLM namespace so you can subscribe and verify the operator before publishing. Use the same `VERSION`, `IMG`, and `BUNDLE_IMG` you intend to ship.
-
-> **Note:** The CRD conversion webhook `clientConfig` hardcodes `namespace: agent-sandbox-system`. Because `webhookdefinitions` is stripped from the CSV (preventing OLM from rewriting the `clientConfig`), the operator **must** be installed in the `agent-sandbox-system` namespace for conversion webhooks to function. If you use `operator-sdk run bundle`, pass `--namespace agent-sandbox-system`; the `operatorframework.io/suggested-namespace` annotation is only a hint and is not enforced.
 
 ## Contributing
 Please read our [Contributing Guidelines](../CONTRIBUTING.md) for our full code review and PR policies.

--- a/roadmap.md
+++ b/roadmap.md
@@ -80,8 +80,8 @@ Advanced ingress/egress isolation, lifecycle state retention, and security contr
 
 Audit trails, custom telemetry, reliability, and automated regression testing.
 
-*   **Alpha to Beta API Versioning** `⏳ In Progress`
-    *   `v1beta1` API types now exist alongside `v1alpha1` across all CRDs, and `v1alpha1` is marked deprecated. Remaining work: finish migrating clients/docs/examples fully to `v1beta1` and remove `v1alpha1` once the deprecation window closes.
+*   **Alpha to Beta API Versioning** `✅ Done`
+    *   `v1beta1` is the exclusive served API version across all CRDs. Legacy `v1alpha1` types, conversion webhooks, and migration harnesses have been removed.
 *   **Security Fixes** `⏳ In Progress`
     *   Maintain active patching cycles for third-party dependencies and container base image security.
 *   **CI for PodSnapshot & AgentSandbox Regression Prevention** `⏳ In Progress`

--- a/site/content/docs/getting_started/_index.md
+++ b/site/content/docs/getting_started/_index.md
@@ -14,7 +14,7 @@ description: >
   <div class="warning-content">
     <div class="warning-title">Upgrading from v0.4.x (v1alpha1)?</div>
     <p class="warning-text">
-      Version <strong>v0.5.0</strong> introduces breaking API schema changes and transitions to <strong>v1beta1</strong>. In-place upgrades are not supported. You must follow our manual <a href="/docs/getting_started/api-migration-guide/">v1alpha1 to v1beta1 Migration Guide</a> to prevent workload disruption.
+      Support for the <strong>v1alpha1</strong> API has been removed. If you are upgrading from an older release, you must follow our <a href="/docs/getting_started/api-migration-guide/">v1alpha1 to v1beta1 Migration Guide</a> to migrate to <strong>v0.5.x</strong> first before upgrading to this release.
     </p>
   </div>
 </div>

--- a/site/content/docs/getting_started/_index.md
+++ b/site/content/docs/getting_started/_index.md
@@ -14,7 +14,7 @@ description: >
   <div class="warning-content">
     <div class="warning-title">Upgrading from v0.4.x (v1alpha1)?</div>
     <p class="warning-text">
-      Support for the <strong>v1alpha1</strong> API has been removed. If you are upgrading from an older release, you must follow our <a href="/docs/getting_started/api-migration-guide/">v1alpha1 to v1beta1 Migration Guide</a> to migrate to <strong>v0.5.x</strong> first before upgrading to this release.
+      Support for the <strong>v1alpha1</strong> API has been removed. If you are upgrading from an older release, you must upgrade to <strong>v0.5.x</strong> and follow our <a href="/docs/getting_started/api-migration-guide/">v1alpha1 to v1beta1 Migration Guide</a> to complete the storage migration before upgrading to this release.
     </p>
   </div>
 </div>


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
This is **PR 4 of 4**, the final PR in the phased split of the `drop-v1alpha1` epic (#1265), targeting `feature/drop-v1alpha1` ahead of the `v1.0.0` release. Tracker: #1307.

With the API packages (PR 1, #1393), conversion webhook infrastructure (PR 2, #1404), and migration harness (PR 3, #1414) removed, this PR updates the user-facing documentation and the one remaining example that still spoke `v1alpha1`. It also closes out every transient that PRs 1–3 declared.

Documentation only — no Go, manifests, or CI configuration is touched. 8 files, +106 / −362.

**Key Changes:**

1. **Migration guide** (`docs/api-migration-guide.md`):
   - Replaced the in-place v0.5 conversion walkthrough with a 58-line historical pointer: users on a release older than `v0.5` upgrade to a `v0.5.x` release and complete the storage migration there, then upgrade to `v1.0.0`. The old walkthrough drove `dev/tools/migrate.sh`, which PR 3 deleted.
   - Added a pre-upgrade `status.storedVersions` verification loop covering all four CRDs, a **Helm Upgrade Ordering** section, and a **Post-Upgrade Cleanup** section for the orphaned webhook resources PR 2 stopped creating.
2. **OLM upgrade path** (`olm/README.md`):
   - New "Upgrading from v0.5.x to v1.0.0+" section: the `storedVersions` prune loop, InstallPlan failure behavior when it is skipped (the apiserver rejects the CRD update; OperatorHub surfaces this generically, with the root cause in `Subscription` status conditions), and a note that OLM garbage-collects the legacy webhook `Service` and `Role`/`RoleBinding` on CSV replacement.
   - Documented the one exception: `Secret/agent-sandbox-webhook-certs` was created at runtime by the controller with no owner reference, so OLM has no ownership link and it must be deleted manually.
   - Removed the stale conversion webhook note.
3. **Chart docs** (`helm/README.md`):
   - Replaced the `dev/tools/migrate.sh` instructions with a pointer to the rewritten guide.
4. **Site banner** (`site/content/docs/getting_started/_index.md`):
   - Reworded the upgrade warning from "v0.5.0 introduces breaking schema changes" to "v1alpha1 support has been removed; migrate via v0.5.x first." Link target unchanged.
5. **Roadmap** (`roadmap.md`):
   - **Alpha to Beta API Versioning** flipped from `⏳ In Progress` to `✅ Done`.
6. **KEP** (`docs/keps/694-kep-for-suspend-and-resume-for-beta/README.md`):
   - One illustrative API path in a rejected-alternatives bullet updated from `v1alpha1` to `v1beta1`. Body text only — no heading changed, so the generated TOC is unaffected.
7. **Latebind example** (`examples/latebind-storage-gke-sandbox/`):
   - `sandbox-warmpool.yaml` (a two-document file holding the `SandboxTemplate` and `SandboxWarmPool`) bumped to `extensions.agents.x-k8s.io/v1beta1`.
   - README `SandboxClaim` snippets bumped to `v1beta1`, with the `spec.warmPoolRef` / `spec.sandboxTemplateRef` difference called out.

#### Transients closed:

Every remaining reference declared in the earlier PRs is resolved here. Grepping the merged tree for `migrate.sh`, `test-migration`, `test/migration`, or `helm/files` now returns nothing.

* `docs/api-migration-guide.md` — 11 lines invoking `dev/tools/migrate.sh` (declared in PR 3) → rewritten.
* `helm/README.md:56` — named `dev/tools/migrate.sh` (declared in PRs 1 and 3) → now links to the guide.
* `helm/README.md` `webhookServiceName` (declared in PR 2) → gone.
* `examples/latebind-storage-gke-sandbox/` (declared in PR 1) → on `v1beta1`.

#### Deliberately retained `v1alpha1` references:

A grep for `v1alpha1` on this branch still returns hits. All are intentional:

* **GKE add-on note** (`examples/latebind-storage-gke-sandbox/README.md:80-83`) — the add-on still serves `v1alpha1`, so the adaptation instructions stay accurate and useful. Per the epic decision to leave add-on documentation alone.
* **Version-agnostic owner-reference handling** (`extensions/controllers/sandboxclaim_controller.go:2493`, `internal/metrics/sandbox_collector.go:143`, and their tests) — owner references written by a pre-`v1beta1` pool controller survive an in-place upgrade, so these match on group rather than version. Kept per the epic decision.
* **RL preflight negative test** (`examples/agent-sandbox-rl/tests/test_preflight.py:86`) — `test_crd_wrong_version` asserts preflight *fails* when a cluster serves only `v1alpha1`. More relevant after this epic, not less.
* **Historical/operational notes** (`dev/load-test/test-recipes/README-rapid-burst.md:97`, `examples/agent-sandbox-rl/examples/rl_integration.md:140`) — describe the behavior of clusters and external scripts that predate the drop.
* **Third-party API groups** — `kro.run/v1alpha1`, `keda.sh/v1alpha1`, `chainsaw.kyverno.io/v1alpha1`, `config.gatekeeper.sh/v1alpha1`, `operators.coreos.com/v1alpha1`. Unrelated to the agent-sandbox API.

#### Validation:

- [x] `make toc-update && git diff --exit-code` (0 diff — this PR touches `docs/keps/**`, so the `checks / toc-update` workflow runs)
- [x] `./dev/ci/presubmits/test-autogen-up-to-date` (0 diff)
- [x] `./dev/tools/lint-api` & `./dev/tools/lint-go` (PASSED, 0 issues)
- [x] `./dev/tools/lint-olm` (PASSED)
- [x] `./dev/tools/verify-olm-manifests` (PASSED)
- [x] `make test-unit` (Go + Python SDK unit tests PASSED)
- [x] `make build` (PASSED)
- [x] Whole-tree grep confirms no reference to any path deleted across PRs 1–3.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

Part of #1265

Tracking epic: #1307

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance for upgrading from `v1alpha1` to `v1beta1`, including CRD storage checks and Helm, kubectl, and OLM procedures.
  * Added cleanup guidance for obsolete webhook resources and clarified upgrade requirements for version 1.0.0 and later.
  * Updated examples and API references to use `v1beta1`, including GKE sandbox resources.
  * Marked the Alpha-to-Beta API transition as complete and refreshed getting-started guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->