### PR TITLE
fix(ci): declare kubeadm v1beta4 apiVersion in create-kind-cluster

### DIFF
--- a/dev/tools/create-kind-cluster
+++ b/dev/tools/create-kind-cluster
@@ -33,6 +33,7 @@ def create_kind_config(kubelet_verbosity, containerd_loglevel=None):
           kubeadmConfigPatches:
           - |
             kind: ClusterConfiguration
+            apiVersion: kubeadm.k8s.io/v1beta4
             apiServer:
               extraArgs:
                 - name: "enable-admission-plugins"


### PR DESCRIPTION
#### What this PR does / why we need it:

#1126 moved the apiServer extraArgs patch to the kubeadm v1beta4 name/value list format, but the patch declares no apiVersion. Without it, kubeadm parses the document as deprecated v1beta3 — where extraArgs is map[string]string — and `make deploy-kind` fails with kind v0.30+ / node v1.34:

```
error unmarshaling configuration ... "v1beta3" ...: json: cannot unmarshal array into Go struct field APIServer.apiServer.extraArgs of type map[string]string
```

Declare `apiVersion: kubeadm.k8s.io/v1beta4` so the v1beta4 list format parses as intended.

Tested with kind v0.30.0 + `kindest/node:v1.34.0`: `kubeadm config validate` passes for v1beta4+list (and rejects v1beta4+map), cluster creation succeeds with the admission-plugins arg applied, and `make deploy-kind EXTENSIONS=true` completes end to end.

#### Which issue(s) this PR is related to:

Ref #1126

#### Release Note

```release-note
Fixes `make deploy-kind` cluster creation with kind v0.30+ / node v1.34 by declaring `apiVersion: kubeadm.k8s.io/v1beta4` in the create-kind-cluster patch.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the local Kubernetes cluster configuration to use the supported kubeadm API version, improving cluster creation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->