### PR TITLE
ci(helm): lint the chart and verify rendered resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/**"
+      - "helm/**"
+      - "dev/tools/lint-helm"
+      - "dev/ci/presubmits/lint-helm"
 
 jobs:
   lint-workflows:
@@ -14,3 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: devops-actions/actionlint@ec02b36684b2f574f1d219ad0a43b082e46bf3e4 # v0.1.13
+
+  lint-helm:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.19.0
+
+      - name: Lint chart
+        run: dev/ci/presubmits/lint-helm

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,10 @@ lint-api:
 fix-api:
 	./dev/tools/lint-api --fix
 
+.PHONY: lint-helm
+lint-helm:
+	./dev/tools/lint-helm
+
 .PHONY: verify-chart-version
 verify-chart-version:
 	./dev/tools/verify-chart-version

--- a/dev/ci/presubmits/lint-helm
+++ b/dev/ci/presubmits/lint-helm
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from shared import utils
+
+
+def main():
+    """ invokes the helm chart linter """
+    return utils.run_dev_tool("lint-helm")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/tools/lint-helm
+++ b/dev/tools/lint-helm
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lints the helm chart and renders it across the value permutations we support.
+
+`helm lint` on its own only exercises the default values, which leaves the
+conditional templates (extensions, namespace creation, the Prometheus Operator
+resources) unrendered and therefore unchecked. This additionally runs
+`helm template` over each permutation and asserts the resulting resource set,
+so a template that fails to render -- or that renders when it should not -- is
+caught in presubmit.
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHART_DIR = REPO_ROOT / "helm"
+
+# image.tag is `required` by the chart, so every invocation must set it.
+IMAGE_TAG = ["--set", "image.tag=v0.0.0-lint"]
+
+# Resources the chart always renders, regardless of values.
+CORE_RESOURCES = [
+    ("ServiceAccount", "agent-sandbox-controller"),
+    ("Deployment", "agent-sandbox-controller"),
+    ("ClusterRole", "agent-sandbox-controller"),
+    ("ClusterRoleBinding", "agent-sandbox-controller"),
+    ("Role", "agent-sandbox-controller"),
+    ("RoleBinding", "agent-sandbox-controller"),
+    ("Service", "agent-sandbox-controller"),
+    ("Service", "agent-sandbox-webhook-service"),
+    # controller-gen writes extensions-rbac.generated.yaml straight into
+    # templates/, so the extensions ClusterRole renders unconditionally. Only its
+    # ClusterRoleBinding is gated on controller.extensions.
+    ("ClusterRole", "agent-sandbox-controller-extensions"),
+]
+
+EXTENSIONS_BINDING = ("ClusterRoleBinding", "agent-sandbox-controller-extensions")
+NAMESPACE = ("Namespace", "agent-sandbox-system")
+SERVICE_MONITOR = ("ServiceMonitor", "agent-sandbox-controller")
+PROMETHEUS_RULE = ("PrometheusRule", "agent-sandbox-controller")
+
+CASES = [
+    {
+        "name": "defaults",
+        "sets": [],
+        "present": CORE_RESOURCES + [NAMESPACE],
+        "absent": [EXTENSIONS_BINDING, SERVICE_MONITOR, PROMETHEUS_RULE],
+    },
+    {
+        "name": "extensions enabled",
+        "sets": ["--set", "controller.extensions=true"],
+        "present": CORE_RESOURCES + [NAMESPACE, EXTENSIONS_BINDING],
+        "absent": [SERVICE_MONITOR, PROMETHEUS_RULE],
+    },
+    {
+        "name": "existing namespace",
+        "sets": [
+            "--set", "namespace.create=false",
+            "--set", "namespace.name=my-namespace",
+        ],
+        "present": CORE_RESOURCES,
+        "absent": [NAMESPACE, ("Namespace", "my-namespace")],
+    },
+    {
+        "name": "prometheus operator resources enabled",
+        "sets": [
+            "--set", "metrics.serviceMonitor.enabled=true",
+            "--set", "metrics.prometheusRule.enabled=true",
+        ],
+        "present": CORE_RESOURCES + [SERVICE_MONITOR, PROMETHEUS_RULE],
+        "absent": [EXTENSIONS_BINDING],
+    },
+]
+
+KIND_RE = re.compile(r"^kind:[ \t]+(\S+)[ \t]*$", re.MULTILINE)
+NAME_RE = re.compile(r"^[ \t]{2}name:[ \t]+(\S+)[ \t]*$", re.MULTILINE)
+
+
+def rendered_resources(output):
+    """Extracts the (kind, name) pairs from multi-document helm template output."""
+    resources = set()
+    for document in output.split("\n---"):
+        kind = KIND_RE.search(document)
+        name = NAME_RE.search(document)
+        if kind and name:
+            resources.add((kind.group(1), name.group(1)))
+    return resources
+
+
+def run(args):
+    """Runs a helm command, returning (ok, combined output)."""
+    result = subprocess.run(args, capture_output=True, text=True)
+    return result.returncode == 0, result.stdout + result.stderr
+
+
+def lint(case):
+    ok, output = run(["helm", "lint", str(CHART_DIR)] + IMAGE_TAG + case["sets"])
+    if not ok:
+        print(f"FAIL: helm lint ({case['name']})", file=sys.stderr)
+        print(output, file=sys.stderr)
+    return ok
+
+
+def template(case):
+    ok, output = run(
+        ["helm", "template", "agent-sandbox", str(CHART_DIR)]
+        + IMAGE_TAG
+        + case["sets"]
+    )
+    if not ok:
+        print(f"FAIL: helm template ({case['name']})", file=sys.stderr)
+        print(output, file=sys.stderr)
+        return False
+
+    resources = rendered_resources(output)
+    failed = False
+
+    for expected in case["present"]:
+        if expected not in resources:
+            print(
+                f"FAIL: {case['name']}: expected {expected[0]}/{expected[1]} "
+                "to be rendered, but it was not.",
+                file=sys.stderr,
+            )
+            failed = True
+
+    for unexpected in case["absent"]:
+        if unexpected in resources:
+            print(
+                f"FAIL: {case['name']}: {unexpected[0]}/{unexpected[1]} was "
+                "rendered, but it should not have been.",
+                file=sys.stderr,
+            )
+            failed = True
+
+    return not failed
+
+
+def main():
+    if shutil.which("helm") is None:
+        print("ERROR: helm is not installed; see https://helm.sh/docs/intro/install/", file=sys.stderr)
+        return 1
+
+    if not CHART_DIR.is_dir():
+        print(f"ERROR: {CHART_DIR} does not exist.", file=sys.stderr)
+        return 1
+
+    failed = False
+    for case in CASES:
+        print(f"==> {case['name']}")
+        if not lint(case) or not template(case):
+            failed = True
+
+    if failed:
+        return 1
+
+    print(f"\nChart is valid across {len(CASES)} value permutations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#### What this PR does / why we need it:
Nothing in CI renders the chart today, so its conditional templates (`controller.extensions`, `namespace.create`, and the two `metrics.*` toggles) are never exercised — and `helm lint` alone only evaluates default values. Adds `dev/tools/lint-helm`, which runs `helm lint` and `helm template` across four value permutations and asserts the rendered resource set, wired up as a presubmit, a CI job and a make target.

Stacked on #1463 — only the second commit belongs to this PR. I will rebase once #1463 merges.

#### Which issue(s) this PR is related to:
Ref #483

#### Release Note
```release-note
NONE
```
