### PR TITLE
examples/agentclientprotocol: simple ACP client

### DIFF
--- a/examples/agentclientprotocol/README.md
+++ b/examples/agentclientprotocol/README.md
@@ -1,0 +1,84 @@
+# Agent Client Protocol (ACP) Go Client Example
+
+This example demonstrates a lightweight client in Go for the [Agent Client Protocol (ACP)](https://agentclientprotocol.com).
+
+## Why ACP in Agent Sandbox?
+
+The Agent Client Protocol (ACP) standardizes communication between developer environments / editors and AI coding agents via JSON-RPC 2.0 over standard I/O (`stdio`) or network streams.
+
+In Kubernetes **Agent Sandbox**, ACP enables:
+1. **Isolated Execution**: The agent (such as `gemini-cli`, `aider`, or custom agents) runs inside an isolated, stateful Sandbox container.
+2. **Standardized Control**: The client interacts with the agent using a standard protocol for session lifecycle (`session/new`, `session/load`), prompting (`session/prompt`), tool permissions, and real-time updates (`session/update`).
+3. **Decoupled Architecture**: Any ACP-compliant client or IDE can seamlessly connect to agent runtimes running inside Kubernetes Sandboxes over `kubectl exec`, port forwarding, or gateway routes.
+
+## How This Example Works
+
+The example is a minimal but complete ACP client using only Go standard library packages, split into two parts:
+
+- **`pkg/acp`** — the protocol implementation: a `Client` with a bidirectional JSON-RPC 2.0 transport, plus Go types for the ACP messages. A single reader goroutine routes responses to pending calls by `id`, dispatches `session/update` notifications, and answers agent → client requests — all concurrently, since the agent calls back into the client while a prompt is running.
+- **`main.go`** — the terminal front end: flag parsing, spawning the agent, rendering streamed updates, and answering permission and file system requests.
+
+Together they cover the core ACP flows:
+
+- **Handshake (`initialize`)**: Negotiates the protocol version and declares client capabilities (file system read/write).
+- **Authentication (`authenticate`)**: If `session/new` is rejected because auth is required, the client authenticates with the agent's first advertised method (override with `-auth-method`).
+- **Sessions (`session/new`, `session/load`)**: Creates a new session, or resumes one with `-session-id`.
+- **Prompting (`session/prompt`)**: Sends user prompts and streams the agent's replies, thoughts, tool calls, and plan updates to the console as they arrive.
+- **Tool call approval (`session/request_permission`)**: When the agent wants to run a tool (edit a file, run a shell command), the client shows the permission options and lets you choose; `-yolo` auto-approves.
+- **File system proxy (`fs/read_text_file`, `fs/write_text_file`)**: Serves the agent's file reads/writes from the client side, as an editor would.
+
+## Running the Example
+
+### Interactive session against `gemini --acp`
+
+```bash
+go run ./examples/agentclientprotocol
+```
+
+This launches `gemini --acp` as a subprocess, creates a session in the current directory, and drops you into a prompt loop:
+
+```text
+Connected to ACP agent (protocol v1)
+  Agent: gemini-cli 0.57.0
+Created session dfed9cee-a170-478e-a64c-a4a42866c0d7
+Type a prompt and press Enter ("exit" or Ctrl-D to quit).
+
+> create a file named proof.txt containing hello
+
+[permission] Agent wants to run: echo hello > proof.txt
+  1) Allow for this session [allow_always]
+  2) Allow [allow_once]
+  3) Reject [reject_once]
+Choose 1-3 (Enter = 1):
+[tool] run_shell_command__call_963059 → completed
+Done — proof.txt now contains "hello".
+[turn ended: end_turn]
+```
+
+### One-shot prompt
+
+```bash
+go run ./examples/agentclientprotocol -yolo -prompt "Summarize the README in this directory"
+```
+
+`-prompt` sends a single prompt and exits when the turn completes; `-yolo` auto-approves all tool permission requests.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `-cmd` | Agent command to spawn (default `gemini --acp`) |
+| `-cwd` | Working directory for the session (default: current directory) |
+| `-prompt` | Send one prompt and exit instead of running interactively |
+| `-session-id` | Resume an existing session instead of creating a new one |
+| `-yolo` | Auto-approve all tool call permission requests |
+| `-auth-method` | Auth method ID to use if the agent requires authentication |
+| `-debug` | Show agent stderr, thoughts, and raw notification traffic |
+
+### Running against an Agent inside a Sandbox
+
+You can connect to an agent running inside a Kubernetes Sandbox pod by giving `-cmd` a command whose stdio is wired to the remote agent:
+
+```bash
+go run ./examples/agentclientprotocol -cmd "kubectl exec -i sandbox-claim-pod -c agent -- gemini --acp"
+```

--- a/examples/agentclientprotocol/main.go
+++ b/examples/agentclientprotocol/main.go
@@ -1,0 +1,557 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command acp-client is a terminal front end for an Agent Client Protocol
+// (ACP) agent such as `gemini --acp`.
+//
+// It spawns the agent as a subprocess, creates or resumes a session, and
+// runs an interactive prompt loop. While a prompt is being processed, the
+// agent's streamed output is rendered to the terminal and tool call
+// permission requests are answered by the user.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"sigs.k8s.io/agent-sandbox/examples/agentclientprotocol/pkg/acp"
+)
+
+type options struct {
+	// AgentCommand is the command line used to spawn the ACP agent subprocess.
+	AgentCommand string
+	// WorkingDirectory is the session working directory; file system requests
+	// from the agent are confined to it. Empty means the current directory.
+	WorkingDirectory string
+	// SessionID, if set, resumes an existing session instead of creating one.
+	SessionID string
+	// Prompt, if set, is sent as a single prompt turn instead of running the
+	// interactive loop.
+	Prompt string
+	// AuthMethod is the authentication method ID to use if the agent requires
+	// auth; empty selects the first method the agent advertises.
+	AuthMethod string
+	// AutoApprove approves every tool call permission request without asking.
+	AutoApprove bool
+	// Debug shows agent stderr, thoughts, and raw notification traffic.
+	Debug bool
+	// SetupTimeout bounds the initialize/authenticate/session setup calls.
+	// Prompt turns are not subject to a timeout.
+	SetupTimeout time.Duration
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	var opt options
+	flag.StringVar(&opt.AgentCommand, "cmd", "gemini --acp", "Command to start the ACP agent (e.g. 'gemini --acp')")
+	flag.StringVar(&opt.WorkingDirectory, "cwd", "", "Working directory for the session (defaults to current directory)")
+	flag.StringVar(&opt.SessionID, "session-id", "", "Resume an existing session ID instead of creating a new one")
+	flag.StringVar(&opt.Prompt, "prompt", "", "Send a single prompt and exit instead of running interactively")
+	flag.StringVar(&opt.AuthMethod, "auth-method", "", "Authentication method ID to use if the agent requires auth (defaults to the first advertised method)")
+	flag.BoolVar(&opt.AutoApprove, "yolo", false, "Automatically approve all tool call permission requests")
+	flag.BoolVar(&opt.Debug, "debug", false, "Show agent stderr, thoughts, and raw notification traffic")
+	flag.DurationVar(&opt.SetupTimeout, "setup-timeout", 60*time.Second, "Timeout for initialize/authenticate/session setup calls")
+	flag.Parse()
+
+	cwd := opt.WorkingDirectory
+	if cwd == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting current working directory: %w", err)
+		}
+	}
+	cwd, err := filepath.Abs(cwd)
+	if err != nil {
+		return fmt.Errorf("resolving working directory: %w", err)
+	}
+	// Resolve symlinks (e.g. /tmp → /private/tmp on macOS) so that the
+	// paths the agent sends back compare correctly against cwd.
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = resolved
+	}
+
+	agentOut, agentIn, cleanup, err := connectAgent(ctx, opt, cwd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	cons := newConsole(cwd, opt.Debug, opt.AutoApprove)
+
+	client := acp.NewClient(agentOut, agentIn)
+	client.OnNotification = cons.handleNotification
+	client.OnRequest = cons.handleRequest
+	go client.Run()
+
+	setupCtx, cancel := context.WithTimeout(ctx, opt.SetupTimeout)
+	defer cancel()
+
+	sessionID, err := setupSession(setupCtx, client, opt, cwd)
+	if err != nil {
+		return err
+	}
+
+	// One-shot mode: send a single prompt and exit.
+	if opt.Prompt != "" {
+		return sendPrompt(ctx, client, cons, sessionID, opt.Prompt)
+	}
+
+	// Interactive prompt loop.
+	fmt.Println(`Type a prompt and press Enter ("exit" or Ctrl-D to quit).`)
+	for {
+		fmt.Print("\n> ")
+		line, err := cons.stdin.ReadString('\n')
+		if err == io.EOF {
+			fmt.Println()
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("reading input: %w", err)
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if line == "exit" || line == "quit" {
+			return nil
+		}
+		if err := sendPrompt(ctx, client, cons, sessionID, line); err != nil {
+			fmt.Fprintf(os.Stderr, "prompt failed: %v\n", err)
+		}
+	}
+}
+
+// connectAgent spawns the configured agent command and returns the reader
+// and writer connected to its stdout and stdin.
+func connectAgent(ctx context.Context, opt options, cwd string) (io.Reader, io.Writer, func(), error) {
+	args := strings.Fields(opt.AgentCommand)
+	if len(args) == 0 {
+		return nil, nil, nil, fmt.Errorf("empty agent command")
+	}
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Dir = cwd
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	if opt.Debug {
+		cmd.Stderr = os.Stderr
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, nil, nil, fmt.Errorf("starting agent process (%s): %w", opt.AgentCommand, err)
+	}
+
+	cleanup := func() {
+		stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+	return stdout, stdin, cleanup, nil
+}
+
+// setupSession initializes the ACP connection and creates or resumes a
+// session, authenticating first if the agent requires it.
+func setupSession(ctx context.Context, client *acp.Client, opt options, cwd string) (string, error) {
+	initResp, err := client.Initialize(ctx, acp.InitializeRequest{
+		ProtocolVersion: acp.ProtocolVersion,
+		ClientCapabilities: acp.ClientCapabilities{
+			FS: acp.FSCapabilities{ReadTextFile: true, WriteTextFile: true},
+		},
+		ClientInfo: &acp.ClientInfo{Name: "simple-acp-client", Version: "0.1.0"},
+	})
+	if err != nil {
+		return "", fmt.Errorf("ACP initialize failed: %w", err)
+	}
+
+	fmt.Printf("Connected to ACP agent (protocol v%d)\n", initResp.ProtocolVersion)
+	if initResp.AgentInfo != nil {
+		fmt.Printf("  Agent: %s %s\n", initResp.AgentInfo.Name, initResp.AgentInfo.Version)
+	}
+
+	if opt.SessionID != "" {
+		fmt.Printf("Loading session %s...\n", opt.SessionID)
+		err := withAuthRetry(ctx, client, initResp, opt.AuthMethod, func() error {
+			return client.LoadSession(ctx, acp.LoadSessionRequest{SessionID: opt.SessionID, CWD: cwd})
+		})
+		if err != nil {
+			return "", fmt.Errorf("loading session %s: %w", opt.SessionID, err)
+		}
+		return opt.SessionID, nil
+	}
+
+	var newResp *acp.NewSessionResponse
+	err = withAuthRetry(ctx, client, initResp, opt.AuthMethod, func() error {
+		var err error
+		newResp, err = client.NewSession(ctx, acp.NewSessionRequest{CWD: cwd})
+		return err
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating session: %w", err)
+	}
+	fmt.Printf("Created session %s\n", newResp.SessionID)
+	return newResp.SessionID, nil
+}
+
+// withAuthRetry invokes fn, and if it fails on an agent that advertises
+// authentication methods, authenticates and retries once. Agents reject
+// session/new and session/load until authenticate succeeds.
+func withAuthRetry(ctx context.Context, client *acp.Client, initResp *acp.InitializeResponse, authMethod string, fn func() error) error {
+	err := fn()
+	if err == nil || len(initResp.AuthMethods) == 0 {
+		return err
+	}
+	method := authMethod
+	if method == "" {
+		method = initResp.AuthMethods[0].ID
+	}
+	fmt.Printf("Request failed (%v); authenticating with method %q...\n", err, method)
+	if err := client.Authenticate(ctx, acp.AuthenticateRequest{MethodID: method}); err != nil {
+		return fmt.Errorf("authenticate (%s) failed: %w", method, err)
+	}
+	return fn()
+}
+
+// sendPrompt runs one prompt turn, leaving the console at the start of a
+// fresh line afterwards.
+func sendPrompt(ctx context.Context, client *acp.Client, cons *console, sessionID, text string) error {
+	result, err := client.Prompt(ctx, acp.PromptRequest{
+		SessionID: sessionID,
+		Prompt:    []acp.ContentBlock{{Type: "text", Text: text}},
+	})
+	if err != nil {
+		return err
+	}
+	cons.endTurn(result.StopReason)
+	return nil
+}
+
+// console renders session updates and answers agent requests (permission
+// prompts, file system access). It owns stdin/stdout for the interactive
+// loop.
+type console struct {
+	stdin *bufio.Reader
+	// workDir is the session working directory (symlinks resolved); agent
+	// file system requests are confined to it.
+	workDir string
+	debug   bool
+	// autoApprove selects the first "allow" option of every permission
+	// request instead of asking the user.
+	autoApprove bool
+
+	mu             sync.Mutex
+	midAgentOutput bool              // true while streamed agent text lacks a trailing newline
+	toolTitles     map[string]string // toolCallId → title, for labeling status updates
+}
+
+func newConsole(workDir string, debug, autoApprove bool) *console {
+	return &console{
+		stdin:       bufio.NewReader(os.Stdin),
+		workDir:     workDir,
+		debug:       debug,
+		autoApprove: autoApprove,
+		toolTitles:  make(map[string]string),
+	}
+}
+
+// breakAgentOutput ensures we are at the start of a line before printing
+// non-chunk output (tool status, prompts). Callers must hold c.mu.
+func (c *console) breakAgentOutput() {
+	if c.midAgentOutput {
+		fmt.Println()
+		c.midAgentOutput = false
+	}
+}
+
+// endTurn prints the turn's stop reason once the prompt call returns.
+func (c *console) endTurn(stopReason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.breakAgentOutput()
+	fmt.Printf("[turn ended: %s]\n", stopReason)
+}
+
+// textContent decodes a session update's content as a single text block,
+// returning "" if it is anything else.
+func textContent(content json.RawMessage) string {
+	var block acp.ContentBlock
+	if err := json.Unmarshal(content, &block); err != nil {
+		return ""
+	}
+	return block.Text
+}
+
+func (c *console) handleNotification(method string, params json.RawMessage) {
+	if method != acp.MethodSessionUpdate {
+		if c.debug {
+			fmt.Fprintf(os.Stderr, "[debug] notification %s: %s\n", method, string(params))
+		}
+		return
+	}
+
+	var notif acp.SessionUpdateNotification
+	if err := json.Unmarshal(params, &notif); err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing session/update: %v\n", err)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	update := notif.Update
+	switch update.SessionUpdateKind {
+	case acp.UpdateAgentMessageChunk:
+		if text := textContent(update.Content); text != "" {
+			fmt.Print(text)
+			c.midAgentOutput = !strings.HasSuffix(text, "\n")
+		}
+	case acp.UpdateAgentThoughtChunk:
+		if !c.debug {
+			return
+		}
+		if text := textContent(update.Content); text != "" {
+			c.breakAgentOutput()
+			fmt.Printf("[thought] %s\n", strings.TrimSpace(text))
+		}
+	case acp.UpdateUserMessageChunk:
+		// Replay of a prompt, e.g. while loading an existing session.
+		if text := textContent(update.Content); text != "" {
+			c.breakAgentOutput()
+			fmt.Printf("[user] %s\n", strings.TrimSpace(text))
+		}
+	case acp.UpdateToolCall:
+		c.breakAgentOutput()
+		c.toolTitles[update.ToolCallID] = update.Title
+		fmt.Printf("[tool: %s] %s (%s)\n", update.ToolKind, update.Title, update.Status)
+	case acp.UpdateToolCallUpdate:
+		if update.Status == "" {
+			return
+		}
+		c.breakAgentOutput()
+		title := c.toolTitles[update.ToolCallID]
+		if title == "" {
+			title = update.ToolCallID
+		}
+		fmt.Printf("[tool] %s → %s\n", title, update.Status)
+	case acp.UpdatePlan:
+		c.breakAgentOutput()
+		fmt.Println("[plan]")
+		for _, entry := range update.Entries {
+			fmt.Printf("  - [%s] %s\n", entry.Status, entry.Content)
+		}
+	default:
+		if c.debug {
+			fmt.Fprintf(os.Stderr, "[debug] session update %s\n", update.SessionUpdateKind)
+		}
+	}
+}
+
+// handleRequest answers agent → client requests.
+func (c *console) handleRequest(method string, params json.RawMessage) (any, *acp.RPCError) {
+	switch method {
+	case acp.MethodRequestPermission:
+		var req acp.RequestPermissionParams
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, invalidParams(err)
+		}
+		return c.requestPermission(req), nil
+
+	case acp.MethodReadTextFile:
+		var req acp.ReadTextFileParams
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, invalidParams(err)
+		}
+		if req.Line != nil && *req.Line < 1 {
+			return nil, invalidParams(fmt.Errorf("line must be >= 1, got %d", *req.Line))
+		}
+		if req.Limit != nil && *req.Limit < 0 {
+			return nil, invalidParams(fmt.Errorf("limit must be >= 0, got %d", *req.Limit))
+		}
+		path, err := c.resolvePath(req.Path)
+		if err != nil {
+			return nil, internalError(err)
+		}
+		req.Path = path
+		content, err := readTextFile(req)
+		if err != nil {
+			return nil, internalError(err)
+		}
+		return acp.ReadTextFileResult{Content: content}, nil
+
+	case acp.MethodWriteTextFile:
+		var req acp.WriteTextFileParams
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, invalidParams(err)
+		}
+		path, err := c.resolvePath(req.Path)
+		if err != nil {
+			return nil, internalError(err)
+		}
+		if err := os.WriteFile(path, []byte(req.Content), 0o644); err != nil {
+			return nil, internalError(err)
+		}
+		return struct{}{}, nil
+
+	default:
+		return nil, &acp.RPCError{Code: acp.MethodNotFound, Message: fmt.Sprintf("method not supported: %s", method)}
+	}
+}
+
+func invalidParams(err error) *acp.RPCError {
+	return &acp.RPCError{Code: acp.InvalidParams, Message: fmt.Sprintf("invalid params: %v", err)}
+}
+
+func internalError(err error) *acp.RPCError {
+	return &acp.RPCError{Code: acp.InternalError, Message: err.Error()}
+}
+
+// resolvePath makes an agent-supplied path absolute (relative paths are
+// resolved against the session working directory) and rejects paths that
+// escape the working directory, so a misbehaving agent cannot read or write
+// arbitrary files on the client.
+func (c *console) resolvePath(path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(c.workDir, path)
+	}
+	path = filepath.Clean(path)
+	// Resolve symlinks on the file itself, so that a symlink inside the
+	// working directory cannot point a read or write outside of it (and so
+	// that equivalent paths, e.g. /tmp vs /private/tmp on macOS, compare
+	// correctly below). The file may not exist yet for a write; in that
+	// case resolve its parent directory instead.
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	} else {
+		dir, base := filepath.Split(path)
+		resolvedDir, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			return "", fmt.Errorf("resolving %q: %w", path, err)
+		}
+		path = filepath.Join(resolvedDir, base)
+	}
+	rel, err := filepath.Rel(c.workDir, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside the session working directory %q", path, c.workDir)
+	}
+	return path, nil
+}
+
+// requestPermission asks the user (or auto-approves with -yolo) which
+// permission option to select for a tool call. Concurrent requests are
+// serialized by c.mu, so at most one prompt reads stdin at a time.
+func (c *console) requestPermission(req acp.RequestPermissionParams) acp.RequestPermissionResult {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.breakAgentOutput()
+
+	title := req.ToolCall.Title
+	if title == "" {
+		title = req.ToolCall.ToolCallID
+	}
+	fmt.Printf("\n[permission] Agent wants to run: %s\n", title)
+	if c.debug && len(req.ToolCall.RawInput) > 0 {
+		fmt.Printf("  input: %s\n", string(req.ToolCall.RawInput))
+	}
+
+	if len(req.Options) == 0 {
+		fmt.Println("  (agent offered no permission options; cancelling)")
+		return acp.RequestPermissionResult{
+			Outcome: acp.PermissionOutcome{Outcome: acp.PermissionCancelled},
+		}
+	}
+
+	if c.autoApprove {
+		for _, opt := range req.Options {
+			if strings.HasPrefix(opt.Kind, "allow") {
+				fmt.Printf("  auto-approving (-yolo): %s\n", opt.Name)
+				return selected(opt)
+			}
+		}
+	}
+
+	for i, opt := range req.Options {
+		fmt.Printf("  %d) %s [%s]\n", i+1, opt.Name, opt.Kind)
+	}
+	for {
+		fmt.Printf("Choose 1-%d (Enter = 1): ", len(req.Options))
+		line, err := c.stdin.ReadString('\n')
+		if err != nil {
+			return acp.RequestPermissionResult{
+				Outcome: acp.PermissionOutcome{Outcome: acp.PermissionCancelled},
+			}
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return selected(req.Options[0])
+		}
+		if n, err := strconv.Atoi(line); err == nil && n >= 1 && n <= len(req.Options) {
+			return selected(req.Options[n-1])
+		}
+		fmt.Println("Invalid choice.")
+	}
+}
+
+func selected(opt acp.PermissionOption) acp.RequestPermissionResult {
+	return acp.RequestPermissionResult{
+		Outcome: acp.PermissionOutcome{Outcome: acp.PermissionSelected, OptionID: opt.OptionID},
+	}
+}
+
+// readTextFile serves an fs/read_text_file request, optionally returning
+// only the requested line range.
+func readTextFile(req acp.ReadTextFileParams) (string, error) {
+	data, err := os.ReadFile(req.Path)
+	if err != nil {
+		return "", err
+	}
+	content := string(data)
+	if req.Line == nil && req.Limit == nil {
+		return content, nil
+	}
+
+	lines := strings.Split(content, "\n")
+	start := 0
+	if req.Line != nil && *req.Line > 1 {
+		start = min(*req.Line-1, len(lines))
+	}
+	end := len(lines)
+	if req.Limit != nil {
+		end = min(start+*req.Limit, len(lines))
+	}
+	return strings.Join(lines[start:end], "\n"), nil
+}

