### PR TITLE
feat(rl): OpenHands fleet adapter + fan-out example (stacked on #1488)

### DIFF
--- a/clients/integrations/openhands/configs/agent-server-template.yaml
+++ b/clients/integrations/openhands/configs/agent-server-template.yaml
@@ -11,7 +11,11 @@ metadata:
 spec:
   podTemplate:
     spec:
-      runtimeClassName: gvisor          # recommended: model-driven code runs here
+      # Strongly recommended: agents execute model-generated code. Uncomment on
+      # clusters with the gVisor RuntimeClass installed (see the repo's gVisor
+      # quickstart); left commented so the template admits on clusters without
+      # it. Kata works the same way (runtimeClassName: kata-qemu).
+      # runtimeClassName: gvisor
       containers:
       - name: agent-server
         # Pin to the openhands-sdk release you install client-side; the SDK and
@@ -47,4 +51,11 @@ spec:
             cpu: "500m"
             memory: "1Gi"
             ephemeral-storage: "2Gi"
+          # Limits are part of the isolation posture: the controller copies
+          # this template into every pod, so caps must live here (or in a
+          # namespace LimitRange).
+          limits:
+            cpu: "2"
+            memory: "4Gi"
+            ephemeral-storage: "4Gi"
       restartPolicy: "OnFailure"

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -141,6 +141,15 @@ class AgentSandboxWorkspace(RemoteWorkspace):
     claim_labels: dict[str, str] | None = Field(
         default=None, description="Labels for the SandboxClaim object."
     )
+    check_server_version: bool = Field(
+        default=True,
+        description=(
+            "After attach, compare the agent-server's reported version with "
+            "the installed openhands-sdk and log a loud warning on skew (the "
+            "SDK and server image are released together). Never fails the "
+            "attach; disable for offline tests."
+        ),
+    )
     sandbox_client: Any = Field(
         default=None,
         exclude=True,
@@ -214,6 +223,27 @@ class AgentSandboxWorkspace(RemoteWorkspace):
             raise
         logger.info("Agent-sandbox workspace is ready at %s", self.host)
         super().model_post_init(context)
+        if self.check_server_version:
+            self._log_version_skew()
+
+    def _log_version_skew(self) -> None:
+        """Warn (never fail) when the server and SDK versions diverge."""
+        try:
+            info = self.get_server_info()
+            server_version = str(info.get("version") or "")
+            from importlib.metadata import version as _dist_version
+
+            sdk_version = _dist_version("openhands-sdk")
+            if server_version and server_version != sdk_version:
+                logger.warning(
+                    "agent-server reports version %s but the installed "
+                    "openhands-sdk is %s — align the SandboxTemplate image "
+                    "tag with the SDK release to avoid protocol skew",
+                    server_version,
+                    sdk_version,
+                )
+        except Exception as e:  # noqa: BLE001 — advisory only
+            logger.debug("server version check skipped: %s", e)
 
     def _endpoint_url(self, sandbox: Any) -> str:
         if self.router_url:

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -315,8 +315,16 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         self.cleanup()
 
     def cleanup(self) -> None:
-        """Delete the claim (the pool replenishes) and drop an owned client."""
+        """Delete the claim (the pool replenishes) and drop an owned client.
+
+        A failed termination keeps the claim reference so a later cleanup()
+        (or __del__) can retry — otherwise a claim with no ttl_s would leak
+        and silently eat warm-pool capacity. The owned client is kept open
+        while a retry is still possible.
+        """
         self._terminate_sandbox()
+        if self._sandbox is not None:
+            return  # termination failed; keep the client for the retry
         if self._owns_client and self.sandbox_client is not None:
             close = getattr(self.sandbox_client, "close", None)
             if callable(close):
@@ -331,16 +339,18 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         sandbox = self._sandbox
         if sandbox is None:
             return
-        self._sandbox = None
         # Capture before terminate(): the SDK clears identity fields on close.
         claim_name = getattr(sandbox, "claim_name", "?")
         try:
             sandbox.terminate()
-            logger.info("Released sandbox claim %s", claim_name)
-        except Exception as e:  # noqa: BLE001 — ttl_s backstops a failed delete
+        except Exception as e:  # noqa: BLE001 — retried on the next cleanup()
             logger.warning(
-                "Failed to terminate sandbox %s: %s (ttl_s backstop applies "
-                "if configured)",
+                "Failed to terminate sandbox %s: %s (kept for retry; ttl_s "
+                "backstop applies if configured)",
                 claim_name,
                 e,
             )
+            return
+        # Clear only after success so a failed delete stays retryable.
+        self._sandbox = None
+        logger.info("Released sandbox claim %s", claim_name)

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -75,7 +75,12 @@ class AgentSandboxWorkspace(RemoteWorkspace):
     )
     host: str = Field(
         default="",
-        description="Agent-server URL (set automatically after the claim binds).",
+        description=(
+            "Agent-server URL. Always derived from the claimed sandbox once "
+            "the claim binds; a caller-supplied value is replaced (with a "
+            "warning). Use router_url or endpoint_template to reach pods "
+            "through a gateway."
+        ),
     )
 
     # Provisioning configuration.
@@ -219,10 +224,16 @@ class AgentSandboxWorkspace(RemoteWorkspace):
             self.namespace,
         )
         try:
-            # Mirror DockerWorkspace: bypass validate-assignment plumbing when
-            # rewriting connection fields mid-init.
-            if not self.host:
-                object.__setattr__(self, "host", self._endpoint_url(sandbox))
+            if self.host:
+                logger.warning(
+                    "host=%r is ignored: the endpoint is always derived from "
+                    "the claimed sandbox (use router_url or endpoint_template "
+                    "for gateway/proxied paths)",
+                    self.host,
+                )
+            # Bypass validate-assignment plumbing when rewriting connection
+            # fields mid-init (the same trick DockerWorkspace uses).
+            object.__setattr__(self, "host", self._endpoint_url(sandbox))
             self._wait_for_health(timeout=self.health_check_timeout)
         except Exception:
             # Never leave an orphaned claim behind a failed init.

--- a/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
+++ b/clients/integrations/openhands/openhands_k8s_agent_sandbox/workspace.py
@@ -30,9 +30,12 @@ The warm pool's SandboxTemplate must run the agent-server image with
 from __future__ import annotations
 
 import time
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 from typing import Any
 from urllib.request import Request, urlopen
 
+import httpx
 from pydantic import Field, PrivateAttr
 
 from openhands.sdk.logger import get_logger
@@ -154,8 +157,12 @@ class AgentSandboxWorkspace(RemoteWorkspace):
         default=None,
         exclude=True,
         description=(
-            "Injected k8s_agent_sandbox.SandboxClient (or compatible). Built "
-            "lazily with defaults when omitted; tests inject fakes."
+            "Injected k8s_agent_sandbox.SandboxClient (or compatible: "
+            "create_sandbox() returns an object with claim_name, sandbox_id, "
+            "get_pod_ip() and terminate()). Built lazily with defaults when "
+            "omitted; tests inject fakes. A returned object may set "
+            "releases_on_terminate=False when its terminate() does not "
+            "release the pod, so cleanup logs a detach rather than a release."
         ),
     )
 
@@ -227,23 +234,47 @@ class AgentSandboxWorkspace(RemoteWorkspace):
             self._log_version_skew()
 
     def _log_version_skew(self) -> None:
-        """Warn (never fail) when the server and SDK versions diverge."""
+        """Warn (never fail) when the server and SDK versions diverge.
+
+        Only the failures an advisory probe is expected to hit stay quiet:
+        transport/HTTP errors reaching ``/server_info``, a non-JSON body, or
+        an SDK that isn't installed as a distribution. Anything else — an
+        unexpected payload shape or a bug in this check — is logged at
+        WARNING so it cannot silently disable the advisory on every attach.
+        """
         try:
             info = self.get_server_info()
-            server_version = str(info.get("version") or "")
-            from importlib.metadata import version as _dist_version
-
-            sdk_version = _dist_version("openhands-sdk")
-            if server_version and server_version != sdk_version:
-                logger.warning(
-                    "agent-server reports version %s but the installed "
-                    "openhands-sdk is %s — align the SandboxTemplate image "
-                    "tag with the SDK release to avoid protocol skew",
-                    server_version,
-                    sdk_version,
-                )
-        except Exception as e:  # noqa: BLE001 — advisory only
+        except (httpx.HTTPError, ValueError) as e:
+            # Connection refused / timeout, non-2xx, or a body that isn't JSON.
             logger.debug("server version check skipped: %s", e)
