### PR TITLE
fix(python-sdk): use synchronous client for atexit sandbox cleanup

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -39,6 +39,11 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=AsyncSandbox)
 
+# Bounds each per-claim delete issued by the atexit cleanup below. urllib3
+# (used by the synchronous K8sHelper) has no default read timeout, so an
+# unresponsive apiserver would otherwise hang process exit indefinitely.
+_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS = 300
+
 
 class AsyncSandboxClient(Generic[T]):
     """
@@ -399,7 +404,9 @@ class AsyncSandboxClient(Generic[T]):
             helper = K8sHelper()
             for ns, claim_name in claims:
                 try:
-                    helper.delete_sandbox_claim(claim_name, ns)
+                    helper.delete_sandbox_claim(
+                        claim_name, ns, _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
+                    )
                 except Exception as e:
                     if sys.stderr is not None:
                         print(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_sandbox_client.py
@@ -29,6 +29,7 @@ from typing import Generic, TypeVar
 from .async_k8s_helper import AsyncK8sHelper
 from .async_sandbox import AsyncSandbox
 from .exceptions import SandboxNotFoundError
+from .k8s_helper import K8sHelper
 from .pod_metadata import build_pod_metadata, validate_labels
 from .utils import construct_sandbox_claim_lifecycle_spec
 from .models import SandboxConnectionConfig, SandboxInClusterConnectionConfig, SandboxTracerConfig
@@ -85,14 +86,15 @@ class AsyncSandboxClient(Generic[T]):
                 Defaults to an empty SandboxTracerConfig (tracing disabled).
             cleanup: If True, registers an atexit hook to automatically delete
                 all tracked sandboxes when the program terminates. The hook
-                snapshots the tracked claim names and opens fresh async
-                resources in a new event loop, so it is safe to call after
-                the main event loop has exited. Cleanup is best-effort —
-                per-claim and top-level failures emit warnings to
-                ``sys.stderr`` rather than raising. Defaults to True so that
-                sandboxes are not leaked when a caller forgets to clean up;
-                pass ``cleanup=False`` to opt out. Note this differs from the
-                synchronous ``SandboxClient``, which defaults to False.
+                uses a snapshot of the tracked claim names and the
+                synchronous ``K8sHelper``, which has no event loop
+                dependency, so it works correctly during interpreter
+                shutdown. Cleanup is best-effort — per-claim and top-level
+                failures emit warnings to ``sys.stderr`` rather than raising.
+                Defaults to True so that sandboxes are not leaked when a
+                caller forgets to clean up; pass ``cleanup=False`` to opt
+                out. Note this differs from the synchronous ``SandboxClient``,
+                which defaults to False.
         """
         if connection_config is None:
             raise ValueError(
@@ -376,38 +378,35 @@ class AsyncSandboxClient(Generic[T]):
                 logger.error(f"Cleanup failed for {claim_name} in namespace {ns}: {e}")
 
     def _atexit_cleanup(self):
-        """Best-effort atexit handler that deletes all tracked sandbox claims.
+        """Best-effort atexit handler that deletes the current snapshot of tracked sandbox claims.
 
-        Uses a snapshot of the tracked claims and a fresh :class:`AsyncK8sHelper`
-        so that no loop-bound objects from the original client are reused across
-        event loop boundaries. Per-claim failures and top-level errors emit
+        Uses the synchronous :class:`K8sHelper` rather than kubernetes_asyncio,
+        even though this class is otherwise fully async. atexit runs during
+        interpreter shutdown, after Python has begun tearing down its
+        process-wide thread pool; kubernetes_asyncio's aiohttp transport does a
+        per-request netrc lookup via a background thread, which raises "cannot
+        schedule new futures after interpreter shutdown" once that teardown has
+        started. The synchronous client's urllib3 transport has no event loop or
+        executor dependency, so it isn't affected. Per-claim failures emit
         warnings to ``sys.stderr`` rather than raising — atexit cleanup is
         best-effort.
         """
-        claims = list(self._active_connection_sandboxes.keys())
-        if not claims:
-            return
-
-        async def _do_cleanup():
-            helper = AsyncK8sHelper()
-            try:
-                async def _delete_one(ns, claim_name):
-                    try:
-                        await helper.delete_sandbox_claim(claim_name, ns)
-                    except Exception as e:
-                        if sys.stderr is not None:
-                            print(
-                                f"[agent-sandbox] Warning: failed to delete sandbox claim "
-                                f"'{claim_name}' in namespace '{ns}' during atexit cleanup: {e}",
-                                file=sys.stderr,
-                            )
-
-                await asyncio.gather(*(_delete_one(ns, claim_name) for ns, claim_name in claims))
-            finally:
-                await helper.close()
-
         try:
-            asyncio.run(_do_cleanup())
+            claims = list(self._active_connection_sandboxes.keys())
+            if not claims:
+                return
+
+            helper = K8sHelper()
+            for ns, claim_name in claims:
+                try:
+                    helper.delete_sandbox_claim(claim_name, ns)
+                except Exception as e:
+                    if sys.stderr is not None:
+                        print(
+                            f"[agent-sandbox] Warning: failed to delete sandbox claim "
+                            f"'{claim_name}' in namespace '{ns}' during atexit cleanup: {e}",
+                            file=sys.stderr,
+                        )
         except Exception as e:
             if sys.stderr is not None:
                 print(

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/k8s_helper.py
@@ -297,15 +297,23 @@ class K8sHelper:
                     w.stop()
                     raise SandboxNotFoundError(f"Sandbox {name} was deleted before becoming ready.")
 
-    def delete_sandbox_claim(self, name: str, namespace: str):
-        """Deletes a SandboxClaim custom resource."""
+    def delete_sandbox_claim(
+        self, name: str, namespace: str, _request_timeout: float | tuple[float, float] | None = None
+    ):
+        """Deletes a SandboxClaim custom resource.
+
+        Args:
+            _request_timeout: Optional timeout (seconds, or a ``(connect, read)``
+                pair) forwarded to the underlying urllib3-based request.
+        """
         try:
             self.custom_objects_api.delete_namespaced_custom_object(
                 group=CLAIM_API_GROUP,
                 version=CLAIM_API_VERSION,
                 namespace=namespace,
                 plural=CLAIM_PLURAL_NAME,
-                name=name
+                name=name,
+                _request_timeout=_request_timeout,
             )
             logging.info(f"Terminated SandboxClaim: {name}")
         except client.ApiException as e:

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -261,26 +261,24 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
             mock_atexit.register.assert_not_called()
 
     def test_atexit_cleanup_deletes_tracked_claims(self):
-        """_atexit_cleanup should open a fresh AsyncK8sHelper and delete all tracked claims."""
+        """_atexit_cleanup should open a fresh K8sHelper and delete all tracked claims."""
         self.client._active_connection_sandboxes = {
             ("default", "claim-abc"): MagicMock(),
             ("other-ns", "claim-xyz"): MagicMock(),
         }
         mock_helper_instance = MagicMock()
-        mock_helper_instance.delete_sandbox_claim = AsyncMock()
-        mock_helper_instance.close = AsyncMock()
+        mock_helper_instance.delete_sandbox_claim = MagicMock()
 
-        with patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper", return_value=mock_helper_instance):
+        with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper", return_value=mock_helper_instance):
             self.client._atexit_cleanup()
 
         mock_helper_instance.delete_sandbox_claim.assert_any_call("claim-abc", "default")
         mock_helper_instance.delete_sandbox_claim.assert_any_call("claim-xyz", "other-ns")
-        mock_helper_instance.close.assert_called_once()
 
     def test_atexit_cleanup_skips_when_no_sandboxes(self):
         """_atexit_cleanup should be a no-op when there are no tracked sandboxes."""
         self.client._active_connection_sandboxes = {}
-        with patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper") as MockHelper:
+        with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper") as MockHelper:
             self.client._atexit_cleanup()
             MockHelper.assert_not_called()
 
@@ -289,15 +287,41 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         A warning is printed to stderr so the user knows a sandbox was orphaned."""
         self.client._active_connection_sandboxes = {("default", "claim-abc"): MagicMock()}
         mock_helper_instance = MagicMock()
-        mock_helper_instance.delete_sandbox_claim = AsyncMock(side_effect=Exception("network error"))
-        mock_helper_instance.close = AsyncMock()
+        mock_helper_instance.delete_sandbox_claim = MagicMock(side_effect=Exception("network error"))
 
-        with patch("k8s_agent_sandbox.async_sandbox_client.AsyncK8sHelper", return_value=mock_helper_instance):
+        with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper", return_value=mock_helper_instance):
             with patch("k8s_agent_sandbox.async_sandbox_client.sys.stderr") as mock_stderr:
                 # Should not raise
                 self.client._atexit_cleanup()
                 # Should have printed a warning
                 mock_stderr.write.assert_called()
+
+    def test_atexit_cleanup_suppresses_helper_construction_errors(self):
+        """A failure constructing K8sHelper itself (e.g. no reachable kubeconfig)
+        must not escape _atexit_cleanup either — cleanup is best-effort."""
+        self.client._active_connection_sandboxes = {("default", "claim-abc"): MagicMock()}
+
+        with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper", side_effect=Exception("no kubeconfig")):
+            with patch("k8s_agent_sandbox.async_sandbox_client.sys.stderr") as mock_stderr:
+                # Should not raise
+                self.client._atexit_cleanup()
+                # Should have printed a warning
+                mock_stderr.write.assert_called()
+
+    def test_atexit_cleanup_suppresses_claim_snapshot_errors(self):
+        """A failure snapshotting _active_connection_sandboxes itself (e.g. a
+        concurrent mutation raising "dictionary changed size during
+        iteration") must not escape _atexit_cleanup either — cleanup is
+        best-effort."""
+        mock_sandboxes = MagicMock()
+        mock_sandboxes.keys.side_effect = RuntimeError("dictionary changed size during iteration")
+        self.client._active_connection_sandboxes = mock_sandboxes
+
+        with patch("k8s_agent_sandbox.async_sandbox_client.sys.stderr") as mock_stderr:
+            # Should not raise
+            self.client._atexit_cleanup()
+            # Should have printed a warning
+            mock_stderr.write.assert_called()
 
     async def test_validate_labels_rejects_invalid_value(self):
         with self.assertRaises(ValueError):

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -31,7 +31,7 @@ pytest.importorskip("kubernetes_asyncio")
 
 from k8s_agent_sandbox.async_connector import AsyncSandboxConnector
 from k8s_agent_sandbox.async_sandbox import AsyncSandbox
-from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
+from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient, _ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
 from k8s_agent_sandbox.exceptions import SandboxRequestError
 from k8s_agent_sandbox.models import (
     SandboxDirectConnectionConfig,
@@ -276,8 +276,12 @@ class TestAsyncSandboxClient(unittest.IsolatedAsyncioTestCase):
         with patch("k8s_agent_sandbox.async_sandbox_client.K8sHelper", return_value=mock_helper_instance):
             self.client._atexit_cleanup()
 
-        mock_helper_instance.delete_sandbox_claim.assert_any_call("claim-abc", "default")
-        mock_helper_instance.delete_sandbox_claim.assert_any_call("claim-xyz", "other-ns")
+        mock_helper_instance.delete_sandbox_claim.assert_any_call(
+            "claim-abc", "default", _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
+        )
+        mock_helper_instance.delete_sandbox_claim.assert_any_call(
+            "claim-xyz", "other-ns", _request_timeout=_ATEXIT_DELETE_REQUEST_TIMEOUT_SECONDS
+        )
 
     def test_atexit_cleanup_skips_when_no_sandboxes(self):
         """_atexit_cleanup should be a no-op when there are no tracked sandboxes."""

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -875,21 +875,33 @@ class AsyncSandboxHandler(BaseHTTPRequestHandler):
         pass
 
 
+def _start_stub_server(handler_cls):
+    """Starts handler_cls on a local HTTPServer on a daemon thread.
+
+    Returns (server, thread, port); pass to _stop_stub_server in tearDownClass.
+    """
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
+    port = server.server_address[1]
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, port
+
+
+def _stop_stub_server(server, thread):
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+
+
 class TestAsyncConnectorHTTP(unittest.IsolatedAsyncioTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.server = HTTPServer(("127.0.0.1", 0), AsyncSandboxHandler)
-        cls.port = cls.server.server_address[1]
-        cls.server_thread = Thread(target=cls.server.serve_forever)
-        cls.server_thread.daemon = True
-        cls.server_thread.start()
+        cls.server, cls.server_thread, cls.port = _start_stub_server(AsyncSandboxHandler)
 
     @classmethod
     def tearDownClass(cls):
-        cls.server.shutdown()
-        cls.server.server_close()
-        cls.server_thread.join(timeout=5)
+        _stop_stub_server(cls.server, cls.server_thread)
 
     def _make_connector(self) -> AsyncSandboxConnector:
         config = SandboxDirectConnectionConfig(
@@ -1267,17 +1279,11 @@ class TestAtexitCleanupRealInterpreterShutdown(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.server = HTTPServer(("127.0.0.1", 0), SandboxClaimDeleteHandler)
-        cls.port = cls.server.server_address[1]
-        cls.server_thread = Thread(target=cls.server.serve_forever)
-        cls.server_thread.daemon = True
-        cls.server_thread.start()
+        cls.server, cls.server_thread, cls.port = _start_stub_server(SandboxClaimDeleteHandler)
 
     @classmethod
     def tearDownClass(cls):
-        cls.server.shutdown()
-        cls.server.server_close()
-        cls.server_thread.join(timeout=5)
+        _stop_stub_server(cls.server, cls.server_thread)
 
     def setUp(self):
         SandboxClaimDeleteHandler.received_deletes = []

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -14,6 +14,10 @@
 
 import asyncio
 import json
+import os
+import subprocess
+import sys
+import tempfile
 import unittest
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -1235,6 +1239,115 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
                             "HTTPStatusError should clear gateway base_url cache")
         finally:
             await connector.close()
+
+
+class SandboxClaimDeleteHandler(BaseHTTPRequestHandler):
+    """Stub K8s apiserver; only handles the DELETE call atexit cleanup makes."""
+
+    received_deletes = []
+
+    def do_DELETE(self):
+        self.__class__.received_deletes.append(self.path)
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        payload = b"{}"
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass  # silence BaseHTTPRequestHandler's default per-request access-log line
+
+
+class TestAtexitCleanupRealInterpreterShutdown(unittest.TestCase):
+    """Regression test for a bug where AsyncSandboxClient's atexit cleanup only failed at real interpreter shutdown: 
+    kubernetes_asyncio's aiohttp transport dispatches a per-request netrc lookup via a background thread, which fails
+    once Python's own thread-pool teardown has begun. No in-process test can reproduce that condition because the 
+    interpreter never actually exits mid-suite, so this spawns a real subprocess and lets it exit for real."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = HTTPServer(("127.0.0.1", 0), SandboxClaimDeleteHandler)
+        cls.port = cls.server.server_address[1]
+        cls.server_thread = Thread(target=cls.server.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.server_thread.join(timeout=5)
+
+    def setUp(self):
+        SandboxClaimDeleteHandler.received_deletes = []
+
+    def _write_fake_kubeconfig(self) -> str:
+        fd, path = tempfile.mkstemp(suffix=".yaml")
+        with os.fdopen(fd, "w") as f:
+            f.write(f"""\
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: http://127.0.0.1:{self.port}
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user: {{}}
+""")
+        self.addCleanup(os.remove, path)
+        return path
+
+    def test_atexit_cleanup_deletes_claim_on_real_process_exit(self):
+        kubeconfig_path = self._write_fake_kubeconfig()
+        script = """
+import asyncio
+from k8s_agent_sandbox.async_sandbox_client import AsyncSandboxClient
+from k8s_agent_sandbox.models import SandboxDirectConnectionConfig
+
+async def main():
+    client = AsyncSandboxClient(
+        connection_config=SandboxDirectConnectionConfig(api_url="http://unused:8080"),
+        cleanup=True,
+    )
+    client._active_connection_sandboxes[("default", "claim-abc")] = object()
+
+asyncio.run(main())
+# No explicit close()/delete_all() — relying entirely on the atexit hook.
+"""
+        # K8sHelper.__init__ tries load_incluster_config() before falling
+        # back to KUBECONFIG. If the parent process happens to be running
+        # inside a real pod (e.g. in CI), KUBERNETES_SERVICE_HOST/PORT are
+        # already set and inherited via os.environ, which would make the
+        # subprocess skip KUBECONFIG entirely and talk to the real in-cluster
+        # apiserver instead of this stub. Strip them so it deterministically
+        # falls through to the fake kubeconfig.
+        env = dict(os.environ)
+        for k in ("KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT", "KUBERNETES_PORT"):
+            env.pop(k, None)
+        env["KUBECONFIG"] = kubeconfig_path
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("Traceback", result.stderr, result.stderr)
+        self.assertEqual(
+            SandboxClaimDeleteHandler.received_deletes,
+            ["/apis/extensions.agents.x-k8s.io/v1beta1/namespaces/default/sandboxclaims/claim-abc"],
+        )
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_k8s_helper.py
@@ -425,6 +425,24 @@ class TestK8sHelperDeleteSandboxClaim(unittest.TestCase):
             helper.delete_sandbox_claim("claim", "default")
         self.assertEqual(ctx.exception.status, 403)
 
+    def test_delete_defaults_to_no_request_timeout(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.delete_sandbox_claim("claim", "default")
+
+        self.assertIsNone(mock_api.delete_namespaced_custom_object.call_args.kwargs["_request_timeout"])
+
+    def test_delete_forwards_request_timeout(self, mock_config, mock_api_cls, mock_core_cls):
+        mock_api = MagicMock()
+        mock_api_cls.return_value = mock_api
+
+        helper = K8sHelper()
+        helper.delete_sandbox_claim("claim", "default", _request_timeout=30)
+
+        self.assertEqual(mock_api.delete_namespaced_custom_object.call_args.kwargs["_request_timeout"], 30)
+
 
 @patch("k8s_agent_sandbox.k8s_helper.client.CoreV1Api")
 @patch("k8s_agent_sandbox.k8s_helper.client.CustomObjectsApi")


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

This PR fixes a bug in `AsyncSandboxClient`'s `atexit`'s default cleanup (i.e. cleanup=True) by switching it from the async `kubernetes_asyncio` client to the synchronous `K8sHelper` already used by `SandboxClient`.

The `atexit` hook built a fresh event loop and client via asyncio.run() to delete sandboxes on exit, since the original loop and its session are already gone by then. Building that new client means kubernetes_asyncio's `aiohttp` transport (trust_env=True) dispatches a netrc lookup to a background thread via loop.run_in_executor() on its first request — but interpreter shutdown has already disabled new thread scheduling by that point, so the dispatch fails before the delete request is even sent, silently leaking the sandbox.

The synchronous client's urllib3 transport has no event loop or thread dependency, so it isn't affected by interpreter shutdown.

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #1510

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
Fixed AsyncSandboxClient's atexit default cleanup, which previously failed silently and leaked sandboxes on process exit due to an interpreter-shutdown race in its async HTTP client.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic sandbox cleanup during application shutdown.
  - Cleanup requests now use a defined timeout, reducing the risk of hanging during interpreter exit.
  - Cleanup errors are safely suppressed so shutdown can complete reliably.

- **Tests**
  - Added coverage for cleanup during real interpreter shutdown.
  - Added tests for request timeout handling and cleanup failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->