### PR TITLE
examples: golden-snapshot warm pools with GKE Pod Snapshots

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ This directory contains examples of how to use the Agent Sandbox. Each subdirect
 - [**openclaw-gvisor-sandbox**](./openclaw-gvisor-sandbox): A production-shaped, gVisor-isolated OpenClaw sandbox using the template/claim pattern and persistent storage.
 - [**openclaw-kata-aks-sandbox**](./openclaw-kata-aks-sandbox): An OpenClaw sandbox isolated by Kata Containers on AKS, so the agent runtime gets its own VM and guest kernel.
 - [**playwright-sandbox**](./playwright-sandbox): An example of running Playwright with Chromium in a sandbox for web scraping and screenshots.
+- [**podsnapshot-golden-warmpool**](./podsnapshot-golden-warmpool): Golden-snapshot warm pools on GKE — snapshot one primed sandbox (memory + filesystem) and every pool member pre-warmed afterward boots already restored from it, so claims adopt pre-initialized sandboxes.
 - [**policy**](./policy): Examples of using different policies with sandboxes.
 - [**python-runtime-sandbox**](./python-runtime-sandbox): An example of a Python runtime sandbox.
 - [**ray-integration**](./ray-integration): An example of integrating Ray with agent-sandbox for secure Proxy Execution during Agentic Reinforcement Learning (RL) training.

--- a/examples/podsnapshot-golden-warmpool/00-storageconfig.yaml
+++ b/examples/podsnapshot-golden-warmpool/00-storageconfig.yaml
@@ -1,0 +1,14 @@
+# Where GKE stores the snapshots. The bucket must exist and the pod's
+# Kubernetes ServiceAccount (10-rbac.yaml) needs storage.bucketViewer +
+# storage.objectUser on it via Workload Identity — see the README.
+# Substitute ${SNAPSHOT_BUCKET} before applying (envsubst).
+apiVersion: podsnapshot.gke.io/v1
+kind: PodSnapshotStorageConfig
+metadata:
+  name: podsnap-golden-storage
+spec:
+  snapshotStorageConfig:
+    gcs:
+      bucket: ${SNAPSHOT_BUCKET}
+      path: podsnap-golden-warmpool
+      tokenSource: podKSA

--- a/examples/podsnapshot-golden-warmpool/00-storageconfig.yaml
+++ b/examples/podsnapshot-golden-warmpool/00-storageconfig.yaml
@@ -1,5 +1,5 @@
 # Where GKE stores the snapshots. The bucket must exist and the pod's
-# Kubernetes ServiceAccount (10-rbac.yaml) needs storage.bucketViewer +
+# Kubernetes ServiceAccount (10-sandboxtemplate.yaml) needs storage.bucketViewer +
 # storage.objectUser on it via Workload Identity — see the README.
 # Substitute ${SNAPSHOT_BUCKET} before applying (envsubst).
 apiVersion: podsnapshot.gke.io/v1

--- a/examples/podsnapshot-golden-warmpool/05-podsnapshotpolicy.yaml
+++ b/examples/podsnapshot-golden-warmpool/05-podsnapshotpolicy.yaml
@@ -17,7 +17,7 @@ spec:
   storageConfigName: podsnap-golden-storage
   selector:
     matchLabels:
-      app: podsnap-golden
+      golden-pool: podsnap-demo
   snapshotScope: whole-pod
   triggerConfig:
     # manual: snapshots happen only when a PodSnapshotManualTrigger is
@@ -30,7 +30,7 @@ spec:
   snapshotGroupingRules:
     groupByLabelValue:
       labels:
-        - app
+        - golden-pool
       groupRetentionPolicy:
         # keep the last few golden images; oldest are pruned first
         maxSnapshotCountPerGroup: 3

--- a/examples/podsnapshot-golden-warmpool/05-podsnapshotpolicy.yaml
+++ b/examples/podsnapshot-golden-warmpool/05-podsnapshotpolicy.yaml
@@ -12,6 +12,7 @@ apiVersion: podsnapshot.gke.io/v1
 kind: PodSnapshotPolicy
 metadata:
   name: podsnap-golden-policy
+  namespace: default
 spec:
   storageConfigName: podsnap-golden-storage
   selector:

--- a/examples/podsnapshot-golden-warmpool/05-podsnapshotpolicy.yaml
+++ b/examples/podsnapshot-golden-warmpool/05-podsnapshotpolicy.yaml
@@ -1,0 +1,35 @@
+# The policy that turns the warm pool golden.
+#
+# Deliberately DIFFERENT from the per-session policy in
+# clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md:
+# that one groups snapshots by agents.x-k8s.io/sandbox-name-hash, which
+# isolates every sandbox to its own snapshots (self-restore only). Here we
+# group by the shared template label instead, so ONE snapshot group covers
+# every pod the template produces — and any NEW matching pod (including
+# pre-warmed pool members) automatically restores from the latest Ready
+# snapshot in the group.
+apiVersion: podsnapshot.gke.io/v1
+kind: PodSnapshotPolicy
+metadata:
+  name: podsnap-golden-policy
+spec:
+  storageConfigName: podsnap-golden-storage
+  selector:
+    matchLabels:
+      app: podsnap-golden
+  snapshotScope: whole-pod
+  triggerConfig:
+    # manual: snapshots happen only when a PodSnapshotManualTrigger is
+    # created (30-snapshot-trigger.yaml). This is the control point — with a
+    # shared group, whoever snapshots last defines what every future pod
+    # restores; keep that ability to yourself.
+    type: manual
+    # resume: the primer keeps running after the checkpoint is taken.
+    postCheckpoint: resume
+  snapshotGroupingRules:
+    groupByLabelValue:
+      labels:
+        - app
+      groupRetentionPolicy:
+        # keep the last few golden images; oldest are pruned first
+        maxSnapshotCountPerGroup: 3

