### PR TITLE
test(benchmarks): capture control-plane serial logs on failure and parameterize validation wait

### DIFF
--- a/test/benchmarks/scenarios/benchmarks-kops-gcp/run
+++ b/test/benchmarks/scenarios/benchmarks-kops-gcp/run
@@ -301,8 +301,33 @@ kops update cluster --name "${CLUSTER_NAME}" --yes
 echo "Exporting kubeconfig..."
 kops export kubeconfig --name "${CLUSTER_NAME}" --admin
 
-echo "Waiting for cluster to be ready..."
-kops validate cluster --wait 15m
+capture_control_plane_serial_port() {
+  echo "kOps cluster validation failed. Capturing control plane serial port output for diagnosis..."
+  local out_dir="${ARTIFACTS:-.}"
+  mkdir -p "${out_dir}"
+  local cp_instance
+  cp_instance=$(gcloud compute instance-groups managed list-instances "a-control-plane-${ZONE}-${CLUSTER_NAME}" --zone="${ZONE}" --project="${PROJECT_ID}" --format="value(instance.basename())" 2>/dev/null | head -n1 || true)
+  if [[ -z "${cp_instance}" ]]; then
+    cp_instance=$(gcloud compute instances list --project="${PROJECT_ID}" --filter="name ~ 'control-plane.*${CLUSTER_NAME}' AND zone:${ZONE}" --format="value(name)" 2>/dev/null | head -n1 || true)
+  fi
+  if [[ -n "${cp_instance}" ]]; then
+    echo "Saving serial port output from ${cp_instance} to ${out_dir}/control-plane-serial-port.log..."
+    gcloud compute instances get-serial-port-output "${cp_instance}" --zone="${ZONE}" --project="${PROJECT_ID}" > "${out_dir}/control-plane-serial-port.log" 2>&1 || true
+  else
+    echo "WARNING: Could not find control-plane instance for cluster ${CLUSTER_NAME} in zone ${ZONE}; serial port output was not captured." >&2
+  fi
+}
+
+validate_cluster() {
+  local wait_time="${1:-${STRESS_VALIDATE_WAIT:-15m}}"
+  echo "Waiting for cluster to be ready (timeout: ${wait_time})..."
+  if ! kops validate cluster --wait "${wait_time}"; then
+    capture_control_plane_serial_port
+    exit 1
+  fi
+}
+
+validate_cluster "${STRESS_VALIDATE_WAIT:-15m}"
 
 if [[ "${CNI}" == "cilium" ]]; then
   # Raise Cilium's endpoint-create API rate limit. The agent rate-limits
@@ -330,7 +355,7 @@ if [[ "${CNI}" == "cilium" ]]; then
   # out). Delete the agent pods so the DaemonSet brings them back with the
   # new config, then re-validate the cluster to wait for them to be Ready.
   kubectl --namespace kube-system delete pods --selector=k8s-app=cilium
-  kops validate cluster --wait 5m
+  validate_cluster "${STRESS_CILIUM_VALIDATE_WAIT:-5m}"
 fi
 
 # node-exporter: node-level CPU (incl. iowait), memory and disk stats for


### PR DESCRIPTION
#### What this PR does / why we need it:
kOps GCP benchmark presubmits occasionally fail during cluster validation with `dial tcp <external-ip>:443: i/o timeout`, indicating that the apiserver never became reachable through the external load balancer before the validation timeout expired. When validation fails, the exit cleanup handler immediately tears down the cluster VMs, destroying the console output needed to determine why the control plane node failed bootstrap or health checks. In addition, the cluster validation timeout was hardcoded in the runner script.

This PR:
1. **Captures control-plane serial port console logs on validation failure**: Extracts the control-plane VM's serial port output via `gcloud` and writes it to `$ARTIFACTS/control-plane-serial-port.log` before teardown, preserving critical boot and `nodeup` logs in Prow. The VM lookup is scoped to the cluster's managed instance group (`a-control-plane-${ZONE}-${CLUSTER_NAME}`) to prevent cross-contamination during concurrent runs.
2. **Unifies cluster validation handling**: Consolidates cluster validation into a `validate_cluster()` helper used by both initial cluster validation and the Cilium post-restart re-validation, ensuring failure diagnostic capture is applied consistently.
3. **Parameterizes validation timeout**: Replaces the hardcoded `15m` initial wait and `5m` Cilium re-validation wait with `"${STRESS_VALIDATE_WAIT:-15m}"` and `"${STRESS_CILIUM_VALIDATE_WAIT:-5m}"`, allowing manual or periodic runs to adjust timeouts without modifying code.

#### Which issue(s) this PR is related to:
Ref #1377
Ref #1551

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster validation reliability for initial checks and Cilium re-validation.
  - Validation processes now consistently honor configured timeouts.
  - Control-plane serial output is captured when validation fails, providing better diagnostic information.
  - Improved control-plane instance discovery with a fallback lookup method.

- **Configuration**
  - Added support for configuring the Cilium validation retry timeout through `STRESS_CILIUM_VALIDATE_WAIT`.
  - The default Cilium validation retry timeout is 5 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->