### PR TITLE
feat(python-sdk): allow injecting a pre-configured ApiClient

### DIFF
--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -384,6 +384,8 @@ Latency guidance:
 
 By default, `SandboxClient` and `AsyncSandboxClient` load their Kubernetes credentials via an in-cluster config if running inside a pod, otherwise `KUBECONFIG`, falling back to `~/.kube/config`'s `current-context` if unset. To target a different cluster/context instead, pass a pre-configured `api_client`.
 
+> **Warning:** In local-tunnel connection mode, `api_client` only redirects the Kubernetes API calls (creating/watching the `Sandbox`/`SandboxClaim`). The `kubectl port-forward` subprocess used to reach the sandbox-router service still uses your ambient kubeconfig context, not the context configured on `api_client`. If those two point at different clusters, the tunnel silently connects to the wrong one. There is an open follow-up to make the tunnel context-aware (e.g. a `context`/`kubeconfig` field on `SandboxLocalTunnelConnectionConfig`); until then, make sure your ambient `kubectl` context matches the cluster targeted by `api_client` when using local-tunnel mode.
+
 **A kubeconfig file outside the default location** (e.g. a `pytest-kind` cluster):
 
 ```python

--- a/clients/python/agentic-sandbox-client/README.md
+++ b/clients/python/agentic-sandbox-client/README.md
@@ -380,6 +380,45 @@ Latency guidance:
   for the `kubectl port-forward` startup; the SDK probes the local port every
   50ms while it comes up. Gateway/in-cluster modes do not have this step.
 
+### 10. Targeting a Specific Cluster or Context
+
+By default, `SandboxClient` and `AsyncSandboxClient` load their Kubernetes credentials via an in-cluster config if running inside a pod, otherwise `KUBECONFIG`, falling back to `~/.kube/config`'s `current-context` if unset. To target a different cluster/context instead, pass a pre-configured `api_client`.
+
+**A kubeconfig file outside the default location** (e.g. a `pytest-kind` cluster):
+
+```python
+from kubernetes import client, config
+from k8s_agent_sandbox import SandboxClient
+
+cfg = client.Configuration()
+config.load_kube_config(
+    config_file="/path/to/other-kubeconfig.yaml",  # not KUBECONFIG/~/.kube/config
+    context="my-cluster-context",
+    client_configuration=cfg,
+)
+
+sandbox_client = SandboxClient(api_client=client.ApiClient(configuration=cfg))
+```
+
+**Multiple clusters in one process** — each `SandboxClient` needs its own `api_client`, built from its own `Configuration`; constructing one doesn't affect another already in use:
+
+```python
+from kubernetes import client, config
+from k8s_agent_sandbox import SandboxClient
+
+def build_client(context: str) -> SandboxClient:
+    cfg = client.Configuration()
+    config.load_kube_config(context=context, client_configuration=cfg)
+    return SandboxClient(api_client=client.ApiClient(configuration=cfg))
+
+client_a = build_client("cluster-a")
+client_b = build_client("cluster-b")
+```
+
+The async client takes the same parameter with a `kubernetes_asyncio.client.ApiClient`.
+
+An injected `api_client` is caller-owned: `AsyncSandboxClient` and `AsyncK8sHelper` never close it (only a client they create internally is closed). The synchronous `SandboxClient` and `K8sHelper` don't close their underlying client either way, injected or not. Closing an injected client is the caller's responsibility in both cases.
+
 ## Testing
 
 A test script is included to verify the full lifecycle (Creation -> Execution -> File I/O -> Cleanup).

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -47,10 +47,10 @@ from .utils import (
 class AsyncK8sHelper:
     """Async helper class for Kubernetes API interactions using kubernetes_asyncio."""
 
-    def __init__(self):
+    def __init__(self, api_client: client.ApiClient | None = None):
         self._initialized = False
         self._init_lock = asyncio.Lock()
-        self._api_client: client.ApiClient | None = None
+        self._api_client: client.ApiClient | None = api_client
 
     async def _ensure_initialized(self):
         if self._initialized:
@@ -58,11 +58,12 @@ class AsyncK8sHelper:
         async with self._init_lock:
             if self._initialized:
                 return
-            try:
-                config.load_incluster_config()
-            except config.ConfigException:
-                await config.load_kube_config()
-            self._api_client = client.ApiClient()
+            if self._api_client is None:
+                try:
+                    config.load_incluster_config()
+                except config.ConfigException:
+                    await config.load_kube_config()
+                self._api_client = client.ApiClient()
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
             self._initialized = True

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -461,10 +461,10 @@ class AsyncK8sHelper:
     async def close(self):
         """Closes the shared Kubernetes API client session.
 
-        A caller-injected ``api_client`` is left open (the caller owns its
-        lifecycle); only a client created internally is closed here.
+        A caller-injected ``api_client`` is left open and remains attached to
+        this helper. Only a client created internally is closed and cleared.
         """
         if self._api_client and self._owns_api_client:
             await self._api_client.close()
-        self._api_client = None
-        self._initialized = False
+            self._api_client = None
+            self._initialized = False

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_k8s_helper.py
@@ -51,6 +51,8 @@ class AsyncK8sHelper:
         self._initialized = False
         self._init_lock = asyncio.Lock()
         self._api_client: client.ApiClient | None = api_client
+        # An injected client is caller-owned; only close clients we create.
+        self._owns_api_client = api_client is None
 
     async def _ensure_initialized(self):
         if self._initialized:
@@ -64,6 +66,7 @@ class AsyncK8sHelper:
                 except config.ConfigException:
                     await config.load_kube_config()
                 self._api_client = client.ApiClient()
+                self._owns_api_client = True
             self.custom_objects_api = client.CustomObjectsApi(self._api_client)
             self.core_v1_api = client.CoreV1Api(self._api_client)
             self._initialized = True
@@ -456,8 +459,12 @@ class AsyncK8sHelper:
                 await w.close()
 
     async def close(self):
-        """Closes the shared Kubernetes API client session."""
-        if self._api_client:
+        """Closes the shared Kubernetes API client session.
+
+        A caller-injected ``api_client`` is left open (the caller owns its
+        lifecycle); only a client created internally is closed here.
+        """
+        if self._api_client and self._owns_api_client:
             await self._api_client.close()
-            self._api_client = None
-            self._initialized = False
+        self._api_client = None
+        self._initialized = False

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -26,6 +26,7 @@ import sys
 import uuid
 from typing import Generic, TypeVar
 
+from kubernetes import client as sync_client
 from kubernetes_asyncio import client as async_client
 
 from .async_k8s_helper import AsyncK8sHelper
@@ -45,6 +46,47 @@ T = TypeVar("T", bound=AsyncSandbox)
 # (used by the synchronous K8sHelper) has no default read timeout, so an
 # unresponsive apiserver would otherwise hang process exit indefinitely.
 _ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS = 300
+
+# Connection/auth fields copied from an injected kubernetes_asyncio
+# Configuration onto the sync kubernetes.client.Configuration built for
+# atexit cleanup. kubernetes.client and kubernetes_asyncio.client are
+# separate generated packages that happen to expose the same attribute names
+# for these fields, but they aren't interchangeable: e.g. the sync client's
+# urllib3 transport reads configuration.no_proxy, which the async
+# Configuration class doesn't define, so passing an async Configuration
+# directly into a sync ApiClient risks an AttributeError. Hence an explicit
+# allowlist instead of reusing the object or copying its whole __dict__.
+_ATEXIT_CONFIGURATION_FIELDS = (
+    "host",
+    "api_key",
+    "api_key_prefix",
+    "username",
+    "password",
+    "ssl_ca_cert",
+    "cert_file",
+    "key_file",
+    "verify_ssl",
+    "assert_hostname",
+    "proxy",
+    "proxy_headers",
+    "connection_pool_maxsize",
+    "retries",
+    "socket_options",
+    "tls_server_name",
+    "refresh_api_key_hook",
+    "discard_unknown_keys",
+)
+
+
+def _sync_configuration_from_async(async_configuration) -> sync_client.Configuration:
+    """Mirrors an injected ``kubernetes_asyncio`` ``Configuration`` onto a
+    ``kubernetes`` one, so atexit cleanup's synchronous ``K8sHelper`` targets
+    the same cluster/credentials as the caller's injected ``api_client``.
+    """
+    sync_configuration = sync_client.Configuration()
+    for field in _ATEXIT_CONFIGURATION_FIELDS:
+        setattr(sync_configuration, field, getattr(async_configuration, field))
+    return sync_configuration
 
 
 class AsyncSandboxClient(Generic[T]):
@@ -123,6 +165,13 @@ class AsyncSandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         self.k8s_helper = AsyncK8sHelper(api_client=api_client)
+        self._atexit_api_client_configuration = (
+            api_client.configuration if api_client is not None else None
+        )
+        self._atexit_api_client_default_headers = (
+            dict(api_client.default_headers) if api_client is not None else {}
+        )
+        self._atexit_api_client_cookie = api_client.cookie if api_client is not None else None
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()
@@ -398,16 +447,28 @@ class AsyncSandboxClient(Generic[T]):
         per-request netrc lookup via a background thread, which raises "cannot
         schedule new futures after interpreter shutdown" once that teardown has
         started. The synchronous client's urllib3 transport has no event loop or
-        executor dependency, so it isn't affected. Per-claim failures emit
-        warnings to ``sys.stderr`` rather than raising — atexit cleanup is
-        best-effort.
+        executor dependency, so it isn't affected. When an ApiClient was
+        injected, its Configuration is mirrored onto a fresh sync ApiClient
+        (see ``_sync_configuration_from_async``) so cleanup targets the same
+        cluster instead of falling back to the ambient kubeconfig. Per-claim
+        failures emit warnings to ``sys.stderr`` rather than raising — atexit
+        cleanup is best-effort.
         """
         try:
             claims = list(self._active_connection_sandboxes.keys())
             if not claims:
                 return
 
-            helper = K8sHelper()
+            atexit_api_client = None
+            if self._atexit_api_client_configuration is not None:
+                atexit_api_client = sync_client.ApiClient(
+                    configuration=_sync_configuration_from_async(self._atexit_api_client_configuration),
+                    cookie=self._atexit_api_client_cookie,
+                )
+                for name, value in self._atexit_api_client_default_headers.items():
+                    atexit_api_client.set_default_header(name, value)
+
+            helper = K8sHelper(api_client=atexit_api_client)
             for ns, claim_name in claims:
                 try:
                     helper.delete_sandbox_claim(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -26,6 +26,8 @@ import sys
 import uuid
 from typing import Generic, TypeVar
 
+from kubernetes_asyncio import client as async_client
+
 from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
@@ -81,6 +83,7 @@ class AsyncSandboxClient(Generic[T]):
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         cleanup: bool = True,
+        api_client: async_client.ApiClient | None = None,
     ):
         """
         Args:
@@ -100,6 +103,9 @@ class AsyncSandboxClient(Generic[T]):
                 caller forgets to clean up; pass ``cleanup=False`` to opt
                 out. Note this differs from the synchronous ``SandboxClient``,
                 which defaults to False.
+            api_client: Optional pre-configured ``kubernetes_asyncio`` ``ApiClient``
+                forwarded to the underlying ``AsyncK8sHelper`` to target a specific
+                cluster/context.
         """
         if connection_config is None:
             raise ValueError(
@@ -116,7 +122,7 @@ class AsyncSandboxClient(Generic[T]):
             initialize_tracer(self.tracer_config.trace_service_name)
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
-        self.k8s_helper = AsyncK8sHelper()
+        self.k8s_helper = AsyncK8sHelper(api_client=api_client)
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -21,6 +21,7 @@ Requires the ``async`` optional dependencies::
 
 import atexit
 import asyncio
+import copy
 import logging
 import sys
 import uuid
@@ -47,45 +48,22 @@ T = TypeVar("T", bound=AsyncSandbox)
 # unresponsive apiserver would otherwise hang process exit indefinitely.
 _ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS = 300
 
-# Connection/auth fields copied from an injected kubernetes_asyncio
-# Configuration onto the sync kubernetes.client.Configuration built for
-# atexit cleanup. kubernetes.client and kubernetes_asyncio.client are
-# separate generated packages that happen to expose the same attribute names
-# for these fields, but they aren't interchangeable: e.g. the sync client's
-# urllib3 transport reads configuration.no_proxy, which the async
-# Configuration class doesn't define, so passing an async Configuration
-# directly into a sync ApiClient risks an AttributeError. Hence an explicit
-# allowlist instead of reusing the object or copying its whole __dict__.
-_ATEXIT_CONFIGURATION_FIELDS = (
-    "host",
-    "api_key",
-    "api_key_prefix",
-    "username",
-    "password",
-    "ssl_ca_cert",
-    "cert_file",
-    "key_file",
-    "verify_ssl",
-    "assert_hostname",
-    "proxy",
-    "proxy_headers",
-    "connection_pool_maxsize",
-    "retries",
-    "socket_options",
-    "tls_server_name",
-    "refresh_api_key_hook",
-    "discard_unknown_keys",
-)
-
-
 def _sync_configuration_from_async(async_configuration) -> sync_client.Configuration:
     """Mirrors an injected ``kubernetes_asyncio`` ``Configuration`` onto a
     ``kubernetes`` one, so atexit cleanup's synchronous ``K8sHelper`` targets
     the same cluster/credentials as the caller's injected ``api_client``.
+
+    Shallow copying and reclassing is used as the two classes have the same underlying
+    layout (plain ``__dict__`` attribute bags) but are different types, so re-using the configuration
+    object directly would break the sync client due to its async methods returning unawaited coroutines.
     """
-    sync_configuration = sync_client.Configuration()
-    for field in _ATEXIT_CONFIGURATION_FIELDS:
-        setattr(sync_configuration, field, getattr(async_configuration, field))
+    sync_configuration = copy.copy(async_configuration)
+    sync_configuration.__class__ = sync_client.Configuration
+    # The sync client reads this unconditionally when a proxy is set, but the async Configuration class
+    # never sets it, so we give it an explicit default.
+    sync_configuration.no_proxy = None
+    # An async refresh hook would never be awaited by the sync client, so we use the existing api_key value.
+    sync_configuration.refresh_api_key_hook = None
     return sync_configuration
 
 
@@ -165,13 +143,8 @@ class AsyncSandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         self.k8s_helper = AsyncK8sHelper(api_client=api_client)
-        self._atexit_api_client_configuration = (
-            api_client.configuration if api_client is not None else None
-        )
-        self._atexit_api_client_default_headers = (
-            dict(api_client.default_headers) if api_client is not None else {}
-        )
-        self._atexit_api_client_cookie = api_client.cookie if api_client is not None else None
+        # Held so atexit cleanup can read configuration/default_headers/cookie live at cleanup time
+        self._injected_api_client = api_client
 
         self._active_connection_sandboxes: dict[tuple[str, str], T] = {}
         self._lock = asyncio.Lock()
@@ -442,17 +415,17 @@ class AsyncSandboxClient(Generic[T]):
 
         Uses the synchronous :class:`K8sHelper` rather than kubernetes_asyncio,
         even though this class is otherwise fully async. atexit runs during
-        interpreter shutdown, after Python has begun tearing down its
-        process-wide thread pool; kubernetes_asyncio's aiohttp transport does a
+        interpreter shutdown, after Python has begun blocking new work on any
+        ``ThreadPoolExecutor``; kubernetes_asyncio's aiohttp transport does a
         per-request netrc lookup via a background thread, which raises "cannot
-        schedule new futures after interpreter shutdown" once that teardown has
-        started. The synchronous client's urllib3 transport has no event loop or
-        executor dependency, so it isn't affected. When an ApiClient was
-        injected, its Configuration is mirrored onto a fresh sync ApiClient
-        (see ``_sync_configuration_from_async``) so cleanup targets the same
-        cluster instead of falling back to the ambient kubeconfig. Per-claim
-        failures emit warnings to ``sys.stderr`` rather than raising — atexit
-        cleanup is best-effort.
+        schedule new futures after interpreter shutdown" once that block has
+        taken effect. The synchronous client's urllib3 transport has no event loop or
+        executor dependency, so it isn't affected. When an ApiClient is
+        injected, its configuration/default_headers/cookie are read live off
+        that client at cleanup time (so a caller that refreshes credentials
+        after construction still gets a cleanup client with current
+        credentials) and mirrored onto a fresh sync ApiClient so cleanup targets the same
+        cluster instead of falling back to the ambient kubeconfig.
         """
         try:
             claims = list(self._active_connection_sandboxes.keys())
@@ -460,12 +433,12 @@ class AsyncSandboxClient(Generic[T]):
                 return
 
             atexit_api_client = None
-            if self._atexit_api_client_configuration is not None:
+            if self._injected_api_client is not None:
                 atexit_api_client = sync_client.ApiClient(
-                    configuration=_sync_configuration_from_async(self._atexit_api_client_configuration),
-                    cookie=self._atexit_api_client_cookie,
+                    configuration=_sync_configuration_from_async(self._injected_api_client.configuration),
+                    cookie=self._injected_api_client.cookie,
                 )
-                for name, value in self._atexit_api_client_default_headers.items():
+                for name, value in dict(self._injected_api_client.default_headers).items():
                     atexit_api_client.set_default_header(name, value)
 
             helper = K8sHelper(api_client=atexit_api_client)

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -42,13 +42,16 @@ from .constants import (
 class K8sHelper:
     """Helper class for Kubernetes API interactions."""
 
-    def __init__(self):
-        try:
-            config.load_incluster_config()
-        except config.ConfigException:
-            config.load_kube_config()
-        self.custom_objects_api = client.CustomObjectsApi()
-        self.core_v1_api = client.CoreV1Api()
+    def __init__(self, api_client: client.ApiClient | None = None):
+        """When ``api_client`` is provided it is used directly; otherwise the
+        default kubeconfig (in-cluster, then ``~/.kube/config``) is loaded."""
+        if api_client is None:
+            try:
+                config.load_incluster_config()
+            except config.ConfigException:
+                config.load_kube_config()
+        self.custom_objects_api = client.CustomObjectsApi(api_client)
+        self.core_v1_api = client.CoreV1Api(api_client)
 
     def create_sandbox_claim(
         self,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -43,8 +43,8 @@ class K8sHelper:
     """Helper class for Kubernetes API interactions."""
 
     def __init__(self, api_client: client.ApiClient | None = None):
-        """When ``api_client`` is provided it is used directly; otherwise the
-        default kubeconfig (in-cluster, then ``~/.kube/config``) is loaded."""
+        """When ``api_client`` is provided it is used directly; otherwise the underlying Kubernetes client
+        config is loaded (in-cluster, then ``KUBECONFIG``, falling back to ``~/.kube/config`` if unset)."""
         if api_client is None:
             try:
                 config.load_incluster_config()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/sandbox_client.py
@@ -23,6 +23,8 @@ import sys
 import logging
 from typing import List, Dict, Tuple, TypeVar, Generic, Type
 
+from kubernetes import client
+
 # Import all tracing components from the trace_manager module
 from .trace_manager import (
     create_tracer_manager, initialize_tracer, trace_span, trace
@@ -57,6 +59,7 @@ class SandboxClient(Generic[T]):
         connection_config: SandboxConnectionConfig | None = None,
         tracer_config: SandboxTracerConfig | None = None,
         cleanup: bool = False,
+        api_client: client.ApiClient | None = None,
     ):
         """
         Initializes the SandboxClient.
@@ -70,6 +73,8 @@ class SandboxClient(Generic[T]):
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
             cleanup: If True, registers an atexit hook to automatically delete 
                 all tracked sandboxes when the program terminates. Defaults to False.
+            api_client: Optional pre-configured Kubernetes ``ApiClient`` forwarded
+                to the underlying ``K8sHelper`` to target a specific cluster/context.
         """
         # Sandbox related configuration
         self.connection_config = connection_config or SandboxLocalTunnelConnectionConfig()
@@ -81,7 +86,7 @@ class SandboxClient(Generic[T]):
         self.tracing_manager, self.tracer = create_tracer_manager(self.tracer_config)
 
         # Downstream Kubernetes Configuration
-        self.k8s_helper = K8sHelper()
+        self.k8s_helper = K8sHelper(api_client=api_client)
         
         # Tracks all the active client side connections to the created sandbox claims
         self._active_connection_sandboxes: Dict[Tuple[str, str], T] = {}

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -792,5 +792,24 @@ class TestAsyncK8sHelperWaitForGatewayIP(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(ip, "192.168.1.1")
 
 
+@patch("k8s_agent_sandbox.async_k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.async_k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.async_k8s_helper.client.ApiClient")
+@patch("k8s_agent_sandbox.async_k8s_helper.config")
+class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
+
+    async def test_injected_api_client_used_and_no_config_loaded(
+        self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
+    ):
+        injected = AsyncMock(name="ApiClient")
+        helper = AsyncK8sHelper(api_client=injected)
+        await helper._ensure_initialized()
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+        mock_api_client_cls.assert_not_called()
+        mock_custom_cls.assert_called_once_with(injected)
+        mock_core_cls.assert_called_once_with(injected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -810,6 +810,23 @@ class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
         mock_custom_cls.assert_called_once_with(injected)
         mock_core_cls.assert_called_once_with(injected)
 
+        # A caller-injected client must not be closed by the helper.
+        await helper.close()
+        injected.close.assert_not_awaited()
+
+    async def test_internally_created_api_client_is_closed(
+        self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
+    ):
+        created = AsyncMock(name="ApiClient")
+        mock_api_client_cls.return_value = created
+        helper = AsyncK8sHelper()
+        await helper._ensure_initialized()
+        mock_api_client_cls.assert_called_once_with()
+
+        # A client the helper created must be closed.
+        await helper.close()
+        created.close.assert_awaited_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_k8s_helper.py
@@ -814,6 +814,21 @@ class TestAsyncK8sHelperApiClientInjection(unittest.IsolatedAsyncioTestCase):
         await helper.close()
         injected.close.assert_not_awaited()
 
+    async def test_injected_api_client_still_used_after_close(
+        self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
+    ):
+        injected = AsyncMock(name="ApiClient")
+        helper = AsyncK8sHelper(api_client=injected)
+
+        await helper.close()
+        await helper._ensure_initialized()
+
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+        mock_api_client_cls.assert_not_called()
+        mock_custom_cls.assert_called_once_with(injected)
+        mock_core_cls.assert_called_once_with(injected)
+
     async def test_internally_created_api_client_is_closed(
         self, mock_config, mock_api_client_cls, mock_custom_cls, mock_core_cls
     ):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -29,6 +29,9 @@ import pytest
 httpx = pytest.importorskip("httpx")
 pytest.importorskip("kubernetes_asyncio")
 
+from kubernetes import client as sync_client
+from kubernetes_asyncio import client as async_client
+
 from k8s_agent_sandbox.async_connector import AsyncSandboxConnector
 from k8s_agent_sandbox.async_sandbox import AsyncSandbox
 from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient, _ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
@@ -288,6 +291,43 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         mock_helper_instance.delete_sandbox_claim.assert_any_call(
             "claim-xyz", "other-ns", _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
         )
+
+    def test_atexit_cleanup_does_not_fall_back_to_default_kubeconfig_with_injected_api_client(self):
+        """Atexit cleanup should preserve the cluster targeted by an injected ApiClient.
+
+        The atexit hook uses the synchronous K8sHelper (see
+        _sync_configuration_from_async), so this asserts on a real sync
+        kubernetes.client.Configuration mirroring the injected async one,
+        rather than object identity across the two client libraries.
+        """
+        injected_configuration = async_client.Configuration(host="https://tenant-a.example.com")
+        injected_configuration.verify_ssl = False
+        injected_api_client = MagicMock(name="InjectedApiClient")
+        injected_api_client.configuration = injected_configuration
+        injected_api_client.default_headers = {"Impersonate-User": "tenant-a"}
+        injected_api_client.cookie = "session=abc"
+        client = AsyncSandboxClient(
+            connection_config=self.config,
+            cleanup=False,
+            api_client=injected_api_client,
+        )
+        client._active_connection_sandboxes = {("tenant-ns", "claim-abc"): MagicMock()}
+        mock_helper_instance = MagicMock()
+        mock_helper_instance.delete_sandbox_claim = MagicMock()
+
+        with patch(
+            "k8s_agent_sandbox.async_sandbox_client.K8sHelper",
+            return_value=mock_helper_instance,
+        ) as MockHelper:
+            client._atexit_cleanup()
+
+        MockHelper.assert_called_once()
+        atexit_api_client = MockHelper.call_args.kwargs["api_client"]
+        self.assertIsInstance(atexit_api_client, sync_client.ApiClient)
+        self.assertEqual(atexit_api_client.configuration.host, "https://tenant-a.example.com")
+        self.assertFalse(atexit_api_client.configuration.verify_ssl)
+        self.assertEqual(atexit_api_client.cookie, "session=abc")
+        self.assertEqual(atexit_api_client.default_headers.get("Impersonate-User"), "tenant-a")
 
     def test_atexit_cleanup_skips_when_no_sandboxes(self):
         """_atexit_cleanup should be a no-op when there are no tracked sandboxes."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -246,6 +246,12 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             AsyncSandboxClient(connection_config=None)
         self.assertIn("connection_config is required", str(ctx.exception))
 
+    def test_api_client_forwarded_to_k8s_helper(self):
+        sentinel = MagicMock(name="ApiClient")
+        with patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper") as MockHelper:
+            AsyncSandboxClient(connection_config=self.config, cleanup=False, api_client=sentinel)
+            MockHelper.assert_called_once_with(api_client=sentinel)
+
     def test_cleanup_default_registers_atexit(self):
         """Constructing without cleanup= should default to True and register the hook."""
         with patch("k8s_agent_sandbox.async_sandbox_client.atexit") as mock_atexit:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import warnings
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
@@ -274,7 +275,6 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             mock_atexit.register.assert_not_called()
 
     def test_atexit_cleanup_deletes_tracked_claims(self):
-        """_atexit_cleanup should open a fresh K8sHelper and delete all tracked claims."""
         self.client._active_connection_sandboxes = {
             ("default", "claim-abc"): MagicMock(),
             ("other-ns", "claim-xyz"): MagicMock(),
@@ -293,13 +293,7 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_atexit_cleanup_does_not_fall_back_to_default_kubeconfig_with_injected_api_client(self):
-        """Atexit cleanup should preserve the cluster targeted by an injected ApiClient.
-
-        The atexit hook uses the synchronous K8sHelper (see
-        _sync_configuration_from_async), so this asserts on a real sync
-        kubernetes.client.Configuration mirroring the injected async one,
-        rather than object identity across the two client libraries.
-        """
+        """Atexit cleanup should preserve the cluster targeted by an injected ApiClient."""
         injected_configuration = async_client.Configuration(host="https://tenant-a.example.com")
         injected_configuration.verify_ssl = False
         injected_api_client = MagicMock(name="InjectedApiClient")
@@ -329,16 +323,97 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(atexit_api_client.cookie, "session=abc")
         self.assertEqual(atexit_api_client.default_headers.get("Impersonate-User"), "tenant-a")
 
+    def test_atexit_cleanup_reflects_injected_client_state_at_cleanup_time_not_construction_time(self):
+        injected_configuration = async_client.Configuration(host="https://old.example.com")
+        injected_api_client = MagicMock(name="InjectedApiClient")
+        injected_api_client.configuration = injected_configuration
+        injected_api_client.default_headers = {"Authorization": "Bearer old-token"}
+        injected_api_client.cookie = "session=old"
+        client = AsyncSandboxClient(
+            connection_config=self.config,
+            cleanup=False,
+            api_client=injected_api_client,
+        )
+        client._active_connection_sandboxes = {("tenant-ns", "claim-abc"): MagicMock()}
+        mock_helper_instance = MagicMock()
+        mock_helper_instance.delete_sandbox_claim = MagicMock()
+
+        refreshed_configuration = async_client.Configuration(host="https://refreshed.example.com")
+        injected_api_client.configuration = refreshed_configuration
+        injected_api_client.default_headers["Authorization"] = "Bearer refreshed-token"
+        injected_api_client.cookie = "session=refreshed"
+
+        with patch(
+            "k8s_agent_sandbox.async_sandbox_client.K8sHelper",
+            return_value=mock_helper_instance,
+        ) as MockHelper:
+            client._atexit_cleanup()
+
+        atexit_api_client = MockHelper.call_args.kwargs["api_client"]
+        self.assertEqual(atexit_api_client.configuration.host, "https://refreshed.example.com")
+        self.assertEqual(atexit_api_client.cookie, "session=refreshed")
+        self.assertEqual(
+            atexit_api_client.default_headers.get("Authorization"), "Bearer refreshed-token"
+        )
+
+    def test_atexit_cleanup_does_not_copy_async_refresh_api_key_hook(self):
+        """kubernetes_asyncio's get_api_key_with_prefix awaits the hook's return value when it's a coroutine;
+        the sync client's get_api_key_with_prefix does not. Copying the hook reference across would make the sync
+        client invoke it, get back an un-awaited coroutine (with a RuntimeWarning), and never actually refresh.
+        The hook must be excluded, and whatever api_key value is already live used instead.
+        """
+        async def async_refresh_hook(config):
+            config.api_key["BearerToken"] = "should-not-be-used"
+
+        injected_configuration = async_client.Configuration(host="https://tenant-a.example.com")
+        injected_configuration.api_key["BearerToken"] = "live-token"
+        injected_configuration.refresh_api_key_hook = async_refresh_hook
+        injected_api_client = MagicMock(name="InjectedApiClient")
+        injected_api_client.configuration = injected_configuration
+        injected_api_client.default_headers = {}
+        injected_api_client.cookie = None
+        client = AsyncSandboxClient(
+            connection_config=self.config,
+            cleanup=False,
+            api_client=injected_api_client,
+        )
+        client._active_connection_sandboxes = {("tenant-ns", "claim-abc"): MagicMock()}
+        mock_helper_instance = MagicMock()
+        mock_helper_instance.delete_sandbox_claim = MagicMock()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with patch(
+                "k8s_agent_sandbox.async_sandbox_client.K8sHelper",
+                return_value=mock_helper_instance,
+            ) as MockHelper:
+                client._atexit_cleanup()
+
+        self.assertFalse(
+            any("was never awaited" in str(w.message) for w in caught),
+            "copying an async refresh_api_key_hook must not leave an un-awaited coroutine",
+        )
+        atexit_api_client = MockHelper.call_args.kwargs["api_client"]
+        self.assertIsNone(atexit_api_client.configuration.refresh_api_key_hook)
+        self.assertEqual(
+            atexit_api_client.configuration.get_api_key_with_prefix("BearerToken"), "live-token"
+        )
+
+    def test_sync_configuration_from_async_relies_on_no_slots(self):
+        """_sync_configuration_from_async reclasses a shallow copy of the async client's configuration, which only
+        works because neither Configuration class uses __slots__. If a future kubernetes/kubernetes_asyncio release adds
+        __slots__ to either class, reclassing would raise TypeError.
+        """
+        self.assertFalse(hasattr(sync_client.Configuration, "__slots__"))
+        self.assertFalse(hasattr(async_client.Configuration, "__slots__"))
+
     def test_atexit_cleanup_skips_when_no_sandboxes(self):
-        """_atexit_cleanup should be a no-op when there are no tracked sandboxes."""
         self.client._active_connection_sandboxes = {}
         with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper") as MockHelper:
             self.client._atexit_cleanup()
             MockHelper.assert_not_called()
 
     def test_atexit_cleanup_suppresses_errors(self):
-        """_atexit_cleanup should not propagate exceptions — cleanup is best-effort.
-        A warning is printed to stderr so the user knows a sandbox was orphaned."""
         self.client._active_connection_sandboxes = {("default", "claim-abc"): MagicMock()}
         mock_helper_instance = MagicMock()
         mock_helper_instance.delete_sandbox_claim = MagicMock(side_effect=Exception("network error"))
@@ -351,8 +426,6 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
                 mock_stderr.write.assert_called()
 
     def test_atexit_cleanup_suppresses_helper_construction_errors(self):
-        """A failure constructing K8sHelper itself (e.g. no reachable kubeconfig)
-        must not escape _atexit_cleanup either — cleanup is best-effort."""
         self.client._active_connection_sandboxes = {("default", "claim-abc"): MagicMock()}
 
         with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper", side_effect=Exception("no kubeconfig")):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -898,5 +898,21 @@ class TestK8sHelperWatchResourceVersion(unittest.TestCase):
         self.assertEqual(ctx.exception.status, 403)
 
 
+@patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
+@patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")
+@patch("k8s_agent_sandbox.k8s_helper.config")
+class TestK8sHelperApiClientInjection(unittest.TestCase):
+
+    def test_injected_api_client_used_and_no_config_loaded(
+        self, mock_config, mock_custom_cls, mock_core_cls
+    ):
+        sentinel = MagicMock(name="ApiClient")
+        K8sHelper(api_client=sentinel)
+        mock_custom_cls.assert_called_once_with(sentinel)
+        mock_core_cls.assert_called_once_with(sentinel)
+        mock_config.load_incluster_config.assert_not_called()
+        mock_config.load_kube_config.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_sandboxclient.py
@@ -49,6 +49,12 @@ class TestSandboxClient(unittest.TestCase):
         self.mock_sandbox_class = MagicMock()
         self.client.sandbox_class = self.mock_sandbox_class
 
+    @patch('k8s_agent_sandbox.sandbox_client.K8sHelper')
+    def test_api_client_forwarded_to_k8s_helper(self, MockK8sHelper):
+        sentinel = MagicMock(name="ApiClient")
+        SandboxClient(api_client=sentinel)
+        MockK8sHelper.assert_called_once_with(api_client=sentinel)
+
     @patch('uuid.uuid4')
     def test_create_sandbox_success(self, mock_uuid):
         mock_uuid.return_value.hex = '1234abcd'

--- a/docs/python_sdk_reference.md
+++ b/docs/python_sdk_reference.md
@@ -30,7 +30,8 @@ type: ignore
 ```python
 def __init__(connection_config: SandboxConnectionConfig | None = None,
              tracer_config: SandboxTracerConfig | None = None,
-             cleanup: bool = False)
+             cleanup: bool = False,
+             api_client: client.ApiClient | None = None)
 ```
 
 Initializes the SandboxClient.
@@ -45,6 +46,8 @@ Initializes the SandboxClient.
   Defaults to an empty SandboxTracerConfig (tracing disabled).
 - `cleanup` - If True, registers an atexit hook to automatically delete
   all tracked sandboxes when the program terminates. Defaults to False.
+- `api_client` - Optional pre-configured Kubernetes ``ApiClient`` forwarded
+  to the underlying ``K8sHelper`` to target a specific cluster/context.
 
 <a id="k8s_agent_sandbox.sandbox_client.SandboxClient.create_sandbox"></a>
 


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

This PR adds an optional `api_client` parameter in the Python SDK's `SandboxClient`, `K8sHelper`, `AsyncSandboxClient`, and `AsyncK8sHelper` constructors to support multi-cluster/context environments.

**Credit:** The first four commits are all @vincent0426's work in #1088. I took over the PR after it was marked stale and added `api_client` state tracking for accurate atexit cleanup in ac7a31b and updated documentation with some examples in 884f4bc.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #1069 and fixes #1201 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
The Python SDK's `SandboxClient`, `K8sHelper`, `AsyncSandboxClient`, and `AsyncK8sHelper` now accept an optional pre-configured `api_client`, letting callers target a specific cluster/context (e.g. multi-cluster setups or tests) instead of relying on `KUBECONFIG`/`~/.kube/config`.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional preconfigured Kubernetes API client support for synchronous and asynchronous sandbox clients.
  * Applications can target specific clusters, contexts, kubeconfig files, or multiple clusters.
  * Existing in-cluster and kubeconfig-based configuration remains supported.
  * Caller-provided clients remain under application control; internally created clients close automatically.
  * Cleanup uses the client’s latest connection and authentication settings, with request timeouts supported.

* **Documentation**
  * Added usage examples, lifecycle guidance, and local-tunnel behavior details.
  * Updated the Python SDK reference with the new parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->