### PR TITLE
Add periodic GHA job to file GitHub issues for failing TestGrid jobs

### DIFF
--- a/.github/workflows/testgrid-failure-issues.yml
+++ b/.github/workflows/testgrid-failure-issues.yml
@@ -24,6 +24,8 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: "Check TestGrid and file/close issues"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testgrid-failure-issues.yml
+++ b/.github/workflows/testgrid-failure-issues.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: "Check TestGrid and file/close issues"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testgrid-failure-issues.yml
+++ b/.github/workflows/testgrid-failure-issues.yml
@@ -1,0 +1,30 @@
+name: "TestGrid failure issue filer"
+
+# Checks the sig-apps-agent-sandbox TestGrid dashboard for jobs whose
+# overall_status is FAILING and files a tracking issue in this repo for
+# each one (skipping presubmits, whose failures are already surfaced as PR
+# checks). Recovered jobs get their tracking issue closed automatically.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *" # hourly
+
+# Serialize runs instead of letting them overlap: two concurrent runs could
+# both search-then-create before either issue is search-indexed, filing a
+# duplicate. Let an in-flight run finish rather than cancel it.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  file-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: "Check TestGrid and file/close issues"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dev/ci/periodics/test-testgrid-failure-issues

--- a/.github/workflows/testgrid-failure-issues.yml
+++ b/.github/workflows/testgrid-failure-issues.yml
@@ -10,8 +10,9 @@ on:
     - cron: "0 * * * *" # hourly
 
 # Serialize runs instead of letting them overlap: two concurrent runs could
-# both search-then-create before either issue is search-indexed, filing a
-# duplicate. Let an in-flight run finish rather than cancel it.
+# both list-then-create before either one's new issue shows up in the
+# other's listing, filing a duplicate. Let an in-flight run finish rather
+# than cancel it.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false

--- a/dev/ci/periodics/test-testgrid-failure-issues
+++ b/dev/ci/periodics/test-testgrid-failure-issues
@@ -66,10 +66,18 @@ def _request(method, url, token, body=None):
 def _token():
     """GITHUB_TOKEN env var (GitHub Actions) or mounted secret file (Prow)."""
     env_token = os.environ.get("GITHUB_TOKEN")
-    if env_token:
-        return env_token
-    with open(TOKEN_PATH) as f:
-        return f.read().strip()
+    if env_token is not None:
+        if env_token:
+            return env_token
+
+    try:
+        with open(TOKEN_PATH) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        raise RuntimeError(
+            f"no GitHub token found: GITHUB_TOKEN is unset and {TOKEN_PATH} "
+            "does not exist"
+        ) from None
 
 
 def fetch_summary(dashboard):
@@ -158,17 +166,18 @@ def close_issue(repo, token, issue, dashboard, tab, dry_run):
 
 
 def handle_tab(repo, token, dashboard, tab, tab_data, dry_run):
-    marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)
     status = tab_data.get("overall_status")
+    # Only FAILING and PASSING can change anything (file or close an issue).
+    # Skipping the search lookup for every other status (FLAKY, STALE,
+    # PENDING, NO_RESULTS, ...) avoids burning search-API rate limit on tabs
+    # this run has no action for anyway.
+    if status not in ("FAILING", "PASSING"):
+        return
+    marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)
     issue = find_open_tracking_issue(repo, token, marker)
     if status == "FAILING" and issue is None:
         file_issue(repo, token, dashboard, tab, tab_data, dry_run)
     elif status == "PASSING" and issue is not None:
-        # Only a definite PASSING counts as recovered. Anything else
-        # (FLAKY, STALE, PENDING, NO_RESULTS, ...) leaves the existing
-        # issue open rather than closing it: STALE in particular can mean
-        # the job stopped reporting entirely, which is worse than a known
-        # failure, not a fix.
         close_issue(repo, token, issue, dashboard, tab, dry_run)
 
 

--- a/dev/ci/periodics/test-testgrid-failure-issues
+++ b/dev/ci/periodics/test-testgrid-failure-issues
@@ -43,6 +43,7 @@ LABEL = "kind/failing-test"
 SKIP_TAB_PREFIXES = ("presubmit-", "pull-")
 MAX_FAILING_TESTS_LISTED = 5
 MAX_FAILURE_MESSAGE_LENGTH = 200
+HTTP_TIMEOUT_SECONDS = 30
 
 # (testgrid dashboard, repo to file issues in). The repo must match the
 # repo this workflow runs in, since it authenticates with the GitHub
@@ -58,7 +59,7 @@ def _request(method, url, token, body=None):
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("User-Agent", "agent-sandbox-testgrid-failure-issues")
-    with urllib.request.urlopen(req) as resp:
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_SECONDS) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
@@ -73,7 +74,7 @@ def _token():
 
 def fetch_summary(dashboard):
     url = f"{TESTGRID_ROOT}/{dashboard}/summary"
-    with urllib.request.urlopen(url) as resp:
+    with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT_SECONDS) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
@@ -179,7 +180,7 @@ def main():
     for dashboard, repo in DASHBOARD_REPOS:
         try:
             summary = fetch_summary(dashboard)
-        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as e:
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError) as e:
             print(f"error fetching TestGrid summary for {dashboard}: {e}", file=sys.stderr)
             exit_code = 1
             continue
