### PR TITLE
AGENTS.md: refine the unit-test guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ The Python SDK lives at [clients/python/agentic-sandbox-client/](clients/python/
 
 ## Tests
 
-- Unit tests live next to the code they cover (`*_test.go`) and run under `make test-unit`. New behavior needs a unit test.
+- Unit tests live next to the code they cover (`*_test.go`) and run under `make test-unit`. New behavior in the controllers, SDKs, and shared packages needs a unit test. Tests and test fixtures do not themselves need tests. Be more lenient in `examples/`: test what is genuinely load-bearing there (protocol logic, security checks, tricky parsing), and don't demand coverage of example code for its own sake.
 - Reconciler tests use envtest-style fixtures in [controllers/](controllers/) and [extensions/controllers/](extensions/controllers/); follow the existing harness rather than inventing a new one.
 - E2E tests live in [test/e2e/](test/e2e/) and run against a kind cluster created by `make deploy-kind`. Use them for behavior that crosses the controller/apiserver boundary.
 - Benchmarks: [test/benchmarks/](test/benchmarks/), runnable via `make test-e2e-benchmarks`.


### PR DESCRIPTION
The Tests section says "New behavior needs a unit test", unqualified. Review bots apply it literally: on #1459 they asked for a unit test of a trivial factory branch used only by the tests of a fake LLM in an example (coderabbit citing this exact guideline, and withdrawing when challenged).

This scopes the rule to where it earns its keep:

- New behavior in the **controllers, SDKs, and shared packages** needs a unit test (unchanged in spirit).
- **Tests and test fixtures do not themselves need tests.**
- **`examples/` are held to a lighter standard**: test what is genuinely load-bearing (protocol logic, security checks, tricky parsing); don't demand coverage of example code for its own sake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified unit-testing guidance for controllers, SDKs, and shared packages.
  * Documented exceptions for test code and fixtures.
  * Added guidance to test example code only when it contains critical logic, security checks, or complex parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->