### PR TITLE
fix(dev/tools): append missing image blocks in tag-promote-images

### DIFF
--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -136,6 +136,22 @@ def get_latest_digest(image_name, tag):
     return None
 
 
+def parse_image_name(line):
+    """Extracts the image name from a line starting with '- name:'.
+
+    Handles inline comments (e.g. '# ...') and optional quotes.
+    Returns None if the line does not define an image name.
+    """
+    stripped = line.strip()
+    if not stripped.startswith("- name:"):
+        return None
+    rest = stripped[len("- name:"):].strip()
+    if not rest:
+        return None
+    token = rest.split()[0]
+    return token.strip("'\"")
+
+
 def update_images_yaml(yaml_path, tag, collected_digests):
     """Updates images.yaml with new digests for promoted images."""
     if not os.path.exists(yaml_path):
@@ -152,28 +168,37 @@ def update_images_yaml(yaml_path, tag, collected_digests):
     inserted_digests = set()
     all_target_images = set(IMAGES_TO_PROMOTE) | set(collected_digests.keys())
 
-    # Determine base indentation of `- name:` entries if present
+    # Determine base indentation of list items
     base_indent = ""
-    for line in lines:
-        if "- name:" in line:
-            base_indent = line[:line.find("- name:")]
-            break
+    has_list_items = any(parse_image_name(line) is not None for line in lines)
+    if not has_list_items:
+        for i, line in enumerate(lines):
+            clean = line.strip().split("#")[0].strip()
+            if clean in ("images: []", "images:[]") or (clean.startswith("images:") and "[]" in clean):
+                indent = line[:line.find("images:")]
+                lines[i] = f"{indent}images:\n"
+                base_indent = indent + "  "
+                break
+            elif clean == "images:":
+                indent = line[:line.find("images:")]
+                base_indent = indent + "  "
+                break
     else:
         for line in lines:
-            if line.strip() == "images:" or line.strip().startswith("images:"):
-                base_indent = line[:line.find("images:")] + "  "
+            if parse_image_name(line) is not None:
+                base_indent = line[:line.find("- name:")]
                 break
 
     # Iterate and inject digests
     for line in lines:
         # Detect which image block we are inside
-        if "- name:" in line:
-            active_image_block = None
-            for img in all_target_images:
-                if f"- name: {img}" in line:
-                    active_image_block = img
-                    existing_images.add(img)
-                    break
+        img_name = parse_image_name(line)
+        if img_name is not None:
+            if img_name in all_target_images:
+                active_image_block = img_name
+                existing_images.add(img_name)
+            else:
+                active_image_block = None
 
         # If inside an active image block, skip old entries matching this tag to avoid duplicates
         if active_image_block and (f'"{tag}"' in line or f"'{tag}'" in line):

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -150,6 +150,13 @@ def update_images_yaml(yaml_path, tag, collected_digests):
     active_image_block = None
     inserted_digests = set()
 
+    # Determine base indentation of `- name:` entries if present
+    base_indent = ""
+    for line in lines:
+        if "- name:" in line:
+            base_indent = line[:line.find("- name:")]
+            break
+
     # Iterate and inject digests
     for line in lines:
         # Detect which image block we are inside
@@ -177,6 +184,29 @@ def update_images_yaml(yaml_path, tag, collected_digests):
                 new_lines.append(new_entry)
                 inserted_digests.add(active_image_block)
                 print(f"   Updated {active_image_block}")
+
+    # Append new image blocks for images not previously in images.yaml
+    remaining = [img for img in IMAGES_TO_PROMOTE if img in collected_digests and img not in inserted_digests]
+    for img in collected_digests:
+        if img not in remaining and img not in inserted_digests:
+            remaining.append(img)
+
+    for img in remaining:
+        digest = collected_digests.get(img)
+        if not digest:
+            continue
+        if new_lines and not new_lines[-1].endswith("\n"):
+            new_lines[-1] += "\n"
+        new_lines.append(f"{base_indent}- name: {img}\n")
+        new_lines.append(f"{base_indent}  dmap:\n")
+        new_lines.append(f'{base_indent}    "{digest}": ["{tag}"]\n')
+        inserted_digests.add(img)
+        print(f"   Added new image block for {img}")
+
+    missing = set(collected_digests.keys()) - inserted_digests
+    if missing:
+        print(f"❌ Failed to insert digests for: {', '.join(sorted(missing))}")
+        sys.exit(1)
 
     with open(yaml_path, "w") as f:
         f.writelines(new_lines)

--- a/dev/tools/tag-promote-images
+++ b/dev/tools/tag-promote-images
@@ -148,7 +148,9 @@ def update_images_yaml(yaml_path, tag, collected_digests):
 
     new_lines = []
     active_image_block = None
+    existing_images = set()
     inserted_digests = set()
+    all_target_images = set(IMAGES_TO_PROMOTE) | set(collected_digests.keys())
 
     # Determine base indentation of `- name:` entries if present
     base_indent = ""
