### PR TITLE
feat(rl): GKE Pod Snapshot primitives — snapshot/suspend/resume/restore on fleet handles (opt-in)

### DIFF
--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to `agent-sandbox-rl`. Format loosely follows
 
 ## [0.1.0.dev0] — unreleased
 
+### Added (GKE Pod Snapshots — primitives, opt-in)
+- **`ClusterConfig(snapshots=True)`** builds the SDK's GKE PodSnapshot-capable client
+  for that cluster (bound to the cluster's own context *before* the extension's CRD
+  check, so multi-context fleets check the right cluster). Everything else is unchanged
+  when unset.
+- **`SandboxHandle.snapshot() / suspend() / resume() / restore(uid) / list_snapshots()
+  / delete_snapshot(s)() / is_suspended / refresh()`** — thin wrappers over the SDK
+  extension. Resume/restore bring up a new pod: the handle refreshes `pod_name` /
+  `pod_ip` and drops its exec session; identity (`hostname` / `sandbox_id` /
+  `claim_name`) is stable. Extension result objects map to `SnapshotError`
+  (`error_reason` preserved); a non-snapshot sandbox raises `SnapshotsUnavailable`.
+- **`SandboxFleet.snapshot / suspend / resume / restore`** — timed wrappers (run-report
+  phases `snapshot` / `suspend` / `resume` / `restore`, plus a `restored` / `cold`
+  resume count in the report). **`fleet.acquire(task, snapshot_uid=…,
+  pod_annotations=…)`** pins a claim's pod to one snapshot
+  (`podsnapshot.gke.io/ps-name`) — honored on cold start. **`fleet.release(handle,
+  delete_snapshots=True)`** cleans up the sandbox's snapshots (they outlive the claim
+  otherwise; failures are logged, never block release).
+- **Preflight** (only for clusters with `snapshots=True`): PodSnapshot CRDs served and
+  a gVisor runtime class configured are hard failures; a missing `PodSnapshotPolicy`
+  in the namespace is a warning. `agent_sandbox_rl.snapshots.pod_restore_status()`
+  reads a pod's `PodRestored` condition (never raises).
+- **`AsyncSandboxFleet`** mirrors the wrappers (`snapshot / suspend / resume / restore`,
+  `acquire(snapshot_uid=…, pod_annotations=…)`, `release(delete_snapshots=…)`) on its
+  thread pool. **`fleet.recording(label)`** records a `RunReport` around primitive
+  calls made outside `run()` (sets `fleet.report`).
+- README → *Snapshots — suspend / resume / restore* (prerequisites, semantics, limits);
+  `examples/run_snapshot_demo.py` (claim → snapshot → suspend → resume → verify).
+
 ### Changed (docs / guidance)
 - **Warm-pool worker guidance updated for Agent Sandbox v0.5.4**: the #1215
   over-creation churn is fixed upstream by

--- a/examples/agent-sandbox-rl/CHANGELOG.md
+++ b/examples/agent-sandbox-rl/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to `agent-sandbox-rl`. Format loosely follows
   check, so multi-context fleets check the right cluster). Everything else is unchanged
   when unset.
 - **`SandboxHandle.snapshot() / suspend() / resume() / restore(uid) / list_snapshots()
-  / delete_snapshot(s)() / is_suspended / refresh()`** — thin wrappers over the SDK
+  / delete_snapshot(uid) / delete_snapshots() / is_suspended / refresh()`** — thin
+  wrappers over the SDK
   extension. Resume/restore bring up a new pod: the handle refreshes `pod_name` /
   `pod_ip` and drops its exec session; identity (`hostname` / `sandbox_id` /
   `claim_name`) is stable. Extension result objects map to `SnapshotError`

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -484,7 +484,9 @@ the `k8s-agent-sandbox` SDK's GKE extension on its handles; nothing about pools,
 sizing, or strategies changes.
 
 **Prerequisites** (cluster side; the SDK creates only the per-snapshot triggers):
-a GKE cluster (≥ 1.35.3) with Pod Snapshots enabled and a **gVisor** runtime class;
+a GKE cluster on **1.35.3-gke.1234000 or later** with Pod Snapshots enabled (see
+[Prepare for Pod snapshots](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/pod-snapshots-prepare))
+and a **gVisor** runtime class;
 a `PodSnapshotStorageConfig` (GCS bucket, `tokenSource: podKSA`) and a
 `PodSnapshotPolicy` whose grouping rules include `agents.x-k8s.io/sandbox-name-hash`
 and whose selector matches your template's pod labels (every fleet pod carries

--- a/examples/agent-sandbox-rl/README.md
+++ b/examples/agent-sandbox-rl/README.md
@@ -435,7 +435,8 @@ agent_sandbox_rl.reaper` is the recovery path — sweeping an orphaned run by la
 for footprint/concurrency beyond what the control plane comfortably absorbs.
 
 **ClusterConfig:** `name`, `kubeconfig`, `context`, `in_cluster`, `namespace`,
