### PR TITLE
bench: raise etcd backend quota to 8GiB

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -294,6 +294,18 @@ kops edit cluster --name "${CLUSTER_NAME}" \
 kops edit cluster --name "${CLUSTER_NAME}" \
   --set "cluster.spec.kubeControllerManager.nodeCIDRMaskSize=${STRESS_NODE_CIDR_MASK_SIZE:-23}"
 
+# etcd backend quota: etcd's default is 2GiB; if we exceed it,
+# etcd raises the NOSPACE alarm and rejects EVERY write with
+# "mvcc: database space exceeded" until the alarm is cleared.
+# Defaults to 8GiB (overridable via STRESS_ETCD_QUOTA_BYTES), which puts
+# the cliff far from any benchmark workload; etcd only uses the space it
+# actually writes.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set 'cluster.spec.etcdClusters[0].manager.env[0].name=ETCD_QUOTA_BACKEND_BYTES' \
+  --set "cluster.spec.etcdClusters[0].manager.env[0].value=${STRESS_ETCD_QUOTA_BYTES:-8589934592}" \
+  --set 'cluster.spec.etcdClusters[1].manager.env[0].name=ETCD_QUOTA_BACKEND_BYTES' \
+  --set "cluster.spec.etcdClusters[1].manager.env[0].value=${STRESS_ETCD_QUOTA_BYTES:-8589934592}"
+
 if [[ "${CNI}" == "cilium" ]]; then
   # cilium.enablePrometheusMetrics: serve cilium-agent metrics on :9090 so the
   # stress test can scrape them (promscrape.go already targets this port; the


### PR DESCRIPTION
etcd's default quota is 2GiB, and crossing it is a cliff rather than a slowdown: etcd raises the NOSPACE alarm and rejects **every** write with `mvcc: database space exceeded` until the alarm is cleared.

A 100k-pod benchmark launch writes ~2GB into etcd. Fast runs finished at ~1.7GB; a marginally slower run crossed the quota mid-fill and collapsed into a kubelet retry storm — 3.6M failed status PATCHes at ~3,200/s for 15 minutes — while etcd-manager never cleared the alarm.

8GiB puts the cliff far from any benchmark workload; etcd only uses the space it actually writes. Overridable via `STRESS_ETCD_QUOTA_BYTES`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Benchmark scenarios now apply an 8 GiB backend quota to both the primary and events etcd clusters.
  - The quota can be customized using the `STRESS_ETCD_QUOTA_BYTES` setting.
  - This enables benchmark runs to use consistent default storage limits or alternative quota configurations for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->