### PR TITLE
feat: add OpenHands agent-SDK workspace integration (AgentSandboxWorkspace)

### DIFF
--- a/clients/integrations/README.md
+++ b/clients/integrations/README.md
@@ -9,6 +9,7 @@ This directory contains specialized adapters and integration packages that bridg
 | [**`deepagents/`**](./deepagents) | `deepagents-k8s-agent-sandbox` | [LangChain DeepAgents](https://github.com/langchain-ai/deepagents) | Plugs into LangChain agent graphs as a secure, sandboxed execution backend (`K8sAgentSandbox`). |
 | [**`mcp-server/`**](./mcp-server) | `k8s-agent-sandbox-mcp-server` | [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) | Exposes Sandbox provisioning and execution tools over MCP for Antigravity, Claude Desktop, Cursor, and other MCP hosts. |
 | [**`nemo-gym/`**](./nemo-gym) | `nemo-gym-k8s-agent-sandbox` | [NVIDIA NeMo Gym](https://github.com/NVIDIA-NeMo/Gym) | Registers Agent Sandbox warm pools as the `agent_sandbox` sandbox provider for NeMo Gym RL training environments. |
+| [**`openhands/`**](./openhands) | `openhands-k8s-agent-sandbox` | [OpenHands agent SDK](https://github.com/OpenHands/software-agent-sdk) | `AgentSandboxWorkspace`: runs OpenHands conversations on pre-warmed Agent Sandbox pods instead of cold-started Docker containers. |
 
 ## Adding a New Integration
 

--- a/clients/integrations/openhands/README.md
+++ b/clients/integrations/openhands/README.md
@@ -140,12 +140,39 @@ python example.py
 | `api_key` | `None` | sent as `X-Session-API-Key`; must equal the pool's session key |
 | `working_dir` | `/workspace` | agent/tool cwd inside the pod |
 | `server_port` | `8000` | agent-server port inside the pod |
-| `endpoint_template` | `None` | URL template for gateway/proxied data paths; supports `{pod_ip}`, `{port}`, `{namespace}`, `{claim_name}`, `{sandbox_id}` |
+| `endpoint_template` | `None` | URL template for gateway/proxied data paths; supports `{pod_ip}`, `{port}`, `{namespace}`, `{claim_name}`, `{sandbox_id}`; mutually exclusive with `router_url` |
+| `router_url` | `None` | base URL of a [sandbox-router](../../python/agentic-sandbox-client/sandbox-router) deployment; all traffic (health check included) goes to the router with `X-Sandbox-*` routing headers injected |
+| `router_auth_token` | `None` | Bearer token for the router (`ROUTER_AUTH_TOKEN`); stripped by the router before forwarding, so it composes with `api_key` |
 | `claim_timeout_s` | `60` | wait for the claim to bind a Ready sandbox |
 | `health_check_timeout` | `10.0` | wait for `/health`; deliberately short — a warm pod that isn't healthy is broken, fail fast and re-claim |
 | `ttl_s` | `None` | claim TTL (`spec.lifecycle` shutdownTime) — the controller deletes the claim on expiry even if this process died |
 | `claim_labels` | `None` | labels on the `SandboxClaim` object |
 | `sandbox_client` | `None` | inject a configured `k8s_agent_sandbox.SandboxClient`; built with defaults when omitted |
+
+## Routing through sandbox-router
+
+When pod IPs aren't routable from the client (off-VPC clients, laptop dev), route
+through the client SDK's [sandbox-router](../../python/agentic-sandbox-client/sandbox-router)
+instead of raw pod IPs:
+
+```python
+AgentSandboxWorkspace(
+    warmpool="agent-server-pool",
+    router_url="http://sandbox-router.default.svc:8080",   # or its LB/Gateway address
+    router_auth_token="<ROUTER_AUTH_TOKEN>",
+    api_key="<pool session key>",
+)
+```
+
+The workspace sends `X-Sandbox-ID`/`-Namespace`/`-Port`/`-Pod-IP` routing headers on
+every request (health check included); paths pass through the router verbatim, so
+the agent-server protocol is unchanged. Two auth layers compose: the Bearer token
+authenticates to the router, which strips `Authorization` before forwarding, while
+`X-Session-API-Key` passes through to the agent-server. The router's proxy timeout
+(default 180 s) is compatible with the SDK's start-then-poll command pattern — no
+long-lived requests. Laptop tip: the router is a regular runc Deployment, so
+`kubectl port-forward svc/sandbox-router` works even when the sandboxes themselves
+are gVisor pods (where direct pod port-forward does not — see Troubleshooting).
 
 ## Auth model
 

--- a/clients/integrations/openhands/README.md
+++ b/clients/integrations/openhands/README.md
@@ -182,6 +182,7 @@ up). Leaving key and `api_key` unset is acceptable only on a private, trusted ne
 | claim times out | pool empty or still filling — check `kubectl get sandboxwarmpool`; raise `replicas` or `claim_timeout_s` |
 | health check fails instantly | probe path/port mismatch in the template, or the pod isn't the agent-server image — a Ready pod must mean a serving `/health:8000` |
 | `no pod IP` / connect timeouts | client can't route to pod IPs — use `endpoint_template` through a gateway, or run the client inside the VPC |
+| `kubectl port-forward` refused while the pod is Ready | expected with gVisor: the forwarder dials loopback in the host-side netns, which isn't connected to runsc's netstack. Pod-IP traffic is unaffected; for laptop dev use a runc template variant or an in-VPC runner |
 | HTTP 401 from the server | `api_key` doesn't match the pool's `OH_SESSION_API_KEYS_0` Secret value |
 | odd protocol errors | SDK ↔ server version skew — compare `workspace.get_server_info()` with your installed `openhands-sdk` version and realign the template image tag |
 

--- a/clients/integrations/openhands/README.md
+++ b/clients/integrations/openhands/README.md
@@ -1,0 +1,71 @@
+# OpenHands × agent-sandbox: `AgentSandboxWorkspace`
+
+A workspace backend for the [OpenHands agent SDK](https://github.com/OpenHands/software-agent-sdk)
+that runs conversations on **pre-warmed agent-sandbox pods** instead of
+cold-starting a Docker container per session.
+
+OpenHands' `DockerWorkspace` pays image pull + container start + agent-server
+boot on every workspace. `AgentSandboxWorkspace` replaces that with a
+**warm-pool claim — a bind, not a boot**: the pod is already Running, the
+agent-server already healthy (the template's readinessProbe guarantees it).
+Everything after provisioning is inherited from the SDK's `RemoteWorkspace`,
+which speaks HTTP to the agent-server: bash, file transfer, git operations —
+this package adds no execution plumbing of its own. You also get agent-sandbox's
+isolation posture (gVisor runtime class, network policy, per-pod resource
+limits) for the model-driven code the agent executes.
+
+## Quickstart
+
+1. Install the controller + extensions ([releases](https://github.com/kubernetes-sigs/agent-sandbox/releases)),
+   then create the template and pool (edit the image tag to match your
+   `openhands-sdk` version — they are released together):
+
+```bash
+kubectl create secret generic openhands-session-key --from-literal=key="$(openssl rand -hex 24)"
+kubectl apply -f configs/agent-server-template.yaml
+kubectl apply -f configs/agent-server-warmpool.yaml
+```
+
+2. Install and use:
+
+```bash
+pip install openhands-k8s-agent-sandbox
+```
+
+```python
+from openhands_k8s_agent_sandbox import AgentSandboxWorkspace
+
+with AgentSandboxWorkspace(
+    warmpool="agent-server-pool",
+    namespace="default",
+    api_key="<value of the openhands-session-key secret>",
+    ttl_s=3600,                       # controller-side backstop cleanup
+) as workspace:
+    result = workspace.execute_command("echo hello from a warm pod")
+    print(result.stdout)
+```
+
+The workspace works anywhere OpenHands accepts a workspace object —
+`Conversation(agent=..., workspace=workspace)` runs the whole agent loop
+against the warm pod.
+
+## How it maps onto `DockerWorkspace`
+
+| `DockerWorkspace` | `AgentSandboxWorkspace` |
+|---|---|
+| `docker run` agent-server image, port-map | claim from `SandboxWarmPool` (pod already Running) |
+| wait up to 120 s for `/health` | 10 s budget — Ready pods are healthy by construction; fail fast and re-claim |
+| `host = http://127.0.0.1:{port}` | `host = http://{pod_ip}:8000` (VPC-routable), or `endpoint_template` for gateway/proxied paths |
+| `docker stop` on exit | delete the claim (pool replenishes); `ttl_s` backstops dead clients |
+
+## Notes
+
+- **Auth is pool-level.** Pre-warmed servers cannot take a per-claim key, so all
+  pods in a pool share `OH_SESSION_API_KEYS_0` from one Secret; pass the same
+  value as `api_key`. Scope pools/namespaces accordingly.
+- **Version skew.** The SDK pins its agent-server image per release; keep the
+  template image tag aligned with your installed `openhands-sdk`
+  (`workspace.get_server_info()` shows the server's version).
+- **Pods are single-conversation.** Claims are deleted on close, not reused —
+  reuse across conversations needs a reset story (see the sandbox-recycling
+  design notes before attempting it).

--- a/clients/integrations/openhands/README.md
+++ b/clients/integrations/openhands/README.md
@@ -44,7 +44,9 @@ policy, per-pod resource limits) for the model-driven code the agent executes.
 1. **Session key** (pool-level auth — see [Auth model](#auth-model)):
 
    ```bash
-   kubectl create secret generic openhands-session-key \
+   # -n must match the namespace the template/pool manifests use (default);
+   # the pods read the secret from their own namespace.
+   kubectl create secret generic openhands-session-key -n default \
      --from-literal=key="$(openssl rand -hex 24)"
    ```
 

--- a/clients/integrations/openhands/README.md
+++ b/clients/integrations/openhands/README.md
@@ -1,36 +1,91 @@
-# OpenHands × agent-sandbox: `AgentSandboxWorkspace`
+# OpenHands × Agent Sandbox: `AgentSandboxWorkspace`
 
 A workspace backend for the [OpenHands agent SDK](https://github.com/OpenHands/software-agent-sdk)
-that runs conversations on **pre-warmed agent-sandbox pods** instead of
-cold-starting a Docker container per session.
+that runs conversations on **pre-warmed Agent Sandbox pods** instead of cold-starting
+a Docker container per session.
 
-OpenHands' `DockerWorkspace` pays image pull + container start + agent-server
-boot on every workspace. `AgentSandboxWorkspace` replaces that with a
-**warm-pool claim — a bind, not a boot**: the pod is already Running, the
-agent-server already healthy (the template's readinessProbe guarantees it).
-Everything after provisioning is inherited from the SDK's `RemoteWorkspace`,
-which speaks HTTP to the agent-server: bash, file transfer, git operations —
-this package adds no execution plumbing of its own. You also get agent-sandbox's
-isolation posture (gVisor runtime class, network policy, per-pod resource
-limits) for the model-driven code the agent executes.
+OpenHands' `DockerWorkspace` pays image pull + container start + agent-server boot on
+every workspace. `AgentSandboxWorkspace` replaces that with a **warm-pool claim — a
+bind, not a boot**: the pod is already Running and the agent-server already healthy
+(the template's readinessProbe guarantees it). Everything after provisioning is
+inherited from the SDK's `RemoteWorkspace`, which speaks HTTP to the agent-server —
+bash, file transfer, git operations; this package adds no execution plumbing of its
+own. You also get Agent Sandbox's isolation posture (gVisor runtime class, network
+policy, per-pod resource limits) for the model-driven code the agent executes.
 
-## Quickstart
+| `DockerWorkspace` | `AgentSandboxWorkspace` |
+|---|---|
+| `docker run` agent-server image, port-map | claim from a `SandboxWarmPool` (pod already Running) |
+| wait up to 120 s for `/health` | 10 s budget — Ready pods are healthy by construction; fail fast and re-claim |
+| `host = http://127.0.0.1:{port}` | `host = http://{pod_ip}:8000`, or `endpoint_template` for gateway/proxied paths |
+| `docker stop` on exit | delete the claim (pool replenishes); `ttl_s` backstops dead clients |
 
-1. Install the controller + extensions ([releases](https://github.com/kubernetes-sigs/agent-sandbox/releases)),
-   then create the template and pool (edit the image tag to match your
-   `openhands-sdk` version — they are released together):
+## Prerequisites
 
-```bash
-kubectl create secret generic openhands-session-key --from-literal=key="$(openssl rand -hex 24)"
-kubectl apply -f configs/agent-server-template.yaml
-kubectl apply -f configs/agent-server-warmpool.yaml
-```
+- **A Kubernetes cluster** with the Agent Sandbox controller **and extensions**
+  installed (`Sandbox`, `SandboxClaim`, `SandboxTemplate`, `SandboxWarmPool` CRDs):
 
-2. Install and use:
+  ```bash
+  VERSION=v1.0.0   # pin to a release
+  kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox-with-extensions.yaml
+  ```
+
+- **`kubectl` + a kube context** — the client reads your kubeconfig.
+- **Network reachability from the client to the pods.** The default endpoint is the
+  pod IP on port 8000. On GKE, pod IPs are VPC-routable, so anything in the VPC
+  (GCE VMs, other clusters) works out of the box; from outside the VPC use
+  `endpoint_template` to route through a gateway/proxy instead.
+- **Python ≥ 3.12** (the `openhands-sdk` floor).
+- *(Recommended)* a **gVisor node pool** and the `gvisor` RuntimeClass — agents run
+  model-generated code; see the repo's gVisor quickstart.
+
+## Deploy
+
+1. **Session key** (pool-level auth — see [Auth model](#auth-model)):
+
+   ```bash
+   kubectl create secret generic openhands-session-key \
+     --from-literal=key="$(openssl rand -hex 24)"
+   ```
+
+2. **SandboxTemplate** — defines what an agent-server pod is. Edit the image tag in
+   [`configs/agent-server-template.yaml`](./configs/agent-server-template.yaml) to
+   match your installed `openhands-sdk` version (SDK and agent-server image are
+   released together), then:
+
+   ```bash
+   kubectl apply -f configs/agent-server-template.yaml
+   ```
+
+   The template's readinessProbe on `/health:8000` is **load-bearing**: it is what
+   makes a Ready pod equal a healthy agent-server, which is what lets the client use
+   a short health budget.
+
+3. **SandboxWarmPool** — how many pods sit Ready. `replicas` should be at least your
+   peak *concurrent* conversations:
+
+   ```bash
+   kubectl apply -f configs/agent-server-warmpool.yaml
+   ```
+
+4. **Verify** the pool is filled:
+
+   ```bash
+   kubectl get sandboxwarmpool agent-server-pool
+   kubectl get pods -l 'agents.x-k8s.io/sandbox-template=openhands-agent-server'
+   ```
+
+## Install
 
 ```bash
 pip install openhands-k8s-agent-sandbox
+# for the agent half of the example (tool presets):
+pip install openhands-tools
 ```
+
+## Quickstart
+
+Workspace operations only (no LLM needed):
 
 ```python
 from openhands_k8s_agent_sandbox import AgentSandboxWorkspace
@@ -39,33 +94,100 @@ with AgentSandboxWorkspace(
     warmpool="agent-server-pool",
     namespace="default",
     api_key="<value of the openhands-session-key secret>",
-    ttl_s=3600,                       # controller-side backstop cleanup
+    ttl_s=3600,
 ) as workspace:
-    result = workspace.execute_command("echo hello from a warm pod")
+    print(workspace.get_server_info())          # server version — check skew
+    result = workspace.execute_command("echo hello from a warm pod && uname -a")
     print(result.stdout)
 ```
 
-The workspace works anywhere OpenHands accepts a workspace object —
-`Conversation(agent=..., workspace=workspace)` runs the whole agent loop
-against the warm pod.
+A full agent conversation — the standard SDK pattern with exactly one class swapped
+relative to the SDK's own `DockerWorkspace` examples:
 
-## How it maps onto `DockerWorkspace`
+```python
+import os
+from pydantic import SecretStr
+from openhands.sdk import LLM, Conversation
+from openhands.tools.preset.default import get_default_agent
+from openhands_k8s_agent_sandbox import AgentSandboxWorkspace
 
-| `DockerWorkspace` | `AgentSandboxWorkspace` |
+llm = LLM(usage_id="agent", model=os.environ["LLM_MODEL"],
+          api_key=SecretStr(os.environ["LLM_API_KEY"]))
+
+with AgentSandboxWorkspace(warmpool="agent-server-pool",
+                           api_key=os.environ["SANDBOX_SESSION_KEY"]) as workspace:
+    agent = get_default_agent(llm=llm, cli_mode=True)
+    conversation = Conversation(agent=agent, workspace=workspace)
+    conversation.send_message("Write 3 facts about this environment into FACTS.txt")
+    conversation.run()
+    conversation.close()
+```
+
+Or run the ready-made [`example.py`](./example.py):
+
+```bash
+export SANDBOX_WARMPOOL=agent-server-pool SANDBOX_SESSION_KEY=<secret value>
+export LLM_API_KEY=... LLM_MODEL=...        # optional: enables the agent phase
+python example.py
+```
+
+## Configuration reference
+
+| field | default | meaning |
+|---|---|---|
+| `warmpool` | *(required)* | `SandboxWarmPool` to claim from |
+| `namespace` | `default` | namespace of the pool |
+| `api_key` | `None` | sent as `X-Session-API-Key`; must equal the pool's session key |
+| `working_dir` | `/workspace` | agent/tool cwd inside the pod |
+| `server_port` | `8000` | agent-server port inside the pod |
+| `endpoint_template` | `None` | URL template for gateway/proxied data paths; supports `{pod_ip}`, `{port}`, `{namespace}`, `{claim_name}`, `{sandbox_id}` |
+| `claim_timeout_s` | `60` | wait for the claim to bind a Ready sandbox |
+| `health_check_timeout` | `10.0` | wait for `/health`; deliberately short — a warm pod that isn't healthy is broken, fail fast and re-claim |
+| `ttl_s` | `None` | claim TTL (`spec.lifecycle` shutdownTime) — the controller deletes the claim on expiry even if this process died |
+| `claim_labels` | `None` | labels on the `SandboxClaim` object |
+| `sandbox_client` | `None` | inject a configured `k8s_agent_sandbox.SandboxClient`; built with defaults when omitted |
+
+## Auth model
+
+Pre-warmed servers cannot receive a per-claim key, so **all pods in a pool share**
+the session key the template injects (`OH_SESSION_API_KEYS_0` from one Secret); pass
+the same value as `api_key`. Scope pools and namespaces accordingly, and treat key
+rotation as a pool rollout (update the Secret, then recreate the pool so pods pick it
+up). Leaving key and `api_key` unset is acceptable only on a private, trusted network.
+
+## Lifecycle semantics
+
+- A claim **binds** an existing warm pod; nothing boots on the critical path.
+- `close()` / context-manager exit / GC **deletes the claim**; the pool replenishes
+  in the background. Pods are **single-conversation** — reuse across conversations
+  needs a reset story (see the sandbox-recycling design notes before attempting it).
+- Set `ttl_s` in anything long-running: it is the server-side backstop that reaps
+  claims from clients that died without cleanup.
+
+## Sizing and scale
+
+- Pool `replicas` ≈ peak concurrent conversations, plus slack for replenish lag.
+- For large pools (hundreds+), raise the controller's worker counts
+  (`--sandbox-concurrent-workers`, `--sandbox-claim-concurrent-workers`,
+  `--sandbox-warm-pool-concurrent-workers`) — see `docs/configuration.md`.
+- **Per-task images at high cardinality** (e.g. SWE-bench-style pools per repo
+  image) and rolling warm windows are the territory of
+  [`examples/agent-sandbox-rl`](../../../examples/agent-sandbox-rl) — use its fleet
+  as the off-cluster pre-warmer and claim here by per-image pool name.
+
+## Troubleshooting
+
+| symptom | likely cause / fix |
 |---|---|
-| `docker run` agent-server image, port-map | claim from `SandboxWarmPool` (pod already Running) |
-| wait up to 120 s for `/health` | 10 s budget — Ready pods are healthy by construction; fail fast and re-claim |
-| `host = http://127.0.0.1:{port}` | `host = http://{pod_ip}:8000` (VPC-routable), or `endpoint_template` for gateway/proxied paths |
-| `docker stop` on exit | delete the claim (pool replenishes); `ttl_s` backstops dead clients |
+| claim times out | pool empty or still filling — check `kubectl get sandboxwarmpool`; raise `replicas` or `claim_timeout_s` |
+| health check fails instantly | probe path/port mismatch in the template, or the pod isn't the agent-server image — a Ready pod must mean a serving `/health:8000` |
+| `no pod IP` / connect timeouts | client can't route to pod IPs — use `endpoint_template` through a gateway, or run the client inside the VPC |
+| HTTP 401 from the server | `api_key` doesn't match the pool's `OH_SESSION_API_KEYS_0` Secret value |
+| odd protocol errors | SDK ↔ server version skew — compare `workspace.get_server_info()` with your installed `openhands-sdk` version and realign the template image tag |
 
-## Notes
+## Development
 
-- **Auth is pool-level.** Pre-warmed servers cannot take a per-claim key, so all
-  pods in a pool share `OH_SESSION_API_KEYS_0` from one Secret; pass the same
-  value as `api_key`. Scope pools/namespaces accordingly.
-- **Version skew.** The SDK pins its agent-server image per release; keep the
-  template image tag aligned with your installed `openhands-sdk`
-  (`workspace.get_server_info()` shows the server's version).
-- **Pods are single-conversation.** Claims are deleted on close, not reused —
-  reuse across conversations needs a reset story (see the sandbox-recycling
-  design notes before attempting it).
+```bash
+pip install -e ../../python/agentic-sandbox-client -e '.[test]'
+python -m pytest tests/unit -q
+```

--- a/clients/integrations/openhands/configs/agent-server-template.yaml
+++ b/clients/integrations/openhands/configs/agent-server-template.yaml
@@ -1,0 +1,50 @@
+# SandboxTemplate for pre-warmed OpenHands agent-server pods.
+#
+# The readinessProbe on /health:8000 is load-bearing: SandboxClient waits for
+# the claim's Ready condition, so Ready MUST mean "agent-server is serving" —
+# that is what lets AgentSandboxWorkspace use a short (10 s) health budget.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: openhands-agent-server
+  namespace: default
+spec:
+  podTemplate:
+    spec:
+      runtimeClassName: gvisor          # recommended: model-driven code runs here
+      containers:
+      - name: agent-server
+        # Pin to the openhands-sdk release you install client-side; the SDK and
+        # the agent-server image are versioned together.
+        image: ghcr.io/openhands/agent-server:1.44.1-python
+        args: ["--host", "0.0.0.0", "--port", "8000"]
+        ports:
+        - containerPort: 8000
+        # Pool-level session key: pre-warmed servers cannot take a per-claim
+        # key, so every pod in the pool shares this one. Pass the same value as
+        # AgentSandboxWorkspace(api_key=...). Delete this block only on a
+        # private, trusted network.
+        env:
+        - name: OH_SESSION_API_KEYS_0
+          valueFrom:
+            secretKeyRef:
+              name: openhands-session-key
+              key: key
+        readinessProbe:
+          httpGet:
+            path: "/health"
+            port: 8000
+          initialDelaySeconds: 0
+          periodSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: "/health"
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+            ephemeral-storage: "2Gi"
+      restartPolicy: "OnFailure"

--- a/clients/integrations/openhands/configs/agent-server-warmpool.yaml
+++ b/clients/integrations/openhands/configs/agent-server-warmpool.yaml
@@ -1,0 +1,12 @@
+# Warm pool of ready agent-server pods. Depth = expected concurrent
+# conversations; a claim binds one instantly instead of cold-starting a
+# container (DockerWorkspace) per conversation.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: agent-server-pool
+  namespace: default
+spec:
+  templateRef:
+    name: openhands-agent-server
+  replicas: 8

--- a/clients/integrations/openhands/configs/agent-server-warmpool.yaml
+++ b/clients/integrations/openhands/configs/agent-server-warmpool.yaml
@@ -7,6 +7,7 @@ metadata:
   name: agent-server-pool
   namespace: default
 spec:
-  templateRef:
-    name: openhands-agent-server
   replicas: 8
+  sandboxTemplateRef:
+    # Must exactly match the SandboxTemplate's metadata.name.
+    name: openhands-agent-server

--- a/clients/integrations/openhands/example.py
+++ b/clients/integrations/openhands/example.py
@@ -46,17 +46,17 @@ def workspace_ops(workspace: AgentSandboxWorkspace) -> None:
     result = workspace.execute_command("echo hello from a warm pod && uname -a")
     print(f"$ {result.command!r} -> exit {result.exit_code}\n{result.stdout}")
 
-    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
-        f.write("round-trip payload\n")
-        local_path = f.name
-    upload = workspace.file_upload(local_path, "/workspace/roundtrip.txt")
-    print(f"upload ok={upload.success}")
-    download = workspace.file_download(
-        "/workspace/roundtrip.txt", local_path + ".back"
-    )
-    print(f"download ok={download.success}")
-    with open(local_path + ".back") as f:
-        assert f.read() == "round-trip payload\n"
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        local_path = os.path.join(tmp_dir, "roundtrip.txt")
+        back_path = os.path.join(tmp_dir, "roundtrip.txt.back")
+        with open(local_path, "w") as f:
+            f.write("round-trip payload\n")
+        upload = workspace.file_upload(local_path, "/workspace/roundtrip.txt")
+        print(f"upload ok={upload.success}")
+        download = workspace.file_download("/workspace/roundtrip.txt", back_path)
+        print(f"download ok={download.success}")
+        with open(back_path) as f:
+            assert f.read() == "round-trip payload\n"
     print("file round-trip verified")
 
 

--- a/clients/integrations/openhands/example.py
+++ b/clients/integrations/openhands/example.py
@@ -1,0 +1,112 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end example: OpenHands on a pre-warmed Agent Sandbox pod.
+
+Phase 1 (always): claim a warm pod and drive workspace operations directly —
+server info, a shell command, a file round-trip. Needs only cluster access.
+
+Phase 2 (optional): run a real agent conversation on the same workspace.
+Enabled when LLM_API_KEY is set and the `openhands-tools` package (agent
+presets) is installed.
+
+Environment:
+  SANDBOX_WARMPOOL     warm pool name        (default: agent-server-pool)
+  SANDBOX_NAMESPACE    pool namespace        (default: default)
+  SANDBOX_SESSION_KEY  pool session key      (default: unset — no auth header)
+  LLM_API_KEY          enables phase 2
+  LLM_MODEL            model for phase 2     (default: gpt-5.5)
+  LLM_BASE_URL         optional LLM endpoint override
+
+Run:  python example.py
+"""
+
+import os
+import tempfile
+
+from openhands_k8s_agent_sandbox import AgentSandboxWorkspace
+
+
+def workspace_ops(workspace: AgentSandboxWorkspace) -> None:
+    """Phase 1: raw workspace operations — no LLM involved."""
+    info = workspace.get_server_info()
+    print(f"agent-server info: {info}")
+
+    result = workspace.execute_command("echo hello from a warm pod && uname -a")
+    print(f"$ {result.command!r} -> exit {result.exit_code}\n{result.stdout}")
+
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+        f.write("round-trip payload\n")
+        local_path = f.name
+    upload = workspace.file_upload(local_path, "/workspace/roundtrip.txt")
+    print(f"upload ok={upload.success}")
+    download = workspace.file_download(
+        "/workspace/roundtrip.txt", local_path + ".back"
+    )
+    print(f"download ok={download.success}")
+    with open(local_path + ".back") as f:
+        assert f.read() == "round-trip payload\n"
+    print("file round-trip verified")
+
+
+def agent_conversation(workspace: AgentSandboxWorkspace) -> None:
+    """Phase 2: the standard SDK conversation, workspace class swapped."""
+    from pydantic import SecretStr
+
+    from openhands.sdk import LLM, Conversation
+    from openhands.tools.preset.default import get_default_agent
+
+    llm = LLM(
+        usage_id="agent",
+        model=os.getenv("LLM_MODEL", "gpt-5.5"),
+        base_url=os.getenv("LLM_BASE_URL"),
+        api_key=SecretStr(os.environ["LLM_API_KEY"]),
+    )
+    agent = get_default_agent(llm=llm, cli_mode=True)
+    conversation = Conversation(agent=agent, workspace=workspace)
+    try:
+        conversation.send_message(
+            "Write three facts about this environment into FACTS.txt, "
+            "then print the file."
+        )
+        conversation.run()
+        print(f"agent finished: {conversation.state.execution_status}")
+    finally:
+        conversation.close()
+
+
+def main() -> None:
+    with AgentSandboxWorkspace(
+        warmpool=os.getenv("SANDBOX_WARMPOOL", "agent-server-pool"),
+        namespace=os.getenv("SANDBOX_NAMESPACE", "default"),
+        api_key=os.getenv("SANDBOX_SESSION_KEY"),
+        ttl_s=1800,  # backstop: the controller reaps the claim if we die here
+    ) as workspace:
+        print(f"claimed warm workspace at {workspace.host}")
+        workspace_ops(workspace)
+
+        if not os.getenv("LLM_API_KEY"):
+            print("LLM_API_KEY not set — skipping the agent-conversation phase")
+            return
+        try:
+            import openhands.tools  # noqa: F401
+        except ImportError:
+            print("openhands-tools not installed — skipping the agent phase "
+                  "(pip install openhands-tools)")
+            return
+        agent_conversation(workspace)
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/__init__.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenHands agent-SDK workspace backed by agent-sandbox warm pools."""
+
+from openhands_k8s_agent_sandbox.workspace import AgentSandboxWorkspace
+
+
+__all__ = ["AgentSandboxWorkspace"]

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import time
 from typing import Any
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 from pydantic import Field, PrivateAttr
 
@@ -94,7 +94,26 @@ class AgentSandboxWorkspace(RemoteWorkspace):
             "Optional URL template for the agent-server endpoint, for gateway or "
             "proxied data paths. Supports {pod_ip}, {port}, {namespace}, "
             "{claim_name}, {sandbox_id}. Default: http://{pod_ip}:{port} "
-            "(GKE pod IPs are VPC-routable)."
+            "(GKE pod IPs are VPC-routable). Mutually exclusive with router_url."
+        ),
+    )
+    router_url: str | None = Field(
+        default=None,
+        description=(
+            "Base URL of a sandbox-router deployment (see the client's "
+            "sandbox-router/). When set, all traffic goes to the router with "
+            "X-Sandbox-* routing headers (ID, namespace, port, pod IP) injected "
+            "on every request — including the health check. Use when pod IPs "
+            "are not routable from the client. Mutually exclusive with "
+            "endpoint_template."
+        ),
+    )
+    router_auth_token: str | None = Field(
+        default=None,
+        description=(
+            "Bearer token for the sandbox-router (its ROUTER_AUTH_TOKEN). Sent "
+            "as Authorization to the router, which strips it before forwarding "
+            "— it never reaches the agent-server, so it composes with api_key."
         ),
     )
     claim_timeout_s: int = Field(
@@ -134,8 +153,33 @@ class AgentSandboxWorkspace(RemoteWorkspace):
     _sandbox: Any = PrivateAttr(default=None)
     _owns_client: bool = PrivateAttr(default=False)
 
+    @property
+    def _headers(self):
+        """Session headers, plus router routing/auth headers in router mode.
+
+        The router resolves the backend from X-Sandbox-* headers on EVERY
+        request; the pod IP shortcut skips the per-sandbox Service DNS hop.
+        The Bearer token authenticates to the router only — the router strips
+        Authorization before forwarding, so it never shadows api_key.
+        """
+        headers = dict(super()._headers)
+        if self.router_url and self._sandbox is not None:
+            headers["X-Sandbox-ID"] = getattr(self._sandbox, "sandbox_id", "")
+            headers["X-Sandbox-Namespace"] = self.namespace
+            headers["X-Sandbox-Port"] = str(self.server_port)
+            pod_ip = self._sandbox.get_pod_ip()
+            if pod_ip:
+                headers["X-Sandbox-Pod-IP"] = pod_ip
+            if self.router_auth_token:
+                headers["Authorization"] = f"Bearer {self.router_auth_token}"
+        return headers
+
     def model_post_init(self, context: Any) -> None:
         """Claim a warm pod, point RemoteWorkspace at it, verify health."""
+        if self.router_url and self.endpoint_template:
+            raise ValueError(
+                "router_url and endpoint_template are mutually exclusive"
+            )
         client = self.sandbox_client
         if client is None:
             from k8s_agent_sandbox import SandboxClient
@@ -172,6 +216,8 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         super().model_post_init(context)
 
     def _endpoint_url(self, sandbox: Any) -> str:
+        if self.router_url:
+            return self.router_url.rstrip("/")
         pod_ip = sandbox.get_pod_ip()
         if self.endpoint_template:
             return self.endpoint_template.format(
@@ -190,13 +236,18 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         return f"http://{pod_ip}:{self.server_port}"
 
     def _wait_for_health(self, *, timeout: float) -> None:
-        """Poll GET /health until 2xx or the (short) budget elapses."""
+        """Poll GET /health until 2xx or the (short) budget elapses.
+
+        In router mode the routing headers must ride along or the router
+        rejects the probe with 400 before it ever reaches the sandbox.
+        """
         health_url = f"{self.host.rstrip('/')}/health"
         deadline = time.monotonic() + timeout
         last_error: Exception | None = None
         while time.monotonic() < deadline:
             try:
-                with urlopen(health_url, timeout=1.0) as resp:
+                request = Request(health_url, headers=self._headers)
+                with urlopen(request, timeout=1.0) as resp:
                     if 200 <= getattr(resp, "status", 200) < 300:
                         return
             except Exception as e:  # noqa: BLE001 — retried until the deadline

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -244,15 +244,23 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         health_url = f"{self.host.rstrip('/')}/health"
         deadline = time.monotonic() + timeout
         last_error: Exception | None = None
-        while time.monotonic() < deadline:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
             try:
                 request = Request(health_url, headers=self._headers)
-                with urlopen(request, timeout=1.0) as resp:
+                # Bound each probe and the backoff by the remaining budget so
+                # the caller's timeout is honored, not just approximated.
+                with urlopen(request, timeout=min(1.0, remaining)) as resp:
                     if 200 <= getattr(resp, "status", 200) < 300:
                         return
             except Exception as e:  # noqa: BLE001 — retried until the deadline
                 last_error = e
-            time.sleep(0.5)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(0.5, remaining))
         raise RuntimeError(
             f"agent-server at {health_url} failed to become healthy within "
             f"{timeout}s (pre-warmed pods should be healthy at claim time; "

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -294,11 +294,11 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         if sandbox is None:
             return
         self._sandbox = None
+        # Capture before terminate(): the SDK clears identity fields on close.
+        claim_name = getattr(sandbox, "claim_name", "?")
         try:
             sandbox.terminate()
-            logger.info(
-                "Released sandbox claim %s", getattr(sandbox, "claim_name", "?")
-            )
+            logger.info("Released sandbox claim %s", claim_name)
         except Exception as e:  # noqa: BLE001 — ttl_s backstops a failed delete
             logger.warning(
                 "Failed to terminate sandbox %s: %s (ttl_s backstop applies "

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -1,0 +1,257 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent-sandbox-backed workspace for the OpenHands agent SDK.
+
+``AgentSandboxWorkspace`` is a provisioning-only ``RemoteWorkspace`` subclass:
+instead of ``docker run`` + health-wait (``DockerWorkspace``), it claims a
+**pre-warmed** pod from a ``SandboxWarmPool`` whose template already runs the
+OpenHands agent-server image, and hands the pod's URL to the base class. All
+workspace operations (bash, files, git) are inherited from ``RemoteWorkspace``,
+which speaks HTTP to the agent-server — this module adds no execution plumbing.
+
+The warm pool's SandboxTemplate must run the agent-server image with
+``--host 0.0.0.0 --port <server_port>`` and a readinessProbe on
+``/health:<server_port>`` so that a Ready pod == a healthy agent-server
+(see ``configs/agent-server-template.yaml``).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from urllib.request import urlopen
+
+from pydantic import Field, PrivateAttr
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.workspace import RemoteWorkspace
+
+
+logger = get_logger(__name__)
+
+
+class AgentSandboxWorkspace(RemoteWorkspace):
+    """Remote workspace bound to a pre-warmed agent-sandbox pod.
+
+    Provisioning maps 1:1 onto ``DockerWorkspace``'s lifecycle, with the cold
+    container start replaced by a warm-pool claim (a bind, not a boot):
+
+    - ``model_post_init``: claim → resolve endpoint → health check → hand off
+      to ``RemoteWorkspace``.
+    - ``cleanup()`` (also via ``with`` / ``__del__``): delete the claim; the
+      pool replenishes in the background. ``ttl_s`` backstops clients that die
+      without cleanup.
+
+    Example:
+        >>> with AgentSandboxWorkspace(warmpool="agent-server-pool",
+        ...                            namespace="openhands") as workspace:
+        ...     result = workspace.execute_command("ls -la")
+
+    Auth note: pre-warmed servers cannot receive a per-claim key, so all pods
+    in a pool share the session key their template injects (env
+    ``OH_SESSION_API_KEYS_0``, typically from one Secret). Pass that same value
+    as ``api_key``; leave both unset only on a private, trusted network.
+    """
+
+    # Overridden parent defaults.
+    working_dir: str = Field(
+        default="/workspace",
+        description="Working directory inside the sandbox pod.",
+    )
+    host: str = Field(
+        default="",
+        description="Agent-server URL (set automatically after the claim binds).",
+    )
+
+    # Provisioning configuration.
+    warmpool: str = Field(
+        description="SandboxWarmPool holding pre-warmed agent-server pods."
+    )
+    namespace: str = Field(
+        default="default", description="Kubernetes namespace of the warm pool."
+    )
+    server_port: int = Field(
+        default=8000,
+        ge=1,
+        le=65535,
+        description="Port the agent-server listens on inside the pod.",
+    )
+    endpoint_template: str | None = Field(
+        default=None,
+        description=(
+            "Optional URL template for the agent-server endpoint, for gateway or "
+            "proxied data paths. Supports {pod_ip}, {port}, {namespace}, "
+            "{claim_name}, {sandbox_id}. Default: http://{pod_ip}:{port} "
+            "(GKE pod IPs are VPC-routable)."
+        ),
+    )
+    claim_timeout_s: int = Field(
+        default=60,
+        gt=0,
+        description="Seconds to wait for the claim to bind a Ready sandbox.",
+    )
+    health_check_timeout: float = Field(
+        default=10.0,
+        gt=0.0,
+        description=(
+            "Seconds to wait for /health. Deliberately short: a warm pod that "
+            "is Ready but unhealthy is broken — fail fast and re-claim rather "
+            "than wait out a Docker-style cold-boot budget."
+        ),
+    )
+    ttl_s: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional claim TTL (spec.lifecycle shutdownTime). The controller "
+            "deletes the claim on expiry even if this process dies first."
+        ),
+    )
+    claim_labels: dict[str, str] | None = Field(
+        default=None, description="Labels for the SandboxClaim object."
+    )
+    sandbox_client: Any = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Injected k8s_agent_sandbox.SandboxClient (or compatible). Built "
+            "lazily with defaults when omitted; tests inject fakes."
+        ),
+    )
+
+    _sandbox: Any = PrivateAttr(default=None)
+    _owns_client: bool = PrivateAttr(default=False)
+
+    def model_post_init(self, context: Any) -> None:
+        """Claim a warm pod, point RemoteWorkspace at it, verify health."""
+        client = self.sandbox_client
+        if client is None:
+            from k8s_agent_sandbox import SandboxClient
+
+            client = SandboxClient()
+            self.sandbox_client = client
+            self._owns_client = True
+
+        sandbox = client.create_sandbox(
+            self.warmpool,
+            namespace=self.namespace,
+            sandbox_ready_timeout=self.claim_timeout_s,
+            labels=self.claim_labels,
+            shutdown_after_seconds=self.ttl_s,
+        )
+        self._sandbox = sandbox
+        logger.info(
+            "Claimed sandbox %s from warm pool %r (ns=%s)",
+            getattr(sandbox, "claim_name", "?"),
+            self.warmpool,
+            self.namespace,
+        )
+        try:
+            # Mirror DockerWorkspace: bypass validate-assignment plumbing when
+            # rewriting connection fields mid-init.
+            if not self.host:
+                object.__setattr__(self, "host", self._endpoint_url(sandbox))
+            self._wait_for_health(timeout=self.health_check_timeout)
+        except Exception:
+            # Never leave an orphaned claim behind a failed init.
+            self._terminate_sandbox()
+            raise
+        logger.info("Agent-sandbox workspace is ready at %s", self.host)
+        super().model_post_init(context)
+
+    def _endpoint_url(self, sandbox: Any) -> str:
+        pod_ip = sandbox.get_pod_ip()
+        if self.endpoint_template:
+            return self.endpoint_template.format(
+                pod_ip=pod_ip or "",
+                port=self.server_port,
+                namespace=self.namespace,
+                claim_name=getattr(sandbox, "claim_name", ""),
+                sandbox_id=getattr(sandbox, "sandbox_id", ""),
+            )
+        if not pod_ip:
+            raise RuntimeError(
+                f"sandbox {getattr(sandbox, 'claim_name', '?')!r} bound but has "
+                "no pod IP; cannot build the agent-server endpoint (set "
+                "endpoint_template for gateway/proxied data paths)"
+            )
+        return f"http://{pod_ip}:{self.server_port}"
+
+    def _wait_for_health(self, *, timeout: float) -> None:
+        """Poll GET /health until 2xx or the (short) budget elapses."""
+        health_url = f"{self.host.rstrip('/')}/health"
+        deadline = time.monotonic() + timeout
+        last_error: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                with urlopen(health_url, timeout=1.0) as resp:
+                    if 200 <= getattr(resp, "status", 200) < 300:
+                        return
+            except Exception as e:  # noqa: BLE001 — retried until the deadline
+                last_error = e
+            time.sleep(0.5)
+        raise RuntimeError(
+            f"agent-server at {health_url} failed to become healthy within "
+            f"{timeout}s (pre-warmed pods should be healthy at claim time; "
+            f"last error: {last_error!r})"
+        )
+
+    # ------------------------------------------------------------- lifecycle
+
+    def __enter__(self) -> "AgentSandboxWorkspace":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
+        self.cleanup()
+
+    def __del__(self) -> None:
+        # Guard against interpreter-shutdown states where pydantic private
+        # attributes are already gone (same pattern as DockerWorkspace).
+        try:
+            object.__getattribute__(self, "__pydantic_private__")
+        except AttributeError:
+            return
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        """Delete the claim (the pool replenishes) and drop an owned client."""
+        self._terminate_sandbox()
+        if self._owns_client and self.sandbox_client is not None:
+            close = getattr(self.sandbox_client, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception as e:  # noqa: BLE001 — best-effort teardown
+                    logger.warning("Error closing sandbox client: %s", e)
+            self.sandbox_client = None
+            self._owns_client = False
+
+    def _terminate_sandbox(self) -> None:
+        sandbox = self._sandbox
+        if sandbox is None:
+            return
+        self._sandbox = None
+        try:
+            sandbox.terminate()
+            logger.info(
+                "Released sandbox claim %s", getattr(sandbox, "claim_name", "?")
+            )
+        except Exception as e:  # noqa: BLE001 — ttl_s backstops a failed delete
+            logger.warning(
+                "Failed to terminate sandbox %s: %s (ttl_s backstop applies "
+                "if configured)",
+                getattr(sandbox, "claim_name", "?"),
+                e,
+            )

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -303,6 +303,6 @@ class AgentSandboxWorkspace(RemoteWorkspace):
             logger.warning(
                 "Failed to terminate sandbox %s: %s (ttl_s backstop applies "
                 "if configured)",
-                getattr(sandbox, "claim_name", "?"),
+                claim_name,
                 e,
             )

--- a/clients/integrations/openhands/pyproject.toml
+++ b/clients/integrations/openhands/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools>=61.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openhands-k8s-agent-sandbox"
+description = "OpenHands agent-SDK workspace backed by Kubernetes agent-sandbox warm pools."
+readme = "README.md"
+
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dynamic = ["version"]
+# openhands-sdk publishes requires-python >=3.12; we inherit that floor.
+requires-python = ">=3.12"
+dependencies = [
+    # RemoteWorkspace (the base class) and the agent-server HTTP contract.
+    # The SDK versions its agent-server image per release, so keep the band
+    # narrow enough that client and server speak the same protocol.
+    "openhands-sdk>=1.44,<2",
+    # SandboxClient.create_sandbox(warmpool=...) claim path. The client is only
+    # imported when the caller does not inject one (tests inject fakes). The
+    # claim API (create_sandbox / get_pod_ip / terminate) is stable across the
+    # 0.5 → 1.x line.
+    "k8s-agent-sandbox>=0.5.1",
+]
+
+[project.urls]
+Homepage = "https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/openhands"
+Repository = "https://github.com/kubernetes-sigs/agent-sandbox"
+Documentation = "https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/openhands"
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["openhands_k8s_agent_sandbox*"]
+exclude = ["tests*"]
+
+[tool.setuptools.exclude-package-data]
+# setuptools_scm automatically bundles tracked files as package data.
+# We need to explicitly exclude test directories and files from being bundled.
+"*" = ["test/*", "tests/*", "*/test/*", "*/tests/*", "test_*.py", "*_test.py"]
+
+[tool.setuptools_scm]
+root = "../../.."
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]

--- a/clients/integrations/openhands/tests/unit/test_workspace.py
+++ b/clients/integrations/openhands/tests/unit/test_workspace.py
@@ -1,0 +1,219 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for AgentSandboxWorkspace.
+
+All tests inject a fake SandboxClient — no cluster, no k8s_agent_sandbox
+import, no network. The health check is stubbed per test (its real
+implementation is exercised separately against a fake urlopen).
+"""
+
+import pytest
+
+from openhands_k8s_agent_sandbox.workspace import AgentSandboxWorkspace
+
+
+class FakeSandbox:
+    def __init__(self, pod_ip="10.12.0.7", claim_name="sandbox-claim-abc123",
+                 sandbox_id="sbx-xyz"):
+        self._pod_ip = pod_ip
+        self.claim_name = claim_name
+        self.sandbox_id = sandbox_id
+        self.terminated = 0
+
+    def get_pod_ip(self):
+        return self._pod_ip
+
+    def terminate(self):
+        self.terminated += 1
+
+
+class FakeClient:
+    def __init__(self, sandbox=None, create_error=None):
+        self.sandbox = sandbox or FakeSandbox()
+        self.create_error = create_error
+        self.create_calls = []
+        self.closed = 0
+
+    def create_sandbox(self, warmpool, **kwargs):
+        self.create_calls.append((warmpool, kwargs))
+        if self.create_error is not None:
+            raise self.create_error
+        return self.sandbox
+
+    def close(self):
+        self.closed += 1
+
+
+@pytest.fixture
+def no_health(monkeypatch):
+    """Stub the health wait; provisioning tests don't exercise HTTP."""
+    monkeypatch.setattr(
+        AgentSandboxWorkspace, "_wait_for_health", lambda self, *, timeout: None
+    )
+
+
+def make_workspace(client=None, **kwargs):
+    kwargs.setdefault("warmpool", "agent-server-pool")
+    return AgentSandboxWorkspace(sandbox_client=client or FakeClient(), **kwargs)
+
+
+# -------------------------------------------------------------- provisioning
+
+
+def test_provision_sets_host_from_pod_ip(no_health):
+    client = FakeClient(FakeSandbox(pod_ip="10.9.8.7"))
+    ws = make_workspace(client)
+    assert ws.host == "http://10.9.8.7:8000"
+    assert ws.working_dir == "/workspace"
+
+
+def test_claim_kwargs_forwarded(no_health):
+    client = FakeClient()
+    make_workspace(
+        client,
+        namespace="openhands",
+        claim_timeout_s=25,
+        ttl_s=3600,
+        claim_labels={"run": "demo"},
+    )
+    warmpool, kwargs = client.create_calls[0]
+    assert warmpool == "agent-server-pool"
+    assert kwargs["namespace"] == "openhands"
+    assert kwargs["sandbox_ready_timeout"] == 25
+    assert kwargs["shutdown_after_seconds"] == 3600
+    assert kwargs["labels"] == {"run": "demo"}
+
+
+def test_endpoint_template_override(no_health):
+    client = FakeClient(FakeSandbox(claim_name="claim-1"))
+    ws = make_workspace(
+        client,
+        namespace="rl",
+        endpoint_template="https://gw.example.com/{namespace}/{claim_name}",
+    )
+    assert ws.host == "https://gw.example.com/rl/claim-1"
+
+
+def test_custom_server_port(no_health):
+    ws = make_workspace(FakeClient(FakeSandbox(pod_ip="10.0.0.2")), server_port=9000)
+    assert ws.host == "http://10.0.0.2:9000"
+
+
+def test_api_key_passthrough(no_health):
+    ws = make_workspace(api_key="pool-secret")
+    assert ws.api_key == "pool-secret"
+    assert ws._headers == {"X-Session-API-Key": "pool-secret"}
+
+
+def test_ttl_must_be_positive(no_health):
+    with pytest.raises(ValueError):
+        make_workspace(ttl_s=0)
+
+
+# -------------------------------------------------------------- error paths
+
+
+def test_create_failure_propagates():
+    client = FakeClient(create_error=RuntimeError("no capacity"))
+    with pytest.raises(RuntimeError, match="no capacity"):
+        make_workspace(client)
+
+
+def test_missing_pod_ip_terminates_claim_and_raises(no_health):
+    sandbox = FakeSandbox(pod_ip=None)
+    client = FakeClient(sandbox)
+    with pytest.raises(RuntimeError, match="no pod IP"):
+        make_workspace(client)
+    assert sandbox.terminated == 1
+
+
+def test_health_failure_terminates_claim_and_raises(monkeypatch):
+    def failing_health(self, *, timeout):
+        raise RuntimeError("failed to become healthy")
+
+    monkeypatch.setattr(AgentSandboxWorkspace, "_wait_for_health", failing_health)
+    sandbox = FakeSandbox()
+    client = FakeClient(sandbox)
+    with pytest.raises(RuntimeError, match="healthy"):
+        make_workspace(client)
+    assert sandbox.terminated == 1
+
+
+def test_health_check_polls_urlopen(monkeypatch):
+    # Real _wait_for_health against a fake urlopen, exercised through
+    # construction. First probe refuses, second succeeds.
+    calls = []
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_urlopen(url, timeout):
+        calls.append(url)
+        if len(calls) == 1:
+            raise ConnectionError("not yet")
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "openhands_k8s_agent_sandbox.workspace.urlopen", fake_urlopen
+    )
+    ws = make_workspace(FakeClient(FakeSandbox(pod_ip="10.0.0.3")))
+    assert ws.host == "http://10.0.0.3:8000"
+    assert len(calls) == 2
+    assert calls[0] == "http://10.0.0.3:8000/health"
+
+
+# ----------------------------------------------------------------- teardown
+
+
+def test_cleanup_terminates_once(no_health):
+    sandbox = FakeSandbox()
+    ws = make_workspace(FakeClient(sandbox))
+    ws.cleanup()
+    ws.cleanup()
+    assert sandbox.terminated == 1
+
+
+def test_context_manager_cleans_up(no_health):
+    sandbox = FakeSandbox()
+    with make_workspace(FakeClient(sandbox)) as ws:
+        assert ws.host.startswith("http://")
+    assert sandbox.terminated == 1
+
+
+def test_injected_client_not_closed(no_health):
+    client = FakeClient()
+    ws = make_workspace(client)
+    ws.cleanup()
+    # We only close clients we built ourselves.
+    assert client.closed == 0
+
+
+def test_terminate_error_is_swallowed(no_health):
+    sandbox = FakeSandbox()
+
+    def boom():
+        sandbox.terminated += 1
+        raise RuntimeError("apiserver hiccup")
+
+    sandbox.terminate = boom
+    ws = make_workspace(FakeClient(sandbox))
+    ws.cleanup()  # must not raise; ttl_s is the backstop
+    assert sandbox.terminated == 1

--- a/clients/integrations/openhands/tests/unit/test_workspace.py
+++ b/clients/integrations/openhands/tests/unit/test_workspace.py
@@ -165,8 +165,8 @@ def test_health_check_polls_urlopen(monkeypatch):
         def __exit__(self, *args):
             return False
 
-    def fake_urlopen(url, timeout):
-        calls.append(url)
+    def fake_urlopen(request, timeout):
+        calls.append(request)
         if len(calls) == 1:
             raise ConnectionError("not yet")
         return FakeResponse()
@@ -177,7 +177,73 @@ def test_health_check_polls_urlopen(monkeypatch):
     ws = make_workspace(FakeClient(FakeSandbox(pod_ip="10.0.0.3")))
     assert ws.host == "http://10.0.0.3:8000"
     assert len(calls) == 2
-    assert calls[0] == "http://10.0.0.3:8000/health"
+    assert calls[0].full_url == "http://10.0.0.3:8000/health"
+
+
+# ------------------------------------------------------------- router mode
+
+
+def test_router_mode_host_and_headers(no_health):
+    sandbox = FakeSandbox(pod_ip="10.4.4.4", sandbox_id="sbx-777")
+    ws = make_workspace(
+        FakeClient(sandbox),
+        namespace="rl",
+        router_url="http://sandbox-router.default.svc:8080/",
+        router_auth_token="router-secret",
+        api_key="pool-secret",
+    )
+    assert ws.host == "http://sandbox-router.default.svc:8080"
+    headers = ws._headers
+    assert headers["X-Sandbox-ID"] == "sbx-777"
+    assert headers["X-Sandbox-Namespace"] == "rl"
+    assert headers["X-Sandbox-Port"] == "8000"
+    assert headers["X-Sandbox-Pod-IP"] == "10.4.4.4"
+    assert headers["Authorization"] == "Bearer router-secret"
+    # Session auth for the agent-server rides along; the router strips only
+    # Authorization before forwarding.
+    assert headers["X-Session-API-Key"] == "pool-secret"
+
+
+def test_router_mode_health_check_sends_routing_headers(monkeypatch):
+    captured = []
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def fake_urlopen(request, timeout):
+        captured.append(request)
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "openhands_k8s_agent_sandbox.workspace.urlopen", fake_urlopen
+    )
+    make_workspace(
+        FakeClient(FakeSandbox(sandbox_id="sbx-9")),
+        router_url="http://router:8080",
+        router_auth_token="tok",
+    )
+    request = captured[0]
+    assert request.full_url == "http://router:8080/health"
+    # urllib capitalizes header names on add
+    assert request.get_header("X-sandbox-id") == "sbx-9"
+    assert request.get_header("Authorization") == "Bearer tok"
+
+
+def test_router_and_endpoint_template_are_exclusive():
+    client = FakeClient()
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        make_workspace(
+            client,
+            router_url="http://router:8080",
+            endpoint_template="http://gw/{claim_name}",
+        )
+    assert client.create_calls == []  # rejected before any claim
 
 
 # ----------------------------------------------------------------- teardown

--- a/dev/tools/test-unit
+++ b/dev/tools/test-unit
@@ -117,6 +117,16 @@ PYTHON_TEST_SUITES = [
             (os.path.join("clients", "integrations", "nemo-gym"), "[test]"),
         ],
     },
+    {
+        "name": "integrations-openhands",
+        "dir": os.path.join("clients", "integrations", "openhands"),
+        # openhands-sdk publishes requires-python >=3.12.
+        "min_python": (3, 12),
+        "editable_installs": [
+            (os.path.join("clients", "python", "agentic-sandbox-client"), ""),
+            (os.path.join("clients", "integrations", "openhands"), "[test]"),
+        ],
+    },
 ]
 
 


### PR DESCRIPTION
## What

A new integration package `clients/integrations/openhands/` (`openhands-k8s-agent-sandbox`): **`AgentSandboxWorkspace`**, a workspace backend for the [OpenHands agent SDK](https://github.com/OpenHands/software-agent-sdk) that runs conversations on **pre-warmed Agent Sandbox pods** instead of cold-starting a Docker container per session.

It is a provisioning-only `RemoteWorkspace` subclass — the claim replaces `docker run` + health-wait, and every operation (bash, files, git) is inherited from the SDK, which speaks HTTP to the agent-server running in the pod. A claim is a **bind, not a boot**: the template's readinessProbe on `/health` makes Ready ≡ healthy, so the client uses a 10 s fail-fast health budget instead of Docker's 120 s.

## Endpoint modes

- **Default (in-cluster / in-VPC):** `http://{pod_ip}:{server_port}` — selected by setting nothing.
- **`router_url` + `router_auth_token`:** first-class sandbox-router mode. The router is header-routed, so the `X-Sandbox-*` headers are injected on every request *including the health probe*; the router Bearer token is stripped by the router before forwarding and therefore composes with the pool session key.
- **`endpoint_template`:** escape hatch for custom gateway/proxy URL shapes.

Auth is pool-level by design (pre-warmed servers cannot take a per-claim key): all pods in a pool share `OH_SESSION_API_KEYS_0` from one Secret, documented with rotation guidance. `ttl_s` maps to the claim's `shutdownTime` as a dead-client backstop.

## Contents

- `openhands_k8s_agent_sandbox/workspace.py` — the workspace
- `configs/` — example SandboxTemplate (readinessProbe is load-bearing) + SandboxWarmPool
- `example.py` — runnable: workspace ops always; full `get_default_agent` conversation when `LLM_API_KEY` is set
- README with deploy guide, configuration reference, auth model, troubleshooting
- `dev/tools/test-unit` suite registration (`min_python` 3.12, matching `openhands-sdk`)
- drive-by fix: `SandboxWarmPool` example field is `sandboxTemplateRef`, not `templateRef`

## Test plan

- **17 unit tests** (no cluster; fake client injected; real `RemoteWorkspace` base class exercised): claim kwarg forwarding, endpoint resolution across all three modes, header layering, TTL validation, orphan-free error paths (health failure / missing pod IP terminate the claim), idempotent teardown.
- **Live smoke, pod-IP mode** (GKE, controller main build): claim bind **0.537 s**, time-to-usable **< 1 s** in-VPC; server/SDK versions matched (1.44.1); exec + file round-trip verified; pod boot (45 s–4 min) confirmed hidden inside the pool.
- **Live smoke, router mode against gVisor pods**: full chain (claim → router Bearer auth → pod IP → agent-server under runsc) — `uname` reports `4.19.0-gvisor`; 1.93 s to usable workspace through a laptop port-forward. Also documents the discovered caveat that direct `kubectl port-forward` cannot reach gVisor pods (runsc netstack loopback), while the runc router can.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenHands integration that runs agent sessions on pre-warmed Kubernetes sandbox pods.
  * Added workspace support for shell, file, and Git operations, with optional agent conversations.
  * Added configurable routing, health checks, session limits, cleanup, and authentication.
  * Added Kubernetes templates for OpenHands agent servers and an eight-pod warm pool.
  * Added installation guidance, configuration reference, troubleshooting documentation, and usage examples.

* **Tests**
  * Added coverage for provisioning, routing, health checks, errors, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->