@@ -189,7 +190,7 @@ def main():
                 continue
             try:
                 handle_tab(repo, token, dashboard, tab, tab_data, dry_run)
-            except (urllib.error.URLError, urllib.error.HTTPError) as e:
+            except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
                 print(f"error handling {dashboard}/{tab}: {e}", file=sys.stderr)
                 exit_code = 1
 

--- a/dev/ci/periodics/test-testgrid-failure-issues
+++ b/dev/ci/periodics/test-testgrid-failure-issues
@@ -87,20 +87,27 @@ def fetch_summary(dashboard):
 
 
 def find_open_tracking_issue(repo, token, marker):
-    # GitHub's full-text search tokenizes "in:body" queries, so a quoted
-    # marker containing "/" and ":" (as ours does, unlike a single fixed
-    # string) isn't guaranteed to match as one literal unit -- it could
-    # under- or over-match against a different tab's marker. The search API
-    # is used only to narrow candidates; matches are confirmed below by an
-    # exact substring check against the real body, which the search results
-    # already include.
-    query = f'repo:{repo} is:issue is:open in:body "{marker}"'
-    url = f"{API_ROOT}/search/issues?q={urllib.parse.quote(query)}"
-    results = _request("GET", url, token)
-    for item in results.get("items", []):
-        if marker in (item.get("body") or ""):
-            return item
-    return None
+    # Listing open LABEL-labeled issues directly (rather than querying
+    # GitHub's search API) keeps this deterministic: search indexing lag or
+    # tokenization of the marker's "/" and ":" characters could otherwise
+    # make a currently open tracking issue invisible to a search query,
+    # which would file a duplicate on the next run instead of finding the
+    # issue that's already there. Matches are still confirmed below by an
+    # exact substring check against the real body.
+    page = 1
+    while True:
+        url = (
+            f"{API_ROOT}/repos/{repo}/issues"
+            f"?labels={urllib.parse.quote(LABEL, safe='')}&state=open"
+            f"&per_page=100&page={page}"
+        )
+        items = _request("GET", url, token)
+        for item in items:
+            if "pull_request" not in item and marker in (item.get("body") or ""):
+                return item
+        if len(items) < 100:
+            return None
+        page += 1
 
 
 def issue_body(dashboard, tab, tab_data, marker):
@@ -168,9 +175,9 @@ def close_issue(repo, token, issue, dashboard, tab, dry_run):
 def handle_tab(repo, token, dashboard, tab, tab_data, dry_run):
     status = tab_data.get("overall_status")
     # Only FAILING and PASSING can change anything (file or close an issue).
-    # Skipping the search lookup for every other status (FLAKY, STALE,
-    # PENDING, NO_RESULTS, ...) avoids burning search-API rate limit on tabs
-    # this run has no action for anyway.
+    # Skipping the lookup for every other status (FLAKY, STALE, PENDING,
+    # NO_RESULTS, ...) avoids an API call for tabs this run has no action
+    # for anyway.
     if status not in ("FAILING", "PASSING"):
         return
     marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)

