### PR TITLE
sandboxed-tools: add per-tool execution timeout

### DIFF
--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -24,6 +24,9 @@ The application accepts the following command-line flags:
 | `-namespace`| The Kubernetes namespace where sandbox pods are created. | `default` (overrides `SANDBOX_NAMESPACE` env var) |
 | `-image` | The container image used for the temporary sandbox pod. | `debian:bookworm-slim` (overrides `SANDBOX_IMAGE` env var) |
 | `-homedir` | The directory inside the sandbox that is persisted via snapshot/restore. | `/home/clawtainer` (overrides `SANDBOX_HOME_DIR` env var) |
+| `-tool-timeout` | Maximum duration a single tool invocation (`run_command`, `ls`, `read`, or `write`) may run before it is cancelled. Accepts Go duration syntax, e.g. `30s`, `2m`, `1h`. `<= 0` disables the timeout. | `2m` |
+
+> **Note:** `-tool-timeout` cancels the Kubernetes exec connection and unblocks the agent loop; it does not guarantee that every process the command started inside the container (e.g. a detached background process) has actually been terminated.
 
 ## Configuration
 

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -54,6 +54,11 @@ import (
 // We keep sandboxes around for 5 minutes after we last used them.
 const SandboxInactivityTimeout = 5 * time.Minute
 
+// defaultToolTimeout bounds how long a single tool invocation may run before
+// it is cancelled, so a hung command (e.g. "sleep 99999") fails fast instead
+// of blocking the agent loop indefinitely.
+const defaultToolTimeout = 2 * time.Minute
+
 func main() {
 	ctx := context.Background()
 
@@ -80,6 +85,7 @@ func main() {
 	flag.StringVar(&opts.Namespace, "namespace", opts.Namespace, "namespace")
 	flag.StringVar(&opts.Image, "image", opts.Image, "image")
 	flag.StringVar(&opts.HomeDir, "homedir", opts.HomeDir, "Home directory in the sandbox; this is currently the only directory that we persist with snapshot/restore.")
+	flag.DurationVar(&opts.ToolTimeout, "tool-timeout", opts.ToolTimeout, "Maximum duration a single tool invocation may run before it is cancelled (Go duration syntax, e.g. \"30s\", \"2m\"). <= 0 disables the timeout.")
 	flag.Parse()
 
 	log := klog.FromContext(ctx)
@@ -655,6 +661,10 @@ type RunOptions struct {
 
 	// ModelName is the name of the model to use with the LLM.
 	ModelName string
+
+	// ToolTimeout bounds how long a single tool invocation may run before it
+	// is cancelled. <= 0 disables the timeout. Default: defaultToolTimeout.
+	ToolTimeout time.Duration
 }
 
 func (o *RunOptions) InitDefaults() {
@@ -687,6 +697,7 @@ func (o *RunOptions) InitDefaults() {
 	}
 	o.ModelName = modelName
 
+	o.ToolTimeout = defaultToolTimeout
 }
 
 func run(ctx context.Context, opts RunOptions) error {
@@ -739,6 +750,7 @@ func run(ctx context.Context, opts RunOptions) error {
 	}()
 
 	toolsRegistry := tools.NewRegistry()
+	toolsRegistry.ToolTimeout = opts.ToolTimeout
 	toolsRegistry.Add(&tools.RunCommand{})
 
 	toolsRegistry.Add(&tools.ListFilesTool{})
@@ -946,7 +958,6 @@ func (h *Harness) RunSession(ctx context.Context, session *Session) error {
 			}
 
 			for _, tc := range assistantMessage.ToolCalls {
-				// TODO: Add a timeout to the tool execution?
 				result, err := h.toolsRegistry.Call(ctx, activeSandbox, tc)
 
 				var toolMsg llm.Message

--- a/examples/sandboxed-tools/pkg/tools/fake_sandbox_test.go
+++ b/examples/sandboxed-tools/pkg/tools/fake_sandbox_test.go
@@ -23,6 +23,12 @@ import (
 type fakeResponse struct {
 	result *ExecCommandResult
 	err    error
+
+	// block, if true, makes ExecCommand ignore result/err and instead block
+	// until the call's context is done, then return its Err(). This lets
+	// tests deterministically exercise cancellation/timeout behavior without
+	// real sleeps or polling.
+	block bool
 }
 
 // fakeSandbox is a test double for the Sandbox interface. It records every
@@ -31,17 +37,23 @@ type fakeResponse struct {
 // can be exercised by queueing multiple responses.
 type fakeSandbox struct {
 	calls     []ExecCommandOptions
+	ctxs      []context.Context
 	responses []fakeResponse
 }
 
-func (f *fakeSandbox) ExecCommand(_ context.Context, opts ExecCommandOptions) (*ExecCommandResult, error) {
+func (f *fakeSandbox) ExecCommand(ctx context.Context, opts ExecCommandOptions) (*ExecCommandResult, error) {
 	i := len(f.calls)
 	f.calls = append(f.calls, opts)
+	f.ctxs = append(f.ctxs, ctx)
 
 	if i >= len(f.responses) {
 		return nil, fmt.Errorf("unexpected ExecCommand call %d", i+1)
 	}
 	resp := f.responses[i]
+	if resp.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	if resp.err != nil {
 		return nil, resp.err
 	}

--- a/examples/sandboxed-tools/pkg/tools/registry.go
+++ b/examples/sandboxed-tools/pkg/tools/registry.go
@@ -17,9 +17,11 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
+	"time"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
@@ -28,6 +30,10 @@ import (
 // Registry keeps track of available tools and handles their invocations.
 type Registry struct {
 	tools map[string]Tool
+
+	// ToolTimeout bounds how long a single tool invocation (Tool.Run) may run.
+	// A value <= 0 disables the timeout, preserving unbounded execution.
+	ToolTimeout time.Duration
 }
 
 // NewRegistry initializes a new tool registry.
@@ -68,6 +74,18 @@ func (r *Registry) All() []llm.Tool {
 	return list
 }
 
+// errToolTimeout is the internal cancellation cause set on the context passed
+// to Tool.Run when Registry.ToolTimeout is enabled. context.WithTimeout's
+// Err() reports context.DeadlineExceeded both when our own timeout fires and
+// when an earlier parent deadline expires first, so Err() alone can't tell
+// them apart. Setting this cause via context.WithTimeoutCause lets Call use
+// context.Cause to identify precisely which one happened: Cause reports
+// errToolTimeout only when our own timer fired first: if the parent expired
+// or was cancelled first, Cause reports the parent's cause instead. Never
+// exposed outside this package; callers only ever see the wrapped
+// context.DeadlineExceeded in the returned error (see Call).
+var errToolTimeout = errors.New("tool execution timeout")
+
 // Call executes a tool call inside the provided sandbox and returns the LLM tool response message.
 func (r *Registry) Call(ctx context.Context, sandbox Sandbox, tc llm.ToolCall) (llm.Message, error) {
 	log := klog.FromContext(ctx)
@@ -86,8 +104,27 @@ func (r *Registry) Call(ctx context.Context, sandbox Sandbox, tc llm.ToolCall) (
 		return llm.Message{}, fmt.Errorf("failed to parse arguments: %w", err)
 	}
 
-	res, err := toolInvocation.Run(ctx, sandbox)
+	// runCtx bounds the individual tool invocation. Only wrap ctx when a
+	// timeout is configured, so the disabled (ToolTimeout <= 0) case passes
+	// the caller's context through unchanged.
+	runCtx := ctx
+	if r.ToolTimeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeoutCause(ctx, r.ToolTimeout, errToolTimeout)
+		defer cancel()
+	}
+
+	res, err := toolInvocation.Run(runCtx, sandbox)
 	if err != nil {
+		// Classify via context.Cause(runCtx), not runCtx.Err(): Err() reports
+		// context.DeadlineExceeded both when our own timeout fires and when an
+		// earlier parent deadline expired first, so checking Err() alone would
+		// mislabel a parent deadline as our configured tool timeout. Cause
+		// reports errToolTimeout only when runCtx's own timer won the race; it
+		// does not depend on whatever error Tool.Run happens to return.
+		if r.ToolTimeout > 0 && context.Cause(runCtx) == errToolTimeout {
+			return llm.Message{}, fmt.Errorf("tool %q timed out after %s: %w", tc.Function.Name, r.ToolTimeout, context.DeadlineExceeded)
+		}
 		return llm.Message{}, fmt.Errorf("failed to run tool: %w", err)
 	}
 

--- a/examples/sandboxed-tools/pkg/tools/registry.go
+++ b/examples/sandboxed-tools/pkg/tools/registry.go
@@ -123,7 +123,7 @@ func (r *Registry) Call(ctx context.Context, sandbox Sandbox, tc llm.ToolCall) (
 		// reports errToolTimeout only when runCtx's own timer won the race; it
 		// does not depend on whatever error Tool.Run happens to return.
 		if r.ToolTimeout > 0 && context.Cause(runCtx) == errToolTimeout {
-			return llm.Message{}, fmt.Errorf("tool %q timed out after %s: %w", tc.Function.Name, r.ToolTimeout, context.DeadlineExceeded)
+			return llm.Message{}, fmt.Errorf("tool %q timed out after %s: %w", tc.Function.Name, r.ToolTimeout, err)
 		}
 		return llm.Message{}, fmt.Errorf("failed to run tool: %w", err)
 	}

--- a/examples/sandboxed-tools/pkg/tools/registry_test.go
+++ b/examples/sandboxed-tools/pkg/tools/registry_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
@@ -197,6 +198,174 @@ func TestRegistryCall_DoesNotMutateRegisteredTemplate(t *testing.T) {
 	}
 	if template.Command != "should-not-be-used" {
 		t.Errorf("registered template was mutated: Command = %q, want unchanged %q", template.Command, "should-not-be-used")
+	}
+}
+
+// --- Registry.ToolTimeout ---
+
+func TestRegistryCall_SucceedsWithTimeoutConfigured(t *testing.T) {
+	r := NewRegistry()
+	r.Add(&RunCommand{})
+	r.ToolTimeout = time.Minute
+	sandbox := &fakeSandbox{
+		responses: []fakeResponse{{result: &ExecCommandResult{Stdout: "hi\n", ExitCode: 0}}},
+	}
+
+	msg, err := r.Call(context.Background(), sandbox, llm.ToolCall{
+		ID:       "call_1",
+		Function: llm.FunctionCall{Name: "run_command", Arguments: `{"command":"echo hi"}`},
+	})
+	if err != nil {
+		t.Fatalf("Call() returned error: %v", err)
+	}
+	if msg.Content == nil || !strings.Contains(*msg.Content, "hi") {
+		t.Errorf("Content = %v, want it to contain %q", msg.Content, "hi")
+	}
+}
+
+func TestRegistryCall_TimeoutCancelsBlockingTool(t *testing.T) {
+	r := NewRegistry()
+	r.Add(&RunCommand{})
+	// A short but non-trivial real timeout: this test genuinely waits for
+	// this timer to fire. Large enough to avoid flaking under CI scheduling
+	// jitter, small enough to keep the test fast.
+	r.ToolTimeout = 20 * time.Millisecond
+	sandbox := &fakeSandbox{
+		responses: []fakeResponse{{block: true}},
+	}
+
+	_, err := r.Call(context.Background(), sandbox, llm.ToolCall{
+		ID:       "call_1",
+		Function: llm.FunctionCall{Name: "run_command", Arguments: `{"command":"sleep 99999"}`},
+	})
+	if err == nil {
+		t.Fatal("Call() returned nil error for a tool that never returns on its own")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want it to wrap context.DeadlineExceeded", err)
+	}
+	wantSubstrings := []string{`"run_command"`, "timed out", r.ToolTimeout.String()}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+}
+
+func TestRegistryCall_ParentCancellationIsNotReportedAsTimeout(t *testing.T) {
+	r := NewRegistry()
+	r.Add(&RunCommand{})
+	// Configured long enough that it would never fire on its own; the test
+	// proves parent cancellation wins the race deterministically, not by
+	// chance.
+	r.ToolTimeout = time.Hour
+	sandbox := &fakeSandbox{
+		responses: []fakeResponse{{block: true}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Parent is already done before Call ever runs.
+
+	_, err := r.Call(ctx, sandbox, llm.ToolCall{
+		ID:       "call_1",
+		Function: llm.FunctionCall{Name: "run_command", Arguments: `{"command":"sleep 99999"}`},
+	})
+	if err == nil {
+		t.Fatal("Call() returned nil error for a cancelled parent context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want it to wrap context.Canceled", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, incorrectly wraps context.DeadlineExceeded for parent cancellation", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("err = %q, incorrectly describes parent cancellation as a timeout", err.Error())
+	}
+}
+
+func TestRegistryCall_ParentDeadlineIsNotReportedAsToolTimeout(t *testing.T) {
+	r := NewRegistry()
+	r.Add(&RunCommand{})
+	// Configured long enough that, if this fired on its own, it would prove
+	// exactly the bug this test guards against: the registry must never
+	// blame its own configured timeout for a deadline the parent already
+	// owned, even though both report context.DeadlineExceeded from Err().
+	r.ToolTimeout = time.Hour
+	sandbox := &fakeSandbox{
+		responses: []fakeResponse{{block: true}},
+	}
+
+	// Parent deadline already in the past: context.WithTimeoutCause
+	// synchronously inherits the parent's already-set cause when
+	// constructing runCtx (see context.propagateCancel), so this never
+	// waits on a timer.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+
+	_, err := r.Call(ctx, sandbox, llm.ToolCall{
+		ID:       "call_1",
+		Function: llm.FunctionCall{Name: "run_command", Arguments: `{"command":"sleep 99999"}`},
+	})
+	if err == nil {
+		t.Fatal("Call() returned nil error for an already-expired parent deadline")
+	}
+	// The parent's own deadline genuinely did expire, so this must still
+	// wrap DeadlineExceeded -- just not attribute it to our ToolTimeout.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want it to wrap context.DeadlineExceeded", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("err = %q, incorrectly describes the parent's own expired deadline as our configured tool timeout", err.Error())
+	}
+	if strings.Contains(err.Error(), r.ToolTimeout.String()) {
+		t.Errorf("err = %q, incorrectly claims the configured ToolTimeout (%s) fired", err.Error(), r.ToolTimeout)
+	}
+}
+
+func TestRegistryCall_ZeroTimeoutDisablesWrapping(t *testing.T) {
+	r := NewRegistry()
+	r.Add(&RunCommand{})
+	// r.ToolTimeout left at its zero value: timeout disabled.
+	sandbox := &fakeSandbox{
+		responses: []fakeResponse{{result: &ExecCommandResult{ExitCode: 0}}},
+	}
+
+	_, err := r.Call(context.Background(), sandbox, llm.ToolCall{
+		ID:       "call_1",
+		Function: llm.FunctionCall{Name: "run_command", Arguments: `{"command":"echo hi"}`},
+	})
+	if err != nil {
+		t.Fatalf("Call() returned error: %v", err)
+	}
+	if len(sandbox.ctxs) != 1 {
+		t.Fatalf("ExecCommand called %d times, want 1", len(sandbox.ctxs))
+	}
+	if _, ok := sandbox.ctxs[0].Deadline(); ok {
+		t.Error("ExecCommand received a context with a deadline despite ToolTimeout being disabled")
+	}
+}
+
+func TestRegistryCall_ConfiguredTimeoutSetsDeadline(t *testing.T) {
+	r := NewRegistry()
+	r.Add(&RunCommand{})
+	r.ToolTimeout = time.Minute
+	sandbox := &fakeSandbox{
+		responses: []fakeResponse{{result: &ExecCommandResult{ExitCode: 0}}},
+	}
+
+	_, err := r.Call(context.Background(), sandbox, llm.ToolCall{
+		ID:       "call_1",
+		Function: llm.FunctionCall{Name: "run_command", Arguments: `{"command":"echo hi"}`},
+	})
+	if err != nil {
+		t.Fatalf("Call() returned error: %v", err)
+	}
+	if len(sandbox.ctxs) != 1 {
+		t.Fatalf("ExecCommand called %d times, want 1", len(sandbox.ctxs))
+	}
+	if _, ok := sandbox.ctxs[0].Deadline(); !ok {
+		t.Error("ExecCommand did not receive a context with a deadline despite ToolTimeout being configured")
 	}
 }
 

--- a/examples/sandboxed-tools/pkg/tools/run_command.go
+++ b/examples/sandboxed-tools/pkg/tools/run_command.go
@@ -51,7 +51,6 @@ func (t *RunCommand) Run(ctx context.Context, sandbox Sandbox) (llm.Message, err
 	log := klog.FromContext(ctx)
 
 	log.Info("executing command in sandbox", "command", t.Command)
-	// TODO: Add a timeout to the tool execution?
 	res, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
 		Command: []string{"sh", "-c", t.Command},
 	})


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a configurable per-tool execution timeout to the `sandboxed-tools` example so a hung tool call cannot block the agent loop indefinitely.

The timeout is enforced centrally in `Registry.Call`, so it applies consistently to all tool invocations. The default is 2 minutes and can be changed with `-tool-timeout`; values less than or equal to zero disable the timeout.

The implementation uses `context.WithTimeoutCause` to distinguish the configured tool timeout from parent context cancellation or an earlier parent deadline. Timeout handling preserves `context.DeadlineExceeded` for callers while returning a clear error that identifies the tool and configured duration.

The README documents the new flag and notes that cancelling the Kubernetes exec connection unblocks the agent but does not guarantee termination of detached processes inside the container.

Tests cover:
- successful execution with a timeout configured
- cancellation of a blocking tool
- parent context cancellation
- parent deadline expiration
- disabled timeout behavior
- deadline propagation to tool execution

#### Which issue(s) this PR is related to:

Fixes #1426

#### Release Note

```release-note
The sandboxed-tools example now applies a configurable 2-minute timeout to each tool invocation. Use the -tool-timeout flag to change or disable the timeout.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable timeout for individual tool executions.
  - Added the `-tool-timeout` option, accepting Go duration values and defaulting to two minutes.
  - Non-positive timeout values disable the limit.

- **Bug Fixes**
  - Tool timeouts now cancel blocked operations and report a clear timeout error.
  - Existing parent-context cancellations and deadlines are reported accurately.

- **Documentation**
  - Documented timeout behavior, including limitations for detached processes inside containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->