### PR TITLE
examples/agentclientprotocol: address review follow-ups from #1450

### DIFF
--- a/examples/agentclientprotocol/README.md
+++ b/examples/agentclientprotocol/README.md
@@ -32,7 +32,8 @@ Together they cover the core ACP flows:
 ### Interactive session against `gemini --acp`
 
 ```bash
-go run ./examples/agentclientprotocol
+cd examples/agentclientprotocol
+go run .
 ```
 
 This launches `gemini --acp` as a subprocess, creates a session in the current directory, and drops you into a prompt loop:
@@ -58,7 +59,8 @@ Done — proof.txt now contains "hello".
 ### One-shot prompt
 
 ```bash
-go run ./examples/agentclientprotocol -yolo -prompt "Summarize the README in this directory"
+cd examples/agentclientprotocol
+go run . -yolo -prompt "Summarize the README in this directory"
 ```
 
 `-prompt` sends a single prompt and exits when the turn completes; `-yolo` auto-approves all tool permission requests.
@@ -67,12 +69,13 @@ go run ./examples/agentclientprotocol -yolo -prompt "Summarize the README in thi
 
 | Flag | Description |
 |---|---|
-| `-cmd` | Agent command to spawn (default `gemini --acp`) |
+| `-cmd` | Agent command to spawn (default `gemini --acp`). Use shell quoting to pass the whole command as one flag value; the program then splits that value on whitespace, so individual arguments cannot themselves contain spaces (quotes inside the value are not interpreted). |
 | `-cwd` | Working directory for the session (default: current directory) |
 | `-prompt` | Send one prompt and exit instead of running interactively |
 | `-session-id` | Resume an existing session instead of creating a new one |
 | `-yolo` | Auto-approve all tool call permission requests |
 | `-auth-method` | Auth method ID to use if the agent requires authentication |
+| `-setup-timeout` | Timeout for the initialize/authenticate/session setup calls (default `60s`); prompt turns have no timeout |
 | `-debug` | Show agent stderr, thoughts, and raw notification traffic |
 
 ### Running against an Agent inside a Sandbox
@@ -80,5 +83,6 @@ go run ./examples/agentclientprotocol -yolo -prompt "Summarize the README in thi
 You can connect to an agent running inside a Kubernetes Sandbox pod by giving `-cmd` a command whose stdio is wired to the remote agent:
 
 ```bash
-go run ./examples/agentclientprotocol -cmd "kubectl exec -i sandbox-claim-pod -c agent -- gemini --acp"
+cd examples/agentclientprotocol
+go run . -cmd "kubectl exec -i sandbox-claim-pod -c agent -- gemini --acp"
 ```

--- a/examples/agentclientprotocol/go.mod
+++ b/examples/agentclientprotocol/go.mod
@@ -1,0 +1,5 @@
+module sigs.k8s.io/agent-sandbox/examples/agentclientprotocol
+
+go 1.26.0
+
+toolchain go1.26.4