--- a/dev/ci/periodics/test-testgrid-failure-issues
+++ b/dev/ci/periodics/test-testgrid-failure-issues
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Periodic job: files a GitHub issue for each TestGrid tab that is FAILING.
+
+Runs from GitHub Actions (.github/workflows/testgrid-failure-issues.yml).
+Reads the public TestGrid summary API (no auth needed) for each configured
+dashboard, and for every tab whose overall_status is FAILING, files (or
+leaves alone, if one is already open) a tracking issue in the tab's repo. A
+tab that recovers to PASSING gets its open tracking issue closed
+automatically; any other status (FLAKY, STALE, PENDING, ...) leaves an
+existing tracking issue open.
+
+Presubmit tabs (name prefix "presubmit-"/"pull-") are skipped: their
+failures are already surfaced as required checks on the PR in question, so
+filing a standing issue for them would just be noise.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_ROOT = "https://api.github.com"
+TESTGRID_ROOT = "https://testgrid.k8s.io"
+TOKEN_PATH = "/etc/github-token/token"
+MARKER_TEMPLATE = "<!-- testgrid-failure:{dashboard}/{tab} -->"
+LABEL = "kind/failing-test"
+SKIP_TAB_PREFIXES = ("presubmit-", "pull-")
+MAX_FAILING_TESTS_LISTED = 5
+MAX_FAILURE_MESSAGE_LENGTH = 200
+
+# (testgrid dashboard, repo to file issues in). The repo must match the
+# repo this workflow runs in, since it authenticates with the GitHub
+# Actions default GITHUB_TOKEN, which can only write to that one repo.
+DASHBOARD_REPOS = [
+    ("sig-apps-agent-sandbox", "kubernetes-sigs/agent-sandbox"),
+]
+
+
+def _request(method, url, token, body=None):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("User-Agent", "agent-sandbox-testgrid-failure-issues")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _token():
+    """GITHUB_TOKEN env var (GitHub Actions) or mounted secret file (Prow)."""
+    env_token = os.environ.get("GITHUB_TOKEN")
+    if env_token:
+        return env_token
+    with open(TOKEN_PATH) as f:
+        return f.read().strip()
+
+
+def fetch_summary(dashboard):
+    url = f"{TESTGRID_ROOT}/{dashboard}/summary"
+    with urllib.request.urlopen(url) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def find_open_tracking_issue(repo, token, marker):
+    # GitHub's full-text search tokenizes "in:body" queries, so a quoted
+    # marker containing "/" and ":" (as ours does, unlike a single fixed
+    # string) isn't guaranteed to match as one literal unit -- it could
+    # under- or over-match against a different tab's marker. The search API
+    # is used only to narrow candidates; matches are confirmed below by an
+    # exact substring check against the real body, which the search results
+    # already include.
+    query = f'repo:{repo} is:issue is:open in:body "{marker}"'
+    url = f"{API_ROOT}/search/issues?q={urllib.parse.quote(query)}"
+    results = _request("GET", url, token)
+    for item in results.get("items", []):
+        if marker in (item.get("body") or ""):
+            return item
+    return None
+
+
+def issue_body(dashboard, tab, tab_data, marker):
+    tab_url = f"{TESTGRID_ROOT}/{dashboard}#{tab}"
+    lines = [
+        marker,
+        f"### TestGrid job failing: `{tab}`",
+        "",
+        f"Filed automatically by a periodic job that checks [TestGrid]({tab_url}) "
+        "for jobs that are consistently failing. If this issue is closed and the "
+        "job fails again, a new issue will be filed.",
+        "",
+        f"**Status:** {tab_data.get('status', 'unknown')}",
+    ]
+    tests = tab_data.get("tests") or []
+    if tests:
+        lines += ["", "**Failing tests:**"]
+        for t in tests[:MAX_FAILING_TESTS_LISTED]:
+            name = t.get("display_name") or t.get("test_name") or "unknown test"
+            message_lines = (t.get("failure_message") or "").strip().splitlines()
+            first_line = message_lines[0] if message_lines else ""
+            if len(first_line) > MAX_FAILURE_MESSAGE_LENGTH:
+                first_line = first_line[:MAX_FAILURE_MESSAGE_LENGTH] + "..."
+            entry = f"- `{name}`"
+            if first_line:
+                entry += f": {first_line}"
+            lines.append(entry)
+        if len(tests) > MAX_FAILING_TESTS_LISTED:
+            lines.append(f"- ...and {len(tests) - MAX_FAILING_TESTS_LISTED} more")
+    return "\n".join(lines)
+
+
+def file_issue(repo, token, dashboard, tab, tab_data, dry_run):
+    marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)
+    body = {
+        "title": f"[TestGrid] {tab} is failing",
+        "body": issue_body(dashboard, tab, tab_data, marker),
+        "labels": [LABEL],
+    }
+    if dry_run:
+        print(f"[dry-run] would file issue in {repo}: {body['title']}")
+        return
+    _request("POST", f"{API_ROOT}/repos/{repo}/issues", token, body)
+    print(f"filed issue in {repo}: {body['title']}")
+
+
+def close_issue(repo, token, issue, dashboard, tab, dry_run):
+    marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)
+    tab_url = f"{TESTGRID_ROOT}/{dashboard}#{tab}"
+    comment = "\n".join(
+        [marker, f"`{tab}` is passing again on [TestGrid]({tab_url}). Closing."]
+    )
+    if dry_run:
+        print(f"[dry-run] would close {repo}#{issue['number']} ({tab})")
+        return
+    _request(
+        "POST", f"{API_ROOT}/repos/{repo}/issues/{issue['number']}/comments", token, {"body": comment}
+    )
+    _request(
+        "PATCH", f"{API_ROOT}/repos/{repo}/issues/{issue['number']}", token, {"state": "closed"}
+    )
+    print(f"closed {repo}#{issue['number']} ({tab})")
+
+
+def handle_tab(repo, token, dashboard, tab, tab_data, dry_run):
+    marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)
+    status = tab_data.get("overall_status")
+    issue = find_open_tracking_issue(repo, token, marker)
+    if status == "FAILING" and issue is None:
+        file_issue(repo, token, dashboard, tab, tab_data, dry_run)
+    elif status == "PASSING" and issue is not None:
+        # Only a definite PASSING counts as recovered. Anything else
+        # (FLAKY, STALE, PENDING, NO_RESULTS, ...) leaves the existing
+        # issue open rather than closing it: STALE in particular can mean
+        # the job stopped reporting entirely, which is worse than a known
+        # failure, not a fix.
+        close_issue(repo, token, issue, dashboard, tab, dry_run)
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv[1:]
+    token = _token()
+    exit_code = 0
+
+    for dashboard, repo in DASHBOARD_REPOS:
+        try:
+            summary = fetch_summary(dashboard)
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError) as e:
+            print(f"error fetching TestGrid summary for {dashboard}: {e}", file=sys.stderr)
+            exit_code = 1
+            continue
+
+        for tab, tab_data in sorted(summary.items()):
+            if tab.startswith(SKIP_TAB_PREFIXES):
+                continue
+            try:
+                handle_tab(repo, token, dashboard, tab, tab_data, dry_run)
+            except (urllib.error.URLError, urllib.error.HTTPError) as e:
+                print(f"error handling {dashboard}/{tab}: {e}", file=sys.stderr)
+                exit_code = 1
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/ci/periodics/test-testgrid-failure-issues
+++ b/dev/ci/periodics/test-testgrid-failure-issues
@@ -26,6 +26,10 @@ existing tracking issue open.
 Presubmit tabs (name prefix "presubmit-"/"pull-") are skipped: their
 failures are already surfaced as required checks on the PR in question, so
 filing a standing issue for them would just be noise.
