### PR TITLE
feat(sandbox): emit Kubernetes Events for Sandbox lifecycle transitions

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -81,6 +81,7 @@ func main() {
 	var enableWarmPoolEviction bool
 	var cacheLabelSelectors bool
 	var printVersion bool
+	var disableSandboxEvents bool
 	var disableClaimEvents bool
 	var disableClaimObservabilityAnnotations bool
 
@@ -145,6 +146,9 @@ func main() {
 			"that rely on the "+sandboxv1beta1.SandboxAdoptableLabel+"=true adoption path MUST also carry the "+
 			"tracking label (value = the owning sandbox's name hash) to remain visible to the controller when "+
 			"this flag is enabled.")
+	flag.BoolVar(&disableSandboxEvents, "disable-sandbox-events", false,
+		"Disable Kubernetes Event emission from the Sandbox controller (its Eventf calls become no-ops), "+
+			"reducing API server writes during large warm-pool fills. Default false (events enabled).")
 	flag.BoolVar(&disableClaimEvents, "disable-claim-events", false,
 		"Disable Kubernetes Event emission from the SandboxClaim controller (its Eventf calls become no-ops), "+
 			"reducing API server writes during large claim bursts. Default false (events enabled).")
@@ -376,10 +380,19 @@ func main() {
 			"window", sandboxWriteBehindWindow, "podPatchBound", "1s")
 	}
 
+	// Every Eventf site in the sandbox controller is nil-guarded on the
+	// recorder, so a nil recorder cleanly disables event emission.
+	var sandboxRecorder events.EventRecorder
+	if disableSandboxEvents {
+		setupLog.Info("Sandbox controller event emission disabled (--disable-sandbox-events)")
+	} else {
+		sandboxRecorder = mgr.GetEventRecorder("sandbox-controller")
+	}
+
 	if err = (&controllers.SandboxReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorder("sandbox-controller"),
+		Recorder:          sandboxRecorder,
 		Tracer:            instrumenter,
 		ClusterDomain:     clusterDomain,
 		WriteBehindWindow: sandboxWriteBehindWindow,

--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -762,8 +762,42 @@ func (r *SandboxReconciler) updateStatus(ctx context.Context, oldStatus *sandbox
 		return err
 	}
 
+	// Events are only emitted once the new status is persisted, so a failed patch does not produce a misleading event
+	// and a no-op reconcile does not re-emit one (due to deepEqual check above).
+	r.recordReadyTransitionEvent(sandbox, oldStatus)
+
 	// Surface error
 	return nil
+}
+
+func (r *SandboxReconciler) recordReadyTransitionEvent(sandbox *sandboxv1beta1.Sandbox, oldStatus *sandboxv1beta1.SandboxStatus) {
+	if r.Recorder == nil {
+		return
+	}
+	var oldReason string
+	if oldReady := meta.FindStatusCondition(oldStatus.Conditions, string(sandboxv1beta1.SandboxConditionReady)); oldReady != nil {
+		oldReason = oldReady.Reason
+	}
+	newReady := meta.FindStatusCondition(sandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	if newReady == nil || newReady.Reason == oldReason {
+		return
+	}
+	switch newReady.Reason {
+	case sandboxv1beta1.SandboxReasonDependenciesReady:
+		r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, "SandboxReady", "Ready", "Sandbox is ready")
+	case sandboxv1beta1.SandboxReasonExpired:
+		// This event should only be emitted when ShutdownPolicy=Retain since in the Delete case, the Sandbox is torn down immediately on expiry.
+		// The ShutdownPolicy is checked here because updateStatus is called before handleSandboxExpiry's later policy check.
+		if sandbox.Spec.ShutdownPolicy == nil || *sandbox.Spec.ShutdownPolicy != sandboxv1beta1.ShutdownPolicyDelete {
+			r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, sandboxv1beta1.SandboxReasonExpired, "Expiry", "Sandbox has expired")
+		}
+	case sandboxv1beta1.SandboxReasonSuspended:
+		r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, sandboxv1beta1.SandboxReasonSuspended, "Suspension", "Sandbox is suspended")
+	case sandboxv1beta1.SandboxReasonPodSucceeded:
+		r.Recorder.Eventf(sandbox, nil, corev1.EventTypeNormal, sandboxv1beta1.SandboxReasonPodSucceeded, "PodCompletion", "Pod completed successfully")
+	case sandboxv1beta1.SandboxReasonPodFailed:
+		r.Recorder.Eventf(sandbox, nil, corev1.EventTypeWarning, sandboxv1beta1.SandboxReasonPodFailed, "PodCompletion", "Pod failed")
+	}
 }
 
 // nodeNameOnlyChange reports whether the node assignment is the only
