### PR TITLE
docs(mcp-server): add agent skill for the MCP server

### DIFF
--- a/clients/integrations/mcp-server/skill/README.md
+++ b/clients/integrations/mcp-server/skill/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 - A Kubernetes cluster.
 - [k8s-agent-sandbox CRDs and Router installed](https://github.com/kubernetes-sigs/agent-sandbox).
-- The [mcp-server](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/mcp-server) deployed and reachable — see that repo's own deployment docs for how to run it.
+- The [mcp-server](../README.md) deployed and reachable — see its deployment documentation for how to run it.
 - Any sandbox warmpool deployed to the Kubernetes cluster.
 
 ## Setup

--- a/clients/integrations/mcp-server/skill/README.md
+++ b/clients/integrations/mcp-server/skill/README.md
@@ -4,8 +4,9 @@
 - A Kubernetes cluster.
 - [k8s-agent-sandbox CRDs and Router installed](https://github.com/kubernetes-sigs/agent-sandbox).
 - The [mcp-server](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/mcp-server) deployed and reachable — see that repo's own deployment docs for how to run it.
+- Any sandbox warmpool deployed to the Kubernetes cluster.
 
 ## Setup
 1. Deploy the mcp-server per the link above, and note its URL.
-2. Install the skill (for example, `openclaw skills install @<owner>/k8s-agent-sandbox`)
+2. Install the `k8s-agent-sandbox-mcp` skill into your environment (consult your specific agent client's documentation for the exact installation procedure).
 3. Edit `mcp-config.json` in this skill's directory, setting `mcpServers.k8s-agent-sandbox.url` to that URL.

--- a/clients/integrations/mcp-server/skill/README.md
+++ b/clients/integrations/mcp-server/skill/README.md
@@ -1,0 +1,11 @@
+# k8s-agent-sandbox-mcp
+
+## Prerequisites
+- A Kubernetes cluster.
+- [k8s-agent-sandbox CRDs and Router installed](https://github.com/kubernetes-sigs/agent-sandbox).
+- The [mcp-server](https://github.com/kubernetes-sigs/agent-sandbox/tree/main/clients/integrations/mcp-server) deployed and reachable — see that repo's own deployment docs for how to run it.
+
+## Setup
+1. Deploy the mcp-server per the link above, and note its URL.
+2. Install the skill (for example, `openclaw skills install @<owner>/k8s-agent-sandbox`)
+3. Edit `mcp-config.json` in this skill's directory, setting `mcpServers.k8s-agent-sandbox.url` to that URL.

--- a/clients/integrations/mcp-server/skill/SKILL.md
+++ b/clients/integrations/mcp-server/skill/SKILL.md
@@ -5,19 +5,19 @@ description: "An MCP server skill for managing Kubernetes sandboxes. Enables cre
 
 # Kubernetes Agent Sandbox Manager (MCP)
 
-Use this skill when a task requires running code, executing untrusted scripts, or performing heavy parallel workloads in an isolated Kubernetes environment.
+> **⚠️ SECURITY WARNING:** This MCP server does not have built-in authentication. It exposes tools that can create sandboxes, execute arbitrary commands, and read or write files using the permissions of its Kubernetes service account. Before proceeding, ensure that the server is strictly isolated on a private network or secured behind an authenticating proxy.
 
-This skill connects to the official `kubernetes-sigs/agent-sandbox` MCP server, deployed as a service inside the same Kubernetes cluster as this OpenClaw Gateway. It is registered via mcporter — see `mcp-config.json` in this skill's directory.
+Use this skill when a task requires running code, executing untrusted scripts, or performing heavy parallel workloads in an isolated Kubernetes environment. This skill connects to the official `kubernetes-sigs/agent-sandbox` MCP server. It can be configured using `mcp-config.json` in this skill's directory.
 
 ## Architecture & State
 Unlike basic shell execution, this sandbox is **stateful**.
-When you create a sandbox, a persistent Kubernetes Pod is provisioned and identified by a `sandbox_claim_name`. You can run multiple sequential commands against the same `sandbox_claim_name` (e.g., install a package, then run a script). You must hold onto the `sandbox_claim_name` value in context for the lifetime of the task — there is currently no reliable way to recover it if lost (see Troubleshooting).
+When you create a sandbox, a persistent Kubernetes Pod is provisioned and identified by a `sandbox_claim_name`. You can run multiple sequential commands against the same `sandbox_claim_name` (e.g., install a package, then run a script). You must hold onto the `sandbox_claim_name` value in context for the lifetime of the task, you can acquire it using labels assigned during the sandbox creation.
 
 ## Available MCP Tools
 
 - **`create_sandbox`**
-  - **Arguments:** `warmpool` (string), `namespace` (string), `sandbox_ready_timeout` (int, optional), `labels` (dict[string, string], optional), `shutdown_after_seconds` (int, optional), `pod_labels` (dict[string, string], optional), `pod_annotations` (dict[string, string], optional).
-  - **Returns:** JSON object with `sandbox_claim_name` and `status`.
+  - **Arguments:** `warmpool` (string), `namespace` (string), `sandbox_ready_timeout` (int, optional), `labels` (dict[string, string], optional), `shutdown_after_seconds` (int, optional, defaults to 300 — the sandbox self-deletes after 5 minutes unless raised), `pod_labels` (dict[string, string], optional), `pod_annotations` (dict[string, string], optional).
+  - **Returns:** JSON object with `sandbox_claim_name`.
   - **Purpose:** Create a new sandbox.
 
 - **`execute_command`**
@@ -46,11 +46,11 @@ When you create a sandbox, a persistent Kubernetes Pod is provisioned and identi
   - **Purpose:** Get the readiness status of a sandbox. Use this before executing commands or transferring files to confirm the sandbox is Ready (e.g. after creation, resume, or warm-pool adoption).
 
 - **`list_files`**
-  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `timeout` (int, optional), max_entries, (int, optional).
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `timeout` (int, optional), `max_entries`, (int, optional, default value is 1000, maximum is 10000).
   - **Returns:** JSON object containing fields `entries`, `total_entries`, and `truncated`.
   - **Purpose:** List the contents of a directory in a sandbox. At most max_entries entries are returned (1000 by default). When the directory holds more, the response is truncated and 'truncated' is True while 'total_entries' reports the full count.
 
-- **`upload_files`**
+- **`upload_file`**
   - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `content` (string), `binary` (bool, optional), `timeout` (int, optional).
   - **Returns:** JSON object containing field `bytes_written`.
   - **Purpose:** Upload file to a sandbox.

--- a/clients/integrations/mcp-server/skill/SKILL.md
+++ b/clients/integrations/mcp-server/skill/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when a task requires running code, executing untrusted scripts, o
 
 ## Architecture & State
 Unlike basic shell execution, this sandbox is **stateful**.
-When you create a sandbox, a persistent Kubernetes Pod is provisioned and identified by a `sandbox_claim_name`. You can run multiple sequential commands against the same `sandbox_claim_name` (e.g., install a package, then run a script). You must hold onto the `sandbox_claim_name` value in context for the lifetime of the task, you can acquire it using labels assigned during the sandbox creation.
+When you create a sandbox, a persistent Kubernetes Pod is provisioned and identified by a `sandbox_claim_name`. You can run multiple sequential commands against the same `sandbox_claim_name` (e.g., install a package, then run a script). You must retain the `sandbox_claim_name` value in context for the lifetime of the task.
 
 ## Available MCP Tools
 
@@ -46,14 +46,14 @@ When you create a sandbox, a persistent Kubernetes Pod is provisioned and identi
   - **Purpose:** Get the readiness status of a sandbox. Use this before executing commands or transferring files to confirm the sandbox is Ready (e.g. after creation, resume, or warm-pool adoption).
 
 - **`list_files`**
-  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `timeout` (int, optional), `max_entries`, (int, optional, default value is 1000, maximum is 10000).
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `timeout` (int, optional), `max_entries` (int, optional, default value is 1000, maximum is 10000).
   - **Returns:** JSON object containing fields `entries`, `total_entries`, and `truncated`.
-  - **Purpose:** List the contents of a directory in a sandbox. At most max_entries entries are returned (1000 by default). When the directory holds more, the response is truncated and 'truncated' is True while 'total_entries' reports the full count.
+  - **Purpose:** List the contents of a directory in a sandbox. At most `max_entries` entries are returned (1000 by default). When the directory holds more, the response is truncated and 'truncated' is True while 'total_entries' reports the full count.
 
 - **`upload_file`**
   - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `content` (string), `binary` (bool, optional), `timeout` (int, optional).
   - **Returns:** JSON object containing field `bytes_written`.
-  - **Purpose:** Upload file to a sandbox.
+  - **Purpose:** Upload a file to a sandbox.
 
 ## Strict Usage Workflow
 
@@ -65,7 +65,7 @@ ALWAYS follow this exact sequence when using the sandbox:
 
 ### Example Workflow Concept
 *(Do not write Python wrappers for this, use the provided MCP tools directly)*
-1. Tool Call: `create_sandbox(warmpool="simple-sandbox-warmpool", namespace="default")` → returns `{"sandbox_claim_name": "sbx-12345", "status": "success"}`
+1. Tool Call: `create_sandbox(warmpool="simple-sandbox-warmpool", namespace="default")` → returns `{"sandbox_claim_name": "sbx-12345"}`
 2. Tool Call: `execute_command(sandbox_claim_name="sbx-12345", namespace="default", command="pip install requests")`
 3. Tool Call: `execute_command(sandbox_claim_name="sbx-12345", namespace="default", command="python -c 'import requests; print(requests.get(\"https://example.com\").status_code)'")`
 4. Tool Call: `delete_sandbox(sandbox_claim_name="sbx-12345", namespace="default")`

--- a/clients/integrations/mcp-server/skill/SKILL.md
+++ b/clients/integrations/mcp-server/skill/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: "k8s-agent-sandbox-mcp"
+description: "An MCP server skill for managing Kubernetes sandboxes. Enables creating, executing commands, managing files, and terminating instances via the official kubernetes-sigs/agent-sandbox MCP server."
+---
+
+# Kubernetes Agent Sandbox Manager (MCP)
+
+Use this skill when a task requires running code, executing untrusted scripts, or performing heavy parallel workloads in an isolated Kubernetes environment.
+
+This skill connects to the official `kubernetes-sigs/agent-sandbox` MCP server, deployed as a service inside the same Kubernetes cluster as this OpenClaw Gateway. It is registered via mcporter — see `mcp-config.json` in this skill's directory.
+
+## Architecture & State
+Unlike basic shell execution, this sandbox is **stateful**.
+When you create a sandbox, a persistent Kubernetes Pod is provisioned and identified by a `sandbox_claim_name`. You can run multiple sequential commands against the same `sandbox_claim_name` (e.g., install a package, then run a script). You must hold onto the `sandbox_claim_name` value in context for the lifetime of the task — there is currently no reliable way to recover it if lost (see Troubleshooting).
+
+## Available MCP Tools
+
+- **`create_sandbox`**
+  - **Arguments:** `warmpool` (string), `namespace` (string), `sandbox_ready_timeout` (int, optional), `labels` (dict[string, string], optional), `shutdown_after_seconds` (int, optional), `pod_labels` (dict[string, string], optional), `pod_annotations` (dict[string, string], optional).
+  - **Returns:** JSON object with `sandbox_claim_name` and `status`.
+  - **Purpose:** Create a new sandbox.
+
+- **`execute_command`**
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `command` (string — shell command or python inline script), `timeout` (int — seconds before the command times out, optional).
+  - **Returns:** JSON object containing `stdout`, `stderr`, and `exit_code`, or JSON with an `error` field.
+  - **Purpose:** Executes commands inside the provisioned sandbox.
+
+- **`delete_sandbox`**
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string).
+  - **Returns:** Success or error JSON object.
+  - **Purpose:** Destroys the Kubernetes Pod and frees resources.
+
+- **`download_file`**
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `binary` (bool, optional), `timeout` (int, optional).
+  - **Returns:** JSON object containing `content` and `bytes_read` fields.
+  - **Purpose:** Download a file from a sandbox.
+
+- **`file_exists`**
+  -  **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `timeout` (int, optional).
+  -  **Returns:** JSON object containing field `exists`.
+  -  **Purpose:** Check whether a file or directory exists in a sandbox.
+
+- **`get_sandbox_status`**
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string).
+  - **Returns:** JSON object containing fields `status`, `ready`, and `message`.
+  - **Purpose:** Get the readiness status of a sandbox. Use this before executing commands or transferring files to confirm the sandbox is Ready (e.g. after creation, resume, or warm-pool adoption).
+
+- **`list_files`**
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `timeout` (int, optional), max_entries, (int, optional).
+  - **Returns:** JSON object containing fields `entries`, `total_entries`, and `truncated`.
+  - **Purpose:** List the contents of a directory in a sandbox. At most max_entries entries are returned (1000 by default). When the directory holds more, the response is truncated and 'truncated' is True while 'total_entries' reports the full count.
+
+- **`upload_files`**
+  - **Arguments:** `sandbox_claim_name` (string), `namespace` (string), `path` (string), `content` (string), `binary` (bool, optional), `timeout` (int, optional).
+  - **Returns:** JSON object containing field `bytes_written`.
+  - **Purpose:** Upload file to a sandbox.
+
+## Strict Usage Workflow
+
+ALWAYS follow this exact sequence when using the sandbox:
+
+1. **Initialize:** Call `create_sandbox` and store the returned `sandbox_claim_name` in your context.
+2. **Execute:** Call `execute_command` using the `sandbox_claim_name` as many times as needed to complete the task.
+3. **Cleanup:** Call `delete_sandbox` when the task is complete, even if previous steps failed. Do not leave orphaned sandboxes running in the cluster.
+
+### Example Workflow Concept
+*(Do not write Python wrappers for this, use the provided MCP tools directly)*
+1. Tool Call: `create_sandbox(warmpool="simple-sandbox-warmpool", namespace="default")` → returns `{"sandbox_claim_name": "sbx-12345", "status": "success"}`
+2. Tool Call: `execute_command(sandbox_claim_name="sbx-12345", namespace="default", command="pip install requests")`
+3. Tool Call: `execute_command(sandbox_claim_name="sbx-12345", namespace="default", command="python -c 'import requests; print(requests.get(\"https://example.com\").status_code)'")`
+4. Tool Call: `delete_sandbox(sandbox_claim_name="sbx-12345", namespace="default")`

--- a/clients/integrations/mcp-server/skill/mcp-config.json
+++ b/clients/integrations/mcp-server/skill/mcp-config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "k8s-agent-sandbox": {
+      "url": "http://localhost:8000/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a new directory called `skill` to `clients/integrations/mcp-server` documenting that
the MCP server works with any MCP-compatible client.

- `SKILL.md:` the skill itself.
- `README.md:` describes how to install the skill.
- `mcp-config.json:` the skill configuration.

No code changes — documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added an MCP skill for managing Kubernetes sandboxes, including creation, command execution, file operations, status checks, and deletion.
* Added configuration for connecting to the Kubernetes sandbox MCP server using streamable HTTP.
* Added documentation covering prerequisites, installation, server configuration, persistent sandbox usage, and the recommended create–use–delete workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->