### PR TITLE
fix(sdk): treat empty legacy pod-name annotation as unset

### DIFF
--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -443,7 +443,7 @@ func extractState(sb *sandboxv1beta1.Sandbox) *sandboxState {
 		state.Annotations = make(map[string]string, len(sb.Annotations))
 		maps.Copy(state.Annotations, sb.Annotations)
 	}
-	if name, ok := sb.Annotations[PodNameAnnotation]; ok {
+	if name, ok := sb.Annotations[PodNameAnnotation]; ok && name != "" {
 		state.PodName = name
 	} else {
 		state.PodName = sb.Name

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -252,6 +252,23 @@ func TestNew_DefaultsApplied(t *testing.T) {
 	}
 }
 
+func TestExtractState_EmptyPodNameAnnotationFallsBackToSandboxName(t *testing.T) {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sandbox",
+			Annotations: map[string]string{
+				PodNameAnnotation: "",
+			},
+		},
+	}
+
+	state := extractState(sb)
+
+	if state.PodName != sb.Name {
+		t.Errorf("expected PodName to fall back to sandbox name %q for empty legacy annotation, got %q", sb.Name, state.PodName)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Lifecycle tests
 // ---------------------------------------------------------------------------

--- a/clients/go/sandbox/sandbox_test.go
+++ b/clients/go/sandbox/sandbox_test.go
@@ -252,20 +252,44 @@ func TestNew_DefaultsApplied(t *testing.T) {
 	}
 }
 
-func TestExtractState_EmptyPodNameAnnotationFallsBackToSandboxName(t *testing.T) {
-	sb := &sandboxv1beta1.Sandbox{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-sandbox",
-			Annotations: map[string]string{
-				PodNameAnnotation: "",
-			},
+func TestExtractState_PodNameAnnotationFallback(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name:        "empty annotation falls back to sandbox name",
+			annotations: map[string]string{PodNameAnnotation: ""},
+			want:        "test-sandbox",
+		},
+		{
+			name:        "absent annotation falls back to sandbox name",
+			annotations: nil,
+			want:        "test-sandbox",
+		},
+		{
+			name:        "set annotation is honored",
+			annotations: map[string]string{PodNameAnnotation: "custom-pod"},
+			want:        "custom-pod",
 		},
 	}
 
-	state := extractState(sb)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sb := &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sandbox",
+					Annotations: tt.annotations,
+				},
+			}
 
-	if state.PodName != sb.Name {
-		t.Errorf("expected PodName to fall back to sandbox name %q for empty legacy annotation, got %q", sb.Name, state.PodName)
+			state := extractState(sb)
+
+			if state.PodName != tt.want {
+				t.Errorf("expected PodName=%q, got %q", tt.want, state.PodName)
+			}
+		})
 	}
 }
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox.py
@@ -93,7 +93,7 @@ class AsyncSandbox:
         metadata = sandbox_object.get("metadata") or {}
         annotations = metadata.get("annotations") or {}
         pod_name = annotations.get(POD_NAME_ANNOTATION)
-        self._pod_name = pod_name if pod_name is not None else self.sandbox_id
+        self._pod_name = pod_name if pod_name else self.sandbox_id
         return self._pod_name
 
     async def get_sandbox_name_hash(self) -> str | None:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox.py
@@ -87,7 +87,7 @@ class Sandbox:
         metadata = sandbox_object.get('metadata') or {}
         annotations = metadata.get('annotations') or {}
         pod_name = annotations.get(POD_NAME_ANNOTATION)
-        self._pod_name = pod_name if pod_name is not None else self.sandbox_id
+        self._pod_name = pod_name if pod_name else self.sandbox_id
         return self._pod_name
 
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandbox.py
@@ -190,6 +190,16 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         self.mock_k8s_helper.get_sandbox.return_value = None
         self.assertEqual(await self.sandbox.get_pod_name(), self.sandbox_id)
 
+    async def test_get_pod_name_empty_annotation_falls_back(self):
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "metadata": {
+                "annotations": {
+                    "agents.x-k8s.io/pod-name": "",
+                },
+            },
+        }
+        self.assertEqual(await self.sandbox.get_pod_name(), self.sandbox_id)
+
     async def test_get_pod_name_caching(self):
         self.mock_k8s_helper.get_sandbox.return_value = {
             "metadata": {

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandbox.py
@@ -200,6 +200,11 @@ class TestAsyncSandbox(unittest.IsolatedAsyncioTestCase):
         }
         self.assertEqual(await self.sandbox.get_pod_name(), self.sandbox_id)
 
+        # The fallback value is cached and not re-queried from Kubernetes.
+        self.mock_k8s_helper.get_sandbox.reset_mock()
+        self.assertEqual(await self.sandbox.get_pod_name(), self.sandbox_id)
+        self.mock_k8s_helper.get_sandbox.assert_not_awaited()
+
     async def test_get_pod_name_caching(self):
         self.mock_k8s_helper.get_sandbox.return_value = {
             "metadata": {

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -169,6 +169,11 @@ class TestSandbox(unittest.TestCase):
         }
         self.assertEqual(self.sandbox.get_pod_name(), self.sandbox_id)
 
+        # The fallback value is cached and not re-queried from Kubernetes.
+        self.mock_k8s_helper.get_sandbox.reset_mock()
+        self.assertEqual(self.sandbox.get_pod_name(), self.sandbox_id)
+        self.mock_k8s_helper.get_sandbox.assert_not_called()
+
     def test_status_not_found(self):
         self.mock_k8s_helper.get_sandbox.return_value = None
         status, message = self.sandbox.status()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandbox.py
@@ -159,6 +159,16 @@ class TestSandbox(unittest.TestCase):
         self.mock_k8s_helper.get_sandbox.return_value = None
         self.assertEqual(self.sandbox.get_pod_name(), self.sandbox_id)
 
+    def test_get_pod_name_empty_annotation_falls_back(self):
+        self.mock_k8s_helper.get_sandbox.return_value = {
+            "metadata": {
+                "annotations": {
+                    'agents.x-k8s.io/pod-name': ""
+                }
+            }
+        }
+        self.assertEqual(self.sandbox.get_pod_name(), self.sandbox_id)
+
     def test_status_not_found(self):
         self.mock_k8s_helper.get_sandbox.return_value = None
         status, message = self.sandbox.status()


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

This PR hardens Sandbox pod name reads in the Python and Go SDKs by having empty string pod name annotations fallback to the Sandbox's name, rather than the current behavior of using the empty string directly.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

Fixes comment made in https://github.com/kubernetes-sigs/agent-sandbox/pull/1417#discussion_r3865884681

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
SDK pod name lookup will now default to the Sandbox name rather than an empty string if a Sandbox contains the deprecated pod name annotation.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Pod names now correctly fall back to the sandbox name or ID when the pod-name annotation is empty or unavailable.
- Prevents empty pod names from being returned or cached, improving reliability when retrieving sandbox information.

## Tests

- Added coverage for empty and missing pod-name annotations across synchronous, asynchronous, and Go clients.
- Verified that fallback values are retained for subsequent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->