### PR TITLE
feat(agtsbx): add "agtsbx run" for docker-like sandbox usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ LD_FLAGS := -s -w -X $(VERSION_PKG).gitVersion=$(GIT_VERSION) \
 	-X $(VERSION_PKG).buildDate=$(BUILD_DATE)
 
 .PHONY: build
-build: build-controller build-sandbox-router build-sandboxd
+build: build-controller build-sandbox-router build-sandboxd build-agtsbx
 
 .PHONY: build-controller
 build-controller:
@@ -82,6 +82,10 @@ build-sandbox-router:
 .PHONY: build-sandboxd
 build-sandboxd:
 	go build -ldflags "$(LD_FLAGS)" -o bin/sandboxd ./packages/sandboxd/cmd/sandboxd
+
+.PHONY: build-agtsbx
+build-agtsbx:
+	go build -ldflags "$(LD_FLAGS)" -o bin/agtsbx ./cmd/agtsbx
 
 KIND_CLUSTER=agent-sandbox
 CONTAINER_ENGINE ?= docker

--- a/cmd/agtsbx/README.md
+++ b/cmd/agtsbx/README.md
@@ -1,0 +1,182 @@
+# agtsbx
+
+`agtsbx` is a docker-like command-line front end for agent-sandbox. It runs a
+single command in a throwaway sandbox and streams the output back:
+
+```console
+$ agtsbx run sandboxd:latest echo hello
+agtsbx: starting sandboxd:latest on docker as agtsbx-1b75a73862a3
+hello
+```
+
+The sandbox is created, the command runs, and the sandbox is torn down. The
+exit status of `agtsbx run` is the exit status of the command, so it composes
+in shell pipelines the way `docker run` does.
+
+## Why
+
+Trying agent-sandbox has meant standing up a cluster, installing the
+controller and writing a `SandboxTemplate` before running anything. That is a
+lot of ceremony for "does my agent's code work in a sandbox?". `agtsbx run`
+removes it for the local case while keeping the same runtime semantics as the
+cluster case.
+
+## Runtimes
+
+The sandbox can run on a local container engine or in a Kubernetes cluster.
+`--runtime` selects; the default (`auto`) probes for docker, then podman, then
+falls back to kubernetes.
+
+| `--runtime` | What it creates | Needs |
+| --- | --- | --- |
+| `docker` | a local container | the `docker` CLI |
+| `podman` | a local container | the `podman` CLI |
+| `kubernetes` | a `Sandbox` object | a kubeconfig and the agent-sandbox controller |
+
+An explicit `--runtime` is never silently downgraded: asking for `podman` on a
+host without podman is an error, not a fallback to docker.
+
+All three converge on the same in-sandbox contract, so a command behaves the
+same wherever it ran:
+
+```console
+$ agtsbx run --runtime docker     sandboxd:latest sh -c 'echo $((6*7))'
+42
+$ agtsbx run --runtime kubernetes sandboxd:latest sh -c 'echo $((6*7))'
+42
+```
+
+## The image contract
+
+`IMAGE` must start [`sandboxd`](../../packages/sandboxd/USER_GUIDE.md), the
+portable runtime daemon defined by
+[KEP-539.2](../../docs/keps/539.2-runtime-standardization/README.md), as its
+entrypoint. `agtsbx` does not exec into the container; it talks to sandboxd's
+`ProcessService`, which is what makes the behaviour identical across backends.
+
+`packages/sandboxd/Dockerfile` builds a suitable base image, and
+`examples/sandboxd-sandbox/` shows how to add tools to it:
+
+```console
+$ docker build -f packages/sandboxd/Dockerfile -t sandboxd:local .
+$ agtsbx run sandboxd:local sh -c 'echo ready'
+```
+
+A command is required. Running the image with no command would just start the
+daemon and appear to hang, so `agtsbx` asks for one up front.
+
+## Usage
+
+```text
+agtsbx run [OPTIONS] IMAGE COMMAND [ARG...]
+```
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `--runtime` | `auto` | `auto`, `docker`, `podman` or `kubernetes` |
+| `-e`, `--env KEY=VALUE` | | Environment variable for the command; `-e KEY` forwards it from the current environment (repeatable) |
+| `-w`, `--workdir` | sandbox root | Working directory for the command |
+| `--name` | generated | Name for the sandbox |
+| `-n`, `--namespace` | `default` | Namespace, for the `kubernetes` runtime |
+| `--keep` | `false` | Leave the sandbox running after the command exits |
+| `--timeout` | `3m` | How long to wait for the sandbox to become ready |
+| `--grpc-port` | `9090` | sandboxd `ProcessService` port inside the sandbox |
+| `--rest-port` | `8080` | sandboxd REST API port inside the sandbox |
+| `-q`, `--quiet` | `false` | Suppress progress messages on stderr |
+
+Everything after `IMAGE` is passed to the sandboxed command untouched, so its
+own flags need no escaping:
+
+```console
+$ agtsbx run sandboxd:local ls -la /workspace
+```
+
+Progress messages go to stderr and the command's output to stdout, so stdout
+stays clean for piping:
+
+```console
+$ agtsbx run -q sandboxd:local cat /etc/os-release | grep ^ID
+ID=debian
+```
+
+### `--workdir` is inside the sandbox
+
+sandboxd confines the working directory to the sandbox root (`/workspace` by
+default), so `--workdir` is resolved there and must already exist. Passing a
+host path such as `/tmp` resolves to `/workspace/tmp`, which usually does not
+exist; `agtsbx` detects that case and says so rather than letting the
+underlying error blame the command binary.
+
+## Coding agents
+
+A coding agent edits files and runs commands on your behalf, which is the work
+a sandbox exists to contain, and all three of the popular CLIs have a headless
+mode that fits a one-shot `agtsbx run`.
+[`examples/agtsbx-agents`](../../examples/agtsbx-agents) builds an image with
+them installed:
+
+```console
+$ docker build -t agtsbx-agents:latest examples/agtsbx-agents
+$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest claude -p 'write hello.py'
+$ agtsbx run -e OPENAI_API_KEY    agtsbx-agents:latest codex exec 'write hello.py'
+$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest opencode run 'write hello.py'
+```
+
+`-e KEY` with no value forwards the variable from your own environment, so the
+credential stays out of the command line and the shell history. Variables are
+sent with the command itself, so they are not stored on the container or in
+the `Sandbox` object.
+
+## Examples
+
+```console
+# Environment variables
+$ agtsbx run -q -e GREETING=hi sandboxd:local sh -c 'echo $GREETING'
+hi
+
+# Exit statuses propagate
+$ agtsbx run -q sandboxd:local sh -c 'exit 42'; echo $?
+42
+
+# Output streams as it is produced, not buffered until exit
+$ agtsbx run -q sandboxd:local sh -c 'for i in 1 2 3; do echo $i; sleep 1; done'
+
+# Keep the sandbox for inspection
+$ agtsbx run --keep --name debugbox sandboxd:local echo started
+$ docker exec -it debugbox sh
+```
+
+## Cleanup
+
+The sandbox is removed when the command exits, including when it fails and
+when `agtsbx` is interrupted with Ctrl-C. A `Start` that fails part-way tears
+down whatever it had already created, so a failed run leaves nothing behind.
+`--keep` opts out and leaves the sandbox running.
+
+## Security
+
+The sandbox is meant to run untrusted code, and sandboxd performs no
+authentication of its own: KEP-539.2 places containment in the network layer.
+`agtsbx` therefore:
+
+- publishes container ports on `127.0.0.1` only, never on all interfaces, so
+  the sandbox control plane is not reachable off-host;
+- reaches Kubernetes sandboxes over a port-forward, so nothing is exposed
+  cluster-wide and no `Service`, `Gateway` or router is required;
+- creates Kubernetes sandboxes with `automountServiceAccountToken: false`,
+  `runAsNonRoot`, `allowPrivilegeEscalation: false` and all capabilities
+  dropped, matching `examples/sandboxd-sandbox/sandbox-template.yaml`;
+- runs containers with `--cap-drop ALL` and `--security-opt
+  no-new-privileges`;
+- sends the command's environment with the command, so credentials passed
+  with `-e` are not written to the engine's argv or the `Sandbox` object.
+
+Local engines have no `runAsNonRoot` equivalent, so on that path the image
+decides which user the command runs as; the `kubernetes` runtime rejects an
+image that would run as root.
+
+## Building
+
+```console
+$ make build-agtsbx   # -> bin/agtsbx
+```

--- a/cmd/agtsbx/main.go
+++ b/cmd/agtsbx/main.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary agtsbx is a docker-like command-line front end for agent-sandbox.
+//
+//	agtsbx run [OPTIONS] IMAGE COMMAND [ARG...]
+//
+// It starts a sandbox from a container image, waits for the sandboxd runtime
+// daemon inside it to report healthy, runs one command through sandboxd's
+// ProcessService and streams the output back. The sandbox is torn down when
+// the command exits.
+//
+// The sandbox runs as a local Docker or Podman container, or as a Sandbox
+// object in a Kubernetes cluster. Every backend exposes the same KEP-539.2
+// runtime API, so a command behaves identically wherever it ran.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"sigs.k8s.io/agent-sandbox/internal/agtsbx"
+	"sigs.k8s.io/agent-sandbox/internal/version"
+)
+
+const usage = `agtsbx runs commands in agent sandboxes.
+
+Usage:
+  agtsbx run [OPTIONS] IMAGE COMMAND [ARG...]   Run a command in a sandbox
+  agtsbx version                                Print version information
+  agtsbx help                                   Show this message
+
+Run "agtsbx run --help" for the options of the run command.
+`
+
+func main() {
+	os.Exit(run())
+}
+
+// run holds the body of main so deferred cleanup still executes; os.Exit
+// would skip it.
+func run() int {
+	// Ctrl-C cancels the context rather than killing the process outright, so
+	// the sandbox is torn down instead of leaking.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Deregister as soon as the first signal lands, so a second one takes the
+	// default action instead of being swallowed by a stalled teardown.
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
+
+	args := os.Args[1:]
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, usage)
+		return 1
+	}
+
+	switch args[0] {
+	case "run":
+		streams := agtsbx.IO{Stdout: os.Stdout, Stderr: os.Stderr}
+		exitCode, err := agtsbx.Run(ctx, args[1:], streams)
+		if err != nil {
+			// Usage errors have already printed their own guidance.
+			if !errors.Is(err, agtsbx.ErrUsage) {
+				fmt.Fprintf(os.Stderr, "agtsbx: %v\n", err)
+			}
+			return exitCode
+		}
+		return exitCode
+	case "version", "--version", "-v":
+		fmt.Fprintln(os.Stdout, version.Print("agtsbx"))
+		return 0
+	case "help", "--help", "-h":
+		fmt.Fprint(os.Stdout, usage)
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "agtsbx: unknown command %q\n\n%s", args[0], usage)
+		return 1
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This directory contains examples of how to use the Agent Sandbox. Each subdirectory contains a different example.
 
 - [**agent-sandbox-rl**](./agent-sandbox-rl): Generic, multi-cluster batch orchestration for running SWE-bench-style RL/eval workloads on Agent Sandbox warm pools.
+- [**agtsbx-agents**](./agtsbx-agents): A sandboxd runtime image with the opencode, Claude Code and Codex CLIs, for running a coding agent in a throwaway sandbox with `agtsbx run`.
 - [**aio-sandbox**](./aio-sandbox): An example of running All-in-One (AIO) Sandbox using agent-sandbox.
 - [**apf-insulation**](./apf-insulation): An opt-in API Priority and Fairness overlay giving the controller dedicated apiserver concurrency for high-rate claim workloads (claim path > bulk refill > events).
 - [**chrome-sandbox**](./chrome-sandbox): An example of running a Chrome browser in a sandbox.

--- a/examples/agtsbx-agents/Dockerfile
+++ b/examples/agtsbx-agents/Dockerfile
@@ -1,0 +1,37 @@
+# A sandboxd runtime image carrying three coding-agent CLIs, so that
+# "agtsbx run" can drive them. Build it with:
+#
+#     docker build -t agtsbx-agents:latest examples/agtsbx-agents
+
+ARG SANDBOXD_IMAGE=us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandboxd:latest-main
+FROM ${SANDBOXD_IMAGE} AS sandboxd
+
+# All three agents ship as npm packages, so start from a Node base and copy
+# sandboxd in, rather than adding Node to the sandboxd image.
+FROM node:22-bookworm-slim
+
+# The agents shell out to git constantly, and need CA certificates to reach
+# their model APIs.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+      opencode-ai \
+      @anthropic-ai/claude-code \
+      @openai/codex \
+    && npm cache clean --force
+
+COPY --from=sandboxd /usr/local/bin/sandboxd /usr/local/bin/sandboxd
+
+# Each agent keeps its config and session state under $HOME. Pointing HOME at
+# the sandbox root keeps that state inside the sandbox, where it is discarded
+# with it, instead of in a directory the sandbox user cannot write.
+ENV HOME=/workspace
+RUN mkdir -p /workspace && chown 1000:1000 /workspace
+
+WORKDIR /workspace
+# node:22 already defines UID 1000; the numeric form satisfies runAsNonRoot.
+USER 1000
+EXPOSE 8080 9090
+ENTRYPOINT ["/usr/local/bin/sandboxd"]

