### PR TITLE
fix(examples): preserve POSIX paths in sandbox file writes

### DIFF
--- a/examples/sandboxed-tools/pkg/tools/write_file.go
+++ b/examples/sandboxed-tools/pkg/tools/write_file.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/agent-sandbox/examples/sandboxed-tools/pkg/llm"
@@ -63,7 +63,7 @@ func (t *WriteFileTool) Run(ctx context.Context, sandbox Sandbox) (llm.Message, 
 		return llm.Message{}, fmt.Errorf("path is required")
 	}
 
-	dir := filepath.Dir(p)
+	dir := path.Dir(p)
 	log.Info("creating directory in sandbox", "dir", dir)
 	if _, err := sandbox.ExecCommand(ctx, ExecCommandOptions{
 		// The -- separator makes execution more robust e.g. if path is "--help"


### PR DESCRIPTION
#### What this PR does / why we need it:

`WriteFileTool` executes commands inside a Linux sandbox, but it derived the parent directory with the host-dependent `path/filepath` package. On a Windows client, a sandbox path such as `/tmp/sub/foo.txt` became `\tmp\sub`, so the generated `mkdir` command targeted the wrong path.

Use POSIX `path.Dir` semantics for the remote sandbox path. The existing write-file unit test now passes on Windows, while behavior on Unix hosts is unchanged.

Validation:
- `go test ./examples/sandboxed-tools/...`

#### Which issue(s) this PR is related to:

None.

#### Release Note

```release-note
Fix sandboxed-tools file writes from non-Unix client hosts.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parent-directory path resolution when writing files on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->