### PR TITLE
examples: fix stale commands, manifests, and docs across the examples tree

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,13 +2,18 @@
 
 This directory contains examples of how to use the Agent Sandbox. Each subdirectory contains a different example.
 
+- [**agent-sandbox-gymnasium**](./agent-sandbox-gymnasium): A Gymnasium environment backed by Agent Sandbox warm pools for RL agent training and evaluation.
 - [**agent-sandbox-rl**](./agent-sandbox-rl): Generic, multi-cluster batch orchestration for running SWE-bench-style RL/eval workloads on Agent Sandbox warm pools.
+- [**agentclientprotocol**](./agentclientprotocol): A simple Agent Client Protocol (ACP) client that drives an agent running inside a sandbox.
+- [**aider-sandbox**](./aider-sandbox): An example of running the Aider coding agent in a sandbox using the template/claim pattern.
 - [**aio-sandbox**](./aio-sandbox): An example of running All-in-One (AIO) Sandbox using agent-sandbox.
+- [**analytics-tool**](./analytics-tool): An example of running an analytics workload in a sandbox with a companion service.
 - [**apf-insulation**](./apf-insulation): An opt-in API Priority and Fairness overlay giving the controller dedicated apiserver concurrency for high-rate claim workloads (claim path > bulk refill > events).
 - [**chrome-sandbox**](./chrome-sandbox): An example of running a Chrome browser in a sandbox.
 - [**code-interpreter-agent-on-adk**](./code-interpreter-agent-on-adk): An example of using Agent Sandbox as a tool in Agent Development Kit (ADK).
 - [**composing-sandbox-nw-policies**](./composing-sandbox-nw-policies): An example of composing network policies for sandboxes.
 - [**containarium-ssh-sandbox**](./containarium-ssh-sandbox): An example of running Containarium's agent-box runtime in a Sandbox, reached over SSH with an in-container MCP server (no kube-apiserver token held by the agent).
+- [**demo-cilium-egress**](./demo-cilium-egress): A demo of enforcing sandbox egress rules with Cilium network policies.
 - [**envd-sandbox**](./envd-sandbox): An example of running E2B's envd daemon as the container entrypoint, providing an E2B-compatible REST and gRPC API for filesystem, process execution, and metrics.
 - [**firecracker-sandbox**](./firecracker-sandbox): An example of running a sandbox on Kata Containers with the Firecracker VMM (`kata-fc`) plus an envd-compatible runtime that matches the E2B data-plane contract.
 - [**gemini-cu-sandbox**](./gemini-cu-sandbox): An example of a Python runtime sandbox for Gemini Computer Use Agent.
@@ -17,23 +22,33 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**hermes-agent**](./hermes-agent): An example of running Hermes Agent with persistence and custom skills.
 - [**hermes-agents-as-a-service**](./hermes-agents-as-a-service): The multi-user platform pattern distilled from a real agents-as-a-service product: per-user claims over a warm pool, suspend/resume as the cost dial, PVC state survival, and injection-policy enforcement.
 - [**hpa-swp-scaling**](./hpa-swp-scaling): An example of scaling a SandboxWarmPool using Kubernetes Horizontal Pod Autoscaler (HPA).
+- [**irsa-simulation-localstack**](./irsa-simulation-localstack): Simulating IAM Roles for Service Accounts (IRSA) credential flows for sandboxes using LocalStack.
 - [**jupyterlab**](./jupyterlab): An example of running JupyterLab on Agent-Sandbox.
 - [**kata-aks**](./kata-aks): Full end-to-end example — Python agent, Go client, and sandbox-router — on AKS with Kata Containers (Hyper-V) VM isolation and the warm-pool/claim pattern.
 - [**kata-aks-sandbox**](./kata-aks-sandbox): An example of running a sandbox with Kata Containers hardware-virtualized isolation on AKS, using the built-in Pod Sandboxing feature.
 - [**kata-gke-sandbox**](./kata-gke-sandbox): An example of running a sandbox with Kata Containers hardware-virtualized isolation on GKE.
 - [**keda-scale-to-zero**](./keda-scale-to-zero): An example of scaling a SandboxWarmPool down to zero (and back up) using KEDA and Google Managed Service for Prometheus (GMP).
+- [**kueue-agent-sandbox**](./kueue-agent-sandbox): An example of admission-controlling sandbox workloads with Kueue.
 - [**langchain**](./langchain): An example of a coding agent using Agent-Sandbox and LangGraph.
+- [**latebind-storage-gke-sandbox**](./latebind-storage-gke-sandbox): Late-binding persistent storage for sandboxes on GKE using the managed add-on APIs.
 - [**manual-pdb**](./manual-pdb): An example of manual PodDisruptionBudget (PDB) configuration for sandboxes.
 - [**mcp-server-sandbox**](./mcp-server-sandbox): Run an MCP (Model Context Protocol) server inside a Sandbox with attached storage.
+- [**n8n-mcp**](./n8n-mcp): An example of connecting n8n workflows to sandboxes through the MCP server integration.
 - [**nono-sandbox**](./nono-sandbox): An example of running nono inside an Agent Sandbox, with fine-grained filesystem isolation, network filtering, credential brokering, and ephemeral per-tool micro-sandboxes.
 - [**nullclaw-sandbox**](./nullclaw-sandbox): An example of running Nullclaw, a minimal AI assistant runtime, inside the Agent Sandbox.
 - [**openclaw-gvisor-sandbox**](./openclaw-gvisor-sandbox): A production-shaped, gVisor-isolated OpenClaw sandbox using the template/claim pattern and persistent storage.
 - [**openclaw-kata-aks-sandbox**](./openclaw-kata-aks-sandbox): An OpenClaw sandbox isolated by Kata Containers on AKS, so the agent runtime gets its own VM and guest kernel.
+- [**pi-code-agent**](./pi-code-agent): An example of running the pi code agent inside a sandbox.
 - [**playwright-sandbox**](./playwright-sandbox): An example of running Playwright with Chromium in a sandbox for web scraping and screenshots.
 - [**policy**](./policy): Examples of using different policies with sandboxes.
 - [**python-runtime-sandbox**](./python-runtime-sandbox): An example of a Python runtime sandbox.
+- [**python-sdk-quickstart**](./python-sdk-quickstart): A quickstart for the Python SDK: create a sandbox, run commands, and manage files without Kubernetes primitives.
+- [**quickstart**](./quickstart): An end-to-end getting-started walkthrough — controller install, warm pool, router, and SDK test client — plus gVisor and Kata isolation variants.
 - [**ray-integration**](./ray-integration): An example of integrating Ray with agent-sandbox for secure Proxy Execution during Agentic Reinforcement Learning (RL) training.
 - [**sandbox-ksa**](./sandbox-ksa): Examples of a sandbox with a service account, namespace, and a basic sandbox.