@@ -156,17 +158,22 @@ def update_images_yaml(yaml_path, tag, collected_digests):
         if "- name:" in line:
             base_indent = line[:line.find("- name:")]
             break
+    else:
+        for line in lines:
+            if line.strip() == "images:" or line.strip().startswith("images:"):
+                base_indent = line[:line.find("images:")] + "  "
+                break
 
     # Iterate and inject digests
     for line in lines:
         # Detect which image block we are inside
         if "- name:" in line:
-            for img in IMAGES_TO_PROMOTE:
+            active_image_block = None
+            for img in all_target_images:
                 if f"- name: {img}" in line:
                     active_image_block = img
+                    existing_images.add(img)
                     break
-            else:
-                active_image_block = None
 
         # If inside an active image block, skip old entries matching this tag to avoid duplicates
         if active_image_block and (f'"{tag}"' in line or f"'{tag}'" in line):
@@ -185,13 +192,13 @@ def update_images_yaml(yaml_path, tag, collected_digests):
                 inserted_digests.add(active_image_block)
                 print(f"   Updated {active_image_block}")
 
-    # Append new image blocks for images not previously in images.yaml
-    remaining = [img for img in IMAGES_TO_PROMOTE if img in collected_digests and img not in inserted_digests]
+    # Append new image blocks only for images truly absent from images.yaml
+    images_to_append = [img for img in IMAGES_TO_PROMOTE if img in collected_digests and img not in existing_images]
     for img in collected_digests:
-        if img not in remaining and img not in inserted_digests:
-            remaining.append(img)
+        if img not in images_to_append and img not in existing_images:
+            images_to_append.append(img)
 
-    for img in remaining:
+    for img in images_to_append:
         digest = collected_digests.get(img)
         if not digest:
             continue

--- a/dev/tools/tag_promote_images_test.py
+++ b/dev/tools/tag_promote_images_test.py
@@ -233,6 +233,83 @@ class UpdateImagesYamlTest(unittest.TestCase):
             content = f.read()
         self.assertEqual(content.count("- name: sandbox-router-go"), 1)
 
