### PR TITLE
test: fix for runtime burst test stale pool state and simplify latency zones to green/grey/cold

### DIFF
--- a/test/e2e/extensions/README.md
+++ b/test/e2e/extensions/README.md
@@ -141,11 +141,11 @@ delay = coldStartSec × batchSize / poolSize   (floor 50ms)
 This is static (computed once) to avoid fighting with adaptive batch sizing.
 For runc this yields ~50ms, for kata ~500ms.
 
-In regular (non-longevity) mode, the delay defaults to 100ms. The test always
-fires `2 × poolSize` claims to capture the warm-to-cold transition point.
-Pool depletion (`ReadyReplicas ≤ 1`) is logged but does not stop the test —
-claims past depletion exercise the cold fallback path and appear as
-`is_warm=false` in the CSV.
+In regular (non-longevity) mode, the delay defaults to 100ms. The test
+always fires `2×poolSize` claims to capture the warm-to-cold transition
+point. Pool depletion (`ReadyReplicas ≤ 1`) is logged but does not stop
+the test — claims past depletion exercise the cold fallback path and
+appear as `is_warm=false` in the CSV.
 
 ## Pool Lifecycle and Fill Measurement
 
@@ -158,11 +158,15 @@ degrading fill times across iterations. The flow:
    latency. The calibration pool and claim are deleted before burst iterations.
 2. **Per pool size**: a new pool is created at target replicas, **fill time**
    is measured (time for `ReadyReplicas` to reach target), burst claims run,
-   then the pool and all claims are deleted. Between iterations, the test
-   polls until all pods in the namespace (including Terminating) are fully
-   gone — this ensures the next pool size starts with all CPU capacity
-   available, which is critical for kata where pod termination can take
-   5-10 seconds per VM.
+   then the pool and all claims are deleted. In longevity mode, `pool_fill_sec`
+   measures time until `minReady` (roughly `2×batchSize`) rather than full
+   target replicas — the pool continues filling in the background while claims
+   fire, so this metric is not comparable to full-fill times in regular mode.
+   Between iterations, the test requires all pods in the namespace (including
+   Terminating) to be fully gone before proceeding — this ensures the next
+   pool size starts with all CPU capacity available, which is critical for kata
+   where pod termination can take 5-10 seconds per VM. Cleanup failures
+   (claim deletion, pod drain) fail the test to prevent invalid measurements.
 
 VM runtimes skip pool sizes that exceed **300%** of worker CPU capacity.
 Overprovisioning works well for kata — scheduler queues VMs while the
@@ -209,8 +213,15 @@ Header metadata:
 
 ```text
 # cluster_id,my-cluster-abcde
+# kubernetes_version,v1.32.1
+# sandbox_version,0.5.3
+# provider,gce
 # worker_count,3
 # total_cpu_capacity,24
+# total_ram_capacity_bytes,100663296000
+# preexisting_pods,12
+# allocated_cpu_millis,3500
+# allocated_ram_bytes,4294967296
 # instance_type,n2-standard-8
 # runtime_class,kata
 # pool_size,8
@@ -236,6 +247,9 @@ Footer summary:
 # total_duration_sec,18.450
 # time_to_all_ready_sec,15.720
 # throughput_claims_per_sec,0.9
+# pods_on_node,worker-1,6
+# pods_on_node,worker-2,5
+# pods_on_node,worker-3,5
 ```
 
 ### Quality zones
@@ -326,10 +340,30 @@ the full (unscoped) controller log as a fallback.
 
 ## Roadmap
 