+- [**sandboxd-sandbox**](./sandboxd-sandbox): An example of running the sandboxd runtime daemon inside a sandbox for command execution and file I/O.
+- [**sandboxed-tools**](./sandboxed-tools): An example of an agent executing its tools inside a sandbox via the Go SDK.
 - [**vscode-sandbox**](./vscode-sandbox): An example of running VSCode in a sandbox.
 - [**warmpool-quickstart**](./warmpool-quickstart): Reference YAML for the three extension CRDs — SandboxTemplate, SandboxWarmPool, and SandboxClaim — including a secure template and an LLM-scoped network policy example.
+- [**webhook-inject-timestamp**](./webhook-inject-timestamp): A mutating webhook that stamps sandbox resources with a creation-observed timestamp for latency metrics.
 - [**windows-sandbox**](./windows-sandbox): An example of running a Windows guest inside the Agent Sandbox via KVM/QEMU.

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -598,9 +598,8 @@ PYTHONPATH=. python tests/run_full_swebench_benchmark.py \
 The fleet can fan out hundreds–thousands of concurrent claims, but throughput is
 ultimately bounded by the **Agent Sandbox controller's** reconcile concurrency, not
 this package. The controller ships with conservative defaults: the **Sandbox**
-controller reconciles at **1 worker** and **SandboxClaim** at **50** — so a
-1000-wide `max_concurrent` run still has its sandbox state transitions serialized
-one at a time. For large eval/RL batches, raise the controller's worker flags (on
+controller reconciles at **100 workers** and **SandboxClaim** at **50** — so a
+1000-wide `max_concurrent` run can still queue behind reconcile concurrency. For large eval/RL batches, raise the controller's worker flags (on
 the controller Deployment's container args, namespace `agent-sandbox-system`):
 
 | flag | default | recommended (high scale) | why |

--- a/examples/aio-sandbox/README.md
+++ b/examples/aio-sandbox/README.md
@@ -19,8 +19,8 @@ Verify sandbox and pod are running:
 kubectl wait --for=condition=Ready sandbox aio-sandbox-example
 
 kubectl get sandbox
-# NAME                  AGE
-# aio-sandbox-example   41s
+# NAME                  READY   REASON              AGE
+# aio-sandbox-example   True    DependenciesReady   41s
 kubectl get pod aio-sandbox-example
 # NAME                  READY   STATUS    RESTARTS   AGE
 # aio-sandbox-example   1/1     Running   0          49s

--- a/examples/chrome-sandbox/README.md
+++ b/examples/chrome-sandbox/README.md
@@ -22,14 +22,14 @@ spec:
     spec:
       containers:
         - name: chrome
-          image: registry.k8s.io/chrome-sandbox
+          image: kind.local/chrome-sandbox:latest
           ports:
             - containerPort: 9222
 ```
 
 ## How to Run
 
-Apply the Sandbox:
+Save the manifest above as `chrome-sandbox.yaml`, then apply it:
 
 ```bash
 kubectl apply -f chrome-sandbox.yaml
@@ -45,10 +45,7 @@ kubectl port-forward pod/chrome-sandbox 9222:9222
 
 This example can be run locally using Docker for development and debugging purposes. It is already integrated with the `agent-sandbox` framework and used in end-to-end (e2e) tests via the Sandbox CRD.
 
-Currently you can test it out by running `run-test`; it will build a (local) container image, then run it. The image will capture screenshots roughly every 100ms so you can observe the progress as Chrome launches and opens (currently) https://google.com
-
-The screenshots are in an unusual xwg format, so the script depends on the `convert`
-utility to convert those to an animated gif.
+Currently you can test it out by running `run-test`; it builds a local container image and runs it for ~5 seconds. The container starts a VNC server (display `:1`) and Chromium, and exposes the Chrome DevTools Protocol on port 9222 (readiness is probed via `http://localhost:9222/json/version`).
 
 ---
 
@@ -61,10 +58,11 @@ The Chrome sandbox is already used in the project’s end-to-end tests.
 - The test creates a `Sandbox` resource running Chrome
 - This ensures Chrome runs correctly inside a Sandbox environment
 
-The container image used is available at:
+The container image is built locally (there is no published `chrome-sandbox` image):
 
 ```bash
-docker pull registry.k8s.io/chrome-sandbox
+docker buildx build --load --tag chrome-sandbox .
+kind load docker-image chrome-sandbox   # when running against a kind cluster
 ```
 ---
 

--- a/examples/chrome-sandbox/README.md
+++ b/examples/chrome-sandbox/README.md
@@ -22,7 +22,8 @@ spec:
     spec:
       containers:
         - name: chrome
-          image: kind.local/chrome-sandbox:latest
+          image: chrome-sandbox:local
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9222
 ```
@@ -61,8 +62,8 @@ The Chrome sandbox is already used in the project’s end-to-end tests.
 The container image is built locally (there is no published `chrome-sandbox` image):
 
 ```bash
-docker buildx build --load --tag chrome-sandbox .
-kind load docker-image chrome-sandbox   # when running against a kind cluster
+docker buildx build --load --tag chrome-sandbox:local .
+kind load docker-image chrome-sandbox:local   # when running against a kind cluster
 ```
 ---
 

--- a/examples/code-interpreter-agent-on-adk/README.md
+++ b/examples/code-interpreter-agent-on-adk/README.md
@@ -4,9 +4,9 @@ The guide walks you through the process of creating a simple [ADK](https://googl
 
 ## Installation
 
-1. Install the Agent-Sandbox controller and CRDs to a cluster. You can follow the instructions from the [installation section from the Getting Started page](/README.md/#installation).
+1. Install the Agent-Sandbox controller and CRDs to a cluster. You can follow the instructions from the [installation section from the Getting Started page](../../README.md#installation).
 
-2. Install the Agent Sandbox [router](/clients/python/agentic-sandbox-client/README.md#setup-deploying-the-router)
+2. Install the Agent Sandbox [router](../../clients/python/agentic-sandbox-client/README.md#setup-deploying-the-router)
 
 3. Create a Python virtual environment:
    ```sh

--- a/examples/composing-sandbox-nw-policies/README.md
+++ b/examples/composing-sandbox-nw-policies/README.md
@@ -26,6 +26,8 @@ This composition can be achieved in multiple ways:
 
 This example demonstrates the second approach, using KRO to define a new `AgenticSandbox` CRD that encapsulates a `Sandbox`, a `NetworkPolicy`, and a `Service`.
 
