### PR TITLE
spec(sandboxd): pin remote Buf Python plugins to avoid unpinned codegen drift

### DIFF
--- a/packages/sandboxd/spec/buf.gen.python.yaml
+++ b/packages/sandboxd/spec/buf.gen.python.yaml
@@ -23,9 +23,9 @@ version: v2
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/python
+  - remote: buf.build/protocolbuffers/python:v36.1
     out: ../../../clients/python/agentic-sandbox-client/k8s_agent_sandbox/_proto
-  - remote: buf.build/protocolbuffers/pyi
+  - remote: buf.build/protocolbuffers/pyi:v36.1
     out: ../../../clients/python/agentic-sandbox-client/k8s_agent_sandbox/_proto
-  - remote: buf.build/grpc/python
+  - remote: buf.build/grpc/python:v1.83.1
     out: ../../../clients/python/agentic-sandbox-client/k8s_agent_sandbox/_proto


### PR DESCRIPTION
#### What this PR does / why we need it:
Pins remote Buf Python compiler plugins in `packages/sandboxd/spec/buf.gen.python.yaml` (`protocolbuffers/python:v36.1`, `protocolbuffers/pyi:v36.1`, and `grpc/python:v1.83.1`).

Previously, these plugins were unpinned (`buf.build/protocolbuffers/python`, etc.), causing `buf generate` via `dev/tools/fix-go-generate` to fetch floating compiler versions from the Buf Schema Registry. When upstream released Protobuf 7.36.1, code generation produced drift against checked-in 7.36.0 stubs (as observed in #1520). Pinning them ensures reproducible code generation across environments.

#### Which issue(s) this PR is related to:
Ref #1520

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned exact versions for Python, type stub, and gRPC code-generation plugins to improve build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->