+            return
+        except Exception:  # noqa: BLE001 — advisory: never break the attach
+            logger.warning("server version check failed unexpectedly", exc_info=True)
+            return
+        if not isinstance(info, dict):
+            logger.warning(
+                "server version check skipped: /server_info returned %s, "
+                "expected a JSON object",
+                type(info).__name__,
+            )
+            return
+        server_version = str(info.get("version") or "")
+        try:
+            sdk_version = _dist_version("openhands-sdk")
+        except PackageNotFoundError:
+            logger.debug(
+                "server version check skipped: openhands-sdk is not installed "
+                "as a distribution"
+            )
+            return
+        if server_version and server_version != sdk_version:
+            logger.warning(
+                "agent-server reports version %s but the installed "
+                "openhands-sdk is %s — align the SandboxTemplate image "
+                "tag with the SDK release to avoid protocol skew",
+                server_version,
+                sdk_version,
+            )
 
     def _endpoint_url(self, sandbox: Any) -> str:
         if self.router_url:
@@ -353,4 +384,12 @@ class AgentSandboxWorkspace(RemoteWorkspace):
             return
         # Clear only after success so a failed delete stays retryable.
         self._sandbox = None
-        logger.info("Released sandbox claim %s", claim_name)
+        if getattr(sandbox, "releases_on_terminate", True):
+            logger.info("Released sandbox claim %s", claim_name)
+        else:
+            # Injected view whose terminate() is a no-op on the pod (e.g. a
+            # fleet-bound handle): we only detached; its owner releases it.
+            logger.info(
+                "Detached from sandbox %s (its owner releases the claim)",
+                claim_name,
+            )

--- a/clients/integrations/openhands/pyproject.toml
+++ b/clients/integrations/openhands/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     # claim API (create_sandbox / get_pod_ip / terminate) is stable across the
     # 0.5 → 1.x line.
     "k8s-agent-sandbox>=0.5.1",
+    # RemoteWorkspace's HTTP transport (already pulled in by openhands-sdk);
+    # imported directly so the advisory version check can narrow its error
+    # handling to transport/HTTP failures.
+    "httpx",
 ]
 
 [project.urls]

--- a/clients/integrations/openhands/pyproject.toml
+++ b/clients/integrations/openhands/pyproject.toml
@@ -17,9 +17,11 @@ dynamic = ["version"]
 requires-python = ">=3.12"
 dependencies = [
     # RemoteWorkspace (the base class) and the agent-server HTTP contract.
-    # The SDK versions its agent-server image per release, so keep the band
-    # narrow enough that client and server speak the same protocol.
-    "openhands-sdk>=1.44,<2",
+    # The SDK versions its agent-server image per release; the floor is the
+    # release the example template pins, and the workspace's advisory
+    # version-skew check (get_server_info vs installed SDK) flags drift at
+    # attach time. An exact pin would block every SDK patch release.
+    "openhands-sdk>=1.44.1,<2",
     # SandboxClient.create_sandbox(warmpool=...) claim path. The client is only
     # imported when the caller does not inject one (tests inject fakes). The
     # claim API (create_sandbox / get_pod_ip / terminate) is stable across the

--- a/clients/integrations/openhands/tests/unit/test_workspace.py
+++ b/clients/integrations/openhands/tests/unit/test_workspace.py
@@ -66,6 +66,8 @@ def no_health(monkeypatch):
 
 def make_workspace(client=None, **kwargs):
     kwargs.setdefault("warmpool", "agent-server-pool")
+    # Offline tests: the advisory version check would issue a real HTTP call.
+    kwargs.setdefault("check_server_version", False)
     return AgentSandboxWorkspace(sandbox_client=client or FakeClient(), **kwargs)
 
 
@@ -244,6 +246,33 @@ def test_router_and_endpoint_template_are_exclusive():
             endpoint_template="http://gw/{claim_name}",
         )
     assert client.create_calls == []  # rejected before any claim
+
+
+# -------------------------------------------------------- version skew check
+
+
+def test_version_skew_warns(no_health, monkeypatch, caplog):
+    monkeypatch.setattr(
+        AgentSandboxWorkspace, "get_server_info",
+        lambda self: {"version": "0.0.1-other"},
+    )
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        make_workspace(check_server_version=True)
+    assert any("protocol skew" in r.message for r in caplog.records)
+
+
+def test_version_check_failure_is_silent(no_health, monkeypatch, caplog):
+    def boom(self):
+        raise ConnectionError("unreachable")
+
+    monkeypatch.setattr(AgentSandboxWorkspace, "get_server_info", boom)
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        make_workspace(check_server_version=True)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 # ----------------------------------------------------------------- teardown

--- a/clients/integrations/openhands/tests/unit/test_workspace.py
+++ b/clients/integrations/openhands/tests/unit/test_workspace.py
@@ -83,6 +83,19 @@ def test_provision_sets_host_from_pod_ip(no_health):
     client = FakeClient(FakeSandbox(pod_ip="10.9.8.7"))
     ws = make_workspace(client)
     assert ws.host == "http://10.9.8.7:8000"
+
+
+def test_explicit_host_is_replaced_by_claimed_endpoint(no_health, caplog):
+    # A caller-supplied host must never win over the claimed pod: commands
+    # (and the pool session key) would go to an unrelated server while the
+    # claim sits idle.
+    client = FakeClient(FakeSandbox(pod_ip="10.9.8.7"))
+    with caplog.at_level(logging.WARNING):
+        ws = make_workspace(client, host="http://elsewhere:9999")
+    assert ws.host == "http://10.9.8.7:8000"
+    assert any(
+        "host=" in r.message and "ignored" in r.message for r in caplog.records
+    )
     assert ws.working_dir == "/workspace"
 
 
@@ -261,8 +274,6 @@ def test_version_skew_warns(no_health, monkeypatch, caplog):
         AgentSandboxWorkspace, "get_server_info",
         lambda self: {"version": "0.0.1-other"},
     )
-    import logging
-
     with caplog.at_level(logging.WARNING):
         make_workspace(check_server_version=True)
     assert any("protocol skew" in r.message for r in caplog.records)

--- a/clients/integrations/openhands/tests/unit/test_workspace.py
+++ b/clients/integrations/openhands/tests/unit/test_workspace.py
@@ -312,3 +312,26 @@ def test_terminate_error_is_swallowed(no_health):
     ws = make_workspace(FakeClient(sandbox))
     ws.cleanup()  # must not raise; ttl_s is the backstop
     assert sandbox.terminated == 1
+
+
+def test_cleanup_retries_after_failed_terminate(no_health):
+    # First attempt fails -> the claim reference is kept and the next
+    # cleanup() retries; only success clears it (else a no-ttl claim leaks).
+    sandbox = FakeSandbox()
+    attempts = []
+
+    def flaky():
+        attempts.append(True)
+        if len(attempts) == 1:
+            raise RuntimeError("apiserver hiccup")
+        sandbox.terminated += 1
+
+    sandbox.terminate = flaky
+    ws = make_workspace(FakeClient(sandbox))
+    ws.cleanup()
+    assert ws._sandbox is not None  # kept for retry
+    ws.cleanup()
+    assert sandbox.terminated == 1
+    assert ws._sandbox is None
+    ws.cleanup()  # idempotent after success
+    assert len(attempts) == 2

