### PR TITLE
docs(examples): add command-governance example under examples/policy

### DIFF
--- a/examples/policy/command-governance/README.md
+++ b/examples/policy/command-governance/README.md
@@ -21,14 +21,16 @@ running, plus `pip install k8s-agent-sandbox`.
 ## Usage
 
 ```python
-import re
+import os
 import shlex
 from k8s_agent_sandbox import SandboxClient
 
-_DENY_PATTERNS = [
-    r"\bmkfs\b",
-    r"\bdd\s+if=",
-]
+def _flags(tokens: list[str]) -> list[str]:
+    # Tokens up to (not including) a bare "--" end-of-options marker, so
+    # `rm -- --recursive --force` (real filenames, not flags) isn't denied.
+    if "--" in tokens:
+        return tokens[: tokens.index("--")]
+    return tokens
 
 def _has_flag(tokens: list[str], short: str, long_name: str) -> bool:
     # Checks parsed argv tokens, not the raw string, so quoting/escaping
@@ -40,17 +42,25 @@ def _has_flag(tokens: list[str], short: str, long_name: str) -> bool:
             return True
     return False
 
-def _is_destructive_rm(command: str) -> bool:
+def _is_denied(command: str) -> bool:
     try:
         tokens = shlex.split(command)  # parses quoting the way a POSIX shell would
     except ValueError:
         return True  # unparseable quoting - fail safe, deny
-    if not tokens or tokens[0] != "rm":
+    if not tokens:
         return False
-    return _has_flag(tokens[1:], "r", "--recursive") and _has_flag(tokens[1:], "f", "--force")
+    exe = os.path.basename(tokens[0])  # strips a path prefix like /bin/rm
+    args = _flags(tokens[1:])
+    if exe == "rm":
+        return _has_flag(args, "r", "--recursive") and _has_flag(args, "f", "--force")
+    if exe == "mkfs" or exe.startswith("mkfs."):
+        return True
+    if exe == "dd":
+        return any(t.startswith("if=") for t in tokens[1:])  # order-independent
+    return False
 
 def governed_run(sandbox, command: str):
-    if _is_destructive_rm(command) or any(re.search(p, command) for p in _DENY_PATTERNS):
+    if _is_denied(command):
         raise PermissionError(f"denied by command policy: {command}")
     return sandbox.commands.run(command)
 
@@ -67,15 +77,17 @@ finally:
 ```
 
 `rm -rf /` is rejected in this script's own process — the sandbox pod is
