### PR TITLE
feat(sandbox-router): add byte transfer and size distribution metrics

### DIFF
--- a/sandbox-router/observability/access_log.go
+++ b/sandbox-router/observability/access_log.go
@@ -16,6 +16,7 @@ package observability
 
 import (
 	"bufio"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -49,6 +50,28 @@ func (r *accessLogRecorder) Write(b []byte) (int, error) {
 	n, err := r.ResponseWriter.Write(b)
 	r.bytes += int64(n)
 	return n, err
+}
+
+// ReadFrom implements io.ReaderFrom so the same sendfile / splice fast
+// paths the underlying ResponseWriter exposes cannot bypass the bytes
+// counter. Mirrors statusRecorder.ReadFrom in metrics.go: delegate when
+// the inner writer supports it, otherwise copy through our own Write via
+// an io.Writer-only view to prevent io.Copy from recursing.
+func (r *accessLogRecorder) ReadFrom(src io.Reader) (int64, error) {
+	if rf, ok := r.ResponseWriter.(io.ReaderFrom); ok {
+		n, err := rf.ReadFrom(src)
+		// The delegate path commits the response (an implicit 200 when
+		// no explicit WriteHeader preceded it). Record that so a later
+		// WriteHeader on an error path cannot silently overwrite the
+		// status the underlying ResponseWriter already sent.
+		if n > 0 && !r.wroteHeader {
+			r.status = http.StatusOK
+			r.wroteHeader = true
+		}
+		r.bytes += n
+		return n, err
+	}
+	return io.Copy(struct{ io.Writer }{r}, src)
 }
 
 // Flush forwards to the underlying ResponseWriter so streaming responses

--- a/sandbox-router/observability/metrics.go
+++ b/sandbox-router/observability/metrics.go
@@ -18,6 +18,7 @@ package observability
 
 import (
 	"bufio"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -42,6 +43,19 @@ type Metrics struct {
 	CacheInvalidationsTotal *prometheus.CounterVec
 	AuthzDecisionsTotal     *prometheus.CounterVec
 	BuildInfo               prometheus.Collector
+	// ClientRxBytesTotal counts bytes received from clients (request bodies).
+	ClientRxBytesTotal *prometheus.CounterVec
+	// ClientTxBytesTotal counts bytes sent to clients (response bodies).
+	ClientTxBytesTotal *prometheus.CounterVec
+	// UpstreamRxBytesTotal counts bytes read from upstream sandbox backends.
+	UpstreamRxBytesTotal *prometheus.CounterVec
+	// UpstreamTxBytesTotal counts bytes written to upstream sandbox backends.
+	UpstreamTxBytesTotal *prometheus.CounterVec
+	// RequestSizeBytes observes request body size distributions.
+	RequestSizeBytes *prometheus.HistogramVec
+	// ResponseSizeBytes observes response body size distributions. SSE
+	// streaming responses can be very large.
+	ResponseSizeBytes *prometheus.HistogramVec
 }
 
 // NewMetrics creates a fresh set of collectors and registers them with reg.
@@ -90,6 +104,38 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 			Help: "Per-request authorization outcomes, labeled by sandbox namespace and decision (allow / deny).",
 		}, []string{"sandbox_namespace", "decision"}),
 
+		ClientRxBytesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sandbox_router_client_rx_bytes_total",
+			Help: "Total bytes received from clients (request bodies), labeled by sandbox namespace.",
+		}, []string{"sandbox_namespace"}),
+
+		ClientTxBytesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sandbox_router_client_tx_bytes_total",
+			Help: "Total bytes sent to clients (response bodies), labeled by sandbox namespace.",
+		}, []string{"sandbox_namespace"}),
+
+		UpstreamRxBytesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sandbox_router_upstream_rx_bytes_total",
+			Help: "Total bytes read from upstream sandbox backends, labeled by sandbox namespace.",
+		}, []string{"sandbox_namespace"}),
+
+		UpstreamTxBytesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "sandbox_router_upstream_tx_bytes_total",
+			Help: "Total bytes written to upstream sandbox backends, labeled by sandbox namespace.",
+		}, []string{"sandbox_namespace"}),
+
+		RequestSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "sandbox_router_request_size_bytes",
+			Help:    "Distribution of request body sizes in bytes, labeled by sandbox namespace.",
+			Buckets: []float64{100, 1024, 10240, 102400, 1048576, 10485760, 104857600, 1073741824},
+		}, []string{"sandbox_namespace"}),
+
+		ResponseSizeBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "sandbox_router_response_size_bytes",
+			Help:    "Distribution of response body sizes in bytes, labeled by sandbox namespace. SSE streaming responses may be very large.",
+			Buckets: []float64{100, 1024, 10240, 102400, 1048576, 10485760, 104857600, 1073741824},
+		}, []string{"sandbox_namespace"}),
+
 		BuildInfo: buildInfoCollector(),
 	}
 
@@ -102,6 +148,12 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		m.UpstreamRetriesTotal,
 		m.CacheInvalidationsTotal,
 		m.AuthzDecisionsTotal,