--- a/clients/integrations/openhands/tests/unit/test_workspace.py
+++ b/clients/integrations/openhands/tests/unit/test_workspace.py
@@ -19,8 +19,13 @@ import, no network. The health check is stubbed per test (its real
 implementation is exercised separately against a fake urlopen).
 """
 
+import logging
+from importlib.metadata import PackageNotFoundError
+
+import httpx
 import pytest
 
+from openhands_k8s_agent_sandbox import workspace as workspace_module
 from openhands_k8s_agent_sandbox.workspace import AgentSandboxWorkspace
 
 
@@ -263,16 +268,62 @@ def test_version_skew_warns(no_health, monkeypatch, caplog):
     assert any("protocol skew" in r.message for r in caplog.records)
 
 
-def test_version_check_failure_is_silent(no_health, monkeypatch, caplog):
+@pytest.mark.parametrize(
+    "error",
+    [httpx.ConnectError("unreachable"), ValueError("body is not JSON")],
+    ids=["transport", "not-json"],
+)
+def test_version_check_expected_failures_are_silent(
+    no_health, monkeypatch, caplog, error
+):
     def boom(self):
-        raise ConnectionError("unreachable")
+        raise error
 
     monkeypatch.setattr(AgentSandboxWorkspace, "get_server_info", boom)
-    import logging
-
     with caplog.at_level(logging.WARNING):
         make_workspace(check_server_version=True)
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_version_check_missing_sdk_dist_is_silent(no_health, monkeypatch, caplog):
+    monkeypatch.setattr(
+        AgentSandboxWorkspace, "get_server_info", lambda self: {"version": "1.0"}
+    )
+
+    def missing(_name):
+        raise PackageNotFoundError("openhands-sdk")
+
+    monkeypatch.setattr(workspace_module, "_dist_version", missing)
+    with caplog.at_level(logging.WARNING):
+        make_workspace(check_server_version=True)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_version_check_unexpected_payload_warns(no_health, monkeypatch, caplog):
+    # A non-dict payload must not raise (AttributeError on .get) nor vanish.
+    monkeypatch.setattr(
+        AgentSandboxWorkspace, "get_server_info", lambda self: ["1.0"]
+    )
+    with caplog.at_level(logging.WARNING):
+        ws = make_workspace(check_server_version=True)
+    assert ws.host.startswith("http://")  # attach still succeeded
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "expected a JSON object" in warnings[0].message
+
+
+def test_version_check_bug_is_loud_but_not_fatal(no_health, monkeypatch, caplog):
+    def bug(self):
+        raise TypeError("bug in the check")
+
+    monkeypatch.setattr(AgentSandboxWorkspace, "get_server_info", bug)
+    with caplog.at_level(logging.WARNING):
+        ws = make_workspace(check_server_version=True)
+    assert ws.host.startswith("http://")
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "failed unexpectedly" in warnings[0].message
+    assert warnings[0].exc_info is not None  # traceback attached, not hidden
 
 
 # ----------------------------------------------------------------- teardown
@@ -291,6 +342,28 @@ def test_context_manager_cleans_up(no_health):
     with make_workspace(FakeClient(sandbox)) as ws:
         assert ws.host.startswith("http://")
     assert sandbox.terminated == 1
+
+
+def test_cleanup_logs_release_for_owning_sandbox(no_health, caplog):
+    ws = make_workspace(FakeClient(FakeSandbox(claim_name="claim-own")))
+    with caplog.at_level(logging.INFO):
+        ws.cleanup()
+    messages = [r.message for r in caplog.records]
+    assert "Released sandbox claim claim-own" in messages
+
+
+def test_cleanup_logs_detach_for_non_releasing_view(no_health, caplog):
+    # Injected views (e.g. a fleet handle bound for fleet.run) whose
+    # terminate() is a no-op on the pod must not claim a release.
+    sandbox = FakeSandbox(claim_name="claim-bound")
+    sandbox.releases_on_terminate = False
+    ws = make_workspace(FakeClient(sandbox))
+    with caplog.at_level(logging.INFO):
+        ws.cleanup()
+    messages = [r.message for r in caplog.records]
+    assert sandbox.terminated == 1
+    assert not any("Released sandbox claim" in m for m in messages)
+    assert any("Detached from sandbox claim-bound" in m for m in messages)
 
 
 def test_injected_client_not_closed(no_health):

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -92,7 +92,7 @@ raises a clear error if it's missing. (No `r2egym` extra for that reason.)
 The **OpenHands adapter** (`adapters.openhands`) likewise imports lazily and
 needs the [`openhands-k8s-agent-sandbox`](../../clients/integrations/openhands)
 integration (`pip install openhands-k8s-agent-sandbox`), which pulls the
-OpenHands agent SDK.
+OpenHands agent SDK — note the SDK requires **Python >= 3.12**.
 
 ### 4. Verify
 

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -89,6 +89,11 @@ The **R2E-Gym adapter** (`adapters.r2egym`) needs R2E-Gym, which isn't on PyPI �
 install it from its checkout (`pip install -e path/to/R2E-Gym`); the adapter
 raises a clear error if it's missing. (No `r2egym` extra for that reason.)
 
+The **OpenHands adapter** (`adapters.openhands`) likewise imports lazily and
+needs the [`openhands-k8s-agent-sandbox`](../../clients/integrations/openhands)
+integration (`pip install openhands-k8s-agent-sandbox`), which pulls the
+OpenHands agent SDK.
+
 ### 4. Verify
 
 ```bash
@@ -166,7 +171,7 @@ python run_swebench_fleet.py
 | **Placement** | Which cluster serves an image: `round-robin`, `least-loaded`, `capacity-weighted`, `image-affinity`. |
 | **Strategy** | *When* pools exist: `none`, `naive`, `sliding`, `pipelined`. |
 | **Recycling** | *Reuse* one sandbox across same-image tasks (reset between): `run(recycle=True)` — orthogonal to strategy — backed by `reuse_git_restore_sandbox` + `GitRestoreReset` (claims scale ÷ tasks-per-image). |
-| **Adapters** | Framework glue: `adapters.swebench` (dataset → tasks), `adapters.r2egym` (`make_fleet_repo_env` binds a warm pod into R2E-Gym/tunix `RepoEnv`). |
+| **Adapters** | Framework glue: `adapters.swebench` (dataset → tasks), `adapters.r2egym` (`make_fleet_repo_env` binds a warm pod into R2E-Gym/tunix `RepoEnv`), `adapters.openhands` (`make_fleet_workspace`/`make_handle_workspace` put OpenHands agent-SDK workspaces on fleet pods). |
 
 ## Warm-pool strategies
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
@@ -1,0 +1,132 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenHands adapter: run `AgentSandboxWorkspace` on fleet-acquired pods.
+
+The standalone integration (`clients/integrations/openhands`) claims its own pod
+per workspace and deletes the claim on close. This adapter inverts ownership the
+same way `adapters.r2egym` does for R2E-Gym: the **fleet** acquires and releases
+pods (pools, placement, budgets, accounting), and the workspace merely binds one.
+``workspace close -> fleet.release(handle)`` — the workspace never deletes.
+
+Usage::
+
+    from agent_sandbox_rl import SandboxFleet, FleetConfig
+    from agent_sandbox_rl.adapters.openhands import make_fleet_workspace
+
+    fleet = SandboxFleet(FleetConfig(...))   # pools of agent-server pods
+    fleet.load_tasks(...)
+    fleet.setup()
+
+    with make_fleet_workspace(fleet, task, api_key=POOL_KEY) as workspace:
+        conversation = Conversation(agent=agent, workspace=workspace)
+        ...
+
+The mechanism is the workspace's ``sandbox_client`` injection seam: the shim's
+``create_sandbox`` is a fleet acquire and the returned handle view's
+``terminate`` is a fleet release, so the workspace class runs byte-identical.
+
+Requires the `openhands-k8s-agent-sandbox` integration (which pulls
+`openhands-sdk`). Importing THIS module is cheap; OpenHands imports happen
+inside `make_fleet_workspace` so the core package works without them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("agent_sandbox_rl.adapters.openhands")
+
+_HINT = (
+    "requires the OpenHands integration — `pip install openhands-k8s-agent-sandbox` "
+    "(or `pip install -e clients/integrations/openhands` from the repo root)."
+)
+
+# Workspace kwargs that would fight the fleet over pod lifecycle/identity.
+_FLEET_OWNED_KWARGS = ("sandbox_client", "warmpool", "ttl_s")
+
+
+class FleetWorkspaceClient:
+  """Duck-typed ``sandbox_client`` backed by a fleet.
+
+  ``create_sandbox()`` acquires a warm pod from the fleet (the ``warmpool``
+  argument and lifecycle kwargs the workspace passes are ignored — the fleet
+  owns pools, placement, and claim TTLs). The returned view's ``terminate()``
+  releases the handle back to the fleet instead of deleting anything itself.
+  """
+
+  def __init__(self, fleet, task):
+    self._fleet = fleet
+    self._task = task
+    self.handle = None
+
+  def create_sandbox(self, warmpool, **_fleet_owned):  # noqa: ARG002
+    handle = self._fleet.acquire(self._task)
+    self.handle = handle
+    fleet = self._fleet
+
+    class _HandleView:
+      claim_name = handle.claim_name
+      sandbox_id = handle.sandbox_id
+
+      @staticmethod
+      def get_pod_ip():
+        if handle.pod_ip:
+          return handle.pod_ip
+        sandbox = handle.sandbox
+        if sandbox is not None:
+          return sandbox.get_pod_ip()
+        return None
+
+      @staticmethod
+      def terminate():
+        # Ownership inversion: release to the fleet, never delete directly.
+        fleet.release(handle)
+
+    return _HandleView()
+
+
+def make_fleet_workspace(fleet, task, *, namespace: str | None = None,
+                         **workspace_kwargs):
+  """Build an `AgentSandboxWorkspace` bound to a fleet-acquired pod.
+
+  The fleet owns the pod's lifecycle: the workspace's ``close()`` releases the
+  handle via ``fleet.release`` (through the shim), and lifecycle knobs belong
+  to the fleet — passing ``warmpool``, ``ttl_s``, or ``sandbox_client`` here
+  raises. ``namespace`` matters only for router mode (routing headers); pass
+  the fleet cluster's namespace when using ``router_url``.
+
+  All other kwargs (``api_key``, ``router_url``, ``router_auth_token``,
+  ``server_port``, timeouts, ...) pass through to the workspace.
+  """
+  for key in _FLEET_OWNED_KWARGS:
+    if key in workspace_kwargs:
+      raise ValueError(
+          f"{key!r} is fleet-owned when using make_fleet_workspace — "
+          "configure it on the fleet, not the workspace")
+  try:
+    from openhands_k8s_agent_sandbox import AgentSandboxWorkspace
+  except ImportError as e:
+    raise RuntimeError(f"agent_sandbox_rl.adapters.openhands {_HINT}") from e
+
+  kwargs = dict(workspace_kwargs)
+  if namespace is not None:
+    kwargs["namespace"] = namespace
+  return AgentSandboxWorkspace(
+      # Informational only — the claim goes through the fleet, which already
+      # planned a pool for this task's image.
+      warmpool=f"fleet:{task.image}",
+      sandbox_client=FleetWorkspaceClient(fleet, task),
+      **kwargs,
+  )

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
@@ -74,27 +74,47 @@ class FleetWorkspaceClient:
   def create_sandbox(self, warmpool, **_fleet_owned):  # noqa: ARG002
     handle = self._fleet.acquire(self._task)
     self.handle = handle
-    fleet = self._fleet
+    # Ownership inversion: release to the fleet, never delete directly.
+    return _handle_view(handle, lambda: self._fleet.release(handle))
 
-    class _HandleView:
-      claim_name = handle.claim_name
-      sandbox_id = handle.sandbox_id
 
-      @staticmethod
-      def get_pod_ip():
-        if handle.pod_ip:
-          return handle.pod_ip
-        sandbox = handle.sandbox
-        if sandbox is not None:
-          return sandbox.get_pod_ip()
-        return None
+def _handle_view(handle, on_terminate):
+  """Duck-typed SDK-sandbox view over a fleet handle for the workspace."""
 
-      @staticmethod
-      def terminate():
-        # Ownership inversion: release to the fleet, never delete directly.
-        fleet.release(handle)
+  class _HandleView:
+    claim_name = handle.claim_name
+    sandbox_id = handle.sandbox_id
 
-    return _HandleView()
+    @staticmethod
+    def get_pod_ip():
+      if handle.pod_ip:
+        return handle.pod_ip
+      sandbox = handle.sandbox
+      if sandbox is not None:
+        return sandbox.get_pod_ip()
+      return None
+
+    @staticmethod
+    def terminate():
+      on_terminate()
+
+  return _HandleView()
+
+
+class BoundHandleClient:
+  """Duck-typed ``sandbox_client`` over an ALREADY-acquired handle.
+
+  For ``fleet.run(process_fn)`` flows: the fleet acquired the handle before
+  calling ``process_fn(task, handle)`` and releases it after the function
+  returns, so the workspace must neither acquire nor release — ``terminate()``
+  is a no-op on the pod (closing the workspace only drops HTTP state).
+  """
+
+  def __init__(self, handle):
+    self.handle = handle
+
+  def create_sandbox(self, warmpool, **_fleet_owned):  # noqa: ARG002
+    return _handle_view(self.handle, lambda: None)
 
 
 def make_fleet_workspace(fleet, task, *, namespace: str | None = None,
@@ -128,5 +148,53 @@ def make_fleet_workspace(fleet, task, *, namespace: str | None = None,
       # planned a pool for this task's image.
       warmpool=f"fleet:{task.image}",
       sandbox_client=FleetWorkspaceClient(fleet, task),
+      **kwargs,
+  )
+
+
+def make_handle_workspace(handle, *, namespace: str | None = None,
+                          **workspace_kwargs):
+  """Build an `AgentSandboxWorkspace` bound to an ALREADY-acquired handle.
+
+  This is the form to use inside ``fleet.run(process_fn)``: the fleet passes
+  ``(task, handle)`` to your function and releases the handle when it returns,
+  so the workspace binds the pod without acquiring or releasing anything —
+  ``workspace.cleanup()`` is safe to call and touches only HTTP state.
+
+  ::
+
+      def rollout(task, handle):
+          workspace = make_handle_workspace(handle, api_key=POOL_KEY)
+          try:
+              conversation = Conversation(agent=agent, workspace=workspace)
+              ...
+          finally:
+              workspace.cleanup()   # no-op on the pod; the fleet releases
+
+      results = fleet.run(rollout)
+
+  ``namespace`` defaults from the handle's cluster (it matters for router-mode
+  headers); fleet-owned kwargs (``warmpool``, ``ttl_s``, ``sandbox_client``)
+  raise, as in `make_fleet_workspace`.
+  """
+  for key in _FLEET_OWNED_KWARGS:
+    if key in workspace_kwargs:
+      raise ValueError(
+          f"{key!r} is fleet-owned when using make_handle_workspace — "
+          "configure it on the fleet, not the workspace")
+  try:
+    from openhands_k8s_agent_sandbox import AgentSandboxWorkspace
+  except ImportError as e:
+    raise RuntimeError(f"agent_sandbox_rl.adapters.openhands {_HINT}") from e
+
+  kwargs = dict(workspace_kwargs)
+  if namespace is None:
+    namespace = getattr(getattr(handle, "_cluster", None), "namespace", None)
+  if namespace is not None:
+    kwargs["namespace"] = namespace
+  task_image = getattr(getattr(handle, "task", None), "image", "?")
+  return AgentSandboxWorkspace(
+      warmpool=f"handle:{task_image}",     # informational; nothing is claimed
+      sandbox_client=BoundHandleClient(handle),
       **kwargs,
   )

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
@@ -57,27 +57,6 @@ _HINT = (
 _FLEET_OWNED_KWARGS = ("sandbox_client", "warmpool", "ttl_s")
 
 
-class FleetWorkspaceClient:
-  """Duck-typed ``sandbox_client`` backed by a fleet.
-
-  ``create_sandbox()`` acquires a warm pod from the fleet (the ``warmpool``
-  argument and lifecycle kwargs the workspace passes are ignored — the fleet
-  owns pools, placement, and claim TTLs). The returned view's ``terminate()``
-  releases the handle back to the fleet instead of deleting anything itself.
-  """
-
-  def __init__(self, fleet, task):
-    self._fleet = fleet
-    self._task = task
-    self.handle = None
-
-  def create_sandbox(self, warmpool, **_fleet_owned):  # noqa: ARG002
-    handle = self._fleet.acquire(self._task)
-    self.handle = handle
-    # Ownership inversion: release to the fleet, never delete directly.
-    return _handle_view(handle, lambda: self._fleet.release(handle))
-
-
 def _handle_view(handle, on_terminate):
   """Duck-typed SDK-sandbox view over a fleet handle for the workspace."""
 
@@ -99,6 +78,27 @@ def _handle_view(handle, on_terminate):
       on_terminate()
 
   return _HandleView()
+
+
+class FleetWorkspaceClient:
+  """Duck-typed ``sandbox_client`` backed by a fleet.
+
+  ``create_sandbox()`` acquires a warm pod from the fleet (the ``warmpool``
+  argument and lifecycle kwargs the workspace passes are ignored — the fleet
+  owns pools, placement, and claim TTLs). The returned view's ``terminate()``
+  releases the handle back to the fleet instead of deleting anything itself.
+  """
+
+  def __init__(self, fleet, task):
+    self._fleet = fleet
+    self._task = task
+    self.handle = None
+
+  def create_sandbox(self, warmpool, **_fleet_owned):  # noqa: ARG002
+    handle = self._fleet.acquire(self._task)
+    self.handle = handle
+    # Ownership inversion: release to the fleet, never delete directly.
+    return _handle_view(handle, lambda: self._fleet.release(handle))
 
 
 class BoundHandleClient:

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/adapters/openhands.py
@@ -57,12 +57,18 @@ _HINT = (
 _FLEET_OWNED_KWARGS = ("sandbox_client", "warmpool", "ttl_s")
 
 
-def _handle_view(handle, on_terminate):
-  """Duck-typed SDK-sandbox view over a fleet handle for the workspace."""
+def _handle_view(handle, on_terminate, *, releases=True):
+  """Duck-typed SDK-sandbox view over a fleet handle for the workspace.
+
+  ``releases`` tells the workspace what ``terminate()`` means here: a fleet
+  release (True) or nothing at all (False, handle-bound mode) — it logs a
+  release or a detach accordingly instead of claiming a release it never did.
+  """
 
   class _HandleView:
     claim_name = handle.claim_name
     sandbox_id = handle.sandbox_id
+    releases_on_terminate = releases
 
     @staticmethod
     def get_pod_ip():
@@ -107,14 +113,16 @@ class BoundHandleClient:
   For ``fleet.run(process_fn)`` flows: the fleet acquired the handle before
   calling ``process_fn(task, handle)`` and releases it after the function
   returns, so the workspace must neither acquire nor release — ``terminate()``
-  is a no-op on the pod (closing the workspace only drops HTTP state).
+  is a no-op on the pod (closing the workspace only drops HTTP state), and the
+  view says so (``releases_on_terminate=False``) so the workspace's cleanup
+  logs a detach, not a release the fleet actually performs later.
   """
 
   def __init__(self, handle):
     self.handle = handle
 
   def create_sandbox(self, warmpool, **_fleet_owned):  # noqa: ARG002