+
+A tab already tracked by dev/tools/flake-report's infra-failure detection
+(job died before any test ran) is skipped too, so the same breakage doesn't
+end up with two open issues under two different labels.
 """
 
 import json
@@ -41,6 +45,14 @@ TOKEN_PATH = "/etc/github-token/token"
 MARKER_TEMPLATE = "<!-- testgrid-failure:{dashboard}/{tab} -->"
 LABEL = "kind/failing-test"
 SKIP_TAB_PREFIXES = ("presubmit-", "pull-")
+
+# dev/tools/flake-report already files a kind/flake issue, marked this way,
+# when a tab's recent runs are dying before any test runs (its "infra
+# failure" bucket). That looks like FAILING here too, so before filing our
+# own issue we check for one of theirs on the same tab and defer to it
+# instead of tracking the same breakage twice.
+FLAKE_REPORT_LABEL = "kind/flake"
+FLAKE_REPORT_INFRA_MARKER_TEMPLATE = "<!-- flake-report:infra-tab={tab} -->"
 MAX_FAILING_TESTS_LISTED = 5
 MAX_FAILURE_MESSAGE_LENGTH = 200
 HTTP_TIMEOUT_SECONDS = 30
@@ -86,8 +98,8 @@ def fetch_summary(dashboard):
         return json.loads(resp.read().decode("utf-8"))
 
 
-def find_open_tracking_issue(repo, token, marker):
-    # Listing open LABEL-labeled issues directly (rather than querying
+def find_issue_with_marker(repo, token, label, marker):
+    # Listing open label-labeled issues directly (rather than querying
     # GitHub's search API) keeps this deterministic: search indexing lag or
     # tokenization of the marker's "/" and ":" characters could otherwise
     # make a currently open tracking issue invisible to a search query,
@@ -98,7 +110,7 @@ def find_open_tracking_issue(repo, token, marker):
     while True:
         url = (
             f"{API_ROOT}/repos/{repo}/issues"
-            f"?labels={urllib.parse.quote(LABEL, safe='')}&state=open"
+            f"?labels={urllib.parse.quote(label, safe='')}&state=open"
             f"&per_page=100&page={page}"
         )
         items = _request("GET", url, token)
@@ -108,6 +120,15 @@ def find_open_tracking_issue(repo, token, marker):
         if len(items) < 100:
             return None
         page += 1
+
+
+def find_open_tracking_issue(repo, token, marker):
+    return find_issue_with_marker(repo, token, LABEL, marker)
+
+
+def find_flake_report_infra_issue(repo, token, tab):
+    marker = FLAKE_REPORT_INFRA_MARKER_TEMPLATE.format(tab=tab)
+    return find_issue_with_marker(repo, token, FLAKE_REPORT_LABEL, marker)
 
 
 def issue_body(dashboard, tab, tab_data, marker):
@@ -183,6 +204,9 @@ def handle_tab(repo, token, dashboard, tab, tab_data, dry_run):
     marker = MARKER_TEMPLATE.format(dashboard=dashboard, tab=tab)
     issue = find_open_tracking_issue(repo, token, marker)
     if status == "FAILING" and issue is None:
+        if find_flake_report_infra_issue(repo, token, tab) is not None:
+            print(f"skipping {dashboard}/{tab}: already tracked by flake-report")
+            return
         file_issue(repo, token, dashboard, tab, tab_data, dry_run)
     elif status == "PASSING" and issue is not None:
         close_issue(repo, token, issue, dashboard, tab, dry_run)

--- a/dev/ci/periodics/test_testgrid_failure_issues_test.py
+++ b/dev/ci/periodics/test_testgrid_failure_issues_test.py
@@ -40,11 +40,10 @@ _loader.exec_module(tgfi)
 class FakeGitHub:
     """In-memory stand-in for the GitHub REST calls the script makes.
 