@@ -1461,7 +1495,14 @@ func (r *SandboxReconciler) reconcilePod(ctx context.Context, sandbox *sandboxv1
 			return reconcileExistingPod(existingPod)
 		}
 		logger.Error(err, "Failed to create", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		if r.Recorder != nil {
+			r.Recorder.Eventf(sandbox, nil, corev1.EventTypeWarning, "SandboxPodCreateFailed", "PodCreation", "Failed to create Pod %q: %s", pod.Name, err.Error())
+		}
 		return nil, err
+	}
+
+	if r.Recorder != nil {
+		r.Recorder.Eventf(sandbox, pod, corev1.EventTypeNormal, "SandboxPodCreated", "PodCreation", "Created Pod %q", pod.Name)
 	}
 
 	if r.Tracer.IsRecording(ctx) {

--- a/controllers/sandbox_controller_test.go
+++ b/controllers/sandbox_controller_test.go
@@ -5485,3 +5485,261 @@ func TestReconcileCoalescesNodeNameStatusWrite(t *testing.T) {
 	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
 	assert.Equal(t, "node-2", live.Status.NodeName, "node changes on a Ready sandbox must be written immediately")
 }
+
+// drainEvent reads and returns one event off the fake recorder, failing the test if none arrives before the timeout.
+func drainEvent(t *testing.T, recorder *events.FakeRecorder) string {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return ""
+	}
+}
+
+// assertNoEvent fails the test if an event was recorded.
+func assertNoEvent(t *testing.T, recorder *events.FakeRecorder) {
+	t.Helper()
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("expected no event, got %q", event)
+	default:
+	}
+}
+
+func TestReconcileEvents_PodCreated(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-name", Namespace: "default", UID: sandboxUID},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+		}},
+	}
+	recorder := events.NewFakeRecorder(10)
+	r := &SandboxReconciler{
+		Client:   newFakeClient(sandbox),
+		Scheme:   Scheme,
+		Recorder: recorder,
+		Tracer:   asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+
+	require.Equal(t, "Normal SandboxPodCreated Created Pod \"sandbox-name\"", drainEvent(t, recorder))
+}
+
+func TestReconcileEvents_PodCreationFailed(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-name", Namespace: "default", UID: sandboxUID},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+		}},
+	}
+	createErr := errors.New("injected create failure")
+	fc := interceptor.NewClient(newFakeClient(sandbox), interceptor.Funcs{
+		Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*corev1.Pod); ok {
+				return createErr
+			}
+			return client.Create(ctx, obj, opts...)
+		},
+	})
+	recorder := events.NewFakeRecorder(10)
+	r := &SandboxReconciler{
+		Client:   fc,
+		Scheme:   Scheme,
+		Recorder: recorder,
+		Tracer:   asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.Error(t, err)
+
+	require.Equal(t, "Warning SandboxPodCreateFailed Failed to create Pod \"sandbox-name\": injected create failure", drainEvent(t, recorder))
+}
+
+// TestReconcileEvents_ReadyTransitions tests every recordReadyTransitionEvent case aside from Suspended: each builds a
+// Sandbox already in the target state, reconciles once to expect the event, then reconciles again to confirm a no-op on no change.
+func TestReconcileEvents_ReadyTransitions(t *testing.T) {
+	podTemplateSpec := sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+		PodTemplate: sandboxv1beta1.PodTemplate{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		},
+	}}
+	shutdownTime := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+
+	testCases := []struct {
+		name        string
+		sandboxSpec sandboxv1beta1.SandboxSpec
+		pod         *corev1.Pod
+		wantEvent   string
+	}{
+		{
+			name:        "pod ready",
+			sandboxSpec: podTemplateSpec,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "sandbox-name",
+					Namespace:       "default",
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef("sandbox-name")},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				Status: corev1.PodStatus{
+					Phase:      corev1.PodRunning,
+					PodIPs:     []corev1.PodIP{{IP: "10.244.0.1"}},
+					Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+				},
+			},
+			wantEvent: "Normal SandboxReady Sandbox is ready",
+		},
+		{
+			name:        "pod succeeded",
+			sandboxSpec: podTemplateSpec,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "sandbox-name",
+					Namespace:       "default",
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef("sandbox-name")},
+				},
+				Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
+			},
+			wantEvent: "Normal PodSucceeded Pod completed successfully",
+		},
+		{
+			name:        "pod failed",
+			sandboxSpec: podTemplateSpec,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "sandbox-name",
+					Namespace:       "default",
+					OwnerReferences: []metav1.OwnerReference{sandboxControllerRef("sandbox-name")},
+				},
+				Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+				Status: corev1.PodStatus{Phase: corev1.PodFailed},
+			},
+			wantEvent: "Warning PodFailed Pod failed",
+		},
+		// The expired cases are treated separately because delete is silent on both reconciles, while retain emits an event
+		// once on the first reconcile and no-ops on the second (due to unchanged state).
+		{
+			name: "expired, retain policy",
+			sandboxSpec: sandboxv1beta1.SandboxSpec{
+				SandboxBlueprint: podTemplateSpec.SandboxBlueprint,
+				Lifecycle: sandboxv1beta1.Lifecycle{
+					ShutdownTime:   &shutdownTime,
+					ShutdownPolicy: ptr.To(sandboxv1beta1.ShutdownPolicyRetain),
+				},
+			},
+			wantEvent: "Normal SandboxExpired Sandbox has expired",
+		},
+		{
+			name: "expired, delete policy",
+			sandboxSpec: sandboxv1beta1.SandboxSpec{
+				SandboxBlueprint: podTemplateSpec.SandboxBlueprint,
+				Lifecycle: sandboxv1beta1.Lifecycle{
+					ShutdownTime:   &shutdownTime,
+					ShutdownPolicy: ptr.To(sandboxv1beta1.ShutdownPolicyDelete),
+				},
+			},
+			wantEvent: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandbox := &sandboxv1beta1.Sandbox{
+				ObjectMeta: metav1.ObjectMeta{Name: "sandbox-name", Namespace: "default", UID: sandboxUID},
+				Spec:       tc.sandboxSpec,
+			}
+			objs := []runtime.Object{sandbox}
+			if tc.pod != nil {
+				objs = append(objs, tc.pod)
+			}
+			recorder := events.NewFakeRecorder(10)
+			r := &SandboxReconciler{
+				Client:   newFakeClient(objs...),
+				Scheme:   Scheme,
+				Recorder: recorder,
+				Tracer:   asmetrics.NewNoOp(),
+			}
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+			_, err := r.Reconcile(t.Context(), req)
+			require.NoError(t, err)
+			if tc.wantEvent == "" {
+				assertNoEvent(t, recorder)
+			} else {
+				require.Equal(t, tc.wantEvent, drainEvent(t, recorder))
+			}
+
+			_, err = r.Reconcile(t.Context(), req)
+			require.NoError(t, err)
+			assertNoEvent(t, recorder)
+		})
+	}
+}
+
+func TestReconcileEvents_SandboxSuspended(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-name", Namespace: "default", UID: sandboxUID},
+		Spec: sandboxv1beta1.SandboxSpec{SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+			PodTemplate: sandboxv1beta1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+			},
+		}},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            sandbox.Name,
+			Namespace:       sandbox.Namespace,
+			OwnerReferences: []metav1.OwnerReference{sandboxControllerRef(sandbox.Name)},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "test-container"}}},
+		Status: corev1.PodStatus{
+			Phase:      corev1.PodRunning,
+			PodIPs:     []corev1.PodIP{{IP: "10.244.0.1"}},
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	recorder := events.NewFakeRecorder(10)
+	r := &SandboxReconciler{
+		Client:   newFakeClient(sandbox, pod),
+		Scheme:   Scheme,
+		Recorder: recorder,
+		Tracer:   asmetrics.NewNoOp(),
+	}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: sandbox.Name, Namespace: sandbox.Namespace}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Normal SandboxReady Sandbox is ready", drainEvent(t, recorder))
+
+	live := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
+	live.Spec.OperatingMode = sandboxv1beta1.SandboxOperatingModeSuspended
+	require.NoError(t, r.Update(t.Context(), live))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Normal SandboxSuspended Sandbox is suspended", drainEvent(t, recorder))
+
+	require.NoError(t, r.Get(t.Context(), req.NamespacedName, live))
+	live.Spec.OperatingMode = ""
+	require.NoError(t, r.Update(t.Context(), live))
+	// The suspension deleted the Pod so recreate it already Ready so this reconcile emits SandboxReady,
+	// not SandboxPodCreated for a blank new Pod.
+	pod.ResourceVersion = ""
+	require.NoError(t, r.Create(t.Context(), pod))
+
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, "Normal SandboxReady Sandbox is ready", drainEvent(t, recorder))
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