+> **Note:** KRO serves a single schema version per RGD. If you previously applied an older revision of this example (which declared `v1alpha1`), delete the old RGD and any `AgenticSandbox` instances first (`kubectl delete agenticsandbox --all && kubectl delete rgd agentic-sandbox`), then apply this one and recreate your instances at `v1beta1`.
+
 The controller only creates its own headless `Service` when the Sandbox sets `spec.service: true`; this example leaves it unset, so the `Service` defined here is the only one. This layering allows for more complex networking configurations and showcases the value of composing resources.
 
 ## Brief introduction to KRO

--- a/examples/composing-sandbox-nw-policies/README.md
+++ b/examples/composing-sandbox-nw-policies/README.md
@@ -26,7 +26,7 @@ This composition can be achieved in multiple ways:
 
 This example demonstrates the second approach, using KRO to define a new `AgenticSandbox` CRD that encapsulates a `Sandbox`, a `NetworkPolicy`, and a `Service`.
 
-The `Service` created here is distinct from the one created by the `agent-sandbox` controller. This layering allows for more complex networking configurations and showcases the value of composing resources.
+The controller only creates its own headless `Service` when the Sandbox sets `spec.service: true`; this example leaves it unset, so the `Service` defined here is the only one. This layering allows for more complex networking configurations and showcases the value of composing resources.
 
 ## Brief introduction to KRO
 

--- a/examples/composing-sandbox-nw-policies/rgd.yaml
+++ b/examples/composing-sandbox-nw-policies/rgd.yaml
@@ -8,7 +8,7 @@ spec:
   # This follows a simplified specification: https://kro.run/docs/concepts/simple-schema/
   schema:
     # The user facing CRD that KRO will create
-    apiVersion: v1alpha1
+    apiVersion: v1beta1
     group: custom.agents.x-k8s.io
     kind: AgenticSandbox
     # Spec fields that users can provide.