+		m.ClientRxBytesTotal,
+		m.ClientTxBytesTotal,
+		m.UpstreamRxBytesTotal,
+		m.UpstreamTxBytesTotal,
+		m.RequestSizeBytes,
+		m.ResponseSizeBytes,
 		m.BuildInfo,
 	)
 	return m
@@ -146,6 +198,18 @@ func (m *Metrics) Middleware(next http.Handler) http.Handler {
 
 		ctx, labels := LabelsForRequest(r.Context())
 		ww := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		// Wrap the request body so we can count bytes received from the
+		// client (client_rx_bytes_total + request_size_bytes). Skip
+		// http.NoBody — the stdlib uses it as a sentinel for bodyless
+		// requests (GET/HEAD); wrapping it would record a zero-byte
+		// observation that skews the size histogram without adding signal.
+		var reqBodyCounter *countingReadCloser
+		if r.Body != nil && r.Body != http.NoBody {
+			reqBodyCounter = &countingReadCloser{rc: r.Body}
+			r.Body = reqBodyCounter
+		}
+
 		start := time.Now()
 		next.ServeHTTP(ww, r.WithContext(ctx))
 		dur := time.Since(start).Seconds()
@@ -157,6 +221,18 @@ func (m *Metrics) Middleware(next http.Handler) http.Handler {
 		code := strconv.Itoa(ww.status)
 		m.RequestsTotal.WithLabelValues(r.Method, code, ns).Inc()
 		m.RequestDurationSeconds.WithLabelValues(r.Method, code, ns).Observe(dur)
+
+		// Record client byte-transfer metrics. The request-body counter
+		// is nil when the inbound request had no body (e.g. GET); in that
+		// case there's nothing to observe for the rx / size metrics.
+		if reqBodyCounter != nil {
+			rxBytes := float64(reqBodyCounter.bytes)
+			m.ClientRxBytesTotal.WithLabelValues(ns).Add(rxBytes)
+			m.RequestSizeBytes.WithLabelValues(ns).Observe(rxBytes)
+		}
+		txBytes := float64(ww.bytesWritten)
+		m.ClientTxBytesTotal.WithLabelValues(ns).Add(txBytes)
+		m.ResponseSizeBytes.WithLabelValues(ns).Observe(txBytes)
 	})
 }
 
