### PR TITLE
fix(clients/ts): address non-blocking review follow-ups from #976

### DIFF
--- a/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
+++ b/clients/typescript/agentic-sandbox-client/src/__tests__/sandbox-client.test.ts
@@ -2160,6 +2160,16 @@ describe("SandboxClient (registry)", () => {
       expect(callArgs.name).toBe("my-claim");
     });
 
+    it("returns undefined for a claim without a warmPoolRef", async () => {
+      mockGetNamespacedCustomObject.mockResolvedValueOnce({
+        spec: { sandboxTemplateRef: { name: "my-template" } },
+      });
+
+      const client = new SandboxClient();
+      const name = await client.getSandboxClaimWarmpoolName("cold-claim");
+      expect(name).toBeUndefined();
+    });
+
     it("uses provided namespace", async () => {
       mockGetNamespacedCustomObject.mockResolvedValueOnce({
         spec: { warmPoolRef: { name: "pool-in-ns" } },

--- a/clients/typescript/agentic-sandbox-client/src/sandbox-client.ts
+++ b/clients/typescript/agentic-sandbox-client/src/sandbox-client.ts
@@ -664,13 +664,14 @@ export class SandboxClient {
   }
 
   /**
-   * Returns the WarmPool name referenced by a SandboxClaim.
+   * Returns the WarmPool name referenced by a SandboxClaim, or `undefined` when
+   * the claim is not warm-pool-backed (`spec.warmPoolRef` is absent).
    * Throws SandboxNotFoundError if the claim does not exist.
    */
   async getSandboxClaimWarmpoolName(
     claimName: string,
     namespace?: string,
-  ): Promise<string> {
+  ): Promise<string | undefined> {
     const ns = namespace || this.defaultNamespace;
     let claimObj: unknown;
     try {
@@ -699,7 +700,7 @@ export class SandboxClient {
         unknown
       >) ?? {};
     const warmPoolRef = (spec.warmPoolRef as Record<string, unknown>) ?? {};
-    return warmPoolRef.name as string;
+    return warmPoolRef.name as string | undefined;
   }
 
   /**

--- a/dev/tools/test-e2e
+++ b/dev/tools/test-e2e
@@ -205,7 +205,7 @@ def run_python_e2e_tests(repo_root, artifact_dir, env):
     return result.returncode
 
 
-def ensure_extensions_enabled(repo_root):
+def ensure_extensions_enabled(env):
     """Ensures the controller is running with --extensions flag.
 
     Both k8s/controller.yaml and k8s/extensions.controller.yaml define the
@@ -216,14 +216,12 @@ def ensure_extensions_enabled(repo_root):
     """
     print("========= Ensuring controller extensions are enabled... =========")
 
-    # Target the same cluster the SDK test frameworks use (explicit $KUBECONFIG,
-    # else the kind kubeconfig make deploy-kind writes to bin/KUBECONFIG), not
-    # kubectl's ambient current-context — this call mutates the controller
-    # Deployment, so a drifted context would patch the wrong cluster.
-    kubeconfig = os.environ.get("KUBECONFIG") or os.path.join(
-        repo_root, "bin", "KUBECONFIG"
-    )
-    kubectl = ["kubectl", "--kubeconfig", kubeconfig]
+    # This call mutates the controller Deployment, so it must hit the same
+    # cluster the SDK test frameworks talk to, not kubectl's ambient
+    # current-context. main() has pinned the resolved kubeconfig in the env every
+    # subprocess inherits; pass it explicitly here too so the target is
+    # unambiguous.
+    kubectl = ["kubectl", "--kubeconfig", env["KUBECONFIG"]]
 
     # Check current args
     result = subprocess.run(
@@ -305,6 +303,16 @@ def main(args):
     if not os.environ.get("PIP_EXTRA_INDEX_URL"):
         env.pop("PIP_EXTRA_INDEX_URL", None)
 
+    # Resolve the kubeconfig once and pin it in the environment every test
+    # subprocess inherits (Go, Python, TypeScript) so they all target the same
+    # cluster: an explicit $KUBECONFIG, else the kind kubeconfig make deploy-kind
+    # writes to bin/KUBECONFIG. Without this the SDK frameworks' `kubectl`
+    # invocations (e.g. the Python framework's apply_manifest_text) fall back to
+    # kubectl's ambient current-context, which may point at a different cluster.
+    env["KUBECONFIG"] = os.environ.get("KUBECONFIG") or os.path.join(
+        repo_root, "bin", "KUBECONFIG"
+    )
+
     if not setup_python_sdk(repo_root, env):
         return 1
 
@@ -322,7 +330,7 @@ def main(args):
 
         # SDK tests (Python + TypeScript) use SandboxClaim and SandboxWarmPool,
         # which require --extensions to be set on the controller.
-        if not ensure_extensions_enabled(repo_root):
+        if not ensure_extensions_enabled(env):
             print("Failed to enable extensions on controller. Aborting.")
             return 1
 

--- a/dev/tools/test-e2e
+++ b/dev/tools/test-e2e
@@ -15,12 +15,9 @@
 
 import os
 import argparse
-import shutil
+import json
 import subprocess
 import sys
-
-import json
-import time
 
 from shared import utils
 from shared.node import ensure_node
@@ -208,7 +205,7 @@ def run_python_e2e_tests(repo_root, artifact_dir, env):
     return result.returncode
 
 
-def ensure_extensions_enabled():
+def ensure_extensions_enabled(repo_root):
     """Ensures the controller is running with --extensions flag.
 
     Both k8s/controller.yaml and k8s/extensions.controller.yaml define the
@@ -219,10 +216,19 @@ def ensure_extensions_enabled():
     """
     print("========= Ensuring controller extensions are enabled... =========")
 
+    # Target the same cluster the SDK test frameworks use (explicit $KUBECONFIG,
+    # else the kind kubeconfig make deploy-kind writes to bin/KUBECONFIG), not
+    # kubectl's ambient current-context — this call mutates the controller
+    # Deployment, so a drifted context would patch the wrong cluster.
+    kubeconfig = os.environ.get("KUBECONFIG") or os.path.join(
+        repo_root, "bin", "KUBECONFIG"
+    )
+    kubectl = ["kubectl", "--kubeconfig", kubeconfig]
+
     # Check current args
     result = subprocess.run(
         [
-            "kubectl", "get", "deployment", "agent-sandbox-controller",
+            *kubectl, "get", "deployment", "agent-sandbox-controller",
             "-n", "agent-sandbox-system",
             "-o", "json",
         ],
@@ -257,7 +263,7 @@ def ensure_extensions_enabled():
 
     patch_result = subprocess.run(
         [
-            "kubectl", "patch", "deployment", "agent-sandbox-controller",
+            *kubectl, "patch", "deployment", "agent-sandbox-controller",
             "-n", "agent-sandbox-system",
             "-p", patch,
         ],
@@ -270,7 +276,7 @@ def ensure_extensions_enabled():
     print("Patch applied. Waiting for rollout to complete...")
     rollout_result = subprocess.run(
         [
-            "kubectl", "rollout", "status", "deployment/agent-sandbox-controller",
+            *kubectl, "rollout", "status", "deployment/agent-sandbox-controller",
             "-n", "agent-sandbox-system",
             "--timeout=120s",
         ],
@@ -316,7 +322,7 @@ def main(args):
 
         # SDK tests (Python + TypeScript) use SandboxClaim and SandboxWarmPool,
         # which require --extensions to be set on the controller.
-        if not ensure_extensions_enabled():
+        if not ensure_extensions_enabled(repo_root):
             print("Failed to enable extensions on controller. Aborting.")
             return 1
 

--- a/test/e2e/clients/typescript/framework/context.ts
+++ b/test/e2e/clients/typescript/framework/context.ts
@@ -112,7 +112,7 @@ export class TestContext {
     try {
       const result = execFileSync(
         "kubectl",
-        ["apply", "-f", "-", "-n", ns],
+        ["--kubeconfig", this.kubeconfigPath, "apply", "-f", "-", "-n", ns],
         {
           input: manifestText,
           encoding: "utf-8",
@@ -195,12 +195,18 @@ export class TestContext {
           const resourceType = watchPath.split("/").pop() ?? "object";
           const desc = execFileSync(
             "kubectl",
-            ["describe", resourceType, name, "-n", namespace],
+            [
+              "--kubeconfig", this.kubeconfigPath,
+              "describe", resourceType, name, "-n", namespace,
+            ],
             { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], timeout: 5_000 },
           );
           const pods = execFileSync(
             "kubectl",
-            ["get", "pods", "-n", namespace, "-o", "wide"],
+            [
+              "--kubeconfig", this.kubeconfigPath,
+              "get", "pods", "-n", namespace, "-o", "wide",
+            ],
             { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], timeout: 5_000 },
           );
           console.error(

--- a/test/e2e/clients/typescript/package.json
+++ b/test/e2e/clients/typescript/package.json
@@ -15,8 +15,5 @@
   },
   "dependencies": {
     "agentic-sandbox-client": "file:../../../../clients/typescript/agentic-sandbox-client"
-  },
-  "allowScripts": {
-    "file:../../../../../clients/typescript/agentic-sandbox-client": true
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->

#976 (the initial TypeScript SDK, resource layer) landed with five non-blocking review notes from @aditya-shantanu and @janetkuo deferred to a follow-up. This clears them:

- **`SandboxClient.getSandboxClaimWarmpoolName()` return type was wrong.** 
  It was declared `Promise<string>` but returned `spec.warmPoolRef.name` unchecked, which is `undefined` at runtime for a claim that is not warm-pool-backed (a cold-pool or direct-template claim). 
  Widened to `Promise<string | undefined>` — matching the Python SDK, which reads the same field as optional — so callers handle the absent case instead of hitting an untyped `undefined`. 
  The package has no consumers yet (`private: true`), so this is not a break in practice. 
  Added a unit test for the no-`warmPoolRef` case.
- **e2e `TestContext` `kubectl` calls ignored the configured kubeconfig.**
  `TestContext` builds its Kubernetes client from an explicit kubeconfig (`$KUBECONFIG`, else `bin/KUBECONFIG`), but its `kubectl` subprocesses — `apply`, and the watch-timeout `describe` / `get pods` diagnostics — used the ambient current-context. A developer whose context drifted after `make deploy-kind` would apply manifests to, and dump state from, a different cluster than the test client talks to. Now they pass `--kubeconfig` explicitly.
- **`dev/tools/test-e2e` had the same split.** 
  `ensure_extensions_enabled()` patches the controller Deployment via `kubectl` against the ambient context; it now targets the same kubeconfig the SDK frameworks use.
- Dropped the unused `shutil` and `time` imports from `dev/tools/test-e2e`.
- Dropped the `allowScripts` block from the e2e `package.json`: its key had a five-segment `../` path where the dependency spec has four, and nothing in the repo reads `allowScripts` (there is no lavamoat) — dead config either way.


#### Which issue(s) this PR is related to:
<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->

Part of #977. Addresses the review comments left on #976.

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox claim lookups now correctly handle claims without a warm pool reference, returning no warm pool name when unavailable.
  * End-to-end tests now consistently use the configured Kubernetes environment for deployment checks, manifest operations, and diagnostics.
  * End-to-end test tooling now supports merged, multi-file Kubernetes configurations and continues past missing configuration files when appropriate.

* **Tests**
  * Added coverage for claims that reference sandbox templates without warm pool settings, ensuring accurate results across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->