--- a/examples/agtsbx-agents/README.md
+++ b/examples/agtsbx-agents/README.md
@@ -1,0 +1,93 @@
+# Coding agents with `agtsbx run`
+
+Coding agents edit files and run commands on your behalf, which is exactly the
+work a sandbox exists to contain. [`agtsbx`](../../cmd/agtsbx/README.md) runs
+one in a throwaway sandbox and streams the result back, so nothing the agent
+does touches the host:
+
+```console
+$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest \
+    claude -p 'write hello.py, then run it'
+```
+
+All three agents packaged here have a headless mode, which is what makes them
+a fit for a one-shot `agtsbx run`.
+
+## Build the image
+
+The image is a [sandboxd](../../packages/sandboxd/USER_GUIDE.md) runtime
+image, the KEP-539.2 daemon as its entrypoint, with the agent CLIs added:
+
+```console
+$ docker build -t agtsbx-agents:latest examples/agtsbx-agents
+```
+
+| Agent | Package | Headless invocation |
+| --- | --- | --- |
+| [opencode](https://opencode.ai) | `opencode-ai` | `opencode run PROMPT` |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `@anthropic-ai/claude-code` | `claude -p PROMPT` |
+| [Codex](https://developers.openai.com/codex/cli) | `@openai/codex` | `codex exec PROMPT` |
+
+## Run
+
+Each agent needs its provider credential, passed with `-e`:
+
+```console
+$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest \
+    claude -p 'summarise the files in this directory'
+
+$ agtsbx run -e OPENAI_API_KEY agtsbx-agents:latest \
+    codex exec 'write a fizzbuzz in Rust'
+
+$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest \
+    opencode run 'add a docstring to every function in main.py'
+```
+
+`-e KEY` with no value forwards the variable from your own environment, so the
+credential stays out of the command line and the shell history. Only the
+variables named this way reach the agent, and they travel with the command
+rather than being stored on the sandbox.
+
+Agents stop to ask permission before acting, which a one-shot run cannot
+answer; each has a flag to skip that (`claude --permission-mode`, `codex exec
+--dangerously-bypass-approvals-and-sandbox`, `opencode run --agent build`).
+Those flags are far safer here than on a workstation, because the sandbox is
+the boundary and it is discarded when the command exits.
+
+`--runtime kubernetes` runs the same agent as a `Sandbox` object in a cluster,
+with no other change to the command:
+
+```console
+$ agtsbx run --runtime kubernetes -n agents -e ANTHROPIC_API_KEY \
+    agtsbx-agents:latest claude -p 'what is in this workspace?'
+```
+
+## Giving the agent something to work on
+
+The sandbox starts empty, so clone the repository first and chain the agent
+onto the same command:
+
+```console
+$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest sh -c '
+    git clone --depth 1 https://github.com/kubernetes-sigs/agent-sandbox repo &&
+    cd repo && claude -p "what does the Sandbox controller reconcile?"'
+```
+
+For work you want to keep, `--keep` leaves the sandbox in place so the results
+can be copied out:
+
+```console
+$ agtsbx run --keep --name agentbox -e ANTHROPIC_API_KEY agtsbx-agents:latest \
+    claude -p 'write hello.py'
+$ docker cp agentbox:/workspace/hello.py .
+$ docker rm -f agentbox
+```
+
+## Notes
+
+- The agents are unpinned; add versions to the `npm install` line in the
+  [Dockerfile](Dockerfile) if you need reproducible runs.
+- The sandbox has unrestricted egress, which the agents need in order to reach
+  their model APIs. To narrow that to the provider alone, run under
+  `--runtime kubernetes` and attach a NetworkPolicy, see
+  [`examples/composing-sandbox-nw-policies`](../composing-sandbox-nw-policies).

--- a/internal/agtsbx/backend.go
+++ b/internal/agtsbx/backend.go
@@ -1,0 +1,179 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package agtsbx implements the agtsbx command-line tool: a docker-like front
+// end for running one-shot sandboxes.
+//
+// Every backend converges on the KEP-539.2 sandboxd contract, so a backend
+// only has to answer "where do I dial sandboxd?".
+package agtsbx
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"slices"
+	"time"
+)
+
+// Runtime names accepted by --runtime.
+const (
+	// RuntimeAuto probes the host and picks the first usable backend.
+	RuntimeAuto = "auto"
+	// RuntimeDocker runs the sandbox as a local Docker container.
+	RuntimeDocker = "docker"
+	// RuntimePodman runs the sandbox as a local Podman container.
+	RuntimePodman = "podman"
+	// RuntimeKubernetes runs the sandbox as a Sandbox object in a cluster.
+	RuntimeKubernetes = "kubernetes"
+)
+
+// autoRuntimePreference is the probe order used by RuntimeAuto. Local engines
+// come first because they need no cluster, kubeconfig or controller install.
+var autoRuntimePreference = []string{RuntimeDocker, RuntimePodman, RuntimeKubernetes}
+
+// knownRuntimes is every value --runtime accepts, in help-text order.
+var knownRuntimes = []string{RuntimeAuto, RuntimeDocker, RuntimePodman, RuntimeKubernetes}
+
+// Default sandboxd listener ports inside the sandbox (KEP-539.2).
+const (
+	defaultGRPCPort = 9090
+	defaultRESTPort = 8080
+)
+
+// cleanupTimeout bounds teardown, which runs on paths where the caller's
+// context is already cancelled and so needs a deadline of its own.
+const cleanupTimeout = 30 * time.Second
+
+// managedByValue marks the sandboxes agtsbx created, so failed-start cleanup
+// never removes an object that merely shares the requested name.
+const managedByValue = "agtsbx"
+
+// Endpoints locates a running sandbox's sandboxd listeners, as addresses
+// reachable from the caller: published loopback ports for a container
+// backend, the local ends of a port-forward for Kubernetes.
+type Endpoints struct {
+	// GRPCAddr is the "host:port" of sandboxd's ProcessService.
+	GRPCAddr string
+	// RESTAddr is the "host:port" of sandboxd's Filesystem & Runtime REST API.
+	RESTAddr string
+}
+
+// Spec describes the sandbox to start. It holds only what every backend can
+// honour; backend-specific knobs live in backendOptions.
+//
+// It carries no environment: sandboxd takes the command's variables per
+// request, so keeping them out of here keeps credentials out of the engine
+// argv and out of the Sandbox object.
+type Spec struct {
+	// Image must start sandboxd as its entrypoint.
+	Image string
+	// Name identifies the sandbox to the backend (container name, Sandbox
+	// object name).
+	Name string
+	// GRPCPort and RESTPort are sandboxd's ports inside the sandbox.
+	GRPCPort int
+	RESTPort int
+	// Remove requests that the sandbox be torn down once the command exits.
+	Remove bool
+}
+
+// Instance is a sandbox that has been started and is reachable.
+type Instance interface {
+	// Endpoints reports where to reach sandboxd.
+	Endpoints() Endpoints
+	// Stop releases the sandbox and any local resources held for it. It is
+	// safe to call more than once, and takes its own context because the
+	// caller's is usually cancelled by the time teardown runs.
+	Stop(ctx context.Context) error
+}
+
+// Backend starts sandboxes on one particular runtime.
+type Backend interface {
+	// Name is the --runtime value that selects this backend.
+	Name() string
+	// Start creates the sandbox and returns once sandboxd is reachable and
+	// healthy. On error it cleans up whatever it already created.
+	Start(ctx context.Context, spec Spec) (Instance, error)
+}
+
+// lookPathFunc mirrors exec.LookPath so runtime selection can be tested
+// without depending on what happens to be installed on the machine.
+type lookPathFunc func(file string) (string, error)
+
+// selectRuntime resolves the --runtime value into a concrete backend name.
+// An explicit choice is never silently downgraded to a different engine; only
+// RuntimeAuto probes.
+func selectRuntime(requested string, lookPath lookPathFunc) (string, error) {
+	switch requested {
+	case RuntimeDocker, RuntimePodman:
+		if _, err := lookPath(requested); err != nil {
+			return "", fmt.Errorf("runtime %q selected but the %q executable was not found in PATH: %w", requested, requested, err)
+		}
+		return requested, nil
+	case RuntimeKubernetes:
+		return RuntimeKubernetes, nil
+	case RuntimeAuto:
+		for _, candidate := range autoRuntimePreference {
+			// Kubernetes is the terminal fallback: nothing to probe for, and
+			// its own kubeconfig error beats a generic "no runtime found".
+			if candidate == RuntimeKubernetes {
+				return RuntimeKubernetes, nil
+			}
+			if _, err := lookPath(candidate); err == nil {
+				return candidate, nil
+			}
+		}
+		return "", fmt.Errorf("no usable runtime found")
+	default:
+		return "", fmt.Errorf("unknown runtime %q, expected one of %v", requested, knownRuntimes)
+	}
+}
+
+// newBackend constructs the backend named by runtime, which must already have
+// been resolved by selectRuntime.
+func newBackend(runtime string, opts backendOptions) (Backend, error) {
+	switch runtime {
+	case RuntimeDocker, RuntimePodman:
+		return newContainerBackend(runtime, opts), nil
+	case RuntimeKubernetes:
+		return newKubeBackend(opts)
+	default:
+		return nil, fmt.Errorf("unknown runtime %q, expected one of %v", runtime, knownRuntimes)
+	}
+}
+
+// backendOptions carries the knobs only some backends can act on.
+type backendOptions struct {
+	// Namespace is where the Kubernetes backend creates the Sandbox.
+	Namespace string
+	// ReadyTimeout bounds the whole of Start.
+	ReadyTimeout time.Duration
+	// Stderr receives progress messages, keeping the sandboxed command's
+	// stdout pipeable.
+	Stderr writerFunc
+}
+
+// writerFunc is the minimal sink the backends need for progress output.
+type writerFunc interface {
+	Write(p []byte) (int, error)
+}
+
+// isKnownRuntime reports whether name is an accepted --runtime value.
+func isKnownRuntime(name string) bool {
+	return slices.Contains(knownRuntimes, name)
+}
+
+// defaultLookPath is the production lookPathFunc.
+var defaultLookPath lookPathFunc = exec.LookPath

--- a/internal/agtsbx/backend_test.go
+++ b/internal/agtsbx/backend_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lookPathFor returns a lookPathFunc that reports only the named executables
+// as installed.
+func lookPathFor(available ...string) lookPathFunc {
+	return func(file string) (string, error) {
+		if slices.Contains(available, file) {
+			return "/usr/bin/" + file, nil
+		}
+		return "", errors.New("executable file not found in $PATH")
+	}
+}
+
+func TestSelectRuntime(t *testing.T) {
+	testCases := []struct {
+		name      string
+		requested string
+		available []string
+		want      string
+		wantErr   string
+	}{
+		{
+			name:      "auto prefers docker when both engines are present",
+			requested: RuntimeAuto,
+			available: []string{"docker", "podman"},
+			want:      RuntimeDocker,
+		},
+		{
+			name:      "auto falls through to podman when docker is missing",
+			requested: RuntimeAuto,
+			available: []string{"podman"},
+			want:      RuntimePodman,
+		},
+		{
+			// Kubernetes is the terminal fallback, so auto always resolves.
+			name:      "auto falls back to kubernetes with no container engine",
+			requested: RuntimeAuto,
+			available: nil,
+			want:      RuntimeKubernetes,
+		},
+		{
+			name:      "explicit docker is honoured",
+			requested: RuntimeDocker,
+			available: []string{"docker", "podman"},
+			want:      RuntimeDocker,
+		},
+		{
+			// An explicit choice is never silently downgraded: the error names
+			// what the user actually asked for.
+			name:      "explicit podman fails when podman is missing",
+			requested: RuntimePodman,
+			available: []string{"docker"},
+			wantErr:   `runtime "podman" selected but the "podman" executable was not found`,
+		},
+		{
+			name:      "explicit kubernetes needs no executable",
+			requested: RuntimeKubernetes,
+			available: nil,
+			want:      RuntimeKubernetes,
+		},
+		{
+			name:      "unknown runtime is rejected",
+			requested: "firecracker",
+			available: []string{"docker"},
+			wantErr:   `unknown runtime "firecracker"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectRuntime(tc.requested, lookPathFor(tc.available...))
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsKnownRuntime(t *testing.T) {
+	for _, name := range knownRuntimes {
+		assert.True(t, isKnownRuntime(name), "expected %q to be a known runtime", name)
+	}
+	assert.False(t, isKnownRuntime("gvisor"))
+	assert.False(t, isKnownRuntime(""))
+}
+
+func TestNewBackendRejectsUnknownRuntime(t *testing.T) {
+	_, err := newBackend("firecracker", backendOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown runtime "firecracker"`)
+}
+
+func TestNewBackendBuildsContainerBackends(t *testing.T) {
+	for _, engine := range []string{RuntimeDocker, RuntimePodman} {
+		backend, err := newBackend(engine, backendOptions{})
+		require.NoError(t, err)
+		// The backend name doubles as the executable name; a mismatch would
+		// silently invoke the wrong engine.
+		assert.Equal(t, engine, backend.Name())
+	}
+}

--- a/internal/agtsbx/container.go
+++ b/internal/agtsbx/container.go
@@ -1,0 +1,271 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// managedByLabel marks containers agtsbx created. See managedByValue.
+const managedByLabel = "app.kubernetes.io/managed-by"
+
+// containerBackend runs the sandbox as a local container.
+//
+// It drives the engine CLI rather than linking an engine SDK: the client
+// libraries are large, and podman comes free because the subcommands used
+// here are identical in both engines.
+type containerBackend struct {
+	// engine is the executable name, also the backend name ("docker"/"podman").
+	engine string
+	runner commandRunner
+	// httpClient probes sandboxd readiness on the published port.
+	httpClient   *http.Client
+	readyTimeout time.Duration
+	progress     writerFunc
+}
+
+// commandRunner executes an engine subcommand and returns its stdout, so the
+// backend can be tested with no engine installed.
+type commandRunner interface {
+	run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// execRunner is the production commandRunner.
+type execRunner struct{}
+
+func (execRunner) run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// The engine's diagnostics beat a bare exit status.
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			return nil, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+		}
+		return nil, fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, message)
+	}
+	return stdout.Bytes(), nil
+}
+
+func newContainerBackend(engine string, opts backendOptions) *containerBackend {
+	return &containerBackend{
+		engine:       engine,
+		runner:       execRunner{},
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+		readyTimeout: opts.ReadyTimeout,
+		progress:     opts.Stderr,
+	}
+}
+
+func (b *containerBackend) Name() string { return b.engine }
+
+// containerInstance is a started container sandbox.
+type containerInstance struct {
+	backend   *containerBackend
+	name      string
+	endpoints Endpoints
+	// remove tells Stop whether to delete the container. False under --keep.
+	remove bool
+}
+
+func (i *containerInstance) Endpoints() Endpoints { return i.endpoints }
+
+func (i *containerInstance) Stop(ctx context.Context) error {
+	if !i.remove {
+		return nil
+	}
+	if err := i.backend.remove(ctx, i.name); err != nil {
+		return fmt.Errorf("removing container %s: %w", i.name, err)
+	}
+	return nil
+}
+
+// Start creates the container, discovers its published ports and waits for
+// sandboxd to report healthy.
+func (b *containerBackend) Start(ctx context.Context, spec Spec) (Instance, error) {
+	// One deadline for the whole startup, so Start cannot outlast --timeout.
+	ctx, cancel := context.WithTimeout(ctx, b.readyTimeout)
+	defer cancel()
+
+	if _, err := b.runner.run(ctx, b.engine, containerRunArgs(spec)...); err != nil {
+		// A failed `run` does not prove the engine created nothing: it may
+		// have accepted the request before the CLI lost its answer, and --rm
+		// never fires while sandboxd keeps running.
+		b.removeIfOurs(spec.Name)
+		return nil, fmt.Errorf("starting sandbox container: %w", err)
+	}
+
+	instance := &containerInstance{
+		backend: b,
+		name:    spec.Name,
+		remove:  spec.Remove,
+	}
+
+	// The container now exists, so every failure path below must tear it down
+	// or the user is left with an orphan.
+	endpoints, err := b.resolveEndpoints(ctx, spec)
+	if err != nil {
+		b.cleanup(instance.name)
+		return nil, err
+	}
+	instance.endpoints = endpoints
+
+	if err := waitHealthy(ctx, b.httpClient, endpoints.RESTAddr); err != nil {
+		b.cleanup(instance.name)
+		return nil, err
+	}
+	return instance, nil
+}
+
+// remove deletes the container. --force because sandboxd outlives the one
+// command we sent it, so the container is still running; --volumes stops the
+// image's anonymous volumes accumulating across runs.
+func (b *containerBackend) remove(ctx context.Context, name string) error {
+	_, err := b.runner.run(ctx, b.engine, "rm", "--force", "--volumes", name)
+	// --rm may already have reaped it, which is the state we wanted.
+	if err != nil && !isNoSuchContainer(err) {
+		return err
+	}
+	return nil
+}
+
+// cleanup removes a container created by a Start that then failed. It ignores
+// spec.Remove: the sandbox was never handed to the caller, so leaving it
+// behind would just be a leak.
+func (b *containerBackend) cleanup(name string) {
+	// A fresh context: the caller's is often already cancelled, which is
+	// frequently the very reason Start is unwinding.
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+
+	if err := b.remove(ctx, name); err != nil {
+		fmt.Fprintf(b.progress, "agtsbx: warning: could not remove container %s: %v\n", name, err)
+	}
+}
+
+// removeIfOurs cleans up after an ambiguous `run`, but only if the container
+// carries our label, so a name that collided with the user's own container
+// leaves theirs alone.
+func (b *containerBackend) removeIfOurs(name string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+
+	out, err := b.runner.run(ctx, b.engine, "inspect", "--format",
+		fmt.Sprintf("{{index .Config.Labels %q}}", managedByLabel), name)
+	if err != nil || strings.TrimSpace(string(out)) != managedByValue {
+		return
+	}
+	if err := b.remove(ctx, name); err != nil {
+		fmt.Fprintf(b.progress, "agtsbx: warning: could not remove container %s: %v\n", name, err)
+	}
+}
+
+// isNoSuchContainer reports whether err is the engine complaining that the
+// container is already gone. Both engines say so only in prose.
+func isNoSuchContainer(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no such container") ||
+		strings.Contains(message, "no such object")
+}
+
+// resolveEndpoints asks the engine which host ports it bound to sandboxd's
+// ports.
+func (b *containerBackend) resolveEndpoints(ctx context.Context, spec Spec) (Endpoints, error) {
+	grpcAddr, err := b.publishedAddr(ctx, spec.Name, spec.GRPCPort)
+	if err != nil {
+		return Endpoints{}, err
+	}
+	restAddr, err := b.publishedAddr(ctx, spec.Name, spec.RESTPort)
+	if err != nil {
+		return Endpoints{}, err
+	}
+	return Endpoints{GRPCAddr: grpcAddr, RESTAddr: restAddr}, nil
+}
+
+// publishedAddr returns the host address bound to containerPort.
+func (b *containerBackend) publishedAddr(ctx context.Context, name string, containerPort int) (string, error) {
+	out, err := b.runner.run(ctx, b.engine, "port", name, fmt.Sprintf("%d/tcp", containerPort))
+	if err != nil {
+		return "", fmt.Errorf("looking up published port for container port %d: %w", containerPort, err)
+	}
+	addr, err := parsePublishedPort(string(out))
+	if err != nil {
+		return "", fmt.Errorf("container port %d: %w", containerPort, err)
+	}
+	return addr, nil
+}
+
+// containerRunArgs builds the engine's `run` argument list for spec.
+//
+// The host port is left empty ("127.0.0.1::9090") so the engine allocates a
+// free one; choosing one ourselves would race concurrent invocations. The
+// bind address is pinned to loopback because sandboxd authenticates nothing
+// (KEP-539.2 places containment in the network layer), so its control plane
+// must not be reachable off-host as the engine default would allow.
+//
+// Capabilities and no-new-privileges mirror the securityContext in
+// buildSandbox. The user is not forced here: local engines have no
+// runAsNonRoot equivalent, so on this path the image decides.
+func containerRunArgs(spec Spec) []string {
+	args := []string{"run", "--detach", "--name", spec.Name}
+	if spec.Remove {
+		// Belt and braces alongside Stop: if agtsbx is killed before it can
+		// clean up, the engine still reaps the container once it stops.
+		args = append(args, "--rm")
+	}
+	return append(args,
+		"--label", managedByLabel+"="+managedByValue,
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges",
+		"--publish", fmt.Sprintf("127.0.0.1::%d", spec.GRPCPort),
+		"--publish", fmt.Sprintf("127.0.0.1::%d", spec.RESTPort),
+		spec.Image,
+	)
+}
+
+// parsePublishedPort extracts a dialable address from `docker port` output.
+// The engine prints one binding per line, and may list both IPv4 and IPv6 for
+// one container port; either reaches the same listener, so the first wins.
+func parsePublishedPort(out string) (string, error) {
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		host, port, err := net.SplitHostPort(line)
+		if err != nil {
+			continue
+		}
+		if _, err := strconv.Atoi(port); err != nil {
+			continue
+		}
+		// A wildcard bind address is not dialable as printed.
+		if host == "" || host == "0.0.0.0" || host == "::" {
+			host = "127.0.0.1"
+		}
+		return net.JoinHostPort(host, port), nil
+	}
+	return "", fmt.Errorf("no published host port found in engine output %q", strings.TrimSpace(out))
+}

