### PR TITLE
refactor(warmpool): read mirrored PodScheduled instead of fetching the Pod

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -859,6 +859,14 @@ func (r *SandboxWarmPoolReconciler) setNotProgressing(warmPool *extensionsv1beta
 // transient Pod lookup failure, so both cases fall through to false here — the
 // same outcome as the previous direct Pod read, which returned false on a failed
 // Get.
+//
+// Version-skew dependency: the hold behavior needs a sandbox controller that
+// writes this mirror. The in-tree deployments register both controllers in one
+// binary from one image, so they cannot diverge; but if the extensions
+// controllers are ever run as a separate process from the core sandbox
+// controller, an extensions build newer than its core counterpart sees no
+// PodScheduled condition and unschedulable pool members fall back to
+// delete-and-replace churn (#1215) for the duration of the skew.
 func isSandboxPodUnschedulable(sb *sandboxv1beta1.Sandbox) bool {
 	// A sandbox being torn down keeps its last mirrored condition until the
 	// sandbox controller reconciles the Pod's absence, so a terminating sandbox

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -415,7 +416,6 @@ func (r *SandboxWarmPoolReconciler) exp() *warmPoolExpectations {
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 
@@ -540,7 +540,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 			// loop (#1215). Hold the sandbox and retry on a rate-limited
 			// requeue instead; the scheduler will place it when capacity
 			// frees up.
-			if r.isSandboxPodUnschedulable(ctx, &sb) {
+			if r.isSandboxPodUnschedulable(&sb) {
 				unschedulableReplicas++
 				healthySandboxes = append(healthySandboxes, sb)
 				continue
@@ -841,30 +841,32 @@ func (r *SandboxWarmPoolReconciler) setNotProgressing(warmPool *extensionsv1beta
 
 // isSandboxPodUnschedulable reports whether the sandbox's backing pod is
 // currently unschedulable (PodScheduled=False with reason Unschedulable).
-// Missing pods or pods without a definitive PodScheduled=False/Unschedulable
-// condition report false, preserving the delete-and-replace behavior for
-// genuinely stuck sandboxes.
-func (r *SandboxWarmPoolReconciler) isSandboxPodUnschedulable(ctx context.Context, sb *sandboxv1beta1.Sandbox) bool {
-	// The backing pod normally shares the sandbox's name; a sandbox that
-	// adopted a warm pod tracks the pod name in an annotation (same
-	// resolution the sandbox controller uses).
-	podName := sb.Annotations[sandboxv1beta1.SandboxPodNameAnnotation]
-	if podName == "" {
-		podName = sb.Name
-	}
-	pod := &corev1.Pod{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: sb.Namespace, Name: podName}, pod); err != nil {
+//
+// This reads the PodScheduled condition the sandbox controller mirrors onto
+// Sandbox.status, rather than fetching the Pod: the mirror copies the Pod
+// condition's status and reason verbatim, so it carries exactly the signal this
+// check needs, and the pool already has the Sandbox in hand. Sandboxes without a
+// definitive PodScheduled=False/Unschedulable condition report false, preserving
+// the delete-and-replace behavior for genuinely stuck sandboxes.
+//
+// The mirror is removed when the Pod is confirmed absent and reports Unknown on a
+// transient Pod lookup failure, so both cases fall through to false here — the
+// same outcome as the previous direct Pod read, which returned false on a failed
+// Get.
+func (r *SandboxWarmPoolReconciler) isSandboxPodUnschedulable(sb *sandboxv1beta1.Sandbox) bool {
+	// A sandbox being torn down keeps its last mirrored condition until the
+	// sandbox controller reconciles the Pod's absence, so a terminating sandbox
+	// can still carry a stale Unschedulable. Treat it as not-unschedulable so the
+	// pool does not hold a slot on a sandbox that is already going away; the
+	// previous implementation got this from the Pod's DeletionTimestamp.
+	if !sb.DeletionTimestamp.IsZero() {
 		return false
 	}
-	if !pod.DeletionTimestamp.IsZero() {
+	cond := meta.FindStatusCondition(sb.Status.Conditions, string(sandboxv1beta1.SandboxConditionPodScheduled))
+	if cond == nil {
 		return false
 	}
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodScheduled {
-			return cond.Status == corev1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable
-		}
-	}
-	return false
+	return cond.Status == metav1.ConditionFalse && cond.Reason == corev1.PodReasonUnschedulable
 }
 
 // resolveUpdateStrategy returns the effective update strategy for the warm pool,

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -540,7 +540,7 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 			// loop (#1215). Hold the sandbox and retry on a rate-limited
 			// requeue instead; the scheduler will place it when capacity
 			// frees up.
-			if r.isSandboxPodUnschedulable(&sb) {
+			if isSandboxPodUnschedulable(&sb) {
 				unschedulableReplicas++
 				healthySandboxes = append(healthySandboxes, sb)
 				continue
@@ -849,16 +849,29 @@ func (r *SandboxWarmPoolReconciler) setNotProgressing(warmPool *extensionsv1beta
 // definitive PodScheduled=False/Unschedulable condition report false, preserving
 // the delete-and-replace behavior for genuinely stuck sandboxes.
 //
+// Only Unschedulable is a hold signal. The mirror carries every scheduler reason
+// verbatim, but any other False reason (SchedulingGated, for instance) is a state
+// the scheduler is expected to resolve on its own, so it falls through to the
+// stuck-sandbox path exactly as it did before. Widening the set of hold reasons is
+// a deliberate behavioral decision, not something this should infer.
+//
 // The mirror is removed when the Pod is confirmed absent and reports Unknown on a
 // transient Pod lookup failure, so both cases fall through to false here — the
 // same outcome as the previous direct Pod read, which returned false on a failed
 // Get.
-func (r *SandboxWarmPoolReconciler) isSandboxPodUnschedulable(sb *sandboxv1beta1.Sandbox) bool {
+func isSandboxPodUnschedulable(sb *sandboxv1beta1.Sandbox) bool {
 	// A sandbox being torn down keeps its last mirrored condition until the
 	// sandbox controller reconciles the Pod's absence, so a terminating sandbox
 	// can still carry a stale Unschedulable. Treat it as not-unschedulable so the
-	// pool does not hold a slot on a sandbox that is already going away; the
-	// previous implementation got this from the Pod's DeletionTimestamp.
+	// pool does not hold a slot on a sandbox that is already going away.
+	//
+	// This is the Sandbox's DeletionTimestamp, not the Pod's, so it is not a
+	// like-for-like replacement of the previous check: a Pod can be deleting while
+	// its Sandbox is not (the suspend path deliberately keeps reporting the
+	// deleting Pod). In that window this reports the last mirrored value, so a
+	// stale Unschedulable holds the sandbox until the sandbox controller updates
+	// or removes the mirror. Holding a suspending sandbox is the safer error --
+	// the alternative is GC'ing it as "stuck" mid-suspend.
 	if !sb.DeletionTimestamp.IsZero() {
 		return false
 	}

--- a/extensions/controllers/sandboxwarmpool_overcreation_test.go
+++ b/extensions/controllers/sandboxwarmpool_overcreation_test.go
@@ -485,10 +485,86 @@ func TestReconcilePool_UnschedulableStuckGC(t *testing.T) {
 		sb.DeletionTimestamp = &now
 		sb.Finalizers = []string{"agents.x-k8s.io/test-hold"}
 
-		r := SandboxWarmPoolReconciler{Scheme: newTestScheme()}
-		require.False(t, r.isSandboxPodUnschedulable(sb),
+		require.False(t, isSandboxPodUnschedulable(sb),
 			"a terminating sandbox must not be treated as unschedulable-and-held")
 	})
+}
+
+// TestIsSandboxPodUnschedulable pins the decision table of the mirrored-condition
+// read directly, independent of reconcilePool. Only PodScheduled=False with reason
+// Unschedulable is a hold signal: a missing condition and an Unknown status are the
+// two shapes the mirror uses for "Pod absent" and "Pod state unknown", and any
+// other False reason (SchedulingGated) is a state the scheduler resolves itself, so
+// all of them must fall through to the stuck-sandbox path.
+func TestIsSandboxPodUnschedulable(t *testing.T) {
+	deleting := metav1.Now()
+
+	cond := func(status metav1.ConditionStatus, reason string) []metav1.Condition {
+		return []metav1.Condition{{
+			Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+			Status:             status,
+			Reason:             reason,
+			LastTransitionTime: metav1.Now(),
+		}}
+	}
+
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		deleting   bool
+		want       bool
+	}{
+		{
+			name:       "no PodScheduled condition (mirror removed: Pod confirmed absent)",
+			conditions: nil,
+			want:       false,
+		},
+		{
+			name:       "other conditions but no PodScheduled",
+			conditions: []metav1.Condition{{Type: string(sandboxv1beta1.SandboxConditionReady), Status: metav1.ConditionFalse, Reason: "NotReady", LastTransitionTime: metav1.Now()}},
+			want:       false,
+		},
+		{
+			name:       "Unknown (transient Pod lookup failure)",
+			conditions: cond(metav1.ConditionUnknown, sandboxv1beta1.SandboxReasonPodSchedulingUnknown),
+			want:       false,
+		},
+		{
+			name:       "True/PodScheduled (scheduled fine; stuck for another reason)",
+			conditions: cond(metav1.ConditionTrue, sandboxv1beta1.SandboxReasonPodScheduled),
+			want:       false,
+		},
+		{
+			name:       "False/SchedulingGated (scheduler resolves this itself)",
+			conditions: cond(metav1.ConditionFalse, corev1.PodReasonSchedulingGated),
+			want:       false,
+		},
+		{
+			name:       "False/Unschedulable (the hold signal)",
+			conditions: cond(metav1.ConditionFalse, corev1.PodReasonUnschedulable),
+			want:       true,
+		},
+		{
+			name:       "deleting sandbox with a stale False/Unschedulable",
+			conditions: cond(metav1.ConditionFalse, corev1.PodReasonUnschedulable),
+			deleting:   true,
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sb := &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sb", Namespace: "default"},
+				Status:     sandboxv1beta1.SandboxStatus{Conditions: tc.conditions},
+			}
+			if tc.deleting {
+				sb.DeletionTimestamp = &deleting
+				sb.Finalizers = []string{"agents.x-k8s.io/test-hold"}
+			}
+			require.Equal(t, tc.want, isSandboxPodUnschedulable(sb))
+		})
+	}
 }
 
 // phantomListClient wraps the fake client to model the opposite staleness of

--- a/extensions/controllers/sandboxwarmpool_overcreation_test.go
+++ b/extensions/controllers/sandboxwarmpool_overcreation_test.go
@@ -341,26 +341,25 @@ func TestReconcilePool_UnschedulableStuckGC(t *testing.T) {
 		return sb
 	}
 
-	podWithScheduled := func(name string, status corev1.ConditionStatus, reason string) *corev1.Pod {
-		return &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: poolNamespace},
-			Status: corev1.PodStatus{
-				Conditions: []corev1.PodCondition{{
-					Type:   corev1.PodScheduled,
-					Status: status,
-					Reason: reason,
-				}},
-			},
-		}
+	// withPodScheduled appends the mirrored PodScheduled condition the sandbox
+	// controller copies off the backing Pod. The pool now reads this instead of
+	// fetching the Pod, so the signal belongs on the Sandbox.
+	withPodScheduled := func(sb *sandboxv1beta1.Sandbox, status metav1.ConditionStatus, reason string) *sandboxv1beta1.Sandbox {
+		sb.Status.Conditions = append(sb.Status.Conditions, metav1.Condition{
+			Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+			Status:             status,
+			Reason:             reason,
+			LastTransitionTime: metav1.Now(),
+		})
+		return sb
 	}
 
 	t.Run("unschedulable sandbox is held, not replaced", func(t *testing.T) {
 		warmPool := newPool()
-		sb := agedSandbox("-unsched")
-		pod := podWithScheduled(sb.Name, corev1.ConditionFalse, corev1.PodReasonUnschedulable)
+		sb := withPodScheduled(agedSandbox("-unsched"), metav1.ConditionFalse, corev1.PodReasonUnschedulable)
 
 		recorder := events.NewFakeRecorder(16)
-		lc := newLaggingClient(newFakeClient(newTestScheme(), template, warmPool, sb, pod))
+		lc := newLaggingClient(newFakeClient(newTestScheme(), template, warmPool, sb))
 		r := SandboxWarmPoolReconciler{
 			Client:       lc,
 			Scheme:       newTestScheme(),
@@ -398,12 +397,21 @@ func TestReconcilePool_UnschedulableStuckGC(t *testing.T) {
 		default:
 		}
 
-		// Capacity frees up: the pod schedules and the sandbox goes Ready.
-		// The hold clears and a WarmPoolProgressing event is emitted.
-		got.Status.Conditions = []metav1.Condition{{
-			Type:   string(sandboxv1beta1.SandboxConditionReady),
-			Status: metav1.ConditionTrue,
-		}}
+		// Capacity frees up: the pod schedules and the sandbox goes Ready. The
+		// mirrored PodScheduled flips to True in the same pass, so the hold
+		// clears and a WarmPoolProgressing event is emitted.
+		got.Status.Conditions = []metav1.Condition{
+			{
+				Type:   string(sandboxv1beta1.SandboxConditionReady),
+				Status: metav1.ConditionTrue,
+			},
+			{
+				Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+				Status:             metav1.ConditionTrue,
+				Reason:             sandboxv1beta1.SandboxReasonPodScheduled,
+				LastTransitionTime: metav1.Now(),
+			},
+		}
 		// Plain Update: the fake client only registers a status subresource
 		// for SandboxWarmPool, so sandbox status is part of the main object.
 		require.NoError(t, r.Update(ctx, got))
@@ -422,11 +430,10 @@ func TestReconcilePool_UnschedulableStuckGC(t *testing.T) {
 
 	t.Run("genuinely stuck sandbox (pod scheduled) is still replaced", func(t *testing.T) {
 		warmPool := newPool()
-		sb := agedSandbox("-stuck")
 		// The pod scheduled fine; the sandbox is stuck for some other reason.
-		pod := podWithScheduled(sb.Name, corev1.ConditionTrue, "")
+		sb := withPodScheduled(agedSandbox("-stuck"), metav1.ConditionTrue, sandboxv1beta1.SandboxReasonPodScheduled)
 
-		lc := newLaggingClient(newFakeClient(newTestScheme(), template, warmPool, sb, pod))
+		lc := newLaggingClient(newFakeClient(newTestScheme(), template, warmPool, sb))
 		r := SandboxWarmPoolReconciler{
 			Client:       lc,
 			Scheme:       newTestScheme(),
@@ -465,6 +472,22 @@ func TestReconcilePool_UnschedulableStuckGC(t *testing.T) {
 		require.NoError(t, err)
 		err = r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: sb.Name}, &sandboxv1beta1.Sandbox{})
 		require.True(t, client.IgnoreNotFound(err) == nil && err != nil, "sandbox without a pod should be deleted")
+	})
+
+	// A terminating sandbox keeps its last mirrored PodScheduled condition until
+	// the sandbox controller observes the Pod's absence, so a stale Unschedulable
+	// must not hold a pool slot on an object that is already going away. The
+	// previous implementation got this from the backing Pod's DeletionTimestamp;
+	// reading the mirror requires checking the Sandbox's instead.
+	t.Run("terminating sandbox with a stale unschedulable condition is not held", func(t *testing.T) {
+		sb := withPodScheduled(agedSandbox("-terminating"), metav1.ConditionFalse, corev1.PodReasonUnschedulable)
+		now := metav1.Now()
+		sb.DeletionTimestamp = &now
+		sb.Finalizers = []string{"agents.x-k8s.io/test-hold"}
+
+		r := SandboxWarmPoolReconciler{Scheme: newTestScheme()}
+		require.False(t, r.isSandboxPodUnschedulable(sb),
+			"a terminating sandbox must not be treated as unschedulable-and-held")
 	})
 }
 
@@ -749,21 +772,19 @@ func TestReconcilePool_QuietClusterSelfScheduledGraceEvaluation(t *testing.T) {
 		UID:        warmPool.UID,
 		Controller: &controller,
 	}}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: sb.Name, Namespace: poolNamespace},
-		Status: corev1.PodStatus{
-			Conditions: []corev1.PodCondition{{
-				Type:   corev1.PodScheduled,
-				Status: corev1.ConditionFalse,
-				Reason: corev1.PodReasonUnschedulable,
-			}},
-		},
-	}
+	// The pool reads the PodScheduled condition the sandbox controller mirrors
+	// onto Sandbox.status, so the unschedulable signal belongs on the Sandbox.
+	sb.Status.Conditions = append(sb.Status.Conditions, metav1.Condition{
+		Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+		Status:             metav1.ConditionFalse,
+		Reason:             corev1.PodReasonUnschedulable,
+		LastTransitionTime: metav1.Now(),
+	})
 
 	current := base
 	recorder := events.NewFakeRecorder(16)
 	scheme := newTestScheme()
-	lc := newLaggingClient(newFakeClient(scheme, template, warmPool, sb, pod))
+	lc := newLaggingClient(newFakeClient(scheme, template, warmPool, sb))
 	r := SandboxWarmPoolReconciler{
 		Client:       lc,
 		Scheme:       scheme,
@@ -859,21 +880,19 @@ func TestReconcilePool_ConfigurableGraceAndRecheck(t *testing.T) {
 		UID:        warmPool.UID,
 		Controller: &controller,
 	}}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: sb.Name, Namespace: poolNamespace},
-		Status: corev1.PodStatus{
-			Conditions: []corev1.PodCondition{{
-				Type:   corev1.PodScheduled,
-				Status: corev1.ConditionFalse,
-				Reason: corev1.PodReasonUnschedulable,
-			}},
-		},
-	}
+	// The pool reads the PodScheduled condition the sandbox controller mirrors
+	// onto Sandbox.status, so the unschedulable signal belongs on the Sandbox.
+	sb.Status.Conditions = append(sb.Status.Conditions, metav1.Condition{
+		Type:               string(sandboxv1beta1.SandboxConditionPodScheduled),
+		Status:             metav1.ConditionFalse,
+		Reason:             corev1.PodReasonUnschedulable,
+		LastTransitionTime: metav1.Now(),
+	})
 
 	current := base
 	recorder := events.NewFakeRecorder(16)
 	scheme := newTestScheme()
-	lc := newLaggingClient(newFakeClient(scheme, template, warmPool, sb, pod))
+	lc := newLaggingClient(newFakeClient(scheme, template, warmPool, sb))
 	r := SandboxWarmPoolReconciler{
 		Client:                       lc,
 		Scheme:                       scheme,


### PR DESCRIPTION
#### What this PR does / why we need it:

The warm pool asked the API server for a Pod on every non-Ready pool member past the
readiness grace period, purely to read its `PodScheduled` condition. The sandbox controller
now mirrors that condition onto `Sandbox.status` — copying the Pod condition's status and
reason verbatim — so the pool already has the signal on an object it holds.
`isSandboxPodUnschedulable` reads the mirror instead.

The motivation is removing a duplicated invariant, not performance. The old code
re-implemented the sandbox controller's pod-name resolution, and its own comment said so
("same resolution the sandbox controller uses") — two copies of one rule in two packages
with no compiler link between them. That duplication is live and the project is
actively deprecating the annotation it depends on: #1417 (merged) marks
`SandboxPodNameAnnotation` `Deprecated`, with new Sandboxes using their own name for the
backing pod while "non-empty legacy annotations may still be honored". This change removes
the warm pool's copy of that lookup entirely, so the pool stops depending on a deprecated
field ahead of its eventual removal.

*(Correction: an earlier revision of this description said #1417 had to rename this lookup
and that the two changes conflicted. That was true of #1417's original 30-file revision; it
was scoped down before merging and no longer touches `sandboxwarmpool_controller.go`, so
there is no conflict — this branch still merges cleanly. The deprecation, and therefore the
reason to stop reading the annotation here, stands.)*

To be explicit about what this is **not**: it is not a latency or API-budget win. The
manager's client is cache-backed and Pods are already in the informer cache, because the
core sandbox controller watches them — so the old `Get` was an in-memory read.

**Behavior at the edges.** The mirror is removed when the Pod is confirmed absent and
reports `Unknown` on a transient Pod lookup failure, so both fall through to `false` exactly
as the previous failed-`Get` path did. Only `Unschedulable` is a hold signal; the mirror
carries every scheduler reason verbatim, but other `False` reasons (`SchedulingGated`) remain
the scheduler's to resolve and still take the stuck-sandbox path, unchanged.

One deliberate asymmetry, called out in the code comment rather than papered over: the old
code keyed the terminating case off the **Pod's** `DeletionTimestamp`; this reads the
**Sandbox's**. A Pod can be deleting while its Sandbox is not (the suspend path deliberately
keeps reporting the deleting Pod), and in that window a stale `Unschedulable` holds the
sandbox until the sandbox controller updates or removes the mirror. Holding a suspending
sandbox is the safer error — the alternative is GC'ing it as "stuck" mid-suspend — but it is
a real behavior change and the part most worth a reviewer's attention.

Also drops the now-unused `core/pods` RBAC marker. This does **not** change the generated
role: the claim controller in the same binary requests `pods` with a superset of these verbs,
so the aggregated extensions role is byte-identical (confirmed by regenerating). It is marker
hygiene, not a privilege reduction.

#### Which issue(s) this PR is related to:

Follow-up to https://github.com/kubernetes-sigs/agent-sandbox/issues/1281, which was closed
when https://github.com/kubernetes-sigs/agent-sandbox/pull/1291 merged. That PR added the
mirrored `PodScheduled` condition; this is the consumer half, planned at the time as a
separate PR so the API addition could land and be reviewed on its own.

#### Special notes for your reviewer:

- **Test fixtures moved, deliberately.** The unschedulable signal now lives on
  `Sandbox.status.conditions` in three fixtures, because that is where the controller reads
  it. Leaving them on Pods would have let the tests pass without exercising the new path —
  which is exactly what happened on my first pass, so this is worth a look.
- **New `TestIsSandboxPodUnschedulable`** pins the decision table directly: missing
  condition, a non-`PodScheduled` condition, `Unknown`, `True/PodScheduled`,
  `False/SchedulingGated`, `False/Unschedulable`, and a deleting Sandbox carrying a stale
  `False/Unschedulable`.
- `isSandboxPodUnschedulable` is now a package-level helper rather than a reconciler method,
  since it no longer touches `r` and the neighbouring `isSandboxReady` is already a free
  function.
- Verified locally: `make test-unit` (1345 tests), `make lint-go`, `make lint-api`, and
  `fix-go-generate` / `fix-api-docs` / `fix-go-format` all clean with no drift. e2e was not
  run locally (no kind available here); relying on prow.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox scheduling decisions using the latest mirrored scheduling status.
  * Correctly handles missing, unknown, scheduled, gated, unschedulable, and deleting states.
  * Prevents stale unschedulable status from affecting terminating sandboxes.
  * Improves consistency when determining whether sandboxes can be scheduled.

* **Reliability**
  * Improved warm-pool requeue and hold behavior during quiet-cluster and configurable-grace scenarios.
  * Added more comprehensive handling for scheduling status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