-    Search intentionally ignores the query text and returns every open
-    issue, so tests exercise the script's own exact-marker check rather
-    than depending on GitHub's (unavailable here) full-text search
-    relevance -- that check is what actually guarantees correctness (see
-    find_open_tracking_issue's docstring comment).
+    The list-issues call is paginated the same way the real endpoint is
+    (bounded by per_page, more pages while a page comes back full), so
+    tests can exercise find_open_tracking_issue's pagination loop directly
+    instead of trusting it by inspection.
     """
 
     def __init__(self):
@@ -52,8 +51,14 @@ class FakeGitHub:
         self._next_number = 1
 
     def request(self, method, url, token, body=None):
-        if method == "GET" and "/search/issues" in url:
-            return {"items": [i for i in self.issues if i["state"] == "open"]}
+        if method == "GET" and "/issues?" in url:
+            # "[?&]" (not a bare substring match) so this doesn't match the
+            # "page=100" tail of "per_page=100" and misread the page number.
+            page = int(re.search(r"[?&]page=(\d+)", url).group(1))
+            per_page = int(re.search(r"per_page=(\d+)", url).group(1))
+            open_issues = [i for i in self.issues if i["state"] == "open"]
+            start = (page - 1) * per_page
+            return open_issues[start : start + per_page]
         if method == "POST" and url.endswith("/issues"):
             issue = {
                 "number": self._next_number,
@@ -157,10 +162,9 @@ class HandleTabTest(unittest.TestCase):
         self._handle(FAILING, dry_run=True)
         self.assertEqual(self.github.issues, [])
 
-    def test_search_false_positive_is_rejected(self):
-        # An issue that a fuzzy full-text search might surface but that does
-        # not actually contain this tab's exact marker must not be treated
-        # as the tracking issue for this tab.
+    def test_unrelated_issue_is_not_mistaken_for_tracking_issue(self):
+        # An open issue that doesn't contain this tab's exact marker (e.g.
+        # another tab's tracking issue) must not be treated as this tab's.
         self.github.issues.append({
             "number": 99,
             "state": "open",
@@ -175,6 +179,37 @@ class HandleTabTest(unittest.TestCase):
         self.assertIn(
             tgfi.MARKER_TEMPLATE.format(dashboard=DASHBOARD, tab=TAB), new_issue["body"]
         )
+
+    def test_finds_existing_issue_past_first_page(self):
+        # 150 other open issues push this tab's existing tracking issue onto
+        # the lookup's second page (per_page=100). The lookup must keep
+        # paginating and find it, rather than stopping after page one and
+        # wrongly concluding no tracking issue exists (which would file a
+        # duplicate).
+        for i in range(150):
+            self.github.issues.append({
+                "number": i,
+                "state": "open",
+                "title": "other tab",
+                "body": f"<!-- testgrid-failure:{DASHBOARD}/other-tab-{i} -->",
+                "comments": [],
+            })
+        real_marker = tgfi.MARKER_TEMPLATE.format(dashboard=DASHBOARD, tab=TAB)
+        self.github.issues.append({
+            "number": 150,
+            "state": "open",
+            "title": f"[TestGrid] {TAB} is failing",
+            "body": real_marker,
+            "comments": [],
+        })
+
+        self._handle(FAILING)
+        self.assertEqual(
+            len(self.github.issues), 151, "existing issue on page 2 must be found, not duplicated"
+        )
+
+        self._handle(PASSING)
+        self.assertEqual(self.github.issues[150]["state"], "closed")
 
 
 class IssueBodyTest(unittest.TestCase):

--- a/dev/ci/periodics/test_testgrid_failure_issues_test.py
+++ b/dev/ci/periodics/test_testgrid_failure_issues_test.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for dev/ci/periodics/test-testgrid-failure-issues.
+
+Runs entirely offline: the GitHub REST API is replaced by an in-memory
+fake, and TestGrid's summary endpoint is stubbed per test. Nothing here
+talks to a network or writes a real issue.
+"""
+
+import importlib.util
+import os
+import re
+import sys
+import unittest
+from importlib.machinery import SourceFileLoader
+
+# The script is an extensionless file, so load it via importlib rather than
+# a normal import (same pattern as dev/tools/push_images_test.py).
+_PERIODICS_DIR = os.path.dirname(os.path.abspath(__file__))
+_SCRIPT_PATH = os.path.join(_PERIODICS_DIR, "test-testgrid-failure-issues")
+_loader = SourceFileLoader("testgrid_failure_issues", _SCRIPT_PATH)
+_spec = importlib.util.spec_from_loader("testgrid_failure_issues", _loader)
+tgfi = importlib.util.module_from_spec(_spec)
+_loader.exec_module(tgfi)
+
+
+class FakeGitHub:
+    """In-memory stand-in for the GitHub REST calls the script makes.
+
+    Search intentionally ignores the query text and returns every open
+    issue, so tests exercise the script's own exact-marker check rather
+    than depending on GitHub's (unavailable here) full-text search
+    relevance -- that check is what actually guarantees correctness (see
+    find_open_tracking_issue's docstring comment).
+    """
+
+    def __init__(self):
+        self.issues = []
+        self._next_number = 1
+
+    def request(self, method, url, token, body=None):
+        if method == "GET" and "/search/issues" in url:
+            return {"items": [i for i in self.issues if i["state"] == "open"]}
+        if method == "POST" and url.endswith("/issues"):
+            issue = {
+                "number": self._next_number,
+                "title": body["title"],
+                "body": body["body"],
+                "labels": body.get("labels", []),
+                "state": "open",
+                "comments": [],
+            }
+            self._next_number += 1
+            self.issues.append(issue)
+            return issue
+        if method == "POST" and "/comments" in url:
+            number = int(re.search(r"/issues/(\d+)/comments", url).group(1))
+            self._get(number)["comments"].append(body["body"])
+            return {}
+        if method == "PATCH" and re.search(r"/issues/\d+$", url):
+            number = int(re.search(r"/issues/(\d+)$", url).group(1))
+            self._get(number)["state"] = body["state"]
+            return {}
+        raise AssertionError(f"unexpected GitHub call: {method} {url}")
+
+    def _get(self, number):
+        return next(i for i in self.issues if i["number"] == number)
+
+
+DASHBOARD = "sig-apps-agent-sandbox"
+REPO = "kubernetes-sigs/agent-sandbox"
+TAB = "periodic-agent-sandbox-migration-test"
+
+FAILING = {
+    "overall_status": "FAILING",
+    "status": "3 of 10 recent runs failing",
+    "tests": [{"display_name": "pkg.TestThing", "failure_message": "boom\nstack..."}],
+}
+PASSING = {"overall_status": "PASSING", "status": "10 of 10 recent runs passing", "tests": []}
+FLAKY = {"overall_status": "FLAKY", "status": "7 of 10 recent runs passing", "tests": []}
+STALE = {"overall_status": "STALE", "status": "no recent results", "tests": []}
+
+
+class HandleTabTest(unittest.TestCase):
+    def setUp(self):
+        self.github = FakeGitHub()
+        self._orig_request = tgfi._request
+        tgfi._request = self.github.request
+
+    def tearDown(self):
+        tgfi._request = self._orig_request
+
+    def _handle(self, tab_data, dry_run=False):
+        tgfi.handle_tab(REPO, "tok", DASHBOARD, TAB, tab_data, dry_run=dry_run)
+
+    def test_files_issue_on_first_failure(self):
+        self._handle(FAILING)
+        self.assertEqual(len(self.github.issues), 1)
+        issue = self.github.issues[0]
+        self.assertIn(TAB, issue["title"])
+        self.assertEqual(issue["labels"], [tgfi.LABEL])
+        self.assertIn(
+            tgfi.MARKER_TEMPLATE.format(dashboard=DASHBOARD, tab=TAB), issue["body"]
+        )
+
+    def test_does_not_duplicate_across_repeated_failures(self):
+        self._handle(FAILING)
+        self._handle(FAILING)
+        self._handle(FAILING)
+        self.assertEqual(
+            len(self.github.issues), 1,
+            "a persisting failure must not file more than one issue",
+        )
+
+    def test_closes_on_passing(self):
+        self._handle(FAILING)
+        self._handle(PASSING)
+        issue = self.github.issues[0]
+        self.assertEqual(issue["state"], "closed")
+        self.assertEqual(len(issue["comments"]), 1)
+
+    def test_flaky_does_not_close_open_issue(self):
+        self._handle(FAILING)
+        self._handle(FLAKY)
+        self.assertEqual(self.github.issues[0]["state"], "open")
+
+    def test_stale_does_not_close_open_issue(self):
+        self._handle(FAILING)
+        self._handle(STALE)
+        self.assertEqual(
+            self.github.issues[0]["state"], "open",
+            "STALE can mean the job stopped reporting results -- not a fix",
+        )
+
+    def test_files_fresh_issue_after_prior_one_closed(self):
+        self._handle(FAILING)
+        self._handle(PASSING)
+        self._handle(FAILING)
+        self.assertEqual(len(self.github.issues), 2)
+        self.assertEqual(self.github.issues[0]["state"], "closed")
+        self.assertEqual(self.github.issues[1]["state"], "open")
+
+    def test_dry_run_makes_no_writes(self):
+        self._handle(FAILING, dry_run=True)
+        self.assertEqual(self.github.issues, [])
+
+    def test_search_false_positive_is_rejected(self):
+        # An issue that a fuzzy full-text search might surface but that does
+        # not actually contain this tab's exact marker must not be treated
+        # as the tracking issue for this tab.
+        self.github.issues.append({
+            "number": 99,
+            "state": "open",
+            "title": "unrelated",
+            "body": "mentions testgrid-failure but not the real marker",
+            "comments": [],
+        })
+        self._handle(FAILING)
+        self.assertEqual(len(self.github.issues), 2)
+        self.assertEqual(self.github.issues[0]["state"], "open")  # untouched
+        new_issue = self.github.issues[1]
+        self.assertIn(
+            tgfi.MARKER_TEMPLATE.format(dashboard=DASHBOARD, tab=TAB), new_issue["body"]
+        )
+
+
+class IssueBodyTest(unittest.TestCase):
+    def test_truncates_long_failure_message(self):
+        long_line = "x" * 500
+        data = {
+            "overall_status": "FAILING",
+            "status": "s",
+            "tests": [{"display_name": "t", "failure_message": long_line}],
+        }
+        body = tgfi.issue_body(DASHBOARD, TAB, data, "MARK")
+        self.assertIn("x" * tgfi.MAX_FAILURE_MESSAGE_LENGTH + "...", body)
+        self.assertNotIn(long_line, body)
+
+    def test_lists_up_to_max_failing_tests_and_notes_remainder(self):
+        tests = [{"display_name": f"t{i}", "failure_message": ""} for i in range(8)]
+        data = {"overall_status": "FAILING", "status": "s", "tests": tests}
+        body = tgfi.issue_body(DASHBOARD, TAB, data, "MARK")
+        for i in range(tgfi.MAX_FAILING_TESTS_LISTED):
+            self.assertIn(f"`t{i}`", body)
+        self.assertIn("...and 3 more", body)
+
+
+class MainSkipsPresubmitsTest(unittest.TestCase):
+    def setUp(self):
+        self.github = FakeGitHub()
+        self._orig_request = tgfi._request
+        self._orig_fetch = tgfi.fetch_summary
+        self._orig_token = tgfi._token
+        self._orig_dashboards = tgfi.DASHBOARD_REPOS
+        self._orig_argv = sys.argv
+        tgfi._request = self.github.request
+        tgfi._token = lambda: "tok"
+        tgfi.DASHBOARD_REPOS = [(DASHBOARD, REPO)]
+        sys.argv = ["test-testgrid-failure-issues"]
+
+    def tearDown(self):
+        tgfi._request = self._orig_request
+        tgfi.fetch_summary = self._orig_fetch
+        tgfi._token = self._orig_token
+        tgfi.DASHBOARD_REPOS = self._orig_dashboards
+        sys.argv = self._orig_argv
+
+    def test_presubmit_and_pull_tabs_are_never_actioned(self):
+        tgfi.fetch_summary = lambda dashboard: {
+            "presubmit-test-unit": FAILING,
+            "pull-something": FAILING,
+            TAB: FAILING,
+        }
+        rc = tgfi.main()
+        self.assertEqual(rc, 0)
+        # Only the one non-presubmit, non-pull tab should file an issue.
+        self.assertEqual(len(self.github.issues), 1)
+        self.assertIn(TAB, self.github.issues[0]["title"])
+
+    def test_dashboard_fetch_error_is_isolated_and_reported(self):
+        def failing_fetch(dashboard):
+            raise tgfi.urllib.error.URLError("boom")
+
+        tgfi.DASHBOARD_REPOS = [(DASHBOARD, REPO), ("other-dashboard", REPO)]
+        tgfi.fetch_summary = failing_fetch
+        rc = tgfi.main()
+        self.assertEqual(rc, 1)
+        self.assertEqual(self.github.issues, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dev/ci/periodics/test_testgrid_failure_issues_test.py
+++ b/dev/ci/periodics/test_testgrid_failure_issues_test.py
@@ -180,6 +180,24 @@ class HandleTabTest(unittest.TestCase):
             tgfi.MARKER_TEMPLATE.format(dashboard=DASHBOARD, tab=TAB), new_issue["body"]
         )
 
+    def test_skips_filing_when_flake_report_already_tracks_infra_failure(self):
+        # dev/tools/flake-report runs nightly and files its own kind/flake
+        # issue when a tab's runs are dying before any test runs. A tab in
+        # that state also reads as FAILING here, so we must defer to the
+        # existing issue instead of opening a second one for it.
+        self.github.issues.append({
+            "number": 42,
+            "state": "open",
+            "title": f"[FLAKE] {TAB}: infrastructure failures before tests ran",
+            "body": tgfi.FLAKE_REPORT_INFRA_MARKER_TEMPLATE.format(tab=TAB),
+            "comments": [],
+        })
+        self._handle(FAILING)
+        self.assertEqual(
+            len(self.github.issues), 1,
+            "flake-report's existing issue must not be duplicated",
+        )
+
     def test_finds_existing_issue_past_first_page(self):
         # 150 other open issues push this tab's existing tracking issue onto
         # the lookup's second page (per_page=100). The lookup must keep

--- a/dev/ci/periodics/test_testgrid_failure_issues_test.py
+++ b/dev/ci/periodics/test_testgrid_failure_issues_test.py
@@ -40,10 +40,11 @@ _loader.exec_module(tgfi)
 class FakeGitHub:
     """In-memory stand-in for the GitHub REST calls the script makes.
 
-    The list-issues call is paginated the same way the real endpoint is
-    (bounded by per_page, more pages while a page comes back full), so
-    tests can exercise find_open_tracking_issue's pagination loop directly
-    instead of trusting it by inspection.
+    The list-issues call is paginated and label-filtered the same way the
+    real endpoint is (bounded by per_page, more pages while a page comes
+    back full, and only issues carrying the requested label included), so
+    tests can exercise find_open_tracking_issue's pagination and label
+    matching directly instead of trusting them by inspection.
     """
 
     def __init__(self):
@@ -56,9 +57,16 @@ class FakeGitHub:
             # "page=100" tail of "per_page=100" and misread the page number.
             page = int(re.search(r"[?&]page=(\d+)", url).group(1))
             per_page = int(re.search(r"per_page=(\d+)", url).group(1))
-            open_issues = [i for i in self.issues if i["state"] == "open"]
+            label = tgfi.urllib.parse.unquote(
+                re.search(r"[?&]labels=([^&]+)", url).group(1)
+            )
+            matching = [
+                i
+                for i in self.issues
+                if i["state"] == "open" and label in i.get("labels", [])
+            ]
             start = (page - 1) * per_page
-            return open_issues[start : start + per_page]
+            return matching[start : start + per_page]
         if method == "POST" and url.endswith("/issues"):
             issue = {
                 "number": self._next_number,
@@ -170,6 +178,7 @@ class HandleTabTest(unittest.TestCase):
             "state": "open",
             "title": "unrelated",
             "body": "mentions testgrid-failure but not the real marker",
+            "labels": [tgfi.LABEL],
             "comments": [],
         })
         self._handle(FAILING)
