### PR TITLE
sandbox-router: bind scoped-token v2 to canonical request targets

### DIFF
--- a/sandbox-router/README.md
+++ b/sandbox-router/README.md
@@ -171,11 +171,11 @@ The `Authorizer` interface is intentionally simple:
 
 ```go
 type Authorizer interface {
-    Authorize(ctx context.Context, r *http.Request, sandboxNamespace, sandboxName string) error
+    Authorize(ctx context.Context, r *http.Request, target AuthorizationTarget) error
 }
 ```
 
-Returning `nil` allows the request; returning `authz.ErrUnauthenticated` produces a 401 JSON response, `authz.ErrForbidden` produces 403, anything else produces 500. Implementations pull whatever credential they need (Bearer token via `authz.BearerTokenFromRequest`, TLS client cert, custom header) directly off the request.
+`AuthorizationTarget` carries the namespace, Sandbox name, Sandbox UID, execution port, normalized HTTP method, and the upstream path after path-routing prefixes have been removed. Returning `nil` allows the request; returning `authz.ErrUnauthenticated` produces a 401 JSON response, `authz.ErrForbidden` produces 403, anything else produces 500. Implementations pull whatever credential they need (TLS client cert, Bearer token via `authz.BearerTokenFromRequest`, custom header) directly off the request.
 
 The `sandbox_router_authz_decisions_total{decision="allow|deny",sandbox_namespace="…"}` counter records every verdict so deployments can see whether `AllowAll` is actually allowing the traffic shape they expect.
 
@@ -199,7 +199,11 @@ RBAC: the router's ServiceAccount needs `create` on `tokenreviews.authentication
 
 ### Scoped-token authorizer
 
-Set `--authz-mode=scoped-token` to enable the built-in authorizer that closes exactly the gap called out above, but without requiring the caller to hold a cluster-verifiable K8s credential at all. A scoped token is a small HMAC-SHA256-signed value binding `(namespace, name, exp)` — minted with `authz.MintScopedToken`, wire format `v1.<payload>.<signature>` — and the authorizer both verifies the signature/expiry *and* checks that the token's `(namespace, name)` matches the sandbox actually being addressed. The leading `v1` version lets a future format coexist with outstanding tokens during a rollout, and the signature is domain-separated (MAC'd over a fixed context string) so it can't be cross-verified by any other component sharing the Secret. A token minted for `box-a` gets 403 against `box-b`; there is no TokenReview round-trip and no K8s API access implied by possessing the token. Requests carrying `X-Sandbox-Pod-IP` or `X-Sandbox-UID` are rejected outright in this mode: both override how the proxy picks the dial target *after* authorization (a raw IP, or a UID→IP cache lookup), which would let a token scoped to one sandbox reach a different pod while `X-Sandbox-ID` still names the authorized one. Rejecting them leaves resolution by `(namespace, name)` — exactly the identity the token authorizes — as the only routing path, so the dial target always matches what was authorized. Today that resolution is DNS, so scoped-token mode needs the sandbox reachable by its `(namespace, name)` DNS name (e.g. a headless `Service`), rather than the UID cache fast-path. A `(namespace, name)`-keyed cache name index (added in #1239) resolves the same identity and composes here without weakening the guarantee — it would lift the headless-`Service` requirement for warm-pool sandboxes; whichever of the two lands second should keep this sentence and #1239's wording in sync.
+Set `--authz-mode=scoped-token` to authorize requests without giving callers a cluster-verifiable K8s credential. The original `v1.<payload>.<signature>` format uses HMAC-SHA256 and binds `(namespace, name, exp)`. It remains the default when only `--authz-scoped-token-secret-file` is set, so existing deployments keep the same behavior.
+
+Scoped-token v2 uses Ed25519 and binds the full `AuthorizationTarget` plus expiry. Its wire format is `v2.<kid>.<payload>.<signature>`. The signature covers the key ID as well as the payload, so changing `kid` cannot select another verification key. Key IDs may contain ASCII letters, digits, hyphens, and underscores. A key file may contain multiple public keys during reader-first rotation. Private signing keys never belong in the router.
+
+V2 requires `X-Sandbox-UID` and `--cache-enabled`. It rejects `X-Sandbox-Pod-IP`, because a raw address is not part of the signed target. The current cache still falls back from a missing UID entry to namespace and name. The v2 contract therefore does not yet prove same-name replacement fencing; that requires cache resolution to return the canonical UID it actually selected and to reject a stale UID instead of falling back.
 
 This is the primitive an agent-facing example needs to reproduce the credential-boundary story of `examples/containarium-ssh-sandbox` (agent holds one narrow, single-purpose credential, never a cluster token) using only pieces native to this project — no third-party SSH gateway, no vendor runtime image. `MintScopedToken` is exported so a Sandbox controller (or a test/example harness standing in for one) can mint a token at Sandbox-creation time and hand it to the agent; the router itself never mints, only verifies.
 
@@ -208,9 +212,19 @@ Flags:
 | Flag | Default | Notes |
 |---|---|---|
 | `--authz-mode` | `allow-all` | `allow-all`, `tokenreview`, or `scoped-token`. |
-| `--authz-scoped-token-secret-file` | `""` | Path to a file holding the shared HMAC-SHA256 secret. Required when `--authz-mode=scoped-token`; must match whatever minted the tokens (e.g. the same K8s Secret mounted into the controller and the router). At least 32 bytes after whitespace trimming (`authz.MinScopedTokenSecretLen`) — every observed token is an offline brute-force oracle for this secret, so short values are refused at startup. Minter and verifier both trim surrounding whitespace, so a trailing newline in the mounted file is harmless. |
+| `--authz-scoped-token-secret-file` | `""` | Path to the legacy v1 HMAC-SHA256 secret. Required unless v2 verification keys are configured. At least 32 bytes after whitespace trimming. |
+| `--authz-scoped-token-verification-keys-file` | `""` | Path to a JSON Ed25519 public-key set for v2. Requires `--cache-enabled`. |
+| `--authz-scoped-token-v1-accept-until` | `""` | Exclusive RFC3339 cutoff for v1 verification. Required when v1 and v2 readers overlap. |
 
-**Follow-up, not in this change.** Nothing here mints tokens automatically at Sandbox creation or rotates the shared secret without a restart — both are natural next steps once a controller-side minting story is agreed, tracked alongside the per-sandbox-authorization follow-up on TokenReview above.
+The v2 key file contains unpadded base64url public keys:
+
+```json
+{"keys":[{"kid":"2026-08","publicKey":"<base64url-ed25519-public-key>"}]}
+```
+
+A v2 token authorizes the bound Sandbox UID, method, port, and path until expiry. Query parameters and request bodies are not signed, and tokens are reusable during that interval. For an endpoint that accepts commands in its query or body, a token holder may change those commands while keeping the signed target unchanged. Enforce command-level policy or one-time execution in the upstream service when required.
+
+The router reloads keys on restart. `authz.MintScopedTokenV2` is available to controller-side issuers, but the router never mints tokens itself.
 
 ### Browser-session credentials
 

--- a/sandbox-router/authz/authorizer.go
+++ b/sandbox-router/authz/authorizer.go
@@ -27,7 +27,86 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
+	"strings"
 )