--- a/examples/agentclientprotocol/main.go
+++ b/examples/agentclientprotocol/main.go
@@ -124,20 +124,18 @@ func run(ctx context.Context) error {
 
 	// One-shot mode: send a single prompt and exit.
 	if opt.Prompt != "" {
-		return sendPrompt(ctx, client, cons, sessionID, opt.Prompt)
+		err := sendPrompt(ctx, client, cons, sessionID, opt.Prompt)
+		cons.flush() // don't lose streamed output when the process exits
+		return err
 	}
 
 	// Interactive prompt loop.
 	fmt.Println(`Type a prompt and press Enter ("exit" or Ctrl-D to quit).`)
 	for {
-		fmt.Print("\n> ")
-		line, err := cons.stdin.ReadString('\n')
-		if err == io.EOF {
+		line, ok := cons.ask("\n> ")
+		if !ok {
 			fmt.Println()
 			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("reading input: %w", err)
 		}
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -228,12 +226,17 @@ func setupSession(ctx context.Context, client *acp.Client, opt options, cwd stri
 	return newResp.SessionID, nil
 }
 
-// withAuthRetry invokes fn, and if it fails on an agent that advertises
-// authentication methods, authenticates and retries once. Agents reject
-// session/new and session/load until authenticate succeeds.
+// withAuthRetry invokes fn, and if it fails with an auth-required error on
+// an agent that advertises authentication methods, authenticates and
+// retries once. Agents reject session/new and session/load with
+// acp.AuthRequired until authenticate succeeds; any other error is
+// returned as-is.
 func withAuthRetry(ctx context.Context, client *acp.Client, initResp *acp.InitializeResponse, authMethod string, fn func() error) error {
 	err := fn()
 	if err == nil || len(initResp.AuthMethods) == 0 {
+		return err
+	}
+	if !acp.IsAuthRequiredError(err) {
 		return err
 	}
 	method := authMethod
@@ -261,11 +264,18 @@ func sendPrompt(ctx context.Context, client *acp.Client, cons *console, sessionI
 	return nil
 }
 
-// console renders session updates and answers agent requests (permission
-// prompts, file system access). It owns stdin/stdout for the interactive
-// loop.
+// console shows output and asks questions using a model / view split: the
+// model is an ordered list of items appended by any goroutine, and a single
+// view goroutine (run) — the only writer to stdout and reader of stdin —
+// handles the items in order, keeping track of how far it has gotten.
+//
+// Producers never block on the user: while the view is waiting for the
+// answer to a question, later items simply accumulate in the model. A
+// question therefore holds back everything appended after it, so it is
+// never pushed off the screen. (A TUI could replace the view — for example
+// painting new items above the active question — without touching the
+// model or its producers.)
 type console struct {
-	stdin *bufio.Reader
 	// workDir is the session working directory (symlinks resolved); agent
 	// file system requests are confined to it.
 	workDir string
@@ -274,36 +284,149 @@ type console struct {
 	// request instead of asking the user.
 	autoApprove bool
 
-	mu             sync.Mutex
-	midAgentOutput bool              // true while streamed agent text lacks a trailing newline
-	toolTitles     map[string]string // toolCallId → title, for labeling status updates
+	// mu guards items; itemsChanged signals the view that items has grown.
+	mu           sync.Mutex
+	itemsChanged *sync.Cond
+	// items is the model: output to print and questions to ask, in order.
+	items []*item
+
+	// toolTitles maps toolCallId → title, for labeling status updates. It
+	// is only accessed from handleNotification, which acp.Client invokes on
+	// its single read-loop goroutine.
+	toolTitles map[string]string
 }
 
+// item is one entry in the console model: output to show and, optionally, a
+// question whose answer should be read from the user.
+type item struct {
+	// text is printed verbatim.
+	text string
+	// needsLineStart means text must begin at the start of a line; a
+	// newline is inserted first if streamed agent text left the cursor
+	// mid-line.
+	needsLineStart bool
+
+	// question means one line of user input is read after printing text.
+	question bool
+
+	// handled, if non-nil, is closed by the view once the item has been
+	// printed and any question answered; answer and eof are valid after
+	// that. Producers that need the result (or need to sequence their next
+	// step after the print) set it.
+	handled chan struct{}
+	answer  string
+	eof     bool
+}
+
+// newConsole creates the console and starts its view goroutine.
 func newConsole(workDir string, debug, autoApprove bool) *console {
-	return &console{
-		stdin:       bufio.NewReader(os.Stdin),
+	c := &console{
 		workDir:     workDir,
 		debug:       debug,
 		autoApprove: autoApprove,
 		toolTitles:  make(map[string]string),
 	}
+	c.itemsChanged = sync.NewCond(&c.mu)
+	go c.run()
+	return c
 }
 
-// breakAgentOutput ensures we are at the start of a line before printing
-// non-chunk output (tool status, prompts). Callers must hold c.mu.
-func (c *console) breakAgentOutput() {
-	if c.midAgentOutput {
-		fmt.Println()
-		c.midAgentOutput = false
-	}
-}
-
-// endTurn prints the turn's stop reason once the prompt call returns.
-func (c *console) endTurn(stopReason string) {
+// append adds an item to the model and wakes the view.
+func (c *console) append(it *item) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.breakAgentOutput()
-	fmt.Printf("[turn ended: %s]\n", stopReason)
+	c.items = append(c.items, it)
+	c.itemsChanged.Broadcast()
+}
+
+// render appends output to the model.
+func (c *console) render(text string, needsLineStart bool) {
+	c.append(&item{text: text, needsLineStart: needsLineStart})
+}
+
+// ask appends a question to the model and blocks until the view has read
+// the user's reply, returned without its trailing newline. ok is false if
+// standard input has ended.
+func (c *console) ask(prompt string) (line string, ok bool) {
+	it := &item{text: prompt, needsLineStart: true, question: true, handled: make(chan struct{})}
+	c.append(it)
+	<-it.handled
+	return it.answer, !it.eof
+}
+
+// endTurn renders the turn's stop reason. There is no need to wait for it
+// to print: items are handled in append order, so it is shown before any
+// question the caller asks next.
+func (c *console) endTurn(stopReason string) {
+	c.render(fmt.Sprintf("[turn ended: %s]\n", stopReason), true)
+}
+
+// flush blocks until the view has handled every item appended so far; call
+// it before exiting so pending output is not lost.
+func (c *console) flush() {
+	it := &item{handled: make(chan struct{})}
+	c.append(it)
+	<-it.handled
+}
+
+// run is the view goroutine; see the console type comment.
+func (c *console) run() {
+	stdin := bufio.NewReader(os.Stdin)
+	stdinClosed := false
+	midLine := false // streamed text left the cursor mid-line
+	handledCount := 0
+
+	for {
+		c.mu.Lock()
+		for handledCount >= len(c.items) {
+			c.itemsChanged.Wait()
+		}
+		it := c.items[handledCount]
+		handledCount++
+		// Once the view has caught up, drop the handled prefix so the
+		// model does not grow without bound. clear releases the handled
+		// item pointers still referenced by the backing array.
+		if handledCount == len(c.items) {
+			clear(c.items)
+			c.items = c.items[:0]
+			handledCount = 0
+		}
+		c.mu.Unlock()
+
+		if it.needsLineStart && midLine {
+			fmt.Println()
+			midLine = false
+		}
+		if it.text != "" {
+			fmt.Print(it.text)
+			midLine = !strings.HasSuffix(it.text, "\n")
+		}
+
+		if it.question {
+			if stdinClosed {
+				it.eof = true
+			} else {
+				line, err := stdin.ReadString('\n')
+				if err != nil {
+					stdinClosed = true
+				}
+				line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+				if line == "" && err != nil {
+					it.eof = true
+				} else {
+					it.answer = line
+				}
+			}
+			// Interactively, the user's Enter moved to a fresh line; with
+			// piped input the cursor is still after the prompt, and
+			// continuing from there matches ordinary echoed input.
+			midLine = false
+		}
+
+		if it.handled != nil {
+			close(it.handled)
+		}
+	}
 }
 
 // textContent decodes a session update's content as a single text block,
@@ -330,50 +453,43 @@ func (c *console) handleNotification(method string, params json.RawMessage) {
 		return
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	update := notif.Update
 	switch update.SessionUpdateKind {
 	case acp.UpdateAgentMessageChunk:
 		if text := textContent(update.Content); text != "" {
-			fmt.Print(text)
-			c.midAgentOutput = !strings.HasSuffix(text, "\n")
+			c.render(text, false)
 		}
 	case acp.UpdateAgentThoughtChunk:
 		if !c.debug {
 			return
 		}
 		if text := textContent(update.Content); text != "" {
-			c.breakAgentOutput()
-			fmt.Printf("[thought] %s\n", strings.TrimSpace(text))
+			c.render(fmt.Sprintf("[thought] %s\n", strings.TrimSpace(text)), true)
 		}
 	case acp.UpdateUserMessageChunk:
 		// Replay of a prompt, e.g. while loading an existing session.
 		if text := textContent(update.Content); text != "" {
-			c.breakAgentOutput()
-			fmt.Printf("[user] %s\n", strings.TrimSpace(text))
+			c.render(fmt.Sprintf("[user] %s\n", strings.TrimSpace(text)), true)
 		}
 	case acp.UpdateToolCall:
-		c.breakAgentOutput()
 		c.toolTitles[update.ToolCallID] = update.Title
-		fmt.Printf("[tool: %s] %s (%s)\n", update.ToolKind, update.Title, update.Status)
+		c.render(fmt.Sprintf("[tool: %s] %s (%s)\n", update.ToolKind, update.Title, update.Status), true)
 	case acp.UpdateToolCallUpdate:
 		if update.Status == "" {
 			return
 		}
-		c.breakAgentOutput()
 		title := c.toolTitles[update.ToolCallID]
 		if title == "" {
 			title = update.ToolCallID
 		}
-		fmt.Printf("[tool] %s → %s\n", title, update.Status)
+		c.render(fmt.Sprintf("[tool] %s → %s\n", title, update.Status), true)
 	case acp.UpdatePlan:
-		c.breakAgentOutput()
-		fmt.Println("[plan]")
+		var plan strings.Builder
+		plan.WriteString("[plan]\n")
 		for _, entry := range update.Entries {
-			fmt.Printf("  - [%s] %s\n", entry.Status, entry.Content)
+			fmt.Fprintf(&plan, "  - [%s] %s\n", entry.Status, entry.Content)
 		}
+		c.render(plan.String(), true)
 	default:
 		if c.debug {
 			fmt.Fprintf(os.Stderr, "[debug] session update %s\n", update.SessionUpdateKind)
@@ -472,24 +588,25 @@ func (c *console) resolvePath(path string) (string, error) {
 }
 
 // requestPermission asks the user (or auto-approves with -yolo) which
-// permission option to select for a tool call. Concurrent requests are
-// serialized by c.mu, so at most one prompt reads stdin at a time.
+// permission option to select for a tool call. The console goroutine asks
+// questions one at a time and defers other output while one is pending, so
+// concurrent requests cannot interleave and the question is never pushed
+// off the screen.
 func (c *console) requestPermission(req acp.RequestPermissionParams) acp.RequestPermissionResult {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.breakAgentOutput()
-
 	title := req.ToolCall.Title
 	if title == "" {
 		title = req.ToolCall.ToolCallID
 	}
-	fmt.Printf("\n[permission] Agent wants to run: %s\n", title)
+
+	var header strings.Builder
+	fmt.Fprintf(&header, "\n[permission] Agent wants to run: %s\n", title)
 	if c.debug && len(req.ToolCall.RawInput) > 0 {
-		fmt.Printf("  input: %s\n", string(req.ToolCall.RawInput))
+		fmt.Fprintf(&header, "  input: %s\n", string(req.ToolCall.RawInput))
 	}
 
 	if len(req.Options) == 0 {
-		fmt.Println("  (agent offered no permission options; cancelling)")
+		header.WriteString("  (agent offered no permission options; cancelling)\n")
+		c.render(header.String(), true)
 		return acp.RequestPermissionResult{
 			Outcome: acp.PermissionOutcome{Outcome: acp.PermissionCancelled},
 		}
@@ -498,19 +615,21 @@ func (c *console) requestPermission(req acp.RequestPermissionParams) acp.Request
 	if c.autoApprove {
 		for _, opt := range req.Options {
 			if strings.HasPrefix(opt.Kind, "allow") {
-				fmt.Printf("  auto-approving (-yolo): %s\n", opt.Name)
+				fmt.Fprintf(&header, "  auto-approving (-yolo): %s\n", opt.Name)
+				c.render(header.String(), true)
 				return selected(opt)
 			}
 		}
 	}
 
 	for i, opt := range req.Options {
-		fmt.Printf("  %d) %s [%s]\n", i+1, opt.Name, opt.Kind)
+		fmt.Fprintf(&header, "  %d) %s [%s]\n", i+1, opt.Name, opt.Kind)
 	}
+
+	prompt := header.String() + fmt.Sprintf("Choose 1-%d (Enter = 1): ", len(req.Options))
 	for {
-		fmt.Printf("Choose 1-%d (Enter = 1): ", len(req.Options))
-		line, err := c.stdin.ReadString('\n')
-		if err != nil {
+		line, ok := c.ask(prompt)
+		if !ok {
 			return acp.RequestPermissionResult{
 				Outcome: acp.PermissionOutcome{Outcome: acp.PermissionCancelled},
 			}
@@ -522,7 +641,7 @@ func (c *console) requestPermission(req acp.RequestPermissionParams) acp.Request
 		if n, err := strconv.Atoi(line); err == nil && n >= 1 && n <= len(req.Options) {
 			return selected(req.Options[n-1])
 		}
-		fmt.Println("Invalid choice.")
+		prompt = fmt.Sprintf("Invalid choice.\nChoose 1-%d (Enter = 1): ", len(req.Options))
 	}
 }
 

--- a/examples/agentclientprotocol/main_test.go
+++ b/examples/agentclientprotocol/main_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/examples/agentclientprotocol/pkg/acp"
+)
+
+func newTestConsole(t *testing.T) (*console, string) {
+	t.Helper()
+	workDir := t.TempDir()
+	// Match run(): the console compares against a symlink-resolved workDir.
+	workDir, err := filepath.EvalSymlinks(workDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", workDir, err)
+	}
+	// Construct the console directly rather than via newConsole, so the
+	// test does not start the view goroutine that owns terminal I/O.
+	return &console{workDir: workDir}, workDir
+}
+
+func TestResolvePath(t *testing.T) {
+	cons, workDir := newTestConsole(t)
+
+	grandparent := filepath.Dir(filepath.Dir(workDir))
+
+	// Layout: an existing file and subdirectory inside the working
+	// directory, plus symlinks pointing both inside and outside of it.
+	outside := t.TempDir()
+	outsideFile := filepath.Join(outside, "target.txt")
+	for _, f := range []string{outsideFile, filepath.Join(workDir, "real.txt")} {
+		if err := os.WriteFile(f, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(workDir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	symlinks := map[string]string{
+		"link-outside": outsideFile,                        // file symlink escaping workDir
+		"dir-outside":  outside,                            // directory symlink escaping workDir
+		"link-inside":  filepath.Join(workDir, "real.txt"), // symlink staying inside workDir
+	}
+	for name, target := range symlinks {
+		if err := os.Symlink(target, filepath.Join(workDir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr bool
+	}{
+		{name: "relative inside", path: "sub/file.txt", want: filepath.Join(workDir, "sub", "file.txt")},
+		{name: "absolute inside", path: filepath.Join(workDir, "file.txt"), want: filepath.Join(workDir, "file.txt")},
+		{name: "dot", path: ".", want: workDir},
+		{name: "existing file", path: "real.txt", want: filepath.Join(workDir, "real.txt")},
+		{name: "relative traversal", path: "../escape.txt", wantErr: true},
+		{name: "nested traversal", path: "sub/../../escape.txt", wantErr: true},
+		{name: "absolute outside", path: filepath.Join(grandparent, "escape.txt"), wantErr: true},
+		{name: "parent directory itself", path: "..", wantErr: true},
+		{name: "nonexistent parent", path: "no-such-dir/file.txt", wantErr: true},
+		{name: "symlink file escaping", path: "link-outside", wantErr: true},
+		{name: "symlink dir escaping", path: "dir-outside/target.txt", wantErr: true},
+		{name: "symlink staying inside", path: "link-inside", want: filepath.Join(workDir, "real.txt")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cons.resolvePath(tc.path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("resolvePath(%q) = %q, want error", tc.path, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolvePath(%q): %v", tc.path, err)
+			}
+			if got != tc.want {
+				t.Errorf("resolvePath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadTextFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("one\ntwo\nthree\nfour"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	intp := func(n int) *int { return &n }
+
+	tests := []struct {
+		name  string
+		line  *int
+		limit *int
+		want  string
+	}{
+		{name: "whole file", want: "one\ntwo\nthree\nfour"},
+		{name: "from line 2", line: intp(2), want: "two\nthree\nfour"},
+		{name: "line and limit", line: intp(2), limit: intp(2), want: "two\nthree"},
+		{name: "limit only", limit: intp(1), want: "one"},
+		{name: "line past end", line: intp(10), want: ""},
+		{name: "limit past end", line: intp(3), limit: intp(10), want: "three\nfour"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := readTextFile(acp.ReadTextFileParams{Path: path, Line: tc.line, Limit: tc.limit})
+			if err != nil {
+				t.Fatalf("readTextFile: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("readTextFile(line=%v, limit=%v) = %q, want %q", tc.line, tc.limit, got, tc.want)
+			}
+		})
+	}
+}

--- a/examples/agentclientprotocol/pkg/acp/jsonrpc.go
+++ b/examples/agentclientprotocol/pkg/acp/jsonrpc.go
@@ -18,6 +18,7 @@ package acp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -92,4 +93,24 @@ const (
 	InvalidParams = -32602
 	// InternalError indicates the request failed while being handled.
 	InternalError = -32603
+
+	// AuthRequired is the ACP error code reporting that the client must
+	// authenticate before the request can succeed.
+	AuthRequired = -32000
 )
+
+// ErrorCode returns the JSON-RPC error code carried by err (looking through
+// wrapped errors), or 0 if err does not carry an *RPCError.
+func ErrorCode(err error) int {
+	var rpcErr *RPCError
+	if errors.As(err, &rpcErr) {
+		return rpcErr.Code
+	}
+	return 0
+}
+
+// IsAuthRequiredError reports whether err is the agent telling the client
+// that it must call authenticate before the request can succeed.
+func IsAuthRequiredError(err error) bool {
+	return ErrorCode(err) == AuthRequired
+}

--- a/examples/agentclientprotocol/pkg/acp/jsonrpc_test.go
+++ b/examples/agentclientprotocol/pkg/acp/jsonrpc_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acp
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrorCode(t *testing.T) {
+	authErr := &RPCError{Code: AuthRequired, Message: "authentication required"}
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "nil", err: nil, want: 0},
+		{name: "plain error", err: errors.New("connection closed"), want: 0},
+		{name: "rpc error", err: authErr, want: AuthRequired},
+		{name: "wrapped rpc error", err: fmt.Errorf("creating session: %w", authErr), want: AuthRequired},
+		{name: "doubly wrapped", err: fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", authErr)), want: AuthRequired},
+		{name: "method not found", err: &RPCError{Code: MethodNotFound, Message: "no such method"}, want: MethodNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ErrorCode(tc.err); got != tc.want {
+				t.Errorf("ErrorCode(%v) = %d, want %d", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAuthRequiredError(t *testing.T) {
+	authErr := &RPCError{Code: AuthRequired, Message: "authentication required"}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "plain error", err: errors.New("connection closed"), want: false},
+		{name: "auth required", err: authErr, want: true},
+		{name: "wrapped auth required", err: fmt.Errorf("session/new: %w", authErr), want: true},
+		{name: "other rpc error", err: &RPCError{Code: InternalError, Message: "boom"}, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAuthRequiredError(tc.err); got != tc.want {
+				t.Errorf("IsAuthRequiredError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Better handle console output in case of concurrent output
* More unit testing
* Refactor error handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication retries now occur only for recognized authentication-required errors.
  * Permission prompts no longer interrupt streamed notification output.
  * Pending console output is flushed before one-shot mode exits.

* **Documentation**
  * Clarified command argument parsing and quoting limitations.
  * Documented the setup timeout option and its default behavior.
  * Updated instructions for running the example.

* **Tests**
  * Added coverage for secure path resolution and text-file reading scenarios.
  * Added coverage for authentication error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