This PR modifies the Sandbox reconciler to support the following Kubernetes events:
- `SandboxPodCreated` / `SandboxPodCreateFailed` (Normal/Warning) — Pod create call succeeds/fails
- `SandboxReady` (Normal) — Pod becomes Ready
- `SandboxSuspended` (Normal) — administrative suspend via Spec.OperatingMode
- `SandboxExpired` (Normal) — ShutdownTime expiry (Retain policy only; Delete removes the object before this could fire)
- `PodSucceeded` / `PodFailed` (Normal/Warning) — Pod later exits successfully/unsuccessfully

This is motivated by `kubectl describe sandbox` showing no events on pod creation, readiness, suspension, and expiry due to `Sandbox` emitting none of these, in contrast to SandboxClaim, which already has support for this. This closes that gap, also helps resolve the downstream issue https://github.com/volcano-sh/agentcube/issues/302, and fixes #759.

**Note:** Earlier work was done on this issue by @Maximus-08 in #782 which closed as stale, but this PR does not use the code or architecture from it, aside from the event action strings (e.g. "PodCreation", "Expiry").

#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #759 

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
Sandboxes now emit Kubernetes Events for lifecycle transitions (pod created/failed, ready, suspended, expired, pod succeeded/failed).
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added lifecycle event notifications when sandboxes become ready, expire, suspend, succeed, or fail.
  - Added notifications for successful sandbox pod creation.
  - Added warning notifications when pod creation fails or a sandbox reaches a failed state.
  - Events are emitted only after status changes are successfully saved, preventing notifications for unchanged states.
  - Added an option to disable sandbox event notifications when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->