+
+// AuthorizationTarget is the canonical request identity an Authorizer
+// evaluates. The proxy constructs it only after routing has selected the
+// sandbox and stripped any path-routing prefix, so Path is the path the
+// upstream sandbox will receive rather than the router-facing path.
+type AuthorizationTarget struct {
+	Namespace   string
+	SandboxName string
+	SandboxUID  string
+	Port        int
+	Method      string
+	Path        string
+}
+
+// NormalizeAuthorizationTarget returns the stable representation used in
+// scoped-token claims and request comparisons.
+func NormalizeAuthorizationTarget(target AuthorizationTarget) (AuthorizationTarget, error) {
+	target.Method = strings.ToUpper(strings.TrimSpace(target.Method))
+	if !validHTTPMethod(target.Method) {
+		return AuthorizationTarget{}, errors.New("authorization target: invalid HTTP method")
+	}
+	if target.Namespace == "" || target.SandboxName == "" {
+		return AuthorizationTarget{}, errors.New("authorization target: namespace and sandbox name are required")
+	}
+	if target.Port < 1 || target.Port > 65535 {
+		return AuthorizationTarget{}, errors.New("authorization target: port must be between 1 and 65535")
+	}
+	if target.Path == "" {
+		target.Path = "/"
+	}
+	if !strings.HasPrefix(target.Path, "/") {
+		return AuthorizationTarget{}, errors.New("authorization target: path must be absolute")
+	}
+	decodedPath, err := url.PathUnescape(target.Path)
+	if err != nil {
+		return AuthorizationTarget{}, errors.New("authorization target: path has invalid percent-encoding")
+	}
+	pathURL := &url.URL{Path: decodedPath, RawPath: target.Path}
+	target.Path = uppercasePercentEncoding(pathURL.EscapedPath())
+	return target, nil
+}
+
+func uppercasePercentEncoding(value string) string {
+	encoded := []byte(value)
+	for i := 0; i+2 < len(encoded); i++ {
+		if encoded[i] != '%' {
+			continue
+		}
+		encoded[i+1] = uppercaseHex(encoded[i+1])
+		encoded[i+2] = uppercaseHex(encoded[i+2])
+		i += 2
+	}
+	return string(encoded)
+}
+
+func uppercaseHex(value byte) byte {
+	if value >= 'a' && value <= 'f' {
+		return value - ('a' - 'A')
+	}
+	return value
+}
+
+func validHTTPMethod(method string) bool {
+	if method == "" {
+		return false
+	}
+	for i := range len(method) {
+		c := method[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case strings.ContainsRune("!#$%&'*+-.^_`|~", rune(c)):
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // Authorizer decides whether the principal carried by an inbound
 // request may access a particular sandbox. Implementations must be
@@ -44,7 +123,7 @@ import (
 // errors declared in this package so the caller can map it to the
 // right HTTP status code.
 type Authorizer interface {
-	Authorize(ctx context.Context, r *http.Request, sandboxNamespace, sandboxName string) error
+	Authorize(ctx context.Context, r *http.Request, target AuthorizationTarget) error
 }
 
 // Sentinel errors returned by Authorizer implementations. The proxy
@@ -83,6 +162,6 @@ func HTTPStatusFor(err error) int {
 type AllowAll struct{}
 
 // Authorize always returns nil.
-func (AllowAll) Authorize(_ context.Context, _ *http.Request, _, _ string) error {
+func (AllowAll) Authorize(_ context.Context, _ *http.Request, _ AuthorizationTarget) error {
 	return nil
 }

--- a/sandbox-router/authz/authorizer_test.go
+++ b/sandbox-router/authz/authorizer_test.go
@@ -24,11 +24,36 @@ import (
 func TestAllowAllAuthorize(t *testing.T) {
 	a := AllowAll{}
 	req, _ := http.NewRequest("GET", "/", nil)
-	if err := a.Authorize(context.Background(), req, "any", "any"); err != nil {
+	if err := a.Authorize(context.Background(), req, testAuthorizationTarget("any", "any")); err != nil {
 		t.Fatalf("AllowAll should never deny: %v", err)
 	}
-	if err := a.Authorize(context.Background(), nil, "", ""); err != nil {
+	if err := a.Authorize(context.Background(), nil, AuthorizationTarget{}); err != nil {
 		t.Fatalf("AllowAll should not care about nil request: %v", err)
+	}
+}
+
+func TestNormalizeAuthorizationTarget(t *testing.T) {
+	target, err := NormalizeAuthorizationTarget(AuthorizationTarget{
+		Namespace:   "team-a",
+		SandboxName: "box-a",
+		SandboxUID:  "uid-a",
+		Port:        9090,
+		Method:      "post",
+		Path:        "/exec/some%2ffile",
+	})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if target.Method != "POST" || target.Path != "/exec/some%2Ffile" {
+		t.Fatalf("got method %q path %q, want POST and /exec/some%%2Ffile", target.Method, target.Path)
+	}
+}
+
+func TestNormalizeAuthorizationTarget_RejectsInvalidPathEncoding(t *testing.T) {
+	target := testAuthorizationTarget("team-a", "box-a")
+	target.Path = "/exec/%ZZ"
+	if _, err := NormalizeAuthorizationTarget(target); err == nil {
+		t.Fatal("expected invalid percent-encoding to be rejected")
 	}
 }
 

--- a/sandbox-router/authz/scopedtoken.go
+++ b/sandbox-router/authz/scopedtoken.go
@@ -17,6 +17,7 @@ package authz
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -29,20 +30,16 @@ import (
 )
 
 // untrustedRoutingHeaders mirror proxy header names (proxy depends on
-// this package, so they can't be imported). ScopedTokenAuthorizer
-// refuses any request that carries one: each overrides how the proxy
-// picks the dial target *after* authorization, decoupling the address
-// the token was checked against (namespace, name) from the pod the
-// request actually reaches.
+// this package, so they can't be imported). Scoped-token v1 refuses any
+// request that carries one because its claims bind neither override.
 //
 //   - X-Sandbox-Pod-Ip routes straight to a caller-supplied IP.
 //   - X-Sandbox-Uid routes via the router's UID→IP cache, so a token
 //     for box-a plus box-b's UID (with X-Sandbox-Id still box-a, to
 //     pass the claim check) would land on box-b.
 //
-// Rejecting both leaves DNS resolution by (namespace, name) — which is
-// exactly the identity the token authorizes — as the only path, so the
-// dial target always matches what was authorized.
+// Scoped-token v2 binds the UID and permits that header, but continues
+// to reject a raw Pod IP.
 var untrustedRoutingHeaders = []string{"X-Sandbox-Pod-Ip", "X-Sandbox-Uid"}
 
 // scopedTokenVersion is the token format version. It is both the
@@ -151,15 +148,21 @@ func signScopedToken(secret []byte, encPayload string) []byte {
 
 // ScopedTokenOptions configures a ScopedTokenAuthorizer.
 type ScopedTokenOptions struct {
-	// Secret is the shared HMAC-SHA256 key used to verify scoped
-	// tokens. Required, at least MinScopedTokenSecretLen bytes after
+	// Secret is the shared HMAC-SHA256 key used to verify legacy v1
+	// tokens. Optional when VerificationKeys enables v2. When set, it
+	// must be at least MinScopedTokenSecretLen bytes after
 	// whitespace trimming, and must match whatever minted the token
 	// (see MintScopedToken; both sides trim identically, so a mounted
-	// Secret with a trailing newline still interoperates). Rotate by
-	// restarting the router with a new secret; multi-key rotation
-	// without downtime is a follow-up (mirrors how TLSCertFile started
-	// single-cert before hot-reload was added).
+	// Secret with a trailing newline still interoperates).
 	Secret []byte
+	// VerificationKeys selects scoped-token v2 verification by protected
+	// key ID. Multiple public keys may overlap during a reader-first key
+	// rotation. The authorizer copies the map and every key.
+	VerificationKeys map[string]ed25519.PublicKey
+	// V1AcceptUntil bounds legacy HMAC token verification while v2
+	// issuers drain. It is required when VerificationKeys and Secret are
+	// configured together. At and after this instant, v1 is rejected.
+	V1AcceptUntil time.Time
 	// Clock returns the current time; nil defaults to time.Now. Tests
 	// override this to exercise expiry deterministically.
 	Clock func() time.Time
@@ -172,11 +175,9 @@ type ScopedTokenOptions struct {
 }
 
 // ScopedTokenAuthorizer authenticates and authorizes a request in one
-// step: it verifies the Bearer token's HMAC signature and expiry, then
-// checks the token's (namespace, name) claims against the sandbox the
-// request is actually targeting. A verified token for one sandbox is
-// rejected with ErrForbidden against any other — the per-sandbox
-// scoping TokenReviewAuthorizer explicitly leaves out of its v1 scope.
+// step. V1 verifies an HMAC and binds namespace plus name. V2 verifies
+// Ed25519 and binds the complete AuthorizationTarget. A verified token
+// for one target is rejected with ErrForbidden against any other.
 //
 // This gives an agent a single-purpose credential scoped to its own
 // sandbox instead of a cluster-verifiable K8s Bearer token, without a
@@ -186,50 +187,113 @@ type ScopedTokenOptions struct {
 // agent-sandbox (the router's Authorizer contract on this side; the
 // Sandbox controller as the natural minter on the other).
 type ScopedTokenAuthorizer struct {
-	secret []byte
-	clock  func() time.Time
-	locs   TokenLocations
+	secret           []byte
+	verificationKeys map[string]ed25519.PublicKey
+	v1AcceptUntil    time.Time
+	clock            func() time.Time
+	locs             TokenLocations
 }
 
 // NewScopedTokenAuthorizer builds an authorizer from o.
 func NewScopedTokenAuthorizer(o ScopedTokenOptions) (*ScopedTokenAuthorizer, error) {
-	key, err := normalizeScopedSecret(o.Secret)
-	if err != nil {
-		return nil, err
+	var secret []byte
+	if len(bytes.TrimSpace(o.Secret)) > 0 {
+		key, err := normalizeScopedSecret(o.Secret)
+		if err != nil {
+			return nil, err
+		}
+		secret = key
+	}
+	verificationKeys := make(map[string]ed25519.PublicKey, len(o.VerificationKeys))
+	for keyID, key := range o.VerificationKeys {
+		if !validScopedTokenKeyID(keyID) {
+			return nil, fmt.Errorf("scopedtoken: invalid key ID %q", keyID)
+		}
+		if len(key) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("scopedtoken: public key %q must be %d bytes, got %d", keyID, ed25519.PublicKeySize, len(key))
+		}
+		verificationKeys[keyID] = append(ed25519.PublicKey(nil), key...)
+	}
+	if len(secret) == 0 && len(verificationKeys) == 0 {
+		return nil, errors.New("scopedtoken: a v1 secret or v2 verification key is required")
+	}
+	if len(verificationKeys) > 0 && len(secret) > 0 && o.V1AcceptUntil.IsZero() {
+		return nil, errors.New("scopedtoken: V1AcceptUntil is required when v1 and v2 verification are both enabled")
+	}
+	if !o.V1AcceptUntil.IsZero() && len(secret) == 0 {
+		return nil, errors.New("scopedtoken: V1AcceptUntil requires a v1 secret")
 	}
 	clock := o.Clock
 	if clock == nil {
 		clock = time.Now
 	}
-	return &ScopedTokenAuthorizer{secret: key, clock: clock, locs: o.TokenLocations}, nil
+	return &ScopedTokenAuthorizer{
+		secret:           secret,
+		verificationKeys: verificationKeys,
+		v1AcceptUntil:    o.V1AcceptUntil,
+		clock:            clock,
+		locs:             o.TokenLocations,
+	}, nil
 }
 
 // Authorize implements the Authorizer interface.
-func (a *ScopedTokenAuthorizer) Authorize(_ context.Context, r *http.Request, sandboxNamespace, sandboxName string) error {
+func (a *ScopedTokenAuthorizer) Authorize(_ context.Context, r *http.Request, target AuthorizationTarget) error {
 	token, _, ok := TokenFromRequest(r, a.locs)
 	if !ok {
 		return ErrUnauthenticated
 	}
-	claims, err := a.verify(token)
-	if err != nil {
-		return ErrUnauthenticated
-	}
-	// Reject any caller-supplied override of the dial target (see
-	// untrustedRoutingHeaders): they would let a valid token reach a
-	// pod other than the (namespace, name) it authorizes. Scoped-token
-	// routing is by (namespace, name) only.
-	for _, h := range untrustedRoutingHeaders {
-		if r.Header.Get(h) != "" {
+	version, _, _ := strings.Cut(token, ".")
+	switch version {
+	case scopedTokenVersion:
+		claims, err := a.verifyV1(token)
+		if err != nil {
+			return ErrUnauthenticated
+		}
+		for _, header := range untrustedRoutingHeaders {
+			if r.Header.Get(header) != "" {
+				return ErrForbidden
+			}
+		}
+		if claims.Namespace != target.Namespace || claims.Name != target.SandboxName {
 			return ErrForbidden
 		}
+		return nil
+	case scopedTokenV2Version:
+		claims, err := a.verifyV2(token)
+		if err != nil {
+			return ErrUnauthenticated
+		}
+		if r.Header.Get("X-Sandbox-Pod-Ip") != "" {
+			return ErrForbidden
+		}
+		normalized, err := NormalizeAuthorizationTarget(target)
+		if err != nil {
+			return ErrForbidden
+		}
+		if normalized.SandboxUID == "" || r == nil || r.Method != normalized.Method {
+			return ErrForbidden
+		}
+		if claims.Namespace != normalized.Namespace ||
+			claims.SandboxName != normalized.SandboxName ||
+			claims.SandboxUID != normalized.SandboxUID ||
+			claims.Port != normalized.Port ||
+			claims.Method != normalized.Method ||
+			claims.Path != normalized.Path {
+			return ErrForbidden
+		}
+		return nil
+	default:
+		return ErrUnauthenticated
 	}
-	if claims.Namespace != sandboxNamespace || claims.Name != sandboxName {
-		return ErrForbidden
-	}
-	return nil
 }
 
-func (a *ScopedTokenAuthorizer) verify(token string) (*scopedClaims, error) {
+func (a *ScopedTokenAuthorizer) verifyV1(token string) (*scopedClaims, error) {
+	if len(a.secret) == 0 {
+		return nil, errors.New("scopedtoken: v1 verification is disabled")
+	}
+	if !a.v1AcceptUntil.IsZero() && !a.clock().Before(a.v1AcceptUntil) {
+		return nil, errors.New("scopedtoken: v1 acceptance window expired")
+	}
 	// Wire format is version.payload.signature. Switch on the version
 	// prefix before anything else so a future format can be handled (or
 	// cleanly rejected) here without breaking outstanding v1 tokens.
@@ -258,6 +322,42 @@ func (a *ScopedTokenAuthorizer) verify(token string) (*scopedClaims, error) {
 	}
 	// >= : exp is exclusive — a token is invalid from its exp second
 	// onward, rather than staying valid for the whole exp second.
+	if a.clock().Unix() >= claims.Exp {
+		return nil, errors.New("scopedtoken: token expired")
+	}
+	return &claims, nil
+}
+
+func (a *ScopedTokenAuthorizer) verifyV2(token string) (*scopedTokenV2Claims, error) {
+	if len(a.verificationKeys) == 0 {
+		return nil, errors.New("scopedtoken: v2 verification is disabled")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 4 || parts[0] != scopedTokenV2Version {
+		return nil, errors.New("scopedtoken: malformed v2 token")
+	}
+	key, ok := a.verificationKeys[parts[1]]
+	if !ok {
+		return nil, errors.New("scopedtoken: unknown key ID")
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[3])
+	if err != nil {
+		return nil, fmt.Errorf("scopedtoken: decode v2 signature: %w", err)
+	}
+	if !ed25519.Verify(key, scopedTokenV2SigningInput(parts[1], parts[2]), signature) {
+		return nil, errors.New("scopedtoken: v2 signature mismatch")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("scopedtoken: decode v2 payload: %w", err)
+	}
+	var claims scopedTokenV2Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("scopedtoken: unmarshal v2 claims: %w", err)
+	}
+	if claims.SandboxUID == "" {
+		return nil, errors.New("scopedtoken: v2 Sandbox UID is required")
+	}
 	if a.clock().Unix() >= claims.Exp {
 		return nil, errors.New("scopedtoken: token expired")
 	}

--- a/sandbox-router/authz/scopedtoken_test.go
+++ b/sandbox-router/authz/scopedtoken_test.go
@@ -37,7 +37,7 @@ func TestScopedToken_ValidTokenAllowsItsOwnSandbox(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	if err := auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box-a"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box-a")); err != nil {
 		t.Fatalf("expected allow, got %v", err)
 	}
 }
@@ -49,7 +49,7 @@ func TestScopedToken_RejectsOtherSandbox(t *testing.T) {
 		t.Fatalf("mint: %v", err)
 	}
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: secret})
-	err = auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box-b")
+	err = auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box-b"))
 	if !errors.Is(err, ErrForbidden) {
 		t.Fatalf("expected ErrForbidden, got %v", err)
 	}
@@ -62,7 +62,7 @@ func TestScopedToken_RejectsOtherNamespace(t *testing.T) {
 		t.Fatalf("mint: %v", err)
 	}
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: secret})
-	err = auth.Authorize(context.Background(), reqWithBearer(tok), "ns-b", "box")
+	err = auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns-b", "box"))
 	if !errors.Is(err, ErrForbidden) {
 		t.Fatalf("expected ErrForbidden, got %v", err)
 	}
@@ -74,7 +74,7 @@ func TestScopedToken_RejectsWrongSecret(t *testing.T) {
 		t.Fatalf("mint: %v", err)
 	}
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: []byte("bbbb456789abcdef0123456789abcdef")})
-	err = auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box")
+	err = auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
@@ -90,7 +90,7 @@ func TestScopedToken_RejectsExpiredToken(t *testing.T) {
 		Secret: secret,
 		Clock:  func() time.Time { return time.Now().Add(time.Hour) },
 	})
-	err = auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box")
+	err = auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
@@ -98,7 +98,7 @@ func TestScopedToken_RejectsExpiredToken(t *testing.T) {
 
 func TestScopedToken_RejectsMalformedToken(t *testing.T) {
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: []byte("0123456789abcdef0123456789abcdef")})
-	err := auth.Authorize(context.Background(), reqWithBearer("not-a-real-token"), "ns", "box")
+	err := auth.Authorize(context.Background(), reqWithBearer("not-a-real-token"), testAuthorizationTarget("ns", "box"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
@@ -106,7 +106,7 @@ func TestScopedToken_RejectsMalformedToken(t *testing.T) {
 
 func TestScopedToken_MissingBearerRejected(t *testing.T) {
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: []byte("0123456789abcdef0123456789abcdef")})
-	err := auth.Authorize(context.Background(), reqWithBearer(""), "ns", "box")
+	err := auth.Authorize(context.Background(), reqWithBearer(""), testAuthorizationTarget("ns", "box"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestScopedToken_RejectsRoutingOverrides(t *testing.T) {
 		t.Run(tc.header, func(t *testing.T) {
 			req := reqWithBearer(tok)
 			req.Header.Set(tc.header, tc.value)
-			err := auth.Authorize(context.Background(), req, "ns", "box-a")
+			err := auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "box-a"))
 			if !errors.Is(err, ErrForbidden) {
 				t.Fatalf("expected ErrForbidden with %s override, got %v", tc.header, err)
 			}
@@ -172,7 +172,7 @@ func TestScopedToken_RejectsTokenAtExactExpiry(t *testing.T) {
 		Secret: secret,
 		Clock:  func() time.Time { return exp },
 	})
-	err = auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box")
+	err = auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated at exact expiry, got %v", err)
 	}
@@ -194,7 +194,7 @@ func TestScopedToken_ShortestTTLIsNotBornExpired(t *testing.T) {
 		Secret: secret,
 		Clock:  func() time.Time { return minted },
 	})
-	if err := auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box")); err != nil {
 		t.Fatalf("expected allow for a 1s token at mint time, got %v", err)
 	}
 }
@@ -209,7 +209,7 @@ func TestScopedToken_SecretWhitespaceNormalized(t *testing.T) {
 		t.Fatalf("mint: %v", err)
 	}
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: secret})
-	if err := auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box")); err != nil {
 		t.Fatalf("expected allow across newline-suffixed secret, got %v", err)
 	}
 }
@@ -227,7 +227,7 @@ func TestScopedToken_SecretIsCopied(t *testing.T) {
 	for i := range callerOwned {
 		callerOwned[i] = 'x'
 	}
-	if err := auth.Authorize(context.Background(), reqWithBearer(tok), "ns", "box"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer(tok), testAuthorizationTarget("ns", "box")); err != nil {
 		t.Fatalf("expected allow after mutating caller's slice, got %v", err)
 	}
 }
@@ -260,7 +260,7 @@ func TestScopedToken_RejectsUnversionedToken(t *testing.T) {
 	}
 	unversioned := strings.TrimPrefix(tok, "v1.")
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: secret})
-	err = auth.Authorize(context.Background(), reqWithBearer(unversioned), "ns", "box")
+	err = auth.Authorize(context.Background(), reqWithBearer(unversioned), testAuthorizationTarget("ns", "box"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated for unversioned token, got %v", err)
 	}
@@ -289,7 +289,7 @@ func TestScopedToken_MACIsDomainSeparated(t *testing.T) {
 	forged := "v1." + encPayload + "." + bareSig
 
 	auth, _ := NewScopedTokenAuthorizer(ScopedTokenOptions{Secret: secret})
-	if err := auth.Authorize(context.Background(), reqWithBearer(forged), "ns", "box"); !errors.Is(err, ErrUnauthenticated) {
+	if err := auth.Authorize(context.Background(), reqWithBearer(forged), testAuthorizationTarget("ns", "box")); !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated for context-less signature, got %v", err)
 	}
 }
@@ -324,14 +324,14 @@ func TestScopedToken_AuthorizesFromQueryAndCookie(t *testing.T) {
 
 	t.Run("query", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/?token="+tok, nil)
-		if err := auth.Authorize(context.Background(), req, "ns", "box-a"); err != nil {
+		if err := auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "box-a")); err != nil {
 			t.Fatalf("expected allow, got %v", err)
 		}
 	})
 	t.Run("cookie", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.AddCookie(&http.Cookie{Name: "sid", Value: tok})
-		if err := auth.Authorize(context.Background(), req, "ns", "box-a"); err != nil {
+		if err := auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "box-a")); err != nil {
 			t.Fatalf("expected allow, got %v", err)
 		}
 	})
