### PR TITLE
bench: set nodeCIDRMaskSize=23

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -285,6 +285,14 @@ kops edit cluster --name "${CLUSTER_NAME}" \
   --set cluster.spec.kubelet.eventQPS=5 \
   --set cluster.spec.kubelet.eventBurst=50
 
+# kubeControllerManager.nodeCIDRMaskSize: each node's pod CIDR is carved
+# out of the cluster pod CIDR (10.4.0.0/14 on kOps GCE), and the mask
+# bounds the cluster along two axes:
+#   pods per node  <= 2^(32-mask) - 2   (/24 -> 254, /23 -> 510)
+#   nodes          <= 2^(mask-14)       (/24 -> 1024, /23 -> 512, /22 -> 256)
+# /23 balances the two axes: up to 510 pods/node AND up to 512 nodes.
+kops edit cluster --name "${CLUSTER_NAME}" \
+  --set "cluster.spec.kubeControllerManager.nodeCIDRMaskSize=${STRESS_NODE_CIDR_MASK_SIZE:-23}"
 
 if [[ "${CNI}" == "cilium" ]]; then
   # cilium.enablePrometheusMetrics: serve cilium-agent metrics on :9090 so the


### PR DESCRIPTION
Each node's pod CIDR is carved from the cluster pod CIDR (10.4.0.0/14 on kOps GCE), and the mask bounds the cluster along **two axes at once**:

- pods per node ≤ 2^(32−mask) − 2 (/24 → 254, /23 → 510)
- node count ≤ 2^(mask−14) (/24 → 1024, /23 → 512, /22 → 256)

Both cliffs fail hard, and the node-count one fails confusingly: GCE rejects instance creation with `IP_SPACE_EXHAUSTED` when the per-node alias range can't be allocated. A 300-node scale run with /22 stalled at exactly 253 workers + 3 support nodes = 256 slots.

/23 balances the axes for benchmark shapes: up to 510 pods/node **and** up to 512 nodes. Overridable via `STRESS_NODE_CIDR_MASK_SIZE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default Kubernetes cluster networking configuration for stress test scenarios, setting the node CIDR mask size to 23.
  * Added support for overriding the default mask size through the `STRESS_NODE_CIDR_MASK_SIZE` environment variable.
  * The configuration helps control both the number of pods supported per node and the maximum number of nodes in a cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->