### PR TITLE
fix(perf): regression on SandboxClaim latency 

### DIFF
--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -66,7 +66,7 @@ const (
 	// warm candidate to receive a Pod IP. This covers short IPAM delays without
 	// allowing an unavailable warm pool to postpone cold creation indefinitely.
 	warmCandidateGracePeriod   = 2 * time.Second
-	warmCandidateRetryInterval = 500 * time.Millisecond
+	warmCandidateRetryInterval = 100 * time.Millisecond
 )
 
 // ErrTemplateNotFound is a sentinel error indicating a SandboxTemplate was not found.
@@ -1822,7 +1822,18 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 
 	if err := r.Create(ctx, sandbox); err != nil {
 		if k8errors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("%w: %w", errSandboxAlreadyExists, err)
+			liveSandbox := &v1beta1.Sandbox{}
+			if readErr := r.authoritativeReader().Get(ctx, client.ObjectKeyFromObject(sandbox), liveSandbox); readErr != nil {
+				logger.V(1).Info("Authoritative read after AlreadyExists failed; falling back to bounded requeue", "sandbox", sandbox.Name, "error", readErr.Error())
+				return nil, fmt.Errorf("%w: %w", errSandboxAlreadyExists, err)
+			}
+			if !metav1.IsControlledBy(liveSandbox, claim) {
+				collisionErr := fmt.Errorf("sandbox %q is not controlled by claim %q. Please use a different claim name or delete the sandbox manually", liveSandbox.Name, claim.Name)
+				logger.Error(collisionErr, "Sandbox controller mismatch")
+				return nil, collisionErr
+			}
+			logger.V(4).Info("Recovered just-created sandbox via authoritative read after AlreadyExists", "claim", claim.Name, "sandbox", liveSandbox.Name)
+			return liveSandbox, nil
 		}
 		err = fmt.Errorf("sandbox create error: %w", err)
 		logger.Error(err, "Error creating sandbox for claim", "claimName", claim.Name)

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -1824,12 +1824,12 @@ func (r *SandboxClaimReconciler) createSandbox(ctx context.Context, claim *exten
 		if k8errors.IsAlreadyExists(err) {
 			liveSandbox := &v1beta1.Sandbox{}
 			if readErr := r.authoritativeReader().Get(ctx, client.ObjectKeyFromObject(sandbox), liveSandbox); readErr != nil {
-				logger.V(1).Info("Authoritative read after AlreadyExists failed; falling back to bounded requeue", "sandbox", sandbox.Name, "error", readErr.Error())
-				return nil, fmt.Errorf("%w: %w", errSandboxAlreadyExists, err)
+				logger.V(1).Info("Authoritative read after AlreadyExists failed; falling back to bounded requeue", "claim", claim.Name, "sandbox", sandbox.Name, "error", readErr)
+				return nil, fmt.Errorf("%w: %w (authoritative read failed: %w)", errSandboxAlreadyExists, err, readErr)
 			}
 			if !metav1.IsControlledBy(liveSandbox, claim) {
 				collisionErr := fmt.Errorf("sandbox %q is not controlled by claim %q. Please use a different claim name or delete the sandbox manually", liveSandbox.Name, claim.Name)
-				logger.Error(collisionErr, "Sandbox controller mismatch")
+				logger.Error(collisionErr, "Sandbox controller mismatch", "claim", claim.Name, "sandbox", liveSandbox.Name)
 				return nil, collisionErr
 			}
 			logger.V(4).Info("Recovered just-created sandbox via authoritative read after AlreadyExists", "claim", claim.Name, "sandbox", liveSandbox.Name)

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -8132,3 +8132,190 @@ func TestCreateSandboxToleratesAlreadyExists(t *testing.T) {
 	require.NotNil(t, readyCond, "expected Ready condition after cache converged")
 	require.NotEqual(t, "SandboxCreatePending", readyCond.Reason, "expected pending reason to clear once cache converged")
 }
+
+// TestCreateSandboxAlreadyExistsRecoversViaAuthoritativeRead verifies that an
+// AlreadyExists from a cold-start Create is resolved in the same pass: the
+// APIReader read-back returns the live sandbox even though the informer cache
+// never converges, so the claim binds immediately with no cache-lag requeue.
+func TestCreateSandboxAlreadyExistsRecoversViaAuthoritativeRead(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "already-exists-live-read-claim"
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// Pre-create the sandbox owned by this claim to simulate a previous successful create.
+	existingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxClaim",
+				Name:       claimName,
+				UID:        "claim-uid",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// The cache never converges in this test: every cached sandbox Get stays
+	// NotFound, so recovery can only come from the authoritative read.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, warmPool, template, existingSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == claimName {
+					return k8errors.NewNotFound(
+						schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+						key.Name,
+					)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(existingSandbox.DeepCopy()).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		APIReader:        apiReader,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.NotEqual(t, cacheLagRequeueDelay, result.RequeueAfter, "in-pass recovery must not fall back to the cache-lag requeue")
+
+	// The claim binds to the pre-existing sandbox in the first pass.
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Equal(t, claimName, updatedClaim.Status.SandboxStatus.Name, "claim should bind to the live-read sandbox in the same pass")
+
+	readyCond := meta.FindStatusCondition(updatedClaim.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, readyCond, "expected Ready condition after in-pass recovery")
+	require.NotEqual(t, "SandboxCreatePending", readyCond.Reason, "in-pass recovery must not report SandboxCreatePending")
+}
+
+// TestCreateSandboxAlreadyExistsNameCollisionIsTerminal verifies that when the
+// authoritative read-back shows the existing sandbox is NOT controlled by the
+// claim, the pass reports the collision instead of adopting it or retrying on
+// the cache-lag sentinel.
+func TestCreateSandboxAlreadyExistsNameCollisionIsTerminal(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "already-exists-collision-claim"
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// A sandbox with the claim's name but controlled by a DIFFERENT claim.
+	foreignSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxClaim",
+				Name:       "some-other-claim",
+				UID:        "other-claim-uid",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, warmPool, template, foreignSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == claimName {
+					return k8errors.NewNotFound(
+						schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+						key.Name,
+					)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(foreignSandbox.DeepCopy()).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		APIReader:        apiReader,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+
+	_, err := reconciler.Reconcile(context.Background(), req)
+	require.Error(t, err, "a name collision must surface as an error, not be adopted")
+	require.ErrorContains(t, err, "is not controlled by claim")
+	require.NotErrorIs(t, err, errSandboxAlreadyExists, "collision must not be classified as benign cache lag")
+
+	// The claim must not bind to the foreign sandbox.
+	updatedClaim := &extensionsv1beta1.SandboxClaim{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
+	require.Empty(t, updatedClaim.Status.SandboxStatus.Name, "claim must not bind to a sandbox it does not control")
+}

--- a/extensions/controllers/sandboxclaim_controller_test.go
+++ b/extensions/controllers/sandboxclaim_controller_test.go
@@ -8217,7 +8217,7 @@ func TestCreateSandboxAlreadyExistsRecoversViaAuthoritativeRead(t *testing.T) {
 
 	result, err := reconciler.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	require.NotEqual(t, cacheLagRequeueDelay, result.RequeueAfter, "in-pass recovery must not fall back to the cache-lag requeue")
+	require.Zero(t, result.RequeueAfter, "in-pass recovery must not fall back to the cache-lag requeue or any other delay")
 
 	// The claim binds to the pre-existing sandbox in the first pass.
 	updatedClaim := &extensionsv1beta1.SandboxClaim{}
@@ -8318,4 +8318,104 @@ func TestCreateSandboxAlreadyExistsNameCollisionIsTerminal(t *testing.T) {
 	updatedClaim := &extensionsv1beta1.SandboxClaim{}
 	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, updatedClaim))
 	require.Empty(t, updatedClaim.Status.SandboxStatus.Name, "claim must not bind to a sandbox it does not control")
+}
+
+// TestCreateSandboxAlreadyExistsAuthoritativeReadFailure verifies the fallback
+// when a CONFIGURED APIReader fails after an AlreadyExists: createSandbox must
+// keep the cache-lag sentinel, the original AlreadyExists, and the read error
+// all identifiable in the error chain, and Reconcile must convert the sentinel
+// into the bounded cacheLagRequeueDelay requeue with a nil error.
+func TestCreateSandboxAlreadyExistsAuthoritativeReadFailure(t *testing.T) {
+	scheme := newScheme(t)
+	claimName := "already-exists-read-failure-claim"
+
+	claim := &extensionsv1beta1.SandboxClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: "default", UID: "claim-uid"},
+		Spec: extensionsv1beta1.SandboxClaimSpec{
+			WarmPoolRef: extensionsv1beta1.SandboxWarmPoolRef{Name: "test-pool"},
+		},
+	}
+
+	warmPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pool", Namespace: "default"},
+		Spec:       extensionsv1beta1.SandboxWarmPoolSpec{TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: "test-template"}},
+	}
+
+	template := &extensionsv1beta1.SandboxTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-template", Namespace: "default"},
+		Spec: extensionsv1beta1.SandboxTemplateSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	// Pre-create the sandbox owned by this claim to simulate a previous successful create.
+	existingSandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: "default",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "extensions.agents.x-k8s.io/v1beta1",
+				Kind:       "SandboxClaim",
+				Name:       claimName,
+				UID:        "claim-uid",
+				Controller: ptr.To(true), // nolint:modernize
+			}},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "test"}},
+			},
+		}}},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(claim, warmPool, template, existingSandbox).
+		WithStatusSubresource(claim).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*sandboxv1beta1.Sandbox); ok && key.Name == claimName {
+					return k8errors.NewNotFound(
+						schema.GroupResource{Group: "agents.x-k8s.io", Resource: "sandboxes"},
+						key.Name,
+					)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	// The APIReader is configured but unhealthy: every read fails with a
+	// distinguishable sentinel.
+	readFailure := errors.New("authoritative reader unavailable")
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return readFailure
+			},
+		}).
+		Build()
+
+	reconciler := &SandboxClaimReconciler{
+		Client:           fakeClient,
+		APIReader:        apiReader,
+		Scheme:           scheme,
+		Recorder:         events.NewFakeRecorder(10),
+		Tracer:           asmetrics.NewNoOp(),
+		WarmSandboxQueue: queue.NewSimpleSandboxQueue(),
+	}
+
+	// Direct createSandbox call: the full error chain must stay inspectable.
+	_, err := reconciler.createSandbox(context.Background(), claim.DeepCopy(), template)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSandboxAlreadyExists, "sentinel must survive for the bounded-requeue conversion")
+	require.ErrorIs(t, err, readFailure, "read failure cause must stay identifiable via errors.Is")
+	require.True(t, k8errors.IsAlreadyExists(err), "original AlreadyExists must stay identifiable")
+
+	// Reconcile-level: the sentinel converts to the bounded requeue with nil error.
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: claimName, Namespace: "default"}}
+	result, reconcileErr := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, reconcileErr, "sentinel should be converted to nil error")
+	require.Equal(t, cacheLagRequeueDelay, result.RequeueAfter, "expected bounded requeue delay when the authoritative read fails")
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Issue: When running continuous burst test for Agentic Sandbox, scaling with a warm pool of 3,700 sandboxes and creating 3,600 sandbox claims, there was sudden spike in the p99 latency (from the last release):
 - Metric: `ControllerStartupLatency99`
 - Measured Value: 851.48ms 
 - Threshold: 500ms