@@ -340,7 +340,7 @@ func TestScopedToken_AuthorizesFromQueryAndCookie(t *testing.T) {
 	t.Run("cookie against other sandbox", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.AddCookie(&http.Cookie{Name: "sid", Value: tok})
-		err := auth.Authorize(context.Background(), req, "ns", "box-b")
+		err := auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "box-b"))
 		if !errors.Is(err, ErrForbidden) {
 			t.Fatalf("expected ErrForbidden, got %v", err)
 		}
@@ -360,7 +360,7 @@ func TestScopedToken_IgnoresQueryAndCookieByDefault(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/?token="+tok, nil)
 	req.AddCookie(&http.Cookie{Name: "sid", Value: tok})
-	err = auth.Authorize(context.Background(), req, "ns", "box-a")
+	err = auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "box-a"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated with locations disabled, got %v", err)
 	}

--- a/sandbox-router/authz/scopedtoken_v2.go
+++ b/sandbox-router/authz/scopedtoken_v2.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+const (
+	scopedTokenV2Version        = "v2"
+	scopedTokenV2SigningContext = "agent-sandbox/scoped-token/v2."
+	maxScopedTokenKeyIDLen      = 128
+)
+
+type scopedTokenV2Claims struct {
+	Namespace   string `json:"ns"`
+	SandboxName string `json:"name"`
+	SandboxUID  string `json:"uid"`
+	Port        int    `json:"port"`
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Exp         int64  `json:"exp"`
+}
+
+type scopedTokenVerificationKeyFile struct {
+	Keys []scopedTokenVerificationKey `json:"keys"`
+}
+
+type scopedTokenVerificationKey struct {
+	KeyID     string `json:"kid"`
+	PublicKey string `json:"publicKey"`
+}
+
+// ParseScopedTokenVerificationKeys parses a JSON public-key set for the
+// router. Each publicKey is an unpadded base64url Ed25519 public key.
+func ParseScopedTokenVerificationKeys(data []byte) (map[string]ed25519.PublicKey, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var keyFile scopedTokenVerificationKeyFile
+	if err := dec.Decode(&keyFile); err != nil {
+		return nil, fmt.Errorf("scopedtoken: decode verification keys: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("scopedtoken: verification key file contains trailing data")
+		}
+		return nil, fmt.Errorf("scopedtoken: decode verification key trailer: %w", err)
+	}
+	if len(keyFile.Keys) == 0 {
+		return nil, errors.New("scopedtoken: verification key file must contain at least one key")
+	}
+
+	keys := make(map[string]ed25519.PublicKey, len(keyFile.Keys))
+	for _, entry := range keyFile.Keys {
+		if !validScopedTokenKeyID(entry.KeyID) {
+			return nil, fmt.Errorf("scopedtoken: invalid key ID %q", entry.KeyID)
+		}
+		if _, exists := keys[entry.KeyID]; exists {
+			return nil, fmt.Errorf("scopedtoken: duplicate key ID %q", entry.KeyID)
+		}
+		key, err := base64.RawURLEncoding.DecodeString(entry.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("scopedtoken: decode public key %q: %w", entry.KeyID, err)
+		}
+		if len(key) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("scopedtoken: public key %q must be %d bytes, got %d", entry.KeyID, ed25519.PublicKeySize, len(key))
+		}
+		keys[entry.KeyID] = append(ed25519.PublicKey(nil), key...)
+	}
+	return keys, nil
+}
+
+// MintScopedTokenV2 produces an Ed25519 token bound to one canonical
+// authorization target. The key ID is protected by the signature so it
+// cannot be swapped to select a different verification key.
+func MintScopedTokenV2(privateKey ed25519.PrivateKey, keyID string, target AuthorizationTarget, ttl time.Duration) (string, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return "", fmt.Errorf("scopedtoken: private key must be %d bytes, got %d", ed25519.PrivateKeySize, len(privateKey))
+	}
+	if !validScopedTokenKeyID(keyID) {
+		return "", fmt.Errorf("scopedtoken: invalid key ID %q", keyID)
+	}
+	if target.SandboxUID == "" {
+		return "", errors.New("scopedtoken: Sandbox UID is required")
+	}
+	normalized, err := NormalizeAuthorizationTarget(target)
+	if err != nil {
+		return "", fmt.Errorf("scopedtoken: %w", err)
+	}
+	if ttl < time.Second {
+		return "", fmt.Errorf("scopedtoken: ttl must be at least %s (exp has one-second resolution), got %s", time.Second, ttl)
+	}
+	claims := scopedTokenV2Claims{
+		Namespace:   normalized.Namespace,
+		SandboxName: normalized.SandboxName,
+		SandboxUID:  normalized.SandboxUID,
+		Port:        normalized.Port,
+		Method:      normalized.Method,
+		Path:        normalized.Path,
+		Exp:         time.Now().Add(ttl).Unix(),
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("scopedtoken: marshal v2 claims: %w", err)
+	}
+	encPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signature := ed25519.Sign(privateKey, scopedTokenV2SigningInput(keyID, encPayload))
+	return strings.Join([]string{
+		scopedTokenV2Version,
+		keyID,
+		encPayload,
+		base64.RawURLEncoding.EncodeToString(signature),
+	}, "."), nil
+}
+
+func scopedTokenV2SigningInput(keyID, encPayload string) []byte {
+	return []byte(scopedTokenV2SigningContext + keyID + "." + encPayload)
+}
+
+func validScopedTokenKeyID(keyID string) bool {
+	if keyID == "" || len(keyID) > maxScopedTokenKeyIDLen {
+		return false
+	}
+	for i := range len(keyID) {
+		c := keyID[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '-' || c == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/sandbox-router/authz/scopedtoken_v2_test.go
+++ b/sandbox-router/authz/scopedtoken_v2_test.go
@@ -1,0 +1,317 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newScopedTokenV2Key(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+	return publicKey, privateKey
+}
+
+func scopedTokenV2Target() AuthorizationTarget {
+	return AuthorizationTarget{
+		Namespace:   "team-a",
+		SandboxName: "box-a",
+		SandboxUID:  "4f737e4b-22dc-4a61-a2db-c765fe28f967",
+		Port:        9090,
+		Method:      "GET",
+		Path:        "/exec/run",
+	}
+}
+
+func TestScopedTokenV2_BindsCanonicalAuthorizationTarget(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	target := scopedTokenV2Target()
+	mintTarget := target
+	mintTarget.Method = "get"
+	token, err := MintScopedTokenV2(privateKey, "current", mintTarget, time.Minute)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	if err := authorizer.Authorize(context.Background(), reqWithBearer(token), target); err != nil {
+		t.Fatalf("expected canonical target to authorize, got %v", err)
+	}
+}
+
+func TestScopedTokenV2_RejectsNoncanonicalRequestMethod(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	target := scopedTokenV2Target()
+	token, err := MintScopedTokenV2(privateKey, "current", target, time.Minute)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	target.Method = "get"
+	request := reqWithBearer(token)
+	request.Method = "get"
+	if err := authorizer.Authorize(context.Background(), request, target); !errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected lowercase request method to be forbidden, got %v", err)
+	}
+}
+
+func TestScopedTokenV2_RejectsEveryMismatchedTargetField(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	target := scopedTokenV2Target()
+	token, err := MintScopedTokenV2(privateKey, "current", target, time.Minute)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*AuthorizationTarget)
+	}{
+		{"namespace", func(t *AuthorizationTarget) { t.Namespace = "team-b" }},
+		{"sandbox name", func(t *AuthorizationTarget) { t.SandboxName = "box-b" }},
+		{"Sandbox UID", func(t *AuthorizationTarget) { t.SandboxUID = "replacement-uid" }},
+		{"execution port", func(t *AuthorizationTarget) { t.Port++ }},
+		{"HTTP method", func(t *AuthorizationTarget) { t.Method = "POST" }},
+		{"upstream path", func(t *AuthorizationTarget) { t.Path = "/exec/other" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := target
+			test.mutate(&got)
+			err := authorizer.Authorize(context.Background(), reqWithBearer(token), got)
+			if !errors.Is(err, ErrForbidden) {
+				t.Fatalf("expected ErrForbidden, got %v", err)
+			}
+		})
+	}
+}
+
+func TestScopedTokenV2_RejectsTokenAtExactExpiry(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	token, err := MintScopedTokenV2(privateKey, "current", scopedTokenV2Target(), time.Minute)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	claims := decodeScopedTokenV2Claims(t, token)
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+		Clock:            func() time.Time { return time.Unix(claims.Exp, 0) },
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	if err := authorizer.Authorize(context.Background(), reqWithBearer(token), scopedTokenV2Target()); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("expected ErrUnauthenticated at exact expiry, got %v", err)
+	}
+}
+
+func TestScopedTokenV2_AcceptsOverlappingVerificationKeys(t *testing.T) {
+	oldPublic, oldPrivate := newScopedTokenV2Key(t)
+	newPublic, newPrivate := newScopedTokenV2Key(t)
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{
+			"old": oldPublic,
+			"new": newPublic,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	for keyID, privateKey := range map[string]ed25519.PrivateKey{"old": oldPrivate, "new": newPrivate} {
+		t.Run(keyID, func(t *testing.T) {
+			token, err := MintScopedTokenV2(privateKey, keyID, scopedTokenV2Target(), time.Minute)
+			if err != nil {
+				t.Fatalf("mint: %v", err)
+			}
+			if err := authorizer.Authorize(context.Background(), reqWithBearer(token), scopedTokenV2Target()); err != nil {
+				t.Fatalf("expected %s key to authorize, got %v", keyID, err)
+			}
+		})
+	}
+}
+
+func TestScopedTokenV2_RejectsUnknownOrSubstitutedKeyID(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	token, err := MintScopedTokenV2(privateKey, "current", scopedTokenV2Target(), time.Minute)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey, "next": publicKey},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+
+	for name, changed := range map[string]string{
+		"unknown":     strings.Replace(token, "v2.current.", "v2.unknown.", 1),
+		"substituted": strings.Replace(token, "v2.current.", "v2.next.", 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := authorizer.Authorize(context.Background(), reqWithBearer(changed), scopedTokenV2Target())
+			if !errors.Is(err, ErrUnauthenticated) {
+				t.Fatalf("expected ErrUnauthenticated, got %v", err)
+			}
+		})
+	}
+}
+
+func TestScopedTokenV2_RejectsDotDelimitedKeyID(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	if _, err := MintScopedTokenV2(privateKey, "2026.08", scopedTokenV2Target(), time.Minute); err == nil {
+		t.Fatal("expected dot-delimited key ID to be rejected by minter")
+	}
+	if _, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"2026.08": publicKey},
+	}); err == nil {
+		t.Fatal("expected dot-delimited key ID to be rejected by verifier")
+	}
+}
+
+func TestScopedTokenV2_RejectsSignedTokenWithoutSandboxUID(t *testing.T) {
+	publicKey, privateKey := newScopedTokenV2Key(t)
+	claims := scopedTokenV2Claims{
+		Namespace:   "team-a",
+		SandboxName: "box-a",
+		Port:        9090,
+		Method:      "GET",
+		Path:        "/exec/run",
+		Exp:         time.Now().Add(time.Minute).Unix(),
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	token := strings.Join([]string{
+		scopedTokenV2Version,
+		"current",
+		encodedPayload,
+		base64.RawURLEncoding.EncodeToString(ed25519.Sign(privateKey, scopedTokenV2SigningInput("current", encodedPayload))),
+	}, ".")
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	target := scopedTokenV2Target()
+	target.SandboxUID = ""
+	if err := authorizer.Authorize(context.Background(), reqWithBearer(token), target); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("expected empty-UID token to be unauthenticated, got %v", err)
+	}
+}
+
+func TestScopedTokenV2_BoundsLegacyV1Drain(t *testing.T) {
+	publicKey, _ := newScopedTokenV2Key(t)
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	legacyToken, err := MintScopedToken(secret, "team-a", "box-a", time.Minute)
+	if err != nil {
+		t.Fatalf("mint v1: %v", err)
+	}
+	cutoff := time.Now().Add(time.Minute).Truncate(time.Second)
+	target := testAuthorizationTarget("team-a", "box-a")
+
+	authorizer, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		Secret:           secret,
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+		V1AcceptUntil:    cutoff,
+		Clock:            func() time.Time { return cutoff.Add(-time.Second) },
+	})
+	if err != nil {
+		t.Fatalf("new overlap authorizer: %v", err)
+	}
+	if err := authorizer.Authorize(context.Background(), reqWithBearer(legacyToken), target); err != nil {
+		t.Fatalf("expected v1 token during drain to authorize, got %v", err)
+	}
+
+	authorizer.clock = func() time.Time { return cutoff }
+	if err := authorizer.Authorize(context.Background(), reqWithBearer(legacyToken), target); !errors.Is(err, ErrUnauthenticated) {
+		t.Fatalf("expected v1 token at cutoff to be rejected, got %v", err)
+	}
+}
+
+func TestNewScopedTokenAuthorizer_RejectsUnboundedV1AndV2Overlap(t *testing.T) {
+	publicKey, _ := newScopedTokenV2Key(t)
+	_, err := NewScopedTokenAuthorizer(ScopedTokenOptions{
+		Secret:           []byte("0123456789abcdef0123456789abcdef"),
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+	})
+	if err == nil || !strings.Contains(err.Error(), "V1AcceptUntil") {
+		t.Fatalf("expected bounded v1 overlap error, got %v", err)
+	}
+}
+
+func TestParseScopedTokenVerificationKeys_AcceptsOverlapKeySet(t *testing.T) {
+	oldPublic, _ := newScopedTokenV2Key(t)
+	newPublic, _ := newScopedTokenV2Key(t)
+	data := []byte(`{"keys":[` +
+		`{"kid":"old","publicKey":"` + base64.RawURLEncoding.EncodeToString(oldPublic) + `"},` +
+		`{"kid":"new","publicKey":"` + base64.RawURLEncoding.EncodeToString(newPublic) + `"}` +
+		`]}`)
+	keys, err := ParseScopedTokenVerificationKeys(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(keys) != 2 || !oldPublic.Equal(keys["old"]) || !newPublic.Equal(keys["new"]) {
+		t.Fatalf("parsed keys do not match input")
+	}
+}
+
+func decodeScopedTokenV2Claims(t *testing.T, token string) scopedTokenV2Claims {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 4 {
+		t.Fatalf("expected v2.kid.payload.signature, got %q", token)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var claims scopedTokenV2Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+	return claims
+}

--- a/sandbox-router/authz/testmain_test.go
+++ b/sandbox-router/authz/testmain_test.go
@@ -23,3 +23,13 @@ import (
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }
+
+func testAuthorizationTarget(namespace, sandboxName string) AuthorizationTarget {
+	return AuthorizationTarget{
+		Namespace:   namespace,
+		SandboxName: sandboxName,
+		Port:        8888,
+		Method:      "GET",
+		Path:        "/",
+	}
+}

--- a/sandbox-router/authz/tokenreview.go
+++ b/sandbox-router/authz/tokenreview.go
@@ -161,12 +161,12 @@ func NewTokenReviewAuthorizer(o TokenReviewOptions) (*TokenReviewAuthorizer, err
 }
 
 // Authorize implements the Authorizer interface.
-func (a *TokenReviewAuthorizer) Authorize(ctx context.Context, r *http.Request, sandboxNamespace, sandboxName string) error {
+func (a *TokenReviewAuthorizer) Authorize(ctx context.Context, r *http.Request, target AuthorizationTarget) error {
 	token, _, ok := TokenFromRequest(r, a.locs)
 	if !ok {
 		if a.require {
 			a.log.V(1).Info("authz deny: missing Bearer token",
-				"sandbox", sandboxName, "namespace", sandboxNamespace)
+				"sandbox", target.SandboxName, "namespace", target.Namespace)
 			return ErrUnauthenticated
 		}
 		// Token not required and not provided → allow. This matches the
@@ -178,7 +178,7 @@ func (a *TokenReviewAuthorizer) Authorize(ctx context.Context, r *http.Request, 
 	key := hashToken(token)
 	if v, hit := a.cache.Get(key); hit {
 		d := v.(*tokenDecision)
-		return a.decide(d, sandboxName, sandboxNamespace, true)
+		return a.decide(d, target.SandboxName, target.Namespace, true)
 	}
 
 	// Bound the TokenReview RPC; the proxy's per-request deadline still
@@ -202,7 +202,7 @@ func (a *TokenReviewAuthorizer) Authorize(ctx context.Context, r *http.Request, 
 		ttl := max(a.ttl/3, time.Second)
 		a.cache.Add(key, d, ttl)
 		a.log.Error(err, "tokenreview API call failed",
-			"sandbox", sandboxName, "namespace", sandboxNamespace)
+			"sandbox", target.SandboxName, "namespace", target.Namespace)
 		return fmt.Errorf("tokenreview: %w", err)
 	}
 	d.authenticated = out.Status.Authenticated
@@ -223,7 +223,7 @@ func (a *TokenReviewAuthorizer) Authorize(ctx context.Context, r *http.Request, 
 			"ttl", a.ttl,
 		)
 	}
-	return a.decide(d, sandboxName, sandboxNamespace, false)
+	return a.decide(d, target.SandboxName, target.Namespace, false)
 }
 
 // decide converts a tokenDecision into an authz error or nil. Logs at

--- a/sandbox-router/authz/tokenreview_test.go
+++ b/sandbox-router/authz/tokenreview_test.go
@@ -62,7 +62,7 @@ func TestTokenReview_AuthenticatedAllow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new: %v", err)
 	}
-	if err := auth.Authorize(context.Background(), reqWithBearer("t1"), "ns", "s"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer("t1"), testAuthorizationTarget("ns", "s")); err != nil {
 		t.Fatalf("expected allow, got %v", err)
 	}
 	if calls.Load() != 1 {
@@ -77,7 +77,7 @@ func TestTokenReview_UnauthenticatedRejected(t *testing.T) {
 		return true, tr, nil
 	})
 	auth, _ := NewTokenReviewAuthorizer(TokenReviewOptions{Client: cs, Log: logr.Discard()})
-	err := auth.Authorize(context.Background(), reqWithBearer("bad-token"), "ns", "s")
+	err := auth.Authorize(context.Background(), reqWithBearer("bad-token"), testAuthorizationTarget("ns", "s"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("expected ErrUnauthenticated, got %v", err)
 	}
@@ -90,12 +90,12 @@ func TestTokenReview_MissingTokenRespectsRequire(t *testing.T) {
 	})
 	// require=false → allow when token missing
 	auth, _ := NewTokenReviewAuthorizer(TokenReviewOptions{Client: cs, Log: logr.Discard(), RequireToken: false})
-	if err := auth.Authorize(context.Background(), reqWithBearer(""), "ns", "s"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer(""), testAuthorizationTarget("ns", "s")); err != nil {
 		t.Fatalf("require=false should allow missing token, got %v", err)
 	}
 	// require=true → ErrUnauthenticated
 	auth, _ = NewTokenReviewAuthorizer(TokenReviewOptions{Client: cs, Log: logr.Discard(), RequireToken: true})
-	err := auth.Authorize(context.Background(), reqWithBearer(""), "ns", "s")
+	err := auth.Authorize(context.Background(), reqWithBearer(""), testAuthorizationTarget("ns", "s"))
 	if !errors.Is(err, ErrUnauthenticated) {
 		t.Fatalf("require=true should reject missing token, got %v", err)
 	}
@@ -114,7 +114,7 @@ func TestTokenReview_PositiveResultCached(t *testing.T) {
 	auth, _ := NewTokenReviewAuthorizer(TokenReviewOptions{Client: cs, Log: logr.Discard(), TTL: 30 * time.Second})
 
 	for i := range 5 {
-		if err := auth.Authorize(context.Background(), reqWithBearer("same-token"), "ns", "s"); err != nil {
+		if err := auth.Authorize(context.Background(), reqWithBearer("same-token"), testAuthorizationTarget("ns", "s")); err != nil {
 			t.Fatalf("call %d: %v", i, err)
 		}
 	}
@@ -123,7 +123,7 @@ func TestTokenReview_PositiveResultCached(t *testing.T) {
 	}
 
 	// Different token should bypass cache.
-	if err := auth.Authorize(context.Background(), reqWithBearer("other-token"), "ns", "s"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer("other-token"), testAuthorizationTarget("ns", "s")); err != nil {
 		t.Fatalf("%v", err)
 	}
 	if calls.Load() != 2 {
@@ -140,7 +140,7 @@ func TestTokenReview_NegativeResultCached(t *testing.T) {
 	auth, _ := NewTokenReviewAuthorizer(TokenReviewOptions{Client: cs, Log: logr.Discard(), TTL: 30 * time.Second})
 
 	for i := range 3 {
-		if err := auth.Authorize(context.Background(), reqWithBearer("bad"), "ns", "s"); !errors.Is(err, ErrUnauthenticated) {
+		if err := auth.Authorize(context.Background(), reqWithBearer("bad"), testAuthorizationTarget("ns", "s")); !errors.Is(err, ErrUnauthenticated) {
 			t.Fatalf("call %d expected ErrUnauthenticated, got %v", i, err)
 		}
 	}
@@ -155,7 +155,7 @@ func TestTokenReview_APIFailureSurfaces(t *testing.T) {
 	})
 	auth, _ := NewTokenReviewAuthorizer(TokenReviewOptions{Client: cs, Log: logr.Discard()})
 
-	err := auth.Authorize(context.Background(), reqWithBearer("x"), "ns", "s")
+	err := auth.Authorize(context.Background(), reqWithBearer("x"), testAuthorizationTarget("ns", "s"))
 	if err == nil {
 		t.Fatal("expected error on API failure")
 	}
@@ -164,7 +164,7 @@ func TestTokenReview_APIFailureSurfaces(t *testing.T) {
 		t.Fatalf("API failure should not look like auth deny, got %v", err)
 	}
 	// Briefly cached: subsequent call within TTL should NOT re-hit the API.
-	_ = auth.Authorize(context.Background(), reqWithBearer("x"), "ns", "s")
+	_ = auth.Authorize(context.Background(), reqWithBearer("x"), testAuthorizationTarget("ns", "s"))
 	if calls.Load() != 1 {
 		t.Fatalf("expected error cached; got %d API calls", calls.Load())
 	}
@@ -219,7 +219,7 @@ func TestTokenReview_PassesAudiences(t *testing.T) {
 		Log:       logr.Discard(),
 		Audiences: []string{"sandbox-router"},
 	})
-	if err := auth.Authorize(context.Background(), reqWithBearer("t"), "ns", "s"); err != nil {
+	if err := auth.Authorize(context.Background(), reqWithBearer("t"), testAuthorizationTarget("ns", "s")); err != nil {
 		t.Fatalf("%v", err)
 	}
 	if len(seenAudiences) != 1 || seenAudiences[0] != "sandbox-router" {
@@ -244,13 +244,13 @@ func TestTokenReview_AuthenticatesFromQueryAndCookie(t *testing.T) {
 	})
 
 	req, _ := http.NewRequest("GET", "/?token=q1", nil)
-	if err := auth.Authorize(context.Background(), req, "ns", "s"); err != nil {
+	if err := auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "s")); err != nil {
 		t.Fatalf("query: expected allow, got %v", err)
 	}
 
 	req, _ = http.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: "sid", Value: "c1"})
-	if err := auth.Authorize(context.Background(), req, "ns", "s"); err != nil {
+	if err := auth.Authorize(context.Background(), req, testAuthorizationTarget("ns", "s")); err != nil {
 		t.Fatalf("cookie: expected allow, got %v", err)
 	}
 }

--- a/sandbox-router/cmd/main.go
+++ b/sandbox-router/cmd/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
 	"crypto/tls"
 	"errors"
 	"flag"
@@ -220,15 +221,40 @@ func run(cfg *config.Config, log logr.Logger) error {
 		authorizer = tr
 	}
 	if cfg.AuthzMode == config.AuthzScopedToken {
-		secret, err := os.ReadFile(cfg.AuthzScopedTokenSecretFile)
-		if err != nil {
-			return fmt.Errorf("read --authz-scoped-token-secret-file: %w", err)
+		var secret []byte
+		if cfg.AuthzScopedTokenSecretFile != "" {
+			var err error
+			secret, err = os.ReadFile(cfg.AuthzScopedTokenSecretFile)
+			if err != nil {
+				return fmt.Errorf("read --authz-scoped-token-secret-file: %w", err)
+			}
+		}
+		var verificationKeys map[string]ed25519.PublicKey
+		if cfg.AuthzScopedTokenVerificationKeysFile != "" {
+			keyData, err := os.ReadFile(cfg.AuthzScopedTokenVerificationKeysFile)
+			if err != nil {
+				return fmt.Errorf("read --authz-scoped-token-verification-keys-file: %w", err)
+			}
+			verificationKeys, err = authz.ParseScopedTokenVerificationKeys(keyData)
+			if err != nil {
+				return fmt.Errorf("parse --authz-scoped-token-verification-keys-file: %w", err)
+			}
+		}
+		var v1AcceptUntil time.Time
+		if cfg.AuthzScopedTokenV1AcceptUntil != "" {
+			var err error
+			v1AcceptUntil, err = time.Parse(time.RFC3339, cfg.AuthzScopedTokenV1AcceptUntil)
+			if err != nil {
+				return fmt.Errorf("parse --authz-scoped-token-v1-accept-until: %w", err)
+			}
 		}
 		st, err := authz.NewScopedTokenAuthorizer(authz.ScopedTokenOptions{
 			// NewScopedTokenAuthorizer trims whitespace itself, so a
 			// mounted Secret with a trailing newline just works.
-			Secret:         secret,
-			TokenLocations: tokenLocations,
+			Secret:           secret,
+			VerificationKeys: verificationKeys,
+			V1AcceptUntil:    v1AcceptUntil,
+			TokenLocations:   tokenLocations,
 		})
 		if err != nil {
 			return fmt.Errorf("build scoped-token authorizer: %w", err)

--- a/sandbox-router/config/config.go
+++ b/sandbox-router/config/config.go
@@ -77,10 +77,9 @@ const (
 	AuthzTokenReview AuthzMode = "tokenreview"
 	// AuthzScopedToken authorizes each request against a signed,
 	// per-sandbox token instead of a cluster-verifiable K8s
-	// credential: the token is bound to one (namespace, name) pair at
-	// mint time (see authz.MintScopedToken) and the router rejects it
-	// with 403 against any other sandbox. Use this when the caller
-	// should never need to hold a K8s Bearer token at all.
+	// credential. V1 binds namespace plus name. V2 binds the canonical
+	// authorization target, including Sandbox UID, port, method, and
+	// upstream path.
 	AuthzScopedToken AuthzMode = "scoped-token"
 )
 
@@ -233,14 +232,19 @@ type Config struct {
 	// match. Empty disables the audience check.
 	AuthzTokenReviewAudiences []string
 
-	// AuthzScopedTokenSecretFile is the path to a file holding the
-	// shared HMAC-SHA256 secret used to verify scoped tokens (see
-	// authz.ScopedTokenAuthorizer). Required when AuthzMode is
-	// scoped-token. The router never generates this secret — whoever
-	// mints tokens (typically the Sandbox controller) and the router
-	// must share it out-of-band, e.g. the same K8s Secret mounted into
-	// both.
+	// AuthzScopedTokenSecretFile is the path to the shared HMAC-SHA256
+	// secret used to verify legacy v1 tokens. It is required when
+	// AuthzMode is scoped-token unless v2 verification keys are set.
 	AuthzScopedTokenSecretFile string
+	// AuthzScopedTokenVerificationKeysFile is a JSON key set containing
+	// the Ed25519 public keys accepted for scoped-token v2. Setting it
+	// enables v2 and requires the Pod cache so callers can route by the
+	// Sandbox UID carried in every v2 claim.
+	AuthzScopedTokenVerificationKeysFile string
+	// AuthzScopedTokenV1AcceptUntil is the exclusive RFC3339 cutoff for
+	// legacy v1 HMAC verification during a v2 rollout. It is required
+	// when both the v1 secret and v2 verification keys are configured.
+	AuthzScopedTokenV1AcceptUntil string
 
 	// AuthzCookieName, when non-empty, additionally lets the configured
 	// Authorizer accept a credential carried in a cookie of this name —
@@ -419,8 +423,27 @@ func (c *Config) Validate() error {
 	if c.AuthzTokenReviewCacheSize <= 0 {
 		return fmt.Errorf("--authz-tokenreview-cache-size must be positive, got %d", c.AuthzTokenReviewCacheSize)
 	}
-	if c.AuthzMode == AuthzScopedToken && c.AuthzScopedTokenSecretFile == "" {
-		return errors.New("--authz-scoped-token-secret-file is required when --authz-mode=scoped-token")
+	if c.AuthzMode == AuthzScopedToken && c.AuthzScopedTokenSecretFile == "" && c.AuthzScopedTokenVerificationKeysFile == "" {
+		return errors.New("--authz-mode=scoped-token requires --authz-scoped-token-secret-file or --authz-scoped-token-verification-keys-file")
+	}
+	if c.AuthzScopedTokenVerificationKeysFile != "" {
+		if c.AuthzMode != AuthzScopedToken {
+			return errors.New("--authz-scoped-token-verification-keys-file requires --authz-mode=scoped-token")
+		}
+		if !c.CacheEnabled {
+			return errors.New("--authz-scoped-token-verification-keys-file requires --cache-enabled so v2 requests carry a routable Sandbox UID")
+		}
+		if c.AuthzScopedTokenSecretFile != "" && c.AuthzScopedTokenV1AcceptUntil == "" {
+			return errors.New("--authz-scoped-token-v1-accept-until is required when v1 and v2 scoped-token verification are both enabled")
+		}
+	}
+	if c.AuthzScopedTokenV1AcceptUntil != "" {
+		if c.AuthzMode != AuthzScopedToken || c.AuthzScopedTokenSecretFile == "" {
+			return errors.New("--authz-scoped-token-v1-accept-until requires --authz-mode=scoped-token and --authz-scoped-token-secret-file")
+		}
+		if _, err := time.Parse(time.RFC3339, c.AuthzScopedTokenV1AcceptUntil); err != nil {
+			return fmt.Errorf("--authz-scoped-token-v1-accept-until must be RFC3339: %w", err)
+		}
 	}
 
 	switch c.AuthzCookieSameSite {

--- a/sandbox-router/config/config_test.go
+++ b/sandbox-router/config/config_test.go
@@ -365,6 +365,53 @@ func TestValidate(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "scoped-token v2 requires cache",
+			mut: func(c *Config) {
+				c.AuthzMode = AuthzScopedToken
+				c.AuthzScopedTokenVerificationKeysFile = "/etc/scoped-token/keys.json"
+			},
+			wantErr: "requires --cache-enabled",
+		},
+		{
+			name: "valid scoped-token v2 configuration",
+			mut: func(c *Config) {
+				c.AuthzMode = AuthzScopedToken
+				c.AuthzScopedTokenVerificationKeysFile = "/etc/scoped-token/keys.json"
+				c.CacheEnabled = true
+			},
+			wantErr: "",
+		},
+		{
+			name: "scoped-token v1 and v2 overlap requires cutoff",
+			mut: func(c *Config) {
+				c.AuthzMode = AuthzScopedToken
+				c.AuthzScopedTokenSecretFile = "/etc/scoped-token/secret"
+				c.AuthzScopedTokenVerificationKeysFile = "/etc/scoped-token/keys.json"
+				c.CacheEnabled = true
+			},
+			wantErr: "authz-scoped-token-v1-accept-until is required",
+		},
+		{
+			name: "valid scoped-token v1 and v2 overlap",
+			mut: func(c *Config) {
+				c.AuthzMode = AuthzScopedToken
+				c.AuthzScopedTokenSecretFile = "/etc/scoped-token/secret"
+				c.AuthzScopedTokenVerificationKeysFile = "/etc/scoped-token/keys.json"
+				c.AuthzScopedTokenV1AcceptUntil = "2026-09-01T00:00:00Z"
+				c.CacheEnabled = true
+			},
+			wantErr: "",
+		},
+		{
+			name: "scoped-token v1 cutoff must be RFC3339",
+			mut: func(c *Config) {
+				c.AuthzMode = AuthzScopedToken
+				c.AuthzScopedTokenSecretFile = "/etc/scoped-token/secret"
+				c.AuthzScopedTokenV1AcceptUntil = "tomorrow"
+			},
+			wantErr: "must be RFC3339",
+		},
+		{
 			name:    "empty path routing prefix is valid (disabled)",
 			mut:     func(c *Config) { c.PathRoutingPrefix = "" },
 			wantErr: "",

--- a/sandbox-router/config/flags.go
+++ b/sandbox-router/config/flags.go
@@ -148,8 +148,14 @@ func RegisterFlags(fs *flag.FlagSet, c *Config, lookup LookupEnvFunc) {
 			"projected ServiceAccount tokens minted with --audience.")
 	fs.StringVar(&c.AuthzScopedTokenSecretFile, "authz-scoped-token-secret-file", c.AuthzScopedTokenSecretFile,
 		"Path to a file holding the shared HMAC-SHA256 secret used to verify "+
-			"scoped tokens (see authz.MintScopedToken). Required when "+
-			"--authz-mode=scoped-token; must match whatever mints the tokens.")
+			"legacy v1 scoped tokens (see authz.MintScopedToken). Required when "+
+			"--authz-mode=scoped-token unless v2 verification keys are configured.")
+	fs.StringVar(&c.AuthzScopedTokenVerificationKeysFile, "authz-scoped-token-verification-keys-file", c.AuthzScopedTokenVerificationKeysFile,
+		"Path to a JSON key set containing Ed25519 public keys for scoped-token "+
+			"v2 verification. Enables v2 and requires --cache-enabled.")
+	fs.StringVar(&c.AuthzScopedTokenV1AcceptUntil, "authz-scoped-token-v1-accept-until", c.AuthzScopedTokenV1AcceptUntil,
+		"Exclusive RFC3339 cutoff for legacy v1 HMAC verification during a v2 "+
+			"rollout. Required when v1 and v2 verification are both configured.")
 	fs.StringVar(&c.AuthzCookieName, "authz-cookie-name", c.AuthzCookieName,
 		"Name of a cookie the configured Authorizer additionally accepts a "+
 			"credential from — the only channel a browser attaches "+

--- a/sandbox-router/proxy/authz_test.go
+++ b/sandbox-router/proxy/authz_test.go
@@ -16,11 +16,14 @@ package proxy
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -35,7 +38,7 @@ import (
 )
 
 // recordingAuthz lets a test pin the verdict for every call and inspect
-// the (ns, sandbox) arguments after the fact.
+// the canonical authorization target after the fact.
 type recordingAuthz struct {
 	mu       sync.Mutex
 	err      error
@@ -43,14 +46,22 @@ type recordingAuthz struct {
 }
 
 type recordedAuthzReq struct {
-	ns      string
-	sandbox string
-	hasTLS  bool
-	bearer  string
+	target authz.AuthorizationTarget
+	hasTLS bool
+	bearer string
 }
 
-func (a *recordingAuthz) Authorize(_ context.Context, r *http.Request, ns, name string) error {
-	rec := recordedAuthzReq{ns: ns, sandbox: name}
+func mustAtoi(t *testing.T, value string) int {
+	t.Helper()
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		t.Fatalf("parse integer %q: %v", value, err)
+	}
+	return parsed
+}
+
+func (a *recordingAuthz) Authorize(_ context.Context, r *http.Request, target authz.AuthorizationTarget) error {
+	rec := recordedAuthzReq{target: target}
 	if r != nil && r.TLS != nil {
 		rec.hasTLS = true
 	}
@@ -157,8 +168,8 @@ func TestAuthzDenialMapsToStatus(t *testing.T) {
 				t.Fatalf("expected exactly one Authorize call, got %d", len(calls))
 			}
 			req0 := calls[0]
-			if req0.ns != "team" || req0.sandbox != "abc" {
-				t.Fatalf("Authorize got (ns=%q, sandbox=%q), want (team, abc)", req0.ns, req0.sandbox)
+			if req0.target.Namespace != "team" || req0.target.SandboxName != "abc" {
+				t.Fatalf("Authorize got (ns=%q, sandbox=%q), want (team, abc)", req0.target.Namespace, req0.target.SandboxName)
 			}
 			if req0.bearer != "test-token" {
 				t.Fatalf("Authorize should see bearer token, got %q", req0.bearer)
@@ -218,7 +229,7 @@ func TestAuthzRunsForPathRoutedRequests(t *testing.T) {
 			}))
 			defer router.Close()
 
-			resp, err := http.Get(router.URL + "/router/team-a/sandbox-7/" + backendURL.Port() + "/x")
+			resp, err := http.Get(router.URL + "/router/team-a/sandbox-7/" + backendURL.Port() + "/x%2Fy")
 			if err != nil {
 				t.Fatalf("get: %v", err)
 			}
@@ -231,8 +242,11 @@ func TestAuthzRunsForPathRoutedRequests(t *testing.T) {
 			if len(calls) != 1 {
 				t.Fatalf("expected exactly one Authorize call, got %d", len(calls))
 			}
-			if calls[0].ns != "team-a" || calls[0].sandbox != "sandbox-7" {
-				t.Fatalf("Authorize got (ns=%q, sandbox=%q) from the path, want (team-a, sandbox-7)", calls[0].ns, calls[0].sandbox)
+			if calls[0].target.Namespace != "team-a" || calls[0].target.SandboxName != "sandbox-7" {
+				t.Fatalf("Authorize got (ns=%q, sandbox=%q) from the path, want (team-a, sandbox-7)", calls[0].target.Namespace, calls[0].target.SandboxName)
+			}
+			if calls[0].target.Port != mustAtoi(t, backendURL.Port()) || calls[0].target.Method != http.MethodGet || calls[0].target.Path != "/x%2Fy" {
+				t.Fatalf("Authorize got target %+v, want routed port, GET, and /x%%2Fy", calls[0].target)
 			}
 		})
 	}
@@ -254,8 +268,10 @@ func TestAuthzPassesNamespaceAndID(t *testing.T) {
 	req, _ := http.NewRequest("GET", router.URL+"/x", nil)
 	req.Header.Set(HeaderSandboxID, "sandbox-7")
 	req.Header.Set(HeaderSandboxNamespace, "team-a")
+	req.Header.Set(HeaderSandboxUID, "uid-7")
 	req.Header.Set(HeaderSandboxPodIP, "127.0.0.1")
-	req.Header.Set(HeaderSandboxPort, pickFreePortStr(t))
+	port := pickFreePortStr(t)
+	req.Header.Set(HeaderSandboxPort, port)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("do: %v", err)
@@ -266,7 +282,200 @@ func TestAuthzPassesNamespaceAndID(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("expected one Authorize call, got %d", len(calls))
 	}
-	if calls[0].ns != "team-a" || calls[0].sandbox != "sandbox-7" {
-		t.Fatalf("Authorize got (%q,%q) want (team-a, sandbox-7)", calls[0].ns, calls[0].sandbox)
+	if calls[0].target.Namespace != "team-a" || calls[0].target.SandboxName != "sandbox-7" {
+		t.Fatalf("Authorize got (%q,%q) want (team-a, sandbox-7)", calls[0].target.Namespace, calls[0].target.SandboxName)
+	}
+	if calls[0].target.SandboxUID != "uid-7" || calls[0].target.Port != mustAtoi(t, port) || calls[0].target.Method != http.MethodGet || calls[0].target.Path != "/x" {
+		t.Fatalf("Authorize got target %+v, want uid-7, routed port, GET, and /x", calls[0].target)
+	}
+}
+
+func TestScopedTokenV2BindsTheForwardedHeaderRoutedPath(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+
+	tests := []struct {
+		name            string
+		requestPath     string
+		requestRawPath  string
+		tokenPath       string
+		wantRequestPath string
+	}{
+		{
+			name:            "literal percent",
+			requestPath:     "/x%zz",
+			requestRawPath:  "/x%25zz",
+			tokenPath:       "/x%25zz",
+			wantRequestPath: "/x%25zz",
+		},
+		{
+			name:            "encoded slash follows header routing semantics",
+			requestPath:     "/x/y",
+			requestRawPath:  "/x%2Fy",
+			tokenPath:       "/x/y",
+			wantRequestPath: "/x/y",
+		},
+		{
+			name:            "lowercase escapes become canonical",
+			requestPath:     "/café",
+			requestRawPath:  "/caf%c3%a9",
+			tokenPath:       "/caf%C3%A9",
+			wantRequestPath: "/caf%C3%A9",
+		},
+		{
+			name:            "malformed raw escape becomes a literal percent",
+			requestPath:     "/x%ZZ",
+			requestRawPath:  "/x%ZZ",
+			tokenPath:       "/x%25ZZ",
+			wantRequestPath: "/x%25ZZ",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := make(chan string, 1)
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests <- r.RequestURI
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer backend.Close()
+			backendURL, err := url.Parse(backend.URL)
+			if err != nil {
+				t.Fatalf("parse backend URL: %v", err)
+			}
+			port := mustAtoi(t, backendURL.Port())
+
+			token, err := authz.MintScopedTokenV2(privateKey, "current", authz.AuthorizationTarget{
+				Namespace:   "team-a",
+				SandboxName: "sandbox-7",
+				SandboxUID:  "uid-7",
+				Port:        port,
+				Method:      http.MethodGet,
+				Path:        test.tokenPath,
+			}, time.Minute)
+			if err != nil {
+				t.Fatalf("mint v2 token: %v", err)
+			}
+			authorizer, err := authz.NewScopedTokenAuthorizer(authz.ScopedTokenOptions{
+				VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+			})
+			if err != nil {
+				t.Fatalf("new scoped-token authorizer: %v", err)
+			}
+
+			cfg := config.Defaults()
+			cfg.AllowLoopbackPodIP = true
+			cfg.ProxyTimeout = 2 * time.Second
+			cfg.UpstreamMaxRetries = 0
+			lookup := &stubLookup{entries: map[types.UID]cache.Entry{
+				"uid-7": {
+					PodIP:       backendURL.Hostname(),
+					Namespace:   "team-a",
+					SandboxName: "sandbox-7",
+				},
+			}}
+			handler := NewHandler(Options{
+				Config:     &cfg,
+				Cache:      lookup,
+				Authorizer: authorizer,
+				Logger:     logr.Discard(),
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "http://router.invalid/", nil)
+			req.URL.Path = test.requestPath
+			req.URL.RawPath = test.requestRawPath
+			req.Header.Set(HeaderSandboxID, "sandbox-7")
+			req.Header.Set(HeaderSandboxNamespace, "team-a")
+			req.Header.Set(HeaderSandboxUID, "uid-7")
+			req.Header.Set(HeaderSandboxPort, backendURL.Port())
+			req.Header.Set("Authorization", "Bearer "+token)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, req)
+			resp := response.Result()
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusNoContent {
+				t.Fatalf("status: got %d want %d", resp.StatusCode, http.StatusNoContent)
+			}
+			if got := <-requests; got != test.wantRequestPath {
+				t.Fatalf("upstream request path: got %q want %q", got, test.wantRequestPath)
+			}
+		})
+	}
+}
+
+func TestScopedTokenV2RejectsNoncanonicalMethodBeforeForwarding(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+	backendCalled := make(chan struct{}, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		backendCalled <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer backend.Close()
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	token, err := authz.MintScopedTokenV2(privateKey, "current", authz.AuthorizationTarget{
+		Namespace:   "team-a",
+		SandboxName: "sandbox-7",
+		SandboxUID:  "uid-7",
+		Port:        mustAtoi(t, backendURL.Port()),
+		Method:      http.MethodPost,
+		Path:        "/exec",
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("mint v2 token: %v", err)
+	}
+	authorizer, err := authz.NewScopedTokenAuthorizer(authz.ScopedTokenOptions{
+		VerificationKeys: map[string]ed25519.PublicKey{"current": publicKey},
+	})
+	if err != nil {
+		t.Fatalf("new scoped-token authorizer: %v", err)
+	}
+
+	cfg := config.Defaults()
+	cfg.ProxyTimeout = 2 * time.Second
+	cfg.UpstreamMaxRetries = 0
+	lookup := &stubLookup{entries: map[types.UID]cache.Entry{
+		"uid-7": {
+			PodIP:       backendURL.Hostname(),
+			Namespace:   "team-a",
+			SandboxName: "sandbox-7",
+		},
+	}}
+	router := httptest.NewServer(NewHandler(Options{
+		Config:     &cfg,
+		Cache:      lookup,
+		Authorizer: authorizer,
+		Logger:     logr.Discard(),
+	}))
+	defer router.Close()
+
+	req, err := http.NewRequest("post", router.URL+"/exec", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set(HeaderSandboxID, "sandbox-7")
+	req.Header.Set(HeaderSandboxNamespace, "team-a")
+	req.Header.Set(HeaderSandboxUID, "uid-7")
+	req.Header.Set(HeaderSandboxPort, backendURL.Port())
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	select {
+	case <-backendCalled:
+		t.Fatal("noncanonical method reached upstream")
+	default:
 	}
 }

--- a/sandbox-router/proxy/proxy.go
+++ b/sandbox-router/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"strings"
 	"time"
 
@@ -170,7 +171,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// errors in package authz. The default AllowAll authorizer wired in
 	// by NewHandler always permits, preserving the Python router's
 	// no-auth contract.
-	if err := h.authz.Authorize(r.Context(), r, target.Namespace, target.ID); err != nil {
+	upstreamPathURL := url.URL{Path: upstreamPath, RawPath: upstreamRawPath}
+	authorizationTarget, err := authz.NormalizeAuthorizationTarget(authz.AuthorizationTarget{
+		Namespace:   target.Namespace,
+		SandboxName: target.ID,
+		SandboxUID:  target.UID,
+		Port:        target.Port,
+		Method:      r.Method,
+		Path:        upstreamPathURL.EscapedPath(),
+	})
+	if err != nil {
+		WriteJSONError(w, &Error{Status: http.StatusInternalServerError, Detail: err.Error()})
+		return
+	}
+	if err := h.authz.Authorize(r.Context(), r, authorizationTarget); err != nil {
 		status := authz.HTTPStatusFor(err)
 		observability.LoggerFromContext(r.Context(), h.log).Info("authorization denied",
 			"sandbox", target.ID,


### PR DESCRIPTION
#### What this PR does / why we need it:

> **Stack PR 1 of 3**: scoped-token v2 target binding.
> **You are here** → `#1498` → `#1499`.
> Each branch is stacked on the branch to its left.

## 💡 What this is

The router needs an authorization identity that matches the request a sandbox will receive. Namespace and name are too broad for a capability token because they do not distinguish replacement Sandbox objects, ports, methods, or paths.

This PR adds `authz.AuthorizationTarget` and scoped-token v2. The v2 token uses Ed25519 and binds the namespace, Sandbox name, Sandbox UID, port, HTTP method, exact escaped upstream path, expiry, and protected key ID. The router constructs the target after route parsing removes any browser-routing prefix and before authorization or forwarding.

The exported `authz.Authorizer` interface changes from separate namespace and name arguments to one `AuthorizationTarget`. External implementations must update their `Authorize` method, so this PR needs the `release-note-action-required` label. The built-in authorizers are updated in the same commit.

## 🎯 Review anchor

Anchor on one property: the target verified by a v2 token is the normalized target handed to the authorizer for the upstream request. Method normalization, percent-encoding normalization, and route-prefix removal happen before the comparison.

PR 2 supplies the other half of the identity guarantee. Until `nova/router-uid-fenced-cache` lands, the UID in the target still originates in the request header rather than one atomic canonical cache resolution. Scoped-token v2 deployment should wait for that PR.

## 🛠️ How it works

1. The authorization contract in `sandbox-router/authz/authorizer.go` replaces the two string arguments with `AuthorizationTarget`. `NormalizeAuthorizationTarget` validates the port and method, requires an absolute path, and canonicalizes escaped-path hex digits.
2. The token implementation in `sandbox-router/authz/scopedtoken_v2.go` signs `v2.<kid>.<payload>` with Ed25519. The parser accepts a JSON set of public verification keys, rejects malformed or duplicate key IDs, and copies the key material before use.
3. The multi-version authorizer in `sandbox-router/authz/scopedtoken.go` dispatches by token version. V2 requires a Sandbox UID and rejects every target-field mismatch. Overlapping public keys support reader-first v2 rotation.
4. The v1 drain remains explicit. A deployment that configures both the legacy HMAC secret and v2 verification keys must set the exclusive RFC3339 cutoff `--authz-scoped-token-v1-accept-until`. V1 is rejected at and after that instant.
5. The proxy in `sandbox-router/proxy/proxy.go` builds the target from the resolved route, the forwarded escaped path, and the inbound request method before it calls `Authorize`.
6. The configuration path in `sandbox-router/config` and `sandbox-router/cmd/main.go` keeps v1-only configuration valid. V2 requires `--cache-enabled` and a public verification-key file. The router never needs an Ed25519 private key.

## 🔄 Compatibility and blast radius

V1-only scoped-token configuration retains its existing runtime behavior. The default `allow-all` mode and TokenReview mode retain their authorization behavior. Scoped-token v2 is opt-in, and mixed v1 plus v2 readers cannot start without a bounded v1 cutoff.

The public `Authorizer` method signature is source-incompatible for external implementations. The required migration is to accept `authz.AuthorizationTarget` and read `Namespace` and `SandboxName` from that value instead of separate arguments.

This PR does not provide canonical cache-derived UID fencing or authenticated replacement conformance. PR 2 owns those changes. This PR also does not add Kubernetes key projection, ServiceAccount hardening, or rotation manifests. PR 3 owns the deployment contract.

## 🧪 Validation

The receipts below are anchored to head commit `5a01f118`.

- `go test -count=1 ./sandbox-router/...` → PASS
- `go test -race -count=1 ./sandbox-router/authz ./sandbox-router/proxy` → PASS
- `go vet ./sandbox-router/...` → PASS
- `make lint-go` → PASS, 0 issues
- `git diff --check` → PASS
- The independent adversarial review → PASS

The broader `make all` completed generation, binaries, Go and API lint, router tests, and Python suites. It then hit the reproducible pre-existing macOS failure in `packages/sandboxd/pkg/pathutil` at `TestSanitizePathAbsolutePathConfined`. The isolated test failed identically, and no unrelated generated diff remained.

## 🔍 What reviewers should focus on

- Check whether `AuthorizationTarget` contains the exact fields every authorizer needs without coupling it to the proxy's internal `Target` type.
- Check the signing context, key-ID protection, expiry boundary, and constant-time legacy HMAC verification.
- Check that escaped path normalization preserves the path the upstream receives, including encoded separators.
- Check that the mixed-reader cutoff fails closed and remains exclusive at the configured instant.
- Treat cache-derived UID authority as deliberately deferred to PR 2, not as a guarantee made by this PR.

#### Which issue(s) this PR is related to:

None.

#### Release Note

```release-note
Add Ed25519 scoped-token v2 verification bound to Sandbox UID, port, HTTP method, and exact upstream path. Custom sandbox-router Authorizer implementations must update Authorize to accept authz.AuthorizationTarget.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

