### PR TITLE
chore: use the last git commit date as the build date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ VERSION_PKG := sigs.k8s.io/agent-sandbox/internal/version
 
 GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
 GIT_SHA     ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-BUILD_DATE  ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+BUILD_DATE  ?= $(shell dev/tools/build-date)
 
 LD_FLAGS := -s -w -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
 	-X $(VERSION_PKG).gitSHA=$(GIT_SHA) \

--- a/dev/tools/build-date
+++ b/dev/tools/build-date
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+
+from shared import utils
+
+
+def main():
+    print(utils.build_date())
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/tools/push-images
+++ b/dev/tools/push-images
@@ -24,10 +24,9 @@ from shared import utils
 
 def _get_version_build_args():
     """Returns build args for version info injection into Go binaries."""
-    import datetime
     git_version = utils.git_describe()
     git_sha = utils.git_sha()
-    build_date = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    build_date = utils.build_date()
     return [
         f"--build-arg=GIT_VERSION={git_version}",
         f"--build-arg=GIT_SHA={git_sha}",

--- a/dev/tools/shared/utils.py
+++ b/dev/tools/shared/utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import re
 import subprocess
@@ -53,6 +53,67 @@ def git_sha():
         ["git", "rev-parse", "--short", "HEAD"], text=True
     ).strip()
     return _validate_version_string(raw_sha, "git sha")
+
+
+def build_date():
+    """Gets the build date in RFC3339 UTC format (%Y-%m-%dT%H:%M:%SZ).
+
+    If BUILD_DATE env var is set, it is returned.
+    Otherwise:
+    - If the repository is clean, returns the HEAD commit date.
+    - If the repository is dirty, returns the mtime of the most recently modified file.
+    """
+    env_date = os.getenv("BUILD_DATE")
+    if env_date:
+        return env_date
+
+    repo_root = get_repo_root()
+
+    res = subprocess.run(
+        ["git", "status", "--porcelain", "-z"],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+    )
+    raw_status = res.stdout
+
+    if not raw_status:
+        # Repo is clean -> return HEAD commit date
+        ts_str = subprocess.check_output(
+            ["git", "log", "-1", "--format=%ct"],
+            cwd=repo_root,
+            text=True,
+        ).strip()
+        dt = datetime.fromtimestamp(int(ts_str), tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Repo is dirty -> find most recently changed dirty file
+    entries = raw_status.split(b"\x00")
+    mtimes = []
+    i = 0
+    while i < len(entries):
+        entry = entries[i]
+        if not entry:
+            i += 1
+            continue
+        status = entry[:2]
+        filename = entry[3:].decode("utf-8", errors="replace")
+        # If rename or copy (R or C), the next entry in -z output is the old path
+        if status[0:1] in (b"R", b"C") or status[1:2] in (b"R", b"C"):
+            i += 1  # skip old path
+        abs_path = os.path.join(repo_root, filename)
+        if os.path.exists(abs_path):
+            try:
+                mtimes.append(os.path.getmtime(abs_path))
+            except OSError:
+                pass
+        i += 1
+
+    if mtimes:
+        latest_dt = datetime.fromtimestamp(max(mtimes), tz=timezone.utc)
+        return latest_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def get_image_tag():


### PR DESCRIPTION
This is probably more correct, and improves the development loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Standardized build timestamps across release and image-building workflows.
  - Build metadata now reflects the latest relevant source changes, including worktree modifications when applicable.
  - Supports consistent RFC3339 UTC timestamps and honors explicitly configured build dates.
  - Improved handling of renamed files, filesystem issues, and environments without usable timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->