**Possible Reasons:**
- `cacheLagRequeueDelay`(#1072 - merged Aug 17)- When the informer cache lags during a cold-start burst — exactly the condition this test creates — the reconciler used to return an error and retry via the rate limiter (~5ms initial backoff). It now returns a flat `RequeueAfter`: 200ms (`cacheLagRequeueDelay`). Every affected claim eats ≥200ms plus workqueue delay inside the exact window this metric measures.
    **Fix:**
  - On `AlreadyExists`, `createSandbox` reads the sandbox back through direct API (bypassing the informer cache) and, if it is controlled by the claim, returns it immediately — no requeue, no added latency, no repeated Creates.
  - Only when the API server errors/times out does the pass fall back to the existing `errSandboxAlreadyExists` sentinel and its 200ms bounded `requeue`.
  
- `warmCandidateRetryInterval` (#683 - merged Aug 14)- Claims waiting on warm candidates without observed Pod IPs are woken only by this timer — nothing re-enqueues them when a candidate's Pod IPs are observed — so the interval is a direct additive term in claim startup latency. 
   **Fix:**
  - Reduce retry interval `500ms` to `100ms`. The wait remains bounded by the unchanged 2s `warmCandidateGracePeriod`; a finer poll caps the per-hop tail cost at ~100ms.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when sandbox creation encounters an existing resource.
  * Claims now bind correctly when the existing sandbox belongs to them.
  * Name collisions with sandboxes owned by another claim now report a clear error.
  * Warm-pool candidate retries now occur more frequently for faster recovery.
  * Removed unnecessary reconciliation delays after confirming sandbox ownership.
  * Improved error details when sandbox state cannot be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->