@@ -190,6 +199,7 @@ class HandleTabTest(unittest.TestCase):
             "state": "open",
             "title": f"[FLAKE] {TAB}: infrastructure failures before tests ran",
             "body": tgfi.FLAKE_REPORT_INFRA_MARKER_TEMPLATE.format(tab=TAB),
+            "labels": [tgfi.FLAKE_REPORT_LABEL],
             "comments": [],
         })
         self._handle(FAILING)
@@ -197,6 +207,26 @@ class HandleTabTest(unittest.TestCase):
             len(self.github.issues), 1,
             "flake-report's existing issue must not be duplicated",
         )
+
+    def test_marker_match_under_wrong_label_does_not_defer_to_flake_report(self):
+        # Same marker text flake-report would use, but filed under a
+        # different label -- find_flake_report_infra_issue filters by
+        # FLAKE_REPORT_LABEL, so a same-marker issue under some other label
+        # must not be mistaken for it, and filing must proceed normally.
+        self.github.issues.append({
+            "number": 42,
+            "state": "open",
+            "title": "coincidentally contains the infra marker",
+            "body": tgfi.FLAKE_REPORT_INFRA_MARKER_TEMPLATE.format(tab=TAB),
+            "labels": ["some-other-label"],
+            "comments": [],
+        })
+        self._handle(FAILING)
+        self.assertEqual(
+            len(self.github.issues), 2,
+            "a marker match under the wrong label must not suppress filing",
+        )
+        self.assertEqual(self.github.issues[1]["labels"], [tgfi.LABEL])
 
     def test_finds_existing_issue_past_first_page(self):
         # 150 other open issues push this tab's existing tracking issue onto
