### PR TITLE
fix(dev): accept case-insensitive and 1 values for env flags

### DIFF
--- a/dev/tools/deploy-kind
+++ b/dev/tools/deploy-kind
@@ -57,8 +57,8 @@ _spec.loader.exec_module(_latest_published_tag)
 
 
 def _env_flag(name):
-    """Treat an env var as true when it is literally "true"."""
-    return os.environ.get(name, "") == "true"
+    """Treat an env var as true when it is "true" or "1" (case-insensitive)."""
+    return os.environ.get(name, "").strip().lower() in ("true", "1")
 
 
 def _run_tool(tool, *args):

--- a/dev/tools/deploy_kind_test.py
+++ b/dev/tools/deploy_kind_test.py
@@ -53,6 +53,16 @@ class DeployKindTest(unittest.TestCase):
              os.path.join(_REPO_ROOT, "bin", "KUBECONFIG"),
              "--container-engine", engine])
 
+    def test_env_flag_accepts_true_and_one_case_insensitive(self):
+        for value in ("true", "TRUE", "True", "1", " 1 "):
+            with mock.patch.dict(os.environ, {"FLAG": value}, clear=True):
+                self.assertTrue(deploy_kind._env_flag("FLAG"))
+
+    def test_env_flag_rejects_other_values(self):
+        for value in ("false", "FALSE", "0", "yes", "", " false "):
+            with mock.patch.dict(os.environ, {"FLAG": value}, clear=True):
+                self.assertFalse(deploy_kind._env_flag("FLAG"))
+
     def test_default_flow(self):
         calls = self._run_with()
         self._assert_create_call(calls, "agent-sandbox", "docker")


### PR DESCRIPTION
Addresses review comment on #1382: SKIP_BUILD=1 or SKIP_BUILD=True
are now recognized as true by deploy-kind, not just the literal
string "true".

refer the origin review comments follow-up actions https://github.com/kubernetes-sigs/agent-sandbox/pull/1382#discussion_r3897393460

cc @janetkuo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment flags now accept `true` in any capitalization and the value `1`, including surrounding whitespace.
  * Invalid values such as `false`, `0`, `yes`, and empty values remain rejected.

* **Tests**
  * Added coverage for accepted and rejected environment flag values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->