--- a/internal/agtsbx/container_test.go
+++ b/internal/agtsbx/container_test.go
@@ -1,0 +1,372 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRunner records engine invocations and replays canned responses, so the
+// container backend can be exercised with no engine installed.
+type fakeRunner struct {
+	mu    sync.Mutex
+	calls [][]string
+	// responses maps the first argument (the subcommand) to its stdout.
+	responses map[string]string
+	// errs maps a subcommand to an error to return instead.
+	errs map[string]error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{responses: map[string]string{}, errs: map[string]error{}}
+}
+
+func (f *fakeRunner) run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, append([]string{name}, args...))
+	if len(args) == 0 {
+		return nil, nil
+	}
+	if err, ok := f.errs[args[0]]; ok {
+		return nil, err
+	}
+	return []byte(f.responses[args[0]]), nil
+}
+
+// callsFor returns every recorded invocation whose subcommand is sub.
+func (f *fakeRunner) callsFor(sub string) [][]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out [][]string
+	for _, call := range f.calls {
+		if len(call) > 1 && call[1] == sub {
+			out = append(out, call)
+		}
+	}
+	return out
+}
+
+func TestContainerRunArgs(t *testing.T) {
+	t.Run("publishes both sandboxd ports on loopback with an ephemeral host port", func(t *testing.T) {
+		args := containerRunArgs(Spec{
+			Image:    "sandboxd:latest",
+			Name:     "agtsbx-abc",
+			GRPCPort: 9090,
+			RESTPort: 8080,
+		})
+
+		// Loopback pinning is a security property: sandboxd authenticates
+		// nothing, so its control plane must not be published to the network.
+		joined := strings.Join(args, " ")
+		assert.Contains(t, joined, "--publish 127.0.0.1::9090")
+		assert.Contains(t, joined, "--publish 127.0.0.1::8080")
+		assert.NotContains(t, joined, "0.0.0.0")
+	})
+
+	t.Run("confines the container the way buildSandbox confines the pod", func(t *testing.T) {
+		// A local sandbox runs the same untrusted code as a cluster one, so
+		// it must not be the softer target of the two.
+		args := containerRunArgs(Spec{Image: "sandboxd:latest", Name: "agtsbx-abc"})
+
+		joined := strings.Join(args, " ")
+		assert.Contains(t, joined, "--cap-drop ALL")
+		assert.Contains(t, joined, "--security-opt no-new-privileges")
+	})
+
+	t.Run("runs detached with the image last", func(t *testing.T) {
+		args := containerRunArgs(Spec{Image: "sandboxd:latest", Name: "agtsbx-abc"})
+
+		assert.Equal(t, "run", args[0])
+		assert.Contains(t, args, "--detach")
+		// Everything after the image is the container's command, so the image
+		// must terminate the argument list.
+		assert.Equal(t, "sandboxd:latest", args[len(args)-1])
+	})
+
+	t.Run("keeps the environment off the engine argv", func(t *testing.T) {
+		// The command's variables travel in the sandboxd request, so a
+		// credential never appears in host ps output or docker inspect.
+		args := containerRunArgs(Spec{Image: "sandboxd:latest", Name: "agtsbx-abc"})
+		assert.NotContains(t, args, "--env")
+		assert.NotContains(t, args, "-e")
+	})
+
+	t.Run("labels the container as ours", func(t *testing.T) {
+		// Failed-start cleanup removes only labelled containers.
+		args := containerRunArgs(Spec{Image: "i", Name: "n"})
+		assert.Contains(t, strings.Join(args, " "), "--label "+managedByLabel+"="+managedByValue)
+	})
+
+	t.Run("adds --rm only when the sandbox is ephemeral", func(t *testing.T) {
+		ephemeral := containerRunArgs(Spec{Image: "i", Name: "n", Remove: true})
+		assert.Contains(t, ephemeral, "--rm")
+
+		kept := containerRunArgs(Spec{Image: "i", Name: "n", Remove: false})
+		assert.NotContains(t, kept, "--rm")
+	})
+
+	t.Run("does not set a container workdir", func(t *testing.T) {
+		// --workdir belongs to the command, not the sandbox: it travels as
+		// ProcessConfig.cwd. On the container it would move sandboxd's own cwd.
+		args := containerRunArgs(Spec{Image: "i", Name: "n"})
+		assert.NotContains(t, args, "--workdir")
+		assert.NotContains(t, args, "-w")
+	})
+}
+
+func TestParsePublishedPort(t *testing.T) {
+	testCases := []struct {
+		name    string
+		output  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "loopback binding",
+			output: "127.0.0.1:32768\n",
+			want:   "127.0.0.1:32768",
+		},
+		{
+			// Either of an IPv4/IPv6 pair reaches the same listener.
+			name:   "first of several bindings wins",
+			output: "127.0.0.1:32768\n[::1]:32769\n",
+			want:   "127.0.0.1:32768",
+		},
+		{
+			// A wildcard bind address is not dialable as printed.
+			name:   "wildcard address is rewritten to loopback",
+			output: "0.0.0.0:32768\n",
+			want:   "127.0.0.1:32768",
+		},
+		{
+			name:   "ipv6 wildcard is rewritten to loopback",
+			output: "[::]:32768\n",
+			want:   "127.0.0.1:32768",
+		},
+		{
+			name:   "surrounding whitespace is tolerated",
+			output: "  \n  127.0.0.1:32768  \n",
+			want:   "127.0.0.1:32768",
+		},
+		{
+			name:    "empty output is an error",
+			output:  "\n  \n",
+			wantErr: true,
+		},
+		{
+			name:    "unparsable output is an error",
+			output:  "no port mapping found",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePublishedPort(tc.output)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// newTestContainerBackend wires a container backend to a fake engine and a
+// health endpoint served by the given handler.
+func newTestContainerBackend(t *testing.T, runner commandRunner, handler http.HandlerFunc) (*containerBackend, string) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return &containerBackend{
+		engine:       "docker",
+		runner:       runner,
+		httpClient:   server.Client(),
+		readyTimeout: 5 * time.Second,
+		progress:     io.Discard,
+	}, strings.TrimPrefix(server.URL, "http://")
+}
+
+func TestContainerBackendStart(t *testing.T) {
+	t.Run("returns endpoints once sandboxd is healthy", func(t *testing.T) {
+		runner := newFakeRunner()
+		backend, addr := newTestContainerBackend(t, runner, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		// Both ports resolve to the stub server so the health probe reaches it.
+		runner.responses["port"] = addr
+
+		instance, err := backend.Start(context.Background(), Spec{
+			Image: "sandboxd:latest", Name: "agtsbx-test", GRPCPort: 9090, RESTPort: 8080, Remove: true,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, addr, instance.Endpoints().RESTAddr)
+		assert.Equal(t, addr, instance.Endpoints().GRPCAddr)
+		// Each sandboxd port must be looked up separately.
+		assert.Len(t, runner.callsFor("port"), 2)
+	})
+
+	t.Run("removes the container when the health probe never succeeds", func(t *testing.T) {
+		runner := newFakeRunner()
+		backend, addr := newTestContainerBackend(t, runner, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+		runner.responses["port"] = addr
+		backend.readyTimeout = 300 * time.Millisecond
+
+		_, err := backend.Start(context.Background(), Spec{
+			Image: "sandboxd:latest", Name: "agtsbx-test", GRPCPort: 9090, RESTPort: 8080, Remove: true,
+		})
+		require.Error(t, err)
+
+		// The caller never received an Instance, so only Start can clean up.
+		removals := runner.callsFor("rm")
+		require.Len(t, removals, 1)
+		assert.Contains(t, removals[0], "--force")
+		assert.Contains(t, removals[0], "agtsbx-test")
+	})
+
+	t.Run("removes the container when port discovery fails", func(t *testing.T) {
+		runner := newFakeRunner()
+		backend, _ := newTestContainerBackend(t, runner, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		runner.errs["port"] = errors.New("no such container")
+
+		_, err := backend.Start(context.Background(), Spec{
+			Image: "sandboxd:latest", Name: "agtsbx-test", GRPCPort: 9090, RESTPort: 8080, Remove: true,
+		})
+		require.Error(t, err)
+		assert.Len(t, runner.callsFor("rm"), 1)
+	})
+
+	t.Run("does not remove anything when the container never started", func(t *testing.T) {
+		runner := newFakeRunner()
+		backend, _ := newTestContainerBackend(t, runner, func(http.ResponseWriter, *http.Request) {})
+		runner.errs["run"] = errors.New("image not found")
+
+		_, err := backend.Start(context.Background(), Spec{
+			Image: "missing:latest", Name: "agtsbx-test", GRPCPort: 9090, RESTPort: 8080, Remove: true,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "image not found")
+		assert.Empty(t, runner.callsFor("rm"))
+	})
+
+	t.Run("removes a container the engine created despite failing the run", func(t *testing.T) {
+		// The daemon can accept the request before the CLI loses its answer,
+		// and --rm never fires while sandboxd keeps running.
+		runner := newFakeRunner()
+		backend, _ := newTestContainerBackend(t, runner, func(http.ResponseWriter, *http.Request) {})
+		runner.errs["run"] = context.DeadlineExceeded
+		runner.responses["inspect"] = managedByValue + "\n"
+
+		_, err := backend.Start(context.Background(), Spec{
+			Image: "sandboxd:latest", Name: "agtsbx-test", GRPCPort: 9090, RESTPort: 8080, Remove: true,
+		})
+		require.Error(t, err)
+		require.Len(t, runner.callsFor("rm"), 1)
+	})
+
+	t.Run("leaves a container that is not ours after a failed run", func(t *testing.T) {
+		// --name can collide with something the user owns.
+		runner := newFakeRunner()
+		backend, _ := newTestContainerBackend(t, runner, func(http.ResponseWriter, *http.Request) {})
+		runner.errs["run"] = errors.New("container name already in use")
+		runner.responses["inspect"] = "\n"
+
+		_, err := backend.Start(context.Background(), Spec{
+			Image: "sandboxd:latest", Name: "mybox", GRPCPort: 9090, RESTPort: 8080, Remove: true,
+		})
+		require.Error(t, err)
+		assert.Empty(t, runner.callsFor("rm"))
+	})
+}
+
+func TestContainerInstanceStop(t *testing.T) {
+	t.Run("removes an ephemeral sandbox", func(t *testing.T) {
+		runner := newFakeRunner()
+		backend := &containerBackend{engine: "docker", runner: runner, progress: io.Discard}
+		instance := &containerInstance{backend: backend, name: "agtsbx-test", remove: true}
+
+		require.NoError(t, instance.Stop(context.Background()))
+
+		// --force is required because sandboxd outlives the single command
+		// agtsbx sent it, so the container is still running.
+		removals := runner.callsFor("rm")
+		require.Len(t, removals, 1)
+		assert.Contains(t, removals[0], "--force")
+		assert.Contains(t, removals[0], "--volumes")
+	})
+
+	t.Run("leaves a kept sandbox running", func(t *testing.T) {
+		runner := newFakeRunner()
+		backend := &containerBackend{engine: "docker", runner: runner, progress: io.Discard}
+		instance := &containerInstance{backend: backend, name: "agtsbx-test", remove: false}
+
+		require.NoError(t, instance.Stop(context.Background()))
+		assert.Empty(t, runner.calls, "--keep must not tear the sandbox down")
+	})
+
+	t.Run("surfaces engine failures", func(t *testing.T) {
+		runner := newFakeRunner()
+		runner.errs["rm"] = errors.New("permission denied")
+		backend := &containerBackend{engine: "docker", runner: runner, progress: io.Discard}
+		instance := &containerInstance{backend: backend, name: "agtsbx-test", remove: true}
+
+		err := instance.Stop(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "permission denied")
+	})
+
+	t.Run("treats an already-removed container as success", func(t *testing.T) {
+		// --rm may have reaped it first; that is the state we wanted.
+		runner := newFakeRunner()
+		runner.errs["rm"] = errors.New("Error response from daemon: No such container: agtsbx-test")
+		backend := &containerBackend{engine: "docker", runner: runner, progress: io.Discard}
+		instance := &containerInstance{backend: backend, name: "agtsbx-test", remove: true}
+
+		require.NoError(t, instance.Stop(context.Background()))
+	})
+}
+
+func TestExecRunnerIncludesStderrInError(t *testing.T) {
+	// A bare exit status tells the user nothing actionable.
+	_, err := execRunner{}.run(context.Background(), "sh", "-c", "echo boom >&2; exit 1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestExecRunnerReturnsStdout(t *testing.T) {
+	out, err := execRunner{}.run(context.Background(), "sh", "-c", fmt.Sprintf("echo %s", "127.0.0.1:32768"))
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:32768", strings.TrimSpace(string(out)))
+}

--- a/internal/agtsbx/exec.go
+++ b/internal/agtsbx/exec.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	processv1 "sigs.k8s.io/agent-sandbox/packages/sandboxd/spec/process/v1"
+)
+
+// healthPollInterval is how often waitHealthy retries. sandboxd starts in
+// well under a second locally, so poll briskly.
+const healthPollInterval = 200 * time.Millisecond
+
+// waitHealthy blocks until sandboxd's REST readiness probe returns 200 or ctx
+// is done, taking its deadline from ctx so it shares one startup budget with
+// whatever ran before it.
+//
+// REST rather than a gRPC dial: with published container ports the engine's
+// proxy binds the port before sandboxd is up, so a TCP probe would report
+// ready too early and the first RPC would fail.
+func waitHealthy(ctx context.Context, client *http.Client, restAddr string) error {
+	url := "http://" + restAddr + "/v1/health"
+	ticker := time.NewTicker(healthPollInterval)
+	defer ticker.Stop()
+
+	// lastErr lets a timeout explain what was actually going wrong.
+	start := time.Now()
+	var lastErr error
+	for {
+		if err := probeHealth(ctx, client, url); err != nil {
+			lastErr = err
+		} else {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("sandbox did not become healthy at %s after %s: %w", restAddr, time.Since(start).Round(time.Second), lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+// probeHealth performs one readiness request.
+func probeHealth(ctx context.Context, client *http.Client, url string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Drain so the connection can be reused across polls.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("health probe returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// execRequest is a single command to run inside a started sandbox.
+type execRequest struct {
+	// Command is the argv to execute.
+	Command []string
+	// Env is the per-command environment, as "KEY=VALUE".
+	Env []string
+	// Workdir is resolved inside the sandbox root. Empty means the root.
+	Workdir string
+	// Stdout and Stderr receive the process output as it streams.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// runCommand executes req against sandboxd at grpcAddr and returns the
+// command's exit code. It uses the streaming ProcessService.Start rather than
+// the unary Execute so output reaches the terminal as it is produced, and it
+// is the only place the command's environment travels.
+func runCommand(ctx context.Context, grpcAddr string, req execRequest) (int, error) {
+	conn, err := grpc.NewClient(grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return 0, fmt.Errorf("connecting to sandboxd at %s: %w", grpcAddr, err)
+	}
+	defer conn.Close()
+
+	config := &processv1.ProcessConfig{
+		Command: req.Command,
+		EnvVars: parseEnv(req.Env),
+	}
+	if req.Workdir != "" {
+		config.Cwd = &req.Workdir
+	}
+
+	stream, err := processv1.NewProcessServiceClient(conn).Start(ctx, &processv1.StartRequest{Config: config})
+	if err != nil {
+		return 0, annotateWorkdir(fmt.Errorf("starting command in sandbox: %w", err), req.Workdir)
+	}
+
+	exitCode, err := copyStream(stream, req.Stdout, req.Stderr)
+	return exitCode, annotateWorkdir(err, req.Workdir)
+}
+
+// annotateWorkdir adds a hint to NotFound errors raised under a --workdir.
+// sandboxd confines cwd to the sandbox root, so a host path such as /tmp
+// resolves somewhere that does not exist, and the failed chdir is reported as
+// if the command binary were missing.
+func annotateWorkdir(err error, workdir string) error {
+	if err == nil || workdir == "" {
+		return err
+	}
+	if status.Code(err) != codes.NotFound && !strings.Contains(err.Error(), "NotFound") {
+		return err
+	}
+	return fmt.Errorf("%w (note: --workdir %q is resolved inside the sandbox root and must already exist there)", err, workdir)
+}
+
+// startStream is the receive side of ProcessService.Start, narrowed so the
+// stream handling can be tested without a gRPC server.
+type startStream interface {
+	Recv() (*processv1.StartResponse, error)
+}
+
+// copyStream drains a Start stream, forwarding output to stdout/stderr and
+// returning the process exit code.
+func copyStream(stream startStream, stdout, stderr io.Writer) (int, error) {
+	// sandboxd closes the stream after the ExitEvent, so a clean EOF without
+	// one means the sandbox died mid-command and the status is unknown.
+	exitCode := 0
+	sawExit := false
+
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			if !sawExit {
+				return 0, fmt.Errorf("sandbox closed the command stream before reporting an exit code")
+			}
+			return exitCode, nil
+		}
+		if err != nil {
+			return 0, fmt.Errorf("reading command output: %w", err)
+		}
+
+		switch event := resp.GetEvent().(type) {
+		case *processv1.StartResponse_Stdout:
+			if _, err := stdout.Write(event.Stdout); err != nil {
+				return 0, fmt.Errorf("writing command stdout: %w", err)
+			}
+		case *processv1.StartResponse_Stderr:
+			if _, err := stderr.Write(event.Stderr); err != nil {
+				return 0, fmt.Errorf("writing command stderr: %w", err)
+			}
+		case *processv1.StartResponse_Exit:
+			exitCode = int(event.Exit.GetExitCode())
+			sawExit = true
+		case *processv1.StartResponse_Init:
+			// The process ID is only needed for signalling and stdin, which
+			// this one-shot path does not use.
+		}
+	}
+}
+
+// parseEnv converts "KEY=VALUE" strings into the map sandboxd expects.
+// Malformed entries are dropped rather than rejected: parseRunArgs already
+// validated them. Values may contain "=", so only the first one separates.
+func parseEnv(env []string) map[string]string {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, found := strings.Cut(entry, "=")
+		if !found || key == "" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}

--- a/internal/agtsbx/exec_test.go
+++ b/internal/agtsbx/exec_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	processv1 "sigs.k8s.io/agent-sandbox/packages/sandboxd/spec/process/v1"
+)
+
+// scriptedStream replays a fixed sequence of Start events and then EOF.
+type scriptedStream struct {
+	events []*processv1.StartResponse
+	err    error
+	index  int
+}
+
+func (s *scriptedStream) Recv() (*processv1.StartResponse, error) {
+	if s.index >= len(s.events) {
+		if s.err != nil {
+			return nil, s.err
+		}
+		return nil, io.EOF
+	}
+	event := s.events[s.index]
+	s.index++
+	return event, nil
+}
+
+func stdoutEvent(data string) *processv1.StartResponse {
+	return &processv1.StartResponse{Event: &processv1.StartResponse_Stdout{Stdout: []byte(data)}}
+}
+
+func stderrEvent(data string) *processv1.StartResponse {
+	return &processv1.StartResponse{Event: &processv1.StartResponse_Stderr{Stderr: []byte(data)}}
+}
+
+func exitEvent(code int32) *processv1.StartResponse {
+	return &processv1.StartResponse{Event: &processv1.StartResponse_Exit{Exit: &processv1.ExitEvent{ExitCode: code}}}
+}
+
+func TestCopyStream(t *testing.T) {
+	t.Run("routes stdout and stderr to separate writers", func(t *testing.T) {
+		stream := &scriptedStream{events: []*processv1.StartResponse{
+			{Event: &processv1.StartResponse_Init{Init: &processv1.InitEvent{ProcessId: 42}}},
+			stdoutEvent("hello "),
+			stderrEvent("warning"),
+			stdoutEvent("world"),
+			exitEvent(0),
+		}}
+
+		var stdout, stderr bytes.Buffer
+		code, err := copyStream(stream, &stdout, &stderr)
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, code)
+		// The daemon may split one logical write across several events.
+		assert.Equal(t, "hello world", stdout.String())
+		assert.Equal(t, "warning", stderr.String())
+	})
+
+	t.Run("propagates a non-zero exit code", func(t *testing.T) {
+		stream := &scriptedStream{events: []*processv1.StartResponse{
+			stderrEvent("boom"),
+			exitEvent(17),
+		}}
+
+		var stdout, stderr bytes.Buffer
+		code, err := copyStream(stream, &stdout, &stderr)
+		require.NoError(t, err)
+		assert.Equal(t, 17, code)
+	})
+
+	t.Run("errors when the stream ends without an exit event", func(t *testing.T) {
+		// Reporting 0 here would turn a mid-command crash into success.
+		stream := &scriptedStream{events: []*processv1.StartResponse{stdoutEvent("partial")}}
+
+		var stdout, stderr bytes.Buffer
+		_, err := copyStream(stream, &stdout, &stderr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "before reporting an exit code")
+	})
+
+	t.Run("propagates stream errors", func(t *testing.T) {
+		stream := &scriptedStream{
+			events: []*processv1.StartResponse{stdoutEvent("x")},
+			err:    errors.New("connection reset"),
+		}
+
+		var stdout, stderr bytes.Buffer
+		_, err := copyStream(stream, &stdout, &stderr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connection reset")
+	})
+
+	t.Run("ignores init events", func(t *testing.T) {
+		stream := &scriptedStream{events: []*processv1.StartResponse{
+			{Event: &processv1.StartResponse_Init{Init: &processv1.InitEvent{ProcessId: 7}}},
+			exitEvent(0),
+		}}
+
+		var stdout, stderr bytes.Buffer
+		code, err := copyStream(stream, &stdout, &stderr)
+		require.NoError(t, err)
+		assert.Equal(t, 0, code)
+		assert.Empty(t, stdout.String())
+		assert.Empty(t, stderr.String())
+	})
+}
+
+func TestParseEnv(t *testing.T) {
+	t.Run("nil for no entries", func(t *testing.T) {
+		assert.Nil(t, parseEnv(nil))
+	})
+
+	t.Run("splits on the first separator only", func(t *testing.T) {
+		// Values legitimately contain "=" (base64 padding, connection strings).
+		got := parseEnv([]string{"TOKEN=abc==", "PATH=/a:/b"})
+		assert.Equal(t, map[string]string{"TOKEN": "abc==", "PATH": "/a:/b"}, got)
+	})
+
+	t.Run("keeps empty values", func(t *testing.T) {
+		assert.Equal(t, map[string]string{"EMPTY": ""}, parseEnv([]string{"EMPTY="}))
+	})
+
+	t.Run("drops malformed entries", func(t *testing.T) {
+		assert.Empty(t, parseEnv([]string{"NOEQUALS", "=novalue"}))
+	})
+
+	t.Run("last occurrence wins", func(t *testing.T) {
+		assert.Equal(t, map[string]string{"A": "2"}, parseEnv([]string{"A=1", "A=2"}))
+	})
+}
+
+func TestWaitHealthy(t *testing.T) {
+	t.Run("returns once the probe succeeds", func(t *testing.T) {
+		// REST rather than a gRPC dial: the engine binds a published port
+		// before sandboxd listens, so a TCP probe would be ready too early.
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/v1/health", r.URL.Path)
+			if attempts.Add(1) < 3 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		addr := strings.TrimPrefix(server.URL, "http://")
+		require.NoError(t, waitHealthy(ctx, server.Client(), addr))
+		assert.GreaterOrEqual(t, attempts.Load(), int32(3))
+	})
+
+	t.Run("reports the last failure on timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+
+		addr := strings.TrimPrefix(server.URL, "http://")
+		err := waitHealthy(ctx, server.Client(), addr)
+		require.Error(t, err)
+		// The message must say what failed, not just that a deadline elapsed.
+		assert.Contains(t, err.Error(), "HTTP 503")
+	})
+
+	t.Run("stops when the context is cancelled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		addr := strings.TrimPrefix(server.URL, "http://")
+		err := waitHealthy(ctx, server.Client(), addr)
+		require.Error(t, err)
+	})
+
+	t.Run("fails when nothing is listening", func(t *testing.T) {
+		// Bind and immediately close to obtain a port nothing is serving.
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		addr := strings.TrimPrefix(server.URL, "http://")
+		client := server.Client()
+		server.Close()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+
+		err := waitHealthy(ctx, client, addr)
+		require.Error(t, err)
+	})
+}
+
+func TestAnnotateWorkdir(t *testing.T) {
+	notFound := status.Error(codes.NotFound, "command or path not found: fork/exec /usr/bin/sh")
+
+	t.Run("adds a hint when a workdir was in effect", func(t *testing.T) {
+		// sandboxd confines cwd to the sandbox root, so a host path like /tmp
+		// resolves somewhere absent and the failed chdir is reported as if the
+		// command binary were missing -- the wrong problem entirely.
+		err := annotateWorkdir(notFound, "/tmp")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolved inside the sandbox root")
+		assert.Contains(t, err.Error(), "/tmp")
+		// The original error must remain inspectable.
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("leaves errors alone when no workdir was set", func(t *testing.T) {
+		assert.Equal(t, notFound, annotateWorkdir(notFound, ""))
+	})
+
+	t.Run("leaves nil alone", func(t *testing.T) {
+		assert.NoError(t, annotateWorkdir(nil, "/tmp"))
+	})
+
+	t.Run("does not annotate unrelated failures", func(t *testing.T) {
+		// A permission error already says what went wrong.
+		denied := status.Error(codes.PermissionDenied, "cwd: path escapes root")
+		assert.Equal(t, denied, annotateWorkdir(denied, "/tmp"))
+	})
+}
+
+func TestRunCommandReportsUnreachableSandbox(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Port 1 on loopback is reserved and never served, so the RPC fails fast.
+	_, err := runCommand(ctx, "127.0.0.1:1", execRequest{
+		Command: []string{"true"},
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+	})
+	require.Error(t, err)
+}

--- a/internal/agtsbx/kube.go
+++ b/internal/agtsbx/kube.go
@@ -1,0 +1,372 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	"sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+)
+
+// sandboxContainerName names the container in the generated pod template.
+const sandboxContainerName = "sandbox"
+
+// kubeBackend runs the sandbox as a core Sandbox object in a cluster.
+//
+// It uses the core Sandbox API rather than the SandboxClaim extension because
+// `agtsbx run` names an image, and only Sandbox accepts one directly.
+type kubeBackend struct {
+	helper       *sandbox.K8sHelper
+	namespace    string
+	readyTimeout time.Duration
+	httpClient   *http.Client
+	progress     writerFunc
+}
+
+func newKubeBackend(opts backendOptions) (Backend, error) {
+	// The SDK logs at a level suited to a long-lived service, which would
+	// drown a one-shot command's output.
+	helper, err := sandbox.NewK8sHelper(nil, logr.Discard())
+	if err != nil {
+		return nil, fmt.Errorf("connecting to Kubernetes (is your kubeconfig valid?): %w", err)
+	}
+	return &kubeBackend{
+		helper:       helper,
+		namespace:    opts.Namespace,
+		readyTimeout: opts.ReadyTimeout,
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+		progress:     opts.Stderr,
+	}, nil
+}
+
+func (b *kubeBackend) Name() string { return RuntimeKubernetes }
+
+// kubeInstance is a started Kubernetes sandbox plus the port-forward that
+// makes it reachable from the local machine.
+type kubeInstance struct {
+	backend   *kubeBackend
+	name      string
+	endpoints Endpoints
+	remove    bool
+	// stopForward is non-nil once Start returns successfully.
+	stopForward func()
+}
+
+func (i *kubeInstance) Endpoints() Endpoints { return i.endpoints }
+
+func (i *kubeInstance) Stop(ctx context.Context) error {
+	i.stopForward()
+	if !i.remove {
+		return nil
+	}
+	if err := i.backend.delete(ctx, i.name); err != nil {
+		return fmt.Errorf("deleting sandbox %s/%s: %w", i.backend.namespace, i.name, err)
+	}
+	return nil
+}
+
+// Start creates the Sandbox, waits for it to become Ready, then port-forwards
+// to sandboxd inside its pod.
+func (b *kubeBackend) Start(ctx context.Context, spec Spec) (Instance, error) {
+	// One deadline for the whole startup: giving each wait below its own
+	// would let Start take a multiple of the requested --timeout.
+	ctx, cancel := context.WithTimeout(ctx, b.readyTimeout)
+	defer cancel()
+
+	client := b.helper.AgentsClient.Sandboxes(b.namespace)
+	if _, err := client.Create(ctx, buildSandbox(spec, b.namespace), metav1.CreateOptions{}); err != nil {
+		// A deadline or connection error can hide a create the API server
+		// already persisted, which would then run unattended. AlreadyExists
+		// is somebody else's object, so leave that one alone.
+		if !k8serrors.IsAlreadyExists(err) {
+			b.deleteIfOurs(spec.Name)
+		}
+		return nil, fmt.Errorf("creating sandbox %s/%s: %w", b.namespace, spec.Name, err)
+	}
+
+	instance := &kubeInstance{backend: b, name: spec.Name, remove: spec.Remove}
+
+	// The Sandbox now exists; unwind it on every failure below so a failed
+	// run does not leave a pod consuming cluster capacity.
+	if err := b.waitReady(ctx, spec.Name); err != nil {
+		b.cleanup(instance.name)
+		return nil, err
+	}
+
+	// The controller names the backing pod after the Sandbox, so the
+	// port-forward target needs no lookup.
+	endpoints, stop, err := b.forward(ctx, spec)
+	if err != nil {
+		b.cleanup(instance.name)
+		return nil, err
+	}
+	instance.endpoints = endpoints
+	instance.stopForward = stop
+
+	// Ready only means the kubelet's probes passed. Confirm sandboxd answers
+	// over the forwarded connection too, so a failure here is reported by
+	// Start rather than by the first command.
+	if err := waitHealthy(ctx, b.httpClient, endpoints.RESTAddr); err != nil {
+		stop()
+		b.cleanup(instance.name)
+		return nil, err
+	}
+	return instance, nil
+}
+
+// delete removes the Sandbox. Foreground propagation makes the API server
+// delete the backing pod before the Sandbox disappears, so teardown cannot be
+// left to background garbage collection.
+func (b *kubeBackend) delete(ctx context.Context, name string) error {
+	policy := metav1.DeletePropagationForeground
+	err := b.helper.AgentsClient.Sandboxes(b.namespace).Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &policy})
+	// A sandbox that is already gone is the state we wanted.
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// cleanup deletes a Sandbox created by a Start that then failed.
+func (b *kubeBackend) cleanup(name string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+
+	if err := b.delete(ctx, name); err != nil {
+		fmt.Fprintf(b.progress, "agtsbx: warning: could not delete sandbox %s/%s: %v\n", b.namespace, name, err)
+	}
+}
+
+// deleteIfOurs cleans up after an ambiguous create, but only if the object
+// carries our label, so a Sandbox that happens to share the name survives.
+func (b *kubeBackend) deleteIfOurs(name string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+	defer cancel()
+
+	existing, err := b.helper.AgentsClient.Sandboxes(b.namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil || existing.Labels[managedByLabel] != managedByValue {
+		return
+	}
+	b.cleanup(name)
+}
+
+// waitReady blocks until the Sandbox reports the Ready condition. It watches
+// rather than polls so a sandbox that starts quickly is not held up by a fixed
+// poll interval.
+func (b *kubeBackend) waitReady(ctx context.Context, name string) error {
+	// Capped by any deadline the caller already set, so this shares one
+	// startup budget with the health wait rather than taking a second one.
+	ctx, cancel := context.WithTimeout(ctx, b.readyTimeout)
+	defer cancel()
+
+	client := b.helper.AgentsClient.Sandboxes(b.namespace)
+
+	// Check the current state first: with a warm image the Sandbox can go
+	// Ready before the watch below is established, missing that event.
+	current, err := client.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("reading sandbox %s/%s: %w", b.namespace, name, err)
+	}
+	if sandboxReady(current) {
+		return nil
+	}
+
+	watcher, err := client.Watch(ctx, metav1.ListOptions{
+		FieldSelector:   "metadata.name=" + name,
+		ResourceVersion: current.ResourceVersion,
+	})
+	if err != nil {
+		return fmt.Errorf("watching sandbox %s/%s: %w", b.namespace, name, err)
+	}
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("sandbox %s/%s did not become ready within %s: %w", b.namespace, name, b.readyTimeout, ctx.Err())
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return fmt.Errorf("watch on sandbox %s/%s closed before it became ready", b.namespace, name)
+			}
+			switch event.Type {
+			case watch.Deleted:
+				return fmt.Errorf("sandbox %s/%s was deleted before it became ready", b.namespace, name)
+			case watch.Error:
+				// Spinning until the deadline would hide the real cause.
+				return fmt.Errorf("watch on sandbox %s/%s failed: %w", b.namespace, name, k8serrors.FromObject(event.Object))
+			}
+			observed, ok := event.Object.(*sandboxv1beta1.Sandbox)
+			if !ok {
+				continue
+			}
+			if sandboxReady(observed) {
+				return nil
+			}
+		}
+	}
+}
+
+// sandboxReady reports whether the Sandbox's Ready condition is True.
+func sandboxReady(sb *sandboxv1beta1.Sandbox) bool {
+	for _, condition := range sb.Status.Conditions {
+		if condition.Type == string(sandboxv1beta1.SandboxConditionReady) {
+			return condition.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// forward establishes a port-forward carrying both sandboxd listeners and
+// returns the local addresses plus a teardown function. Port-forward needs
+// nothing installed in the cluster: no Service, Gateway or sandbox-router.
+func (b *kubeBackend) forward(ctx context.Context, spec Spec) (Endpoints, func(), error) {
+	reqURL := b.helper.CoreClient.RESTClient().Post().
+		Resource("pods").
+		Namespace(b.namespace).
+		Name(spec.Name).
+		SubResource("portforward").
+		URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(b.helper.RestConfig)
+	if err != nil {
+		return Endpoints{}, nil, fmt.Errorf("creating SPDY round tripper: %w", err)
+	}
+	dialer := spdy.NewDialerForStreaming(upgrader, &http.Client{Transport: transport}, http.MethodPost, reqURL)
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	// Local port 0 lets the forwarder pick a free port, avoiding a
+	// bind-then-release race between concurrent invocations.
+	forwardSpecs := []string{
+		fmt.Sprintf("0:%d", spec.RESTPort),
+		fmt.Sprintf("0:%d", spec.GRPCPort),
+	}
+	forwarder, err := portforward.NewForStreaming(dialer, forwardSpecs, stopChan, readyChan, io.Discard, io.Discard)
+	if err != nil {
+		return Endpoints{}, nil, fmt.Errorf("creating port forwarder: %w", err)
+	}
+
+	// Idempotent: error paths call stop and Stop may call it again.
+	stopped := false
+	stop := func() {
+		if !stopped {
+			stopped = true
+			close(stopChan)
+		}
+	}
+
+	errChan := make(chan error, 1)
+	go func() { errChan <- forwarder.ForwardPorts() }()
+
+	select {
+	case <-readyChan:
+	case err := <-errChan:
+		return Endpoints{}, nil, fmt.Errorf("port-forward to pod %s/%s failed: %w", b.namespace, spec.Name, err)
+	case <-ctx.Done():
+		stop()
+		return Endpoints{}, nil, fmt.Errorf("port-forward to pod %s/%s cancelled: %w", b.namespace, spec.Name, ctx.Err())
+	}
+
+	ports, err := forwarder.GetPorts()
+	if err != nil {
+		stop()
+		return Endpoints{}, nil, fmt.Errorf("reading forwarded ports: %w", err)
+	}
+
+	var restLocal, grpcLocal uint16
+	for _, port := range ports {
+		switch int(port.Remote) {
+		case spec.RESTPort:
+			restLocal = port.Local
+		case spec.GRPCPort:
+			grpcLocal = port.Local
+		}
+	}
+	if restLocal == 0 || grpcLocal == 0 {
+		stop()
+		return Endpoints{}, nil, fmt.Errorf("port forwarder did not report both sandboxd ports (rest=%d grpc=%d)", restLocal, grpcLocal)
+	}
+
+	return Endpoints{
+		GRPCAddr: fmt.Sprintf("127.0.0.1:%d", grpcLocal),
+		RESTAddr: fmt.Sprintf("127.0.0.1:%d", restLocal),
+	}, stop, nil
+}
+
+// buildSandbox renders spec into a Sandbox object. The pod template mirrors
+// examples/sandboxd-sandbox/sandbox-template.yaml, so a sandbox behaves the
+// same whether agtsbx started it or it was applied from a manifest.
+//
+// The command's environment is deliberately absent: it travels with the
+// request instead, so credentials are not persisted in the object for anyone
+// with get on sandboxes to read.
+func buildSandbox(spec Spec, namespace string) *sandboxv1beta1.Sandbox {
+	return &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spec.Name,
+			Namespace: namespace,
+			Labels:    map[string]string{managedByLabel: managedByValue},
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: new(false),
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: new(true),
+						},
+						Containers: []corev1.Container{{
+							Name:  sandboxContainerName,
+							Image: spec.Image,
+							Ports: []corev1.ContainerPort{
+								{Name: "rest", ContainerPort: int32(spec.RESTPort)},
+								{Name: "grpc", ContainerPort: int32(spec.GRPCPort)},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: new(false),
+								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							},
+							// Without this the Sandbox reports Ready as soon
+							// as the pod runs, before sandboxd accepts
+							// requests.
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/v1/health",
+										Port: intstr.FromInt32(int32(spec.RESTPort)),
+									},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/agtsbx/kube_test.go
+++ b/internal/agtsbx/kube_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	k8stesting "k8s.io/client-go/testing"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	"sigs.k8s.io/agent-sandbox/clients/go/sandbox"
+	"sigs.k8s.io/agent-sandbox/clients/k8s/clientset/versioned/fake"
+)
+
+func TestBuildSandbox(t *testing.T) {
+	spec := Spec{
+		Image:    "sandboxd:latest",
+		Name:     "agtsbx-abc123",
+		GRPCPort: 9090,
+		RESTPort: 8080,
+	}
+
+	sb := buildSandbox(spec, "agents")
+
+	t.Run("sets identity", func(t *testing.T) {
+		assert.Equal(t, "agtsbx-abc123", sb.Name)
+		assert.Equal(t, "agents", sb.Namespace)
+		// Failed-create cleanup deletes only labelled objects.
+		assert.Equal(t, managedByValue, sb.Labels[managedByLabel])
+	})
+
+	t.Run("runs the requested image in a single container", func(t *testing.T) {
+		containers := sb.Spec.PodTemplate.Spec.Containers
+		require.Len(t, containers, 1)
+		assert.Equal(t, sandboxContainerName, containers[0].Name)
+		assert.Equal(t, "sandboxd:latest", containers[0].Image)
+	})
+
+	t.Run("does not persist the command's environment", func(t *testing.T) {
+		// The variables travel with the sandboxd request instead, so a
+		// credential is not readable by anyone with get on sandboxes.
+		assert.Empty(t, sb.Spec.PodTemplate.Spec.Containers[0].Env)
+	})
+
+	t.Run("exposes both sandboxd ports", func(t *testing.T) {
+		ports := sb.Spec.PodTemplate.Spec.Containers[0].Ports
+		require.Len(t, ports, 2)
+		assert.Equal(t, int32(8080), ports[0].ContainerPort)
+		assert.Equal(t, int32(9090), ports[1].ContainerPort)
+	})
+
+	t.Run("probes readiness on the sandboxd health endpoint", func(t *testing.T) {
+		// Without it the Sandbox reports Ready as soon as the pod runs, and
+		// the run fails on its first RPC instead of waiting.
+		probe := sb.Spec.PodTemplate.Spec.Containers[0].ReadinessProbe
+		require.NotNil(t, probe)
+		require.NotNil(t, probe.HTTPGet)
+		assert.Equal(t, "/v1/health", probe.HTTPGet.Path)
+		assert.Equal(t, int32(8080), probe.HTTPGet.Port.IntVal)
+	})
+
+	t.Run("hardens the pod", func(t *testing.T) {
+		// These match examples/sandboxd-sandbox, so a sandbox behaves the same
+		// whether agtsbx created it or a manifest did.
+		podSpec := sb.Spec.PodTemplate.Spec
+		require.NotNil(t, podSpec.AutomountServiceAccountToken)
+		assert.False(t, *podSpec.AutomountServiceAccountToken, "the sandbox must not receive an API token")
+
+		require.NotNil(t, podSpec.SecurityContext)
+		require.NotNil(t, podSpec.SecurityContext.RunAsNonRoot)
+		assert.True(t, *podSpec.SecurityContext.RunAsNonRoot)
+
+		container := podSpec.Containers[0]
+		require.NotNil(t, container.SecurityContext)
+		require.NotNil(t, container.SecurityContext.AllowPrivilegeEscalation)
+		assert.False(t, *container.SecurityContext.AllowPrivilegeEscalation)
+		require.NotNil(t, container.SecurityContext.Capabilities)
+		assert.Equal(t, []corev1.Capability{"ALL"}, container.SecurityContext.Capabilities.Drop)
+	})
+
+	t.Run("honours custom ports", func(t *testing.T) {
+		custom := buildSandbox(Spec{Image: "i", Name: "n", GRPCPort: 1234, RESTPort: 5678}, "default")
+		container := custom.Spec.PodTemplate.Spec.Containers[0]
+		assert.Equal(t, int32(5678), container.Ports[0].ContainerPort)
+		assert.Equal(t, int32(1234), container.Ports[1].ContainerPort)
+		assert.Equal(t, int32(5678), container.ReadinessProbe.HTTPGet.Port.IntVal)
+	})
+}
+
+// newFakeKubeBackend builds a kubeBackend wired to a fake API server holding
+// the given sandboxes.
+//
+// They are created through the typed client rather than pre-seeded into
+// fake.NewSimpleClientset: the tracker derives the resource name with
+// meta.UnsafeGuessKindToResource, which pluralizes "Sandbox" to "sandboxs", so
+// a seeded object is filed where the client never looks and appears missing.
+func newFakeKubeBackend(t *testing.T, readyTimeout time.Duration, objects ...*sandboxv1beta1.Sandbox) (*kubeBackend, *fake.Clientset) {
+	t.Helper()
+	client := fake.NewSimpleClientset()
+	for _, obj := range objects {
+		_, err := client.AgentsV1beta1().Sandboxes(obj.Namespace).Create(t.Context(), obj, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	return &kubeBackend{
+		helper:       &sandbox.K8sHelper{AgentsClient: client.AgentsV1beta1()},
+		namespace:    "default",
+		readyTimeout: readyTimeout,
+		progress:     io.Discard,
+	}, client
+}
+
+// newSandbox builds a Sandbox carrying the given Ready condition status. An
+// empty status means the Ready condition is absent entirely.
+func newSandbox(ready metav1.ConditionStatus) *sandboxv1beta1.Sandbox {
+	sb := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "box", Namespace: "default"},
+	}
+	if ready != "" {
+		sb.Status.Conditions = []metav1.Condition{
+			{Type: string(sandboxv1beta1.SandboxConditionReady), Status: ready},
+		}
+	}
+	return sb
+}
+
+func TestKubeBackendWaitReady(t *testing.T) {
+	t.Run("returns immediately when the sandbox is already ready", func(t *testing.T) {
+		// With a warm image the Sandbox can go Ready before a watch could be
+		// established, so the current state must be checked first.
+		backend, _ := newFakeKubeBackend(t, 5*time.Second, newSandbox(metav1.ConditionTrue))
+
+		require.NoError(t, backend.waitReady(t.Context(), "box"))
+	})
+
+	t.Run("returns once a watch event reports ready", func(t *testing.T) {
+		backend, client := newFakeKubeBackend(t, 10*time.Second, newSandbox(metav1.ConditionFalse))
+
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("sandboxes", k8stesting.DefaultWatchReactor(watcher, nil))
+
+		go func() {
+			watcher.Modify(newSandbox(metav1.ConditionTrue))
+		}()
+
+		require.NoError(t, backend.waitReady(t.Context(), "box"))
+	})
+
+	t.Run("fails when the sandbox is deleted before becoming ready", func(t *testing.T) {
+		// The object is gone and can never become ready.
+		backend, client := newFakeKubeBackend(t, time.Minute, newSandbox(metav1.ConditionFalse))
+
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("sandboxes", k8stesting.DefaultWatchReactor(watcher, nil))
+
+		go func() {
+			watcher.Delete(newSandbox(metav1.ConditionFalse))
+		}()
+
+		err := backend.waitReady(t.Context(), "box")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deleted before it became ready")
+	})
+
+	t.Run("reports a watch error instead of waiting out the timeout", func(t *testing.T) {
+		backend, client := newFakeKubeBackend(t, time.Minute, newSandbox(metav1.ConditionFalse))
+
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("sandboxes", k8stesting.DefaultWatchReactor(watcher, nil))
+
+		go func() {
+			watcher.Error(&metav1.Status{Message: "too old resource version"})
+		}()
+
+		err := backend.waitReady(t.Context(), "box")
+		require.Error(t, err)
+		// The real cause must survive: a bare timeout would hide it.
+		assert.Contains(t, err.Error(), "too old resource version")
+	})
+
+	t.Run("times out when the sandbox never becomes ready", func(t *testing.T) {
+		backend, client := newFakeKubeBackend(t, 200*time.Millisecond, newSandbox(metav1.ConditionFalse))
+
+		watcher := watch.NewFake()
+		client.PrependWatchReactor("sandboxes", k8stesting.DefaultWatchReactor(watcher, nil))
+
+		err := backend.waitReady(t.Context(), "box")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "did not become ready")
+	})
+
+	t.Run("reports a missing sandbox", func(t *testing.T) {
+		backend, _ := newFakeKubeBackend(t, 5*time.Second)
+
+		err := backend.waitReady(t.Context(), "box")
+		require.Error(t, err)
+		assert.True(t, k8serrors.IsNotFound(errors.Unwrap(err)))
+	})
+}
+
+func TestKubeInstanceStop(t *testing.T) {
+	t.Run("deletes an ephemeral sandbox and stops the port-forward", func(t *testing.T) {
+		backend, client := newFakeKubeBackend(t, time.Second, newSandbox(metav1.ConditionTrue))
+		forwardStopped := false
+		instance := &kubeInstance{
+			backend:     backend,
+			name:        "box",
+			remove:      true,
+			stopForward: func() { forwardStopped = true },
+		}
+
+		require.NoError(t, instance.Stop(t.Context()))
+
+		assert.True(t, forwardStopped, "the port-forward must be torn down")
+		_, err := client.AgentsV1beta1().Sandboxes("default").Get(t.Context(), "box", metav1.GetOptions{})
+		assert.True(t, k8serrors.IsNotFound(err), "the sandbox should have been deleted")
+	})
+
+	t.Run("keeps the sandbox but still stops the port-forward", func(t *testing.T) {
+		// --keep is about the sandbox, not local resources: leaking the
+		// forwarder's goroutines would be a bug either way.
+		backend, client := newFakeKubeBackend(t, time.Second, newSandbox(metav1.ConditionTrue))
+		forwardStopped := false
+		instance := &kubeInstance{
+			backend:     backend,
+			name:        "box",
+			remove:      false,
+			stopForward: func() { forwardStopped = true },
+		}
+
+		require.NoError(t, instance.Stop(t.Context()))
+
+		assert.True(t, forwardStopped)
+		_, err := client.AgentsV1beta1().Sandboxes("default").Get(t.Context(), "box", metav1.GetOptions{})
+		require.NoError(t, err, "--keep must leave the sandbox in place")
+	})
+
+	t.Run("treats an already-deleted sandbox as success", func(t *testing.T) {
+		// Deletion is the desired end state; losing the race to it is not an
+		// error worth reporting.
+		backend, _ := newFakeKubeBackend(t, time.Second)
+		instance := &kubeInstance{backend: backend, name: "gone", remove: true, stopForward: func() {}}
+
+		require.NoError(t, instance.Stop(t.Context()))
+	})
+
+	t.Run("deletes in the foreground so the pod goes with the sandbox", func(t *testing.T) {
+		// Background garbage collection could leave the pod, and the
+		// command's detached processes, running after Stop returned.
+		backend, client := newFakeKubeBackend(t, time.Second, newSandbox(metav1.ConditionTrue))
+		instance := &kubeInstance{backend: backend, name: "box", remove: true, stopForward: func() {}}
+
+		require.NoError(t, instance.Stop(t.Context()))
+
+		var policies []metav1.DeletionPropagation
+		for _, action := range client.Actions() {
+			if deletion, ok := action.(k8stesting.DeleteActionImpl); ok && deletion.GetDeleteOptions().PropagationPolicy != nil {
+				policies = append(policies, *deletion.GetDeleteOptions().PropagationPolicy)
+			}
+		}
+		assert.Equal(t, []metav1.DeletionPropagation{metav1.DeletePropagationForeground}, policies)
+	})
+}
+
+func TestKubeBackendDeleteIfOurs(t *testing.T) {
+	ourSandbox := func() *sandboxv1beta1.Sandbox {
+		sb := newSandbox(metav1.ConditionTrue)
+		sb.Labels = map[string]string{managedByLabel: managedByValue}
+		return sb
+	}
+
+	t.Run("deletes a sandbox left behind by an ambiguous create", func(t *testing.T) {
+		// The API server can persist the object and still fail the call.
+		backend, client := newFakeKubeBackend(t, time.Second, ourSandbox())
+
+		backend.deleteIfOurs("box")
+
+		_, err := client.AgentsV1beta1().Sandboxes("default").Get(t.Context(), "box", metav1.GetOptions{})
+		assert.True(t, k8serrors.IsNotFound(err))
+	})
+
+	t.Run("leaves a sandbox it did not create", func(t *testing.T) {
+		backend, client := newFakeKubeBackend(t, time.Second, newSandbox(metav1.ConditionTrue))
+
+		backend.deleteIfOurs("box")
+
+		_, err := client.AgentsV1beta1().Sandboxes("default").Get(t.Context(), "box", metav1.GetOptions{})
+		require.NoError(t, err)
+	})
+}
+
+func TestSandboxReady(t *testing.T) {
+	ready := func(status metav1.ConditionStatus) *sandboxv1beta1.Sandbox {
+		return &sandboxv1beta1.Sandbox{
+			Status: sandboxv1beta1.SandboxStatus{
+				Conditions: []metav1.Condition{
+					{Type: "PodScheduled", Status: metav1.ConditionTrue},
+					{Type: string(sandboxv1beta1.SandboxConditionReady), Status: status},
+				},
+			},
+		}
+	}
+
+	assert.True(t, sandboxReady(ready(metav1.ConditionTrue)))
+	assert.False(t, sandboxReady(ready(metav1.ConditionFalse)))
+	assert.False(t, sandboxReady(ready(metav1.ConditionUnknown)))
+
+	// A Sandbox with no conditions has not been reconciled yet.
+	assert.False(t, sandboxReady(&sandboxv1beta1.Sandbox{}))
+
+	// Other conditions being True must not be mistaken for readiness.
+	assert.False(t, sandboxReady(&sandboxv1beta1.Sandbox{
+		Status: sandboxv1beta1.SandboxStatus{
+			Conditions: []metav1.Condition{{Type: "PodScheduled", Status: metav1.ConditionTrue}},
+		},
+	}))
+}

--- a/internal/agtsbx/run.go
+++ b/internal/agtsbx/run.go
@@ -1,0 +1,292 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// defaultReadyTimeout bounds waiting for a sandbox to come up: long enough to
+// cover an image pull on a cold host, short enough not to hang the terminal.
+const defaultReadyTimeout = 3 * time.Minute
+
+// generatedNamePrefix makes a leaked container or Sandbox object identifiable
+// as this tool's doing.
+const generatedNamePrefix = "agtsbx-"
+
+// IO groups the streams the CLI reads and writes, so tests can capture them.
+type IO struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// runOptions is the parsed form of `agtsbx run`'s command line.
+type runOptions struct {
+	Image     string
+	Command   []string
+	Runtime   string
+	Namespace string
+	Name      string
+	Env       []string
+	Workdir   string
+	Keep      bool
+	Quiet     bool
+	GRPCPort  int
+	RESTPort  int
+	Timeout   time.Duration
+}
+
+// envFlag collects repeated -e/--env occurrences.
+type envFlag []string
+
+func (e *envFlag) String() string { return strings.Join(*e, ",") }
+
+func (e *envFlag) Set(value string) error {
+	key, _, found := strings.Cut(value, "=")
+	if key == "" {
+		return fmt.Errorf("expected KEY=VALUE, got %q", value)
+	}
+	if !found {
+		// "-e KEY" forwards the host's value, as docker run does, keeping an
+		// API key out of the command line and the shell history.
+		hostValue, set := os.LookupEnv(key)
+		if !set {
+			return fmt.Errorf("%s is not set in the environment; pass %s=VALUE to set it explicitly", key, key)
+		}
+		value = key + "=" + hostValue
+	}
+	*e = append(*e, value)
+	return nil
+}
+
+// ErrUsage signals a bad command line, so the caller can print usage rather
+// than treat it as a runtime failure.
+var ErrUsage = errors.New("usage")
+
+// errHelpRequested is distinct from ErrUsage because asking for help is not a
+// mistake: the text belongs on stdout and the exit status is success.
+var errHelpRequested = errors.New("help requested")
+
+const runUsage = `Usage: agtsbx run [OPTIONS] IMAGE COMMAND [ARG...]
+
+Run a command in a throwaway sandbox and stream its output.
+
+IMAGE must start sandboxd (the KEP-539.2 runtime daemon) as its entrypoint;
+agtsbx talks to that daemon to execute COMMAND.
+
+Options:
+  --runtime string     Runtime to run the sandbox on: auto, docker, podman,
+                       kubernetes (default "auto")
+  -e, --env KEY=VALUE  Set an environment variable, or "-e KEY" to forward it
+                       from the current environment (repeatable)
+  -w, --workdir string Working directory for COMMAND, resolved inside the
+                       sandbox root and required to exist there
+  --name string        Name for the sandbox (default: generated)
+  -n, --namespace string
+                       Namespace for the kubernetes runtime (default "default")
+  --keep               Leave the sandbox running after COMMAND exits
+  --timeout duration   How long to wait for the sandbox to become ready
+                       (default 3m0s)
+  --grpc-port int      sandboxd ProcessService port inside the sandbox (default 9090)
+  --rest-port int      sandboxd REST API port inside the sandbox (default 8080)
+  -q, --quiet          Suppress progress messages on stderr
+
+Examples:
+  agtsbx run sandboxd:latest echo hello
+  agtsbx run -e GREETING=hi sandboxd:latest sh -c 'echo $GREETING'
+  agtsbx run --runtime kubernetes -n agents sandboxd:latest python3 -c 'print(1)'
+`
+
+// parseRunArgs parses the argument list for `agtsbx run`.
+//
+// FlagSet.Parse stops at the first non-flag argument, which is the image, and
+// leaves the rest untouched. That is what lets `agtsbx run img ls -l` pass -l
+// through to the sandboxed command instead of rejecting it.
+func parseRunArgs(args []string, stderr io.Writer) (runOptions, error) {
+	opts := runOptions{}
+	var env envFlag
+
+	set := flag.NewFlagSet("run", flag.ContinueOnError)
+	set.SetOutput(stderr)
+	// The caller prints the usage text; suppress the flag package's own
+	// listing so it is not printed twice.
+	set.Usage = func() {}
+
+	set.StringVar(&opts.Runtime, "runtime", RuntimeAuto, "runtime to run the sandbox on")
+	set.Var(&env, "e", "environment variable KEY=VALUE")
+	set.Var(&env, "env", "environment variable KEY=VALUE")
+	set.StringVar(&opts.Workdir, "w", "", "working directory inside the sandbox root")
+	set.StringVar(&opts.Workdir, "workdir", "", "working directory inside the sandbox root")
+	set.StringVar(&opts.Name, "name", "", "name for the sandbox")
+	set.StringVar(&opts.Namespace, "n", "default", "namespace for the kubernetes runtime")
+	set.StringVar(&opts.Namespace, "namespace", "default", "namespace for the kubernetes runtime")
+	set.BoolVar(&opts.Keep, "keep", false, "leave the sandbox running after the command exits")
+	set.BoolVar(&opts.Quiet, "q", false, "suppress progress messages")
+	set.BoolVar(&opts.Quiet, "quiet", false, "suppress progress messages")
+	set.IntVar(&opts.GRPCPort, "grpc-port", defaultGRPCPort, "sandboxd gRPC port inside the sandbox")
+	set.IntVar(&opts.RESTPort, "rest-port", defaultRESTPort, "sandboxd REST port inside the sandbox")
+	set.DurationVar(&opts.Timeout, "timeout", defaultReadyTimeout, "how long to wait for the sandbox to be ready")
+
+	if err := set.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return runOptions{}, errHelpRequested
+		}
+		return runOptions{}, fmt.Errorf("%w: %w", ErrUsage, err)
+	}
+
+	rest := set.Args()
+	if len(rest) == 0 {
+		return runOptions{}, fmt.Errorf("%w: an IMAGE is required", ErrUsage)
+	}
+	opts.Image = rest[0]
+	opts.Command = rest[1:]
+
+	if len(opts.Command) == 0 {
+		// The entrypoint is sandboxd, so no command would just start a
+		// daemon and appear to hang.
+		return runOptions{}, fmt.Errorf("%w: a COMMAND is required", ErrUsage)
+	}
+	if !isKnownRuntime(opts.Runtime) {
+		return runOptions{}, fmt.Errorf("%w: unknown runtime %q, expected one of %v", ErrUsage, opts.Runtime, knownRuntimes)
+	}
+	if opts.Timeout <= 0 {
+		return runOptions{}, fmt.Errorf("%w: --timeout must be positive, got %s", ErrUsage, opts.Timeout)
+	}
+	if err := validatePort("--grpc-port", opts.GRPCPort); err != nil {
+		return runOptions{}, err
+	}
+	if err := validatePort("--rest-port", opts.RESTPort); err != nil {
+		return runOptions{}, err
+	}
+	if opts.GRPCPort == opts.RESTPort {
+		return runOptions{}, fmt.Errorf("%w: --grpc-port and --rest-port must differ (both are %d)", ErrUsage, opts.GRPCPort)
+	}
+
+	opts.Env = env
+	if opts.Name == "" {
+		name, err := generateName()
+		if err != nil {
+			return runOptions{}, err
+		}
+		opts.Name = name
+	}
+	return opts, nil
+}
+
+// validatePort rejects out-of-range ports here, where the message is clearer
+// than the engine's or the API server's.
+func validatePort(flagName string, port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%w: %s must be between 1 and 65535, got %d", ErrUsage, flagName, port)
+	}
+	return nil
+}
+
+// generateName produces a unique, DNS-label-safe sandbox name: it is used as
+// both a container name and a Kubernetes object name.
+func generateName() (string, error) {
+	suffix := make([]byte, 6)
+	if _, err := rand.Read(suffix); err != nil {
+		return "", fmt.Errorf("generating sandbox name: %w", err)
+	}
+	return generatedNamePrefix + hex.EncodeToString(suffix), nil
+}
+
+// Run executes `agtsbx run` and returns the exit code the process should use.
+// On success that is the sandboxed command's own, so agtsbx composes in shell
+// pipelines the way docker run does.
+func Run(ctx context.Context, args []string, streams IO) (int, error) {
+	opts, err := parseRunArgs(args, streams.Stderr)
+	if errors.Is(err, errHelpRequested) {
+		fmt.Fprint(streams.Stdout, runUsage)
+		return 0, nil
+	}
+	if err != nil {
+		if errors.Is(err, ErrUsage) {
+			fmt.Fprintf(streams.Stderr, "agtsbx: %v\n\n%s", err, runUsage)
+		}
+		return 1, err
+	}
+
+	progress := streams.Stderr
+	if opts.Quiet {
+		progress = io.Discard
+	}
+
+	runtimeName, err := selectRuntime(opts.Runtime, defaultLookPath)
+	if err != nil {
+		return 1, err
+	}
+
+	backend, err := newBackend(runtimeName, backendOptions{
+		Namespace:    opts.Namespace,
+		ReadyTimeout: opts.Timeout,
+		Stderr:       progress,
+	})
+	if err != nil {
+		return 1, err
+	}
+
+	// opts.Env is not part of the spec: it reaches the sandbox with the
+	// command below, so no credential lands in the engine argv or the
+	// Sandbox object.
+	spec := Spec{
+		Image:    opts.Image,
+		Name:     opts.Name,
+		GRPCPort: opts.GRPCPort,
+		RESTPort: opts.RESTPort,
+		Remove:   !opts.Keep,
+	}
+
+	fmt.Fprintf(progress, "agtsbx: starting %s on %s as %s\n", spec.Image, backend.Name(), spec.Name)
+	instance, err := backend.Start(ctx, spec)
+	if err != nil {
+		return 1, err
+	}
+	defer func() {
+		// Teardown must not inherit ctx: a cancelled ctx usually means
+		// Ctrl-C, when the sandbox most needs removing.
+		stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+		defer cancel()
+		if err := instance.Stop(stopCtx); err != nil {
+			fmt.Fprintf(streams.Stderr, "agtsbx: warning: %v\n", err)
+		}
+	}()
+
+	if opts.Keep {
+		fmt.Fprintf(progress, "agtsbx: sandbox %s left running (--keep)\n", spec.Name)
+	}
+
+	exitCode, err := runCommand(ctx, instance.Endpoints().GRPCAddr, execRequest{
+		Command: opts.Command,
+		Env:     opts.Env,
+		Workdir: opts.Workdir,
+		Stdout:  streams.Stdout,
+		Stderr:  streams.Stderr,
+	})
+	if err != nil {
+		return 1, err
+	}
+	return exitCode, nil
+}

--- a/internal/agtsbx/run_test.go
+++ b/internal/agtsbx/run_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agtsbx
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRunArgs(t *testing.T) {
+	t.Run("splits the image from the command", func(t *testing.T) {
+		opts, err := parseRunArgs([]string{"sandboxd:latest", "echo", "hello"}, io.Discard)
+		require.NoError(t, err)
+
+		assert.Equal(t, "sandboxd:latest", opts.Image)
+		assert.Equal(t, []string{"echo", "hello"}, opts.Command)
+	})
+
+	t.Run("passes flag-like command arguments through untouched", func(t *testing.T) {
+		// FlagSet.Parse stops at the image, so -l and --color are the
+		// sandboxed command's, not agtsbx's.
+		opts, err := parseRunArgs([]string{"img", "ls", "-l", "--color=always"}, io.Discard)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"ls", "-l", "--color=always"}, opts.Command)
+	})
+
+	t.Run("does not consume flags that appear after the image", func(t *testing.T) {
+		// --runtime after the image belongs to the sandboxed command.
+		opts, err := parseRunArgs([]string{"img", "mytool", "--runtime", "podman"}, io.Discard)
+		require.NoError(t, err)
+
+		assert.Equal(t, RuntimeAuto, opts.Runtime)
+		assert.Equal(t, []string{"mytool", "--runtime", "podman"}, opts.Command)
+	})
+
+	t.Run("applies defaults", func(t *testing.T) {
+		opts, err := parseRunArgs([]string{"img", "true"}, io.Discard)
+		require.NoError(t, err)
+
+		assert.Equal(t, RuntimeAuto, opts.Runtime)
+		assert.Equal(t, "default", opts.Namespace)
+		assert.Equal(t, defaultGRPCPort, opts.GRPCPort)
+		assert.Equal(t, defaultRESTPort, opts.RESTPort)
+		assert.Equal(t, defaultReadyTimeout, opts.Timeout)
+		// Sandboxes are ephemeral unless --keep is given.
+		assert.False(t, opts.Keep)
+	})
+
+	t.Run("generates a unique prefixed name when none is given", func(t *testing.T) {
+		first, err := parseRunArgs([]string{"img", "true"}, io.Discard)
+		require.NoError(t, err)
+		second, err := parseRunArgs([]string{"img", "true"}, io.Discard)
+		require.NoError(t, err)
+
+		// Concurrent runs must not collide on a container or object name.
+		assert.True(t, strings.HasPrefix(first.Name, generatedNamePrefix))
+		assert.NotEqual(t, first.Name, second.Name)
+	})
+
+	t.Run("honours an explicit name", func(t *testing.T) {
+		opts, err := parseRunArgs([]string{"--name", "mybox", "img", "true"}, io.Discard)
+		require.NoError(t, err)
+		assert.Equal(t, "mybox", opts.Name)
+	})
+
+	t.Run("collects repeated env flags in both spellings", func(t *testing.T) {
+		opts, err := parseRunArgs([]string{"-e", "A=1", "--env", "B=2", "img", "true"}, io.Discard)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"A=1", "B=2"}, opts.Env)
+	})
+
+	t.Run("accepts short and long spellings of the other flags", func(t *testing.T) {
+		opts, err := parseRunArgs([]string{"-w", "/tmp", "-n", "agents", "-q", "img", "true"}, io.Discard)
+		require.NoError(t, err)
+
+		assert.Equal(t, "/tmp", opts.Workdir)
+		assert.Equal(t, "agents", opts.Namespace)
+		assert.True(t, opts.Quiet)
+	})
+
+	t.Run("parses a custom timeout and ports", func(t *testing.T) {
+		opts, err := parseRunArgs([]string{"--timeout", "45s", "--grpc-port", "1234", "--rest-port", "5678", "img", "true"}, io.Discard)
+		require.NoError(t, err)
+
+		assert.Equal(t, 45*time.Second, opts.Timeout)
+		assert.Equal(t, 1234, opts.GRPCPort)
+		assert.Equal(t, 5678, opts.RESTPort)
+	})
+}
+
+func TestParseRunArgsErrors(t *testing.T) {
+	testCases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no arguments",
+			args:    nil,
+			wantErr: "an IMAGE is required",
+		},
+		{
+			// Running the image alone would start sandboxd and appear to hang.
+			name:    "image without a command",
+			args:    []string{"sandboxd:latest"},
+			wantErr: "a COMMAND is required",
+		},
+		{
+			name:    "unknown runtime",
+			args:    []string{"--runtime", "firecracker", "img", "true"},
+			wantErr: `unknown runtime "firecracker"`,
+		},
+		{
+			name:    "env forwarding an unset variable",
+			args:    []string{"-e", "AGTSBX_DEFINITELY_UNSET", "img", "true"},
+			wantErr: "not set in the environment",
+		},
+		{
+			name:    "env with an empty key",
+			args:    []string{"-e", "=value", "img", "true"},
+			wantErr: "KEY=VALUE",
+		},
+		{
+			name:    "non-positive timeout",
+			args:    []string{"--timeout", "0s", "img", "true"},
+			wantErr: "--timeout must be positive",
+		},
+		{
+			name:    "port out of range",
+			args:    []string{"--grpc-port", "70000", "img", "true"},
+			wantErr: "--grpc-port must be between 1 and 65535",
+		},
+		{
+			name:    "zero port",
+			args:    []string{"--rest-port", "0", "img", "true"},
+			wantErr: "--rest-port must be between 1 and 65535",
+		},
+		{
+			// Worth catching before the engine reports it obscurely.
+			name:    "identical sandboxd ports",
+			args:    []string{"--grpc-port", "8080", "--rest-port", "8080", "img", "true"},
+			wantErr: "must differ",
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{"--nope", "img", "true"},
+			wantErr: "usage",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseRunArgs(tc.args, io.Discard)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			// Classified as usage so the CLI prints help, not a bare message.
+			assert.ErrorIs(t, err, ErrUsage)
+		})
+	}
+}
+
+func TestEnvFlag(t *testing.T) {
+	var env envFlag
+
+	require.NoError(t, env.Set("A=1"))
+	require.NoError(t, env.Set("B=with=equals"))
+	assert.Equal(t, "A=1,B=with=equals", env.String())
+
+	require.Error(t, env.Set("=emptykey"))
+}
+
+func TestEnvFlagForwardsFromTheEnvironment(t *testing.T) {
+	// Passing a credential as "-e KEY" keeps it out of the command line and
+	// the shell history, so the pass-through must actually resolve a value.
+	t.Setenv("AGTSBX_TEST_TOKEN", "s3cret")
+
+	var env envFlag
+	require.NoError(t, env.Set("AGTSBX_TEST_TOKEN"))
+	assert.Equal(t, envFlag{"AGTSBX_TEST_TOKEN=s3cret"}, env)
+
+	// An unset variable must be reported rather than silently forwarded as
+	// empty, which would leave the sandboxed agent unauthenticated.
+	err := env.Set("AGTSBX_TEST_ABSENT")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not set in the environment")
+}
+
+func TestRunPrintsHelpOnRequest(t *testing.T) {
+	var stdout, stderr strings.Builder
+
+	code, err := Run(t.Context(), []string{"--help"}, IO{Stdout: &stdout, Stderr: &stderr})
+	require.NoError(t, err)
+	// Asking for help is not an error: the text goes to stdout and the exit
+	// status is success.
+	assert.Equal(t, 0, code)
+	assert.Contains(t, stdout.String(), "Usage: agtsbx run")
+	assert.Empty(t, stderr.String())
+}
+
+func TestRunRejectsBadUsage(t *testing.T) {
+	var stdout, stderr strings.Builder
+
+	code, err := Run(t.Context(), []string{"--runtime", "nope", "img", "true"}, IO{Stdout: &stdout, Stderr: &stderr})
+	require.Error(t, err)
+	assert.Equal(t, 1, code)
+	require.ErrorIs(t, err, ErrUsage)
+	// Guidance on stderr keeps stdout clean for the command's own output.
+	assert.Contains(t, stderr.String(), "Usage: agtsbx run")
+	assert.Empty(t, stdout.String())
+}


