### PR TITLE
fix(site): bump transitive picomatch to patch ReDoS (GHSA-c2c7-rcm5-vvqj)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -461,9 +461,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -735,9 +735,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps the transitive `picomatch` dependency in `site/package-lock.json` from the
vulnerable 2.3.1/4.0.3 releases to the patched 2.3.2/4.0.4 releases.

`picomatch` is pulled in transitively (not a direct dependency of `site/package.json`)
by `anymatch`/`readdirp` (top-level `node_modules/picomatch`, pinned at 2.3.1) and by
`postcss-cli`'s `tinyglobby` dependency (`node_modules/tinyglobby/node_modules/picomatch`,
pinned at 4.0.3). Both versions are affected by GHSA-c2c7-rcm5-vvqj / CVE-2026-33671, a
ReDoS in picomatch's extglob quantifier handling, fixed upstream in 2.3.2 and 4.0.4
respectively.

Note on real-world impact: `picomatch` here is only used at build time by the Hugo/PostCSS
site tooling to match glob patterns supplied by the developer (not untrusted runtime input),
so this is a defense-in-depth dependency hygiene fix rather than a fix for an actively
exploitable path in this project.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1452

#### Release Note
```release-note
Bumped transitive `picomatch` dependency in `site/package-lock.json` to 2.3.2/4.0.4 to fix a ReDoS vulnerability (CVE-2026-33671).
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #1452