-    return _handle_view(self.handle, lambda: None)
+    return _handle_view(self.handle, lambda: None, releases=False)
 
 
 def make_fleet_workspace(fleet, task, *, namespace: str | None = None,

--- a/examples/agent-sandbox-rl/docs/architecture.md
+++ b/examples/agent-sandbox-rl/docs/architecture.md
@@ -62,6 +62,12 @@ injection (no SDK fork).
   `CoreV1Api`, `_stop_kubernetes_sandbox` to a no-op so the fleet owns the pod,
   and exec/file-copy to forward the handle's namespace). Lazy/guarded so the core
   imports without R2E-Gym; serves tunix deepswe transitively.
+  **`adapters/openhands.py`** — `make_fleet_workspace`/`make_handle_workspace`
+  (+ `FleetWorkspaceClient`/`BoundHandleClient`): bind OpenHands agent-SDK
+  workspaces (`openhands-k8s-agent-sandbox`) to fleet pods through the
+  workspace's `sandbox_client` injection seam — acquire-on-create vs
+  bind-already-acquired (for `fleet.run`), terminate → fleet release / no-op.
+  Same lazy/guarded import posture as the R2E-Gym adapter.
 - **`placement.py`** — `RoundRobin`, `LeastLoaded`, `CapacityWeighted`,
   `ImageAffinity` (capacity-aware) + `get_placement`.
 - **`handles.py`** — `SandboxHandle` (`hostname`, `pod_name`, `pod_ip`,

--- a/examples/agent-sandbox-rl/examples/rl_integration.md
+++ b/examples/agent-sandbox-rl/examples/rl_integration.md
@@ -263,10 +263,13 @@ def rollout(task, handle):
     workspace = make_handle_workspace(handle, api_key=POOL_KEY)
     try:
         conversation = Conversation(agent=agent, workspace=workspace)
-        conversation.send_message(prompt); conversation.run()
-        return {"id": task.id, "status": str(conversation.state.execution_status)}
+        try:
+            conversation.send_message(prompt); conversation.run()
+            return {"id": task.id, "status": str(conversation.state.execution_status)}
+        finally:
+            conversation.close()
     finally:
-        conversation.close(); workspace.cleanup()   # no-op on the pod
+        workspace.cleanup()   # no-op on the pod; the fleet releases
 
 results = fleet.run(rollout, strategy="naive", concurrency=64)
 
@@ -280,7 +283,8 @@ The pool's template must *run* the agent-server (`TemplateSpec.keepalive_command
 replaces the image entrypoint) with a `/health` readinessProbe merged via
 `extra_pod_spec` — `examples/run_openhands_fleet.py` is the complete runnable
 version (with a no-LLM smoke mode). Fleet-owned kwargs (`warmpool`, `ttl_s`,
-`sandbox_client`) raise; needs `pip install openhands-k8s-agent-sandbox`.
+`sandbox_client`) raise; needs `pip install openhands-k8s-agent-sandbox`
+(Python >= 3.12 — the `openhands-sdk` floor).
 
 ## Multi-cluster
 