--- a/examples/podsnapshot-golden-warmpool/10-sandboxtemplate.yaml
+++ b/examples/podsnapshot-golden-warmpool/10-sandboxtemplate.yaml
@@ -1,0 +1,44 @@
+# Substitute ${DEMO_IMAGE} before applying (envsubst).
+#
+# Every field of this pod spec feeds GKE's snapshot-matching hash: change the
+# image, resources, securityContext, etc. and existing whole-pod snapshots
+# stop matching (new pods cold-start until you take a new snapshot).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: podsnap-golden-sa
+  namespace: default
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: podsnap-golden-template
+  namespace: default
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        # matched by the PodSnapshotPolicy selector AND used as its snapshot
+        # group key — this label is what makes the pool "golden"
+        app: podsnap-golden
+    spec:
+      # Pod Snapshots require GKE Sandbox (gVisor)
+      runtimeClassName: gvisor
+      # the KSA whose Workload Identity principal has access to the bucket
+      serviceAccountName: podsnap-golden-sa
+      containers:
+        - name: probe
+          image: ${DEMO_IMAGE}
+          ports:
+            - containerPort: 8888
+          readinessProbe:
+            httpGet:
+              path: /state
+              port: 8888
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+              ephemeral-storage: "512Mi"

--- a/examples/podsnapshot-golden-warmpool/10-sandboxtemplate.yaml
+++ b/examples/podsnapshot-golden-warmpool/10-sandboxtemplate.yaml
@@ -19,8 +19,9 @@ spec:
     metadata:
       labels:
         # matched by the PodSnapshotPolicy selector AND used as its snapshot
-        # group key — this label is what makes the pool "golden"
-        app: podsnap-golden
+        # group key — a dedicated key (not a generic one like "app") so no
+        # unrelated pod can accidentally join the golden group
+        golden-pool: podsnap-demo
     spec:
       # Pod Snapshots require GKE Sandbox (gVisor)
       runtimeClassName: gvisor

--- a/examples/podsnapshot-golden-warmpool/20-sandboxwarmpool.yaml
+++ b/examples/podsnapshot-golden-warmpool/20-sandboxwarmpool.yaml
@@ -1,0 +1,9 @@
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: podsnap-golden-pool
+  namespace: default
+spec:
+  replicas: 2
+  sandboxTemplateRef:
+    name: podsnap-golden-template

--- a/examples/podsnapshot-golden-warmpool/25-primer-claim.yaml
+++ b/examples/podsnapshot-golden-warmpool/25-primer-claim.yaml
@@ -1,0 +1,11 @@
+# The primer session: the one sandbox whose state becomes the golden image.
+# No spec.env — env injection would force a cold start with a different pod
+# spec and take the primer (and its snapshot) out of the shared match group.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxClaim
+metadata:
+  name: podsnap-primer
+  namespace: default
+spec:
+  warmPoolRef:
+    name: podsnap-golden-pool

--- a/examples/podsnapshot-golden-warmpool/30-snapshot-trigger.yaml
+++ b/examples/podsnapshot-golden-warmpool/30-snapshot-trigger.yaml
@@ -1,0 +1,11 @@
+# Takes the golden snapshot of the primer's pod. The pod name equals the
+# Sandbox name; substitute ${PRIMER_POD} (read it from the primer claim's
+# .status.sandbox.name) before applying. Each trigger needs a fresh name —
+# bump the suffix for subsequent snapshots.
+apiVersion: podsnapshot.gke.io/v1
+kind: PodSnapshotManualTrigger
+metadata:
+  name: golden-${TRIGGER_SUFFIX}
+  namespace: default
+spec:
+  targetPod: ${PRIMER_POD}

--- a/examples/podsnapshot-golden-warmpool/40-worker-claims.yaml
+++ b/examples/podsnapshot-golden-warmpool/40-worker-claims.yaml
@@ -1,0 +1,19 @@
+# Two worker sessions. Each adopts a pre-warmed pool member — which, if a
+# golden snapshot exists, already booted restored from it.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxClaim
+metadata:
+  name: podsnap-worker-1
+  namespace: default
+spec:
+  warmPoolRef:
+    name: podsnap-golden-pool
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxClaim
+metadata:
+  name: podsnap-worker-2
+  namespace: default
+spec:
+  warmPoolRef:
+    name: podsnap-golden-pool

--- a/examples/podsnapshot-golden-warmpool/50-refresh-claim.yaml
+++ b/examples/podsnapshot-golden-warmpool/50-refresh-claim.yaml
@@ -1,0 +1,10 @@
+# Claim created after a snapshot-then-roll cycle — it must adopt a pool
+# member carrying the newest golden state.
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxClaim
+metadata:
+  name: podsnap-worker-3
+  namespace: default
+spec:
+  warmPoolRef:
+    name: podsnap-golden-pool

