### PR TITLE
chore: rework gomod Dependabot config: full coverage, k8s deps separated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,41 +4,36 @@ updates:
 # Dependabot only supports files named exactly 'go.mod'. 
 # Maintainers will need to manually update tools.mod when shared dependencies change.
 # See discussion in PR #629 and #588 for context.
+# Cover every Go module in the repo: "/" is the root module, and the
+# globstar pattern matches every subdirectory containing a go.mod, so
+# new Go modules are picked up automatically.
 - package-ecosystem: "gomod"
-  directory: "/"
+  directories:
+  - "/"
+  - "**/*"
   schedule:
-    interval: "weekly"
+    interval: "daily"
   groups:
+    # Kubernetes minor bumps (e.g. k8s.io/* 0.36 -> 0.37) track a new
+    # Kubernetes release and can carry API changes, so keep them out of
+    # the routine update group. Combined with the ignore rules below,
+    # only k8s patch releases are raised automatically; minor upgrades
+    # are done by hand as a coordinated migration.
+    kubernetes-dependencies:
+      patterns:
+      - "k8s.io/*"
+      - "sigs.k8s.io/*"
     gomod-dependencies:
       patterns:
       - "*"
-
-- package-ecosystem: "gomod"
-  directory: "/dev/tools"
-  schedule:
-    interval: "weekly"
-  groups:
-    gomod-dependencies:
-      patterns:
-      - "*"
-
-- package-ecosystem: "gomod"
-  directory: "/examples/chrome-sandbox"
-  schedule:
-    interval: "weekly"
-  groups:
-    gomod-dependencies:
-      patterns:
-      - "*"
-
-- package-ecosystem: "gomod"
-  directory: "/site"
-  schedule:
-    interval: "weekly"
-  groups:
-    gomod-dependencies:
-      patterns:
-      - "*"
+      exclude-patterns:
+      - "k8s.io/*"
+      - "sigs.k8s.io/*"
+  ignore:
+  - dependency-name: "k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "sigs.k8s.io/*"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
 - package-ecosystem: "pip"
   directory: "/clients/python/agentic-sandbox-client"


### PR DESCRIPTION
#### What this PR does / why we need it:
Two related fixes to how Dependabot handles Go modules:

**Coverage:** the gomod entries listed four directories explicitly, which missed `olm/` and `examples/webhook-inject-timestamp/` — dependency updates there had to be done by hand (e.g. #1486 for CVE-2026-25681). This replaces the per-directory entries with a single entry listing the root module plus a globstar pattern, so every `go.mod` in the repo (including future modules) is tracked automatically. Also moves gomod updates from weekly to daily.

**Kubernetes deps:** the catch-all update group mixed Kubernetes minor bumps into routine updates — #1507 pulled `k8s.io/apiextensions-apiserver` 0.36.4 → 0.37.0 in alongside otel/grpc bumps, but a Kubernetes minor tracks a new k8s release and can carry API changes, making it a coordinated migration rather than a routine update. This splits `k8s.io/*` and `sigs.k8s.io/*` into their own update group and ignores their minor/major bumps, so only k8s patch releases are raised automatically (in their own PR) and minor upgrades are done by hand.

Caveat: the ignore rules also cover independently-versioned k8s.io modules (klog, utils, kube-openapi), whose minor updates are rare; they still arrive via `go mod tidy` during k8s patch PRs or manual migrations.

`tools.mod` remains untracked — Dependabot only supports files named exactly `go.mod` (see #629 and #588).

#### Which issue(s) this PR is related to:
Context: #1507

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Updated automated Go module maintenance to run daily across the entire project.
- Consolidated update checks for more consistent coverage across project components.
- Added focused grouping for Kubernetes-related updates.
- Limited automated Kubernetes-related updates to patch-level changes, reducing unexpected compatibility risks while preserving routine maintenance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->