### PR DESCRIPTION
#### What this PR does / why we need it

Trying agent-sandbox today means standing up a cluster, installing the controller and writing a `SandboxTemplate` first. This adds `agtsbx`, a docker-like entry point:

```console
$ agtsbx run sandboxd:latest echo hello
agtsbx: starting sandboxd:latest on docker as agtsbx-1b75a73862a3
hello
```

The sandbox is created, the command runs with its output streamed, the sandbox is torn down, and the command's exit status is propagated, so it composes in shell pipelines the way `docker run` does.

**Coding agents are the motivating case.** They edit files and run commands on your behalf, which is the work a sandbox exists to contain, and all three popular CLIs have a headless mode that fits a one-shot run. [`examples/agtsbx-agents`](../blob/main/examples/agtsbx-agents/README.md) builds a `sandboxd` image carrying them:

```console
$ docker build -t agtsbx-agents:latest examples/agtsbx-agents
$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest claude -p 'write hello.py'
$ agtsbx run -e OPENAI_API_KEY    agtsbx-agents:latest codex exec 'write hello.py'
$ agtsbx run -e ANTHROPIC_API_KEY agtsbx-agents:latest opencode run 'write hello.py'
```

`-e KEY` with no value forwards the variable from the caller's environment, and only the variables named that way reach the agent.