@@ -210,6 +240,7 @@ class HandleTabTest(unittest.TestCase):
                 "state": "open",
                 "title": "other tab",
                 "body": f"<!-- testgrid-failure:{DASHBOARD}/other-tab-{i} -->",
+                "labels": [tgfi.LABEL],
                 "comments": [],
             })
         real_marker = tgfi.MARKER_TEMPLATE.format(dashboard=DASHBOARD, tab=TAB)
@@ -218,6 +249,7 @@ class HandleTabTest(unittest.TestCase):
             "state": "open",
             "title": f"[TestGrid] {TAB} is failing",
             "body": real_marker,
+            "labels": [tgfi.LABEL],
             "comments": [],
         })
 

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -46,6 +46,14 @@ PYTHON_TEST_SUITES = [
         "dir": os.path.join("dev", "ci", "presubmits", "shared"),
     },
     {
+        "name": "dev-ci-periodics",
+        # Collect dev/ci/periodics test suites (e.g.
+        # test_testgrid_failure_issues_test.py). Stdlib-only, like
+        # dev-tools-shared above.
+        "dir": os.path.join("dev", "ci", "periodics"),
+        "requirements": "requirements.txt",
+    },
+    {
         "name": "hermes-agent",
         # chat_hermes.py only uses stdlib (urllib.request, json), so the test
         # needs no requirements.txt -- just pytest, installed unconditionally


### PR DESCRIPTION
#### What this PR does / why we need it:
Right now nobody gets pinged when a periodic or postsubmit TestGrid job starts failing -- you have to remember to go check the dashboard. This adds an hourly GitHub Actions workflow (`.github/workflows/testgrid-failure-issues.yml`) that watches the `sig-apps-agent-sandbox` TestGrid dashboard and turns failures into tracking issues automatically.

What it does each run:
- Fetches TestGrid's public summary API for the dashboard (read-only, no auth needed).
- For every tab whose `overall_status` is `FAILING`, files an issue in this repo labeled `kind/failing-test`, with a link to the TestGrid tab, the current status line, and up to 5 failing test names with the first line of their failure message.
- When a tab that has an open tracking issue flips back to `PASSING`, it comments noting the recovery and closes the issue.
- Presubmit tabs (`presubmit-*` / `pull-*`) are skipped entirely -- those failures already show up as required checks on the PR itself, so filing a standing issue for them would just be noise.

**Why this won't spam the issue tracker:**
- Every tab's issue carries a hidden marker (`<!-- testgrid-failure:{dashboard}/{tab} -->`) in its body. Before filing, the job searches for an already-open issue containing that exact marker and confirms it with a plain substring check against the real body (GitHub's search endpoint tokenizes queries, so a match there isn't proof by itself). A job that's still failing on the next hourly run just finds its existing issue and leaves it alone instead of filing a second one.
- Recovery only closes on an explicit `PASSING`. Anything else -- `FLAKY`, `STALE`, `PENDING`, etc. -- leaves the issue open on purpose. A `STALE` job has stopped reporting results altogether, which is arguably worse than a known failure, so it shouldn't read as "fixed."
- Runs are serialized with a concurrency group (`cancel-in-progress: false`) instead of allowed to overlap, so two runs can't both search-then-file at the same time and end up racing each other into duplicate issues before either one is search-indexed.
- A tab that fails again after its last issue was closed does get a fresh issue -- that's intentional, since a regression should be visible again, but it does mean dedup only applies to currently-open issues, not the full history.

Also includes unit tests (`dev/ci/periodics/test_testgrid_failure_issues_test.py`) covering the file/close/skip decisions against an in-memory fake GitHub backend, no network involved, wired into `dev/tools/test-unit`'s Python suite list.

#### Which issue(s) this PR is related to:
None

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hourly and manually triggered monitoring for failing TestGrid jobs.
  * Creates labeled tracking issues with failure details and closes them after jobs definitively recover.
  * Defers tracking when an existing infrastructure-failure issue already covers the problem.

* **Bug Fixes**
  * Prevents duplicate tracking issues and supports reopening tracking when failures return.
  * Skips presubmit and pull-request tabs.
  * Continues processing when individual dashboard checks fail.

* **Tests**
  * Added coverage for failure tracking, recovery, deduplication, filtering, truncation, dry-run behavior, and dashboard errors.
  * Integrated periodic checks into the unit-test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->