-`node_selector`, `runtime_class`, `image_pull_secret`, `weight`, `max_replicas`.
+`node_selector`, `runtime_class`, `image_pull_secret`, `weight`, `max_replicas`,
+`snapshots` (False — GKE Pod Snapshots; see [Snapshots](#snapshots--suspend--resume--restore-gke-opt-in)).
 
 **TemplateSpec:** `resources` (cpu/memory), `keepalive_command` (`sleep infinity`),
 `runtime_class`, `node_selector`, `image_pull_secret`, `image_pull_policy`
@@ -458,7 +459,9 @@ fleet.load_tasks(source, image_rewrite=make_rewriter(
 
 - **Preflight** (`fleet.preflight()`): per-cluster reachability, v1beta1 CRD
   versions, controller, namespace, and (if configured) runtime class + pull
-  secret. Hard failures raise `PreflightError`; soft issues are warnings.
+  secret; on clusters with `snapshots=True` also the PodSnapshot CRDs, a gVisor
+  runtime class, and (warning) a `PodSnapshotPolicy` in the namespace. Hard
+  failures raise `PreflightError`; soft issues are warnings.
 - **Pre-pull** (`fleet.prepull()` / `setup(prepull=True)`): a DaemonSet caches
   task images on every node so warm pools skip the multi-GB pull. This is where
   cold-start time goes — `wait_pool_ready` dominates a cold run (the sample report
@@ -470,6 +473,77 @@ fleet.load_tasks(source, image_rewrite=make_rewriter(
   reconnecting and falling back to a short re-check on watch drops.
 - **Cleanup**: everything created is labeled `app=agent-sandbox-rl`; `teardown`
   sweeps claims → pools → templates (defensive against stray claims).
+
+### Snapshots — suspend / resume / restore (GKE, opt-in)
+
+On GKE clusters with [Pod Snapshots](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/pod-snapshots)
+a claimed sandbox can be **snapshotted (memory + filesystem), suspended, resumed,
+and restored** — park a long-running episode between turns and free the node, or
+checkpoint an episode at a decision point and roll back to it. The fleet exposes
+the `k8s-agent-sandbox` SDK's GKE extension on its handles; nothing about pools,
+sizing, or strategies changes.
+
+**Prerequisites** (cluster side; the SDK creates only the per-snapshot triggers):
+a GKE cluster (≥ 1.35.3) with Pod Snapshots enabled and a **gVisor** runtime class;
+a `PodSnapshotStorageConfig` (GCS bucket, `tokenSource: podKSA`) and a
+`PodSnapshotPolicy` whose grouping rules include `agents.x-k8s.io/sandbox-name-hash`
+and whose selector matches your template's pod labels (every fleet pod carries
+`app=agent-sandbox-rl` and `sandbox=<template-name>`); a pod ServiceAccount with the
+Workload Identity bucket grants (`storage.bucketViewer` + `storage.objectUser`). See
+the SDK extension's README and the
+[site docs](https://agent-sandbox.sigs.k8s.io/docs/sandbox/snapshots/) for manifests.
+
+```python
+fleet = SandboxFleet(FleetConfig(
+    clusters=[ClusterConfig(name="gke", namespace="rl", snapshots=True)],   # snapshot-capable client
+    template=TemplateSpec(runtime_class="gvisor",
+                          extra_pod_spec={"serviceAccountName": "podsnap-sa"})))
+fleet.load_tasks(["python:3.12"]); fleet.setup()
+
+h = fleet.acquire(fleet.tasks[0])
+h.exec("echo hello > /tmp/state && nohup bash -c 'while sleep 1; do :; done' >/dev/null 2>&1 &")
+uid = fleet.snapshot(h, "checkpoint")      # memory + filesystem, sandbox keeps running
+fleet.suspend(h)                           # snapshot again, then delete the pod (claim kept)
+fleet.resume(h)                            # new pod restored from the LATEST snapshot
+h.exec("cat /tmp/state")                   # -> hello ; the loop is still running
+fleet.suspend(h, snapshot=False)
+fleet.restore(h, uid)                      # roll back to the named checkpoint
+fleet.release(h, delete_snapshots=True)    # snapshots outlive the claim otherwise
+```
+
+The same methods exist on the handle (`h.snapshot()`, `h.suspend()`, `h.resume()`,
+`h.restore(uid)`, `h.list_snapshots()`, `h.delete_snapshots()`, `h.is_suspended`); the
+fleet wrappers add run-report phases (`snapshot`/`suspend`/`resume`/`restore`) and a
+`restored`/`cold` resume count. Outside `fleet.run()`, wrap primitive calls in
+`with fleet.recording("label") as report:` to get that report.
+`examples/run_snapshot_demo.py` runs this flow end to end and asserts that both the
+rootfs file and a background process survive.
+
+What to know:
+
+- **A resume or restore is a new pod.** `pod_name` and `pod_ip` change (the handle
+  `refresh()`es itself); `hostname` / `sandbox_id` / `claim_name` are stable. A
+  persistent exec session is dropped — `exec()` falls back to one-shot, call
+  `open_session()` again to re-attach. Code that cached `pod_name` itself must re-read it.
+- **Quiesce before suspending.** An in-flight command is frozen inside the snapshot and
+  resumes into whatever timeout it had.
+- **Failures raise.** The SDK returns result objects; the fleet raises `SnapshotError`
+  with the extension's reason, and `SnapshotsUnavailable` on a cluster/handle without
+  the snapshot client.
+- **Pinning.** `fleet.acquire(task, snapshot_uid=uid)` stamps
+  `podsnapshot.gke.io/ps-name` on the pod so a claim boots from that snapshot instead
+  of the group's latest. It applies at pod creation: a cold start honors it, an adopted
+  already-running warm member does not (until its next pod).
+- **Bookkeeping.** A suspended handle stays tracked and its claim counted; node capacity
+  freed by suspension is not modeled. Snapshots persist after release unless
+  `delete_snapshots=True`; the policy's retention bounds them per sandbox.
+- **Async.** The SDK calls block. `AsyncSandboxFleet` has the same `snapshot` /
+  `suspend` / `resume` / `restore` (and `acquire(snapshot_uid=…)`,
+  `release(delete_snapshots=…)`) running on its thread pool — use those rather than
+  the handle methods from an event loop.
+- **Scope.** GKE only. Restore targets a sandbox's *own* snapshots; sharing one
+  snapshot across a warm pool is a policy-level pattern (see upstream
+  `examples/podsnapshot-golden-warmpool`).
 
 ## Observability
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/__init__.py
@@ -47,6 +47,8 @@ from .exceptions import (
     FleetOvercommitError,
     NoClusterAvailableError,
     PreflightError,
+    SnapshotError,
+    SnapshotsUnavailable,
 )
 from .async_fleet import AsyncSandboxFleet
 from .fleet import FleetPlan, PlanEntry, SandboxFleet
@@ -156,6 +158,8 @@ __all__ = [
     # exceptions
     "FleetError",
     "PreflightError",
+    "SnapshotError",
+    "SnapshotsUnavailable",
     "CapacityError",
     "NoClusterAvailableError",
     "FleetOvercommitError",

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/async_fleet.py
@@ -165,17 +165,40 @@ class AsyncSandboxFleet:
     await self._to_thread(self._fleet.setup, prepull)
     return self
 
-  async def acquire(self, task: Task) -> SandboxHandle:
-    return await self._to_thread(self._fleet.acquire, task)
+  async def acquire(self, task: Task, *, snapshot_uid: str | None = None,
+                    pod_annotations: dict | None = None) -> SandboxHandle:
+    return await self._to_thread(self._fleet.acquire, task, snapshot_uid=snapshot_uid,
+                                 pod_annotations=pod_annotations)
 
   async def acquire_batch(self, tasks: list[Task]) -> list[SandboxHandle]:
     return list(await asyncio.gather(*(self.acquire(t) for t in tasks)))
 
-  async def release(self, handle: SandboxHandle):
-    return await self._to_thread(self._fleet.release, handle)
+  async def release(self, handle: SandboxHandle, *, delete_snapshots: bool = False):
+    return await self._to_thread(self._fleet.release, handle,
+                                 delete_snapshots=delete_snapshots)
 
   async def release_all(self):
     await asyncio.gather(*(self.release(h) for h in self.handles()))
+
+  # --- GKE Pod Snapshots (blocking SDK calls, run on the pool) ------------- #
+  # The handle's snapshot methods block (the SDK extension is synchronous); use
+  # these from an event loop instead of calling the handle directly.
+  async def snapshot(self, handle: SandboxHandle, name: str | None = None, *,
+                     timeout: int = 180) -> str:
+    return await self._to_thread(self._fleet.snapshot, handle, name, timeout=timeout)
+
+  async def suspend(self, handle: SandboxHandle, *, snapshot: bool = True,
+                    timeout: int = 180):
+    return await self._to_thread(self._fleet.suspend, handle, snapshot=snapshot,
+                                 timeout=timeout)
+
+  async def resume(self, handle: SandboxHandle, *, timeout: int = 180) -> bool:
+    return await self._to_thread(self._fleet.resume, handle, timeout=timeout)
+
+  async def restore(self, handle: SandboxHandle, snapshot_uid: str, *,
+                    timeout: int = 180) -> None:
+    return await self._to_thread(self._fleet.restore, handle, snapshot_uid,
+                                 timeout=timeout)
 
   async def teardown(self, delete_namespace: bool = False):
     return await self._to_thread(self._fleet.teardown, delete_namespace)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/cluster.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/cluster.py
@@ -103,12 +103,22 @@ class Cluster:
 
   @property
   def sandbox_client(self):
-    """SDK SandboxClient using this cluster's K8sHelper (lazy, injected)."""
+    """SDK SandboxClient using this cluster's K8sHelper (lazy, injected).
+
+    With ``ClusterConfig(snapshots=True)`` this is the SDK's GKE PodSnapshot-
+    capable client instead (same claim API; its sandboxes add snapshot /
+    suspend / resume / restore — see `agent_sandbox_rl.snapshots`), bound to
+    this cluster's helper *before* its CRD check runs.
+    """
     if self._sandbox_client is None:
-      from k8s_agent_sandbox import SandboxClient
-      c = (SandboxClient(tracer_config=self.tracer_config)
-           if self.tracer_config is not None else SandboxClient())
-      c.k8s_helper = self.k8s_helper
+      if getattr(self.config, "snapshots", False):
+        from .snapshots import build_snapshot_client
+        c = build_snapshot_client(self.k8s_helper, tracer_config=self.tracer_config)
+      else:
+        from k8s_agent_sandbox import SandboxClient
+        c = (SandboxClient(tracer_config=self.tracer_config)
+             if self.tracer_config is not None else SandboxClient())
+        c.k8s_helper = self.k8s_helper
       self._sandbox_client = c
     return self._sandbox_client
 

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/config.py
@@ -89,6 +89,11 @@ class ClusterConfig(BaseModel):
   image_pull_secret: str | None = None
   weight: float = 1.0                        # for CapacityWeighted placement
   max_replicas: int | None = None           # optional hard capacity hint
+  # GKE Pod Snapshots: build the SDK's PodSnapshot-capable client for this
+  # cluster so its handles gain snapshot()/suspend()/resume()/restore().
+  # Needs a GKE cluster with Pod Snapshots enabled, a gVisor runtime class,
+  # and a PodSnapshotStorageConfig + PodSnapshotPolicy (README → Snapshots).
+  snapshots: bool = False
 
   @field_validator("weight")
   @classmethod

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/constants.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/constants.py
@@ -46,3 +46,13 @@ DEFAULT_LABELS = {MANAGED_BY_LABEL: MANAGED_BY_VALUE}
 # Per-run label stamped on every resource a fleet creates, so an orphaned run's
 # resources can always be swept by the reaper (`reap(run_id=…)`).
 RUN_ID_LABEL = "agents.x-k8s.io/asrl-run-id"
+
+# GKE Pod Snapshots (podsnapshot.gke.io) — used only when a cluster opts in with
+# ClusterConfig(snapshots=True). Mirrors the SDK's gke_extensions constants.
+PODSNAPSHOT_GROUP = "podsnapshot.gke.io"
+PODSNAPSHOT_VERSION = "v1"
+PODSNAPSHOTS_PLURAL = "podsnapshots"
+PODSNAPSHOT_TRIGGERS_PLURAL = "podsnapshotmanualtriggers"
+PODSNAPSHOT_POLICIES_PLURAL = "podsnapshotpolicies"
+# Pod annotation pinning a pod to one snapshot (opts out of "latest Ready wins").
+PODSNAPSHOT_NAME_ANNOTATION = "podsnapshot.gke.io/ps-name"

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/exceptions.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/exceptions.py
@@ -35,3 +35,16 @@ class FleetOvercommitError(FleetError):
   """The in-SDK circuit breaker tripped: live sandboxes exceeded the safe ceiling
   (``overcommit_factor`` × expected, or ``max_live_sandboxes``), signalling a
   runaway/over-creation. The fleet is torn down before this is raised."""
+
+
+class SnapshotError(FleetError):
+  """A snapshot / suspend / resume / restore operation failed: the SDK's GKE
+  Pod Snapshot extension reported ``success=False`` (its ``error_reason`` is
+  the message)."""
+
+
+class SnapshotsUnavailable(FleetError):
+  """Snapshot operations were requested where they cannot work: the cluster
+  was not configured with ``ClusterConfig(snapshots=True)``, the installed SDK
+  lacks ``gke_extensions.snapshots``, or the cluster does not serve the
+  PodSnapshot CRDs."""

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/fleet.py
@@ -417,7 +417,8 @@ class SandboxFleet:
       rep = _pf.preflight_cluster(
           c, require_runtime_class=ts.runtime_class,
           image_pull_secret=ts.image_pull_secret, namespace=c.namespace,
-          validate_template=ts, sample_image=sample_image)
+          validate_template=ts, sample_image=sample_image,
+          snapshots=getattr(c.config, "snapshots", False))
       reports[c.name] = rep
       for w in rep.warnings:
         logger.warning("[%s] %s: %s", c.name, w.name, w.detail)
@@ -797,13 +798,26 @@ class SandboxFleet:
     return self
 
   # --- claims ------------------------------------------------------------ #
-  def acquire(self, task: Task) -> SandboxHandle:
+  def acquire(self, task: Task, *, snapshot_uid: str | None = None,
+              pod_annotations: dict | None = None) -> SandboxHandle:
     """Claim a sandbox for ``task`` and return a `SandboxHandle`.
+
+    ``pod_annotations`` are stamped onto the sandbox **pod** (the claim's
+    ``spec.additionalPodMetadata``). ``snapshot_uid`` is shorthand for the GKE
+    Pod Snapshot pin (``podsnapshot.gke.io/ps-name``): a pod created for this
+    claim boots restored from that snapshot instead of "latest Ready wins".
+    The pin applies at pod creation — a cold start (empty pool) honors it; an
+    adopted, already-running warm member does not until its next pod
+    (suspend → resume).
 
     On any failure between claim creation and bookkeeping, the partially-created
     sandbox is terminated and the on-demand replica bump is rolled back, so a
     failed acquire leaks neither a remote sandbox nor capacity counters.
     """
+    annotations = dict(pod_annotations or {})
+    if snapshot_uid:
+      annotations[constants.PODSNAPSHOT_NAME_ANNOTATION] = snapshot_uid
+    extra = {"pod_annotations": annotations} if annotations else {}
     entry = self.plan_.for_image(task.image) if self.plan_ else None
     on_demand = entry is None
     if not on_demand:
@@ -830,7 +844,7 @@ class SandboxFleet:
         sandbox = cluster.sandbox_client.create_sandbox(
             warmpool=pool, namespace=cluster.namespace,
             sandbox_ready_timeout=self.config.ready_timeout,
-            labels=dict(self.config.labels))
+            labels=dict(self.config.labels), **extra)
         pod = sandbox.get_pod_name()
         try:
           pod_ip = sandbox.get_pod_ip()
@@ -881,7 +895,10 @@ class SandboxFleet:
   def endpoints(self, port: int = 8888) -> list[str]:
     return [h.endpoint(port) for h in self._handles]
 
-  def release(self, handle: SandboxHandle) -> None:
+  def release(self, handle: SandboxHandle, *, delete_snapshots: bool = False) -> None:
+    """Release ``handle`` (delete its claim). With ``delete_snapshots`` also
+    delete the sandbox's GKE Pod Snapshots first — they outlive the claim (and
+    cost storage) otherwise; a failure there is logged, never blocks release."""
     # Claim the handle under the lock first, so a concurrent double-release of the
     # same handle issues the remote delete (and counter decrement) exactly once.
     with self._lock:
@@ -890,8 +907,52 @@ class SandboxFleet:
       self._handles.remove(handle)
       c = self.registry.get(handle.cluster_name)
     c.release_claim()
+    if delete_snapshots:
+      try:
+        handle.delete_snapshots()
+      except Exception:  # noqa: BLE001 — best-effort hygiene, release must proceed
+        logger.warning("release: could not delete snapshots of %s",
+                       handle.sandbox_id, exc_info=True)
     with self._obs.phase("release", cluster=handle.cluster_name):
       handle.release()
+
+  # --- GKE Pod Snapshots (opt-in: ClusterConfig(snapshots=True)) ----------- #
+  # Thin, timed wrappers over the SandboxHandle primitives so the run report
+  # (and metrics/spans) see snapshot work next to claim/process/release.
+  def snapshot(self, handle: SandboxHandle, name: str | None = None, *,
+               timeout: int = 180) -> str:
+    """Snapshot ``handle``'s sandbox (memory + filesystem); returns the uid."""
+    with self._obs.phase("snapshot", cluster=handle.cluster_name,
+                         family=repo_family(handle.task)):
+      return handle.snapshot(name, timeout=timeout)
+
+  def suspend(self, handle: SandboxHandle, *, snapshot: bool = True,
+              timeout: int = 180) -> Optional[str]:
+    """Suspend ``handle``'s sandbox (pod deleted, claim kept); returns the
+    pre-suspend snapshot uid (None when ``snapshot=False``). The handle stays
+    tracked and its claim counted — capacity freed by suspension is not
+    modeled in this version."""
+    with self._obs.phase("suspend", cluster=handle.cluster_name,
+                         family=repo_family(handle.task)):
+      return handle.suspend(snapshot=snapshot, timeout=timeout)
+
+  def resume(self, handle: SandboxHandle, *, timeout: int = 180) -> bool:
+    """Resume ``handle``'s sandbox (latest snapshot if any); returns whether it
+    was restored from a snapshot. The handle is refreshed (new pod)."""
+    with self._obs.phase("resume", cluster=handle.cluster_name,
+                         family=repo_family(handle.task)):
+      restored = handle.resume(timeout=timeout)
+    self._obs.restored(handle.cluster_name, restored)
+    return restored
+
+  def restore(self, handle: SandboxHandle, snapshot_uid: str, *,
+              timeout: int = 180) -> None:
+    """Restore ``handle``'s (suspended) sandbox from ``snapshot_uid``; the SDK
+    verifies the pod's ``PodRestored`` condition. The handle is refreshed."""
+    with self._obs.phase("restore", cluster=handle.cluster_name,
+                         family=repo_family(handle.task)):
+      handle.restore(snapshot_uid, timeout=timeout)
+    self._obs.restored(handle.cluster_name, True)
 
   def release_all(self) -> None:
     for h in list(self._handles):
@@ -965,6 +1026,16 @@ class SandboxFleet:
     self.teardown()
 
   # --- managed runner ---------------------------------------------------- #
+  @contextlib.contextmanager
+  def recording(self, label: str = "manual"):
+    """Record a `RunReport` around primitive calls made outside ``run()``
+    (acquire / snapshot / suspend / resume / restore / release …). Sets
+    ``fleet.report`` for the duration (and leaves it set); ``label`` fills the
+    report's ``strategy`` field. ``run()`` records on its own — don't nest."""
+    with self._obs.run(label) as report:
+      self.report = report
+      yield report
+
   def run(self, process_fn: Callable[[Task, SandboxHandle], object],
           strategy: str = "naive", concurrency: int | None = None,
           *, epochs: int = 1, keep_warm: bool = False,

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/handles.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import shlex
 import time
 from dataclasses import dataclass, field
@@ -23,10 +24,14 @@ from typing import TYPE_CHECKING, Optional
 
 from kubernetes.stream import stream
 
+from . import snapshots as _snap
+from .exceptions import SnapshotsUnavailable
 from .sources import Task
 
 if TYPE_CHECKING:
   from .cluster import Cluster
+
+logger = logging.getLogger("agent_sandbox_rl.handles")
 
 
 def exec_in_pod(core_api, pod: str, namespace: str, command) -> str:
@@ -171,6 +176,13 @@ class SandboxHandle:
     pod_ip: Pod IP if known.
     sandbox: The underlying SDK ``Sandbox`` (``.commands`` / ``.files`` — needs
       the Sandbox Router; ``exec()`` below is the router-free path).
+
+  On a cluster with ``ClusterConfig(snapshots=True)`` (GKE Pod Snapshots) the
+  handle also offers ``snapshot()`` / ``suspend()`` / ``resume()`` /
+  ``restore()`` / ``list_snapshots()``; a resume or restore brings up a **new
+  pod**, so those calls end with ``refresh()`` (new ``pod_name`` / ``pod_ip``,
+  exec session dropped). ``hostname`` / ``sandbox_id`` / ``claim_name`` are
+  stable across it.
   """
 
   task: Task
@@ -223,6 +235,112 @@ class SandboxHandle:
     """In-cluster endpoint (``<hostname>.<namespace>:<port>``) for callers that
     reach the sandbox over the network rather than via exec."""
     return f"{self.hostname}.{self._cluster.namespace}:{port}"
+
+  # --- GKE Pod Snapshots (opt-in: ClusterConfig(snapshots=True)) ----------- #
+  def _snapshot_sandbox(self):
+    if not _snap.capable(self.sandbox):
+      raise SnapshotsUnavailable(
+          f"sandbox {self.sandbox_id!r} has no snapshot support — " + _snap.HINT)
+    return self.sandbox
+
+  def _snapshot_engine(self):
+    engine = getattr(self._snapshot_sandbox(), "snapshots", None)
+    if engine is None:
+      raise SnapshotsUnavailable(
+          f"sandbox {self.sandbox_id!r} has no snapshot engine (closed?) — "
+          + _snap.HINT)
+    return engine
+
+  def refresh(self) -> None:
+    """Re-read pod identity after a pod restart (resume / restore).
+
+    A resumed or restored sandbox is a **new pod**: new ``pod_name`` and
+    ``pod_ip``; ``hostname`` / ``sandbox_id`` / ``claim_name`` do not change.
+    Any persistent exec session was bound to the old pod, so it is dropped
+    (``exec()`` falls back to one-shot; call ``open_session()`` again to
+    re-attach). Safe to call at any time.
+    """
+    self.close_session()
+    sb = self.sandbox
+    if sb is None:
+      return
+    try:
+      self.pod_name = sb.get_pod_name() or self.pod_name
+    except Exception:  # noqa: BLE001 — keep the last known name
+      logger.warning("refresh: could not re-read pod name for %s", self.sandbox_id,
+                     exc_info=True)
+    try:
+      self.pod_ip = sb.get_pod_ip()
+    except Exception:  # noqa: BLE001
+      self.pod_ip = None
+
+  def snapshot(self, name: str | None = None, *, timeout: int = 180) -> str:
+    """Snapshot the running sandbox (memory + filesystem); returns the uid.
+
+    ``name`` seeds the ``PodSnapshotManualTrigger`` name (default: the sandbox
+    id). Blocks up to ``timeout`` seconds for the trigger to be processed. The
+    sandbox keeps running (``postCheckpoint: resume`` in the policy).
+    """
+    r = _snap.check(self._snapshot_engine().create(
+        name or f"snap-{self.sandbox_id}", podsnapshot_timeout=timeout), "snapshot")
+    return r.snapshot_uid
+
+  def list_snapshots(self) -> list:
+    """This sandbox's snapshots, newest first (SDK ``SnapshotDetail`` objects)."""
+    return list(_snap.check(self._snapshot_engine().list(), "list snapshots").snapshots)
+
+  def delete_snapshot(self, snapshot_uid: str, *, timeout: int = 180) -> None:
+    _snap.check(self._snapshot_engine().delete(snapshot_uid, timeout=timeout),
+                "delete snapshot")
+
+  def delete_snapshots(self, *, timeout: int = 180) -> None:
+    """Delete every snapshot of this sandbox (they outlive the claim otherwise)."""
+    _snap.check(self._snapshot_engine().delete_all(timeout=timeout), "delete snapshots")
+
+  def suspend(self, *, snapshot: bool = True, timeout: int = 180) -> Optional[str]:
+    """Suspend the sandbox: the pod is deleted, the claim (and identity) kept.
+
+    With ``snapshot`` (default) the live state is captured first so ``resume()``
+    brings back memory + filesystem; returns that snapshot's uid. Without it,
+    resume is a cold boot of the template. Quiesce the sandbox before calling
+    (an in-flight command is frozen inside the snapshot). Blocks up to
+    ``timeout`` seconds for the pod to terminate. The persistent exec session
+    (if any) is closed first, even when the suspend then fails — ``exec()``
+    falls back to one-shot.
+    """
+    sb = self._snapshot_sandbox()
+    self.close_session()          # the stream is bound to the pod being deleted
+    r = _snap.check(sb.suspend(snapshot_before_suspend=snapshot, wait_timeout=timeout),
+                    "suspend")
+    sr = getattr(r, "snapshot_response", None)
+    return getattr(sr, "snapshot_uid", None) if sr is not None else None
+
+  def resume(self, *, timeout: int = 180) -> bool:
+    """Resume a suspended sandbox, restoring its **latest** snapshot if any.
+
+    Returns whether it came back from a snapshot (False = cold boot, or it was
+    not suspended). Waits up to ``timeout`` seconds for the new pod to be Ready,
+    then ``refresh()``es this handle.
+    """
+    r = _snap.check(self._snapshot_sandbox().resume(wait_timeout=timeout), "resume")
+    self.refresh()
+    return bool(getattr(r, "restored_from_snapshot", False))
+
+  def restore(self, snapshot_uid: str, *, timeout: int = 180) -> None:
+    """Restore a **suspended** sandbox from one specific snapshot.
+
+    Pins the snapshot via the claim's pod annotation, resumes, and verifies the
+    pod's ``PodRestored`` condition names it (the SDK does the verification;
+    a mismatch is a `SnapshotError`). Ends with ``refresh()``.
+    """
+    _snap.check(self._snapshot_sandbox().restore(
+        snapshot_uid, sandbox_ready_timeout=timeout), "restore")
+    self.refresh()
+
+  @property
+  def is_suspended(self) -> bool:
+    """Whether the Sandbox's ``spec.operatingMode`` is ``Suspended``."""
+    return bool(self._snapshot_sandbox().is_suspended())
 
   def release(self) -> None:
     """Release this sandbox (delete its claim).

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/observability.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/observability.py
@@ -143,10 +143,13 @@ class RunReport:
   warm_total: int = 0
   peak_warm: int = 0
   environment: dict = field(default_factory=dict)   # per-cluster details
+  # GKE Pod Snapshot resumes/restores: came back from a snapshot vs cold-booted.
+  snap_restored: int = 0
+  snap_cold: int = 0
 
   _ORDER = ("preflight", "plan", "prepull", "create_warmpool", "wait_pool_ready",
-            "prefetch", "claim", "process", "reset", "quarantine", "rotate",
-            "release", "teardown")
+            "prefetch", "claim", "process", "snapshot", "suspend", "resume",
+            "restore", "reset", "quarantine", "rotate", "release", "teardown")
 
   def add_phase(self, name: str, dur: float) -> None:
     c = self.phases.setdefault(name, [0, 0.0, 0.0])
@@ -163,6 +166,12 @@ class RunReport:
   def add_claim(self) -> None:
     self.claims += 1
 
+  def add_restore(self, restored: bool) -> None:
+    if restored:
+      self.snap_restored += 1
+    else:
+      self.snap_cold += 1
+
   def _ordered(self):
     seen = list(self._ORDER) + [p for p in self.phases if p not in self._ORDER]
     return [(p, self.phases[p]) for p in seen if p in self.phases]
@@ -178,6 +187,7 @@ class RunReport:
         "tasks_err": self.tasks_err,
         "warm_replicas_total": self.warm_total,
         "warm_replicas_peak": self.peak_warm,
+        "snapshots": {"restored": self.snap_restored, "cold": self.snap_cold},
         "environment": self.environment,
     }
 
@@ -207,6 +217,9 @@ class RunReport:
     lines.append(f"  {'TOTAL':<18} {self.total_s:8.2f}s")
     lines.append(f"  claims={self.claims}  tasks={self.tasks_ok}ok/{self.tasks_err}err"
                  f"  warm_replicas total={self.warm_total} peak={self.peak_warm}")
+    if self.snap_restored or self.snap_cold:
+      lines.append(f"  snapshot resumes: restored={self.snap_restored} "
+                   f"cold={self.snap_cold}")
     return "\n".join(lines)
 
 
@@ -308,6 +321,12 @@ class Observer:
     if self.report is not None and status == "ok":
       with self._lock:
         self.report.add_claim()
+
+  def restored(self, cluster: str, restored: bool) -> None:
+    """Record a resume/restore outcome (from a snapshot vs cold boot)."""
+    if self.report is not None:
+      with self._lock:
+        self.report.add_restore(bool(restored))
 
   def warm_add(self, cluster: str, n: int) -> None:
     # Gauge set inside the lock so concurrent add/remove can't lose an update.

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/preflight.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/preflight.py
@@ -86,7 +86,8 @@ def preflight_cluster(cluster, *, require_runtime_class: str | None = None,
                       image_pull_secret: str | None = None,
                       namespace: str | None = None,
                       validate_template=None,
-                      sample_image: str = "busybox:latest") -> PreflightReport:
+                      sample_image: str = "busybox:latest",
+                      snapshots: bool = False) -> PreflightReport:
   """Run all checks on one cluster and return a `PreflightReport`.
 
   If ``validate_template`` (a `TemplateSpec`) is given, the hand-built
@@ -94,6 +95,12 @@ def preflight_cluster(cluster, *, require_runtime_class: str | None = None,
   against the live CRD schema — a clear schema rejection (HTTP 400/422) is a hard
   failure (catches drift the mocked unit tests can't); other errors (RBAC,
   dry-run unsupported) are warnings so we never false-fail.
+
+  With ``snapshots`` (the cluster opted into GKE Pod Snapshots) the PodSnapshot
+  CRDs must be served and a gVisor runtime class configured (hard failures —
+  the SDK client refuses to build without the CRDs, and GKE only snapshots
+  gVisor pods); a missing ``PodSnapshotPolicy`` in the namespace is a warning
+  (the SDK creates only triggers, so without a policy snapshots fail later).
   """
   r = PreflightReport(cluster.name)
   ns = namespace or cluster.namespace
@@ -167,6 +174,41 @@ def preflight_cluster(cluster, *, require_runtime_class: str | None = None,
     except Exception as e:  # noqa: BLE001 — connectivity / dry-run unsupported
       r.add("manifests", False, str(e), warn_only=True)
 
+  # 8. GKE Pod Snapshots (only when this cluster opted in)
+  if snapshots:
+    for plural in (constants.PODSNAPSHOTS_PLURAL, constants.PODSNAPSHOT_TRIGGERS_PLURAL):
+      name = f"{plural}.{constants.PODSNAPSHOT_GROUP}"
+      try:
+        crd = crd_api.read_custom_resource_definition(name)
+        served = [v.name for v in crd.spec.versions if v.served]
+        r.add(f"crd:{plural}", constants.PODSNAPSHOT_VERSION in served,
+              ",".join(served) or "none")
+      except client.ApiException as e:
+        r.add(f"crd:{plural}", False,
+              "not found (enable Pod Snapshots on the GKE cluster)"
+              if e.status == 404 else str(e))
+    if not require_runtime_class:
+      r.add("snapshots:runtime_class", False,
+            "Pod Snapshots need a gVisor runtime class — set "
+            "TemplateSpec/ClusterConfig runtime_class='gvisor'")
+    else:
+      # Only the literal GKE class name is known-good; anything else may still
+      # be gVisor under another name, so warn rather than fail.
+      r.add("snapshots:runtime_class", require_runtime_class == "gvisor",
+            require_runtime_class, warn_only=require_runtime_class != "gvisor")
+    try:
+      pols = cluster.custom_api.list_namespaced_custom_object(
+          constants.PODSNAPSHOT_GROUP, constants.PODSNAPSHOT_VERSION, ns,
+          constants.PODSNAPSHOT_POLICIES_PLURAL)
+      n = len((pols or {}).get("items") or [])
+      r.add("snapshots:policy", n > 0,
+            f"{n} PodSnapshotPolicy in {ns}" if n else
+            f"no PodSnapshotPolicy in {ns} — snapshots will fail (the SDK "
+            "creates only triggers; apply a policy grouped by "
+            f"{constants.SANDBOX_NAME_HASH_LABEL})", warn_only=True)
+    except Exception as e:  # noqa: BLE001 — RBAC etc.; advisory only
+      r.add("snapshots:policy", False, str(e), warn_only=True)
+
   return r
 
 
@@ -183,7 +225,8 @@ def preflight(registry, *, runtime_class: str | None = None,
   for c in registry:
     rep = preflight_cluster(
         c, require_runtime_class=runtime_class,
-        image_pull_secret=image_pull_secret, namespace=namespace)
+        image_pull_secret=image_pull_secret, namespace=namespace,
+        snapshots=getattr(getattr(c, "config", None), "snapshots", False))
     reports[c.name] = rep
     for w in rep.warnings:
       logger.warning("[%s] %s: %s", c.name, w.name, w.detail)

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/snapshots.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/snapshots.py
@@ -27,6 +27,7 @@ Nothing here runs unless a cluster sets ``ClusterConfig(snapshots=True)``.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 
 from .exceptions import SnapshotError, SnapshotsUnavailable
@@ -116,10 +117,17 @@ class RestoreStatus:
   message: str = ""
 
   def from_snapshot(self, snapshot_uid: str | None = None) -> bool:
-    """True when restored — and, if ``snapshot_uid`` is given, from *that* one."""
+    """True when restored — and, if ``snapshot_uid`` is given, from *that* one.
+
+    The uid is matched as a whole token in the condition message (GKE names the
+    snapshot there), so ``uid-1`` does not match a message about ``uid-10``.
+    """
     if not self.restored:
       return False
-    return not snapshot_uid or snapshot_uid in self.message
+    if not snapshot_uid:
+      return True
+    return re.search(rf"(?<![\w.-]){re.escape(snapshot_uid)}(?![\w.-])",
+                     self.message) is not None
 
 
 def pod_restore_status(core_api, pod_name: str, namespace: str) -> RestoreStatus:

--- a/examples/agent-sandbox-rl/agent_sandbox_rl/snapshots.py
+++ b/examples/agent-sandbox-rl/agent_sandbox_rl/snapshots.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GKE Pod Snapshot primitives (opt-in).
+
+The `k8s-agent-sandbox` SDK ships a GKE-only extension
+(`k8s_agent_sandbox.gke_extensions.snapshots`) whose sandboxes can snapshot
+(memory + filesystem), suspend, resume, and restore. This module is the thin
+fleet-side glue: build that client bound to a fleet cluster's own context, map
+the extension's result objects onto exceptions, and read a pod's ``PodRestored``
+condition. `SandboxHandle` and `SandboxFleet` expose the user-facing methods.
+
+Nothing here runs unless a cluster sets ``ClusterConfig(snapshots=True)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from .exceptions import SnapshotError, SnapshotsUnavailable
+
+logger = logging.getLogger("agent_sandbox_rl.snapshots")
+
+HINT = (
+    "snapshot operations need the GKE Pod Snapshot-capable SDK client: set "
+    "ClusterConfig(snapshots=True) for this cluster (requires a GKE cluster with "
+    "Pod Snapshots enabled, a gVisor runtime class, and a PodSnapshotStorageConfig "
+    "+ PodSnapshotPolicy grouped by agents.x-k8s.io/sandbox-name-hash — see "
+    "README → Snapshots)."
+)
+
+_REQUIRED_METHODS = ("suspend", "resume", "restore", "is_suspended")
+
+
+def capable(sandbox) -> bool:
+  """Duck-typed: does this SDK sandbox carry the snapshot extension's surface?"""
+  return sandbox is not None and all(
+      callable(getattr(sandbox, m, None)) for m in _REQUIRED_METHODS)
+
+
+def check(result, op: str):
+  """Map the extension's result objects (``success`` flag) onto an exception.
+
+  The extension does not raise for operational failures: it returns
+  ``SuspendResponse`` / ``ResumeResponse`` / ``RestorationResponse`` /
+  ``SnapshotResponse`` / ``ListSnapshotResult`` / ``DeleteSnapshotResult`` with
+  ``success=False`` and an ``error_reason``. Callers here want exceptions — a
+  failed suspend must never read as a parked sandbox.
+  """
+  if getattr(result, "success", False):
+    return result
+  reason = getattr(result, "error_reason", "") or "no error_reason reported"
+  raise SnapshotError(f"{op} failed: {reason}")
+
+
+def _snapshot_client_class():
+  """The SDK's ``PodSnapshotSandboxClient``, subclassed to take the fleet's helper.
+
+  The stock constructor verifies the PodSnapshot CRD through a **fresh**
+  ``K8sHelper()`` (the ambient kube context) before a caller can inject one, so
+  for a multi-context fleet it would check — and possibly reject — the wrong
+  cluster. The subclass runs the base ``SandboxClient`` init, injects the
+  per-cluster helper, then performs the same check against *that* cluster.
+  """
+  try:
+    from k8s_agent_sandbox import SandboxClient
+    from k8s_agent_sandbox.gke_extensions.snapshots import PodSnapshotSandboxClient
+  except ImportError as e:
+    raise SnapshotsUnavailable(
+        "the installed k8s-agent-sandbox has no gke_extensions.snapshots "
+        "(upgrade the SDK); " + HINT) from e
+
+  class FleetPodSnapshotClient(PodSnapshotSandboxClient):
+    def __init__(self, k8s_helper, **kwargs):
+      SandboxClient.__init__(self, **kwargs)
+      self.k8s_helper = k8s_helper
+      self.snapshot_crd_installed = self._check_snapshot_crd_installed()
+      if not self.snapshot_crd_installed:
+        raise SnapshotsUnavailable(
+            "the PodSnapshot CRD (podsnapshot.gke.io/v1) is not served on this "
+            "cluster — enable Pod Snapshots on the GKE cluster; " + HINT)
+
+  return FleetPodSnapshotClient
+
+
+def build_snapshot_client(k8s_helper, *, tracer_config=None):
+  """Build the snapshot-capable SDK client bound to ``k8s_helper``'s cluster."""
+  cls = _snapshot_client_class()
+  kwargs = {"tracer_config": tracer_config} if tracer_config is not None else {}
+  return cls(k8s_helper, **kwargs)
+
+
+@dataclass
+class RestoreStatus:
+  """What a pod's ``PodRestored`` condition says.
+
+  ``restored`` is ``None`` when the condition could not be read (API error),
+  ``False`` when the pod started fresh (no condition, or status not True), and
+  ``True`` when GKE restored it from a snapshot. ``message`` is the condition
+  message (GKE includes the snapshot uid) or the read error.
+  """
+
+  restored: bool | None
+  message: str = ""
+
+  def from_snapshot(self, snapshot_uid: str | None = None) -> bool:
+    """True when restored — and, if ``snapshot_uid`` is given, from *that* one."""
+    if not self.restored:
+      return False
+    return not snapshot_uid or snapshot_uid in self.message
+
+
+def pod_restore_status(core_api, pod_name: str, namespace: str) -> RestoreStatus:
+  """Read the pod's ``PodRestored`` condition. Never raises."""
+  try:
+    pod = core_api.read_namespaced_pod(pod_name, namespace)
+  except Exception as e:  # noqa: BLE001 — informational; callers record it
+    return RestoreStatus(None, f"read failed: {e}")
+  conditions = getattr(getattr(pod, "status", None), "conditions", None) or []
+  for cond in conditions:
+    if getattr(cond, "type", "") == "PodRestored":
+      msg = getattr(cond, "message", None) or getattr(cond, "reason", None) or ""
+      return RestoreStatus(str(getattr(cond, "status", "")) == "True", msg)
+  return RestoreStatus(False, "no PodRestored condition (fresh start)")

--- a/examples/agent-sandbox-rl/examples/run_snapshot_demo.py
+++ b/examples/agent-sandbox-rl/examples/run_snapshot_demo.py
@@ -1,0 +1,143 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GKE Pod Snapshot primitives end to end: claim → snapshot → suspend → resume →
+verify → restore. Asserts that both filesystem AND process memory survive.
+
+Requires a snapshot-capable GKE cluster (Pod Snapshots enabled, gVisor runtime
+class) with a PodSnapshotStorageConfig + PodSnapshotPolicy grouped by
+`agents.x-k8s.io/sandbox-name-hash` whose selector matches the fleet's pod label
+(`app=agent-sandbox-rl`), and a pod ServiceAccount holding the Workload Identity
+bucket grants — see README → Snapshots. Env-configured:
+
+  NAMESPACE=rl POD_SA=podsnap-sa RUNTIME_CLASS=gvisor IMAGE=python:3.12-slim \\
+  python examples/run_snapshot_demo.py
+
+The probe: a file on the container rootfs (not a volume) and a background shell
+loop that increments a counter in its own memory and mirrors it to a file only on
+request. A cold boot loses the file and the loop; a restore keeps both.
+"""
+
+import json
+import logging
+import os
+import time
+
+from agent_sandbox_rl import (
+    ClusterConfig,
+    FleetConfig,
+    ResourceSpec,
+    SandboxFleet,
+    TemplateSpec,
+)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+log = logging.getLogger("snapshot-demo")
+
+
+def _env(name, default):
+  return os.getenv(name, default)
+
+
+# A counter that lives in the loop's shell memory; /tmp/counter is written only
+# when we `kill -USR1` the loop, so the file alone can't fake a live process.
+PROBE_START = (
+    "echo golden-v1 > /tmp/marker; "
+    "nohup bash -c 'n=0; trap \"echo \\$n > /tmp/counter\" USR1; "
+    "while sleep 0.2; do n=$((n+1)); done' >/dev/null 2>&1 & "
+    "echo $! > /tmp/loop.pid; sleep 1; echo started")
+PROBE_READ = (
+    "kill -USR1 $(cat /tmp/loop.pid) 2>/dev/null && sleep 0.5; "
+    "printf '{\"marker\":\"%s\",\"counter\":\"%s\",\"pid_alive\":%s}' "
+    "\"$(cat /tmp/marker 2>/dev/null)\" \"$(cat /tmp/counter 2>/dev/null)\" "
+    "$(kill -0 $(cat /tmp/loop.pid 2>/dev/null) 2>/dev/null && echo true || echo false)")
+
+
+def probe(handle) -> dict:
+  return json.loads(handle.exec(PROBE_READ).strip() or "{}")
+
+
+def main():
+  namespace = _env("NAMESPACE", "default")
+  template = TemplateSpec(
+      runtime_class=_env("RUNTIME_CLASS", "gvisor"),
+      resources=ResourceSpec(cpu=_env("CPU", "250m"), memory=_env("MEMORY", "512Mi")),
+      extra_pod_spec={"serviceAccountName": _env("POD_SA", "podsnap-sa")},
+  )
+  contexts = [c for c in _env("KUBE_CONTEXTS", "").split(",") if c]
+  clusters = ([ClusterConfig(name=c, context=c, namespace=namespace, snapshots=True)
+               for c in contexts]
+              or [ClusterConfig(name="default", namespace=namespace, snapshots=True)])
+  fleet = SandboxFleet(FleetConfig(
+      clusters=clusters, max_concurrent=1, template=template,
+      ready_timeout=int(_env("SANDBOX_READY_TIMEOUT", "600"))))
+  fleet.load_tasks([_env("IMAGE", "python:3.12-slim")])
+
+  timings = {}
+  with fleet, fleet.recording("snapshot-demo") as report:
+    fleet.setup()
+    h = fleet.acquire(fleet.tasks[0])
+    log.info("claimed %s (pod %s)", h.sandbox_id, h.pod_name)
+    log.info("probe start: %s", h.exec(PROBE_START).strip())
+    before = probe(h)
+    assert before["marker"] == "golden-v1" and before["pid_alive"], before
+
+    t0 = time.monotonic()
+    uid = fleet.snapshot(h, "checkpoint")
+    timings["snapshot_s"] = round(time.monotonic() - t0, 2)
+    log.info("snapshot %s taken in %.1fs", uid, timings["snapshot_s"])
+    # Let the counter advance well past the checkpoint so a restore to it is
+    # distinguishable from a resume-from-latest.
+    time.sleep(6)
+    at_suspend = probe(h)
+
+    t0 = time.monotonic()
+    latest = fleet.suspend(h)                     # snapshots again, then deletes the pod
+    timings["suspend_s"] = round(time.monotonic() - t0, 2)
+    assert h.is_suspended
+    old_pod = h.pod_name
+
+    t0 = time.monotonic()
+    restored = fleet.resume(h)                    # latest snapshot wins
+    timings["resume_s"] = round(time.monotonic() - t0, 2)
+    after = probe(h)
+    log.info("resume restored=%s new pod %s (was %s): %s", restored, h.pod_name,
+             old_pod, after)
+    assert restored, "resume did not restore from a snapshot"
+    assert h.pod_name != old_pod, "resume must bring up a new pod"
+    assert after["marker"] == "golden-v1", "rootfs file lost across resume"
+    assert after["pid_alive"], "background loop lost across resume (memory not restored)"
+    assert int(after["counter"]) >= int(at_suspend["counter"]), (at_suspend, after)
+
+    fleet.suspend(h, snapshot=False)
+    t0 = time.monotonic()
+    fleet.restore(h, uid)                         # roll back to the first checkpoint
+    timings["restore_s"] = round(time.monotonic() - t0, 2)
+    rolled = probe(h)
+    log.info("restore(%s): %s", uid, rolled)
+    assert rolled["pid_alive"] and rolled["marker"] == "golden-v1", rolled
+    assert int(rolled["counter"]) < int(after["counter"]), (
+        "restore to the earlier checkpoint should rewind the in-memory counter")
+
+    fleet.release(h, delete_snapshots=_env("DELETE_SNAPSHOTS", "1") == "1")
+    log.info("latest-before-suspend snapshot was %s", latest)
+
+  print(report.summary())
+  print(json.dumps({"timings": timings, "snapshots": report.to_dict()["snapshots"]},
+                   indent=2))
+
+
+if __name__ == "__main__":
+  main()

--- a/examples/agent-sandbox-rl/tests/test_preflight.py
+++ b/examples/agent-sandbox-rl/tests/test_preflight.py
@@ -193,3 +193,17 @@ def test_registry_preflight_passes_cluster_snapshot_flag(monkeypatch):
   b = types.SimpleNamespace(name="b", config=types.SimpleNamespace())
   pf.preflight([a, b])
   assert seen == {"a": True, "b": False}
+
+
+def test_snapshots_served_version_mismatch_is_hard_failure(monkeypatch):
+  def route(name):
+    if name.endswith(constants.PODSNAPSHOT_GROUP):
+      return _crd(("v1alpha1",))            # CRD present, but not serving v1
+    return _crd()
+  _patch(monkeypatch, crd_for=route)
+  rep = pf.preflight_cluster(_snapshot_cluster(), snapshots=True,
+                             require_runtime_class="gvisor")
+  assert not rep.ok
+  bad = {ch.name: ch.detail for ch in rep.failures}
+  assert set(bad) == {"crd:podsnapshots", "crd:podsnapshotmanualtriggers"}
+  assert all(detail == "v1alpha1" for detail in bad.values())

--- a/examples/agent-sandbox-rl/tests/test_preflight.py
+++ b/examples/agent-sandbox-rl/tests/test_preflight.py
@@ -111,3 +111,85 @@ def test_controller_down_is_warning_only(monkeypatch):
   rep = pf.preflight_cluster(c)
   assert rep.ok                                   # controller is warn-only
   assert any(w.name == "controller" for w in rep.warnings)
+
+
+# ------------------------------------------------------ GKE Pod Snapshots (opt-in)
+
+
+def _snapshot_cluster(policies=1):
+  c = _healthy_cluster()
+  c.custom_api = MagicMock()
+  c.custom_api.list_namespaced_custom_object.return_value = {
+      "items": [{"metadata": {"name": f"p{i}"}} for i in range(policies)]}
+  return c
+
+
+def _crd_router(missing=()):
+  def route(name):
+    if any(name.startswith(m) for m in missing):
+      raise client.ApiException(status=404)
+    return _crd(("v1",)) if name.endswith(constants.PODSNAPSHOT_GROUP) else _crd()
+  return route
+
+
+def test_snapshots_not_requested_adds_no_checks(monkeypatch):
+  _patch(monkeypatch)
+  rep = pf.preflight_cluster(_snapshot_cluster())
+  assert not [c for c in rep.checks if c.name.startswith(("crd:podsnapshot", "snapshots:"))]
+
+
+def test_snapshots_all_ok_with_gvisor(monkeypatch):
+  _patch(monkeypatch, crd_for=_crd_router())
+  c = _snapshot_cluster()
+  rep = pf.preflight_cluster(c, snapshots=True, require_runtime_class="gvisor")
+  names = {ch.name: ch for ch in rep.checks}
+  assert rep.ok and not rep.warnings
+  assert names["crd:podsnapshots"].ok and names["crd:podsnapshotmanualtriggers"].ok
+  assert names["snapshots:runtime_class"].ok and names["snapshots:policy"].ok
+  c.custom_api.list_namespaced_custom_object.assert_called_once_with(
+      constants.PODSNAPSHOT_GROUP, constants.PODSNAPSHOT_VERSION, "ns",
+      constants.PODSNAPSHOT_POLICIES_PLURAL)
+
+
+def test_snapshots_missing_crd_is_hard_failure(monkeypatch):
+  _patch(monkeypatch, crd_for=_crd_router(missing=("podsnapshots.",)))
+  rep = pf.preflight_cluster(_snapshot_cluster(), snapshots=True,
+                             require_runtime_class="gvisor")
+  assert not rep.ok
+  bad = {ch.name: ch.detail for ch in rep.failures}
+  assert "crd:podsnapshots" in bad and "enable Pod Snapshots" in bad["crd:podsnapshots"]
+
+
+def test_snapshots_require_runtime_class(monkeypatch):
+  _patch(monkeypatch, crd_for=_crd_router())
+  rep = pf.preflight_cluster(_snapshot_cluster(), snapshots=True)
+  assert [ch.name for ch in rep.failures] == ["snapshots:runtime_class"]
+  # A non-"gvisor" name may still be gVisor → warning, not failure.
+  rep = pf.preflight_cluster(_snapshot_cluster(), snapshots=True,
+                             require_runtime_class="gvisor-custom")
+  assert rep.ok and [w.name for w in rep.warnings] == ["snapshots:runtime_class"]
+
+
+def test_snapshots_missing_policy_is_warning(monkeypatch):
+  _patch(monkeypatch, crd_for=_crd_router())
+  rep = pf.preflight_cluster(_snapshot_cluster(policies=0), snapshots=True,
+                             require_runtime_class="gvisor")
+  assert rep.ok
+  w = {ch.name: ch for ch in rep.warnings}
+  assert "snapshots:policy" in w
+  assert constants.SANDBOX_NAME_HASH_LABEL in w["snapshots:policy"].detail
+
+
+def test_registry_preflight_passes_cluster_snapshot_flag(monkeypatch):
+  seen = {}
+
+  def fake(cluster, **kw):
+    seen[cluster.name] = kw.get("snapshots")
+    r = pf.PreflightReport(cluster.name)
+    r.add("stub", True)
+    return r
+  monkeypatch.setattr(pf, "preflight_cluster", fake)
+  a = types.SimpleNamespace(name="a", config=types.SimpleNamespace(snapshots=True))
+  b = types.SimpleNamespace(name="b", config=types.SimpleNamespace())
+  pf.preflight([a, b])
+  assert seen == {"a": True, "b": False}

--- a/examples/agent-sandbox-rl/tests/test_snapshots.py
+++ b/examples/agent-sandbox-rl/tests/test_snapshots.py
@@ -1,0 +1,489 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GKE Pod Snapshot primitives (handle methods, fleet wrappers,
+acquire pin, client construction). Everything runs against fakes that mimic the
+SDK extension's result objects — no cluster, no kubeconfig."""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_sandbox_rl import (
+    ClusterRegistry,
+    FleetConfig,
+    SandboxFleet,
+    SnapshotError,
+    SnapshotsUnavailable,
+    constants,
+)
+from agent_sandbox_rl import snapshots as snap
+from agent_sandbox_rl.handles import SandboxHandle
+from agent_sandbox_rl.preflight import PreflightReport
+from agent_sandbox_rl.sources import Task
+
+PIN = constants.PODSNAPSHOT_NAME_ANNOTATION
+
+
+@pytest.fixture(autouse=True)
+def _stub_preflight(monkeypatch):
+  def ok(cluster, **kw):
+    r = PreflightReport(cluster.name)
+    r.add("stub", True)
+    return r
+  monkeypatch.setattr("agent_sandbox_rl.preflight.preflight_cluster", ok)
+
+
+def _ok(**kw):
+  return types.SimpleNamespace(success=True, error_reason="", **kw)
+
+
+def _fail(reason):
+  return types.SimpleNamespace(success=False, error_reason=reason)
+
+
+class FakeEngine:
+  """Mimics the extension's SnapshotEngine result contract."""
+
+  def __init__(self):
+    self.created, self.deleted, self.deleted_all = [], [], 0
+
+  def create(self, trigger_name, podsnapshot_timeout=180):
+    self.created.append((trigger_name, podsnapshot_timeout))
+    return _ok(snapshot_uid=f"uid-{len(self.created)}", trigger_name=trigger_name)
+
+  def list(self, filter_by=None):
+    return _ok(snapshots=[types.SimpleNamespace(snapshot_uid="uid-1", status="Ready")])
+
+  def delete(self, snapshot_uid, timeout=180):
+    self.deleted.append((snapshot_uid, timeout))
+    return _ok(deleted_snapshots=[snapshot_uid])
+
+  def delete_all(self, delete_by="all", timestamp=None, timeout=180):
+    self.deleted_all += 1
+    return _ok(deleted_snapshots=["uid-1"])
+
+
+class FakeSnapSandbox:
+  """Mimics SandboxWithSnapshotSupport: result objects, new pod on resume."""
+
+  def __init__(self):
+    self.claim_name, self.sandbox_id = "claim-1", "sb-1"
+    self.snapshots = FakeEngine()
+    self._suspended, self._pod = False, 1
+    self.calls, self.fail_next = [], None
+
+  def get_pod_name(self):
+    return f"pod-{self._pod}"
+
+  def get_pod_ip(self):
+    return f"10.0.0.{self._pod}"
+
+  def is_suspended(self):
+    return self._suspended
+
+  def _maybe_fail(self):
+    if self.fail_next:
+      reason, self.fail_next = self.fail_next, None
+      return _fail(reason)
+    return None
+
+  def suspend(self, snapshot_before_suspend=True, wait_timeout=180):
+    self.calls.append(("suspend", snapshot_before_suspend, wait_timeout))
+    if (f := self._maybe_fail()) is not None:
+      return f
+    self._suspended = True
+    sr = _ok(snapshot_uid="uid-s") if snapshot_before_suspend else None
+    return _ok(snapshot_response=sr)
+
+  def resume(self, wait_timeout=180):
+    self.calls.append(("resume", wait_timeout))
+    if (f := self._maybe_fail()) is not None:
+      return f
+    self._suspended, self._pod = False, self._pod + 1
+    return _ok(restored_from_snapshot=True, snapshot_uid="uid-s")
+
+  def restore(self, snapshot_uid, sandbox_ready_timeout=180):
+    self.calls.append(("restore", snapshot_uid, sandbox_ready_timeout))
+    if (f := self._maybe_fail()) is not None:
+      return f
+    self._suspended, self._pod = False, self._pod + 1
+    return _ok(restored_from_snapshot=True, snapshot_uid=snapshot_uid)
+
+  def terminate(self):
+    self.calls.append(("terminate",))
+
+
+class FakeSession:
+  def __init__(self):
+    self.is_open, self.closed = True, 0
+
+  def close(self):
+    self.is_open, self.closed = False, self.closed + 1
+
+
+def _handle(sandbox=None, cluster=None):
+  return SandboxHandle(
+      task=Task(id="t", image="img", metadata={}), cluster_name="c",
+      claim_name="claim-1", sandbox_id="sb-1", pod_name="pod-1", hostname="sb-1",
+      pod_ip="10.0.0.1", sandbox=sandbox if sandbox is not None else FakeSnapSandbox(),
+      _cluster=cluster or types.SimpleNamespace(namespace="ns"))
+
+
+# ------------------------------------------------------------------ handle
+
+
+def test_snapshot_returns_uid_and_names_trigger_after_sandbox():
+  h = _handle()
+  assert h.snapshot() == "uid-1"
+  assert h.sandbox.snapshots.created == [("snap-sb-1", 180)]
+  assert h.snapshot("pristine", timeout=30) == "uid-2"
+  assert h.sandbox.snapshots.created[-1] == ("pristine", 30)
+
+
+def test_suspend_forwards_flags_closes_session_and_returns_uid():
+  h = _handle()
+  s = FakeSession()
+  h._session = s
+  assert h.suspend(timeout=60) == "uid-s"
+  assert h.sandbox.calls == [("suspend", True, 60)]
+  assert s.closed == 1 and h._session is None   # stream bound to the deleted pod
+  assert h.is_suspended
+
+
+def test_suspend_without_snapshot_returns_none():
+  h = _handle()
+  assert h.suspend(snapshot=False) is None
+  assert h.sandbox.calls == [("suspend", False, 180)]
+
+
+def test_failure_raises_snapshot_error_with_reason():
+  h = _handle()
+  h.sandbox.fail_next = "PodSnapshotPolicy not found"
+  with pytest.raises(SnapshotError, match="suspend failed: PodSnapshotPolicy not found"):
+    h.suspend()
+  assert not h.is_suspended                      # a failed suspend never reads as parked
+
+
+def test_resume_refreshes_pod_identity_and_drops_session():
+  h = _handle()
+  h.suspend()
+  h._session = FakeSession()                     # e.g. re-opened by a careless caller
+  assert h.resume(timeout=90) is True
+  assert h.sandbox.calls[-1] == ("resume", 90)
+  assert h.pod_name == "pod-2" and h.pod_ip == "10.0.0.2"     # new pod
+  assert h.hostname == "sb-1" and h.sandbox_id == "sb-1"      # stable identity
+  assert h._session is None
+
+
+def test_restore_pins_uid_and_refreshes():
+  h = _handle()
+  h.suspend()
+  h.restore("uid-7", timeout=45)
+  assert h.sandbox.calls[-1] == ("restore", "uid-7", 45)
+  assert h.pod_name == "pod-2"
+
+
+def test_list_and_delete_snapshots():
+  h = _handle()
+  assert [s.snapshot_uid for s in h.list_snapshots()] == ["uid-1"]
+  h.delete_snapshot("uid-1", timeout=10)
+  assert h.sandbox.snapshots.deleted == [("uid-1", 10)]
+  h.delete_snapshots()
+  assert h.sandbox.snapshots.deleted_all == 1
+
+
+def test_plain_sandbox_raises_snapshots_unavailable():
+  plain = types.SimpleNamespace(claim_name="c", sandbox_id="s",
+                                get_pod_name=lambda: "p", get_pod_ip=lambda: None)
+  h = _handle(sandbox=plain)
+  for call in (h.snapshot, h.suspend, h.resume, lambda: h.restore("u"),
+               h.list_snapshots, h.delete_snapshots):
+    with pytest.raises(SnapshotsUnavailable, match="ClusterConfig\\(snapshots=True\\)"):
+      call()
+  with pytest.raises(SnapshotsUnavailable):
+    h.is_suspended  # noqa: B018 — property access is the call under test
+
+
+def test_refresh_keeps_last_pod_name_when_reread_fails():
+  h = _handle()
+  h.sandbox.get_pod_name = lambda: (_ for _ in ()).throw(RuntimeError("api down"))
+  h.refresh()
+  assert h.pod_name == "pod-1" and h.pod_ip == "10.0.0.1"
+
+
+# ------------------------------------------------------------------- fleet
+
+
+def _fleet(registry, **cfg):
+  return SandboxFleet(FleetConfig(**cfg), registry=registry)
+
+
+def test_acquire_pins_snapshot_uid_via_pod_annotations(make_cluster):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img"])
+  f.acquire(f.tasks[0], snapshot_uid="uid-9", pod_annotations={"x": "y"})
+  kw = c.sandbox_client.create_sandbox.call_args.kwargs
+  assert kw["pod_annotations"] == {"x": "y", PIN: "uid-9"}
+  assert kw["labels"]                                # existing kwargs untouched
+
+
+def test_acquire_without_pin_passes_no_pod_annotations(make_cluster):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img"])
+  f.acquire(f.tasks[0])
+  assert "pod_annotations" not in c.sandbox_client.create_sandbox.call_args.kwargs
+
+
+def test_fleet_wrappers_time_phases_and_count_restores(make_cluster):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img"])
+  h = f.acquire(f.tasks[0])
+  h.sandbox = FakeSnapSandbox()
+  with f._obs.run("test") as rep:
+    assert f.snapshot(h, "pre") == "uid-1"
+    assert f.suspend(h, timeout=30) == "uid-s"
+    assert f.resume(h) is True
+    f.suspend(h, snapshot=False)
+    f.restore(h, "uid-1")
+  assert {"snapshot", "suspend", "resume", "restore"} <= set(rep.phases)
+  assert rep.phases["suspend"][0] == 2
+  assert rep.snap_restored == 2 and rep.snap_cold == 0
+  assert rep.to_dict()["snapshots"] == {"restored": 2, "cold": 0}
+  assert "snapshot resumes: restored=2 cold=0" in rep.summary()
+  assert h.pod_name == "pod-3"                       # refreshed after each new pod
+
+
+def test_release_deletes_snapshots_only_when_asked(make_cluster):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img", "img"])
+  keep, drop = f.acquire(f.tasks[0]), f.acquire(f.tasks[1])
+  keep.sandbox, drop.sandbox = FakeSnapSandbox(), FakeSnapSandbox()
+  f.release(keep)
+  assert keep.sandbox.snapshots.deleted_all == 0 and ("terminate",) in keep.sandbox.calls
+  f.release(drop, delete_snapshots=True)
+  assert drop.sandbox.snapshots.deleted_all == 1 and ("terminate",) in drop.sandbox.calls
+  assert f.handles() == []
+
+
+def test_release_snapshot_cleanup_failure_does_not_block_release(make_cluster, caplog):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img"])
+  h = f.acquire(f.tasks[0])
+  h.sandbox = FakeSnapSandbox()
+  h.sandbox.snapshots.delete_all = lambda **kw: _fail("bucket gone")
+  f.release(h, delete_snapshots=True)
+  assert ("terminate",) in h.sandbox.calls
+  assert f.handles() == []
+  assert any("could not delete snapshots" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------- restore status
+
+
+def _pod_with(conditions):
+  return types.SimpleNamespace(status=types.SimpleNamespace(conditions=conditions))
+
+
+def test_pod_restore_status_reads_condition():
+  core = MagicMock()
+  core.read_namespaced_pod.return_value = _pod_with([
+      types.SimpleNamespace(type="Ready", status="True", message=""),
+      types.SimpleNamespace(type="PodRestored", status="True",
+                            message="restored from snapshot uid-42"),
+  ])
+  st = snap.pod_restore_status(core, "pod", "ns")
+  assert st.restored is True
+  assert st.from_snapshot("uid-42") and not st.from_snapshot("uid-1")
+  assert st.from_snapshot()                          # no uid → any restore counts
+
+
+def test_pod_restore_status_fresh_and_unreadable():
+  core = MagicMock()
+  core.read_namespaced_pod.return_value = _pod_with([])
+  assert snap.pod_restore_status(core, "pod", "ns").restored is False
+  core.read_namespaced_pod.side_effect = RuntimeError("403")
+  st = snap.pod_restore_status(core, "pod", "ns")
+  assert st.restored is None and "403" in st.message and not st.from_snapshot()
+
+
+# ------------------------------------------------------------------ client
+
+
+class _FakeBaseClient:
+  """Stands in for the SDK SandboxClient: records kwargs, sets an ambient helper."""
+
+  def __init__(self, **kwargs):
+    self.init_kwargs = kwargs
+    self.k8s_helper = "ambient-helper"
+
+
+class _FakeExtClient(_FakeBaseClient):
+  """Stands in for PodSnapshotSandboxClient: checks the CRD via self.k8s_helper."""
+
+  def __init__(self, *a, **kw):  # the stock ctor would check too early — must be bypassed
+    raise AssertionError("stock PodSnapshotSandboxClient.__init__ must not run")
+
+  def _check_snapshot_crd_installed(self):
+    self.k8s_helper.checked += 1
+    return self.k8s_helper.crd_ok
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+  import k8s_agent_sandbox
+  monkeypatch.setattr(k8s_agent_sandbox, "SandboxClient", _FakeBaseClient)
+  mod = types.ModuleType("k8s_agent_sandbox.gke_extensions.snapshots")
+  mod.PodSnapshotSandboxClient = _FakeExtClient
+  monkeypatch.setitem(sys.modules, "k8s_agent_sandbox.gke_extensions.snapshots", mod)
+
+
+def _helper(crd_ok):
+  return types.SimpleNamespace(crd_ok=crd_ok, checked=0)
+
+
+def test_build_snapshot_client_injects_helper_before_crd_check(fake_sdk):
+  helper = _helper(True)
+  c = snap.build_snapshot_client(helper, tracer_config="tc")
+  assert c.k8s_helper is helper                     # not the ambient one
+  assert helper.checked == 1                        # checked against THIS cluster
+  assert c.init_kwargs == {"tracer_config": "tc"}
+  assert snap.build_snapshot_client(_helper(True)).init_kwargs == {}
+
+
+def test_build_snapshot_client_fails_clearly_without_crd(fake_sdk):
+  with pytest.raises(SnapshotsUnavailable, match="PodSnapshot CRD"):
+    snap.build_snapshot_client(_helper(False))
+
+
+def test_build_snapshot_client_without_extension(monkeypatch):
+  monkeypatch.setitem(sys.modules, "k8s_agent_sandbox.gke_extensions.snapshots", None)
+  with pytest.raises(SnapshotsUnavailable, match="gke_extensions.snapshots"):
+    snap.build_snapshot_client(_helper(True))
+
+
+def test_cluster_builds_snapshot_client_when_configured(monkeypatch):
+  from agent_sandbox_rl import Cluster, ClusterConfig
+  helper = _helper(True)
+  monkeypatch.setattr(Cluster, "k8s_helper", property(lambda self: helper))
+  built = {}
+
+  def fake_build(k8s_helper, *, tracer_config=None):
+    built["helper"], built["tracer"] = k8s_helper, tracer_config
+    return "snapshot-client"
+  monkeypatch.setattr(snap, "build_snapshot_client", fake_build)
+  c = Cluster(ClusterConfig(name="gke", snapshots=True), api_client=MagicMock())
+  assert c.sandbox_client == "snapshot-client"
+  assert built == {"helper": helper, "tracer": None}
+  assert c.sandbox_client == "snapshot-client"      # cached
+
+
+def test_cluster_default_client_path_unchanged(monkeypatch):
+  from agent_sandbox_rl import Cluster, ClusterConfig
+  import k8s_agent_sandbox
+  monkeypatch.setattr(Cluster, "k8s_helper", property(lambda self: "helper"))
+  monkeypatch.setattr(k8s_agent_sandbox, "SandboxClient", _FakeBaseClient)
+  c = Cluster(ClusterConfig(name="plain"), api_client=MagicMock())
+  assert isinstance(c.sandbox_client, _FakeBaseClient)
+  assert c.sandbox_client.k8s_helper == "helper"
+
+
+# ------------------------------------------------------------- review gaps
+
+
+def test_cold_resume_is_counted(make_cluster):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img"])
+  h = f.acquire(f.tasks[0])
+  h.sandbox = FakeSnapSandbox()
+  h.sandbox.resume = lambda wait_timeout=180: _ok(restored_from_snapshot=False,
+                                                  snapshot_uid=None)
+  with f._obs.run("test") as rep:
+    assert f.resume(h) is False
+  assert (rep.snap_restored, rep.snap_cold) == (0, 1)
+
+
+def test_closed_sandbox_engine_raises_unavailable():
+  h = _handle()
+  h.sandbox.snapshots = None                   # the extension clears it on terminate()
+  with pytest.raises(SnapshotsUnavailable, match="no snapshot engine"):
+    h.snapshot()
+  with pytest.raises(SnapshotsUnavailable, match="no snapshot engine"):
+    h.list_snapshots()
+
+
+def test_fleet_preflight_forwards_cluster_snapshot_flag(make_cluster, monkeypatch):
+  seen = {}
+
+  def capture(cluster, **kw):
+    seen[cluster.name] = kw.get("snapshots")
+    r = PreflightReport(cluster.name)
+    r.add("stub", True)
+    return r
+  monkeypatch.setattr("agent_sandbox_rl.preflight.preflight_cluster", capture)
+  snap_c, plain_c = make_cluster("snap"), make_cluster("plain")
+  snap_c.config.snapshots = True
+  f = _fleet(ClusterRegistry([snap_c, plain_c]))
+  f.load_tasks(["img"])
+  f.preflight()
+  assert seen == {"snap": True, "plain": False}
+
+
+def test_recording_sets_report_around_primitives(make_cluster):
+  c = make_cluster("solo")
+  f = _fleet(ClusterRegistry([c]))
+  f.load_tasks(["img"])
+  assert f.report is None
+  with f.recording("demo") as rep:
+    h = f.acquire(f.tasks[0])
+    f.release(h)
+    assert f.report is rep
+  assert rep.strategy == "demo" and rep.claims == 1
+  assert {"claim", "release"} <= set(rep.phases)
+  assert rep.total_s >= 0
+
+
+async def test_async_fleet_mirrors_snapshot_wrappers(make_cluster):
+  from agent_sandbox_rl import AsyncSandboxFleet
+  c = make_cluster("solo")
+  af = AsyncSandboxFleet(FleetConfig(), registry=ClusterRegistry([c]))
+  try:
+    af._fleet.load_tasks(["img"])
+    h = await af.acquire(af._fleet.tasks[0], snapshot_uid="uid-a",
+                         pod_annotations={"k": "v"})
+    kw = c.sandbox_client.create_sandbox.call_args.kwargs
+    assert kw["pod_annotations"] == {"k": "v", PIN: "uid-a"}
+    h.sandbox = FakeSnapSandbox()
+    with af._fleet.recording("async") as rep:
+      assert await af.snapshot(h, "pre") == "uid-1"
+      assert await af.suspend(h, timeout=30) == "uid-s"
+      assert await af.resume(h) is True
+      await af.suspend(h, snapshot=False)
+      await af.restore(h, "uid-1", timeout=45)
+      await af.release(h, delete_snapshots=True)
+    assert h.sandbox.calls[-2:] == [("restore", "uid-1", 45), ("terminate",)]
+    assert h.sandbox.snapshots.deleted_all == 1
+    assert rep.snap_restored == 2
+    assert {"snapshot", "suspend", "resume", "restore"} <= set(rep.phases)
+    assert af.handles() == []
+  finally:
+    af.close()

--- a/examples/agent-sandbox-rl/tests/test_snapshots.py
+++ b/examples/agent-sandbox-rl/tests/test_snapshots.py
@@ -313,7 +313,12 @@ def test_pod_restore_status_reads_condition():
   st = snap.pod_restore_status(core, "pod", "ns")
   assert st.restored is True
   assert st.from_snapshot("uid-42") and not st.from_snapshot("uid-1")
+  assert not st.from_snapshot("uid-4")               # prefix of uid-42 must not match
+  assert not st.from_snapshot("id-42")               # nor a suffix
   assert st.from_snapshot()                          # no uid → any restore counts
+  st2 = snap.RestoreStatus(True, "PodSnapshot golden-v1-20260903-ab12 restored (uid=x.y)")
+  assert st2.from_snapshot("golden-v1-20260903-ab12") and st2.from_snapshot("x.y")
+  assert not st2.from_snapshot("golden-v1")
 
 
 def test_pod_restore_status_fresh_and_unreadable():


### PR DESCRIPTION
#### What this PR does / why we need it:

Exposes the Python SDK's GKE Pod Snapshot extension (`k8s_agent_sandbox.gke_extensions.snapshots`) through `examples/agent-sandbox-rl`, so an RL loop can **park a claimed sandbox between turns and bring back its exact state (memory + filesystem)**, or checkpoint an episode and roll back to it — without any change to warm pools, sizing, or strategies. Opt-in per cluster; nothing changes when the flag is unset.

**What's added**

- **`ClusterConfig(snapshots=True)`** builds the SDK's `PodSnapshotSandboxClient` for that cluster. It is subclassed so the fleet's per-cluster `K8sHelper` is injected *before* the extension's CRD check runs — the stock constructor checks through a fresh default-context helper, which is the wrong cluster for a multi-context fleet.
- **`SandboxHandle.snapshot() / suspend() / resume() / restore(uid) / list_snapshots() / delete_snapshot(s)() / is_suspended / refresh()`** — thin wrappers over the extension. A resume or restore is a **new pod**, so the handle re-reads `pod_name` / `pod_ip` and drops its persistent exec session; `hostname` / `sandbox_id` / `claim_name` are stable. The extension's result objects (`success` flag) map to `SnapshotError` with the extension's `error_reason`; a sandbox without the extension raises `SnapshotsUnavailable` pointing at the flag.
- **`SandboxFleet.snapshot / suspend / resume / restore`** — timed wrappers (run-report phases plus a `restored` / `cold` resume count). **`acquire(task, snapshot_uid=…, pod_annotations=…)`** pins the claim's pod to one snapshot via `podsnapshot.gke.io/ps-name` (honored at pod creation; an already-running adopted warm member converges on its next pod). **`release(handle, delete_snapshots=True)`** removes the sandbox's snapshots first, best effort — they outlive the claim otherwise. **`fleet.recording(label)`** records a `RunReport` around primitive calls made outside `run()`. `AsyncSandboxFleet` mirrors all of it on its thread pool (the SDK calls block).
- **Preflight** (snapshot clusters only): PodSnapshot CRDs served and a gVisor runtime class configured are hard failures; a missing `PodSnapshotPolicy` in the namespace is a warning (the SDK creates only manual triggers; the policy and storage config are cluster prerequisites, as in the SDK extension's README).
- README → *Snapshots — suspend / resume / restore* (prerequisites, pod-restart semantics, pinning, cost, limits), CHANGELOG, and `examples/run_snapshot_demo.py`: claim → write a rootfs file and start a background process → snapshot → suspend → resume → assert both survived → restore to the earlier checkpoint → assert the in-memory counter rewound.

**How it relates to existing snapshot work.** The site docs and the SDK extension cover per-session self-restore; #1522 covers sharing one snapshot across a warm pool at the GKE policy level. This PR is the fleet-side primitive layer for the former, and the groundwork (client selection, `PodRestored` reader, pin passthrough, refresh-after-restart) for doing the latter inside the fleet's `setup()` in a follow-up.

**Testing.** 38 new unit tests against fakes mimicking the extension's result contract (handle wrappers and refresh, failure mapping, pin passthrough, fleet phases and counters incl. cold resumes, release cleanup, `recording()`, async wrappers, client construction with helper injection, preflight checks); the full `agent-sandbox-rl` suite is green (355). **Live validation is still pending**: `examples/run_snapshot_demo.py` is the end-to-end check and needs a GKE cluster with Pod Snapshots enabled, a gVisor node pool, a `PodSnapshotStorageConfig` + name-hash-grouped `PodSnapshotPolicy` selecting the fleet's `app=agent-sandbox-rl` pod label, and a pod ServiceAccount with the Workload Identity bucket grants. I'll post the demo's timings here once it has run.

#### Which issue(s) this PR is related to:

Ref #1522 (golden-snapshot warm pools example — the pool-level pattern this layer prepares for)

#### Release Note

```release-note
agent-sandbox-rl: opt-in GKE Pod Snapshot primitives. `ClusterConfig(snapshots=True)` builds the SDK's snapshot-capable client; handles gain `snapshot() / suspend() / resume() / restore()`, `fleet.acquire(task, snapshot_uid=…)` pins a claim to a snapshot, `fleet.release(handle, delete_snapshots=True)` cleans up, and the run report shows snapshot phases and restored/cold resume counts. Preflight validates the PodSnapshot CRDs and gVisor runtime class on opted-in clusters.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in GKE Pod Snapshot support for sandbox snapshot, suspend, resume, restore, listing, and deletion workflows.
  - Added snapshot-aware acquisition and release options, including snapshot pinning and cleanup.
  - Added equivalent asynchronous fleet operations.
  - Added restore-status reporting, snapshot metrics, and manual operation recording.
  - Added validation for required snapshot infrastructure and clear errors when unavailable.

- **Documentation**
  - Documented prerequisites, lifecycle operations, behavioral considerations, and usage examples.
  - Added an end-to-end snapshot demonstration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->