### PR TITLE
chore: apply ok-to-test label to Dependabot PRs from config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 updates:
-# TODO: tools.mod in the root directory is NOT tracked by Dependabot because 
-# Dependabot only supports files named exactly 'go.mod'. 
+# TODO: tools.mod in the root directory is NOT tracked by Dependabot because
+# Dependabot only supports files named exactly 'go.mod'.
 # Maintainers will need to manually update tools.mod when shared dependencies change.
 # See discussion in PR #629 and #588 for context.
+#
+# Every entry sets the ok-to-test label: Dependabot is not a Kubernetes
+# org member, so Prow holds all presubmits (including the autogen check)
+# until the label is present. Applying it from config lets the full test
+# suite run on Dependabot PRs without a member commenting /ok-to-test.
+# Note that setting labels replaces Dependabot's defaults, so
+# "dependencies" is listed explicitly to keep it.
 # Cover every Go module in the repo: "/" is the root module, and the
 # globstar pattern matches every subdirectory containing a go.mod, so
 # new Go modules are picked up automatically.
@@ -13,6 +20,9 @@ updates:
   - "**/*"
   schedule:
     interval: "daily"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     # Kubernetes minor bumps (e.g. k8s.io/* 0.36 -> 0.37) track a new
     # Kubernetes release and can carry API changes, so keep them out of
@@ -39,6 +49,9 @@ updates:
   directory: "/clients/python/agentic-sandbox-client"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     python-dependencies:
       patterns:
@@ -48,6 +61,9 @@ updates:
   directory: "/site"
   schedule:
     interval: "daily"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     npm-dependencies:
       patterns:
@@ -57,6 +73,9 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     docker-dependencies:
       patterns:
@@ -66,6 +85,9 @@ updates:
   directory: "/clients/python/agentic-sandbox-client/sandbox-router"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     docker-dependencies:
       patterns:
@@ -75,6 +97,9 @@ updates:
   directory: "/examples/chrome-sandbox"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     docker-dependencies:
       patterns:
@@ -84,6 +109,9 @@ updates:
   directory: "/examples/gemini-cu-sandbox"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     docker-dependencies:
       patterns:
@@ -93,6 +121,9 @@ updates:
   directory: "/examples/hello-world-sandbox"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     docker-dependencies:
       patterns:
@@ -102,6 +133,9 @@ updates:
   directory: "/examples/python-runtime-sandbox"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     docker-dependencies:
       patterns:
@@ -111,6 +145,9 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  labels:
+  - "dependencies"
+  - "ok-to-test"
   groups:
     github-actions:
       patterns:


### PR DESCRIPTION
#### What this PR does / why we need it:
Dependabot is not a Kubernetes org member, so Prow holds every presubmit — including `presubmit-test-autogen-up-to-date` and the unit tests — until a member comments `/ok-to-test`. #1517 sat with `lgtm`+`approved` and no Prow runs at all, and the only green checks were the OLM GitHub Actions jobs, which made the PR look tested when the repo-wide suite never started. That's how a version bump landed with stale generated content (cleaned up in #1520).

This sets the `ok-to-test` label on every Dependabot entry so Prow runs the full presubmit suite as soon as the PR is opened, with no manual step. Prow honors the label regardless of who applied it; kubernetes-sigs/zeitgeist uses the same approach (see kubernetes/org#3282 discussion).

Setting `labels` replaces Dependabot's defaults, so `dependencies` is listed explicitly to keep it (the per-ecosystem labels like `go`/`javascript` are dropped).

#### Which issue(s) this PR is related to:
Context: #1517, #1520

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings with clearer documentation.
  * Added dependency and testing labels to dependency update pull requests across supported ecosystems.
  * Enabled automated presubmit testing for dependency update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->