#### Design

**The backend is pluggable.** `--runtime` selects `docker`, `podman` or `kubernetes`; the default probes for a local engine and falls back to kubernetes. All three converge on the [KEP-539.2](../blob/main/docs/keps/539.2-runtime-standardization/README.md) `sandboxd` contract, so the code that runs the command is backend-agnostic: a backend only answers *"where do I dial sandboxd?"*. An explicit `--runtime` is never silently downgraded.

**The kubernetes backend uses the core `Sandbox` API**, not `SandboxClaim`: `run` names an image, and only `Sandbox` accepts one directly. It reaches sandboxd over a port-forward, so no `Service`, `Gateway` or `sandbox-router` is required.

**No new dependencies and no API or CRD changes.** The container backends drive the engine CLI rather than linking an engine SDK, and flag parsing uses the standard library. `make fix-go-generate` produces no diff.

#### Security

`sandboxd` performs no authentication of its own, since KEP-539.2 places containment in the network layer, so:

- containers run with `--cap-drop ALL` and `--security-opt no-new-privileges`, and publish ports on `127.0.0.1` only;
- Kubernetes sandboxes are reached over a port-forward and match `examples/sandboxd-sandbox/sandbox-template.yaml`: `automountServiceAccountToken: false`, `runAsNonRoot`, `allowPrivilegeEscalation: false`, all capabilities dropped;
- the command's environment travels with the request, so a credential passed with `-e` is written to neither the engine argv nor the `Sandbox` object.

