### PR TITLE
build: add sandbox-router-go to image promotion list

### DIFF
--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -31,7 +31,8 @@ IMAGES_YAML_PATH = "registry.k8s.io/images/k8s-staging-agent-sandbox/images.yaml
 IMAGES_TO_PROMOTE = [
     "agent-sandbox-controller",
     "chrome-sandbox",
-    "python-runtime-sandbox"
+    "python-runtime-sandbox",
+    "sandbox-router-go"
 ]
 
 # Git Remotes defaults are controlled by CLI arguments
@@ -135,6 +136,52 @@ def get_latest_digest(image_name, tag):
     return None
 
 
+def update_images_yaml(yaml_path, tag, collected_digests):
+    """Updates images.yaml with new digests for promoted images."""
+    if not os.path.exists(yaml_path):
+        print(f"❌ {yaml_path} does not exist.")
+        sys.exit(1)
+
+    print(f"📝 Updating {yaml_path}...")
+    with open(yaml_path, "r") as f:
+        lines = f.readlines()
+
+    new_lines = []
+    active_image_block = None
+    inserted_digests = set()
+
+    # Iterate and inject digests
+    for line in lines:
+        # Detect which image block we are inside
+        if "- name:" in line:
+            for img in IMAGES_TO_PROMOTE:
+                if f"- name: {img}" in line:
+                    active_image_block = img
+                    break
+            else:
+                active_image_block = None
+
+        # If inside an active image block, skip old entries matching this tag to avoid duplicates
+        if active_image_block and (f'"{tag}"' in line or f"'{tag}'" in line):
+            print(f"   Removing old tag entry in {active_image_block}: {line.strip()}")
+            continue
+
+        new_lines.append(line)
+
+        # If inside active block, look for 'dmap:' and append new digest
+        if active_image_block and "dmap:" in line and active_image_block not in inserted_digests:
+            digest = collected_digests.get(active_image_block)
+            if digest:
+                indent = line.find("dmap:") + 2
+                new_entry = f'{" " * indent}"{digest}": ["{tag}"]\n'
+                new_lines.append(new_entry)
+                inserted_digests.add(active_image_block)
+                print(f"   Updated {active_image_block}")
+
+    with open(yaml_path, "w") as f:
+        f.writelines(new_lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description='Stage 1: Tag and Promote Agent Sandbox Release')
     parser.add_argument('--tag', required=True, help='The git tag for the release (e.g., v0.1.0)')
@@ -230,47 +277,7 @@ def main():
 
     # Update images.yaml
     yaml_path = os.path.join(k8s_io_dir, IMAGES_YAML_PATH)
-    if not os.path.exists(yaml_path):
-        print(f"❌ {IMAGES_YAML_PATH} does not exist in k8s.io repo.")
-        sys.exit(1)
-
-    print(f"📝 Updating {IMAGES_YAML_PATH}...")
-    with open(yaml_path, 'r') as f:
-        lines = f.readlines()
-
-    new_lines = []
-    active_image_block = None
-    inserted_digests = set()
-    
-    # Iterate and inject digests
-    for line in lines:
-        # Detect which image block we are inside
-        if "- name:" in line:
-            for img in IMAGES_TO_PROMOTE:
-                if f"- name: {img}" in line:
-                    active_image_block = img
-                    break
-            else:
-                active_image_block = None
-
-        # If inside an active image block, skip old entries matching this tag to avoid duplicates
-        if active_image_block and (f'"{tag}"' in line or f"'{tag}'" in line):
-            print(f"   Removing old tag entry in {active_image_block}: {line.strip()}")
-            continue
-
-        new_lines.append(line)
-        
-        # If inside active block, look for 'dmap:' and append new digest
-        if active_image_block and "dmap:" in line and active_image_block not in inserted_digests:
-             digest = collected_digests[active_image_block]
-             indent = line.find("dmap:") + 2 
-             new_entry = f'{" " * indent}"{digest}": ["{tag}"]\n'
-             new_lines.append(new_entry)
-             inserted_digests.add(active_image_block)
-             print(f"   Updated {active_image_block}")
-
-    with open(yaml_path, 'w') as f:
-        f.writelines(new_lines)
+    update_images_yaml(yaml_path, tag, collected_digests)
 
     run_command(["git", "add", IMAGES_YAML_PATH], cwd=k8s_io_dir)
     run_command(["git", "commit", "-m", f"Promote agent-sandbox {tag}"], cwd=k8s_io_dir)