--- a/examples/envd-sandbox/README.md
+++ b/examples/envd-sandbox/README.md
@@ -47,7 +47,7 @@ The [kvcache-ai/AgentENV](https://github.com/kvcache-ai/AgentENV) project uses e
 
 ## Prerequisites
 
-1. Kubernetes cluster with agent-sandbox controller installed ([quickstart](../../README.md#quickstart))
+1. Kubernetes cluster with agent-sandbox controller installed ([installation guide](../../README.md#installation))
 2. `kubectl` configured to access the cluster
 3. Docker (or other OCI builder) to build the envd image
 

--- a/examples/gemini-cu-sandbox/run-test-kind.sh
+++ b/examples/gemini-cu-sandbox/run-test-kind.sh
@@ -69,8 +69,8 @@ export KUBECONFIG="$KUBECFG_FILE"
 # Cleanup function
 cleanup() {
     echo "Cleaning up..."
-    kubectl delete --ignore-not-found -f "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml"
-    kubectl delete --ignore-not-found sandboxclaim -l app.kubernetes.io/created-by=python-client
+    kubectl delete --ignore-not-found -n agent-sandbox-system -f "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml"
+    kubectl delete --ignore-not-found sandboxclaim -l agents.x-k8s.io/created-by=python-client
     kubectl delete --ignore-not-found secret gemini-api-key
     kubectl delete --ignore-not-found -f "$SCRIPT_DIR/sandbox-gemini-computer-use.yaml"
     rm -f "$KUBECFG_FILE" # Delete the temporary kubeconfig file
@@ -78,7 +78,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Applying CRD and deployment..."
-(cd "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router" && ROUTER_IMAGE="${SANDBOX_ROUTER_IMG}" envsubst '$ROUTER_IMAGE' < sandbox_router.yaml | kubectl apply -f -)
+(cd "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router" && ROUTER_IMAGE="${SANDBOX_ROUTER_IMG}" envsubst '$ROUTER_IMAGE' < sandbox_router.yaml | kubectl apply -n agent-sandbox-system -f -)
 kubectl apply -f "$SCRIPT_DIR/sandbox-gemini-computer-use.yaml"
 
 # Ensure the local client is up-to-date for running tests

--- a/examples/gemini-cu-sandbox/run-test-kind.sh
+++ b/examples/gemini-cu-sandbox/run-test-kind.sh
@@ -70,7 +70,7 @@ export KUBECONFIG="$KUBECFG_FILE"
 cleanup() {
     echo "Cleaning up..."
     kubectl delete --ignore-not-found -f "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml"
-    kubectl delete --ignore-not-found sandboxclaim sandbox-computeruse-claim
+    kubectl delete --ignore-not-found sandboxclaim -l app.kubernetes.io/created-by=python-client
     kubectl delete --ignore-not-found secret gemini-api-key
     kubectl delete --ignore-not-found -f "$SCRIPT_DIR/sandbox-gemini-computer-use.yaml"
     rm -f "$KUBECFG_FILE" # Delete the temporary kubeconfig file
@@ -78,11 +78,11 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Applying CRD and deployment..."
-(cd "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router" && kubectl apply -f sandbox_router.yaml)
+(cd "$PROJECT_ROOT/clients/python/agentic-sandbox-client/sandbox-router" && ROUTER_IMAGE="${SANDBOX_ROUTER_IMG}" envsubst '$ROUTER_IMAGE' < sandbox_router.yaml | kubectl apply -f -)
 kubectl apply -f "$SCRIPT_DIR/sandbox-gemini-computer-use.yaml"
 
 # Ensure the local client is up-to-date for running tests
-(cd "$PROJECT_ROOT" && pip install -e . --break-system-packages)
+(cd "$PROJECT_ROOT/clients/python/agentic-sandbox-client" && pip install -e . --break-system-packages)
 
 echo "Running the programmatic test..."
 (cd "$PROJECT_ROOT" && python3 -m unittest "clients.python.agentic-sandbox-client.test_computer_use_extension")

--- a/examples/gemini-cu-sandbox/sandbox-gemini-computer-use.yaml
+++ b/examples/gemini-cu-sandbox/sandbox-gemini-computer-use.yaml
@@ -23,3 +23,12 @@ spec:
             secretKeyRef:
               name: gemini-api-key
               key: key
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: sandbox-python-computeruse-warmpool
+spec:
+  replicas: 1
+  sandboxTemplateRef:
+    name: sandbox-python-computeruse-template

--- a/examples/gemini-cu-sandbox/sandbox-gemini-computer-use.yaml
+++ b/examples/gemini-cu-sandbox/sandbox-gemini-computer-use.yaml
@@ -29,6 +29,8 @@ kind: SandboxWarmPool
 metadata:
   name: sandbox-python-computeruse-warmpool
 spec:
-  replicas: 1
+  # 0: claims cold-start from the template; a pre-warmed spare would be
+  # adopted by test_agent_without_api_key and defeat its timeout assertion
+  replicas: 0
   sandboxTemplateRef:
     name: sandbox-python-computeruse-template

--- a/examples/jupyterlab/README.md
+++ b/examples/jupyterlab/README.md
@@ -257,7 +257,7 @@ volumeClaimTemplates:
 
 ```bash
 kubectl delete sandbox jupyterlab-sandbox
-kubectl delete pvc jupyterlab-sandbox-workspace
+kubectl delete pvc workspace-jupyterlab-sandbox
 kubectl apply -f jupyterlab.yaml
 ```
 
@@ -329,7 +329,7 @@ kubectl delete secret jupyter-hf-token
 kubectl delete sandbox jupyterlab-sandbox --cascade=orphan
 
 # PVC remains - you can reattach it later
-kubectl get pvc jupyterlab-sandbox-workspace
+kubectl get pvc workspace-jupyterlab-sandbox
 ```
 
 ## Additional Resources

--- a/examples/kata-gke-sandbox/README.md
+++ b/examples/kata-gke-sandbox/README.md
@@ -111,8 +111,8 @@ kubectl exec -it $POD_NAME -- uname -r
 | Error                                           | Cause                                                                                  | Solution                                                                                       |
 | :---------------------------------------------- | :------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- |
 | **Pod Stuck in ContainerCreating or CrashLoopBackOff** | The node does not support Nested Virtualization.                                         | Check machine type. Ensure you are using **N2 (Intel)**. Do not use E2 or AMD.                 |
-| **404 Not Found during kubectl apply**          | The GitHub raw URLs in the main branch changed.                                        | Use the pinned 3.2.0 URLs provided in Step 2.                                                  |
-| **no handler found error in Pod events**        | The RuntimeClass is missing or the node hasn't finished installing Kata.                 | Verify Step 3 was applied. Check kube-system pods are running.                               |
+| **404 Not Found during kubectl apply**          | The GitHub raw URLs in the main branch changed.                                        | Use the pinned 3.2.0 URLs used by setup.sh (KATA_VERSION).                                                  |
+| **no handler found error in Pod events**        | The RuntimeClass is missing or the node hasn't finished installing Kata.                 | Verify setup.sh completed its RuntimeClass registration step. Check kube-system pods are running.                               |
 
 ### Further Troubleshooting
 
@@ -120,7 +120,7 @@ For issues not covered in the table, the following resources may be helpful:
 
 *   **Agent Sandbox Controller:** Check the controller's logs for errors related to the sandbox resource:
     ```shell
-    kubectl logs statefulset/agent-sandbox-controller -n agent-sandbox-system
+    kubectl logs deployment/agent-sandbox-controller -n agent-sandbox-system
     ```
 *   **General Pod Issues:** For problems with the pod itself (e.g., `ImagePullBackOff`, `CrashLoopBackOff`), use `kubectl describe pod <pod-name>`. See the official [Kubernetes guide to debugging pods](https://kubernetes.io/docs/tasks/debug/debug-pod-replication-controller/).
 *   **Kata Containers:** For issues related to the Kata runtime itself, refer to the [Kata Containers troubleshooting guide](https://github.com/kata-containers/kata-containers/blob/main/docs/troubleshooting.md).

--- a/examples/kata-gke-sandbox/README.md
+++ b/examples/kata-gke-sandbox/README.md
@@ -114,7 +114,7 @@ kubectl exec -it $POD_NAME -- uname -r
 | **404 Not Found during kubectl apply**          | The GitHub raw URLs in the main branch changed.                                        | Use the pinned 3.2.0 URLs used by setup.sh (KATA_VERSION).                                                  |
 | **no handler found error in Pod events**        | The RuntimeClass is missing or the node hasn't finished installing Kata.                 | Verify setup.sh completed its RuntimeClass registration step. Check kube-system pods are running.                               |
 
-### Further Troubleshooting
+## Further Troubleshooting
 
 For issues not covered in the table, the following resources may be helpful:
 

--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -64,14 +64,14 @@ export HF_TOKEN='your_huggingface_token_here'
 
 Get a token from [HuggingFace](https://huggingface.co/settings/tokens).
 
-### 3. Clone the repository and navigate to the examples, coding-agent directory
+### 3. Clone the repository and navigate to the examples/langchain directory
 
 ```bash
 # Clone the repository
 git clone https://github.com/kubernetes-sigs/agent-sandbox.git
 
-# Navigate to the examples/coding-agent directory
-cd examples/coding-agent
+# Navigate to the examples/langchain directory
+cd agent-sandbox/examples/langchain
 ```
 
 ### 4. Set your huggingface token (Optional)

--- a/examples/openclaw-gvisor-sandbox/README.md
+++ b/examples/openclaw-gvisor-sandbox/README.md
@@ -285,7 +285,7 @@ PVCs are named `<vctName>-<sandboxName>` and owned by the `Sandbox` CR. So:
 - **Delete the `Sandbox`** (or the `SandboxClaim` with `shutdownPolicy: Delete`)
   → PVC is garbage-collected, data is gone.
 
-Do not put `volumeClaimTemplates` on the `SandboxClaim`. A claim containing its own VCTs will bypass the pre-warmed pool entirely and trigger a cold start of a fresh sandbox, defeating the purpose of the warm pool.
+Do not put `volumeClaimTemplates` on the `SandboxClaim`. This template leaves `volumeClaimTemplatesPolicy` at its default (`Disallowed`), so a claim carrying its own VCTs is rejected outright; even on templates that allow them, such a claim bypasses the pre-warmed pool and cold-starts a fresh sandbox, defeating the purpose of the warm pool.
 
 ## Known limitations
 

--- a/examples/openclaw-kata-aks-sandbox/README.md
+++ b/examples/openclaw-kata-aks-sandbox/README.md
@@ -81,4 +81,4 @@ kubectl delete -f openclaw-config.yaml
 kubectl delete secret openclaw-provider-keys --ignore-not-found
 ```
 
-Deleting the Sandbox does not delete the workspace `PersistentVolumeClaim`; remove it explicitly if you no longer need the agent's state.
+Deleting the Sandbox also deletes the workspace `PersistentVolumeClaim` (the PVC is owned by the Sandbox), taking the agent's state with it.

--- a/examples/policy/network-policy-management/dns_poc_walkthrough.md
+++ b/examples/policy/network-policy-management/dns_poc_walkthrough.md
@@ -71,6 +71,7 @@ spec:
 
 ```bash
 kubectl apply -f dns-poc-template.yaml
+kubectl apply -f dns-poc-warmpool.yaml
 kubectl apply -f dns-poc-claim.yaml
 ```
 

--- a/examples/policy/opa-gatekeeper/README.md
+++ b/examples/policy/opa-gatekeeper/README.md
@@ -65,7 +65,7 @@ Apply the template:
 kubectl apply -f template-sandbox-binding.yaml
 ```
 
-This creates a new CRD called `K8sPreventSandboxServiceAccountBinding` that Gatekeeper will recognize. You can verify it by running the following:
+This creates a new CRD called `K8sPreventActiveServiceAccountBinding` that Gatekeeper will recognize. You can verify it by running the following:
 
 ```bash
 kubectl get crd k8spreventactiveserviceaccountbinding

--- a/examples/policy/policy-controller/README.md
+++ b/examples/policy/policy-controller/README.md
@@ -147,7 +147,7 @@ Apply the template:
 kubectl apply -f template-sandbox-binding.yaml
 ```
 
-This creates a new CRD called `K8sPreventSandboxServiceAccountBinding` that Gatekeeper will recognize. You can verify it by running the following:
+This creates a new CRD called `K8sPreventActiveServiceAccountBinding` that Gatekeeper will recognize. You can verify it by running the following:
 
 ```bash
 kubectl get crd k8spreventactiveserviceaccountbinding
@@ -295,7 +295,7 @@ The order in which you apply the gatekeeper yaml files (`Config` -> `ConstraintT
 kubectl delete config config -n gatekeeper-system
 
 # delete constrainttemplate
-kubectl delete constrainttemplate k8spreventsandboxserviceaccountbinding
+kubectl delete constrainttemplate k8spreventactiveserviceaccountbinding
 
 # delete the gatekeeper-controller-manager pod so that it restarts
 kubectl delete pod gatekeeper-controller-manager-xxxx-xxxx -n gatekeeper-system	
@@ -308,10 +308,10 @@ Wait for the gatekeeper-controller-manager pod to be up and running and then app
 
 ```bash
 # delete the constraint
-kubectl delete K8sPreventSandboxServiceAccountBinding prevent-sandbox-sa-binding
+kubectl delete K8sPreventActiveServiceAccountBinding prevent-active-sa-binding
 
 # delete constrainttemplate
-kubectl delete constrainttemplate k8spreventsandboxserviceaccountbinding
+kubectl delete constrainttemplate k8spreventactiveserviceaccountbinding
 
 # delete config
 kubectl delete config config -n gatekeeper-system

--- a/examples/python-sdk-quickstart/README.md
+++ b/examples/python-sdk-quickstart/README.md
@@ -6,7 +6,13 @@ Agent Sandbox is a quick and easy way to start secure containers that will let a
 
 - A running Kubernetes cluster with the [Agent Sandbox Controller](../../README.md#installation) installed.
 - The [Sandbox Router](../../clients/python/agentic-sandbox-client/README.md#setup-deploying-the-router) deployed in your cluster.
-- A `SandboxWarmPool` named `python-sandbox-pool` applied to your cluster. See [`clients/python/agentic-sandbox-client/python-sandbox-warmpool.yaml`](../../clients/python/agentic-sandbox-client/python-sandbox-warmpool.yaml) (apply with `SANDBOX_WARMPOOL_NAME=python-sandbox-pool` and replicas > 0).
+- A `SandboxWarmPool` named `python-sandbox-pool` applied to your cluster, backed by a template using the [python-runtime-sandbox](../python-runtime-sandbox) image. From the repository root:
+
+  ```bash
+  export SANDBOX_NAMESPACE=default SANDBOX_TEMPLATE_NAME=python-sandbox-template SANDBOX_WARMPOOL_NAME=python-sandbox-pool
+  envsubst < clients/python/agentic-sandbox-client/python-sandbox-template.yaml | kubectl apply -f -
+  envsubst < clients/python/agentic-sandbox-client/python-sandbox-warmpool.yaml | sed 's/replicas: 0/replicas: 1/' | kubectl apply -f -
+  ```
 - The [Python SDK](../../clients/python/agentic-sandbox-client/README.md) installed: `pip install k8s-agent-sandbox`.
 
 ## Connection Modes

--- a/examples/python-sdk-quickstart/README.md
+++ b/examples/python-sdk-quickstart/README.md
@@ -4,10 +4,10 @@ Agent Sandbox is a quick and easy way to start secure containers that will let a
 
 ## Prerequisites
 
-- A running Kubernetes cluster with the [Agent Sandbox Controller](/README.md/#installation) installed.
-- The [Sandbox Router](/clients/python/agentic-sandbox-client/README.md#setup-deploying-the-router) deployed in your cluster.
-- A `SandboxWarmPool` named `python-sandbox-pool` applied to your cluster. See the Python Runtime Sandbox guide for setup instructions.
-- The [Python SDK](/clients/python/agentic-sandbox-client/README.md) installed: `pip install k8s-agent-sandbox`.
+- A running Kubernetes cluster with the [Agent Sandbox Controller](../../README.md#installation) installed.
+- The [Sandbox Router](../../clients/python/agentic-sandbox-client/README.md#setup-deploying-the-router) deployed in your cluster.
+- A `SandboxWarmPool` named `python-sandbox-pool` applied to your cluster. See [`clients/python/agentic-sandbox-client/python-sandbox-warmpool.yaml`](../../clients/python/agentic-sandbox-client/python-sandbox-warmpool.yaml) (apply with `SANDBOX_WARMPOOL_NAME=python-sandbox-pool` and replicas > 0).
+- The [Python SDK](../../clients/python/agentic-sandbox-client/README.md) installed: `pip install k8s-agent-sandbox`.
 
 ## Connection Modes
 
@@ -19,7 +19,8 @@ The SDK supports three modes:
 |------|-------------|-------------|
 | **Tunnel** (default) | `SandboxLocalTunnelConnectionConfig` | Local development and CI — tunnels via `kubectl port-forward` |
 | **Gateway** | `SandboxGatewayConnectionConfig` | Production clusters with a public Kubernetes Gateway |
-| **Direct** | `SandboxDirectConnectionConfig` | In-cluster agents or custom domains, bypasses discovery entirely |
+| **Direct** | `SandboxDirectConnectionConfig` | Custom router URLs, bypasses discovery entirely |
+| **In-cluster** | `SandboxInClusterConnectionConfig` | Agents running inside the cluster |
 
 ## Usage
 

--- a/examples/python-sdk-quickstart/README.md
+++ b/examples/python-sdk-quickstart/README.md
@@ -19,7 +19,7 @@ Agent Sandbox is a quick and easy way to start secure containers that will let a
 
 `SandboxClient()` with no arguments defaults to **Tunnel mode** (`SandboxLocalTunnelConnectionConfig`), which opens a `kubectl port-forward` tunnel to the Router Service — no public IP required, works on KinD and Minikube.
 
-The SDK supports three modes:
+The SDK supports four modes:
 
 | Mode | Config class | When to use |
 |------|-------------|-------------|

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -131,12 +131,12 @@ kubectl delete sandboxclaim quickstart-test
 
 ### Understanding How WarmPool Works
 
-The WarmPool creates pre-warmed **Sandbox** resources that are ready to be claimed:
+The WarmPool creates pre-warmed **Sandbox** resources (each backed by a running pod) that are ready to be claimed:
 
-1. **WarmPool creates sandboxes directly** with label `agents.x-k8s.io/warm-pool-sandbox=<hash>`
-2. When you create a **SandboxClaim**, the controller claims a sandbox from the pool
+1. **WarmPool creates Sandbox resources** labeled `agents.x-k8s.io/warm-pool-sandbox=<pool-name-hash>` (the label is propagated to the backing pods)
+2. When you create a **SandboxClaim**, the controller adopts a ready Sandbox from the pool (the Sandbox keeps its pool-generated name and reports it at `.status.sandbox.name`)
 3. The claimed sandbox's backing pod name matches the sandbox name
-4. **WarmPool automatically creates a replacement sandbox** to maintain replica count
+4. **WarmPool automatically creates a replacement Sandbox** to maintain replica count
 
 Performance comparison:
 - **With WarmPool**: Sub-2 second allocation (pod already running)
@@ -188,11 +188,11 @@ envsubst '${ROUTER_IMAGE}' \
 # Check WarmPool status
 kubectl get sandboxwarmpool python-warmpool
 
-# Check pre-warmed PODS (not Sandboxes - WarmPool creates pods directly)
-kubectl get pods -l agents.x-k8s.io/pool
+# Check pre-warmed pods
+kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox
 
 # Wait for pods to be ready
-kubectl wait --for=condition=Ready pod -l agents.x-k8s.io/pool --timeout=60s
+kubectl wait --for=condition=Ready pod -l agents.x-k8s.io/warm-pool-sandbox --timeout=60s
 ```
 
 Expected output:
@@ -244,7 +244,8 @@ Run it against the quickstart namespace and template:
 ```bash
 python clients/python/agentic-sandbox-client/test_client.py \
     --warmpool-name python-warmpool \
-    --namespace agent-sandbox-demo
+    --namespace agent-sandbox-demo \
+    --router-namespace agent-sandbox-system
 ```
 
 ### 9.2 Verify WarmPool Performance
@@ -252,8 +253,19 @@ python clients/python/agentic-sandbox-client/test_client.py \
 To confirm that the WarmPool is pre-warming pods, check whether the pod existed before the claim:
 
 ```bash
-# Pick a claim from the warmpool
-CLAIM_NAME=$(kubectl get sandboxclaim -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+# The test client deletes its claims on exit, so create a throwaway claim to inspect
+CLAIM_NAME=warmpool-perf-test
+cat <<EOF | kubectl apply -f -
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxClaim
+metadata:
+  name: ${CLAIM_NAME}
+  namespace: agent-sandbox-demo
+spec:
+  warmPoolRef:
+    name: python-warmpool
+EOF
+kubectl wait --for=condition=Ready sandboxclaim/${CLAIM_NAME} --timeout=60s
 POD_NAME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.status.sandbox.name}' 2>/dev/null)
 
 if [ -n "$POD_NAME" ] && [ -n "$CLAIM_NAME" ]; then
@@ -267,8 +279,9 @@ if [ -n "$POD_NAME" ] && [ -n "$CLAIM_NAME" ]; then
         echo "Pod created on-demand (not from warmpool)"
     fi
 else
-    echo "No sandbox claims found. Run the test client first (Step 9.1)."
+    echo "Claim did not bind to a sandbox; check the warmpool status."
 fi
+kubectl delete sandboxclaim ${CLAIM_NAME}
 ```
 
 ## Step 10: Cleanup

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -123,7 +123,11 @@ EOF
 
 kubectl wait --for=condition=Ready sandboxclaim/quickstart-test --timeout=60s
 
-POD_NAME=$(kubectl get sandboxclaim quickstart-test -o jsonpath='{.status.sandbox.name}')
+SANDBOX_NAME=$(kubectl get sandboxclaim quickstart-test -o jsonpath='{.status.sandbox.name}')
+# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
+# and are tracked in the pod-name annotation, so prefer it with a fallback.
+POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
+POD_NAME=${POD_NAME:-$SANDBOX_NAME}
 echo "Sandbox pod: $POD_NAME"
 
 kubectl delete sandboxclaim quickstart-test
@@ -266,7 +270,11 @@ spec:
     name: python-warmpool
 EOF
 kubectl wait --for=condition=Ready sandboxclaim/${CLAIM_NAME} --timeout=60s
-POD_NAME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.status.sandbox.name}' 2>/dev/null)
+SANDBOX_NAME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.status.sandbox.name}' 2>/dev/null)
+# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
+# and are tracked in the pod-name annotation, so prefer it with a fallback.
+POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
+POD_NAME=${POD_NAME:-$SANDBOX_NAME}
 
 if [ -n "$POD_NAME" ] && [ -n "$CLAIM_NAME" ]; then
     CLAIM_TIME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.metadata.creationTimestamp}')

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -123,11 +123,8 @@ EOF
 
 kubectl wait --for=condition=Ready sandboxclaim/quickstart-test --timeout=60s
 
-SANDBOX_NAME=$(kubectl get sandboxclaim quickstart-test -o jsonpath='{.status.sandbox.name}')
-# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
-# and are tracked in the pod-name annotation, so prefer it with a fallback.
-POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
-POD_NAME=${POD_NAME:-$SANDBOX_NAME}
+# The backing pod shares the Sandbox name
+POD_NAME=$(kubectl get sandboxclaim quickstart-test -o jsonpath='{.status.sandbox.name}')
 echo "Sandbox pod: $POD_NAME"
 
 kubectl delete sandboxclaim quickstart-test
@@ -270,11 +267,8 @@ spec:
     name: python-warmpool
 EOF
 kubectl wait --for=condition=Ready sandboxclaim/${CLAIM_NAME} --timeout=60s
-SANDBOX_NAME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.status.sandbox.name}' 2>/dev/null)
-# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
-# and are tracked in the pod-name annotation, so prefer it with a fallback.
-POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
-POD_NAME=${POD_NAME:-$SANDBOX_NAME}
+# The backing pod shares the Sandbox name
+POD_NAME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.status.sandbox.name}' 2>/dev/null)
 
 if [ -n "$POD_NAME" ] && [ -n "$CLAIM_NAME" ]; then
     CLAIM_TIME=$(kubectl get sandboxclaim ${CLAIM_NAME} -o jsonpath='{.metadata.creationTimestamp}')

--- a/examples/quickstart/gvisor.md
+++ b/examples/quickstart/gvisor.md
@@ -75,7 +75,11 @@ EOF
 
 kubectl wait --for=condition=Ready sandboxclaim/isolation-test --timeout=60s
 
-POD_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
+SANDBOX_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
+# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
+# and are tracked in the pod-name annotation, so prefer it with a fallback.
+POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
+POD_NAME=${POD_NAME:-$SANDBOX_NAME}
 
 # Verify gVisor runtime
 kubectl get pod $POD_NAME -o jsonpath='{.spec.runtimeClassName}'

--- a/examples/quickstart/gvisor.md
+++ b/examples/quickstart/gvisor.md
@@ -75,11 +75,8 @@ EOF
 
 kubectl wait --for=condition=Ready sandboxclaim/isolation-test --timeout=60s
 
-SANDBOX_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
-# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
-# and are tracked in the pod-name annotation, so prefer it with a fallback.
-POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
-POD_NAME=${POD_NAME:-$SANDBOX_NAME}
+# The backing pod shares the Sandbox name
+POD_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
 
 # Verify gVisor runtime
 kubectl get pod $POD_NAME -o jsonpath='{.spec.runtimeClassName}'

--- a/examples/quickstart/kata-containers.md
+++ b/examples/quickstart/kata-containers.md
@@ -95,11 +95,8 @@ EOF
 
 kubectl wait --for=condition=Ready sandboxclaim/isolation-test --timeout=60s
 
-SANDBOX_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
-# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
-# and are tracked in the pod-name annotation, so prefer it with a fallback.
-POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
-POD_NAME=${POD_NAME:-$SANDBOX_NAME}
+# The backing pod shares the Sandbox name
+POD_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
 
 # Verify Kata runtime
 kubectl get pod $POD_NAME -o jsonpath='{.spec.runtimeClassName}'; echo

--- a/examples/quickstart/kata-containers.md
+++ b/examples/quickstart/kata-containers.md
@@ -95,7 +95,11 @@ EOF
 
 kubectl wait --for=condition=Ready sandboxclaim/isolation-test --timeout=60s
 
-POD_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
+SANDBOX_NAME=$(kubectl get sandboxclaim isolation-test -o jsonpath='{.status.sandbox.name}')
+# The backing pod usually shares the Sandbox name; warm-adopted pods may differ
+# and are tracked in the pod-name annotation, so prefer it with a fallback.
+POD_NAME=$(kubectl get sandbox "$SANDBOX_NAME" -o jsonpath='{.metadata.annotations.agents\.x-k8s\.io/pod-name}')
+POD_NAME=${POD_NAME:-$SANDBOX_NAME}
 
 # Verify Kata runtime
 kubectl get pod $POD_NAME -o jsonpath='{.spec.runtimeClassName}'; echo

--- a/examples/ray-integration/README.md
+++ b/examples/ray-integration/README.md
@@ -51,7 +51,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/downl
 2. Deploy the Sandbox Router:
 
 The router securely funnels traffic from your local Ray script to the GKE sandboxes.
-(Note: Ensure you have built and replaced the IMAGE_PLACEHOLDER in sandbox_router.yaml as per the [router documentation](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/python/agentic-sandbox-client/sandbox-router)).
+(Note: Ensure you have built and replaced the `${ROUTER_IMAGE}` placeholder in sandbox_router.yaml as per the [router documentation](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/python/agentic-sandbox-client/sandbox-router)).
 
 ```bash
 kubectl apply -f clients/python/agentic-sandbox-client/sandbox-router/sandbox_router.yaml

--- a/examples/ray-integration/direct-proxy/README.md
+++ b/examples/ray-integration/direct-proxy/README.md
@@ -109,7 +109,7 @@ Deploy the GKE `SandboxTemplate` and `SandboxWarmPool` resources. Ensure your te
 kubectl apply -f manifest.yaml
 ```
 
-Verify the warm pool pods are hot and ready: `kubectl get pods -l pool-name=ray-native-pool`
+Verify the warm pool pods are hot and ready: `kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox`
 
 ### Step 6: Create the RL Training Source ConfigMap
 Expose your verified `rl_production_loop.py` policy trainer code to the cluster so the Ray nodes can mount it:
@@ -140,7 +140,7 @@ kubectl logs -f -l job-name=secure-rl-production-job
 ## Expected Successful Output
 
 ```bash
-Deploying Distributed RL Policy Trainer on GKE...
+Deploying Scaled RL Policy Trainer on GKE...
 Orchestrating 3 workers and 6 secure sandboxes E2E!
 (RLPolicyTrainer pid=xxx) --- Training Episode: Syncing policy weights to 3 workers ---
 

--- a/examples/ray-integration/direct-proxy/manifest.yaml
+++ b/examples/ray-integration/direct-proxy/manifest.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
       - name: runtime
         # Insert your python runtime image
-        image: # REPLACE_WITH_YOUR_IMAGE
+        image: REPLACE_WITH_YOUR_IMAGE  # e.g. us-central1-docker.pkg.dev/<project>/<repo>/python-runtime-sandbox:latest
         imagePullPolicy: Always
 ---
 apiVersion: extensions.agents.x-k8s.io/v1beta1

--- a/examples/ray-integration/direct-proxy/manifest.yaml
+++ b/examples/ray-integration/direct-proxy/manifest.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
       - name: runtime
         # Insert your python runtime image
-        image: us-docker.pkg.dev/vicenteferrara-gke-dev/python-runtime/sandbox:latest
+        image: # REPLACE_WITH_YOUR_IMAGE
         imagePullPolicy: Always
 ---
 apiVersion: extensions.agents.x-k8s.io/v1beta1

--- a/examples/ray-integration/direct-proxy/rl_production_loop.py
+++ b/examples/ray-integration/direct-proxy/rl_production_loop.py
@@ -55,7 +55,6 @@ class SecureEnvironmentActor:
         # that the SandboxWarmPool has already booted. This reduces provisioning time from 
         # ~60 seconds down to <200 milliseconds.
         self.sandbox = self.client.create_sandbox(
-            template="ray-native-template",
             warmpool="ray-native-pool"
         )
         

--- a/examples/ray-integration/ray-autopilot-setup.yaml
+++ b/examples/ray-integration/ray-autopilot-setup.yaml
@@ -8,7 +8,7 @@ spec:
       runtimeClassName: gvisor
       containers:
       - name: runtime
-        image: # REPLACE_WITH_YOUR_IMAGE
+        image: REPLACE_WITH_YOUR_IMAGE  # e.g. us-central1-docker.pkg.dev/<project>/<repo>/python-runtime-sandbox:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8888

--- a/examples/vscode-sandbox/scripts/apply.sh
+++ b/examples/vscode-sandbox/scripts/apply.sh
@@ -58,7 +58,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export KUBECONFIG="${SCRIPT_DIR}/kubeconfig"
 
 # install agent sandbox
-export VERSION="v0.5.6"
+export VERSION="v1.0.0"
 
 # install only the core components:
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox.yaml

--- a/examples/vscode-sandbox/scripts/apply.sh
+++ b/examples/vscode-sandbox/scripts/apply.sh
@@ -58,7 +58,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export KUBECONFIG="${SCRIPT_DIR}/kubeconfig"
 
 # install agent sandbox
-export VERSION="v0.1.0"
+export VERSION="v0.5.6"
 
 # install only the core components:
 kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox.yaml

--- a/examples/vscode-sandbox/scripts/apply.sh
+++ b/examples/vscode-sandbox/scripts/apply.sh
@@ -68,8 +68,8 @@ kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/downl
 
 # install sandbox-router
 pushd ../../../clients/python/agentic-sandbox-client/sandbox-router
-# replace IMAGE_PLACEHOLDER with the actual image
-sed "s|IMAGE_PLACEHOLDER|${SANDBOX_ROUTER_IMAGE}|g" ./sandbox_router.yaml | kubectl apply -f -
+# substitute the router image placeholder
+ROUTER_IMAGE="${SANDBOX_ROUTER_IMAGE}" envsubst '$ROUTER_IMAGE' < ./sandbox_router.yaml | kubectl apply -f -
 popd
 
 # install vscode-sandbox with kata-mshv overlay

--- a/examples/warmpool-quickstart/sandbox-claim.yaml
+++ b/examples/warmpool-quickstart/sandbox-claim.yaml
@@ -24,7 +24,7 @@ spec:
           requests:
             storage: 6Gi
   lifecycle:
-    # Policy can be "Delete" (clean up everything) or "Retain" (stop resources but keep objects).
+    # Policy can be "Delete", "DeleteForeground", or "Retain" (stop resources but keep the claim object).
     # Default is "Retain".
     shutdownPolicy: Delete
 

--- a/examples/warmpool-quickstart/sandboxtemplate.yaml
+++ b/examples/warmpool-quickstart/sandboxtemplate.yaml
@@ -4,9 +4,6 @@ metadata:
   name: secure-datascience-template
   namespace: default
 spec:
-  #enableDisruptionControl: true
-  # Uncomment and set a future RFC3339 timestamp to auto-expire the template:
-  #shutdownTime: "2026-12-31T23:59:59Z"
   podTemplate:
     spec:
       # This pod uses a non-root user and gVisor for runtime sandboxing.


### PR DESCRIPTION
Fixes verified staleness across 19 example directories (audited all 52 against controller/SDK source at current main). No behavior changes outside examples/.

**Broken-if-followed fixes:**
- **composing-sandbox-nw-policies**: the KRO RGD schema still said `v1alpha1` after the v1beta1 migration, so `instance.yaml` could never apply.
- **gemini-cu-sandbox**: SDK install path (`pip install -e .` at repo root → `clients/python/agentic-sandbox-client`), envsubst the `${ROUTER_IMAGE}` placeholder, add the SandboxWarmPool the driven test requires, fix stale claim cleanup.
- **ray-integration**: drop removed `create_sandbox(template=...)` kwarg (runtime TypeError), fix nonexistent `pool-name` label selector, replace unpullable personal dev image, fix expected-output string.
- **quickstart (+ gvisor/kata)**: correct the warm-pool narrative (pools create Sandbox resources, not bare pods; `agents.x-k8s.io/pool` label doesn't exist → `warm-pool-sandbox`), wait on the claim and read `.status.sandbox.name` instead of claim-named sandboxes, add `--router-namespace`, make the perf check use a throwaway claim (the test client deletes its claims on exit).
- **vscode-sandbox**: v0.1.0 release has no `sandbox.yaml` asset (404) → v0.5.6.
- **policy**: Gatekeeper kind/template names didn't match the shipped templates; DNS walkthrough never applied the warm pool its claim requires.
- **chrome-sandbox**: apply target and `registry.k8s.io/chrome-sandbox` image don't exist; entrypoint description was for removed screenshot/GIF behavior.

**Corrections:** jupyterlab PVC name order (`<template>-<sandbox>`), kata-gke `deployment/` not `statefulset/`, openclaw-kata-aks PVC GC behavior (owner-ref'd, deleted with the Sandbox), openclaw-gvisor VCT policy (claims with VCTs are rejected under default `Disallowed`), warmpool-quickstart nonexistent SandboxTemplate fields removed, agent-sandbox-rl stale worker-count prose, aio-sandbox printer columns, dead anchors / root-absolute links in envd-sandbox, python-sdk-quickstart, and code-interpreter-agent-on-adk.

**Index:** examples/README.md now lists the 15 previously missing examples (including `quickstart` itself).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the examples index with new guides and quickstarts.
  - Updated setup, installation, troubleshooting, cleanup, and verification instructions.
  - Clarified warm-pool workflows, readiness checks, persistence, networking policies, scaling, and connection modes.
  - Corrected links, resource names, labels, image placeholders, schema versions, and commands.

- **Examples**
  - Added warm-pool configuration to the Gemini computer-use example.
  - Updated Chrome instructions for local image builds and DevTools access.
  - Refreshed Ray, JupyterLab, policy, runtime, and quickstart configurations.
  - Updated the VS Code example to install Agent Sandbox v1.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->