### PR TITLE
WIP: sharpen AI review instructions: front-load, drop marginal findings

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -47,6 +47,10 @@ reviews:
       instructions: |
         Focus on technical accuracy, clarity, and markdown formatting. Verify that code snippets and configuration examples match current CRD definitions.
 
+    - path: "examples/**"
+      instructions: |
+        Examples are demonstration code held to a lighter standard than the controllers and SDKs. Flag real bugs and security issues. Do not require test coverage of example code, do not ask for tests of tests or test fixtures, and skip theoretical findings (micro-optimizations, memory retention in short-lived processes, hypothetical scale concerns).
+
   auto_review:
     base_branches:
       - ".*"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,12 @@ Refer to [AGENTS.md](../AGENTS.md) for full project background, module layout, t
 Focus strictly on substantive findings tied to lines the PR actually modifies — logic bugs, concurrency issues, security vulnerabilities, controller-runtime misuse, API contract breaks, and missing tests for new behavior.
 - Do NOT flag style issues in pre-existing code that the PR touches mechanically.
 - When in doubt between flagging a marginal nit and staying silent: **stay silent**. Do not introduce review fatigue.
+- Omit theoretical findings: micro-optimizations, memory retention in short-lived processes, hypothetical scale concerns, and documentation phrasing are not worth a comment unless they cause real incorrect behavior.
+- `examples/` are demonstration code held to a lighter standard than the controllers and SDKs; see the test policy in [AGENTS.md](../AGENTS.md). Tests and test fixtures do not themselves need tests.
+
+**Review Lifecycle:**
+- Front-load: raise everything you intend to raise in your **first** review of a PR. Do not hold findings back for later rounds.
+- In re-reviews, comment ONLY on lines changed since your previous review. Never make a first-time comment on code that was already present in a revision you reviewed — if it was not worth flagging then, it is not worth flagging now.
 
 **Toolchain & Lint Policy:**
 - Defer to the `go` directive in `go.mod` at the base branch head as the authoritative target. Do not suggest lowering the Go version or adding compatibility shims for older toolchains.


### PR DESCRIPTION
**WIP** — sharpen the AI review instructions to front-load feedback and drop marginal findings.

Recent example PRs (#1459, #1462) received a drip-feed of comments across many review rounds: each push triggered a re-review that raised first-time nits on code present since round one (doc phrasing, a `clear()`-before-reslice memory micro-nit in a short-lived CLI, tests for test helpers). Each individual comment is defensible; the aggregate is obstructive.

Changes to `.github/copilot-instructions.md`:

- **Review Lifecycle** (new section): raise everything in the **first** review; in re-reviews comment only on lines changed since the previous review — never first-time comments on already-reviewed code.
- **Scope**: explicitly omit theoretical findings (micro-optimizations, memory retention in short-lived processes, hypothetical scale, doc phrasing); `examples/` are held to a lighter standard per AGENTS.md; tests do not need tests.

Changes to `.coderabbit.yaml`:

- New `examples/**` path instruction mirroring the same policy (coderabbit reads these reliably and also learns from thread replies).

Custom instructions are only partially honored by Copilot, so this is mitigation, not cure — the structural fix is disabling automatic re-review on push (a `kubernetes/org` settings change), which can be pursued separately.

Companion to #1473 (test guideline) and #1474 (PR structure).
