### PR TITLE
examples/sandboxed-tools: add fake 'eliza' LLM for testing

### DIFF
--- a/examples/sandboxed-tools/README.md
+++ b/examples/sandboxed-tools/README.md
@@ -50,6 +50,15 @@ The LLM has access to a powerful suite of tools configured in the registry (`pkg
 * **`read`**: Reads the full contents of a file from the sandbox.
 * **`write`**: Writes specified content to a file, automatically creating parent directories if they do not exist and overwriting the file if it does.
 
+## Fake LLM for Testing
+
+Setting `OPENAI_MODEL=fake-eliza` selects a built-in fake LLM instead of a real API, so the
+agent plumbing can be exercised without an API key or network access. The fake answers every
+message with a question reflecting the user's words back (`"What is the capital of France?"`
+=> `"What do you think it means when you say 'What is the capital of France?'?"`), and knows
+one trick for testing the tool path end to end: a message of the form `run: <command>`
+makes it request a `run_command` tool call and report the result.
+
 ## Running the Example
 
 Make sure your Kubernetes cluster is running and accessible via your active `kubeconfig` context.

--- a/examples/sandboxed-tools/main.go
+++ b/examples/sandboxed-tools/main.go
@@ -703,19 +703,6 @@ func (o *RunOptions) InitDefaults() {
 func run(ctx context.Context, opts RunOptions) error {
 	log := klog.FromContext(ctx)
 
-	apiKey := os.Getenv("GEMINI_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("OPENAI_API_KEY")
-	}
-	if apiKey == "" {
-		return fmt.Errorf("GEMINI_API_KEY or OPENAI_API_KEY environment variable is required")
-	}
-
-	baseURL := os.Getenv("OPENAI_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
-	}
-
 	if opts.HomeDir == "" {
 		return fmt.Errorf("homeDir must not be empty")
 	}
@@ -728,7 +715,7 @@ func run(ctx context.Context, opts RunOptions) error {
 		return fmt.Errorf("invalid sessionName %q: %w", opts.SessionName, err)
 	}
 
-	llmClient, err := llm.NewClient(baseURL, apiKey)
+	llmClient, err := llm.NewFromEnv(opts.ModelName)
 	if err != nil {
 		return fmt.Errorf("failed to initialize llm client: %w", err)
 	}
@@ -781,7 +768,7 @@ func run(ctx context.Context, opts RunOptions) error {
 
 type Harness struct {
 	// llmClient is the client we use to talk to the llm.
-	llmClient *llm.Client
+	llmClient llm.ChatClient
 
 	// toolsRegistry holds all the tools we have available to the llm.
 	toolsRegistry *tools.Registry

--- a/examples/sandboxed-tools/pkg/llm/fake.go
+++ b/examples/sandboxed-tools/pkg/llm/fake.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+// ChatClient is implemented by chat completion backends: the real
+// OpenAI-compatible Client, or a fake for testing.
+type ChatClient interface {
+	CreateChatCompletion(ctx context.Context, req ChatCompletionRequest) (*ChatCompletionResponse, error)
+}
+
+var _ ChatClient = &Client{}
+var _ ChatClient = &ElizaClient{}
+
+// FakeModelEliza is the model name that selects the built-in fake LLM
+// instead of a real API. Use it (e.g. OPENAI_MODEL=fake-eliza) in tests and
+// demos that should not depend on LLM availability or an API key.
+const FakeModelEliza = "fake-eliza"
+
+// NewFromEnv returns the ChatClient for modelName: the built-in fake for
+// FakeModelEliza (which needs no API key), otherwise the real
+// OpenAI-compatible client configured from the GEMINI_API_KEY /
+// OPENAI_API_KEY and OPENAI_BASE_URL environment variables.
+func NewFromEnv(modelName string) (ChatClient, error) {
+	if modelName == FakeModelEliza {
+		return &ElizaClient{}, nil
+	}
+
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("GEMINI_API_KEY or OPENAI_API_KEY environment variable is required")
+	}
+
+	return NewClient(os.Getenv("OPENAI_BASE_URL"), apiKey)
+}
+
+// ElizaClient is a fake ChatClient for testing the agent plumbing without a
+// real LLM. Like its namesake, it answers every message with a question
+// reflecting the user's words back:
+//
+//	"What is the capital of France?" =>
+//	"What do you think it means when you say 'What is the capital of France?'?"
+//
+// It is deterministic. It knows one trick beyond conversation, so that the
+// tool execution path can be tested end to end: a message of the form
+// "run: <command>" makes it request a run_command tool call, and it reports
+// the tool's result on the next iteration.
+type ElizaClient struct{}
+
+// runPrefix triggers ElizaClient's run_command tool call.
+const runPrefix = "run:"
+
+// CreateChatCompletion implements ChatClient.
+func (c *ElizaClient) CreateChatCompletion(_ context.Context, req ChatCompletionRequest) (*ChatCompletionResponse, error) {
+	reply := "How does that make you feel?"
+
+	if len(req.Messages) > 0 {
+		if last := req.Messages[len(req.Messages)-1]; last.Role == "tool" {
+			// We just ran a tool; report its result.
+			reply = fmt.Sprintf("The tool told me:\n%s", valueOf(last.Content))
+			return textResponse(reply), nil
+		}
+	}
+
+	lastUser := ""
+	for _, msg := range slices.Backward(req.Messages) {
+		if msg.Role == "user" && msg.Content != nil {
+			lastUser = *msg.Content
+			break
+		}
+	}
+
+	if command, ok := strings.CutPrefix(lastUser, runPrefix); ok {
+		return runCommandResponse(strings.TrimSpace(command))
+	}
+
+	if lastUser != "" {
+		reply = fmt.Sprintf("What do you think it means when you say '%s'?", lastUser)
+	}
+	return textResponse(reply), nil
+}
+
+func textResponse(reply string) *ChatCompletionResponse {
+	return &ChatCompletionResponse{
+		ID: "fake-eliza",
+		Choices: []Choice{
+			{
+				Message:      Message{Role: "assistant", Content: &reply},
+				FinishReason: "stop",
+			},
+		},
+	}
+}
+
+// runCommandResponse asks the harness to execute command via the
+// run_command tool, exactly as a real LLM would.
+func runCommandResponse(command string) (*ChatCompletionResponse, error) {
+	args, err := json.Marshal(map[string]string{"command": command})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling run_command arguments: %w", err)
+	}
+	return &ChatCompletionResponse{
+		ID: "fake-eliza",
+		Choices: []Choice{
+			{
+				Message: Message{
+					Role: "assistant",
+					ToolCalls: []ToolCall{
+						{
+							ID:   "eliza-run-1",
+							Type: "function",
+							Function: FunctionCall{
+								Name:      "run_command",
+								Arguments: string(args),
+							},
+						},
+					},
+				},
+				FinishReason: "tool_calls",
+			},
+		},
+	}, nil
+}
+
+// valueOf safely dereferences p, returning the zero value if p is nil.
+func valueOf[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
+}

--- a/examples/sandboxed-tools/pkg/llm/fake_test.go
+++ b/examples/sandboxed-tools/pkg/llm/fake_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func userMessage(text string) Message {
+	return Message{Role: "user", Content: &text}
+}
+
+func TestElizaReflectsUserMessage(t *testing.T) {
+	client := &ElizaClient{}
+
+	resp, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
+		Messages: []Message{userMessage("What is the capital of France?")},
+	})
+	if err != nil {
+		t.Fatalf("CreateChatCompletion: %v", err)
+	}
+
+	got := *resp.Choices[0].Message.Content
+	want := "What do you think it means when you say 'What is the capital of France?'?"
+	if got != want {
+		t.Errorf("reply = %q, want %q", got, want)
+	}
+	if len(resp.Choices[0].Message.ToolCalls) != 0 {
+		t.Errorf("unexpected tool calls: %v", resp.Choices[0].Message.ToolCalls)
+	}
+}
+
+func TestElizaRunCommand(t *testing.T) {
+	client := &ElizaClient{}
+
+	resp, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
+		Messages: []Message{userMessage("run: uname -a")},
+	})
+	if err != nil {
+		t.Fatalf("CreateChatCompletion: %v", err)
+	}
+
+	toolCalls := resp.Choices[0].Message.ToolCalls
+	if len(toolCalls) != 1 {
+		t.Fatalf("tool calls = %v, want exactly one", toolCalls)
+	}
+	if toolCalls[0].Function.Name != "run_command" {
+		t.Errorf("tool name = %q, want run_command", toolCalls[0].Function.Name)
+	}
+
+	var args struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal([]byte(toolCalls[0].Function.Arguments), &args); err != nil {
+		t.Fatalf("unmarshaling arguments %q: %v", toolCalls[0].Function.Arguments, err)
+	}
+	if args.Command != "uname -a" {
+		t.Errorf("command = %q, want %q", args.Command, "uname -a")
+	}
+}
+
+func TestElizaReportsToolResult(t *testing.T) {
+	client := &ElizaClient{}
+
+	toolOutput := "stdout:\nLinux"
+	resp, err := client.CreateChatCompletion(context.Background(), ChatCompletionRequest{
+		Messages: []Message{
+			userMessage("run: uname"),
+			{Role: "tool", ToolCallID: "eliza-run-1", Content: &toolOutput},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateChatCompletion: %v", err)
+	}
+
+	got := *resp.Choices[0].Message.Content
+	want := "The tool told me:\nstdout:\nLinux"
+	if got != want {
+		t.Errorf("reply = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Adds a deterministic fake LLM to the sandboxed-tools example so the agent plumbing can be exercised (and eventually e2e-tested) without an API key or dependence on LLM availability.

```console
$ OPENAI_MODEL=fake-eliza go run ./examples/sandboxed-tools -session demo
User> What is the capital of France?
Agent> What do you think it means when you say 'What is the capital of France?'?
User> run: cat /etc/os-release
Agent> The tool told me:
stdout:
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a built-in fake LLM for testing agent and tool workflows without API credentials or network access.
  * Supports conversational responses and requests command execution for prompts formatted as `run: <command>`.
* **Documentation**
  * Corrected the sample response formatting in the sandboxed-tools documentation.
* **Tests**
  * Added coverage for message reflection, command requests, and tool-result responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->