--- a/examples/podsnapshot-golden-warmpool/README.md
+++ b/examples/podsnapshot-golden-warmpool/README.md
@@ -1,0 +1,254 @@
+# Golden-Snapshot Warm Pools with GKE Pod Snapshots
+
+Snapshot one "primer" sandbox — memory and filesystem — and have every
+sandbox the `SandboxWarmPool` pre-warms afterward boot **already restored
+from that snapshot**. One expensive initialization (clone a repo, warm a
+cache, load a model into RAM), then N claims adopt pre-warmed sandboxes that
+start from that exact live state.
+
+This is a different pattern from the two the docs already cover:
+
+- [Sandbox Snapshots](https://agent-sandbox.sigs.k8s.io/docs/sandbox/snapshots/)
+  and the [Python SDK snapshot extension](../../clients/python/agentic-sandbox-client/k8s_agent_sandbox/gke_extensions/snapshots/README.md)
+  park and resume **one session onto its own snapshots** (grouping by
+  `agents.x-k8s.io/sandbox-name-hash` isolates every sandbox).
+- [hermes-agents-as-a-service](../hermes-agents-as-a-service) suspends and
+  resumes with **disk state only** — live process memory is lost.
+
+Here the [`PodSnapshotPolicy`](./05-podsnapshotpolicy.yaml) groups snapshots
+by the **shared template label** instead of the per-sandbox hash. GKE matches
+restores by a hash of the (distilled) pod spec, not by pod identity, so every
+new pod the template produces — including warm-pool members — automatically
+restores from the latest `Ready` snapshot in the group.
+
+```text
+ primer sandbox                        SandboxWarmPool
+ (memory + rootfs seeded)              (fresh members)
+        |                                    |
+        | PodSnapshotManualTrigger           | pod matches policy +
+        v                                    | latest Ready snapshot
+ golden snapshot  ---------------------->    v
+ (GCS bucket)      restored on boot    members start with the
+                                       primer's memory + files
+                                             |
+                                             v
+                                   claims adopt pre-warmed,
+                                   pre-initialized sandboxes
+```
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `image/` | Tiny state probe: in-memory boot nonce + counter, rootfs marker file |
+| `00-storageconfig.yaml` | `PodSnapshotStorageConfig` → GCS bucket |
+| `05-podsnapshotpolicy.yaml` | The golden-pool policy: template-label grouping, manual triggers |
+| `10-sandboxtemplate.yaml` | gVisor `SandboxTemplate` + the pod `ServiceAccount` |
+| `20-sandboxwarmpool.yaml` | Pool of 2 pre-warmed sandboxes |
+| `25-primer-claim.yaml` | The claim whose sandbox becomes the golden image |
+| `30-snapshot-trigger.yaml` | `PodSnapshotManualTrigger` for the primer pod |
+| `40-worker-claims.yaml` | Claims that adopt restored pool members |
+| `50-refresh-claim.yaml` | Claim adopting the freshest member after a snapshot-then-roll (§8) |
+| `run-test-gke.sh` | The full walkthrough below as one asserting script |
+
+## 1. Prerequisites
+
+- A GKE cluster (Autopilot or Standard ≥ 1.35.3) with Pod Snapshots enabled
+  and, on Standard, a gVisor node pool — see
+  [Prepare for Pod snapshots](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/pod-snapshots-prepare):
+
+  ```sh
+  gcloud container clusters create-auto podsnap-demo \
+      --region us-central1 --enable-pod-snapshots
+  ```
+
+- The [agent-sandbox controller with extensions](../../README.md#installation)
+  (v1.0.0+) installed.
+- `envsubst`, `kubectl`, `gcloud`, and Docker.
+
+## 2. Snapshot storage bucket + IAM
+
+Snapshots are stored in Cloud Storage; the **pod's** Kubernetes
+ServiceAccount reads and writes them through Workload Identity:
+
+```sh
+export PROJECT_ID=<your-project> SNAPSHOT_BUCKET=<your-bucket>
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+
+gcloud storage buckets create "gs://$SNAPSHOT_BUCKET" --location=us-central1 \
+    --uniform-bucket-level-access --enable-hierarchical-namespace --soft-delete-duration=0
+
+MEMBER="principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/default/sa/podsnap-golden-sa"
+gcloud storage buckets add-iam-policy-binding "gs://$SNAPSHOT_BUCKET" --member="$MEMBER" --role=roles/storage.bucketViewer
+gcloud storage buckets add-iam-policy-binding "gs://$SNAPSHOT_BUCKET" --member="$MEMBER" --role=roles/storage.objectUser
+
+# GKE's service agent deletes snapshot objects (retention pruning and
+# kubectl delete podsnapshots) — without this grant, deleted PodSnapshots
+# hang in Terminating on their finalizer:
+gcloud storage buckets add-iam-policy-binding "gs://$SNAPSHOT_BUCKET" \
+    --member="serviceAccount:service-$PROJECT_NUMBER@container-engine-robot.iam.gserviceaccount.com" \
+    --role=roles/storage.objectUser
+```
+
+Keep the bucket in the cluster's region, and note the docs' warning that
+soft delete plus parallel composite uploads inflates storage cost — hence
+`--soft-delete-duration=0`.
+
+## 3. Build the state probe image
+
+The probe holds state exactly where a snapshot must capture it: a boot nonce
+and counter in **process memory**, and a marker file on the **container
+rootfs** (deliberately not a volume). A restored pod keeps all three; a
+cold-started pod has a fresh nonce, a zero counter, and no file.
+
+```sh
+export DEMO_IMAGE=us-central1-docker.pkg.dev/$PROJECT_ID/<repo>/podsnap-probe:v1
+docker buildx build --platform linux/amd64 --push -t "$DEMO_IMAGE" image/
+```
+
+## 4. Deploy the snapshot config, template, and pool
+
+```sh
+envsubst < 00-storageconfig.yaml | kubectl apply -f -
+kubectl apply -f 05-podsnapshotpolicy.yaml
+envsubst < 10-sandboxtemplate.yaml | kubectl apply -f -
+kubectl apply -f 20-sandboxwarmpool.yaml
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+```
+
+These first two pool members **cold-start** — no snapshot exists yet.
+
+## 5. Prime and take the golden snapshot
+
+Claim a sandbox and seed both kinds of state:
+
+```sh
+kubectl apply -f 25-primer-claim.yaml
+kubectl wait --for=condition=Ready sandboxclaim/podsnap-primer --timeout=300s
+PRIMER_POD=$(kubectl get sandboxclaim podsnap-primer -o jsonpath='{.status.sandbox.name}')
+
+probe() { kubectl exec "$1" -c probe -- python -c "import urllib.request as u;print(u.urlopen(u.Request(\"http://localhost:8888$2\",data=${3:-None},method=\"${4:-GET}\")).read().decode())"; }
+probe "$PRIMER_POD" /bump 'b""' POST; probe "$PRIMER_POD" /bump 'b""' POST; probe "$PRIMER_POD" /bump 'b""' POST
+probe "$PRIMER_POD" /write 'b"golden-v1"' POST
+probe "$PRIMER_POD" /state
+```
+
+```text
+{"boot_nonce": "8489ca83d8c34536ac7eb5c677db1349", "counter": 3, "marker": "golden-v1"}
+```
+
+Snapshot the primer's pod (pod name = Sandbox name):
+
+```sh
+export PRIMER_POD TRIGGER_SUFFIX=v1
+envsubst < 30-snapshot-trigger.yaml | kubectl apply -f -
+kubectl wait --for=condition=Triggered podsnapshotmanualtrigger/golden-v1 --timeout=600s
+kubectl get podsnapshots.podsnapshot.gke.io   # wait for Ready
+```
+
+## 6. Roll the pool — members now boot restored
+
+Pool members that existed **before** the snapshot keep their cold state;
+replacements restore automatically:
+
+```sh
+kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+for POD in $(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}'); do probe "$POD" /state; done
+```
+
+```text
+{"boot_nonce": "8489ca83d8c34536ac7eb5c677db1349", "counter": 3, "marker": "golden-v1"}
+{"boot_nonce": "8489ca83d8c34536ac7eb5c677db1349", "counter": 3, "marker": "golden-v1"}
+```
+
+The nonce **equals the primer's** — these processes were never cold-started;
+their memory (and the rootfs marker) came from the snapshot. Claims now adopt
+pre-initialized sandboxes:
+
+```sh
+kubectl apply -f 40-worker-claims.yaml
+kubectl wait --for=condition=Ready sandboxclaim/podsnap-worker-1 sandboxclaim/podsnap-worker-2 --timeout=300s
+```
+
+## 7. Subsequent snapshots: latest wins — for new pods only
+
+```sh
+probe "$PRIMER_POD" /bump 'b""' POST                 # counter 3 -> 4
+probe "$PRIMER_POD" /write 'b"golden-v2"' POST
+export TRIGGER_SUFFIX=v2
+envsubst < 30-snapshot-trigger.yaml | kubectl apply -f -
+```
+
+Once the v2 snapshot is `Ready`:
+
+- **Existing** pool members still carry v1 state — a pool can hold **mixed
+  generations** until its members are consumed or rolled.
+- Every pod created **after** restores from v2 (`counter: 4`,
+  `marker: golden-v2`). Roll the pool again to converge it.
+- The policy's `maxSnapshotCountPerGroup: 3` prunes the oldest snapshots;
+  pin a specific one for a pod with the `podsnapshot.gke.io/ps-name`
+  annotation if you need to opt out of latest-wins.
+
+## 8. Keep the pool on the latest snapshot
+
+The pool only converges when its members are replaced, so pre-warmed
+sandboxes can lag the newest snapshot (§7). To keep a small pool always
+serving the latest state, roll it as part of every snapshot — **gated on the
+snapshot's `Ready` condition**, not on the trigger completing (the trigger
+finishes when the checkpoint is written; restore only considers `Ready`
+snapshots, so rolling early re-warms from the previous one):
+
+```sh
+kubectl patch sandboxwarmpool podsnap-golden-pool --type merge -p '{"spec":{"replicas":1}}'
+# ...take a snapshot as in §5, then:
+kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP" --timeout=600s
+kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+kubectl apply -f 50-refresh-claim.yaml     # adopts a member with the newest state
+```
+
+Two properties worth knowing:
+
+- **The re-warm gap costs latency, not correctness.** A claim arriving while
+  the pool refills cold-starts from the same template — and that pod also
+  matches the snapshot, so it restores the latest state anyway; it just
+  skips the pre-warm speedup.
+- **This is best-effort freshness.** A claim can still adopt the old member
+  in the instant between snapshot-Ready and the roll. A consumer that must
+  have a specific snapshot should pin it with the
+  `podsnapshot.gke.io/ps-name` annotation via the claim's
+  `additionalPodMetadata` instead. Snapshot less often than the pool
+  re-warms, or the pool spends its life rebooting.
+
+## Keep in mind
+
+- **Whoever snapshots last redefines the pool.** With a shared group, any
+  matching pod's snapshot becomes the state every future pod boots from.
+  Keep `triggerConfig.type: manual` and treat trigger-creation RBAC as a
+  control point; snapshot only from a dedicated primer.
+- **Claim env injection is rejected — leave it that way.** This template
+  keeps `envVarsInjectionPolicy` at its default (`Disallowed`), so a claim
+  carrying `spec.env` fails with `EnvVarsInjectionRejected` instead of
+  quietly cold-starting outside the golden state (verified on GKE). Don't
+  enable injection on a golden template.
+- **The SandboxTemplate is the cache key.** Snapshot matching hashes the
+  pod spec, so editing the template invalidates existing snapshots — new
+  pods silently cold-start until a new snapshot is taken from the updated
+  template.
+- **This is a GKE-level pattern, not an SDK one.** The Python SDK's
+  `PodSnapshotSandboxClient` deliberately scopes restores to one sandbox;
+  first-class warm-pool restore is tracked upstream in
+  [#208](https://github.com/kubernetes-sigs/agent-sandbox/issues/208).
+
+## Cleanup
+
+```sh
+kubectl delete -f 40-worker-claims.yaml -f 25-primer-claim.yaml \
+    -f 20-sandboxwarmpool.yaml --ignore-not-found
+envsubst < 10-sandboxtemplate.yaml | kubectl delete --ignore-not-found -f -
+kubectl delete podsnapshotmanualtriggers --all
+kubectl delete podsnapshots.podsnapshot.gke.io --all   # also deletes the GCS objects
+kubectl delete -f 05-podsnapshotpolicy.yaml --ignore-not-found
+envsubst < 00-storageconfig.yaml | kubectl delete --ignore-not-found -f -
+```

--- a/examples/podsnapshot-golden-warmpool/README.md
+++ b/examples/podsnapshot-golden-warmpool/README.md
@@ -64,7 +64,7 @@ restores from the latest `Ready` snapshot in the group.
 
 - The [agent-sandbox controller with extensions](../../README.md#installation)
   (v1.0.0+) installed.
-- `envsubst`, `kubectl`, `gcloud`, and Docker.
+- `envsubst`, `kubectl`, `gcloud`, `python3`, and Docker.
 
 ## 2. Snapshot storage bucket + IAM
 

--- a/examples/podsnapshot-golden-warmpool/README.md
+++ b/examples/podsnapshot-golden-warmpool/README.md
@@ -113,7 +113,7 @@ envsubst < 00-storageconfig.yaml | kubectl apply -f -
 kubectl apply -f 05-podsnapshotpolicy.yaml
 envsubst < 10-sandboxtemplate.yaml | kubectl apply -f -
 kubectl apply -f 20-sandboxwarmpool.yaml
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=2 --timeout=600s
 ```
 
 These first two pool members **cold-start** — no snapshot exists yet.
@@ -153,7 +153,7 @@ replacements restore automatically:
 
 ```sh
 kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=2 --timeout=600s
 for POD in $(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}'); do probe "$POD" /state; done
 ```
 
@@ -204,7 +204,7 @@ kubectl patch sandboxwarmpool podsnap-golden-pool --type merge -p '{"spec":{"rep
 # ...take a snapshot as in §5, then:
 kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP" --timeout=600s
 kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=1 --timeout=600s
 kubectl apply -f 50-refresh-claim.yaml     # adopts a member with the newest state
 ```
 
@@ -220,22 +220,38 @@ Two properties worth knowing:
   `podsnapshot.gke.io/ps-name` annotation via the claim's
   `additionalPodMetadata` instead. Snapshot less often than the pool
   re-warms, or the pool spends its life rebooting.
+- **Rolls don't scale linearly.** This example is validated at
+  `replicas: 2`; a label-wide delete on a large pool is a synchronized
+  restore storm — restores queue, per-pod resume latency grows with wave
+  position, and node pod-density limits become the wall before the snapshot
+  machinery does. Roll large pools in batches.
 
 ## Keep in mind
 
-- **Whoever snapshots last redefines the pool.** With a shared group, any
-  matching pod's snapshot becomes the state every future pod boots from.
-  Keep `triggerConfig.type: manual` and treat trigger-creation RBAC as a
-  control point; snapshot only from a dedicated primer.
+- **One user's session can become everyone's golden image.** The primer and
+  workers necessarily share the group label, so the policy cannot tell them
+  apart: a `PodSnapshotManualTrigger` aimed at a worker pod — typo or anyone
+  with trigger RBAC in the namespace — publishes that user's live session as
+  the state every future sandbox boots from. Keep `triggerConfig.type:
+  manual`, treat trigger-creation RBAC as the tenancy boundary, snapshot only
+  from a dedicated primer, and use a dedicated group label key (this example
+  uses `golden-pool`, not a generic `app` label another workload might carry).
+- **Restored members are memory clones of the primer.** The identical
+  `boot_nonce` that proves the demo is also the risk: any secret, cached
+  token, or PRNG state resident before the snapshot is identical in — and
+  disclosed to — every future claimant's sandbox. Prime only deterministic,
+  shareable state; generate per-session secrets and reseed RNGs after
+  adoption, never before the snapshot.
 - **Claim env injection is rejected — leave it that way.** This template
   keeps `envVarsInjectionPolicy` at its default (`Disallowed`), so a claim
   carrying `spec.env` fails with `EnvVarsInjectionRejected` instead of
   quietly cold-starting outside the golden state (verified on GKE). Don't
   enable injection on a golden template.
 - **The SandboxTemplate is the cache key.** Snapshot matching hashes the
-  pod spec, so editing the template invalidates existing snapshots — new
-  pods silently cold-start until a new snapshot is taken from the updated
-  template.
+  pod spec, so editing the template invalidates existing snapshots — when
+  the newest snapshot in the group no longer matches a new pod's spec, GKE
+  silently cold-starts it (no error, no event); take a fresh snapshot from
+  the updated template to re-arm the pool.
 - **This is a GKE-level pattern, not an SDK one.** The Python SDK's
   `PodSnapshotSandboxClient` deliberately scopes restores to one sandbox;
   first-class warm-pool restore is tracked upstream in

--- a/examples/podsnapshot-golden-warmpool/image/Dockerfile
+++ b/examples/podsnapshot-golden-warmpool/image/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.12-slim
+RUN useradd --uid 10001 --create-home probe && mkdir /state && chown probe:probe /state
 COPY server.py /server.py
+USER 10001
 EXPOSE 8888
 CMD ["python", "/server.py"]

--- a/examples/podsnapshot-golden-warmpool/image/Dockerfile
+++ b/examples/podsnapshot-golden-warmpool/image/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.12-slim
+COPY server.py /server.py
+EXPOSE 8888
+CMD ["python", "/server.py"]

--- a/examples/podsnapshot-golden-warmpool/image/server.py
+++ b/examples/podsnapshot-golden-warmpool/image/server.py
@@ -1,0 +1,76 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tiny state probe for demonstrating GKE Pod Snapshot restores.
+
+Holds state in two places a snapshot must capture:
+  - process memory: a boot nonce (random, generated once per cold process
+    start) and a counter mutated via /bump — a restored process keeps both,
+    a fresh process gets a new nonce and a zero counter
+  - container rootfs: /state/marker.txt written via /write — not a volume,
+    so it only survives into a new pod via snapshot restore
+
+GET  /state  -> {"boot_nonce": ..., "counter": N, "marker": <file or null>}
+POST /bump   -> increments the in-memory counter
+POST /write  -> writes the request body to /state/marker.txt
+"""
+
+import json
+import os
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+BOOT_NONCE = uuid.uuid4().hex
+COUNTER = 0
+MARKER_PATH = "/state/marker.txt"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _reply(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path != "/state":
+            return self._reply(404, {"error": "not found"})
+        marker = None
+        if os.path.exists(MARKER_PATH):
+            with open(MARKER_PATH) as f:
+                marker = f.read()
+        self._reply(200, {"boot_nonce": BOOT_NONCE, "counter": COUNTER, "marker": marker})
+
+    def do_POST(self):
+        global COUNTER
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length).decode() if length else ""
+        if self.path == "/bump":
+            COUNTER += 1
+            return self._reply(200, {"counter": COUNTER})
+        if self.path == "/write":
+            os.makedirs(os.path.dirname(MARKER_PATH), exist_ok=True)
+            with open(MARKER_PATH, "w") as f:
+                f.write(body)
+            return self._reply(200, {"marker": body})
+        self._reply(404, {"error": "not found"})
+
+    def log_message(self, *args):  # keep container logs quiet
+        pass
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 8888), Handler).serve_forever()

--- a/examples/podsnapshot-golden-warmpool/run-test-gke.sh
+++ b/examples/podsnapshot-golden-warmpool/run-test-gke.sh
@@ -124,7 +124,7 @@ echo "post-v2 member $FRESH: $S"
 [ "$(field "$S" marker)" = "golden-v2" ]
 [ "$(field "$S" counter)" = "4" ]
 
-echo "=== 8. Extension: snapshot-then-roll keeps a size-1 pool on the latest state"
+echo "=== 7. Extension: snapshot-then-roll keeps a size-1 pool on the latest state"
 kubectl patch sandboxwarmpool podsnap-golden-pool --type merge -p '{"spec":{"replicas":1}}'
 post "$PRIMER_POD" /bump                       # counter 4 -> 5
 post "$PRIMER_POD" /write "golden-v3"
@@ -148,7 +148,7 @@ case " $POOL_BEFORE " in *" $POD "*) ;; *) echo "podsnap-worker-3 did not adopt 
 [ "$(field "$S" counter)" = "5" ]
 [ "$(field "$S" marker)" = "golden-v3" ]
 
-echo "=== 9. Snapshot deletion works (validates the service agent's bucket IAM)"
+echo "=== 8. Snapshot deletion works (validates the service agent's bucket IAM)"
 kubectl delete "podsnapshots.podsnapshot.gke.io/$SNAP_V1" --timeout=300s
 
 echo "ALL CHECKS PASSED"

--- a/examples/podsnapshot-golden-warmpool/run-test-gke.sh
+++ b/examples/podsnapshot-golden-warmpool/run-test-gke.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# End-to-end check of the golden-snapshot warm pool on a GKE cluster that
+# has Pod Snapshots enabled and the agent-sandbox controller installed.
+#
+# Required env:
+#   SNAPSHOT_BUCKET  GCS bucket for snapshots (IAM already granted, README §2)
+#   DEMO_IMAGE       pushed image built from image/ (README §3)
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${SNAPSHOT_BUCKET:?set SNAPSHOT_BUCKET}"
+: "${DEMO_IMAGE:?set DEMO_IMAGE}"
+
+state() { # state <pod> -> prints the /state JSON
+    kubectl exec "$1" -c probe -- python -c \
+        'import urllib.request;print(urllib.request.urlopen("http://localhost:8888/state").read().decode())'
+}
+post() { # post <pod> <path> [body]
+    kubectl exec "$1" -c probe -- python -c \
+        "import urllib.request;print(urllib.request.urlopen(urllib.request.Request(\"http://localhost:8888$2\",data=b\"${3:-}\",method=\"POST\")).read().decode())"
+}
+field() { # field <json> <key>
+    python3 -c "import json,sys;print(json.loads(sys.argv[1]).get(sys.argv[2]))" "$1" "$2"
+}
+pod_of_claim() { kubectl get sandboxclaim "$1" -o jsonpath='{.status.sandbox.name}'; }
+
+snap_of_trigger() { # snap_of_trigger <trigger> -> PodSnapshot name (retries until set)
+    for _ in $(seq 1 120); do
+        NAME=$(kubectl get podsnapshotmanualtrigger "$1" -o json | python3 -c '
+import json,sys
+sc=json.load(sys.stdin).get("status",{}).get("snapshotCreated")
+print(sc.get("name","") if isinstance(sc,dict) else (sc or ""))')
+        [ -n "$NAME" ] && { echo "$NAME"; return 0; }
+        sleep 5
+    done
+    echo "trigger $1 never reported a created snapshot" >&2; return 1
+}
+
+echo "=== 1. Apply snapshot config, template, pool"
+export SNAPSHOT_BUCKET DEMO_IMAGE
+envsubst < 00-storageconfig.yaml | kubectl apply -f -
+kubectl apply -f 05-podsnapshotpolicy.yaml
+envsubst < 10-sandboxtemplate.yaml | kubectl apply -f -
+kubectl apply -f 20-sandboxwarmpool.yaml
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+
+echo "=== 2. Primer: claim, seed memory + filesystem state"
+kubectl apply -f 25-primer-claim.yaml
+kubectl wait --for=condition=Ready sandboxclaim/podsnap-primer --timeout=300s
+PRIMER_POD=$(pod_of_claim podsnap-primer)
+post "$PRIMER_POD" /bump; post "$PRIMER_POD" /bump; post "$PRIMER_POD" /bump
+post "$PRIMER_POD" /write "golden-v1"
+PRIMER_STATE=$(state "$PRIMER_POD")
+PRIMER_NONCE=$(field "$PRIMER_STATE" boot_nonce)
+echo "primer: $PRIMER_STATE"
+[ "$(field "$PRIMER_STATE" counter)" = "3" ]
+
+echo "=== 3. Take the golden snapshot"
+export PRIMER_POD TRIGGER_SUFFIX=v1
+envsubst < 30-snapshot-trigger.yaml | kubectl apply -f -
+kubectl wait --for=condition=Triggered podsnapshotmanualtrigger/golden-v1 --timeout=600s
+SNAP_V1=$(snap_of_trigger golden-v1)
+kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP_V1" --timeout=600s
+echo "golden snapshot: $SNAP_V1"
+
+echo "=== 4. Roll the pool: fresh members must boot restored"
+kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+for POD in $(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}'); do
+    S=$(state "$POD")
+    echo "pool member $POD: $S"
+    [ "$(field "$S" boot_nonce)" = "$PRIMER_NONCE" ]   # memory restored
+    [ "$(field "$S" counter)" = "3" ]                  # memory restored
+    [ "$(field "$S" marker)" = "golden-v1" ]           # filesystem restored
+done
+
+echo "=== 5. Workers adopt pre-warmed restored members"
+kubectl apply -f 40-worker-claims.yaml
+kubectl wait --for=condition=Ready sandboxclaim/podsnap-worker-1 sandboxclaim/podsnap-worker-2 --timeout=300s
+for CLAIM in podsnap-worker-1 podsnap-worker-2; do
+    POD=$(pod_of_claim "$CLAIM")
+    S=$(state "$POD")
+    echo "$CLAIM ($POD): $S"
+    [ "$(field "$S" boot_nonce)" = "$PRIMER_NONCE" ]
+    [ "$(field "$S" marker)" = "golden-v1" ]
+done
+
+echo "=== 6. Subsequent snapshot: latest wins for NEW pods only"
+post "$PRIMER_POD" /bump                       # counter 3 -> 4
+post "$PRIMER_POD" /write "golden-v2"
+export TRIGGER_SUFFIX=v2
+envsubst < 30-snapshot-trigger.yaml | kubectl apply -f -
+kubectl wait --for=condition=Triggered podsnapshotmanualtrigger/golden-v2 --timeout=600s
+SNAP_V2=$(snap_of_trigger golden-v2)
+kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP_V2" --timeout=600s
+# members pre-warmed before v2 still carry v1 (mixed generations)...
+STALE=$(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[0].metadata.name}')
+[ "$(field "$(state "$STALE")" marker)" = "golden-v1" ]
+echo "pre-v2 member $STALE still golden-v1 (expected)"
+# ...until the pool is rolled again
+kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+FRESH=$(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[0].metadata.name}')
+S=$(state "$FRESH")
+echo "post-v2 member $FRESH: $S"
+[ "$(field "$S" marker)" = "golden-v2" ]
+[ "$(field "$S" counter)" = "4" ]
+
+echo "=== 8. Extension: snapshot-then-roll keeps a size-1 pool on the latest state"
+kubectl patch sandboxwarmpool podsnap-golden-pool --type merge -p '{"spec":{"replicas":1}}'
+post "$PRIMER_POD" /bump                       # counter 4 -> 5
+post "$PRIMER_POD" /write "golden-v3"
+export TRIGGER_SUFFIX=v3
+envsubst < 30-snapshot-trigger.yaml | kubectl apply -f -
+kubectl wait --for=condition=Triggered podsnapshotmanualtrigger/golden-v3 --timeout=600s
+SNAP_V3=$(snap_of_trigger golden-v3)
+# THE GATE: roll only after the PodSnapshot is Ready — rolling on trigger
+# completion alone re-warms from the previous snapshot.
+kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP_V3" --timeout=600s
+kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
+kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+kubectl apply -f 50-refresh-claim.yaml
+kubectl wait --for=condition=Ready sandboxclaim/podsnap-worker-3 --timeout=300s
+POD=$(pod_of_claim podsnap-worker-3)
+S=$(state "$POD")
+echo "podsnap-worker-3 ($POD): $S"
+[ "$(field "$S" boot_nonce)" = "$PRIMER_NONCE" ]
+[ "$(field "$S" counter)" = "5" ]
+[ "$(field "$S" marker)" = "golden-v3" ]
+
+echo "ALL CHECKS PASSED"

--- a/examples/podsnapshot-golden-warmpool/run-test-gke.sh
+++ b/examples/podsnapshot-golden-warmpool/run-test-gke.sh
@@ -52,6 +52,8 @@ print(sc.get("name","") if isinstance(sc,dict) else (sc or ""))')
 
 echo "=== 1. Apply snapshot config, template, pool"
 export SNAPSHOT_BUCKET DEMO_IMAGE
+# fixed-name triggers from a previous run would satisfy the waits below
+kubectl delete podsnapshotmanualtriggers golden-v1 golden-v2 golden-v3 --ignore-not-found
 envsubst < 00-storageconfig.yaml | kubectl apply -f -
 kubectl apply -f 05-podsnapshotpolicy.yaml
 envsubst < 10-sandboxtemplate.yaml | kubectl apply -f -
@@ -89,12 +91,14 @@ for POD in $(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='
 done
 
 echo "=== 5. Workers adopt pre-warmed restored members"
+POOL_BEFORE=$(kubectl get sandbox -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}')
 kubectl apply -f 40-worker-claims.yaml
 kubectl wait --for=condition=Ready sandboxclaim/podsnap-worker-1 sandboxclaim/podsnap-worker-2 --timeout=300s
 for CLAIM in podsnap-worker-1 podsnap-worker-2; do
     POD=$(pod_of_claim "$CLAIM")
     S=$(state "$POD")
     echo "$CLAIM ($POD): $S"
+    case " $POOL_BEFORE " in *" $POD "*) ;; *) echo "$CLAIM did not adopt a pool member"; exit 1;; esac
     [ "$(field "$S" boot_nonce)" = "$PRIMER_NONCE" ]
     [ "$(field "$S" marker)" = "golden-v1" ]
 done
@@ -133,13 +137,18 @@ SNAP_V3=$(snap_of_trigger golden-v3)
 kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP_V3" --timeout=600s
 kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
 kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+POOL_BEFORE=$(kubectl get sandbox -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}')
 kubectl apply -f 50-refresh-claim.yaml
 kubectl wait --for=condition=Ready sandboxclaim/podsnap-worker-3 --timeout=300s
 POD=$(pod_of_claim podsnap-worker-3)
 S=$(state "$POD")
 echo "podsnap-worker-3 ($POD): $S"
+case " $POOL_BEFORE " in *" $POD "*) ;; *) echo "podsnap-worker-3 did not adopt a pool member"; exit 1;; esac
 [ "$(field "$S" boot_nonce)" = "$PRIMER_NONCE" ]
 [ "$(field "$S" counter)" = "5" ]
 [ "$(field "$S" marker)" = "golden-v3" ]
+
+echo "=== 9. Snapshot deletion works (validates the service agent's bucket IAM)"
+kubectl delete "podsnapshots.podsnapshot.gke.io/$SNAP_V1" --timeout=300s
 
 echo "ALL CHECKS PASSED"

--- a/examples/podsnapshot-golden-warmpool/run-test-gke.sh
+++ b/examples/podsnapshot-golden-warmpool/run-test-gke.sh
@@ -58,7 +58,9 @@ envsubst < 00-storageconfig.yaml | kubectl apply -f -
 kubectl apply -f 05-podsnapshotpolicy.yaml
 envsubst < 10-sandboxtemplate.yaml | kubectl apply -f -
 kubectl apply -f 20-sandboxwarmpool.yaml
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+# wait on the pool's own status: a label-selector wait races the controller
+# creating the first Sandbox objects ("no matching resources found")
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=2 --timeout=600s
 
 echo "=== 2. Primer: claim, seed memory + filesystem state"
 kubectl apply -f 25-primer-claim.yaml
@@ -81,7 +83,8 @@ echo "golden snapshot: $SNAP_V1"
 
 echo "=== 4. Roll the pool: fresh members must boot restored"
 kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+sleep 10   # let the pool status observe the deletions before waiting on it
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=2 --timeout=600s
 for POD in $(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}'); do
     S=$(state "$POD")
     echo "pool member $POD: $S"
@@ -117,7 +120,8 @@ STALE=$(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.ite
 echo "pre-v2 member $STALE still golden-v1 (expected)"
 # ...until the pool is rolled again
 kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+sleep 10
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=2 --timeout=600s
 FRESH=$(kubectl get pods -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[0].metadata.name}')
 S=$(state "$FRESH")
 echo "post-v2 member $FRESH: $S"
@@ -136,7 +140,8 @@ SNAP_V3=$(snap_of_trigger golden-v3)
 # completion alone re-warms from the previous snapshot.
 kubectl wait --for=condition=Ready "podsnapshots.podsnapshot.gke.io/$SNAP_V3" --timeout=600s
 kubectl delete sandbox -l agents.x-k8s.io/warm-pool-sandbox --wait=true
-kubectl wait --for=condition=Ready sandbox -l agents.x-k8s.io/warm-pool-sandbox --timeout=600s
+sleep 10
+kubectl wait sandboxwarmpool/podsnap-golden-pool --for=jsonpath='{.status.readyReplicas}'=1 --timeout=600s
 POOL_BEFORE=$(kubectl get sandbox -l agents.x-k8s.io/warm-pool-sandbox -o jsonpath='{.items[*].metadata.name}')
 kubectl apply -f 50-refresh-claim.yaml
 kubectl wait --for=condition=Ready sandboxclaim/podsnap-worker-3 --timeout=300s

--- a/site/content/docs/sandbox/snapshots/_index.md
+++ b/site/content/docs/sandbox/snapshots/_index.md
@@ -33,7 +33,7 @@ The following example demonstrates creating a sandbox, modifying its filesystem,
 > Note: this example uses `simple-sandbox-pool`, which you should create in your GKE cluster first (along with its backing `simple-sandbox-template`). See the [snapshots example source folder](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/site/content/docs/sandbox/snapshots/source) for the matching `SandboxTemplate` manifest.
 
 > [!NOTE]
-> A sandbox can only be restored from its own previous snapshots (via the `suspend()` and `resume()` lifecycle).
+> With the SDK's recommended per-sandbox grouping policy (snapshots grouped by `agents.x-k8s.io/sandbox-name-hash`), a sandbox is only restored from its own previous snapshots via the `suspend()` and `resume()` lifecycle. This is a consequence of that grouping policy, not a platform limit — see the section below for a policy that shares one snapshot group across a whole template.
 >
 > Snapshot/suspend/resume support is Python-only for now. `PodSnapshotSandboxClient` drives this through GKE's `podsnapshot.gke.io` custom resources, which the published Go SDK (`clients/go/sandbox`) doesn't wrap yet — there's no equivalent to add here without reimplementing that orchestration from scratch.
 

--- a/site/content/docs/sandbox/snapshots/_index.md
+++ b/site/content/docs/sandbox/snapshots/_index.md
@@ -83,4 +83,12 @@ response = sandbox.commands.run("cat /tmp/data/status.txt")
 print(response.stdout) # Should output 'session_active'
 ```
 
+## Sharing one snapshot across many sandboxes
 
+The workflow above restores a sandbox from **its own** snapshots. To go the
+other way — capture one primed sandbox's memory and filesystem once and have
+every sandbox a `SandboxWarmPool` pre-warms afterward boot already restored
+from it — see the
+[golden-snapshot warm pool example](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/examples/podsnapshot-golden-warmpool),
+which uses a `PodSnapshotPolicy` grouped by the shared template label instead
+of the per-sandbox name hash.

--- a/site/content/docs/sandbox/snapshots/_index.md
+++ b/site/content/docs/sandbox/snapshots/_index.md
@@ -86,9 +86,9 @@ print(response.stdout) # Should output 'session_active'
 ## Sharing one snapshot across many sandboxes
 
 The workflow above restores a sandbox from **its own** snapshots. To go the
-other way — capture one primed sandbox's memory and filesystem once and have
-every sandbox a `SandboxWarmPool` pre-warms afterward boot already restored
-from it — see the
+other way — capture one primed sandbox's memory and filesystem once, then have
+every sandbox pre-warmed by a `SandboxWarmPool` afterward boot with that
+state already restored — see the
 [golden-snapshot warm pool example](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/examples/podsnapshot-golden-warmpool),
 which uses a `PodSnapshotPolicy` grouped by the shared template label instead
 of the per-sandbox name hash.


### PR DESCRIPTION
Adds `examples/podsnapshot-golden-warmpool`: snapshot one primed sandbox (memory + filesystem) with GKE Pod Snapshots and have every sandbox the `SandboxWarmPool` pre-warms afterward boot already restored from it — claims adopt pre-initialized sandboxes.

**How it differs from existing snapshot docs:** the site's Snapshots page and the Python SDK extension cover per-session self-restore (snapshots grouped by `agents.x-k8s.io/sandbox-name-hash`). This example groups the `PodSnapshotPolicy` by the shared template label instead, so GKE's spec-hash matching restores every new pod from the template — including pool members — from the latest Ready snapshot. First-class SDK support for warm-pool restore remains tracked in #208; this shows the GKE-level pattern that works today.

**Contents:** complete manifest set in apply order (`PodSnapshotStorageConfig`, golden-pool `PodSnapshotPolicy`, gVisor `SandboxTemplate` + KSA, warm pool, primer/worker/refresh claims, `PodSnapshotManualTrigger`), a stdlib-only state-probe image (in-memory boot nonce + counter, rootfs marker), an asserting `run-test-gke.sh`, and a README with an ASCII flow diagram, subsequent-snapshot semantics, a snapshot-then-roll section for keeping a small pool on the newest state, and pattern-specific caveats.

**Validated end-to-end on a GKE Autopilot cluster (1.35.7, Pod Snapshots GA)** — every step asserts:
- Rolled pool members and adopted worker claims boot with the primer's exact in-memory state (same boot nonce, counter=3) and rootfs marker — memory and filesystem restoration each verified independently.
- Subsequent snapshots: latest Ready snapshot wins for new pods; pre-existing members keep older state until rolled (mixed generations demonstrated), and a Ready-gated snapshot-then-roll cycle hands the next claim the newest state (counter=5/v3).
- Claims with `spec.env` are rejected (`EnvVarsInjectionRejected`) under the template's default `envVarsInjectionPolicy`, keeping golden pools closed to per-claim spec drift.
- Operational finding baked into the README: the container-engine-robot service agent needs `storage.objectUser` on the snapshot bucket, or deleted `PodSnapshot`s hang in Terminating on their finalizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GKE example demonstrating golden-snapshot warm pools for pre-initialized sandbox claims.
  * Added configuration for snapshot storage, policies, sandbox templates, warm pools, primer and worker claims, and snapshot triggers.
  * Added a sample state-probe container and end-to-end validation for snapshot creation, restoration, pool rollovers, and worker adoption.

* **Documentation**
  * Documented setup requirements, Workload Identity permissions, deployment steps, snapshot updates, operational considerations, cleanup, and shared snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Site:** the Snapshots docs page now links here from a new "Sharing one snapshot across many sandboxes" section (rendered in the Netlify deploy preview).