Local engines have no `runAsNonRoot` equivalent, so on that path the image decides the user; this is now stated rather than claimed as parity.

#### Testing

Unit tests cover runtime selection, argument parsing, engine argument construction, published-port parsing, the stream/exit-code protocol, health polling, the readiness watch, ownership-checked cleanup and teardown.

Manually verified end-to-end against a real `sandboxd` image on all three backends (kind for kubernetes, both engines locally): basic commands, env vars, `--workdir`, exit-code propagation, incremental streaming, stdout/stderr separation, cleanup on success, failure and Ctrl-C, and `--keep`. The agent image was built and all three CLIs exercised inside it.

`make build`, `make lint-go`, `make lint-api`, `make toc-verify` and the Go unit suite pass.

#### Which issue(s) this PR is related to:

None; this is a new user-facing surface with no prior issue or KEP. Related prior art: KEP-539.2 / #747 (runtime standardization) and the "Decouple API from Runtime (Portable Backend)" roadmap item, which this consumes. Happy to convert the design into a KEP under `docs/keps/` if maintainers would rather settle it first.

#### Notes for reviewers

- Addressed since the last push: the command environment no longer reaches `Spec`, the engine argv or the pod spec; an already-removed container is treated as success on teardown; ambiguous `run`/`Create` errors now clean up, but only objects carrying `app.kubernetes.io/managed-by: agtsbx`, so a name collision leaves the user's own container or Sandbox alone; Kubernetes deletes use foreground propagation; the non-root parity claim is corrected. Comments were cut back again.
- Not addressed: probing engine liveness during `auto` selection (an extra `docker info` on every run for a case the engine's own error already explains), and honoring `agents.x-k8s.io/n` before port-forwarding (it is the deprecated warm-pool adoption path, and a Sandbox agtsbx just created cannot carry it).
- It deliberately does **not** touch `README.md` or the docs-site mounts; that can follow if maintainers agree the CLI belongs.
- Incidental finding, **not** addressed here: `fake.NewSimpleClientset(objects...)` cannot pre-seed `Sandbox` objects, because `meta.UnsafeGuessKindToResource` pluralizes `Sandbox` to `sandboxs`, so they are filed under a resource the client never queries. The tests create through the typed client instead. Happy to open an issue.

#### Release Note

```release-note
Added `agtsbx`, a docker-like CLI that runs a single command in a throwaway sandbox on Docker, Podman or Kubernetes, streaming its output and propagating its exit status.
```

/kind feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `agtsbx run` command for executing commands in temporary sandboxes.
  - Supports Docker, Podman, and Kubernetes runtimes with automatic runtime detection.
  - Streams command output, forwards environment variables, supports custom ports, timeouts, and workspace controls.
  - Added secure cleanup and sandbox lifecycle handling.
  - Added an example runtime image for coding agents, including Claude Code, Codex, and opencode.

- **Documentation**
  - Added comprehensive usage documentation, examples, security guidance, and build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->