--- a/examples/agentclientprotocol/pkg/acp/client.go
+++ b/examples/agentclientprotocol/pkg/acp/client.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package acp implements a minimal client for the Agent Client Protocol
+// (https://agentclientprotocol.com).
+//
+// ACP is a JSON-RPC 2.0 protocol, spoken over newline-delimited JSON on a
+// byte stream (typically the stdin/stdout of an agent process). The protocol
+// is bidirectional: while the client's session/prompt request is pending, the
+// agent streams session/update notifications and may issue its own requests
+// back to the client (permission prompts, file system access). Client
+// therefore runs a single reader goroutine that correlates responses to
+// pending calls by request ID and dispatches agent-initiated traffic to
+// caller-provided handlers.
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"sync"
+)
+
+// RequestHandler responds to a request sent by the agent to the client,
+// such as session/request_permission or fs/read_text_file. It returns
+// either a result to marshal into the response, or an *RPCError.
+//
+// Handlers are invoked on their own goroutine and may block (for example,
+// waiting for the user to answer a permission prompt).
+type RequestHandler func(method string, params json.RawMessage) (any, *RPCError)
+
+// NotificationHandler receives notifications sent by the agent, such as
+// session/update. It is invoked synchronously from the read loop, so it
+// must not call back into the Client.
+type NotificationHandler func(method string, params json.RawMessage)
+
+// Client is an Agent Client Protocol client. Create one with NewClient,
+// assign handlers, then start Run in a goroutine before issuing calls.
+type Client struct {
+	reader io.Reader
+
+	writeMu sync.Mutex // serializes writes to writer
+	writer  io.Writer
+
+	pendingMu sync.Mutex
+	nextID    int64
+	// pending holds a completion callback per in-flight request ID, invoked
+	// with the agent's response by the read loop. Keys are the string form
+	// of the ID (see idKey), since JSON-RPC 2.0 permits both number and
+	// string IDs and some agents echo numbers back as strings.
+	pending map[string]func(message)
+
+	// OnNotification, if set, receives agent notifications (session/update);
+	// without it, notifications are ignored.
+	// OnRequest, if set, answers agent-initiated requests; without it, all
+	// such requests fail with MethodNotFound. Both must be assigned before
+	// Run is started.
+	OnNotification NotificationHandler
+	OnRequest      RequestHandler
+
+	done    chan struct{} // closed when the read loop exits
+	readErr error         // reason the read loop exited; valid after done is closed
+}
+
+// NewClient returns a Client that reads agent output from r and writes
+// requests to w.
+func NewClient(r io.Reader, w io.Writer) *Client {
+	return &Client{
+		reader:  r,
+		writer:  w,
+		pending: make(map[string]func(message)),
+		done:    make(chan struct{}),
+	}
+}
+
+// Run reads and dispatches messages from the agent until the stream closes,
+// then fails any pending calls. It must be running (normally on its own
+// goroutine) for calls to complete.
+func (c *Client) Run() {
+	scanner := bufio.NewScanner(c.reader)
+	const maxLineSize = 10 * 1024 * 1024
+	scanner.Buffer(make([]byte, 64*1024), maxLineSize)
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		// Tolerate agents that mix plain log lines into stdout.
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var msg message
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue
+		}
+		c.dispatch(msg)
+	}
+
+	c.readErr = scanner.Err()
+	if c.readErr == nil {
+		c.readErr = io.EOF
+	}
+	close(c.done)
+}
+
+func (c *Client) dispatch(msg message) {
+	switch {
+	case msg.Method != "" && len(msg.ID) > 0:
+		// Agent → client request. Handled on its own goroutine because
+		// handlers may block on user input while the agent continues to
+		// stream notifications.
+		go c.handleRequest(msg)
+	case msg.Method != "":
+		if c.OnNotification != nil {
+			c.OnNotification(msg.Method, msg.Params)
+		}
+	case len(msg.ID) > 0:
+		// Response to one of our requests.
+		key := idKey(msg.ID)
+		c.pendingMu.Lock()
+		complete, ok := c.pending[key]
+		delete(c.pending, key)
+		c.pendingMu.Unlock()
+		if ok {
+			complete(msg)
+		}
+	}
+}
+
+// idKey normalizes a JSON-RPC ID to a map key: the value of a string ID, or
+// the literal text of a number ID, so that 42 and "42" match.
+func idKey(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	return string(raw)
+}
+
+func (c *Client) handleRequest(msg message) {
+	var result any
+	rpcErr := &RPCError{Code: MethodNotFound, Message: fmt.Sprintf("method not supported: %s", msg.Method)}
+	if c.OnRequest != nil {
+		result, rpcErr = c.OnRequest(msg.Method, msg.Params)
+	}
+
+	var resp any
+	if rpcErr != nil {
+		resp = errorResponse{JSONRPC: "2.0", ID: msg.ID, Error: rpcErr}
+	} else {
+		resp = successResponse{JSONRPC: "2.0", ID: msg.ID, Result: result}
+	}
+	// A write failure means the connection is broken; pending calls will
+	// fail when the read loop exits, so there is nothing more to do here.
+	_ = c.write(resp)
+}
+
+func (c *Client) write(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshaling message: %w", err)
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if _, err := fmt.Fprintf(c.writer, "%s\n", data); err != nil {
+		return fmt.Errorf("writing message: %w", err)
+	}
+	return nil
+}
+
+// Call sends a JSON-RPC request and waits for the matching response. If
+// result is non-nil, the response result is unmarshaled into it.
+func (c *Client) Call(ctx context.Context, method string, params any, result any) error {
+	// Register a completion callback; the buffered channel lets the read
+	// loop complete the call without blocking.
+	responses := make(chan message, 1)
+	c.pendingMu.Lock()
+	c.nextID++
+	id := c.nextID
+	key := strconv.FormatInt(id, 10)
+	c.pending[key] = func(msg message) { responses <- msg }
+	c.pendingMu.Unlock()
+
+	defer func() {
+		c.pendingMu.Lock()
+		delete(c.pending, key)
+		c.pendingMu.Unlock()
+	}()
+
+	req := request{JSONRPC: "2.0", ID: id, Method: method, Params: params}
+	if err := c.write(req); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.done:
+		return fmt.Errorf("connection to agent closed: %w", c.readErr)
+	case msg := <-responses:
+		if msg.Error != nil {
+			return msg.Error
+		}
+		if result != nil && len(msg.Result) > 0 {
+			if err := json.Unmarshal(msg.Result, result); err != nil {
+				return fmt.Errorf("unmarshaling %s result: %w", method, err)
+			}
+		}
+		return nil
+	}
+}
+
+// Notify sends a JSON-RPC notification; no response is expected.
+func (c *Client) Notify(method string, params any) error {
+	return c.write(notification{JSONRPC: "2.0", Method: method, Params: params})
+}
+
+// Initialize performs the ACP initialization handshake.
+func (c *Client) Initialize(ctx context.Context, req InitializeRequest) (*InitializeResponse, error) {
+	var resp InitializeResponse
+	if err := c.Call(ctx, "initialize", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Authenticate authenticates with the agent using one of the auth methods
+// advertised in the InitializeResponse.
+func (c *Client) Authenticate(ctx context.Context, req AuthenticateRequest) error {
+	return c.Call(ctx, "authenticate", req, nil)
+}
+
+// NewSession creates a new session. A nil MCPServers field is sent as an
+// empty list, which the protocol requires.
+func (c *Client) NewSession(ctx context.Context, req NewSessionRequest) (*NewSessionResponse, error) {
+	if req.MCPServers == nil {
+		req.MCPServers = []MCPServer{}
+	}
+	var resp NewSessionResponse
+	if err := c.Call(ctx, "session/new", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// LoadSession resumes a previous session by ID. The agent replays the
+// session history as session/update notifications before returning.
+func (c *Client) LoadSession(ctx context.Context, req LoadSessionRequest) error {
+	if req.MCPServers == nil {
+		req.MCPServers = []MCPServer{}
+	}
+	return c.Call(ctx, "session/load", req, nil)
+}
+
+// Prompt sends a user prompt and blocks until the turn completes. Streaming
+// output arrives via session/update notifications while the call is pending.
+func (c *Client) Prompt(ctx context.Context, req PromptRequest) (*PromptResponse, error) {
+	var resp PromptResponse
+	if err := c.Call(ctx, "session/prompt", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/examples/agentclientprotocol/pkg/acp/jsonrpc.go
+++ b/examples/agentclientprotocol/pkg/acp/jsonrpc.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// JSON-RPC 2.0 wire types. These are internal; callers interact with the
+// typed ACP methods on Client and the handler callbacks.
+
+// request is an outgoing JSON-RPC request.
+type request struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int64  `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// notification is an outgoing JSON-RPC notification (a request without an
+// ID, expecting no response).
+type notification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// message is any incoming JSON-RPC message: a response to one of our
+// requests (Result/Error), a request from the agent (Method with ID), or a
+// notification from the agent (Method without ID).
+type message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// successResponse is an outgoing reply to an agent-initiated request.
+// The result member is intentionally not omitempty: JSON-RPC requires it to
+// be present (possibly null) on success.
+type successResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result"`
+}
+
+// errorResponse is an outgoing error reply to an agent-initiated request.
+type errorResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   *RPCError       `json:"error"`
+}
+
+// RPCError is a JSON-RPC 2.0 error object. It is returned from Call (and
+// the typed methods built on it) when the agent responds with an error, and
+// may be returned from a RequestHandler to send an error back to the agent.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	if len(e.Data) > 0 {
+		return fmt.Sprintf("RPC error [%d]: %s (data: %s)", e.Code, e.Message, string(e.Data))
+	}
+	return fmt.Sprintf("RPC error [%d]: %s", e.Code, e.Message)
+}
+
+// JSON-RPC 2.0 error codes.
+const (
+	// MethodNotFound indicates the requested method is not supported.
+	MethodNotFound = -32601
+	// InvalidParams indicates the request parameters could not be parsed.
+	InvalidParams = -32602
+	// InternalError indicates the request failed while being handled.
+	InternalError = -32603
+)

--- a/examples/agentclientprotocol/pkg/acp/types.go
+++ b/examples/agentclientprotocol/pkg/acp/types.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acp
+
+import "encoding/json"
+
+// ProtocolVersion is the ACP protocol version this client implements.
+const ProtocolVersion = 1
+
+// Methods the agent calls on the client.
+const (
+	// MethodRequestPermission asks the client to approve or reject a tool call.
+	MethodRequestPermission = "session/request_permission"
+	// MethodReadTextFile asks the client to read a text file on the agent's behalf.
+	MethodReadTextFile = "fs/read_text_file"
+	// MethodWriteTextFile asks the client to write a text file on the agent's behalf.
+	MethodWriteTextFile = "fs/write_text_file"
+)
+
+// MethodSessionUpdate is the notification streamed by the agent during a
+// prompt turn or session replay.
+const MethodSessionUpdate = "session/update"
+
+// InitializeRequest are the client's parameters for the initialize handshake.
+type InitializeRequest struct {
+	ProtocolVersion    int                `json:"protocolVersion"`
+	ClientCapabilities ClientCapabilities `json:"clientCapabilities"`
+	ClientInfo         *ClientInfo        `json:"clientInfo,omitempty"`
+}
+
+// ClientCapabilities declares which agent → client requests this client can
+// answer. An agent only sends fs/* requests if the corresponding capability
+// is declared.
+type ClientCapabilities struct {
+	FS       FSCapabilities `json:"fs"`
+	Terminal bool           `json:"terminal"`
+}
+
+// FSCapabilities declares client-side file system support.
+type FSCapabilities struct {
+	ReadTextFile  bool `json:"readTextFile"`
+	WriteTextFile bool `json:"writeTextFile"`
+}
+
+// ClientInfo identifies the client implementation to the agent.
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// InitializeResponse is the agent's response to initialize.
+type InitializeResponse struct {
+	ProtocolVersion   int            `json:"protocolVersion"`
+	AgentInfo         *AgentInfo     `json:"agentInfo,omitempty"`
+	AgentCapabilities map[string]any `json:"agentCapabilities,omitempty"`
+	// AuthMethods lists authentication methods accepted by the authenticate
+	// call; empty if the agent does not require authentication.
+	AuthMethods []AuthMethod `json:"authMethods,omitempty"`
+}
+
+// AgentInfo identifies the agent implementation.
+type AgentInfo struct {
+	Name    string `json:"name"`
+	Title   string `json:"title,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// AuthMethod describes one way to authenticate with the agent.
+type AuthMethod struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// AuthenticateRequest are the parameters for the authenticate call.
+type AuthenticateRequest struct {
+	MethodID string `json:"methodId"`
+}
+
+// MCPServer configures an MCP server the agent should connect to for the
+// session. This example does not configure any, so only the empty list is
+// used; see the ACP specification for the full schema.
+type MCPServer struct {
+	Name    string   `json:"name"`
+	Command string   `json:"command"`
+	Args    []string `json:"args,omitempty"`
+}
+
+// NewSessionRequest are the parameters for session/new.
+type NewSessionRequest struct {
+	CWD        string      `json:"cwd"`
+	MCPServers []MCPServer `json:"mcpServers"`
+}
+
+// NewSessionResponse is the agent's response to session/new.
+type NewSessionResponse struct {
+	SessionID string         `json:"sessionId"`
+	Modes     map[string]any `json:"modes,omitempty"`
+	Models    map[string]any `json:"models,omitempty"`
+}
+
+// LoadSessionRequest are the parameters for session/load.
+type LoadSessionRequest struct {
+	SessionID  string      `json:"sessionId"`
+	CWD        string      `json:"cwd"`
+	MCPServers []MCPServer `json:"mcpServers"`
+}
+
+// ContentBlock is a piece of prompt or message content. Only text content
+// is used by this example; the ACP specification also defines image, audio,
+// and resource content.
+type ContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+// PromptRequest are the parameters for session/prompt.
+type PromptRequest struct {
+	SessionID string         `json:"sessionId"`
+	Prompt    []ContentBlock `json:"prompt"`
+}
+
+// PromptResponse is the agent's response to session/prompt, sent once the
+// turn has completed.
+type PromptResponse struct {
+	StopReason string `json:"stopReason"`
+}
+
+// Session update kinds carried in SessionUpdate.Kind.
+const (
+	UpdateUserMessageChunk  = "user_message_chunk"
+	UpdateAgentMessageChunk = "agent_message_chunk"
+	UpdateAgentThoughtChunk = "agent_thought_chunk"
+	UpdateToolCall          = "tool_call"
+	UpdateToolCallUpdate    = "tool_call_update"
+	UpdatePlan              = "plan"
+)
+
+// SessionUpdateNotification is the payload of a session/update notification.
+type SessionUpdateNotification struct {
+	SessionID string        `json:"sessionId"`
+	Update    SessionUpdate `json:"update"`
+}
+
+// SessionUpdate is a union of the session update variants. The variant is
+// discriminated by SessionUpdateKind, which corresponds to the wire field
+// "sessionUpdate" and holds one of the Update* constants.
+// Content is left raw because its shape differs by variant: a single
+// ContentBlock for message and thought chunks, a list of tool call content
+// for tool calls.
+type SessionUpdate struct {
+	SessionUpdateKind string          `json:"sessionUpdate"`
+	Content           json.RawMessage `json:"content,omitempty"`
+
+	// Set for tool_call and tool_call_update.
+	ToolCallID string          `json:"toolCallId,omitempty"`
+	Title      string          `json:"title,omitempty"`
+	ToolKind   string          `json:"kind,omitempty"`
+	Status     string          `json:"status,omitempty"`
+	RawInput   json.RawMessage `json:"rawInput,omitempty"`
+
+	// Set for plan.
+	Entries []PlanEntry `json:"entries,omitempty"`
+}
+
+// PlanEntry is one item in an agent's plan update.
+type PlanEntry struct {
+	Content  string `json:"content"`
+	Priority string `json:"priority,omitempty"`
+	Status   string `json:"status,omitempty"`
+}
+
+// RequestPermissionParams are the parameters of a session/request_permission
+// request from the agent: the tool call awaiting approval and the options
+// the user may choose from.
+type RequestPermissionParams struct {
+	SessionID string             `json:"sessionId"`
+	ToolCall  SessionUpdate      `json:"toolCall"`
+	Options   []PermissionOption `json:"options"`
+}
+
+// Permission option kinds. Options whose kind starts with "allow" approve
+// the tool call; "reject" kinds deny it.
+const (
+	PermissionAllowOnce    = "allow_once"
+	PermissionAllowAlways  = "allow_always"
+	PermissionRejectOnce   = "reject_once"
+	PermissionRejectAlways = "reject_always"
+)
+
+// PermissionOption is one choice offered in a permission request.
+type PermissionOption struct {
+	OptionID string `json:"optionId"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+}
+
+// RequestPermissionResult is the client's response to a permission request.
+type RequestPermissionResult struct {
+	Outcome PermissionOutcome `json:"outcome"`
+}
+
+// Permission outcomes.
+const (
+	// PermissionSelected reports that the user chose one of the options.
+	PermissionSelected = "selected"
+	// PermissionCancelled reports that the prompt turn was cancelled before
+	// the user chose an option.
+	PermissionCancelled = "cancelled"
+)
+
+// PermissionOutcome reports which option the user selected, if any.
+type PermissionOutcome struct {
+	Outcome  string `json:"outcome"`
+	OptionID string `json:"optionId,omitempty"`
+}
+
+// ReadTextFileParams are the parameters of an fs/read_text_file request.
+// Line (1-based) and Limit optionally select a range of lines.
+type ReadTextFileParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Line      *int   `json:"line,omitempty"`
+	Limit     *int   `json:"limit,omitempty"`
+}
+
+// ReadTextFileResult is the client's response to fs/read_text_file.
+type ReadTextFileResult struct {
+	Content string `json:"content"`
+}
+
+// WriteTextFileParams are the parameters of an fs/write_text_file request.
+type WriteTextFileParams struct {
+	SessionID string `json:"sessionId"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+}


### PR DESCRIPTION
It's surprisingly hard to find a low-dependency ACP client,
so this is a simple one that can be used to test the protocol.