+    def test_update_images_yaml_appends_to_flow_style_empty_images_manifest(self):
+        sample_yaml = """images: []\n"""
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "sandbox-router-go": "sha256:new4",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        parsed = yaml.safe_load(content)
+        self.assertEqual(
+            parsed,
+            {
+                "images": [
+                    {
+                        "name": "sandbox-router-go",
+                        "dmap": {
+                            "sha256:new4": ["v1.0.0"],
+                        },
+                    }
+                ]
+            },
+        )
+
+    def test_update_images_yaml_exact_name_matching_prevents_prefix_collision(self):
+        sample_yaml = """- name: sandbox-router-go
+  dmap:
+    "sha256:old_go": ["v0.1.0"]
+- name: sandbox-router
+  dmap:
+    "sha256:old_router": ["v0.1.0"]
+"""
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "sandbox-router": "sha256:new_router",
+            "sandbox-router-go": "sha256:new_go",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        parsed = yaml.safe_load(content)
+        self.assertEqual(
+            parsed,
+            [
+                {
+                    "name": "sandbox-router-go",
+                    "dmap": {
+                        "sha256:new_go": ["v1.0.0"],
+                        "sha256:old_go": ["v0.1.0"],
+                    },
+                },
+                {
+                    "name": "sandbox-router",
+                    "dmap": {
+                        "sha256:new_router": ["v1.0.0"],
+                        "sha256:old_router": ["v0.1.0"],
+                    },
+                },
+            ],
+        )
+
+    def test_parse_image_name(self):
+        self.assertEqual(tag_promote.parse_image_name("- name: my-image"), "my-image")
+        self.assertEqual(tag_promote.parse_image_name("  - name: my-image"), "my-image")
+        self.assertEqual(tag_promote.parse_image_name("- name: 'my-image'"), "my-image")
+        self.assertEqual(tag_promote.parse_image_name('- name: "my-image"'), "my-image")
+        self.assertEqual(tag_promote.parse_image_name("- name: my-image # comment"), "my-image")
+        self.assertIsNone(tag_promote.parse_image_name("- name:"))
+        self.assertIsNone(tag_promote.parse_image_name("# - name: commented"))
+        self.assertIsNone(tag_promote.parse_image_name("images: []"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dev/tools/tag_promote_images_test.py
+++ b/dev/tools/tag_promote_images_test.py
@@ -21,6 +21,7 @@ import tempfile
 import textwrap
 import unittest
 from importlib.machinery import SourceFileLoader
+import yaml
 
 _TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _TOOLS_DIR)
@@ -185,6 +186,52 @@ class UpdateImagesYamlTest(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
         self.assertEqual(cm.exception.code, 1)
+
+    def test_update_images_yaml_appends_to_empty_wrapped_images_manifest(self):
+        sample_yaml = """images:\n"""
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "sandbox-router-go": "sha256:new4",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        self.assertIn("images:\n  - name: sandbox-router-go\n    dmap:\n      \"sha256:new4\": [\"v1.0.0\"]", content)
+        parsed = yaml.safe_load(content)
+        self.assertEqual(
+            parsed,
+            {
+                "images": [
+                    {
+                        "name": "sandbox-router-go",
+                        "dmap": {
+                            "sha256:new4": ["v1.0.0"],
+                        },
+                    }
+                ]
+            },
+        )
+
+    def test_update_images_yaml_fails_when_existing_block_missing_dmap(self):
+        sample_yaml = """- name: sandbox-router-go
+  some_other_field: val
+"""
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "sandbox-router-go": "sha256:new4",
+        }
+
+        with self.assertRaises(SystemExit) as cm:
+            tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+        self.assertEqual(cm.exception.code, 1)
+
+        # Ensure duplicate block was not appended
+        with open(yaml_path, "r") as f:
+            content = f.read()
+        self.assertEqual(content.count("- name: sandbox-router-go"), 1)
 
 
 if __name__ == "__main__":

--- a/dev/tools/tag_promote_images_test.py
+++ b/dev/tools/tag_promote_images_test.py
@@ -118,6 +118,75 @@ class UpdateImagesYamlTest(unittest.TestCase):
         self.assertIn('"sha256:new_v2": ["v0.2.0"]', content)
         self.assertNotIn('"sha256:old_v2": ["v0.2.0"]', content)
 
+    def test_update_images_yaml_appends_missing_image_block(self):
+        sample_yaml = """
+        images:
+          - name: agent-sandbox-controller
+            dmap:
+              "sha256:old1": ["v0.1.0"]
+          - name: chrome-sandbox
+            dmap:
+              "sha256:old2": ["v0.1.0"]
+          - name: python-runtime-sandbox
+            dmap:
+              "sha256:old3": ["v0.1.0"]
+        """
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "agent-sandbox-controller": "sha256:new1",
+            "chrome-sandbox": "sha256:new2",
+            "python-runtime-sandbox": "sha256:new3",
+            "sandbox-router-go": "sha256:new4",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        self.assertIn('"sha256:new1": ["v1.0.0"]', content)
+        self.assertIn('"sha256:new2": ["v1.0.0"]', content)
+        self.assertIn('"sha256:new3": ["v1.0.0"]', content)
+        self.assertIn("- name: sandbox-router-go", content)
+        self.assertIn('"sha256:new4": ["v1.0.0"]', content)
+
+    def test_update_images_yaml_appends_missing_image_block_top_level(self):
+        sample_yaml = """- name: agent-sandbox-controller
+  dmap:
+    "sha256:old1": ["v0.1.0"]
+- name: chrome-sandbox
+  dmap:
+    "sha256:old2": ["v0.1.0"]
+"""
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "agent-sandbox-controller": "sha256:new1",
+            "chrome-sandbox": "sha256:new2",
+            "sandbox-router-go": "sha256:new4",
+        }
+
+        tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+
+        with open(yaml_path, "r") as f:
+            content = f.read()
+
+        self.assertIn("- name: sandbox-router-go\n  dmap:\n    \"sha256:new4\": [\"v1.0.0\"]", content)
+
+    def test_update_images_yaml_fails_when_digest_is_none(self):
+        sample_yaml = """- name: agent-sandbox-controller
+  dmap:
+    "sha256:old1": ["v0.1.0"]
+"""
+        yaml_path = self._write_temp_yaml(sample_yaml)
+        collected_digests = {
+            "agent-sandbox-controller": None,
+        }
+
+        with self.assertRaises(SystemExit) as cm:
+            tag_promote.update_images_yaml(yaml_path, "v1.0.0", collected_digests)
+        self.assertEqual(cm.exception.code, 1)
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
#### What this PR does / why we need it:
When promoting new images that do not yet exist in `images.yaml` (such as `sandbox-router-go` during the v1.0.0 release), `update_images_yaml()` previously scanned only existing `- name:` blocks and silently skipped images missing from the YAML.

This change:
- Appends new `- name: <image>` blocks with `dmap:` entries when an image in `collected_digests` does not yet exist in the target YAML.
- Asserts all collected digests are inserted, exiting with code 1 if any image digest fails to insert.
- Adds unit tests in `dev/tools/tag_promote_images_test.py` covering appending new blocks to indented and top-level YAMLs as well as validation on failure.

#### Which issue(s) this PR is related to:
Ref #1058
Ref https://github.com/kubernetes/k8s.io/pull/9882

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image promotion now appends missing image entries while preserving existing formatting.
  * Prevented duplicate entries and prefix-based image name collisions.
  * Added support for empty manifests and top-level image list formats.
  * Added validation for missing or invalid digests and incomplete existing entries.
* **Tests**
  * Expanded coverage for image insertion, formatting variations, duplicate prevention, and validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->