--- a/examples/agent-sandbox-rl/examples/rl_integration.md
+++ b/examples/agent-sandbox-rl/examples/rl_integration.md
@@ -246,6 +246,42 @@ fleet = AsyncSandboxFleet(cfg); fleet.load_tasks(src)
 results = await fleet.run(async_rollout, strategy="sliding", concurrency=64)
 ```
 
+## OpenHands (agent SDK)
+
+OpenHands conversations run against a *workspace*; the
+[`openhands-k8s-agent-sandbox`](../../../clients/integrations/openhands)
+integration binds one to an agent-sandbox pod. `adapters.openhands` puts those
+workspaces on **fleet-managed** pods (same ownership inversion as R2E-Gym: the
+fleet acquires/releases, the workspace only binds). Two forms, matching who
+drives the loop:
+
+```python
+# fleet.run drives (it acquires + releases around process_fn):
+from agent_sandbox_rl.adapters.openhands import make_handle_workspace
+
+def rollout(task, handle):
+    workspace = make_handle_workspace(handle, api_key=POOL_KEY)
+    try:
+        conversation = Conversation(agent=agent, workspace=workspace)
+        conversation.send_message(prompt); conversation.run()
+        return {"id": task.id, "status": str(conversation.state.execution_status)}
+    finally:
+        conversation.close(); workspace.cleanup()   # no-op on the pod
+
+results = fleet.run(rollout, strategy="naive", concurrency=64)
+
+# you drive (the workspace acquires from the fleet; close() releases):
+from agent_sandbox_rl.adapters.openhands import make_fleet_workspace
+with make_fleet_workspace(fleet, task, api_key=POOL_KEY) as workspace:
+    ...
+```
+
+The pool's template must *run* the agent-server (`TemplateSpec.keepalive_command`
+replaces the image entrypoint) with a `/health` readinessProbe merged via
+`extra_pod_spec` — `examples/run_openhands_fleet.py` is the complete runnable
+version (with a no-LLM smoke mode). Fleet-owned kwargs (`warmpool`, `ttl_s`,
+`sandbox_client`) raise; needs `pip install openhands-k8s-agent-sandbox`.
+
 ## Multi-cluster
 
 Give several `ClusterConfig`s (different `context`/`kubeconfig`) and a

--- a/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
+++ b/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
@@ -93,12 +93,26 @@ def _agent_server_container(session_key):
   return container
 
 
-def _rollout(session_key):
+def _conversation_mode():
+  """LLM configured AND the agent preset installed; else fall back to smoke."""
+  if not os.getenv("LLM_API_KEY"):
+    return False
+  try:
+    import openhands.tools  # noqa: F401
+  except ImportError:
+    logging.warning(
+        "LLM_API_KEY is set but openhands-tools is not installed — falling "
+        "back to smoke mode (pip install openhands-tools)")
+    return False
+  return True
+
+
+def _rollout(session_key, conversation_mode):
   """Per-task fn for fleet.run: bind the handle, converse (or smoke)."""
   def fn(task, handle):
     workspace = make_handle_workspace(handle, api_key=session_key or None)
     try:
-      if os.getenv("LLM_API_KEY"):
+      if conversation_mode:
         return _conversation(task, workspace)
       result = workspace.execute_command("echo ready && uname -m")
       return {"id": task.id, "mode": "smoke", "cluster": handle.cluster_name,
@@ -171,7 +185,7 @@ def main():
   fleet.load_tasks([Task(id=f"conv-{i}", image=image, metadata={})
                     for i in range(n_conversations)])
 
-  results = fleet.run(_rollout(session_key),
+  results = fleet.run(_rollout(session_key, _conversation_mode()),
                       strategy=_env("WARMPOOL_STRATEGY", "naive"),
                       concurrency=max_concurrent)
   print(json.dumps({"conversations": len(results), "results": results},

--- a/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
+++ b/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
@@ -79,8 +79,10 @@ def _agent_server_container(session_key):
       "ports": [{"containerPort": 8000}],
       "readinessProbe": {
           "httpGet": {"path": "/health", "port": 8000},
-          "periodSeconds": 1,
-          "failureThreshold": 120,
+          # 5 min boot budget: agent-server cold boots were measured at up to
+          # ~4 min on runc nodes. This is pool-fill time, off the claim path.
+          "periodSeconds": 2,
+          "failureThreshold": 150,
       },
   }
   if session_key:
@@ -156,8 +158,13 @@ def main():
   else:
     clusters = [ClusterConfig(name="default", namespace=namespace)]
 
+  # Pool depth must cover the concurrency: FleetConfig.max_warmpool_size
+  # hard-caps replicas per image pool (default 8), and every conversation
+  # holds a pod while active — an unraised cap would silently throttle claims.
+  max_pool = max(max_concurrent, int(_env("MAX_WARMPOOL_SIZE", "8")))
   fleet = SandboxFleet(FleetConfig(
       clusters=clusters, max_concurrent=max_concurrent, template=template,
+      max_warmpool_size=max_pool,
       ready_timeout=int(_env("SANDBOX_READY_TIMEOUT", "600"))))
   # One shared agent-server image -> the fleet plans a single warm pool sized
   # to the concurrency; conversations are just tasks against it.

--- a/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
+++ b/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
@@ -69,6 +69,25 @@ def _env(name, default):
   return os.getenv(name, default)
 
 
+def _pool_size(max_concurrent, pool_cap, *, explicit):
+  """Per-image pool cap: MAX_WARMPOOL_SIZE, raised to MAX_CONCURRENT if lower.
+
+  FleetConfig.max_warmpool_size hard-caps replicas per image pool and every
+  active conversation holds a pod, so a cap below the concurrency would
+  silently throttle claims. Raising it means more warm capacity than asked
+  for — say so, and loudly when the cap was set explicitly.
+  """
+  if pool_cap >= max_concurrent:
+    return pool_cap
+  logging.log(
+      logging.WARNING if explicit else logging.INFO,
+      "MAX_WARMPOOL_SIZE=%d (%s) is below MAX_CONCURRENT=%d; using %d so every "
+      "concurrent conversation can hold a warm pod — expect that many replicas",
+      pool_cap, "explicit" if explicit else "default", max_concurrent,
+      max_concurrent)
+  return max_concurrent
+
+
 def _agent_server_container(session_key):
   """Merged into the rendered container via extra_pod_spec (no name = first).
 
@@ -173,10 +192,10 @@ def main():
   else:
     clusters = [ClusterConfig(name="default", namespace=namespace)]
 
-  # Pool depth must cover the concurrency: FleetConfig.max_warmpool_size
-  # hard-caps replicas per image pool (default 8), and every conversation
-  # holds a pod while active — an unraised cap would silently throttle claims.
-  max_pool = max(max_concurrent, int(_env("MAX_WARMPOOL_SIZE", "8")))
+  # Pool depth must cover the concurrency (default cap 8); see _pool_size.
+  pool_cap_env = os.getenv("MAX_WARMPOOL_SIZE")
+  max_pool = _pool_size(max_concurrent, int(pool_cap_env) if pool_cap_env else 8,
+                        explicit=bool(pool_cap_env))
   fleet = SandboxFleet(FleetConfig(
       clusters=clusters, max_concurrent=max_concurrent, template=template,
       max_warmpool_size=max_pool,

--- a/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
+++ b/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
@@ -1,0 +1,175 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fan out OpenHands conversations onto Agent Sandbox warm pools.
+
+The OpenHands twin of run_swebench_fleet.py: the fleet warms one pool of
+agent-server pods, then runs N concurrent "rollouts". Each rollout binds the
+fleet-acquired pod into an `AgentSandboxWorkspace` via
+`adapters.openhands.make_handle_workspace` — the fleet owns every pod
+(acquire/release around the rollout); the workspace only binds.
+
+With LLM_API_KEY set each rollout is a real OpenHands conversation (needs the
+`openhands-tools` package for the default agent); without it, each rollout is a
+workspace smoke (server info + shell command), so the fan-out is testable with
+cluster access alone. Env-configured:
+
+  N_CONVERSATIONS=4 MAX_CONCURRENT=4 SANDBOX_SESSION_KEY=$(openssl rand -hex 24) \
+  LLM_API_KEY=... LLM_MODEL=... NAMESPACE=default python run_openhands_fleet.py
+
+Requires: pip install -e ../../../clients/integrations/openhands  (and
+openhands-tools for the conversation mode). The agent-server image tag should
+match the installed openhands-sdk release.
+"""
+
+import json
+import logging
+import os
+
+from agent_sandbox_rl import (
+    ClusterConfig,
+    FleetConfig,
+    ResourceSpec,
+    SandboxFleet,
+    Task,
+    TemplateSpec,
+)
+from agent_sandbox_rl.adapters.openhands import make_handle_workspace
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+DEFAULT_IMAGE = "ghcr.io/openhands/agent-server:1.44.1-python"
+# The image's ENTRYPOINT, restated: TemplateSpec.keepalive_command renders as
+# the container *command* (it replaces the entrypoint), so the server must be
+# launched explicitly.
+SERVER_COMMAND = [
+    "tini", "--", "/agent-server/.venv/bin/python", "-m",
+    "openhands.agent_server", "--host", "0.0.0.0", "--port", "8000",
+]
+DEFAULT_PROMPT = (
+    "Write a haiku about pre-warmed sandboxes into /workspace/haiku.txt, "
+    "then print the file."
+)
+
+
+def _env(name, default):
+  return os.getenv(name, default)
+
+
+def _agent_server_container(session_key):
+  """Merged into the rendered container via extra_pod_spec (no name = first).
+
+  The readinessProbe is load-bearing: it makes pool-Ready mean
+  "agent-server is serving", which is what lets claims bind instantly and the
+  workspace keep its short health budget.
+  """
+  container = {
+      "ports": [{"containerPort": 8000}],
+      "readinessProbe": {
+          "httpGet": {"path": "/health", "port": 8000},
+          "periodSeconds": 1,
+          "failureThreshold": 120,
+      },
+  }
+  if session_key:
+    # Pool-level key (pre-warmed servers cannot take a per-claim key). The
+    # example inlines the value for brevity; production should use
+    # valueFrom.secretKeyRef — see the integration's README.
+    container["env"] = [{"name": "OH_SESSION_API_KEYS_0", "value": session_key}]
+  return container
+
+
+def _rollout(session_key):
+  """Per-task fn for fleet.run: bind the handle, converse (or smoke)."""
+  def fn(task, handle):
+    workspace = make_handle_workspace(handle, api_key=session_key or None)
+    try:
+      if os.getenv("LLM_API_KEY"):
+        return _conversation(task, workspace)
+      result = workspace.execute_command("echo ready && uname -m")
+      return {"id": task.id, "mode": "smoke", "cluster": handle.cluster_name,
+              "exit_code": result.exit_code, "output": result.stdout.strip()}
+    finally:
+      workspace.cleanup()   # no-op on the pod; the fleet releases the handle
+  return fn
+
+
+def _conversation(task, workspace):
+  from pydantic import SecretStr
+
+  from openhands.sdk import LLM, Conversation
+  from openhands.tools.preset.default import get_default_agent
+
+  llm = LLM(
+      usage_id="agent",
+      model=os.getenv("LLM_MODEL", "gpt-5.5"),
+      base_url=os.getenv("LLM_BASE_URL"),
+      api_key=SecretStr(os.environ["LLM_API_KEY"]),
+  )
+  agent = get_default_agent(llm=llm, cli_mode=True)
+  conversation = Conversation(agent=agent, workspace=workspace)
+  try:
+    conversation.send_message(_env("PROMPT", DEFAULT_PROMPT))
+    conversation.run()
+    return {"id": task.id, "mode": "conversation",
+            "status": str(conversation.state.execution_status)}
+  finally:
+    conversation.close()
+
+
+def main():
+  n_conversations = int(_env("N_CONVERSATIONS", "2"))
+  max_concurrent = int(_env("MAX_CONCURRENT", "2"))
+  namespace = _env("NAMESPACE", "default")
+  image = _env("AGENT_SERVER_IMAGE", DEFAULT_IMAGE)
+  session_key = _env("SANDBOX_SESSION_KEY", "")
+
+  node_selector = None
+  if _env("NODE_SELECTOR_KEY", "") and _env("NODE_SELECTOR_VAL", ""):
+    node_selector = {os.environ["NODE_SELECTOR_KEY"]: os.environ["NODE_SELECTOR_VAL"]}
+
+  template = TemplateSpec(
+      keepalive_command=SERVER_COMMAND,
+      runtime_class=_env("RUNTIME_CLASS", "") or None,
+      node_selector=node_selector,
+      resources=ResourceSpec(
+          cpu=_env("SANDBOX_CPU", "500m"), memory=_env("SANDBOX_MEM", "1Gi")),
+      extra_pod_spec={"containers": [_agent_server_container(session_key)]},
+  )
+
+  contexts = [c for c in _env("KUBE_CONTEXTS", "").split(",") if c]
+  if contexts:
+    clusters = [ClusterConfig(name=c, context=c, namespace=namespace)
+                for c in contexts]
+  else:
+    clusters = [ClusterConfig(name="default", namespace=namespace)]
+
+  fleet = SandboxFleet(FleetConfig(
+      clusters=clusters, max_concurrent=max_concurrent, template=template,
+      ready_timeout=int(_env("SANDBOX_READY_TIMEOUT", "600"))))
+  # One shared agent-server image -> the fleet plans a single warm pool sized
+  # to the concurrency; conversations are just tasks against it.
+  fleet.load_tasks([Task(id=f"conv-{i}", image=image, metadata={})
+                    for i in range(n_conversations)])
+
+  results = fleet.run(_rollout(session_key),
+                      strategy=_env("WARMPOOL_STRATEGY", "naive"),
+                      concurrency=max_concurrent)
+  print(json.dumps({"conversations": len(results), "results": results},
+                   indent=2, default=str))
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
+++ b/examples/agent-sandbox-rl/examples/run_openhands_fleet.py
@@ -28,9 +28,10 @@ cluster access alone. Env-configured:
   N_CONVERSATIONS=4 MAX_CONCURRENT=4 SANDBOX_SESSION_KEY=$(openssl rand -hex 24) \
   LLM_API_KEY=... LLM_MODEL=... NAMESPACE=default python run_openhands_fleet.py
 
-Requires: pip install -e ../../../clients/integrations/openhands  (and
-openhands-tools for the conversation mode). The agent-server image tag should
-match the installed openhands-sdk release.
+Requires: Python >= 3.12 (the openhands-sdk floor) and
+pip install -e ../../../clients/integrations/openhands  (plus openhands-tools
+for the conversation mode). The agent-server image tag should match the
+installed openhands-sdk release.
 """
 
 import json

--- a/examples/agent-sandbox-rl/tests/test_openhands_adapter.py
+++ b/examples/agent-sandbox-rl/tests/test_openhands_adapter.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the OpenHands fleet adapter.
+
+The shim itself has no OpenHands dependency (lazy imports), so most tests run
+with plain fakes; `make_fleet_workspace` is exercised against a stub
+`openhands_k8s_agent_sandbox` module injected into sys.modules — same pattern
+the r2egym adapter tests use for the optional R2E-Gym dependency.
+"""
+
+import sys
+import types
+
+import pytest
+
+from agent_sandbox_rl.adapters.openhands import (
+    FleetWorkspaceClient,
+    make_fleet_workspace,
+)
+from agent_sandbox_rl.sources import Task
+
+
+class FakeSdkSandbox:
+  def __init__(self, pod_ip="10.8.8.8"):
+    self._pod_ip = pod_ip
+
+  def get_pod_ip(self):
+    return self._pod_ip
+
+
+class FakeHandle:
+  def __init__(self, pod_ip="10.1.2.3", sandbox=None):
+    self.claim_name = "claim-42"
+    self.sandbox_id = "sbx-42"
+    self.pod_ip = pod_ip
+    self.sandbox = sandbox
+
+
+class FakeFleet:
+  def __init__(self, handle=None):
+    self.handle = handle or FakeHandle()
+    self.acquired = []
+    self.released = []
+
+  def acquire(self, task):
+    self.acquired.append(task)
+    return self.handle
+
+  def release(self, handle):
+    self.released.append(handle)
+
+
+def make_task():
+  return Task(id="t1", image="img:1", metadata={})
+
+
+# ------------------------------------------------------------------- shim
+
+
+def test_create_sandbox_acquires_from_fleet():
+  fleet = FakeFleet()
+  task = make_task()
+  client = FleetWorkspaceClient(fleet, task)
+  view = client.create_sandbox("ignored-pool", sandbox_ready_timeout=5,
+                               shutdown_after_seconds=999, labels={"x": "y"})
+  assert fleet.acquired == [task]
+  assert view.claim_name == "claim-42"
+  assert view.sandbox_id == "sbx-42"
+  assert view.get_pod_ip() == "10.1.2.3"
+
+
+def test_pod_ip_falls_back_to_sdk_sandbox():
+  fleet = FakeFleet(FakeHandle(pod_ip=None, sandbox=FakeSdkSandbox("10.8.8.8")))
+  view = FleetWorkspaceClient(fleet, make_task()).create_sandbox("p")
+  assert view.get_pod_ip() == "10.8.8.8"
+
+
+def test_terminate_releases_to_fleet():
+  fleet = FakeFleet()
+  view = FleetWorkspaceClient(fleet, make_task()).create_sandbox("p")
+  view.terminate()
+  assert fleet.released == [fleet.handle]
+
+
+# ------------------------------------------------------- make_fleet_workspace
+
+
+@pytest.fixture
+def fake_openhands_integration(monkeypatch):
+  """Stub openhands_k8s_agent_sandbox so no OpenHands install is needed."""
+  captured = {}
+
+  class FakeWorkspace:
+    def __init__(self, **kwargs):
+      captured.update(kwargs)
+
+  module = types.ModuleType("openhands_k8s_agent_sandbox")
+  module.AgentSandboxWorkspace = FakeWorkspace
+  monkeypatch.setitem(sys.modules, "openhands_k8s_agent_sandbox", module)
+  return captured
+
+
+def test_make_fleet_workspace_wires_shim(fake_openhands_integration):
+  fleet, task = FakeFleet(), make_task()
+  make_fleet_workspace(fleet, task, namespace="rl", api_key="pool-key")
+  kwargs = fake_openhands_integration
+  assert kwargs["warmpool"] == "fleet:img:1"          # informational marker
+  assert isinstance(kwargs["sandbox_client"], FleetWorkspaceClient)
+  assert kwargs["namespace"] == "rl"
+  assert kwargs["api_key"] == "pool-key"
+
+
+@pytest.mark.parametrize("key,value", [
+    ("ttl_s", 60), ("warmpool", "p"), ("sandbox_client", object()),
+])
+def test_fleet_owned_kwargs_rejected(fake_openhands_integration, key, value):
+  with pytest.raises(ValueError, match="fleet-owned"):
+    make_fleet_workspace(FakeFleet(), make_task(), **{key: value})
+
+
+def test_missing_integration_raises_clear_hint(monkeypatch):
+  monkeypatch.setitem(sys.modules, "openhands_k8s_agent_sandbox", None)
+  with pytest.raises(RuntimeError, match="openhands-k8s-agent-sandbox"):
+    make_fleet_workspace(FakeFleet(), make_task())

--- a/examples/agent-sandbox-rl/tests/test_openhands_adapter.py
+++ b/examples/agent-sandbox-rl/tests/test_openhands_adapter.py
@@ -99,6 +99,7 @@ def test_pod_ip_falls_back_to_sdk_sandbox():
 def test_terminate_releases_to_fleet():
   fleet = FakeFleet()
   view = FleetWorkspaceClient(fleet, make_task()).create_sandbox("p")
+  assert view.releases_on_terminate is True   # workspace logs a release
   view.terminate()
   assert fleet.released == [fleet.handle]
 
@@ -156,6 +157,8 @@ def test_bound_handle_client_binds_without_acquiring():
   view.terminate()          # must be a no-op: fleet.run owns the release
   # No fleet in sight — nothing to have released; the handle is untouched.
   assert handle.pod_ip == "10.1.2.3"
+  # ...and the view says so, so the workspace logs a detach, not a release.
+  assert view.releases_on_terminate is False
 
 
 def test_make_handle_workspace_wires_bound_client(fake_openhands_integration):

--- a/examples/agent-sandbox-rl/tests/test_openhands_adapter.py
+++ b/examples/agent-sandbox-rl/tests/test_openhands_adapter.py
@@ -26,8 +26,10 @@ import types
 import pytest
 
 from agent_sandbox_rl.adapters.openhands import (
+    BoundHandleClient,
     FleetWorkspaceClient,
     make_fleet_workspace,
+    make_handle_workspace,
 )
 from agent_sandbox_rl.sources import Task
 
@@ -40,12 +42,19 @@ class FakeSdkSandbox:
     return self._pod_ip
 
 
+class FakeCluster:
+  def __init__(self, namespace="fleet-ns"):
+    self.namespace = namespace
+
+
 class FakeHandle:
-  def __init__(self, pod_ip="10.1.2.3", sandbox=None):
+  def __init__(self, pod_ip="10.1.2.3", sandbox=None, task=None, cluster=None):
     self.claim_name = "claim-42"
     self.sandbox_id = "sbx-42"
     self.pod_ip = pod_ip
     self.sandbox = sandbox
+    self.task = task
+    self._cluster = cluster
 
 
 class FakeFleet:
@@ -134,3 +143,48 @@ def test_missing_integration_raises_clear_hint(monkeypatch):
   monkeypatch.setitem(sys.modules, "openhands_k8s_agent_sandbox", None)
   with pytest.raises(RuntimeError, match="openhands-k8s-agent-sandbox"):
     make_fleet_workspace(FakeFleet(), make_task())
+
+
+# ------------------------------------------------------ make_handle_workspace
+
+
+def test_bound_handle_client_binds_without_acquiring():
+  handle = FakeHandle()
+  view = BoundHandleClient(handle).create_sandbox("ignored", labels={"x": "y"})
+  assert view.claim_name == "claim-42"
+  assert view.get_pod_ip() == "10.1.2.3"
+  view.terminate()          # must be a no-op: fleet.run owns the release
+  # No fleet in sight — nothing to have released; the handle is untouched.
+  assert handle.pod_ip == "10.1.2.3"
+
+
+def test_make_handle_workspace_wires_bound_client(fake_openhands_integration):
+  handle = FakeHandle(task=make_task(), cluster=FakeCluster("rl-ns"))
+  make_handle_workspace(handle, api_key="pool-key")
+  kwargs = fake_openhands_integration
+  assert kwargs["warmpool"] == "handle:img:1"       # informational marker
+  assert isinstance(kwargs["sandbox_client"], BoundHandleClient)
+  assert kwargs["sandbox_client"].handle is handle
+  assert kwargs["api_key"] == "pool-key"
+
+
+def test_handle_workspace_namespace_defaults_from_cluster(
+    fake_openhands_integration):
+  handle = FakeHandle(task=make_task(), cluster=FakeCluster("fleet-ns"))
+  make_handle_workspace(handle)
+  assert fake_openhands_integration["namespace"] == "fleet-ns"
+
+
+def test_handle_workspace_namespace_override_wins(fake_openhands_integration):
+  handle = FakeHandle(task=make_task(), cluster=FakeCluster("fleet-ns"))
+  make_handle_workspace(handle, namespace="explicit")
+  assert fake_openhands_integration["namespace"] == "explicit"
+
+
+@pytest.mark.parametrize("key,value", [
+    ("ttl_s", 60), ("warmpool", "p"), ("sandbox_client", object()),
+])
+def test_handle_workspace_fleet_owned_kwargs_rejected(
+    fake_openhands_integration, key, value):
+  with pytest.raises(ValueError, match="fleet-owned"):
+    make_handle_workspace(FakeHandle(), **{key: value})


### PR DESCRIPTION
> **Stacked on #1488** (the `AgentSandboxWorkspace` integration, approved and awaiting prow). The first three commits here are #1488's; **review the last four**: the fleet adapter, the version-skew check, the handle-bound form + example, and the self-review fixes. This branch will be rebased the moment #1488 merges, collapsing the diff to exactly those four commits.

## What

Two layers on top of the #1488 integration:

**1. `agent_sandbox_rl/adapters/openhands.py`** — OpenHands workspaces on fleet-managed pods, the same ownership inversion `adapters/r2egym.py` established: the fleet acquires/releases pods (pools, placement, budgets), the workspace only binds. Implemented through the workspace's `sandbox_client` injection seam — the workspace class runs byte-identical. Two forms, matching how the fleet is driven:

- `make_fleet_workspace(fleet, task)` — the shim acquires from the fleet; `close()` releases back to it (never deletes).
- `make_handle_workspace(handle)` — for `fleet.run(process_fn)` flows, where the fleet passes an already-acquired handle and releases it itself; the workspace neither acquires nor releases (`terminate()` is a no-op on the pod). `namespace` defaults from the handle's cluster (feeds router-mode headers).

Both reject fleet-owned kwargs (`warmpool`, `ttl_s`, `sandbox_client`) so lifecycle can't be configured twice. Module-level imports stay OpenHands-free (lazy import with an install hint), preserving the core package's optional-dependency posture — same pattern as the r2egym adapter.

**2. `examples/run_openhands_fleet.py`** — the OpenHands twin of `run_swebench_fleet.py`: one warm pool of agent-server pods, N concurrent conversations via `fleet.run`, JSON results. Encodes two template-rendering facts verified against `resources.py`: `TemplateSpec.keepalive_command` renders as the container *command* (replacing the image entrypoint, so the server launch is restated explicitly), and `extra_pod_spec.containers` deep-merges the load-bearing `/health` readinessProbe + pool session key into the rendered container. Without `LLM_API_KEY` each rollout degrades to a workspace smoke, so the fan-out is testable with cluster access alone.

Also included: an advisory **server-version skew check** in the integration (`/server_info` vs installed `openhands-sdk` at attach; warns loudly, never fails; `check_server_version=False` for offline tests) — closing the last item from the integration's design spec.

## Test plan

- **15 adapter unit tests** (fakes only; `make_*_workspace` exercised against a `sys.modules` stub of the integration, so no OpenHands install is needed by the RL suite): acquire/release wiring, no-op terminate for the handle-bound form, pod-IP fallback through the SDK sandbox, namespace defaulting/override, fleet-owned-kwarg rejection, missing-integration hint.
- **19 integration unit tests** (includes the two new skew-check tests) — all green.
- Self-review fixes verified against source and measured data: pool depth now follows `MAX_CONCURRENT` (the `max_warmpool_size=8` default would have silently throttled claims), and the example's probe budget is 5 min because agent-server cold boots were measured at ~4 min on runc nodes (pool-fill time, off the claim path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenHands workspace support for provisioning, binding, health checks, routing, authentication, and lifecycle management of Kubernetes agent sandboxes.
  - Added adapters for connecting OpenHands workspaces to fleet-managed warm pools.
  - Added a configurable example for running OpenHands workloads with a sandbox fleet.

- **Bug Fixes**
  - Improved cleanup reliability by retrying failed sandbox termination.
  - Ensured conversations close even when task execution fails.

- **Documentation**
  - Added OpenHands adapter usage, architecture, installation, and integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->