### PR TITLE
chore: track site npm dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,15 @@ updates:
       patterns:
       - "*"
 
+- package-ecosystem: "npm"
+  directory: "/site"
+  schedule:
+    interval: "daily"
+  groups:
+    npm-dependencies:
+      patterns:
+      - "*"
+
 - package-ecosystem: "docker"
   directory: "/"
   schedule:


### PR DESCRIPTION
#### What this PR does / why we need it:
The docs site has npm dependencies (`site/package.json`), but `dependabot.yml` has no npm entry, so updates there had to be done by hand (e.g. #1461 for the picomatch ReDoS advisory GHSA-c2c7-rcm5-vvqj).

This adds a daily npm update entry for `/site`, grouped into a single PR like the other ecosystems. Kept separate from #1489 (gomod coverage) so the two can be reviewed and merged independently; the diffs don't overlap.

Note: scheduled version updates track direct dependencies. CVE-driven fixes of transitive lockfile dependencies (like #1461) come from the Dependabot security updates feature, which is currently disabled on this repo and is being looked at separately.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated daily dependency update checks for the site’s npm packages.
  * Related dependency updates are grouped together for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->