### PR TITLE
fix(router): add label to router deployment to match default NetworkPolicy

### DIFF
--- a/olm/bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml
+++ b/olm/bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml
@@ -77,7 +77,7 @@ metadata:
     capabilities: Basic Install
     categories: AI/Machine Learning
     containerImage: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v1.0.0
-    createdAt: "2026-09-04T04:06:53Z"
+    createdAt: "2026-09-08T20:42:18Z"
     operatorframework.io/suggested-namespace: agent-sandbox-system
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -337,6 +337,7 @@ spec:
                   optional: true
                 name: config-volume
       - label:
+          app: sandbox-router
           app.kubernetes.io/component: sandbox-router
           app.kubernetes.io/name: sandbox-router
         name: sandbox-router
@@ -354,6 +355,7 @@ spec:
                 prometheus.io/port: "9090"
                 prometheus.io/scrape: "true"
               labels:
+                app: sandbox-router
                 app.kubernetes.io/component: sandbox-router
                 app.kubernetes.io/name: sandbox-router
             spec:

--- a/olm/config/sandbox-router/deployment.yaml
+++ b/olm/config/sandbox-router/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   name: sandbox-router
   namespace: agent-sandbox-system
   labels:
+    app: sandbox-router
     app.kubernetes.io/name: sandbox-router
     app.kubernetes.io/component: sandbox-router
 spec:
@@ -22,6 +23,7 @@ spec:
   template:
     metadata:
       labels:
+        app: sandbox-router
         app.kubernetes.io/name: sandbox-router
         app.kubernetes.io/component: sandbox-router
       annotations:

--- a/packages/sandboxd/spec/process/v1/process.pb.go
+++ b/packages/sandboxd/spec/process/v1/process.pb.go
@@ -360,7 +360,6 @@ type StartResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Event:
-	//
 	//	*StartResponse_Init
 	//	*StartResponse_Stdout
 	//	*StartResponse_Stderr
@@ -584,7 +583,6 @@ type WriteStdinRequest struct {
 
 	ProcessId int32 `protobuf:"varint,1,opt,name=process_id,json=processId,proto3" json:"process_id,omitempty"`
 	// Types that are assignable to Payload:
-	//
 	//	*WriteStdinRequest_Input
 	//	*WriteStdinRequest_Eof
 	Payload isWriteStdinRequest_Payload `protobuf_oneof:"payload"`

--- a/sandbox-router/deploy/deployment.yaml
+++ b/sandbox-router/deploy/deployment.yaml
@@ -10,6 +10,7 @@ metadata:
   name: sandbox-router
   namespace: agent-sandbox-system
   labels:
+    app: sandbox-router
     app.kubernetes.io/name: sandbox-router
     app.kubernetes.io/component: sandbox-router
 spec:
@@ -22,6 +23,7 @@ spec:
   template:
     metadata:
       labels:
+        app: sandbox-router
         app.kubernetes.io/name: sandbox-router
         app.kubernetes.io/component: sandbox-router
       annotations:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the `app: sandbox-router` label to `sandbox-router/deploy/deployment.yaml` (metadata and pod template labels) and syncs OLM manifests.

The controller's default NetworkPolicy for `SandboxTemplate` (`buildDefaultNetworkPolicySpec`) admits ingress traffic from pods in `agent-sandbox-system` labeled `app: sandbox-router`. With the Go sandbox-router deployed to `agent-sandbox-system` (via #1537), adding this label ensures template-managed sandboxes with default NetworkPolicies immediately accept traffic from the Go router without requiring controller modifications.

#### Which issue(s) this PR is related to:
Fixes #1409
Ref #1536
Ref #1537

#### Release Note
```release-note
Add app: sandbox-router label to Go sandbox-router deployment manifests to match the default SandboxTemplate NetworkPolicy.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added consistent labeling for the sandbox-router deployment and its pods, making these resources easier to identify and select.
  - Updated operator metadata to reflect the latest manifest revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->