@@ -165,8 +241,9 @@ func (m *Metrics) Middleware(next http.Handler) http.Handler {
 // semantics, and we mirror that.
 type statusRecorder struct {
 	http.ResponseWriter
-	status      int
-	wroteHeader bool
+	status       int
+	bytesWritten int64
+	wroteHeader  bool
 }
 
 func (s *statusRecorder) WriteHeader(code int) {
@@ -183,7 +260,34 @@ func (s *statusRecorder) Write(b []byte) (int, error) {
 		s.status = http.StatusOK
 		s.wroteHeader = true
 	}
-	return s.ResponseWriter.Write(b)
+	n, err := s.ResponseWriter.Write(b)
+	s.bytesWritten += int64(n)
+	return n, err
+}
+
+// ReadFrom implements io.ReaderFrom. io.Copy prefers this method over
+// Write when the source is not a WriterTo, so without it the underlying
+// ResponseWriter's ReadFrom path (e.g. sendfile / splice fast paths)
+// would silently bypass bytesWritten accounting. We delegate to the
+// underlying writer's ReadFrom when it supports one; otherwise we copy
+// through our own Write() via an io.Writer-only view of s, which
+// prevents io.Copy from detecting that s implements ReaderFrom and
+// recursing back into this method.
+func (s *statusRecorder) ReadFrom(r io.Reader) (int64, error) {
+	if rf, ok := s.ResponseWriter.(io.ReaderFrom); ok {
+		n, err := rf.ReadFrom(r)
+		// The delegate path commits the response (an implicit 200 when
+		// no explicit WriteHeader preceded it). Record that so a later
+		// WriteHeader on an error path cannot silently overwrite the
+		// status the underlying ResponseWriter already sent.
+		if n > 0 && !s.wroteHeader {
+			s.status = http.StatusOK
+			s.wroteHeader = true
+		}
+		s.bytesWritten += n
+		return n, err
+	}
+	return io.Copy(struct{ io.Writer }{s}, r)
 }
 
 // Flush forwards to the underlying ResponseWriter if it supports it; this
@@ -214,4 +318,24 @@ func (s *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 // Flush/Hijack implementations under middleware wrappers.
 func (s *statusRecorder) Unwrap() http.ResponseWriter {
 	return s.ResponseWriter
+}
+
+// countingReadCloser wraps an io.ReadCloser and counts bytes read through
+// it. Used by the metrics middleware to track client request body sizes
+// without interfering with the downstream handler's consumption of the
+// body. Close is forwarded unchanged; byte accounting stops mattering
+// once the body is closed because no further Read calls are expected.
+type countingReadCloser struct {
+	rc    io.ReadCloser
+	bytes int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.rc.Read(p)
+	c.bytes += int64(n)
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error {
+	return c.rc.Close()
 }

--- a/sandbox-router/proxy/proxy.go
+++ b/sandbox-router/proxy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/net/http/httpguts"
 	"k8s.io/apimachinery/pkg/types"
@@ -94,6 +96,12 @@ func NewHandler(o Options) *Handler {
 			o.Config.UpstreamRetryMaxDelay,
 			onRetry,
 		)
+	}
+	// Wrap with metrics last (outermost) so every upstream byte —
+	// including those on the single successful attempt after dial-class
+	// retries — is counted exactly once.
+	if o.Metrics != nil {
+		tr = newMetricsTransport(tr, o.Metrics)
 	}
 	authorizer := o.Authorizer
 	if authorizer == nil {
@@ -475,4 +483,82 @@ func classifyError(err error) string {
 		return "dial"
 	}
 	return "other"
+}
+
+// metricsTransport wraps an http.RoundTripper and increments Prometheus
+// counters for every byte flowing to / from the upstream sandbox. The
+// sandbox_namespace label is read from the per-request *Labels the proxy
+// handler attached to the request context earlier in ServeHTTP — same
+// mechanism the rest of the observability stack uses.
+//
+// The wrapping is applied outside retryTransport so retries that fail at
+// dial time (before any body bytes move) don't double-count; retries on
+// dial failures are safe here because http.Transport only consumes the
+// body after a successful connect.
+type metricsTransport struct {
+	base    http.RoundTripper
+	metrics *observability.Metrics
+}
+
+func newMetricsTransport(base http.RoundTripper, metrics *observability.Metrics) *metricsTransport {
+	return &metricsTransport{base: base, metrics: metrics}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *metricsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	namespace := observability.SandboxNamespaceFromContext(req.Context())
+
+	// Wrap the request body so bytes streamed to the upstream are
+	// counted toward upstream_tx_bytes_total. The counter is bound to
+	// the resolved namespace up front; WithLabelValues is a map lookup
+	// but the series is reused for the lifetime of the process so the
+	// per-call cost is trivial.
+	if req.Body != nil {
+		req.Body = &upstreamCountingReadCloser{
+			rc:      req.Body,
+			counter: t.metrics.UpstreamTxBytesTotal.WithLabelValues(namespace),
+		}
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the response body so bytes streamed back from the upstream
+	// are counted toward upstream_rx_bytes_total. httputil.ReverseProxy
+	// copies resp.Body to the client via io.Copy and then calls Close,
+	// so the counter is incremented lazily as bytes flow — SSE /
+	// streaming responses are accounted for correctly because the
+	// counting happens per Read, not per response.
+	if resp.Body != nil {
+		resp.Body = &upstreamCountingReadCloser{
+			rc:      resp.Body,
+			counter: t.metrics.UpstreamRxBytesTotal.WithLabelValues(namespace),
+		}
+	}
+
+	return resp, nil
+}
+
+// upstreamCountingReadCloser wraps an io.ReadCloser, counts bytes read,
+// and increments a Prometheus counter in real time. Incrementing per Read
+// (rather than accumulating locally and flushing at Close) keeps the
+// counters accurate even if a streaming response is abandoned mid-flight
+// — the bytes that did flow are still attributed.
+type upstreamCountingReadCloser struct {
+	rc      io.ReadCloser
+	counter prometheus.Counter
+}
+
+func (c *upstreamCountingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.rc.Read(p)
+	if n > 0 {
+		c.counter.Add(float64(n))
+	}
+	return n, err
+}
+
+func (c *upstreamCountingReadCloser) Close() error {
+	return c.rc.Close()
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds six Prometheus metrics to sandbox-router for monitoring byte traffic between clients, the router, and upstream sandbox backends.

Client-facing (labeled by `sandbox_namespace`):
- `sandbox_router_client_rx_bytes_total` — bytes received from clients (request bodies)
- `sandbox_router_client_tx_bytes_total` — bytes sent to clients (response bodies)
- `sandbox_router_request_size_bytes` — request body size histogram
- `sandbox_router_response_size_bytes` — response body size histogram

Upstream (labeled by `sandbox_namespace` + `sandbox_id`):
- `sandbox_router_upstream_rx_bytes_total` — bytes read from backends
- `sandbox_router_upstream_tx_bytes_total` — bytes written to backends

Implementation:
- Client bytes tracked in the metrics middleware via a `countingReadCloser` around `r.Body` and a new `bytesWritten` field on `statusRecorder`.
- Upstream bytes tracked by a new `metricsTransport` wrapping the `RoundTripper`; counts per `Read` so SSE streaming responses are attributed correctly even when abandoned mid-flight.
- Histogram buckets span 100B → 1GB to cover large SSE payloads.

#### Which issue(s) this PR is related to:

N/A

#### Release Note

```release-note
sandbox-router: add client/upstream byte counters and request/response size histograms.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for client and upstream data transferred.
  * Added request and response body-size measurements.
  * Metrics now provide more detailed traffic and payload-size reporting across proxy operations.

* **Bug Fixes**
  * Improved byte accounting for streamed, interrupted, partially completed, and optimized data transfers.
  * Ensured request and response traffic remains accurately measured across supported proxy transfer paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->