-never contacted for that call. This is a minimal illustration; swap the
-regex list for whatever policy engine (OPA, a YAML rules file, an LLM
+never contacted for that call. This is a minimal illustration; swap
+`_is_denied()` for whatever policy engine (OPA, a YAML rules file, an LLM
 classifier) fits your risk model — the wrapper shape around
 `sandbox.commands.run()` is the actual pattern, not the matching logic.
 
-**Scope:** `_is_destructive_rm()` only inspects the first parsed token, so it
-catches `rm` invoked directly (including quoted/escaped spellings) but not
-`rm` reached via shell chaining or substitution (`echo hi; rm -rf /`,
-`$(rm -rf /)`, pipes). Closing that fully means parsing the command as a
+**Scope:** `_is_denied()` only inspects the first parsed token (the
+executable) and its own flags/arguments, so it catches `rm`/`mkfs`/`dd`
+invoked directly (including quoted/escaped spellings and path-qualified
+executables like `/bin/rm`) but not one reached via shell chaining or
+substitution (`echo hi; rm -rf /`, `$(rm -rf /)`, pipes). Closing that fully
+means parsing the command as a
 shell script (not just a word list) or, more robustly, allowlisting the
 exact commands a sandbox is permitted to run instead of denylisting
 patterns — denylists are inherently a losing game against a determined

--- a/examples/policy/command-governance/README.md
+++ b/examples/policy/command-governance/README.md
@@ -1,0 +1,54 @@
+# Command Governance
+
+The [`network-policy-management`](../network-policy-management), [`vap`](../vap),
+[`opa-gatekeeper`](../opa-gatekeeper), and [`kyverno`](../kyverno) examples in
+this directory govern Kubernetes-level concerns: what a `Sandbox` object is
+allowed to look like, and what its pod can reach over the network. None of
+them see the content of a command dispatched to a running sandbox's
+execution API — a `sandbox.commands.run("rm -rf /")` call is indistinguishable
+from any other command at the L3/L4/admission layer.
+
+This example governs that layer instead: the driving script classifies and
+approves/denies a command *before* calling `sandbox.commands.run()`, so a
+denied command never reaches the pod at all.
+
+## Prerequisites
+
+Same as [python-sdk-quickstart](../../python-sdk-quickstart): a cluster with
+the controller, router, and a `python-sandbox-pool` `SandboxWarmPool`
+running, plus `pip install k8s-agent-sandbox`.
+
+## Usage
+
+```python
+import re
+from k8s_agent_sandbox import SandboxClient
+
+_DENY_PATTERNS = [
+    r"rm\s+-[a-z]*r[a-z]*f|rm\s+-[a-z]*f[a-z]*r",  # rm -rf / -fr
+    r"\bmkfs\b",
+    r"\bdd\s+if=",
+]
+
+def governed_run(sandbox, command: str):
+    if any(re.search(p, command) for p in _DENY_PATTERNS):
+        raise PermissionError(f"denied by command policy: {command}")
+    return sandbox.commands.run(command)
+
+client = SandboxClient()
+sandbox = client.create_sandbox(warmpool="python-sandbox-pool", namespace="default")
+try:
+    print(governed_run(sandbox, "echo hello").stdout)
+    # hello
+
+    governed_run(sandbox, "rm -rf /")
+    # PermissionError: denied by command policy: rm -rf /
+finally:
+    sandbox.terminate()
+```
+
+`rm -rf /` is rejected in this script's own process — the sandbox pod is
+never contacted for that call. This is a minimal illustration; swap the
+regex list for whatever policy engine (OPA, a YAML rules file, an LLM
+classifier) fits your risk model — the wrapper shape around
+`sandbox.commands.run()` is the actual pattern, not the matching logic.

--- a/examples/policy/command-governance/README.md
+++ b/examples/policy/command-governance/README.md
@@ -56,7 +56,7 @@ def _is_denied(command: str) -> bool:
     if exe == "mkfs" or exe.startswith("mkfs."):
         return True
     if exe == "dd":
-        return any(t.startswith("if=") for t in tokens[1:])  # order-independent
+        return any(t.startswith("of=") for t in tokens[1:])  # order-independent
     return False
 
 def governed_run(sandbox, command: str):

--- a/examples/policy/command-governance/README.md
+++ b/examples/policy/command-governance/README.md
@@ -25,7 +25,7 @@ import re
 from k8s_agent_sandbox import SandboxClient
 
 _DENY_PATTERNS = [
-    r"rm\s+-[a-z]*r[a-z]*f|rm\s+-[a-z]*f[a-z]*r",  # rm -rf / -fr
+    r"\brm\s+-[a-z]*r[a-z]*f\b|\brm\s+-[a-z]*f[a-z]*r\b",  # rm -rf / -fr
     r"\bmkfs\b",
     r"\bdd\s+if=",
 ]

--- a/examples/policy/command-governance/README.md
+++ b/examples/policy/command-governance/README.md
@@ -25,13 +25,25 @@ import re
 from k8s_agent_sandbox import SandboxClient
 
 _DENY_PATTERNS = [
-    r"\brm\s+-[a-z]*r[a-z]*f\b|\brm\s+-[a-z]*f[a-z]*r\b",  # rm -rf / -fr
     r"\bmkfs\b",
     r"\bdd\s+if=",
 ]
 
+def _has_flag(command: str, short: str, long_name: str) -> bool:
+    # Matches the short flag standalone or combined with others (-rf, -fr,
+    # -Rf), and the long GNU option, so "-r -f", "-fr", and "--recursive
+    # --force" are all treated the same regardless of order.
+    return bool(re.search(rf"(?:^|\s)-\w*{short}\w*(?:\s|$)", command, re.IGNORECASE)) or long_name in command
+
+def _is_destructive_rm(command: str) -> bool:
+    return (
+        bool(re.search(r"\brm\b", command, re.IGNORECASE))
+        and _has_flag(command, "r", "--recursive")
+        and _has_flag(command, "f", "--force")
+    )
+
 def governed_run(sandbox, command: str):
-    if any(re.search(p, command) for p in _DENY_PATTERNS):
+    if _is_destructive_rm(command) or any(re.search(p, command) for p in _DENY_PATTERNS):
         raise PermissionError(f"denied by command policy: {command}")
     return sandbox.commands.run(command)
 

--- a/examples/policy/command-governance/README.md
+++ b/examples/policy/command-governance/README.md
@@ -22,6 +22,7 @@ running, plus `pip install k8s-agent-sandbox`.
 
 ```python
 import re
+import shlex
 from k8s_agent_sandbox import SandboxClient
 
 _DENY_PATTERNS = [
@@ -29,18 +30,24 @@ _DENY_PATTERNS = [
     r"\bdd\s+if=",
 ]
 
-def _has_flag(command: str, short: str, long_name: str) -> bool:
-    # Matches the short flag standalone or combined with others (-rf, -fr,
-    # -Rf), and the long GNU option, so "-r -f", "-fr", and "--recursive
-    # --force" are all treated the same regardless of order.
-    return bool(re.search(rf"(?:^|\s)-\w*{short}\w*(?:\s|$)", command, re.IGNORECASE)) or long_name in command
+def _has_flag(tokens: list[str], short: str, long_name: str) -> bool:
+    # Checks parsed argv tokens, not the raw string, so quoting/escaping
+    # ("-r -f", "'-rf'") can't hide a flag the shell would still honor.
+    for t in tokens:
+        if t == long_name:
+            return True
+        if t.startswith("-") and not t.startswith("--") and short.lower() in t.lower():
+            return True
+    return False
 
 def _is_destructive_rm(command: str) -> bool:
-    return (
-        bool(re.search(r"\brm\b", command, re.IGNORECASE))
-        and _has_flag(command, "r", "--recursive")
-        and _has_flag(command, "f", "--force")
-    )
+    try:
+        tokens = shlex.split(command)  # parses quoting the way a POSIX shell would
+    except ValueError:
+        return True  # unparseable quoting - fail safe, deny
+    if not tokens or tokens[0] != "rm":
+        return False
+    return _has_flag(tokens[1:], "r", "--recursive") and _has_flag(tokens[1:], "f", "--force")
 
 def governed_run(sandbox, command: str):
     if _is_destructive_rm(command) or any(re.search(p, command) for p in _DENY_PATTERNS):
@@ -64,3 +71,12 @@ never contacted for that call. This is a minimal illustration; swap the
 regex list for whatever policy engine (OPA, a YAML rules file, an LLM
 classifier) fits your risk model — the wrapper shape around
 `sandbox.commands.run()` is the actual pattern, not the matching logic.
+
+**Scope:** `_is_destructive_rm()` only inspects the first parsed token, so it
+catches `rm` invoked directly (including quoted/escaped spellings) but not
+`rm` reached via shell chaining or substitution (`echo hi; rm -rf /`,
+`$(rm -rf /)`, pipes). Closing that fully means parsing the command as a
+shell script (not just a word list) or, more robustly, allowlisting the
+exact commands a sandbox is permitted to run instead of denylisting
+patterns — denylists are inherently a losing game against a determined
+adversary. Pick allowlisting for anything beyond a demo.


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `examples/policy/command-governance/README.md` — a minimal, dependency-free example showing how to govern the *content* of a command before it's dispatched to a running sandbox's execution API.

The existing `examples/policy/` subfolders (`vap`, `opa-gatekeeper`, `kyverno`, `network-policy-management`, `policy-controller`) all govern Kubernetes-object-level or network-level concerns — what a `Sandbox`/`SandboxTemplate` resource may look like, or what its pod can reach over the network. None of them inspect *what command* an agent asks a sandbox to run: `sandbox.commands.run("rm -rf /")` is indistinguishable from any other command at the admission or L3/L4 layer.

This example fills that specific, narrow gap: wrap `sandbox.commands.run()` in a classify/approve/deny check evaluated in the driving script's own process, so a denied command never reaches the pod at all.

Scope notes:
- No new dependency — uses plain Python regex matching, not a specific policy engine, so it doesn't ask the project to bless any particular third-party tool.
- No code changes outside the new example directory.
- Follows the same self-contained, inline-runnable-snippet style as `examples/python-sdk-quickstart` (single README, no separate script files).
- No corresponding `site/content/docs/use-cases/examples/` page added, consistent with 3 of its 4 direct siblings in `examples/policy/` (`vap`, `kyverno`, `network-policy-management`) which also don't have one.

Tested the exact snippet in this README against a real cluster (kind + agent-sandbox controller v0.5.6 + built-from-source sandbox-router + a `python-runtime-sandbox` warm pool):

```
hello
PermissionError: denied by command policy: rm -rf /
```

Verified the deny path is real, not just illustrative: inspected the warm pool's replacement pod filesystem after the run and confirmed `rm -rf /` never reached any pod.

#### Which issue(s) this PR is related to:

None — no existing issue tracks this gap.

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a command-governance example that classifies commands before execution.
  * Documented safeguards for destructive commands, including recursive force deletion, disk formatting, and disk-writing operations.
  * Included examples showing approved commands proceed while unsafe or malformed commands are denied.
  * Added scope guidance, setup instructions, and sandbox cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->