### PR TITLE
fix(deps): bump starlette to 1.1.0 in sandbox-router requirements.txt

### DIFF
--- a/clients/python/agentic-sandbox-client/sandbox-router/requirements.txt
+++ b/clients/python/agentic-sandbox-client/sandbox-router/requirements.txt
@@ -204,9 +204,9 @@ pytest-asyncio==1.3.0 \
     --hash=sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5 \
     --hash=sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5
     # via -r requirements.in
-starlette==1.0.0 \
-    --hash=sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149 \
-    --hash=sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b
+starlette==1.1.0 \
+    --hash=sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382 \
+    --hash=sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f
     # via fastapi
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps the pinned `starlette` dependency in `clients/python/agentic-sandbox-client/sandbox-router/requirements.txt` from `1.0.0` to `1.1.0` to pick up the fix for CVE-2026-48818 (SSRF and NTLMv2 credential theft via UNC paths in `StaticFiles.lookup_path` on Windows, fixed upstream in Starlette 1.1.0 by rejecting absolute paths).

`starlette` is a transitive dependency here (pulled in via `fastapi`, not listed directly in `requirements.in`). `fastapi==0.136.1` (already pinned in this file) requires `starlette>=0.46.0` with no upper bound, so `1.1.0` is within its supported range, and `1.1.0`'s own dependency metadata (`anyio`, `typing-extensions` constraints) is unchanged from `1.0.0`, so no other pins needed to move.

Note: this router's own code does not use `starlette.staticfiles.StaticFiles` anywhere, so the vulnerable code path is not currently reachable through this service, and the CVE itself only affects Windows deployments. This is dependency hygiene against a known, disclosed CVE rather than a fix for an observed exploit in this deployment.

Also note: the issue title says "2 vulnerable dependencies" but the issue body only describes this one (`starlette`). No second finding was named anywhere in the body or comments, so only this one is addressed here.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1451

#### Release Note
```release-note
Bump `starlette` to 1.1.0 in the Python sandbox-router's `requirements.txt` to fix CVE-2026-48818 (Windows-only SSRF/credential-theft via UNC paths in `StaticFiles`).
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #1451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Starlette dependency to version 1.1.0.
  * Refreshed package integrity data to support the dependency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->