-- **Split functional vs stress tests**: Separate `runtime_class_test.go` into
-  functional tests (CI-suitable gating) and stress/benchmarks (hardware-dependent,
-  CSV-producing). Enables a dedicated CI job for runtime-aware e2e validation
-  without benchmark noise.
+### Functional E2E Coverage
+
+- **Volume and initContainer injection**: Validate initContainer + emptyDir
+  execution patterns and file-proxy (virtiofsd/gofer) mount initialization
+  across sandboxed runtimes. The kata image volume gap
+  ([kata-containers#13749](https://github.com/kata-containers/kata-containers/issues/13749))
+  was found via openshell, not direct-driver tests — these paths need explicit
+  coverage.
+- **Warm pool adoption integrity**: Verify that controller state transitions
+  (Pending → Ready → Claimed) and metadata mutations apply cleanly without
+  triggering guest container restarts or corrupting runtime state.
+- **Network proxy reachability**: Confirm end-to-end ingress routing through
+  the sandbox-router into Kata virtual TAP interfaces and gVisor networking
+  stacks.
+- **Virtiofs storage I/O validation**: Verify file-based tool calls (writes,
+  reads, workspace updates) function correctly over virtiofs rather than
+  overlayfs. Perform rapid multi-file agent workspace I/O inside mounted
+  volumes and check file consistency across the guest-host boundary — stale
+  reads, partial writes, and metadata desync are common virtiofs failure
+  modes under concurrent access. Requires bare metal for accurate I/O
+  throughput profiling.
+
+### Infrastructure & Test Harness
+
 - **RuntimeClass auto-detection**: Query installed RuntimeClasses from the cluster
   to drive multi-runtime test sweeps without manual `SANDBOX_RUNTIME_CLASS` env
   var. Not all nodes support all runtimes (e.g., `kata-nvidia-gpu` requires
@@ -337,6 +371,56 @@ the full (unscoped) controller log as a fallback.
 - **Multi-size lifecycle subtests**: Run `TestRuntimeClassLifecycle` at small (2)
   and half-CPU pool sizes to validate the fill → claim → refill cycle under
   moderate scheduling pressure in CI.
+
+### Cluster Health Observability
+
+The CSV header now captures static cluster state (total RAM, preexisting pods,
+allocated CPU/RAM, provider, versions) and the footer includes per-node pod
+counts to surface scheduling skew. The remaining items add *dynamic*
+node-level context — what the cluster was doing *during* the run. A 9s cold
+start at 30% node CPU means something very different from one at 95%.
+
+- **Node resource snapshots**: Sample `kubectl top nodes` (or metrics-server
+  API) at the start and end of each pool iteration, and periodically during
+  longevity runs. Write per-node CPU% and memory usage to a separate
+  `node_health_<runtime>_pool<N>.csv`. Key aggregates: average and peak
+  CPU%, average and peak memory%.
+- **Node condition monitoring**: Poll node conditions (MemoryPressure,
+  DiskPressure, PIDPressure) during the test. Flag iterations where any
+  worker entered a pressure condition — these results are unreliable for
+  benchmarking and should be marked in the CSV.
+- **Runtime daemon health**: For kata, check hypervisor memory overhead
+  (~256MB/VM) and file descriptor counts on runtime proxy daemons
+  (`kata-shim-v2`, `virtiofsd`). For gVisor, check `runsc` sentry memory.
+  High FD counts or OOM kills on the daemon side cause cold starts that look
+  like controller slowness in the CSV.
+
+### Time-to-Ready Breakdown
+
+The current milestone tracker measures coarse phases (create-ack, adoption,
+schedule, runtime, propagate) but does not decompose the runtime phase into
+its constituent steps. For openshell-style workloads the full stack is:
+
+1. **Hypervisor / VM boot** — firmware load → kernel → kata-agent ready.
+   Varies significantly between bare-metal KVM (~1.5s) and nested virt
+   (~4-8s). Requires bare metal for accurate cold-start SLA measurement.
+   The test should detect nested virt and annotate results.
+2. **Virtiofs volume mount** — time for virtiofsd to establish the shared
+   filesystem between host and guest. Blocks container start if workspace
+   volumes are mounted. Requires bare metal for accurate I/O profiling —
+   double-virtualized storage layers inflate latency.
+3. **Supervisor and L7 proxy startup** — sandbox-router, sidecar proxies,
+   and any injected init containers that must be ready before the agent
+   can accept tool calls.
+4. **Agent process execution readiness** — time from container start to
+   the agent process accepting its first request (health check passing).
+
+Exposing these sub-phases in the CSV (as optional columns when the runtime
+supports it) would make it possible to pinpoint whether a regression is in
+the hypervisor layer, the storage layer, or the application stack.
+
+### Controller & Runtime Observability
+
 - **Per-pool metrics capture**: Scrape the controller's Prometheus endpoint
   (`/metrics` on port 8080) before and after each pool iteration. Save the
   delta as `metrics_<runtime>_pool<N>.prom` in the results directory. Key
@@ -362,6 +446,34 @@ the full (unscoped) controller log as a fallback.
   start is invisible without tracing. Alternatively, scrape the per-sandbox
   shim-monitor.sock metrics endpoint while VMs are still running to capture
   boot timing without Jaeger infrastructure.
+
+### Scale & Stress Coverage (Nightly/Non-Blocking)
+
+- **Replenishment latency under burst claims**: Ensure pool controllers
+  gracefully queue concurrent claim bursts and absorb microVM cold-start
+  boot latency (1-3s) without claim timeouts. Currently covered by
+  `TestRuntimeClassBurstRecovery` but only as a manual benchmark — needs
+  a nightly CI job with pass/fail thresholds on green ratio and p95 latency.
+- **Host density and resource overhead**: Stress-test node density limits
+  to monitor hypervisor memory overhead (~256MB/VM) and file descriptor
+  limits on runtime proxy daemons. Identify the point where adding more
+  pool replicas degrades rather than improves claim latency.
+- **Long-term stability and drift (7-day soak)**: Run continuous
+  claim-and-release loops over an extended duration to detect resource
+  leaks and zombie processes under sustained warm pool churn. Assert zero
+  memory growth in sandbox-router, complete finalization of hypervisor
+  processes (qemu/cloud-hypervisor), and no orphaned virtiofsd daemons on
+  host nodes. The existing longevity mode (`SANDBOX_LONGEVITY`) caps at a
+  few hours — a week-long soak needs periodic node-side auditing (process
+  counts, FD counts, RSS snapshots) written to a time-series CSV.
+- **Gateway and node saturation thresholds**: Progressively scale active
+  Kata sandboxes on a single node until CPU/memory saturation or gateway
+  throughput limits are hit. Identifies maximum sandbox density under
+  dual-layer overhead (hypervisor + sandbox-router) and establishes
+  baseline density guidance for platform sizing. Record the inflection
+  point where claim latency degrades and the failure mode (OOM kill,
+  throttling, gateway timeout). Requires bare metal for accurate density
+  limits — nested virt overhead skews the saturation point.
 
 ## Design Decisions
 

--- a/test/e2e/extensions/README.md
+++ b/test/e2e/extensions/README.md
@@ -29,7 +29,7 @@ behaviour across different container runtimes (runc, gVisor, kata).
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SANDBOX_RUNTIME_CLASS` | *(required)* | RuntimeClass name: `default` (cluster default / runc), `gvisor`, `kata`, etc. Tests skip when unset. |
-| `SANDBOX_POOL_SIZES` | total worker CPUs | Comma-separated pool sizes for burst recovery and warm claim benchmarks. Defaults to the cluster's total worker CPU count when unset. |
+| `SANDBOX_POOL_SIZES` | `{cpus/2, cpus, cpus×2}` | Comma-separated pool sizes for burst recovery and warm claim benchmarks. Defaults to half, full, and double the cluster's total worker CPU capacity. |
 | `SANDBOX_BATCH_CAP` | `10` | Maximum number of claims fired per batch in burst recovery. Lower values reduce controller serialization; higher values stress the reconcile loop. |
 | `SANDBOX_LONGEVITY` | *(unset)* | Go duration (e.g. `2h`, `30m`) to run burst recovery in longevity mode: continuous batches with adaptive sizing until the deadline. |
 | `SANDBOX_DEBUG` | *(unset)* | Set to any non-empty value to dump scoped controller logs after each pool iteration even on success. |
@@ -82,7 +82,7 @@ SANDBOX_RUNTIME_CLASS=gvisor \
 ### Kata
 
 Kata VMs consume ~250m CPU + 350Mi RAM each (pod overhead from the RuntimeClass).
-The test auto-detects cluster CPU capacity and skips pool sizes that exceed it.
+The test auto-detects cluster CPU capacity and skips pool sizes exceeding 300%.
 
 ```shell
 SANDBOX_RUNTIME_CLASS=kata \
@@ -141,37 +141,40 @@ delay = coldStartSec × batchSize / poolSize   (floor 50ms)
 This is static (computed once) to avoid fighting with adaptive batch sizing.
 For runc this yields ~50ms, for kata ~500ms.
 
-In regular (non-longevity) mode, the delay defaults to 100ms. The test stops
-when `ReadyReplicas ≤ 1` **and** at least `poolSize` claims have been issued
-(ensuring at least one full pass through the pool), or after `2 × poolSize`
-total claims — whichever comes first.
+In regular (non-longevity) mode, the delay defaults to 100ms. The test always
+fires `2 × poolSize` claims to capture the warm-to-cold transition point.
+Pool depletion (`ReadyReplicas ≤ 1`) is logged but does not stop the test —
+claims past depletion exercise the cold fallback path and appear as
+`is_warm=false` in the CSV.
 
-## Pool Reuse and Fill Measurement
+## Pool Lifecycle and Fill Measurement
 
-`TestRuntimeClassBurstRecovery` creates a single namespace, template, and pool
-that are reused across all pool sizes. The flow:
+`TestRuntimeClassBurstRecovery` creates a fresh pool for each pool size to
+avoid stale controller state (expectations tracker, observedGeneration) from
+degrading fill times across iterations. The flow:
 
-1. **Calibration**: pool is created at 4 replicas (capped by CPU for VM
-   runtimes). A single claim measures **warm baseline** — the irreducible
-   create-claim-watch latency.
-2. **Scale to 0**: pool is drained, calibration claim deleted.
-3. **Per pool size**: scale pool to target replicas, measure **fill time**
-   (time for `ReadyReplicas` to reach target), run burst claims, scale back
-   to 0. Between iterations, the test polls until all pods in the namespace
-   (including Terminating) are fully gone — this ensures the next pool size
-   starts with all CPU capacity available, which is critical for kata where
-   pod termination can take 5-10 seconds per VM.
+1. **Calibration**: a temporary pool at 4 replicas (capped by CPU for VM
+   runtimes) measures **warm baseline** — the irreducible create-claim-watch
+   latency. The calibration pool and claim are deleted before burst iterations.
+2. **Per pool size**: a new pool is created at target replicas, **fill time**
+   is measured (time for `ReadyReplicas` to reach target), burst claims run,
+   then the pool and all claims are deleted. Between iterations, the test
+   polls until all pods in the namespace (including Terminating) are fully
+   gone — this ensures the next pool size starts with all CPU capacity
+   available, which is critical for kata where pod termination can take
+   5-10 seconds per VM.
 
 VM runtimes skip pool sizes that exceed **300%** of worker CPU capacity.
 Overprovisioning works well for kata — scheduler queues VMs while the
-pool maintains a larger buffer of pre-warmed slots. Empirically, warm
+pool maintains a larger buffer of pre-warmed slots. Empirically, green
 ratio and throughput both improve past 100% CPU (e.g., pool-28 on a
-3×8 vCPU cluster yields 89% warm at 3.3 claims/s vs 65% at 2.3 for
+3×8 vCPU cluster yields 89% green at 3.3 claims/s vs 65% at 2.3 for
 pool-16).
 
 Fill time accounts for the controller's `slowStartBatch` exponential ramp
 (1, 2, 4, 8… concurrent creates) and is used to derive claim timeouts for
-that specific pool size. The warm/cold threshold is fixed at **1 second**.
+that specific pool size. The green threshold is fixed at **1 second** — claims
+above this are classified as grey (warm but slow) or cold (fallback).
 
 ## Reading Results
 
@@ -211,9 +214,10 @@ Header metadata:
 # instance_type,n2-standard-8
 # runtime_class,kata
 # pool_size,8
-# workload_sec,0
+# workload_sec,30
+# cold_baseline_sec,8.500
 # warm_baseline_sec,0.350
-# warm_cold_threshold_sec,1.000
+# green_threshold_sec,1.000
 # pool_fill_sec,12.500
 # batch_size,4
 # max_claims,16
@@ -223,32 +227,33 @@ Header metadata:
 Footer summary:
 
 ```text
-# total_batches,6
-# total_claims,48
-# under_1s_claims,48
-# over_1s_claims,0
-# green_claims,21
-# grey_zone_claims,27
-# worst_start_sec,0.752
-# over_cold_claims,2
-# time_to_all_ready_sec,3.214
-# total_duration_sec,4.795
-# throughput_claims_per_sec,10.0
+# total_batches,4
+# total_claims,16
+# green_claims,8
+# grey_claims,4
+# cold_claims,4
+# worst_start_sec,9.215
+# total_duration_sec,18.450
+# time_to_all_ready_sec,15.720
+# throughput_claims_per_sec,0.9
 ```
 
 ### Quality zones
 
-Claims are classified into quality zones based on latency:
+Claims are classified into three zones using the controller's `is_warm` signal
+and a 1-second latency threshold:
 
-| Zone | Range | Meaning |
-|------|-------|---------|
-| **Green** | ≤ 500ms | Invisible to the caller — warm pool delivered its promise |
-| **Grey** | 500ms … 1s | Contention-degraded but still faster than cold start |
-| **Cold** | > 1s | Warm pool failed to mask the cold start |
-| **Over-cold** | > pool fill time | Worse than the measured pool fill time |
+| Zone | Criteria | Meaning |
+|------|----------|---------|
+| **Green** | `is_warm=true` and ≤ 1s | Sub-second from warm pool — target SLA met |
+| **Grey** | `is_warm=true` and > 1s | Warm-served but slow — scheduling or adoption lag |
+| **Cold** | `is_warm=false` | Pool failed to serve the claim — cold fallback path |
 
-The grey zone is dominated by API server round-trip (~170ms) and controller
-adoption overhead (~100-250ms) — it is runtime-independent.
+`is_warm` is ground truth from the controller: `true` when the sandbox pod
+existed before the claim was created (pre-warmed), `false` when the controller
+created a new sandbox on demand. This avoids runtime-specific latency
+thresholds — cold start varies from ~2s (runc) to ~8s (kata), but `is_warm`
+is unambiguous regardless of runtime.
 
 ## Report Directory Structure
 
@@ -296,8 +301,8 @@ Key differences from regular burst mode:
 - **Minimum pool size**: longevity mode skips pool sizes below 20 — smaller
   pools deplete too fast for meaningful adaptive tuning.
 - **Summary CSV**: a `burst_summary_<runtime>_pool<N>.csv` is written every
-  10 batches with aggregated p50/p95 latencies, throughput, warm ratio, and
-  batch size direction for live monitoring.
+  10 batches with aggregated p50/p95 latencies, throughput, green/grey/cold
+  counts, and batch size direction for live monitoring.
 
 ## Controller Log Capture
 
@@ -329,9 +334,6 @@ the full (unscoped) controller log as a fallback.
   to drive multi-runtime test sweeps without manual `SANDBOX_RUNTIME_CLASS` env
   var. Not all nodes support all runtimes (e.g., `kata-nvidia-gpu` requires
   specific node capabilities).
-- **CPU-relative benchmark pool sizes**: Default `SANDBOX_POOL_SIZES` to
-  `{cpuCapacity/2, cpuCapacity, cpuCapacity*2}` — half (comfortable headroom),
-  full (capacity cliff), and double (forced cold starts to measure the penalty).
 - **Multi-size lifecycle subtests**: Run `TestRuntimeClassLifecycle` at small (2)
   and half-CPU pool sizes to validate the fill → claim → refill cycle under
   moderate scheduling pressure in CI.

--- a/test/e2e/extensions/README.md
+++ b/test/e2e/extensions/README.md
@@ -31,7 +31,6 @@ behaviour across different container runtimes (runc, gVisor, kata).
 | `SANDBOX_RUNTIME_CLASS` | *(required)* | RuntimeClass name: `default` (cluster default / runc), `gvisor`, `kata`, etc. Tests skip when unset. |
 | `SANDBOX_POOL_SIZES` | total worker CPUs | Comma-separated pool sizes for burst recovery and warm claim benchmarks. Defaults to the cluster's total worker CPU count when unset. |
 | `SANDBOX_BATCH_CAP` | `10` | Maximum number of claims fired per batch in burst recovery. Lower values reduce controller serialization; higher values stress the reconcile loop. |
-| `SANDBOX_SETTLE_SEC` | `2` | Seconds to wait after pool fill before starting burst claims. Lets the controller work queue drain so fill-residue doesn't inflate batch 1 latencies. Set to `0` to measure raw post-fill behavior. |
 | `SANDBOX_LONGEVITY` | *(unset)* | Go duration (e.g. `2h`, `30m`) to run burst recovery in longevity mode: continuous batches with adaptive sizing until the deadline. |
 | `SANDBOX_DEBUG` | *(unset)* | Set to any non-empty value to dump scoped controller logs after each pool iteration even on success. |
 | `SANDBOX_REPORT_DIR` | `artifacts` | Base directory for CSV output and controller logs. A subdirectory is auto-created per run. |
@@ -218,7 +217,6 @@ Header metadata:
 # pool_fill_sec,12.500
 # batch_size,4
 # max_claims,16
-# settle_sec,2
 # inter_batch_delay_ms,100
 ```
 
@@ -337,12 +335,6 @@ the full (unscoped) controller log as a fallback.
 - **Multi-size lifecycle subtests**: Run `TestRuntimeClassLifecycle` at small (2)
   and half-CPU pool sizes to validate the fill → claim → refill cycle under
   moderate scheduling pressure in CI.
-- **Probe-based settle detection**: Replace the fixed `SANDBOX_SETTLE_SEC` delay
-  with a single probe claim after pool fill. If the probe latency falls within
-  the green threshold (500ms), the controller work queue is empirically drained and burst
-  can start immediately. If not, back off and retry. Eliminates both the risk of
-  starting too early (inflated baselines) and waiting too long (wasted time on
-  fast clusters).
 - **Per-pool metrics capture**: Scrape the controller's Prometheus endpoint
   (`/metrics` on port 8080) before and after each pool iteration. Save the
   delta as `metrics_<runtime>_pool<N>.prom` in the results directory. Key

--- a/test/e2e/extensions/runtime_class_burst_test.go
+++ b/test/e2e/extensions/runtime_class_burst_test.go
@@ -64,15 +64,6 @@ func workloadPodSpec(rcPtr *string, workloadSec int) corev1.PodSpec {
 	}
 }
 
-func benchSettleDuration() time.Duration {
-	if v := os.Getenv("SANDBOX_SETTLE_SEC"); v != "" {
-		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
-			return time.Duration(n) * time.Second
-		}
-	}
-	return 2 * time.Second
-}
-
 func benchBatchCap() int {
 	if v := os.Getenv("SANDBOX_BATCH_CAP"); v != "" {
 		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 1 {
@@ -114,6 +105,7 @@ func waitForNoPods(ctx context.Context, cl *framework.ClusterClient, namespace s
 		}
 	}
 }
+
 
 type claimRecord struct {
 	batch        int
@@ -213,13 +205,16 @@ func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo 
 }
 
 // TestRuntimeClassBurstRecovery measures how a warm pool behaves under
-// sustained batch load that exceeds pool refill capacity. A single pool is
-// reused across all pool sizes — scaled from 0 to the target between subtests.
+// sustained batch load that exceeds pool refill capacity. A fresh pool is
+// created for each pool size to avoid stale controller state (expectations
+// tracker, observedGeneration) from degrading fill times across iterations.
 //
 // Before entering the subtest loop the test measures three baselines:
-// cold start (single bare sandbox), pool fill, and warm claim latency.
+// cold start (single bare sandbox), calibration pool fill, and warm claim
+// latency. The calibration pool is deleted and fully drained before the
+// main loop begins.
 //
-// Each subtest fires claims in dynamically sized batches with 100ms settle
+// Each subtest fires claims in dynamically sized batches with 100ms delay
 // between batches, stopping when ReadyReplicas ≤ 1 and at least poolSize
 // claims have been issued, or after 2×poolSize total claims.
 //
@@ -304,46 +299,38 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 	template.Spec.PodTemplate = sandboxv1beta1.PodTemplate{Spec: workloadPodSpec(rcPtr, workloadSec)}
 	require.NoError(t, tc0.CreateWithCleanup(t.Context(), template))
 
-	zeroReplicas := int32(0)
-	pool := &extensionsv1beta1.SandboxWarmPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "burst-pool",
-			Namespace: ns.Name,
-		},
-		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
-			Replicas:    &zeroReplicas,
-			TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name},
-		},
-	}
-	require.NoError(t, tc0.CreateWithCleanup(t.Context(), pool))
-	poolID := types.NamespacedName{Name: pool.Name, Namespace: ns.Name}
-
-	settleDur := benchSettleDuration()
-
+	// Calibration: measure warm claim baseline using a temporary pool.
 	calibReplicas := int32(4)
 	if isVMRuntime(runtimeClass) && int64(calibReplicas) > cpus {
 		calibReplicas = int32(cpus)
 	}
-	baselinePoolFill(t, tc0, pool, poolID, calibReplicas, fillTimeout)
-
-	if settleDur > 0 {
-		t.Logf("[settle] waiting %s for controller to drain after calibration fill", settleDur)
-		time.Sleep(settleDur)
+	calibPool := &extensionsv1beta1.SandboxWarmPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "calib-pool",
+			Namespace: ns.Name,
+		},
+		Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+			Replicas:    &calibReplicas,
+			TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name},
+		},
 	}
+	require.NoError(t, tc0.CreateWithCleanup(t.Context(), calibPool))
+	calibPoolID := types.NamespacedName{Name: calibPool.Name, Namespace: ns.Name}
+	baselinePoolFill(t, tc0, calibPool, calibPoolID, calibReplicas, fillTimeout)
 
-	warmBaseline, calibClaim := baselineWarmClaim(t, tc0, ns.Name, pool.Name)
+	warmBaseline, calibClaim := baselineWarmClaim(t, tc0, ns.Name, calibPool.Name)
 	warmColdThreshold := time.Second
 	t.Logf("[baseline] cold=%.3fs warm=%.3fs threshold=%.3fs",
 		coldBaseline.Seconds(), warmBaseline.Seconds(), warmColdThreshold.Seconds())
 
-	// Scale to 0 before entering subtest loop
+	// Delete calibration pool and wait for full cleanup.
 	require.NoError(t, tc0.Delete(t.Context(), calibClaim))
-	framework.MustUpdateObject(tc0.ClusterClient, pool, func(p *extensionsv1beta1.SandboxWarmPool) {
-		p.Spec.Replicas = &zeroReplicas
-	})
-	drainCtx, drainCancel := context.WithTimeout(t.Context(), fillTimeout)
-	require.NoError(t, tc0.WaitForWarmPoolReady(drainCtx, poolID))
-	drainCancel()
+	require.NoError(t, tc0.Delete(t.Context(), calibPool))
+	calibDrainCtx, calibDrainCancel := context.WithTimeout(t.Context(), fillTimeout)
+	if err := waitForNoPods(calibDrainCtx, tc0.ClusterClient, ns.Name); err != nil {
+		t.Logf("[calibration drain] WARNING: %v", err)
+	}
+	calibDrainCancel()
 
 	batchCap := benchBatchCap()
 	calcBatchSize := func(poolSize int) int {
@@ -375,6 +362,23 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			continue
 		}
 
+		// Fresh pool per iteration: clean controller state (expectations
+		// tracker, observedGeneration, status). Reusing a pool across
+		// iterations carried stale state that degraded fill times.
+		replicas := int32(poolSize)
+		pool := &extensionsv1beta1.SandboxWarmPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("burst-pool-%d", poolSize),
+				Namespace: ns.Name,
+			},
+			Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+				Replicas:    &replicas,
+				TemplateRef: extensionsv1beta1.SandboxTemplateRef{Name: template.Name},
+			},
+		}
+		require.NoError(t, tc0.CreateWithCleanup(t.Context(), pool))
+		poolID := types.NamespacedName{Name: pool.Name, Namespace: ns.Name}
+
 		preBatchSize := calcBatchSize(poolSize)
 		if longevity > 0 && coldBaseline > 0 {
 			preBatchSize = max(4, int(float64(poolSize)*0.3/coldBaseline.Seconds()))
@@ -386,11 +390,7 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 		var poolFillTime time.Duration
 		if longevity > 0 {
 			minReady := int32(min(2*preBatchSize, poolSize))
-			framework.MustUpdateObject(tc0.ClusterClient, pool, func(p *extensionsv1beta1.SandboxWarmPool) {
-				r := int32(poolSize)
-				p.Spec.Replicas = &r
-			})
-			t.Logf("[longevity] scaling pool to %d, waiting for %d ready replicas...", poolSize, minReady)
+			t.Logf("[longevity] filling pool to %d, waiting for %d ready replicas...", poolSize, minReady)
 			start := time.Now()
 			fillCtx, fillCancel := context.WithTimeout(t.Context(), fillTimeout)
 			require.NoError(t, tc0.WaitForWarmPoolMinReady(fillCtx, poolID, minReady))
@@ -398,17 +398,17 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			poolFillTime = time.Since(start)
 			t.Logf("[longevity] pool has %d+ ready in %.3fs (fill continues in background)", minReady, poolFillTime.Seconds())
 		} else {
-			poolFillTime = baselinePoolFill(t, tc0, pool, poolID, int32(poolSize), fillTimeout)
+			start := time.Now()
+			fillCtx, fillCancel := context.WithTimeout(t.Context(), fillTimeout)
+			require.NoError(t, tc0.WaitForWarmPoolReady(fillCtx, poolID))
+			fillCancel()
+			poolFillTime = time.Since(start)
+			t.Logf("[fill] pool-%d filled in %.3fs", poolSize, poolFillTime.Seconds())
 		}
 
 		t.Run(fmt.Sprintf("pool-%d", poolSize), func(t *testing.T) {
 			tc := framework.NewTestContext(t)
 			poolStart := time.Now()
-
-			if settleDur > 0 && longevity == 0 {
-				t.Logf("[settle] waiting %s for controller work queue to drain after fill", settleDur)
-				time.Sleep(settleDur)
-			}
 
 			tracker := newMilestoneTracker(t.Context(), t, tc.DynamicClient(), ns.Name)
 			defer tracker.Stop()
@@ -457,7 +457,6 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			} else {
 				_ = cw.Write([]string{"# max_claims", strconv.Itoa(poolSize * 2)})
 			}
-			_ = cw.Write([]string{"# settle_sec", strconv.Itoa(int(settleDur.Seconds()))})
 			_ = cw.Write([]string{"# inter_batch_delay_ms", strconv.Itoa(int(interBatchDelay.Milliseconds()))})
 			_ = cw.Write([]string{"batch", "claim", "batch_size", "latency_sec", "timestamp", "wall_offset_sec", "ready_at_start",
 				"create_ack_ms", "adoption_ms", "schedule_ms", "runtime_ms", "propagate_ms", "e2e_ms", "is_warm"})
@@ -548,10 +547,10 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			t.Logf("  cold=%.3fs  warm=%.3fs  fill=%.3fs  threshold=%.3fs",
 				coldBaseline.Seconds(), warmBaseline.Seconds(), poolFillTime.Seconds(), warmColdThreshold.Seconds())
 			if longevity > 0 {
-				t.Logf("  batchSize=%d  longevity=%s  adaptive=%v  settle=%s  delay=%s",
-					batchSize, longevity, adaptiveBatch, settleDur, interBatchDelay)
+				t.Logf("  batchSize=%d  longevity=%s  adaptive=%v  delay=%s",
+					batchSize, longevity, adaptiveBatch, interBatchDelay)
 			} else {
-				t.Logf("  batchSize=%d  maxClaims=%d  settle=%s  inter_batch=%s", batchSize, maxClaims, settleDur, interBatchDelay)
+				t.Logf("  batchSize=%d  maxClaims=%d  inter_batch=%s", batchSize, maxClaims, interBatchDelay)
 			}
 			t.Logf("=======================================================================")
 
@@ -770,23 +769,24 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			}
 		})
 
-		// Scale pool to 0 and wait for all pods (including Terminating) to be gone
-		framework.MustUpdateObject(tc0.ClusterClient, pool, func(p *extensionsv1beta1.SandboxWarmPool) {
-			p.Spec.Replicas = &zeroReplicas
-		})
-		drainCtx, drainCancel := context.WithTimeout(t.Context(), fillTimeout)
-		require.NoError(t, tc0.WaitForWarmPoolReady(drainCtx, poolID))
-		drainCancel()
-
-		// Wait for all pods (including Terminating) to be fully gone before
-		// scaling to the next pool size. This ensures CPU capacity is restored,
-		// which is critical for kata where VM termination takes 5-10s per pod.
-		podDrainTimeout := time.Duration(poolSize)*10*time.Second + 30*time.Second
-		podDrainCtx, podDrainCancel := context.WithTimeout(t.Context(), podDrainTimeout)
-		t.Logf("[drain] waiting for all pods in %s to terminate (timeout %s)", ns.Name, podDrainTimeout)
-		if err := waitForNoPods(podDrainCtx, tc0.ClusterClient, ns.Name); err != nil {
-			t.Logf("[drain] WARNING: %v — proceeding anyway", err)
+		// Delete pool and all claims, then wait for full cleanup.
+		// Pool deletion cascades to unclaimed sandboxes via ownerReference.
+		// Claimed sandboxes are owned by claims (adoption transferred
+		// ownership), so delete claims explicitly too.
+		var claimList extensionsv1beta1.SandboxClaimList
+		if err := tc0.ClusterClient.List(t.Context(), &claimList, client.InNamespace(ns.Name)); err == nil {
+			for i := range claimList.Items {
+				_ = tc0.ClusterClient.Delete(t.Context(), &claimList.Items[i])
+			}
 		}
-		podDrainCancel()
+		require.NoError(t, tc0.Delete(t.Context(), pool))
+
+		drainTimeout := time.Duration(poolSize)*10*time.Second + 30*time.Second
+		drainCtx, drainCancel := context.WithTimeout(t.Context(), drainTimeout)
+		t.Logf("[drain] waiting for pods in %s to terminate (timeout %s)", ns.Name, drainTimeout)
+		if err := waitForNoPods(drainCtx, tc0.ClusterClient, ns.Name); err != nil {
+			t.Logf("[drain] WARNING: %v", err)
+		}
+		drainCancel()
 	}
 }

--- a/test/e2e/extensions/runtime_class_burst_test.go
+++ b/test/e2e/extensions/runtime_class_burst_test.go
@@ -119,7 +119,6 @@ type claimRecord struct {
 
 func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo int,
 	batchSize, startBatchSize int, testStart time.Time,
-	greenThreshold, warmColdThreshold time.Duration,
 	readySum float64, batchCount int) {
 	if len(records) == 0 {
 		return
@@ -136,7 +135,7 @@ func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo 
 	var latencySum float64
 	best := records[0].latency.Seconds()
 	worst := 0.0
-	green, grey, over1s, warm := 0, 0, 0, 0
+	green, grey, cold := 0, 0, 0
 	for i, r := range records {
 		s := r.latency.Seconds()
 		latencies[i] = s
@@ -147,15 +146,12 @@ func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo 
 		if s > worst {
 			worst = s
 		}
-		if r.latency <= greenThreshold {
+		if !r.breakdown.IsWarm {
+			cold++
+		} else if r.latency <= time.Second {
 			green++
-		} else if r.latency <= warmColdThreshold {
-			grey++
 		} else {
-			over1s++
-		}
-		if r.breakdown.IsWarm {
-			warm++
+			grey++
 		}
 	}
 	slices.Sort(latencies)
@@ -166,7 +162,6 @@ func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo 
 		p95Idx = len(latencies) - 1
 	}
 	p95 := latencies[p95Idx]
-	warmRatio := float64(warm) / float64(len(records))
 	var throughput float64
 	if len(records) > 1 {
 		earliest := records[0].wallOffset - records[0].latency
@@ -198,8 +193,7 @@ func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo 
 		fmt.Sprintf("%.3f", worst),
 		strconv.Itoa(green),
 		strconv.Itoa(grey),
-		strconv.Itoa(over1s),
-		fmt.Sprintf("%.2f", warmRatio),
+		strconv.Itoa(cold),
 		fmt.Sprintf("%.1f", throughput),
 	})
 }
@@ -319,9 +313,8 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 	baselinePoolFill(t, tc0, calibPool, calibPoolID, calibReplicas, fillTimeout)
 
 	warmBaseline, calibClaim := baselineWarmClaim(t, tc0, ns.Name, calibPool.Name)
-	warmColdThreshold := time.Second
-	t.Logf("[baseline] cold=%.3fs warm=%.3fs threshold=%.3fs",
-		coldBaseline.Seconds(), warmBaseline.Seconds(), warmColdThreshold.Seconds())
+	t.Logf("[baseline] cold=%.3fs warm=%.3fs",
+		coldBaseline.Seconds(), warmBaseline.Seconds())
 
 	// Delete calibration pool and wait for full cleanup.
 	require.NoError(t, tc0.Delete(t.Context(), calibClaim))
@@ -337,10 +330,6 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 		return min(max(4, poolSize/2), batchCap)
 	}
 
-	isUnder1s := func(d time.Duration) bool {
-		return d < warmColdThreshold
-	}
-
 	var globalClaimCounter atomic.Int64
 	poolSizes, err := benchPoolSizes(cpus)
 	if err != nil {
@@ -349,18 +338,20 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 	if longevity > 0 && os.Getenv("SANDBOX_POOL_SIZES") == "" {
 		poolSizes = []int{int(cpus)}
 	}
+	t.Logf("[plan] pool sizes=%v cpuCapacity=%d runtime=%s", poolSizes, cpus, runtimeClass)
 
-	for _, poolSize := range poolSizes {
+	for i, poolSize := range poolSizes {
 		// Allow up to 300% CPU overprovisioning for VM runtimes — scheduler
 		// queues excess VMs while the larger pool improves warm hit ratio.
 		if isVMRuntime(runtimeClass) && int64(poolSize) > cpus*3 {
-			t.Logf("[skip] pool size %d exceeds 300%% of worker CPU capacity (%d vCPUs)", poolSize, cpus)
+			t.Logf("[skip] pool-%d: exceeds 300%% of worker CPU capacity (%d vCPUs)", poolSize, cpus)
 			continue
 		}
 		if longevity > 0 && poolSize < 20 {
-			t.Logf("[skip] longevity mode requires pool size ≥ 20 (got %d)", poolSize)
+			t.Logf("[skip] pool-%d: longevity mode requires pool size ≥ 20", poolSize)
 			continue
 		}
+		t.Logf("[start] pool-%d (%d/%d)", poolSize, i+1, len(poolSizes))
 
 		// Fresh pool per iteration: clean controller state (expectations
 		// tracker, observedGeneration, status). Reusing a pool across
@@ -414,7 +405,6 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			defer tracker.Stop()
 
 			claimTimeout := poolFillTime + 30*time.Second
-			greenThreshold := 500 * time.Millisecond
 			t.Logf("[setup] Pool-%d filled in %.3fs", poolSize, poolFillTime.Seconds())
 
 			batchSize := calcBatchSize(poolSize)
@@ -448,7 +438,7 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			_ = cw.Write([]string{"# workload_sec", strconv.Itoa(workloadSec)})
 			_ = cw.Write([]string{"# cold_baseline_sec", fmt.Sprintf("%.3f", coldBaseline.Seconds())})
 			_ = cw.Write([]string{"# warm_baseline_sec", fmt.Sprintf("%.3f", warmBaseline.Seconds())})
-			_ = cw.Write([]string{"# warm_cold_threshold_sec", fmt.Sprintf("%.3f", warmColdThreshold.Seconds())})
+			_ = cw.Write([]string{"# green_threshold_sec", "1.000"})
 			_ = cw.Write([]string{"# pool_fill_sec", fmt.Sprintf("%.3f", poolFillTime.Seconds())})
 			_ = cw.Write([]string{"# batch_size", strconv.Itoa(batchSize)})
 			if longevity > 0 {
@@ -474,7 +464,7 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 				defer summCw.Flush()
 				_ = summCw.Write([]string{"wall_min", "batch_from", "batch_to", "batch_size", "direction",
 					"claims", "ready_avg", "latency_avg_sec", "latency_p50_sec", "latency_p95_sec",
-					"best_sec", "worst_sec", "green", "grey", "over_1s", "warm_ratio", "throughput_per_sec"})
+					"best_sec", "worst_sec", "green", "grey", "cold", "throughput_per_sec"})
 				summCw.Flush()
 				t.Logf("[csv] summary: %s", summPath)
 			}
@@ -544,8 +534,8 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			// --- Header ---
 			t.Logf("=======================================================================")
 			t.Logf("  Burst Recovery: runtime=%s pool=%d workload=%ds", runtimeClass, poolSize, workloadSec)
-			t.Logf("  cold=%.3fs  warm=%.3fs  fill=%.3fs  threshold=%.3fs",
-				coldBaseline.Seconds(), warmBaseline.Seconds(), poolFillTime.Seconds(), warmColdThreshold.Seconds())
+			t.Logf("  cold=%.3fs  warm=%.3fs  fill=%.3fs",
+				coldBaseline.Seconds(), warmBaseline.Seconds(), poolFillTime.Seconds())
 			if longevity > 0 {
 				t.Logf("  batchSize=%d  longevity=%s  adaptive=%v  delay=%s",
 					batchSize, longevity, adaptiveBatch, interBatchDelay)
@@ -587,10 +577,9 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 				require.NoError(t, tc.Get(t.Context(), poolID, &poolStatus))
 				readyBefore := poolStatus.Status.ReadyReplicas
 
-				if readyBefore <= 1 && totalClaims >= poolSize && deadline.IsZero() {
-					t.Logf("[drain] pool depleted (ready=%d) after %d batches, %d claims",
-						readyBefore, batchNum-1, totalClaims)
-					break
+				if readyBefore <= 1 && totalClaims >= poolSize && totalClaims < poolSize+batchSize && deadline.IsZero() {
+					t.Logf("[drain] pool depleted (ready=%d) after %d batches, %d claims — continuing to %d",
+						readyBefore, batchNum-1, totalClaims, maxClaims)
 				}
 
 				if adaptiveBatch {
@@ -648,7 +637,7 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 					windowBatchCount++
 					if batchNum%summaryInterval == 0 || !shouldContinue() {
 						emitBatchSummary(summCw, windowRecords, windowBatchFrom, batchNum,
-							batchSize, windowStartBatchSize, testStart, greenThreshold, warmColdThreshold,
+							batchSize, windowStartBatchSize, testStart,
 							windowReadySum, windowBatchCount)
 						summCw.Flush()
 						windowRecords = nil
@@ -662,7 +651,7 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 
 			if summCw != nil && len(windowRecords) > 0 {
 				emitBatchSummary(summCw, windowRecords, windowBatchFrom, batchNum,
-					batchSize, windowStartBatchSize, testStart, greenThreshold, warmColdThreshold,
+					batchSize, windowStartBatchSize, testStart,
 					windowReadySum, windowBatchCount)
 				summCw.Flush()
 			}
@@ -688,10 +677,9 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			// --- Summary ---
 			totalDuration := time.Since(testStart)
 			var firstCreate, lastReady time.Time
-			under1sCount := 0
 			greenCount := 0
-			greyZoneCount := 0
-			overColdCount := 0
+			greyCount := 0
+			coldCount := 0
 			var worstStart time.Duration
 			for _, r := range allRecords {
 				createTime := testStart.Add(r.wallOffset - r.latency)
@@ -702,17 +690,12 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 				if readyTime.After(lastReady) {
 					lastReady = readyTime
 				}
-				if isUnder1s(r.latency) {
-					under1sCount++
-				}
-				if r.latency <= greenThreshold {
+				if !r.breakdown.IsWarm {
+					coldCount++
+				} else if r.latency <= time.Second {
 					greenCount++
-				}
-				if r.latency > greenThreshold && r.latency <= warmColdThreshold {
-					greyZoneCount++
-				}
-				if r.latency > poolFillTime {
-					overColdCount++
+				} else {
+					greyCount++
 				}
 				if r.latency > worstStart {
 					worstStart = r.latency
@@ -731,11 +714,11 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			if longevity > 0 {
 				t.Logf("  Longevity:           %s", longevity)
 			}
-			t.Logf("  Total claims:        %d (%d under1s, %d over1s)", totalClaims, under1sCount, totalClaims-under1sCount)
-			t.Logf("  Green (<=500ms):     %d", greenCount)
-			t.Logf("  Grey (500ms..1s):    %d", greyZoneCount)
+			t.Logf("  Total claims:        %d", totalClaims)
+			t.Logf("  Green (≤1s, warm):   %d", greenCount)
+			t.Logf("  Grey (>1s, warm):    %d", greyCount)
+			t.Logf("  Cold (fallback):     %d", coldCount)
 			t.Logf("  Worst start:         %.3fs", worstStart.Seconds())
-			t.Logf("  Over cold start:     %d (>%.3fs)", overColdCount, poolFillTime.Seconds())
 			t.Logf("  Time to all ready:   %.3fs", timeToAllReadySec)
 			t.Logf("  Total duration(sec): %.3f", totalDuration.Seconds())
 			t.Logf("  Throughput:          %.1f claims/sec", float64(totalClaims)/totalDuration.Seconds())
@@ -750,12 +733,10 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 				_ = cw.Write([]string{"# max_batch_size", strconv.Itoa(maxBatch)})
 			}
 			_ = cw.Write([]string{"# total_claims", strconv.Itoa(totalClaims)})
-			_ = cw.Write([]string{"# under_1s_claims", strconv.Itoa(under1sCount)})
-			_ = cw.Write([]string{"# over_1s_claims", strconv.Itoa(totalClaims - under1sCount)})
 			_ = cw.Write([]string{"# green_claims", strconv.Itoa(greenCount)})
-			_ = cw.Write([]string{"# grey_zone_claims", strconv.Itoa(greyZoneCount)})
+			_ = cw.Write([]string{"# grey_claims", strconv.Itoa(greyCount)})
+			_ = cw.Write([]string{"# cold_claims", strconv.Itoa(coldCount)})
 			_ = cw.Write([]string{"# worst_start_sec", fmt.Sprintf("%.3f", worstStart.Seconds())})
-			_ = cw.Write([]string{"# over_cold_claims", strconv.Itoa(overColdCount)})
 			_ = cw.Write([]string{"# total_duration_sec", fmt.Sprintf("%.3f", totalDuration.Seconds())})
 			_ = cw.Write([]string{"# time_to_all_ready_sec", fmt.Sprintf("%.3f", timeToAllReadySec)})
 			_ = cw.Write([]string{"# throughput_claims_per_sec", fmt.Sprintf("%.1f", float64(totalClaims)/totalDuration.Seconds())})

--- a/test/e2e/extensions/runtime_class_burst_test.go
+++ b/test/e2e/extensions/runtime_class_burst_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// benchWorkloadSec returns the workload sleep duration from SANDBOX_WORKLOAD_SEC (default 30).
 func benchWorkloadSec() int {
 	if v := os.Getenv("SANDBOX_WORKLOAD_SEC"); v != "" {
 		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
@@ -47,6 +48,7 @@ func benchWorkloadSec() int {
 	return 30
 }
 
+// workloadPodSpec returns a PodSpec with the given RuntimeClass and a sleep or pause container.
 func workloadPodSpec(rcPtr *string, workloadSec int) corev1.PodSpec {
 	container := corev1.Container{
 		Name:            "workload",
@@ -82,6 +84,7 @@ func benchLongevity() time.Duration {
 	return 0
 }
 
+// waitForNoPods polls until no pods remain in the namespace, including Terminating ones.
 func waitForNoPods(ctx context.Context, cl *framework.ClusterClient, namespace string) error {
 	for {
 		var podList corev1.PodList
@@ -106,7 +109,6 @@ func waitForNoPods(ctx context.Context, cl *framework.ClusterClient, namespace s
 	}
 }
 
-
 type claimRecord struct {
 	batch        int
 	claimIndex   int
@@ -117,6 +119,7 @@ type claimRecord struct {
 	breakdown    milestoneBreakdown
 }
 
+// emitBatchSummary writes an aggregated summary row (p50/p95, green/grey/cold counts) to the summary CSV.
 func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo int,
 	batchSize, startBatchSize int, testStart time.Time,
 	readySum float64, batchCount int) {
@@ -209,8 +212,9 @@ func emitBatchSummary(cw *csv.Writer, records []claimRecord, batchFrom, batchTo 
 // main loop begins.
 //
 // Each subtest fires claims in dynamically sized batches with 100ms delay
-// between batches, stopping when ReadyReplicas ≤ 1 and at least poolSize
-// claims have been issued, or after 2×poolSize total claims.
+// between batches, always continuing to 2×poolSize total claims. Pool
+// depletion (ReadyReplicas ≤ 1) is logged but does not stop the test —
+// claims past depletion exercise the cold fallback path.
 //
 // Set SANDBOX_LONGEVITY to a Go duration (e.g. "2h", "30m") to run in
 // longevity mode: batches fire continuously until the deadline with adaptive
@@ -320,9 +324,8 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 	require.NoError(t, tc0.Delete(t.Context(), calibClaim))
 	require.NoError(t, tc0.Delete(t.Context(), calibPool))
 	calibDrainCtx, calibDrainCancel := context.WithTimeout(t.Context(), fillTimeout)
-	if err := waitForNoPods(calibDrainCtx, tc0.ClusterClient, ns.Name); err != nil {
-		t.Logf("[calibration drain] WARNING: %v", err)
-	}
+	require.NoError(t, waitForNoPods(calibDrainCtx, tc0.ClusterClient, ns.Name),
+		"calibration drain must complete before burst iterations")
 	calibDrainCancel()
 
 	batchCap := benchBatchCap()
@@ -430,8 +433,15 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			defer cw.Flush()
 
 			_ = cw.Write([]string{"# cluster_id", cluster.Identity})
+			_ = cw.Write([]string{"# kubernetes_version", cluster.KubernetesVersion})
+			_ = cw.Write([]string{"# sandbox_version", cluster.SandboxVersion})
+			_ = cw.Write([]string{"# provider", cluster.Provider})
 			_ = cw.Write([]string{"# worker_count", strconv.Itoa(len(cluster.Workers))})
 			_ = cw.Write([]string{"# total_cpu_capacity", strconv.FormatInt(cpus, 10)})
+			_ = cw.Write([]string{"# total_ram_capacity_bytes", strconv.FormatInt(cluster.TotalRAMCapacity, 10)})
+			_ = cw.Write([]string{"# preexisting_pods", strconv.Itoa(cluster.PreexistingPods)})
+			_ = cw.Write([]string{"# allocated_cpu_millis", strconv.FormatInt(cluster.AllocatedCPUMillis, 10)})
+			_ = cw.Write([]string{"# allocated_ram_bytes", strconv.FormatInt(cluster.AllocatedRAM, 10)})
 			_ = cw.Write([]string{"# instance_type", instanceType})
 			_ = cw.Write([]string{"# runtime_class", runtimeClass})
 			_ = cw.Write([]string{"# pool_size", strconv.Itoa(poolSize)})
@@ -741,6 +751,17 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			_ = cw.Write([]string{"# time_to_all_ready_sec", fmt.Sprintf("%.3f", timeToAllReadySec)})
 			_ = cw.Write([]string{"# throughput_claims_per_sec", fmt.Sprintf("%.1f", float64(totalClaims)/totalDuration.Seconds())})
 
+			var podList corev1.PodList
+			if err := tc.List(t.Context(), &podList, client.InNamespace(ns.Name)); err == nil {
+				nodePods := make(map[string]int)
+				for i := range podList.Items {
+					nodePods[podList.Items[i].Spec.NodeName]++
+				}
+				for _, w := range cluster.Workers {
+					_ = cw.Write([]string{"# pods_on_node", w.Name, strconv.Itoa(nodePods[w.Name])})
+				}
+			}
+
 			if longevity == 0 || t.Failed() || os.Getenv("SANDBOX_DEBUG") != "" {
 				label := fmt.Sprintf("pool%d", poolSize)
 				if longevity > 0 {
@@ -755,9 +776,11 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 		// Claimed sandboxes are owned by claims (adoption transferred
 		// ownership), so delete claims explicitly too.
 		var claimList extensionsv1beta1.SandboxClaimList
-		if err := tc0.ClusterClient.List(t.Context(), &claimList, client.InNamespace(ns.Name)); err == nil {
-			for i := range claimList.Items {
-				_ = tc0.ClusterClient.Delete(t.Context(), &claimList.Items[i])
+		require.NoError(t, tc0.ClusterClient.List(t.Context(), &claimList, client.InNamespace(ns.Name)),
+			"listing claims for cleanup")
+		for i := range claimList.Items {
+			if err := tc0.ClusterClient.Delete(t.Context(), &claimList.Items[i]); client.IgnoreNotFound(err) != nil {
+				require.NoError(t, err, "deleting claim %s", claimList.Items[i].Name)
 			}
 		}
 		require.NoError(t, tc0.Delete(t.Context(), pool))
@@ -765,9 +788,8 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 		drainTimeout := time.Duration(poolSize)*10*time.Second + 30*time.Second
 		drainCtx, drainCancel := context.WithTimeout(t.Context(), drainTimeout)
 		t.Logf("[drain] waiting for pods in %s to terminate (timeout %s)", ns.Name, drainTimeout)
-		if err := waitForNoPods(drainCtx, tc0.ClusterClient, ns.Name); err != nil {
-			t.Logf("[drain] WARNING: %v", err)
-		}
+		require.NoError(t, waitForNoPods(drainCtx, tc0.ClusterClient, ns.Name),
+			"pod drain must complete before next pool iteration")
 		drainCancel()
 	}
 }

--- a/test/e2e/extensions/runtime_class_burst_test.go
+++ b/test/e2e/extensions/runtime_class_burst_test.go
@@ -752,14 +752,14 @@ func TestRuntimeClassBurstRecovery(t *testing.T) {
 			_ = cw.Write([]string{"# throughput_claims_per_sec", fmt.Sprintf("%.1f", float64(totalClaims)/totalDuration.Seconds())})
 
 			var podList corev1.PodList
-			if err := tc.List(t.Context(), &podList, client.InNamespace(ns.Name)); err == nil {
-				nodePods := make(map[string]int)
-				for i := range podList.Items {
-					nodePods[podList.Items[i].Spec.NodeName]++
-				}
-				for _, w := range cluster.Workers {
-					_ = cw.Write([]string{"# pods_on_node", w.Name, strconv.Itoa(nodePods[w.Name])})
-				}
+			require.NoError(t, tc.List(t.Context(), &podList, client.InNamespace(ns.Name)),
+				"listing pods for per-node distribution")
+			nodePods := make(map[string]int)
+			for i := range podList.Items {
+				nodePods[podList.Items[i].Spec.NodeName]++
+			}
+			for _, w := range cluster.Workers {
+				_ = cw.Write([]string{"# pods_on_node", w.Name, strconv.Itoa(nodePods[w.Name])})
 			}
 
 			if longevity == 0 || t.Failed() || os.Getenv("SANDBOX_DEBUG") != "" {

--- a/test/e2e/extensions/runtime_class_helpers_test.go
+++ b/test/e2e/extensions/runtime_class_helpers_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -133,7 +134,8 @@ func benchPoolSizes(cpuCapacity int64) ([]int, error) {
 		half := max(int(cpuCapacity/2), 1)
 		full := int(cpuCapacity)
 		double := full * 2
-		return []int{half, full, double}, nil
+		sizes := slices.Compact([]int{half, full, double})
+		return sizes, nil
 	}
 	return nil, fmt.Errorf("cluster reported 0 worker CPU capacity — cannot derive pool sizes")
 }


### PR DESCRIPTION
**Summary**

Two improvements to TestRuntimeClassBurstRecovery in test/e2e/extensions/:

**Fix: fresh pool per iteration, remove settle timer**

The burst benchmark reused a single **SandboxWarmPool** across all pool sizes, scaling it up and down between iterations. This left stale controller state (expectations tracker, **observedGeneration**) that degraded fill times 2–3× in sequential runs — making results from later pool sizes unreliable.

- Replace pool reuse with a fresh pool per iteration (burst-pool-<N>) so each subtest starts with clean controller state.
- Use a dedicated **calib-pool** for the warm baseline measurement, fully deleted and drained before the main loop.
- Remove **benchSettleDuration()** and **SANDBOX_SETTLE_SEC** — the magic settle timer was masking the stale-state bug. Drain is now deterministic: delete claims → delete pool → **waitForNoPods**.
- Between iterations: delete all claims and the pool, then **waitForNoPods** to ensure CPU capacity is fully restored before the next size (critical for kata, where VM termination takes 5–10s per pod).

Refactor: simplify latency zones to green/grey/cold

The old 4-bucket model (under1s, green ≤500ms, grey 500ms–1s, over-cold >poolFillTime) mixed latency thresholds with a pool-fill-relative band, making cross-runtime comparisons fragile (cold start varies from ~2s for runc to ~8s for kata).

Replace with 3 zones anchored on the controller's is_warm ground truth signal:

┌───────┬───────────────────────┬───────────────────────────────────────────────────┐
│ Zone  │       Criteria        │                      Meaning                      │
├───────┼───────────────────────┼───────────────────────────────────────────────────┤
│ Green │ is_warm=true and ≤ 1s │ Sub-second from warm pool — target SLA met        │
├───────┼───────────────────────┼───────────────────────────────────────────────────┤
│ Grey  │ is_warm=true and > 1s │ Warm-served but slow — scheduling or adoption lag │
├───────┼───────────────────────┼───────────────────────────────────────────────────┤
│ Cold  │ is_warm=false         │ Pool failed to serve — cold fallback path         │
└───────┴───────────────────────┴───────────────────────────────────────────────────┘

is_warm is unambiguous regardless of runtime: true when the sandbox pod pre-existed the claim, false when the controller created one on demand.

**Also:**
- Log [plan] and [start] lines for iteration visibility.
- Continue firing claims past pool depletion (up to 2 × poolSize) to capture the warm-to-cold transition; depletion is logged but no longer stops the run.
- Update **README** to match (fresh pool lifecycle, corrected CSV examples, removed done roadmap item).


#### Release Note
NONE



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated burst-recovery testing across multiple pool sizes with fresh pools for each iteration.
  * Improved calibration, cleanup, and error handling between test runs.
  * Tests now complete the full claim workload while reporting pool depletion.
  * Results classify claim performance as Green, Grey, or Cold using warm-status signals and a one-second threshold.
  * Updated CSV output and logging with revised measurements and environment details.
  * Removed duplicate pool-size entries and refined supported pool-size ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->