--- a/dev/tools/tag_promote_images_test.py
+++ b/dev/tools/tag_promote_images_test.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for dev/tools/tag-promote-images."""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from importlib.machinery import SourceFileLoader
+
+_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _TOOLS_DIR)
+_TAG_PROMOTE_PATH = os.path.join(_TOOLS_DIR, "tag-promote-images")
+_loader = SourceFileLoader("tag_promote_images", _TAG_PROMOTE_PATH)
+_spec = importlib.util.spec_from_loader("tag_promote_images", _loader)
+tag_promote = importlib.util.module_from_spec(_spec)
+_loader.exec_module(tag_promote)
+
+
+class TagPromoteImagesListTest(unittest.TestCase):
+    """Tests that IMAGES_TO_PROMOTE contains the expected images."""
+
+    def test_images_to_promote_contains_required_images(self):
+        expected = [
+            "agent-sandbox-controller",
+            "chrome-sandbox",
+            "python-runtime-sandbox",
+            "sandbox-router-go",
+        ]
+        self.assertEqual(tag_promote.IMAGES_TO_PROMOTE, expected)
+
+
+class UpdateImagesYamlTest(unittest.TestCase):
+    """Tests updating images.yaml with new digests."""
+
+    def setUp(self):
+        self._temp_files = []
+
+    def tearDown(self):
+        for f in self._temp_files:
+            if os.path.exists(f):
+                os.unlink(f)
+
+    def _write_temp_yaml(self, content):
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        tmp.write(textwrap.dedent(content))
+        tmp.close()
+        self._temp_files.append(tmp.name)
+        return tmp.name
+
+    def test_update_images_yaml_inserts_digests(self):
+        sample_yaml = """
+        images:
+          - name: agent-sandbox-controller
+            dmap:
+              "sha256:old1": ["v0.1.0"]
+          - name: chrome-sandbox
+            dmap:
+              "sha256:old2": ["v0.1.0"]
+          - name: python-runtime-sandbox
+            dmap:
+              "sha256:old3": ["v0.1.0"]
+          - name: sandbox-router-go
+            dmap:
+              "sha256:old4": ["v0.1.0"]
+        """
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "agent-sandbox-controller": "sha256:new1",
+            "chrome-sandbox": "sha256:new2",
+            "python-runtime-sandbox": "sha256:new3",
+            "sandbox-router-go": "sha256:new4",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v0.2.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        self.assertIn('"sha256:new1": ["v0.2.0"]', content)
+        self.assertIn('"sha256:new2": ["v0.2.0"]', content)
+        self.assertIn('"sha256:new3": ["v0.2.0"]', content)
+        self.assertIn('"sha256:new4": ["v0.2.0"]', content)
+        # Old entries should be preserved
+        self.assertIn('"sha256:old1": ["v0.1.0"]', content)
+
+    def test_update_images_yaml_replaces_duplicate_tag(self):
+        sample_yaml = """
+        images:
+          - name: sandbox-router-go
+            dmap:
+              "sha256:old_v2": ["v0.2.0"]
+        """
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "sandbox-router-go": "sha256:new_v2",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v0.2.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        self.assertIn('"sha256:new_v2": ["v0.2.0"]', content)
+        self.assertNotIn('"sha256:old_v2": ["v0.2.0"]', content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:
Add `sandbox-router-go` to `IMAGES_TO_PROMOTE` in `dev/tools/tag-promote-images` so that official Go sandbox router container images are promoted to `registry.k8s.io/agent-sandbox/sandbox-router-go` during release promotion. Also factors `update_images_yaml` into a testable helper and adds unit test coverage.

#### Which issue(s) this PR is related to:
Ref #1058

#### Release Note
```release-note
NONE
```