### PR TITLE
feat(python): add async sandboxd runtime support

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -240,8 +240,10 @@ pip install k8s-agent-sandbox[async]
 
 The async client requires an explicit connection config — `SandboxLocalTunnelConnectionConfig`
 is not supported because it relies on a synchronous `kubectl port-forward` subprocess. Use
-`SandboxGatewayConnectionConfig`, `SandboxDirectConnectionConfig`, or
-`SandboxInClusterConnectionConfig` instead.
+`SandboxGatewayConnectionConfig`, `SandboxDirectConnectionConfig`,
+`SandboxInClusterConnectionConfig`, or `SandboxdPodTunnelConnectionConfig`. For the portable
+`sandboxd` runtime, install
+both optional extras: `pip install 'k8s-agent-sandbox[async,grpc]'`.
 
 **Direct connection (explicit URL, e.g. router service):**
 
@@ -283,6 +285,30 @@ async def main():
         )
         result = await sandbox.commands.run("echo 'Hello from async!'")
         print(result.stdout)
+
+asyncio.run(main())
+```
+
+**sandboxd runtime (direct pod tunnel):**
+
+`SandboxdPodTunnelConnectionConfig` forwards sandboxd's REST filesystem port and gRPC
+process port directly from the sandbox Pod. The async client establishes and tears down
+both forwards without blocking the event loop.
+
+```python
+import asyncio
+from k8s_agent_sandbox import AsyncSandboxClient
+from k8s_agent_sandbox.models import SandboxdPodTunnelConnectionConfig
+
+async def main():
+    config = SandboxdPodTunnelConnectionConfig()
+    async with AsyncSandboxClient(connection_config=config) as client:
+        sandbox = await client.create_sandbox(
+            warmpool="sandboxd-warmpool",
+            namespace="default",
+        )
+        result = await sandbox.commands.run("echo 'Hello from sandboxd'")
+        await sandbox.files.write("hello.txt", result.stdout)
 
 asyncio.run(main())
 ```

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Async HTTP and pod-tunnel transports used by the Python SDK.
+
+Router-based connections share an ``httpx`` client. The sandboxd runtime uses
+one direct ``kubectl port-forward`` with separate local endpoints for its REST
+and gRPC listeners, both owned by the connector lifecycle.
+"""
+
 import asyncio
+import inspect
 import logging
 import math
+import socket
 from typing import Callable, Awaitable
 
 import httpx
@@ -22,7 +31,7 @@ import httpx
 logger = logging.getLogger(__name__)
 
 from .async_k8s_helper import AsyncK8sHelper
-from .exceptions import SandboxRequestError
+from .exceptions import SandboxPortForwardError, SandboxRequestError
 from .models import (
     SandboxConnectionConfig,
     SandboxDirectConnectionConfig,
@@ -41,6 +50,7 @@ BACKOFF_FACTOR = 0.5
 
 
 def _router_timeout_header_value(timeout) -> str | None:
+    """Return a positive read timeout suitable for the router header."""
     value = None
     if isinstance(timeout, bool):
         return None
@@ -60,9 +70,9 @@ class AsyncSandboxConnector:
     """
     Async connector for communicating with a Sandbox over HTTP using httpx.
 
-    Supports DirectConnection, GatewayConnection, and InCluster modes. LocalTunnel
-    mode is not supported because it relies on a long-running subprocess; use the
-    sync SandboxConnector for local development.
+    Supports DirectConnection, GatewayConnection, InCluster, and sandboxd pod
+    tunnel modes. LocalTunnel mode is not supported because it relies on a
+    router subprocess; use the sync SandboxConnector for local development.
     """
 
     def __init__(
@@ -72,26 +82,39 @@ class AsyncSandboxConnector:
         connection_config: SandboxConnectionConfig,
         k8s_helper: AsyncK8sHelper,
         get_pod_ip: Callable[[], Awaitable[str | None]] | None = None,
+        get_pod_name: Callable[[], Awaitable[str | None]] | None = None,
     ):
         if isinstance(connection_config, SandboxLocalTunnelConnectionConfig):
             raise ValueError(
                 "AsyncSandboxConnector does not support SandboxLocalTunnelConnectionConfig. "
                 "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, "
-                "or SandboxInClusterConnectionConfig instead. "
+                "SandboxInClusterConnectionConfig, or "
+                "SandboxdPodTunnelConnectionConfig instead. "
                 "For local development, use the synchronous SandboxClient."
             )
-        if isinstance(connection_config, SandboxdPodTunnelConnectionConfig):
-            raise NotImplementedError(
-                "The async client does not support the sandboxd runtime "
-                "(SandboxdPodTunnelConnectionConfig). Use the synchronous "
-                "SandboxClient for sandboxd."
-            )
-
         self.id = sandbox_id
         self.namespace = namespace
         self.connection_config = connection_config
         self.k8s_helper = k8s_helper
         self._get_pod_ip = get_pod_ip
+        self._grpc_channel = None
+        self._grpc_channel_target: str | None = None
+        # Command and filesystem calls may arrive together on first use. The
+        # lock keeps channel creation and replacement single-owner.
+        self._grpc_lock = asyncio.Lock()
+        # Serialize endpoint resolution and teardown so close cannot race with
+        # a new tunnel or gRPC channel being published.
+        self._lifecycle_lock = asyncio.Lock()
+        self._closed = False
+        self.grpc_target: str | None = None
+        self._sandboxd_strategy = None
+        if isinstance(connection_config, SandboxdPodTunnelConnectionConfig):
+            self._sandboxd_strategy = AsyncSandboxdPodTunnelStrategy(
+                sandbox_id=sandbox_id,
+                namespace=namespace,
+                config=connection_config,
+                get_pod_name=get_pod_name,
+            )
 
         self._base_url: str | None = None
         self._pod_ip: str | None = None
@@ -109,7 +132,8 @@ class AsyncSandboxConnector:
             self._server_port = None
 
         self._inject_router_headers = not isinstance(
-            connection_config, SandboxInClusterConnectionConfig
+            connection_config,
+            (SandboxInClusterConnectionConfig, SandboxdPodTunnelConnectionConfig),
         )
 
         transport = httpx.AsyncHTTPTransport(retries=3)
@@ -118,6 +142,11 @@ class AsyncSandboxConnector:
         )
 
     async def _resolve_base_url(self) -> str:
+        """Resolve the HTTP endpoint for the configured connection mode."""
+        if self._sandboxd_strategy is not None:
+            base_url, self.grpc_target = await self._sandboxd_strategy.connect()
+            return base_url
+
         if isinstance(self.connection_config, SandboxInClusterConnectionConfig):
             if self._get_pod_ip:
                 if self._pod_ip_resolved:
@@ -163,7 +192,9 @@ class AsyncSandboxConnector:
             endpoint: The API endpoint path.
             **kwargs: Extra keyword arguments passed directly to the underlying
                 `httpx.AsyncClient.request` invocation. Note that 'follow_redirects'
-                is explicitly popped and overridden.
+                is explicitly popped and overridden. `allowed_statuses` may be
+                supplied as a set of status codes that should be returned without
+                raising an HTTP status error.
 
         Returns:
             The `httpx.Response` object representing the response from the sandbox.
@@ -182,9 +213,12 @@ class AsyncSandboxConnector:
             directly to the caller because httpx does not consider them redirects
             and raise_for_status only raises for status codes 400 and above.
         """
-        base_url = await self._resolve_base_url()
+        async with self._lifecycle_lock:
+            self._ensure_open()
+            base_url = await self._resolve_base_url()
         url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
 
+        allowed_statuses = kwargs.pop("allowed_statuses", None)
         headers = kwargs.pop("headers", {}).copy()
         # For security and SSRF mitigation, the SDK explicitly mandates blocking all HTTP redirects
         # to the internal sandbox endpoints. Any user-provided redirect settings are overridden and
@@ -241,6 +275,8 @@ class AsyncSandboxConnector:
                         request=response.request,
                         response=response,
                     )
+                if allowed_statuses and response.status_code in allowed_statuses:
+                    return response
                 response.raise_for_status()
                 return response
             except httpx.HTTPStatusError as e:
@@ -277,10 +313,276 @@ class AsyncSandboxConnector:
             response=last_response,
         )
 
-    async def close(self):
-        await self.client.aclose()
-        if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
+    async def connect(self) -> str:
+        """Establish the configured transport and return its HTTP base URL."""
+        async with self._lifecycle_lock:
+            self._ensure_open()
+            return await self._resolve_base_url()
+
+    def _ensure_open(self) -> None:
+        """Raise when an operation is attempted after connection teardown."""
+        if self._closed:
+            raise RuntimeError("sandbox connector is closed")
+
+    def _close_for_atexit(self) -> None:
+        """Release loop-independent local resources during interpreter shutdown.
+
+        The regular async close path cannot be used from an ``atexit`` handler:
+        its objects may have been created by an event loop that is already
+        closed. Only the sandboxd subprocess has a synchronous termination
+        operation, so leave async HTTP and gRPC objects to interpreter teardown.
+        """
+        self._closed = True
+        try:
+            if self._sandboxd_strategy is not None:
+                self._sandboxd_strategy._close_for_atexit()
+        finally:
+            self.grpc_target = None
+            self._grpc_channel = None
+            self._grpc_channel_target = None
             self._base_url = None
-        self._pod_ip_resolved = False
-        self._cached_pod_ip_url = None
-        self._pod_ip = None
+            self._pod_ip_resolved = False
+            self._cached_pod_ip_url = None
+            self._pod_ip = None
+
+    def is_sandboxd(self) -> bool:
+        """Return whether this connector targets the sandboxd runtime."""
+        return self._sandboxd_strategy is not None
+
+    def should_inject_router_headers(self) -> bool:
+        """Return whether requests pass through the sandbox router."""
+        return self._inject_router_headers
+
+    async def grpc_channel(self):
+        """Return the reusable ``grpc.aio`` channel for sandboxd commands.
+
+        Dependency validation happens before tunnel setup so a missing optional
+        extra never leaves a ``kubectl`` process behind.
+        """
+        self._ensure_open()
+        if not self.is_sandboxd():
+            raise RuntimeError("grpc_channel() is only available for the sandboxd runtime")
+        try:
+            import grpc
+        except ImportError as e:
+            raise ImportError(
+                "the sandboxd runtime requires gRPC support; install the "
+                "'grpc' extra: pip install k8s-agent-sandbox[grpc]"
+            ) from e
+
+        async with self._lifecycle_lock:
+            self._ensure_open()
+            async with self._grpc_lock:
+                if not self.grpc_target:
+                    _, self.grpc_target = await self._sandboxd_strategy.connect()
+                if (
+                    self._grpc_channel is not None
+                    and self._grpc_channel_target == self.grpc_target
+                ):
+                    return self._grpc_channel
+                if self._grpc_channel is not None:
+                    result = self._grpc_channel.close()
+                    if inspect.isawaitable(result):
+                        await result
+                    self._grpc_channel = None
+                    self._grpc_channel_target = None
+                self._grpc_channel = grpc.aio.insecure_channel(self.grpc_target)
+                self._grpc_channel_target = self.grpc_target
+                return self._grpc_channel
+
+    async def close(self):
+        """Close HTTP, gRPC, and port-forward resources owned by the connector."""
+        async with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            await self.client.aclose()
+            async with self._grpc_lock:
+                if self._grpc_channel is not None:
+                    result = self._grpc_channel.close()
+                    if inspect.isawaitable(result):
+                        await result
+                    self._grpc_channel = None
+                    self._grpc_channel_target = None
+            if self._sandboxd_strategy is not None:
+                await self._sandboxd_strategy.close()
+                self.grpc_target = None
+            if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
+                self._base_url = None
+            self._pod_ip_resolved = False
+            self._cached_pod_ip_url = None
+            self._pod_ip = None
+
+
+class AsyncSandboxdPodTunnelStrategy:
+    """Own the direct Pod tunnel used by sandboxd's REST and gRPC clients.
+
+    A single ``kubectl`` process forwards both ports. Establishment and teardown
+    are serialized because file and command operations can race on first use.
+    """
+
+    def __init__(
+        self,
+        sandbox_id: str,
+        namespace: str,
+        config: SandboxdPodTunnelConnectionConfig,
+        get_pod_name: Callable[[], Awaitable[str | None]] | None = None,
+    ):
+        self.sandbox_id = sandbox_id
+        self.namespace = namespace
+        self.config = config
+        self._get_pod_name = get_pod_name
+        self.port_forward_process: asyncio.subprocess.Process | None = None
+        self.base_url: str | None = None
+        self.grpc_target: str | None = None
+        # Only one task may publish or tear down the shared subprocess state.
+        self._lifecycle_lock = asyncio.Lock()
+        self._closed = False
+
+    @staticmethod
+    def _get_free_port() -> int:
+        """Return an unused loopback port for ``kubectl`` to bind."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return sock.getsockname()[1]
+
+    @staticmethod
+    async def _is_port_open(port: int) -> bool:
+        """Check whether a forwarded local port accepts connections."""
+        try:
+            _reader, writer = await asyncio.wait_for(
+                asyncio.open_connection("127.0.0.1", port), timeout=0.1
+            )
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except (asyncio.TimeoutError, ConnectionRefusedError, OSError):
+            return False
+
+    async def connect(self) -> tuple[str, str]:
+        """Establish or reuse the tunnel and return REST and gRPC endpoints."""
+        async with self._lifecycle_lock:
+            if self._closed:
+                raise SandboxPortForwardError("sandboxd port-forward strategy is closed")
+            return await self._connect_locked()
+
+    async def _connect_locked(self) -> tuple[str, str]:
+        """Establish the tunnel while the caller holds ``_lifecycle_lock``."""
+        if (
+            self.base_url
+            and self.grpc_target
+            and self.port_forward_process
+            and self.port_forward_process.returncode is None
+        ):
+            return self.base_url, self.grpc_target
+
+        if self.port_forward_process:
+            await self._close_locked()
+
+        pod_name = self._get_pod_name() if self._get_pod_name else None
+        if inspect.isawaitable(pod_name):
+            pod_name = await pod_name
+        if not pod_name:
+            raise SandboxPortForwardError(
+                "sandbox pod name not resolved yet; cannot port-forward to sandboxd"
+            )
+
+        rest_local = self._get_free_port()
+        grpc_local = self._get_free_port()
+        try:
+            try:
+                self.port_forward_process = await asyncio.create_subprocess_exec(
+                    "kubectl",
+                    "port-forward",
+                    f"pod/{pod_name}",
+                    f"{rest_local}:{self.config.rest_port}",
+                    f"{grpc_local}:{self.config.grpc_port}",
+                    "-n",
+                    self.namespace,
+                    # kubectl logs each forwarded connection. Discard the
+                    # long-lived subprocess output because this SDK has no log
+                    # consumer for the forwarding process.
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+            except OSError as e:
+                raise SandboxPortForwardError(
+                    "failed to start sandboxd port-forward for pod "
+                    f"{self.namespace}/{pod_name}: {e}"
+                ) from e
+
+            deadline = (
+                asyncio.get_running_loop().time()
+                + self.config.port_forward_ready_timeout
+            )
+            while asyncio.get_running_loop().time() < deadline:
+                if self.port_forward_process.returncode is not None:
+                    await self._close_locked()
+                    raise SandboxPortForwardError(
+                        "sandboxd port-forward exited before it was ready for pod "
+                        f"{self.namespace}/{pod_name}"
+                    )
+                if await self._is_port_open(rest_local) and await self._is_port_open(
+                    grpc_local
+                ):
+                    self.base_url = f"http://127.0.0.1:{rest_local}"
+                    self.grpc_target = f"127.0.0.1:{grpc_local}"
+                    return self.base_url, self.grpc_target
+                await asyncio.sleep(0.05)
+
+            await self._close_locked()
+            raise SandboxPortForwardError(
+                "timed out waiting for sandboxd port-forward for pod "
+                f"{self.namespace}/{pod_name}"
+            )
+        except asyncio.CancelledError:
+            await self._close_locked()
+            raise
+
+    async def close(self):
+        """Stop the port-forward and clear its published endpoints."""
+        async with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+            await self._close_locked()
+
+    def _close_for_atexit(self) -> None:
+        """Terminate the port-forward without awaiting loop-bound state."""
+        self._closed = True
+        process = self.port_forward_process
+        self.port_forward_process = None
+        self.base_url = None
+        self.grpc_target = None
+        if process is None:
+            return
+
+        # ``asyncio.subprocess.Process.wait()`` is tied to the loop that
+        # created the process.  ``terminate``/``kill`` dispatch directly to
+        # the child process and are safe for this last-resort shutdown path.
+        try:
+            if process.returncode is None:
+                process.terminate()
+        except (OSError, ProcessLookupError):
+            pass
+        try:
+            if process.returncode is None:
+                process.kill()
+        except (OSError, ProcessLookupError):
+            pass
+
+    async def _close_locked(self):
+        """Tear down subprocess state while holding ``_lifecycle_lock``."""
+        process = self.port_forward_process
+        self.port_forward_process = None
+        self.base_url = None
+        self.grpc_target = None
+        if process is None:
+            return
+        if process.returncode is None:
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=2)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Async handle for one running Sandbox and its local client resources."""
+
 import logging
 
 from .async_connector import AsyncSandboxConnector
@@ -51,7 +53,7 @@ class AsyncSandbox:
             raise ValueError(
                 "connection_config is required for AsyncSandbox. "
                 "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, "
-                "or SandboxInClusterConnectionConfig."
+                "SandboxInClusterConnectionConfig, or SandboxdPodTunnelConnectionConfig."
             )
 
         self.claim_name = claim_name
@@ -67,6 +69,7 @@ class AsyncSandbox:
             connection_config=self.connection_config,
             k8s_helper=self.k8s_helper,
             get_pod_ip=self.get_pod_ip,
+            get_pod_name=self.get_pod_name,
         )
 
         self.tracer_config = tracer_config or SandboxTracerConfig()
@@ -147,10 +150,12 @@ class AsyncSandbox:
 
     @property
     def commands(self) -> AsyncCommandExecutor | None:
+        """Return the command client while this handle is active."""
         return self._commands
 
     @property
     def files(self) -> AsyncFilesystem | None:
+        """Return the filesystem client while this handle is active."""
         return self._files
 
     @property
@@ -184,6 +189,13 @@ class AsyncSandbox:
 
         self._is_closed = True
         logging.info(f"Connection to sandbox claim '{self.claim_name}' has been closed.")
+
+    def _close_for_atexit(self) -> None:
+        """Release local resources without touching the owning event loop."""
+        self.connector._close_for_atexit()
+        self._commands = None
+        self._files = None
+        self._is_closed = True
 
     async def terminate(self):
         """

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -32,7 +32,7 @@ from .exceptions import SandboxNotFoundError
 from .k8s_helper import K8sHelper
 from .pod_metadata import build_pod_metadata, validate_labels
 from .utils import construct_sandbox_claim_lifecycle_spec
-from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
+from .models import SandboxConnectionConfig, SandboxTracerConfig
 from .trace_manager import async_trace_span, create_tracer_manager, initialize_tracer, trace
 
 logger = logging.getLogger(__name__)
@@ -60,8 +60,9 @@ class AsyncSandboxClient(Generic[T]):
 
     By default (``cleanup=True``) an atexit hook is registered that deletes
     all tracked sandboxes on program termination, so sandboxes are not leaked
-    if the program exits without explicit cleanup. Pass ``cleanup=False`` to
-    opt out of this behavior::
+    if the program exits without explicit cleanup. The hook also terminates
+    loop-independent local resources such as sandboxd port-forward processes.
+    Pass ``cleanup=False`` to opt out of this behavior::
 
         client = AsyncSandboxClient(connection_config=config, cleanup=False)
 
@@ -91,21 +92,20 @@ class AsyncSandboxClient(Generic[T]):
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
             cleanup: If True, registers an atexit hook to automatically delete
                 all tracked sandboxes when the program terminates. The hook
-                uses a snapshot of the tracked claim names and the
-                synchronous ``K8sHelper``, which has no event loop
-                dependency, so it works correctly during interpreter
-                shutdown. Cleanup is best-effort — per-claim and top-level
-                failures emit warnings to ``sys.stderr`` rather than raising.
-                Defaults to True so that sandboxes are not leaked when a
-                caller forgets to clean up; pass ``cleanup=False`` to opt
-                out. Note this differs from the synchronous ``SandboxClient``,
-                which defaults to False.
+                synchronously terminates loop-independent local resources and
+                uses the synchronous ``K8sHelper`` for claim deletion, so it
+                remains usable during interpreter shutdown. Cleanup is
+                best-effort — per-claim and top-level failures emit warnings to
+                ``sys.stderr`` rather than raising. Defaults to True so that
+                sandboxes are not leaked when a caller forgets to clean up;
+                pass ``cleanup=False`` to opt out. Note this differs from the
+                synchronous ``SandboxClient``, which defaults to False.
         """
         if connection_config is None:
             raise ValueError(
                 "connection_config is required for AsyncSandboxClient. "
-                "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, or "
-                "SandboxInClusterConnectionConfig. "
+                "Use SandboxDirectConnectionConfig, SandboxGatewayConnectionConfig, "
+                "SandboxInClusterConnectionConfig, or SandboxdPodTunnelConnectionConfig. "
                 "For local development with kubectl port-forward, use the synchronous SandboxClient."
             )
 
@@ -383,29 +383,41 @@ class AsyncSandboxClient(Generic[T]):
                 logger.error(f"Cleanup failed for {claim_name} in namespace {ns}: {e}")
 
     def _atexit_cleanup(self):
-        """Best-effort atexit handler that deletes the current snapshot of tracked sandbox claims.
+        """Best-effort atexit cleanup for claims and local sandbox resources.
 
-        Uses the synchronous :class:`K8sHelper` rather than kubernetes_asyncio,
-        even though this class is otherwise fully async. atexit runs during
-        interpreter shutdown, after Python has begun tearing down its
-        process-wide thread pool; kubernetes_asyncio's aiohttp transport does a
-        per-request netrc lookup via a background thread, which raises "cannot
-        schedule new futures after interpreter shutdown" once that teardown has
-        started. The synchronous client's urllib3 transport has no event loop or
-        executor dependency, so it isn't affected. Per-claim failures emit
-        warnings to ``sys.stderr`` rather than raising — atexit cleanup is
-        best-effort.
+        Tracked sandbox handles use their synchronous, loop-independent
+        emergency path first so sandboxd port-forward processes are not left
+        behind. Claim deletion uses the synchronous :class:`K8sHelper` because
+        an atexit handler may run after async event-loop resources and the
+        process-wide executor have started shutting down. Per-claim failures
+        and top-level errors are reported to ``sys.stderr`` rather than raised.
         """
         try:
             claims = list(self._active_connection_sandboxes.keys())
-            if not claims:
+            tracked = [
+                (key, self._active_connection_sandboxes[key]) for key in claims
+            ]
+            if not tracked:
                 return
 
+            for _, sandbox in tracked:
+                try:
+                    sandbox._close_for_atexit()
+                except Exception as e:
+                    if sys.stderr is not None:
+                        print(
+                            "[agent-sandbox] Warning: failed to close sandbox "
+                            f"connection during atexit cleanup: {e}",
+                            file=sys.stderr,
+                        )
+
             helper = K8sHelper()
-            for ns, claim_name in claims:
+            for ns, claim_name in (key for key, _ in tracked):
                 try:
                     helper.delete_sandbox_claim(
-                        claim_name, ns, _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
+                        claim_name,
+                        ns,
+                        _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS,
                     )
                 except Exception as e:
                     if sys.stderr is not None:
@@ -433,6 +445,7 @@ class AsyncSandboxClient(Generic[T]):
         pod_metadata: dict | None = None,
         env: dict[str, str] | None = None,
     ):
+        """Create a claim with lifecycle, metadata, and trace context."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.claim.name", claim_name)
@@ -470,4 +483,5 @@ class AsyncSandboxClient(Generic[T]):
 
     @async_trace_span("delete_claim")
     async def _delete_claim(self, claim_name: str, namespace: str):
+        """Delete a claim through the client's shared Kubernetes helper."""
         await self.k8s_helper.delete_sandbox_claim(claim_name, namespace)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/async_command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/commands/async_command_executor.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Non-blocking command execution for legacy and sandboxd runtimes."""
+
 from k8s_agent_sandbox.async_connector import AsyncSandboxConnector
 from k8s_agent_sandbox.models import ExecutionResult
 from k8s_agent_sandbox.trace_manager import async_trace_span, trace
 
 
 def _extract_executable(command: str) -> str:
+    """Extract a low-cardinality executable name for tracing."""
     if not command:
         return ""
     for field in command.split():
@@ -30,9 +33,7 @@ def _extract_executable(command: str) -> str:
 
 
 class AsyncCommandExecutor:
-    """
-    Handles async execution of commands within the sandbox.
-    """
+    """Run commands through legacy HTTP or sandboxd's gRPC service."""
 
     def __init__(self, connector: AsyncSandboxConnector, tracer, trace_service_name: str):
         self.connector = connector
@@ -41,10 +42,17 @@ class AsyncCommandExecutor:
 
     @async_trace_span("run")
     async def run(self, command: str, timeout: int = 60) -> ExecutionResult:
+        """Run a shell command and return its output and exit code."""
         span = trace.get_current_span()
         if span.is_recording():
             executable = _extract_executable(command)
             span.set_attribute("sandbox.command.executable", executable)
+
+        if self.connector.is_sandboxd():
+            result = await self._run_sandboxd(command, timeout)
+            if span.is_recording():
+                span.set_attribute("sandbox.exit_code", result.exit_code)
+            return result
 
         payload = {"command": command}
         response = await self.connector.send_request(
@@ -67,3 +75,35 @@ class AsyncCommandExecutor:
         if span.is_recording():
             span.set_attribute("sandbox.exit_code", result.exit_code)
         return result
+
+    async def _run_sandboxd(self, command: str, timeout: int) -> ExecutionResult:
+        """Execute through sandboxd while preserving the shell-string API."""
+        try:
+            import grpc
+            from k8s_agent_sandbox.commands._process_stubs import (
+                process_pb2,
+                process_pb2_grpc,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "the sandboxd runtime requires gRPC support; install the "
+                "'grpc' extra: pip install k8s-agent-sandbox[grpc]"
+            ) from e
+
+        await self.connector.connect()
+        channel = await self.connector.grpc_channel()
+        stub = process_pb2_grpc.ProcessServiceStub(channel)
+        request = process_pb2.ExecuteRequest(
+            config=process_pb2.ProcessConfig(command=["/bin/sh", "-c", command])
+        )
+        try:
+            response = await stub.Execute(request, timeout=timeout)
+        except grpc.RpcError as e:
+            raise RuntimeError(
+                f"sandboxd process service failed ({e.code()}): {e.details()}"
+            ) from e
+        return ExecutionResult(
+            stdout=response.stdout.decode("utf-8", errors="replace"),
+            stderr=response.stderr.decode("utf-8", errors="replace"),
+            exit_code=response.exit_code,
+        )

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/async_filesystem.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/async_filesystem.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Async filesystem operations for legacy and sandboxd runtimes."""
+
 import logging
 import urllib.parse
 
 from k8s_agent_sandbox.async_connector import AsyncSandboxConnector
-from k8s_agent_sandbox.files.filesystem import Filesystem
+from k8s_agent_sandbox.exceptions import SandboxRequestError
+from k8s_agent_sandbox.files.filesystem import Filesystem, _sandboxd_files_endpoint
 from k8s_agent_sandbox.models import FileEntry
 from k8s_agent_sandbox.trace_manager import async_trace_span, trace
 
 
 class AsyncFilesystem:
-    """
-    Handles async file operations within the sandbox.
-    """
+    """Read and modify sandbox files without blocking the event loop."""
 
     def __init__(self, connector: AsyncSandboxConnector, tracer, trace_service_name: str):
         self.connector = connector
@@ -38,6 +39,7 @@ class AsyncFilesystem:
         timeout: int = 60,
         allow_unsafe_paths: bool = False,
     ):
+        """Write bytes or UTF-8 text to a sandbox-relative path."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
@@ -54,10 +56,19 @@ class AsyncFilesystem:
         # runtime's C layer.
         if not allow_unsafe_paths:
             path = Filesystem._safe_upload_path(path)
-        files_payload = {"file": (path, content)}
-        await self.connector.send_request(
-            "POST", "upload", files=files_payload, timeout=timeout
-        )
+        if self.connector.is_sandboxd():
+            await self.connector.send_request(
+                "PUT",
+                _sandboxd_files_endpoint(path),
+                content=content,
+                headers={"Content-Type": "application/octet-stream"},
+                timeout=timeout,
+            )
+        else:
+            files_payload = {"file": (path, content)}
+            await self.connector.send_request(
+                "POST", "upload", files=files_payload, timeout=timeout
+            )
         logging.info(f"File '{path}' uploaded successfully.")
 
     @async_trace_span("read")
@@ -67,16 +78,19 @@ class AsyncFilesystem:
         timeout: int = 60,
         allow_unsafe_paths: bool = False,
     ) -> bytes:
+        """Read a sandbox-relative file and return its raw bytes."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
 
         if not allow_unsafe_paths:
             path = Filesystem._safe_upload_path(path)
-        encoded_path = urllib.parse.quote(path, safe="")
-        response = await self.connector.send_request(
-            "GET", f"download/{encoded_path}", timeout=timeout
+        endpoint = (
+            _sandboxd_files_endpoint(path)
+            if self.connector.is_sandboxd()
+            else f"download/{urllib.parse.quote(path, safe='')}"
         )
+        response = await self.connector.send_request("GET", endpoint, timeout=timeout)
         content = response.content
 
         if span.is_recording():
@@ -86,13 +100,21 @@ class AsyncFilesystem:
 
     @async_trace_span("list")
     async def list(self, path: str, timeout: int = 60) -> list[FileEntry]:
+        """List files and directories at a sandbox-relative path."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
-        encoded_path = urllib.parse.quote(path, safe="")
-        response = await self.connector.send_request(
-            "GET", f"list/{encoded_path}", timeout=timeout
-        )
+        # sandboxd wraps directory entries in a DirectoryListing envelope;
+        # the legacy runtime returns the entry list directly.
+        if self.connector.is_sandboxd():
+            response = await self.connector.send_request(
+                "GET", _sandboxd_files_endpoint(path), timeout=timeout
+            )
+        else:
+            encoded_path = urllib.parse.quote(path, safe="")
+            response = await self.connector.send_request(
+                "GET", f"list/{encoded_path}", timeout=timeout
+            )
 
         try:
             entries = response.json()
@@ -101,15 +123,37 @@ class AsyncFilesystem:
                 f"Failed to decode JSON response from sandbox: {response.text}"
             ) from e
 
-        if not entries:
-            return []
-
-        try:
-            file_entries = [FileEntry.from_legacy(e) for e in entries]
-        except Exception as e:
-            raise RuntimeError(
-                f"Server returned invalid file entry format: {entries}"
-            ) from e
+        if self.connector.is_sandboxd():
+            if not isinstance(entries, dict) or "entries" not in entries:
+                raise RuntimeError(f"Server returned invalid directory listing: {entries}")
+            raw_entries = entries["entries"]
+            if raw_entries is None:
+                raw_entries = []
+            elif not isinstance(raw_entries, list):
+                raise RuntimeError(f"Server returned invalid directory listing: {entries}")
+            file_entries = []
+            for entry in raw_entries:
+                if not isinstance(entry, dict):
+                    raise RuntimeError(
+                        f"Server returned invalid directory listing: {entries}"
+                    )
+                if entry.get("type") not in ("file", "directory"):
+                    continue
+                try:
+                    file_entries.append(FileEntry.from_sandboxd(entry))
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Server returned invalid file entry format: {entry}"
+                    ) from e
+        else:
+            if not entries:
+                return []
+            try:
+                file_entries = [FileEntry.from_legacy(e) for e in entries]
+            except Exception as e:
+                raise RuntimeError(
+                    f"Server returned invalid file entry format: {entries}"
+                ) from e
 
         if span.is_recording():
             span.set_attribute("sandbox.file.count", len(file_entries))
@@ -117,9 +161,32 @@ class AsyncFilesystem:
 
     @async_trace_span("exists")
     async def exists(self, path: str, timeout: int = 60) -> bool:
+        """Return whether a path exists without downloading its contents."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
+        if self.connector.is_sandboxd():
+            response = await self.connector.send_request(
+                "HEAD",
+                _sandboxd_files_endpoint(path),
+                timeout=timeout,
+                allowed_statuses={404},
+            )
+            if response.status_code == 404:
+                exists = False
+            elif 200 <= response.status_code < 300:
+                exists = True
+            else:
+                raise SandboxRequestError(
+                    f"Unexpected status checking sandbox path existence: "
+                    f"{response.status_code}",
+                    status_code=response.status_code,
+                    response=response,
+                )
+            if span.is_recording():
+                span.set_attribute("sandbox.file.exists", exists)
+            return exists
+
         encoded_path = urllib.parse.quote(path, safe="")
         response = await self.connector.send_request(
             "GET", f"exists/{encoded_path}", timeout=timeout
@@ -136,3 +203,28 @@ class AsyncFilesystem:
         if span.is_recording():
             span.set_attribute("sandbox.file.exists", exists)
         return exists
+
+    @async_trace_span("delete")
+    async def delete(
+        self, path: str, recursive: bool = False, timeout: int = 60
+    ) -> None:
+        """Delete a sandboxd path, optionally including directory contents.
+
+        The legacy runtime has no delete endpoint and raises
+        ``NotImplementedError``.
+        """
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("sandbox.file.path", path)
+        if not self.connector.is_sandboxd():
+            raise NotImplementedError(
+                "delete() is only supported by the sandboxd runtime; the legacy "
+                "python-runtime has no delete endpoint"
+            )
+        if path == "":
+            raise ValueError("delete: path must not be empty")
+        endpoint = _sandboxd_files_endpoint(path)
+        if recursive:
+            endpoint += "?recursive=true"
+        await self.connector.send_request("DELETE", endpoint, timeout=timeout)
+        logging.info(f"Path '{path}' deleted successfully.")

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/filesystem.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/files/filesystem.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Synchronous filesystem operations for legacy and sandboxd runtimes."""
+
 import json
 import logging
 import os
@@ -25,7 +27,15 @@ from k8s_agent_sandbox.trace_manager import trace_span, trace
 
 def _sandboxd_files_endpoint(path: str) -> str:
     """Return the sandboxd REST path for a sandbox-relative file path."""
-    return f"v1/files/{urllib.parse.quote(path, safe='')}"
+    encoded = []
+    for segment in path.split("/"):
+        if segment == ".":
+            encoded.append("%2E")
+        elif segment == "..":
+            encoded.append("%2E%2E")
+        else:
+            encoded.append(urllib.parse.quote(segment, safe=""))
+    return f"v1/files/{'%2F'.join(encoded)}"
 
 
 class Filesystem:
@@ -48,6 +58,7 @@ class Filesystem:
         timeout: int = 60,
         allow_unsafe_paths: bool = False,
     ):
+        """Write bytes or UTF-8 text to a sandbox-relative path."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
@@ -119,6 +130,7 @@ class Filesystem:
         allow_unsafe_paths: bool = False,
 
     ) -> bytes:
+        """Read a sandbox-relative file and return its raw bytes."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
@@ -140,6 +152,7 @@ class Filesystem:
 
     @trace_span("list")
     def list(self, path: str, timeout: int = 60) -> List[FileEntry]:
+        """List files and directories at a sandbox-relative path."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
@@ -187,6 +200,7 @@ class Filesystem:
 
     @trace_span("exists")
     def exists(self, path: str, timeout: int = 60) -> bool:
+        """Return whether a path exists without downloading its contents."""
         span = trace.get_current_span()
         if span.is_recording():
             span.set_attribute("sandbox.file.path", path)
@@ -232,6 +246,8 @@ class Filesystem:
                 "delete() is only supported by the sandboxd runtime; the legacy "
                 "python-runtime has no delete endpoint"
             )
+        if path == "":
+            raise ValueError("delete: path must not be empty")
         endpoint = _sandboxd_files_endpoint(path)
         if recursive:
             endpoint += "?recursive=true"

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_connector.py
@@ -1,0 +1,274 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for async sandboxd tunnel and gRPC channel ownership."""
+
+import asyncio
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from k8s_agent_sandbox.async_connector import (
+    AsyncSandboxConnector,
+    AsyncSandboxdPodTunnelStrategy,
+)
+from k8s_agent_sandbox.exceptions import SandboxPortForwardError
+from k8s_agent_sandbox.models import SandboxdPodTunnelConnectionConfig
+
+
+class TestAsyncSandboxdConnector(unittest.IsolatedAsyncioTestCase):
+    """Exercise sandboxd connection setup, reuse, failures, and cleanup."""
+
+    def _build(self):
+        helper = MagicMock()
+        return AsyncSandboxConnector(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            connection_config=SandboxdPodTunnelConnectionConfig(
+                rest_port=8080,
+                grpc_port=9090,
+            ),
+            k8s_helper=helper,
+            get_pod_name=AsyncMock(return_value="sandbox-1"),
+        )
+
+    async def test_sandboxd_config_is_supported(self):
+        connector = self._build()
+        self.assertTrue(connector.is_sandboxd())
+        self.assertFalse(connector.should_inject_router_headers())
+        await connector.close()
+
+    async def test_connect_exposes_rest_and_grpc_endpoints(self):
+        connector = self._build()
+        connector._sandboxd_strategy.connect = AsyncMock(
+            return_value=("http://127.0.0.1:18080", "127.0.0.1:19090")
+        )
+        try:
+            base_url = await connector.connect()
+
+            self.assertEqual(base_url, "http://127.0.0.1:18080")
+            self.assertEqual(connector.grpc_target, "127.0.0.1:19090")
+        finally:
+            await connector.close()
+
+    async def test_close_closes_tunnel_and_grpc_channel(self):
+        connector = self._build()
+        connector._sandboxd_strategy.close = AsyncMock()
+        channel = MagicMock()
+        channel.close = AsyncMock()
+        connector._grpc_channel = channel
+
+        await connector.close()
+
+        connector._sandboxd_strategy.close.assert_awaited_once()
+        channel.close.assert_awaited_once()
+        self.assertIsNone(connector._grpc_channel)
+
+    async def test_concurrent_grpc_channel_creates_one_channel(self):
+        connector = self._build()
+        connector._sandboxd_strategy.connect = AsyncMock(
+            return_value=("http://127.0.0.1:18080", "127.0.0.1:19090")
+        )
+        channel = MagicMock()
+        insecure_channel = MagicMock(return_value=channel)
+        fake_grpc = SimpleNamespace(
+            aio=SimpleNamespace(insecure_channel=insecure_channel)
+        )
+
+        with patch.dict(sys.modules, {"grpc": fake_grpc}):
+            first, second = await asyncio.gather(
+                connector.grpc_channel(), connector.grpc_channel()
+            )
+
+        self.assertIs(first, second)
+        insecure_channel.assert_called_once_with("127.0.0.1:19090")
+        await connector.close()
+
+    async def test_missing_grpc_does_not_start_tunnel(self):
+        connector = self._build()
+        connector._sandboxd_strategy.connect = AsyncMock()
+
+        try:
+            with patch.dict(sys.modules, {"grpc": None}):
+                with self.assertRaisesRegex(
+                    ImportError, "pip install k8s-agent-sandbox\\[grpc\\]"
+                ):
+                    await connector.grpc_channel()
+            connector._sandboxd_strategy.connect.assert_not_awaited()
+        finally:
+            await connector.close()
+
+    async def test_connector_rejects_connect_after_close(self):
+        connector = self._build()
+        await connector.close()
+
+        with self.assertRaisesRegex(RuntimeError, "closed"):
+            await connector.connect()
+
+    def test_connector_atexit_cleanup_releases_state_without_async_closes(self):
+        """Connector atexit cleanup delegates only to the synchronous tunnel path."""
+        connector = self._build()
+        connector._sandboxd_strategy._close_for_atexit = MagicMock()
+        connector.grpc_target = "127.0.0.1:19090"
+        connector._grpc_channel = MagicMock()
+        connector._grpc_channel_target = connector.grpc_target
+        connector._base_url = "http://127.0.0.1:18080"
+
+        connector._close_for_atexit()
+
+        connector._sandboxd_strategy._close_for_atexit.assert_called_once_with()
+        self.assertTrue(connector._closed)
+        self.assertIsNone(connector.grpc_target)
+        self.assertIsNone(connector._grpc_channel)
+        self.assertIsNone(connector._grpc_channel_target)
+        self.assertIsNone(connector._base_url)
+
+    @patch("k8s_agent_sandbox.async_connector.asyncio.create_subprocess_exec")
+    @patch.object(AsyncSandboxdPodTunnelStrategy, "_is_port_open", new_callable=AsyncMock)
+    @patch.object(AsyncSandboxdPodTunnelStrategy, "_get_free_port")
+    async def test_tunnel_forwards_rest_and_grpc_ports(
+        self, get_free_port, is_port_open, create_subprocess
+    ):
+        process = MagicMock(returncode=None)
+        process.terminate = MagicMock()
+        process.wait = AsyncMock()
+        create_subprocess.return_value = process
+        get_free_port.side_effect = [18080, 19090]
+        is_port_open.return_value = True
+        strategy = AsyncSandboxdPodTunnelStrategy(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            config=SandboxdPodTunnelConnectionConfig(
+                rest_port=8080,
+                grpc_port=9090,
+            ),
+            get_pod_name=AsyncMock(return_value="sandbox-1"),
+        )
+
+        base_url, grpc_target = await strategy.connect()
+
+        self.assertEqual(base_url, "http://127.0.0.1:18080")
+        self.assertEqual(grpc_target, "127.0.0.1:19090")
+        create_subprocess.assert_awaited_once_with(
+            "kubectl",
+            "port-forward",
+            "pod/sandbox-1",
+            "18080:8080",
+            "19090:9090",
+            "-n",
+            "agents",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        await strategy.close()
+
+    @patch("k8s_agent_sandbox.async_connector.asyncio.create_subprocess_exec")
+    @patch.object(AsyncSandboxdPodTunnelStrategy, "_is_port_open", new_callable=AsyncMock)
+    @patch.object(AsyncSandboxdPodTunnelStrategy, "_get_free_port")
+    async def test_concurrent_connect_starts_one_tunnel(
+        self, get_free_port, is_port_open, create_subprocess
+    ):
+        process = MagicMock(returncode=None)
+        process.terminate = MagicMock()
+        process.wait = AsyncMock()
+        create_subprocess.return_value = process
+        get_free_port.side_effect = [18080, 19090]
+        is_port_open.return_value = True
+        strategy = AsyncSandboxdPodTunnelStrategy(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            config=SandboxdPodTunnelConnectionConfig(),
+            get_pod_name=AsyncMock(return_value="sandbox-1"),
+        )
+
+        first, second = await asyncio.gather(strategy.connect(), strategy.connect())
+
+        self.assertEqual(first, second)
+        create_subprocess.assert_awaited_once()
+        await strategy.close()
+
+    @patch(
+        "k8s_agent_sandbox.async_connector.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+    )
+    async def test_tunnel_start_error_includes_pod_context(self, create_subprocess):
+        create_subprocess.side_effect = FileNotFoundError("kubectl not found")
+        strategy = AsyncSandboxdPodTunnelStrategy(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            config=SandboxdPodTunnelConnectionConfig(),
+            get_pod_name=AsyncMock(return_value="sandbox-1"),
+        )
+
+        with self.assertRaisesRegex(
+            SandboxPortForwardError, "sandbox-1.*agents|agents.*sandbox-1"
+        ):
+            await strategy.connect()
+
+    @patch("k8s_agent_sandbox.async_connector.asyncio.create_subprocess_exec")
+    async def test_tunnel_timeout_uses_port_forward_error(self, create_subprocess):
+        process = MagicMock(returncode=None)
+        process.terminate = MagicMock()
+        process.wait = AsyncMock()
+        create_subprocess.return_value = process
+        strategy = AsyncSandboxdPodTunnelStrategy(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            config=SandboxdPodTunnelConnectionConfig(port_forward_ready_timeout=0),
+            get_pod_name=AsyncMock(return_value="sandbox-1"),
+        )
+
+        with self.assertRaisesRegex(
+            SandboxPortForwardError, "sandbox-1.*agents|agents.*sandbox-1"
+        ):
+            await strategy.connect()
+
+    async def test_tunnel_does_not_restart_after_close(self):
+        strategy = AsyncSandboxdPodTunnelStrategy(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            config=SandboxdPodTunnelConnectionConfig(),
+            get_pod_name=AsyncMock(return_value="sandbox-1"),
+        )
+
+        await strategy.close()
+
+        with self.assertRaisesRegex(SandboxPortForwardError, "closed"):
+            await strategy.connect()
+
+    def test_atexit_cleanup_terminates_process_without_waiting(self):
+        """The atexit path must not await a process bound to another loop."""
+        process = MagicMock(returncode=None)
+        strategy = AsyncSandboxdPodTunnelStrategy(
+            sandbox_id="sandbox-1",
+            namespace="agents",
+            config=SandboxdPodTunnelConnectionConfig(),
+        )
+        strategy.port_forward_process = process
+        strategy.base_url = "http://127.0.0.1:18080"
+        strategy.grpc_target = "127.0.0.1:19090"
+
+        strategy._close_for_atexit()
+
+        process.terminate.assert_called_once_with()
+        process.kill.assert_called_once_with()
+        process.wait.assert_not_called()
+        self.assertIsNone(strategy.port_forward_process)
+        self.assertIsNone(strategy.base_url)
+        self.assertIsNone(strategy.grpc_target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandbox.py
@@ -162,6 +162,7 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
             connection_config=mock_connection_config,
             k8s_helper=mock_k8s_helper_instance,
             get_pod_ip=sandbox.get_pod_ip,
+            get_pod_name=sandbox.get_pod_name,
         )
 
         mock_create_tracer_manager.assert_called_once_with(mock_tracer_config)
@@ -295,6 +296,17 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(self.sandbox.is_active)
         self.sandbox._is_closed = True
         self.assertFalse(self.sandbox.is_active)
+
+    def test_close_for_atexit(self):
+        """Atexit cleanup delegates without awaiting the connector."""
+        self.mock_connector._close_for_atexit = MagicMock()
+
+        self.sandbox._close_for_atexit()
+
+        self.mock_connector._close_for_atexit.assert_called_once_with()
+        self.assertIsNone(self.sandbox.commands)
+        self.assertIsNone(self.sandbox.files)
+        self.assertTrue(self.sandbox._is_closed)
 
     async def test_close_connection(self):
         """Tests the public close_connection method."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tests for AsyncSandboxClient lifecycle and transport behavior."""
+
 import asyncio
 import json
 import os
@@ -38,6 +40,7 @@ from k8s_agent_sandbox.models import (
     SandboxGatewayConnectionConfig,
     SandboxInClusterConnectionConfig,
     SandboxLocalTunnelConnectionConfig,
+    SandboxdPodTunnelConnectionConfig,
 )
 
 
@@ -245,6 +248,10 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ValueError) as ctx:
             AsyncSandboxClient(connection_config=None)
         self.assertIn("connection_config is required", str(ctx.exception))
+        self.assertNotIn(
+            "SandboxGatewayConnectionConfig, or SandboxInCluster",
+            str(ctx.exception),
+        )
 
     def test_cleanup_default_registers_atexit(self):
         """Constructing without cleanup= should default to True and register the hook."""
@@ -266,9 +273,15 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
 
     def test_atexit_cleanup_deletes_tracked_claims(self):
         """_atexit_cleanup should open a fresh K8sHelper and delete all tracked claims."""
+        first_sandbox = MagicMock()
+        first_sandbox.close_connection = AsyncMock()
+        first_sandbox._close_for_atexit = MagicMock()
+        second_sandbox = MagicMock()
+        second_sandbox.close_connection = AsyncMock()
+        second_sandbox._close_for_atexit = MagicMock()
         self.client._active_connection_sandboxes = {
-            ("default", "claim-abc"): MagicMock(),
-            ("other-ns", "claim-xyz"): MagicMock(),
+            ("default", "claim-abc"): first_sandbox,
+            ("other-ns", "claim-xyz"): second_sandbox,
         }
         mock_helper_instance = MagicMock()
         mock_helper_instance.delete_sandbox_claim = MagicMock()
@@ -282,6 +295,30 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         mock_helper_instance.delete_sandbox_claim.assert_any_call(
             "claim-xyz", "other-ns", _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
         )
+        first_sandbox._close_for_atexit.assert_called_once_with()
+        second_sandbox._close_for_atexit.assert_called_once_with()
+        first_sandbox.close_connection.assert_not_awaited()
+        second_sandbox.close_connection.assert_not_awaited()
+
+    def test_atexit_cleanup_uses_loop_independent_handle_cleanup(self):
+        """atexit must not await handles created by an earlier event loop."""
+        sandbox = MagicMock()
+        sandbox.close_connection = AsyncMock()
+        sandbox._close_for_atexit = MagicMock()
+        self.client._active_connection_sandboxes = {
+            ("default", "claim-abc"): sandbox,
+        }
+        mock_helper_instance = MagicMock()
+        mock_helper_instance.delete_sandbox_claim = MagicMock()
+
+        with patch(
+            "k8s_agent_sandbox.async_sandbox_client.K8sHelper",
+            return_value=mock_helper_instance,
+        ):
+            self.client._atexit_cleanup()
+
+        sandbox._close_for_atexit.assert_called_once_with()
+        sandbox.close_connection.assert_not_awaited()
 
     def test_atexit_cleanup_skips_when_no_sandboxes(self):
         """_atexit_cleanup should be a no-op when there are no tracked sandboxes."""
@@ -293,7 +330,10 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
     def test_atexit_cleanup_suppresses_errors(self):
         """_atexit_cleanup should not propagate exceptions — cleanup is best-effort.
         A warning is printed to stderr so the user knows a sandbox was orphaned."""
-        self.client._active_connection_sandboxes = {("default", "claim-abc"): MagicMock()}
+        sandbox = MagicMock()
+        sandbox.close_connection = AsyncMock()
+        sandbox._close_for_atexit = MagicMock()
+        self.client._active_connection_sandboxes = {("default", "claim-abc"): sandbox}
         mock_helper_instance = MagicMock()
         mock_helper_instance.delete_sandbox_claim = MagicMock(side_effect=Exception("network error"))
 
@@ -563,6 +603,13 @@ class TestAsyncSandboxClientInCluster(unittest.IsolatedAsyncioTestCase):
         config = SandboxInClusterConnectionConfig()
         client = AsyncSandboxClient(connection_config=config, cleanup=False)
         self.assertIsInstance(client.connection_config, SandboxInClusterConnectionConfig)
+
+    async def test_sandboxd_config_accepted(self):
+        config = SandboxdPodTunnelConnectionConfig()
+        client = AsyncSandboxClient(connection_config=config, cleanup=False)
+        self.assertIsInstance(
+            client.connection_config, SandboxdPodTunnelConnectionConfig
+        )
 
     async def test_in_cluster_connection_config_passed_to_sandbox(self):
         config = SandboxInClusterConnectionConfig()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_command_executor.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_command_executor.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tests for synchronous and asynchronous command execution."""
+
+import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from k8s_agent_sandbox.commands.command_executor import CommandExecutor, _extract_executable
 from k8s_agent_sandbox.commands.async_command_executor import AsyncCommandExecutor
@@ -59,6 +63,7 @@ class TestCommandExecutor(unittest.TestCase):
 
 
 class TestAsyncCommandExecutor(unittest.IsolatedAsyncioTestCase):
+    """Verify async command routing, results, and tracing."""
 
     @patch("k8s_agent_sandbox.commands.async_command_executor.trace")
     async def test_async_executor_logs_executable(self, mock_trace):
@@ -67,6 +72,7 @@ class TestAsyncCommandExecutor(unittest.IsolatedAsyncioTestCase):
         mock_trace.get_current_span.return_value = mock_span
 
         mock_connector = MagicMock()
+        mock_connector.is_sandboxd.return_value = False
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "stdout": "hello_async",
@@ -84,6 +90,41 @@ class TestAsyncCommandExecutor(unittest.IsolatedAsyncioTestCase):
         mock_span.set_attribute.assert_any_call("sandbox.command.executable", "python3")
         mock_span.set_attribute.assert_any_call("sandbox.exit_code", 0)
         self.assertEqual(result.stdout, "hello_async")
+
+    async def test_async_sandboxd_executor_uses_grpc(self):
+        mock_connector = MagicMock()
+        mock_connector.is_sandboxd.return_value = True
+        mock_connector.connect = AsyncMock()
+        mock_connector.grpc_channel = AsyncMock(return_value=MagicMock())
+        mock_response = MagicMock(stdout=b"hello", stderr=b"", exit_code=0)
+        mock_pb2 = SimpleNamespace(
+            ProcessConfig=MagicMock(), ExecuteRequest=MagicMock()
+        )
+        mock_pb2_grpc = SimpleNamespace(ProcessServiceStub=MagicMock())
+        mock_pb2_grpc.ProcessServiceStub.return_value.Execute = AsyncMock(
+            return_value=mock_response
+        )
+        mock_grpc = SimpleNamespace(RpcError=Exception)
+
+        with patch.dict(
+            sys.modules,
+            {
+                "grpc": mock_grpc,
+                "k8s_agent_sandbox.commands._process_stubs": SimpleNamespace(
+                    process_pb2=mock_pb2,
+                    process_pb2_grpc=mock_pb2_grpc,
+                )
+            },
+        ):
+            executor = AsyncCommandExecutor(
+                mock_connector, MagicMock(), "sandbox-client"
+            )
+            result = await executor.run("echo hello", timeout=12)
+
+        mock_connector.connect.assert_awaited_once()
+        mock_pb2.ExecuteRequest.assert_called_once()
+        self.assertEqual(result.stdout, "hello")
+        self.assertEqual(result.exit_code, 0)
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_filesystem.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_filesystem.py
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tests for filesystem path safety and runtime-specific operations."""
 
 import asyncio
 import unittest
-from unittest.mock import MagicMock, AsyncMock
 import urllib.parse
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from k8s_agent_sandbox.exceptions import SandboxRequestError
 from k8s_agent_sandbox.files.async_filesystem import AsyncFilesystem
-from k8s_agent_sandbox.files.filesystem import Filesystem
+from k8s_agent_sandbox.files.filesystem import Filesystem, _sandboxd_files_endpoint
 
 
 class TestFilesystemSafeUploadPath(unittest.TestCase):
@@ -75,6 +77,10 @@ class TestFilesystemSafeUploadPath(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "control characters"):
                 Filesystem._safe_upload_path(bad)
 
+    def test_sandboxd_dot_segments_are_encoded(self):
+        self.assertEqual(_sandboxd_files_endpoint("."), "v1/files/%2E")
+        self.assertEqual(_sandboxd_files_endpoint(".."), "v1/files/%2E%2E")
+
 
 class TestAsyncFilesystemSafeUploadPath(unittest.TestCase):
     """The async twin must apply the same sanitizer as the sync one —
@@ -107,7 +113,8 @@ class TestFilesystemSafePaths(unittest.TestCase):
         self._fs = Filesystem(self._connector, tracer, trace_service_name="test")
 
     def _make_async_fs(self) -> AsyncFilesystem:
-        self._connector = AsyncMock()
+        self._connector = MagicMock()
+        self._connector.send_request = AsyncMock()
         tracer = AsyncMock()
         return AsyncFilesystem(self._connector, tracer, trace_service_name="test")
 
@@ -144,7 +151,8 @@ class TestFilesystemSafePaths(unittest.TestCase):
 
 class TestAsyncFilesystemSafePaths(TestFilesystemSafePaths):
     def setUp(self):
-        self._connector = AsyncMock()
+        self._connector = MagicMock()
+        self._connector.send_request = AsyncMock()
         self._connector.is_sandboxd.return_value = False
         tracer = MagicMock()
         self._fs = AsyncFilesystem(self._connector, tracer, trace_service_name="test")
@@ -154,6 +162,112 @@ class TestAsyncFilesystemSafePaths(TestFilesystemSafePaths):
 
     def _do_read(self, **kwargs):
         asyncio.run(self._fs.read("/dir/foo.txt", **kwargs))
+
+
+class TestAsyncSandboxdFilesystem(unittest.IsolatedAsyncioTestCase):
+    """Verify sandboxd endpoints, response validation, and tracing."""
+
+    def setUp(self):
+        self.connector = MagicMock()
+        self.connector.send_request = AsyncMock()
+        self.connector.is_sandboxd.return_value = True
+        self.fs = AsyncFilesystem(self.connector, MagicMock(), trace_service_name="test")
+
+    async def test_write_uses_sandboxd_put(self):
+        await self.fs.write("dir/script.py", b"print(1)")
+        args, kwargs = self.connector.send_request.call_args
+        self.assertEqual(args[:2], ("PUT", "v1/files/dir%2Fscript.py"))
+        self.assertEqual(kwargs["content"], b"print(1)")
+        self.assertNotIn("data", kwargs)
+
+    async def test_read_uses_sandboxd_get(self):
+        response = MagicMock(content=b"hello")
+        self.connector.send_request.return_value = response
+
+        self.assertEqual(await self.fs.read("notes/hello.txt"), b"hello")
+        args, _ = self.connector.send_request.call_args
+        self.assertEqual(args[:2], ("GET", "v1/files/notes%2Fhello.txt"))
+
+    async def test_list_unwraps_sandboxd_directory_listing(self):
+        response = MagicMock()
+        response.json.return_value = {
+            "path": "/notes",
+            "entries": [
+                {
+                    "name": "a.txt",
+                    "size": 5,
+                    "type": "file",
+                    "modified_at": "2026-08-06T10:00:00Z",
+                    "mode": "0644",
+                }
+            ],
+        }
+        self.connector.send_request.return_value = response
+
+        entries = await self.fs.list("notes")
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].name, "a.txt")
+        self.assertEqual(entries[0].mode, "0644")
+
+    async def test_list_rejects_non_list_entries(self):
+        response = MagicMock()
+        response.json.return_value = {"path": "/notes", "entries": {}}
+        self.connector.send_request.return_value = response
+
+        with self.assertRaisesRegex(RuntimeError, "invalid directory listing"):
+            await self.fs.list("notes")
+
+    async def test_list_rejects_non_object_entry(self):
+        response = MagicMock()
+        response.json.return_value = {"path": "/notes", "entries": ["a.txt"]}
+        self.connector.send_request.return_value = response
+
+        with self.assertRaisesRegex(RuntimeError, "invalid directory listing"):
+            await self.fs.list("notes")
+
+    async def test_list_treats_null_entries_as_empty(self):
+        response = MagicMock()
+        response.json.return_value = {"path": "/notes", "entries": None}
+        self.connector.send_request.return_value = response
+
+        self.assertEqual(await self.fs.list("notes"), [])
+
+    async def test_exists_allows_sandboxd_404(self):
+        response = MagicMock(status_code=404)
+        self.connector.send_request.return_value = response
+
+        self.assertFalse(await self.fs.exists("missing.txt"))
+        _, kwargs = self.connector.send_request.call_args
+        self.assertEqual(kwargs["allowed_statuses"], {404})
+
+    async def test_exists_rejects_non_success_status(self):
+        response = MagicMock(status_code=304)
+        self.connector.send_request.return_value = response
+
+        with self.assertRaises(SandboxRequestError):
+            await self.fs.exists("maybe.txt")
+
+    async def test_delete_uses_sandboxd_endpoint(self):
+        await self.fs.delete("dir", recursive=True)
+        args, _ = self.connector.send_request.call_args
+        self.assertEqual(args[:2], ("DELETE", "v1/files/dir?recursive=true"))
+
+    async def test_delete_rejects_empty_path(self):
+        with self.assertRaisesRegex(ValueError, "path must not be empty"):
+            await self.fs.delete("")
+
+        self.connector.send_request.assert_not_awaited()
+
+    @patch("k8s_agent_sandbox.files.async_filesystem.trace")
+    async def test_delete_records_path_in_trace(self, mock_trace):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = span
+
+        await self.fs.delete("dir")
+
+        span.set_attribute.assert_called_once_with("sandbox.file.path", "dir")
 
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxd.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxd.py
@@ -152,6 +152,11 @@ class TestSandboxdFilesystem(unittest.TestCase):
         args, _ = self._last_call()
         self.assertEqual(args[1], "v1/files/f.txt")
 
+    def test_delete_rejects_empty_path(self):
+        with self.assertRaisesRegex(ValueError, "path must not be empty"):
+            self._fs.delete("")
+        self._connector.send_request.assert_not_called()
+
 
 class TestLegacyDeleteUnsupported(unittest.TestCase):
     def test_delete_raises_on_legacy(self):

--- a/clients/python/agentic-sandbox-client/pyproject.toml
+++ b/clients/python/agentic-sandbox-client/pyproject.toml
@@ -51,7 +51,8 @@ async = [
     "kubernetes_asyncio<34.0.0",
 ]
 # Required for the sandboxd runtime (SandboxdPodTunnelConnectionConfig):
-# command execution runs over gRPC ProcessService. The legacy python-runtime
+# command execution runs over gRPC ProcessService. The generated process stubs
+# validate a protobuf runtime of at least 7.36.1. The legacy python-runtime
 # needs none of this.
 grpc = [
     "grpcio>=1.83.0",


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `sandboxd` runtime support to the Python `AsyncSandboxClient`, bringing the async SDK in line with the existing synchronous sandboxd implementation.

The async connector now establishes a cancellation-safe `kubectl port-forward` directly to the sandbox Pod for both sandboxd listeners: the REST filesystem API and the gRPC `ProcessService`. Tunnel and `grpc.aio` channel creation are serialized so concurrent first operations share one connection, and all subprocess/channel resources are closed with the client.

The async filesystem now supports sandboxd write, read, list, exists, and delete operations. Async command execution uses the existing generated process stubs over `grpc.aio`, while gRPC remains an optional, lazily imported dependency. Legacy python-runtime behavior is unchanged.

The README documents the required `k8s-agent-sandbox[async,grpc]` installation and an async sandboxd example.

The follow-up review fixes also serialize connector teardown with connection creation, close tracked handles during atexit cleanup, validate the generated protobuf runtime floor, reject empty delete paths, preserve sync/async directory-listing behavior, and use the correct async HTTPX request body argument.

#### Which issue(s) this PR is related to:

Fixes #1421

#### Testing

- Added unit coverage for async sandboxd configuration, concurrent tunnel/channel creation, cleanup, filesystem operations, path encoding, and gRPC command execution.
- `368` Python SDK unit tests passed with `0` failures and `0` errors.
- One existing Windows-only local HTTP harness test (`TestAsyncConnectorHTTP.test_post_execute`) was excluded because it independently fails on the baseline with `httpx.ReadError`; all other collected Python SDK unit tests pass.
- Python AST parsing and `git diff --check` pass.

#### Release Note

```release-note
Added sandboxd runtime support to the Python AsyncSandboxClient, including async command execution and filesystem operations.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous sandboxd support through direct pod tunnels.
  - Async command execution now supports gRPC.
  - Async filesystem operations support uploads, directory listings, and deletion.
  - Added setup guidance and usage examples for the new connection configuration.

- **Bug Fixes**
  - Improved filesystem path encoding and empty-path validation.
  - Enhanced connection cleanup, reuse, readiness handling, and error reporting.
  - Improved handling of sandboxd filesystem responses and command results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->