### PR TITLE
rbac: trim over-granted controller verbs and add an e2e RBAC-denial guard

### DIFF
--- a/controllers/sandbox_controller.go
+++ b/controllers/sandbox_controller.go
@@ -257,12 +257,12 @@ type SandboxReconciler struct {
 	deferralClock deferredWriteClock
 }
 
-//+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;patch;delete
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch

--- a/extensions/controllers/sandboxclaim_controller.go
+++ b/extensions/controllers/sandboxclaim_controller.go
@@ -198,16 +198,15 @@ type SandboxClaimReconciler struct {
 	DisableObservabilityAnnotations bool
 }
 
-//+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims,verbs=get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxclaims/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxtemplates,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;delete
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/extensions/controllers/sandboxtemplate_controller.go
+++ b/extensions/controllers/sandboxtemplate_controller.go
@@ -43,11 +43,11 @@ type SandboxTemplateReconciler struct {
 	Tracer   asmetrics.Instrumenter
 }
 
-//+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxtemplates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxtemplates,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxtemplates/finalizers,verbs=get;update;patch
-//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 func (r *SandboxTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)

--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -411,13 +411,13 @@ func (r *SandboxWarmPoolReconciler) exp() *warmPoolExpectations {
 	return r.expectations
 }
 
-//+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=extensions.agents.x-k8s.io,resources=sandboxwarmpools/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=agents.x-k8s.io,resources=sandboxes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
-//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile implements the reconciliation loop for SandboxWarmPool.
 func (r *SandboxWarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: agent-sandbox
 description: Kubernetes controller for managing agent sandboxes
 type: application
-version: 0.1.0
+version: 0.1.1
 keywords:
   - agent
   - sandbox

--- a/helm/templates/extensions-rbac.generated.yaml
+++ b/helm/templates/extensions-rbac.generated.yaml
@@ -11,8 +11,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -22,7 +20,6 @@ rules:
   verbs:
   - create
   - patch
-  - update
 - apiGroups:
   - agents.x-k8s.io
   resources:
@@ -41,7 +38,6 @@ rules:
   - leases
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -51,10 +47,7 @@ rules:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims
-  - sandboxtemplates
-  - sandboxwarmpools
   verbs:
-  - create
   - delete
   - get
   - list
@@ -74,6 +67,23 @@ rules:
   - patch
   - update
 - apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
+  - sandboxtemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
+  - sandboxwarmpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -82,6 +92,5 @@ rules:
   - delete
   - get
   - list
-  - patch
   - update
   - watch

--- a/helm/templates/rbac.generated.yaml
+++ b/helm/templates/rbac.generated.yaml
@@ -8,6 +8,15 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:
@@ -31,12 +40,10 @@ rules:
   resources:
   - sandboxes
   verbs:
-  - create
   - delete
   - get
   - list
   - patch
-  - update
   - watch
 - apiGroups:
   - agents.x-k8s.io

--- a/k8s/extensions-rbac.generated.yaml
+++ b/k8s/extensions-rbac.generated.yaml
@@ -11,8 +11,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -22,7 +20,6 @@ rules:
   verbs:
   - create
   - patch
-  - update
 - apiGroups:
   - agents.x-k8s.io
   resources:
@@ -41,7 +38,6 @@ rules:
   - leases
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -51,10 +47,7 @@ rules:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims
-  - sandboxtemplates
-  - sandboxwarmpools
   verbs:
-  - create
   - delete
   - get
   - list
@@ -74,6 +67,23 @@ rules:
   - patch
   - update
 - apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
+  - sandboxtemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
+  - sandboxwarmpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -82,6 +92,5 @@ rules:
   - delete
   - get
   - list
-  - patch
   - update
   - watch

--- a/k8s/rbac.generated.yaml
+++ b/k8s/rbac.generated.yaml
@@ -8,6 +8,15 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:
@@ -31,12 +40,10 @@ rules:
   resources:
   - sandboxes
   verbs:
-  - create
   - delete
   - get
   - list
   - patch
-  - update
   - watch
 - apiGroups:
   - agents.x-k8s.io

--- a/olm/bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml
+++ b/olm/bundle/manifests/agent-sandbox-operator.clusterserviceversion.yaml
@@ -155,6 +155,15 @@ spec:
           - ""
           resources:
           - persistentvolumeclaims
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - pods
           - services
           verbs:
@@ -178,12 +187,10 @@ spec:
           resources:
           - sandboxes
           verbs:
-          - create
           - delete
           - get
           - list
           - patch
-          - update
           - watch
         - apiGroups:
           - agents.x-k8s.io
@@ -212,8 +219,6 @@ spec:
           verbs:
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - ""
@@ -223,7 +228,6 @@ spec:
           verbs:
           - create
           - patch
-          - update
         - apiGroups:
           - agents.x-k8s.io
           resources:
@@ -242,7 +246,6 @@ spec:
           - leases
           verbs:
           - create
-          - delete
           - get
           - list
           - patch
@@ -252,10 +255,7 @@ spec:
           - extensions.agents.x-k8s.io
           resources:
           - sandboxclaims
-          - sandboxtemplates
-          - sandboxwarmpools
           verbs:
-          - create
           - delete
           - get
           - list
@@ -275,6 +275,23 @@ spec:
           - patch
           - update
         - apiGroups:
+          - extensions.agents.x-k8s.io
+          resources:
+          - sandboxtemplates
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - extensions.agents.x-k8s.io
+          resources:
+          - sandboxwarmpools
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - networking.k8s.io
           resources:
           - networkpolicies
@@ -283,7 +300,6 @@ spec:
           - delete
           - get
           - list
-          - patch
           - update
           - watch
         serviceAccountName: agent-sandbox-controller

--- a/olm/config/rbac/extensions_role.yaml
+++ b/olm/config/rbac/extensions_role.yaml
@@ -11,8 +11,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -22,7 +20,6 @@ rules:
   verbs:
   - create
   - patch
-  - update
 - apiGroups:
   - agents.x-k8s.io
   resources:
@@ -41,7 +38,6 @@ rules:
   - leases
   verbs:
   - create
-  - delete
   - get
   - list
   - patch
@@ -51,10 +47,7 @@ rules:
   - extensions.agents.x-k8s.io
   resources:
   - sandboxclaims
-  - sandboxtemplates
-  - sandboxwarmpools
   verbs:
-  - create
   - delete
   - get
   - list
@@ -74,6 +67,23 @@ rules:
   - patch
   - update
 - apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
+  - sandboxtemplates
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - extensions.agents.x-k8s.io
+  resources:
+  - sandboxwarmpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -82,6 +92,5 @@ rules:
   - delete
   - get
   - list
-  - patch
   - update
   - watch

--- a/olm/config/rbac/role.yaml
+++ b/olm/config/rbac/role.yaml
@@ -8,6 +8,15 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:
@@ -31,12 +40,10 @@ rules:
   resources:
   - sandboxes
   verbs:
-  - create
   - delete
   - get
   - list
   - patch
-  - update
   - watch
 - apiGroups:
   - agents.x-k8s.io

--- a/test/e2e/extensions/testmain_test.go
+++ b/test/e2e/extensions/testmain_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+)
+
+// TestMain scans the controller logs for RBAC denials after the whole suite
+// has run. TestMain is the only hook guaranteed to run after parallel tests
+// finish, and the scan rides on the suite's coverage: any code path that
+// lost a needed RBAC verb — including paths that degrade silently, like
+// event emission or best-effort patches — leaves an
+// "is forbidden: User" line the suite itself would not otherwise notice.
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	denials, err := framework.ScanControllerRBACDenials(context.Background())
+	switch {
+	case err != nil:
+		// Don't mask test results over a log-fetch problem, but say so.
+		fmt.Fprintf(os.Stderr, "WARNING: could not scan controller logs for RBAC denials: %v\n", err)
+	case len(denials) > 0:
+		fmt.Fprintf(os.Stderr, "FAIL: controller logs contain %d RBAC denial(s):\n", len(denials))
+		for _, d := range denials {
+			fmt.Fprintf(os.Stderr, "  %s\n", d)
+		}
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}

--- a/test/e2e/extensions/testmain_test.go
+++ b/test/e2e/extensions/testmain_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
 )
@@ -32,7 +33,11 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 
-	denials, err := framework.ScanControllerRBACDenials(context.Background())
+	// Bound the scan so a wedged apiserver or log stream cannot hang the
+	// whole suite; a timeout surfaces as the warning below instead.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	denials, err := framework.ScanControllerRBACDenials(ctx)
+	cancel()
 	switch {
 	case err != nil:
 		// Don't mask test results over a log-fetch problem, but say so.

--- a/test/e2e/framework/rbacdenials.go
+++ b/test/e2e/framework/rbacdenials.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// rbacDenialMarker is the fixed prefix apimachinery renders for RBAC
+// rejections (`<resource> "<name>" is forbidden: User "..." cannot ...`).
+// The trailing ": User" keeps benign controller messages that merely
+// contain the word "forbidden" from matching.
+const rbacDenialMarker = "is forbidden: User"
+
+// ScanControllerRBACDenials fetches the logs of every controller pod and
+// returns any lines showing an RBAC denial. The e2e suites call this from
+// TestMain after all tests have run: the suite exercises every controller
+// code path, so a missing RBAC verb that only degrades silently (event
+// emission, best-effort patches) still surfaces here.
+func ScanControllerRBACDenials(ctx context.Context) ([]string, error) {
+	restConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: GetKubeconfig()},
+		&clientcmd.ConfigOverrides{},
+	).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("building rest config: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("building clientset: %w", err)
+	}
+
+	pods, err := clientset.CoreV1().Pods("agent-sandbox-system").List(
+		ctx, metav1.ListOptions{LabelSelector: "app=agent-sandbox-controller"},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing controller pods: %w", err)
+	}
+
+	var denials []string
+	for _, pod := range pods.Items {
+		stream, err := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("streaming logs for pod %s: %w", pod.Name, err)
+		}
+		scanner := bufio.NewScanner(stream)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			if line := scanner.Text(); strings.Contains(line, rbacDenialMarker) {
+				denials = append(denials, fmt.Sprintf("%s: %s", pod.Name, line))
+			}
+		}
+		err = scanner.Err()
+		stream.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading logs for pod %s: %w", pod.Name, err)
+		}
+	}
+	return denials, nil
+}

--- a/test/e2e/framework/rbacdenials.go
+++ b/test/e2e/framework/rbacdenials.go
@@ -32,6 +32,11 @@ import (
 // contain the word "forbidden" from matching.
 const rbacDenialMarker = "is forbidden: User"
 
+const (
+	controllerNamespace   = "agent-sandbox-system"
+	controllerPodSelector = "app=agent-sandbox-controller"
+)
+
 // ScanControllerRBACDenials fetches the logs of every controller pod and
 // returns any lines showing an RBAC denial. The e2e suites call this from
 // TestMain after all tests have run: the suite exercises every controller
@@ -50,11 +55,17 @@ func ScanControllerRBACDenials(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("building clientset: %w", err)
 	}
 
-	pods, err := clientset.CoreV1().Pods("agent-sandbox-system").List(
-		ctx, metav1.ListOptions{LabelSelector: "app=agent-sandbox-controller"},
+	pods, err := clientset.CoreV1().Pods(controllerNamespace).List(
+		ctx, metav1.ListOptions{LabelSelector: controllerPodSelector},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing controller pods: %w", err)
+	}
+	// Zero matches means the namespace or label selector drifted from the
+	// deployment manifests; erroring keeps the guard from silently becoming
+	// a no-op.
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no controller pods found in namespace %q matching %q; RBAC denial scan did not run", controllerNamespace, controllerPodSelector)
 	}
 
 	var denials []string

--- a/test/e2e/testmain_test.go
+++ b/test/e2e/testmain_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
+)
+
+// TestMain scans the controller logs for RBAC denials after the whole suite
+// has run. TestMain is the only hook guaranteed to run after parallel tests
+// finish, and the scan rides on the suite's coverage: any code path that
+// lost a needed RBAC verb — including paths that degrade silently, like
+// event emission or best-effort patches — leaves an
+// "is forbidden: User" line the suite itself would not otherwise notice.
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	denials, err := framework.ScanControllerRBACDenials(context.Background())
+	switch {
+	case err != nil:
+		// Don't mask test results over a log-fetch problem, but say so.
+		fmt.Fprintf(os.Stderr, "WARNING: could not scan controller logs for RBAC denials: %v\n", err)
+	case len(denials) > 0:
+		fmt.Fprintf(os.Stderr, "FAIL: controller logs contain %d RBAC denial(s):\n", len(denials))
+		for _, d := range denials {
+			fmt.Fprintf(os.Stderr, "  %s\n", d)
+		}
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}

--- a/test/e2e/testmain_test.go
+++ b/test/e2e/testmain_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/agent-sandbox/test/e2e/framework"
 )
@@ -32,7 +33,11 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 
-	denials, err := framework.ScanControllerRBACDenials(context.Background())
+	// Bound the scan so a wedged apiserver or log stream cannot hang the
+	// whole suite; a timeout surfaces as the warning below instead.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	denials, err := framework.ScanControllerRBACDenials(ctx)
+	cancel()
 	switch {
 	case err != nil:
 		// Don't mask test results over a log-fetch problem, but say so.


### PR DESCRIPTION
Trims controller ClusterRole verbs that no reconciler ever issues, and adds an e2e guard so the trims stay honest. Split out of #1472 to keep one concern per PR. Every trim was verified by call-site audit against current `main` (independent of #1472's deletions — none of that dead code touches these verbs).

**Verb trims (kubebuilder markers; manifests under `k8s/`, `helm/`, `olm/` are regenerated output):**
- Sandbox controller: drop `create;update` on `sandboxes` (users create them; the controller writes only via the status/finalizers subresource rules) and `update;delete` on `persistentvolumeclaims` (create-only; owner-reference GC handles deletion).
- SandboxClaim controller: drop `create` on `sandboxclaims` (it never creates claims), the direct `pods` rule entirely (the claim controller performs no Pod reads or writes — readiness comes from the Sandbox's conditions; the warmpool controller is the only Pod reader and keeps `get;list;watch`), `update` on events, and `delete` on leases.
- SandboxTemplate controller: primary resource down to `get;list;watch;patch`; drop `patch` on NetworkPolicies; `update` on events.
- SandboxWarmPool controller: primary resource down to `get;list;watch` (status/finalizers via subresource rules); `update` on events.

**Guard:** `TestMain` in both e2e suites now scans controller logs after the run for `is forbidden: User` RBAC denials and fails the suite if any appear, so a future verb regression surfaces in presubmit instead of production.

Narrows the blast radius of a compromised controller ServiceAccount; no behavior change for correctly functioning controllers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Tightened controller permissions across sandbox resources, workloads, events, leases, network policies, and related Kubernetes objects.
  - Restricted several resources to read-only access where applicable and removed unnecessary write operations.
  - Added narrowly scoped permissions for persistent volume claims, sandbox templates, and sandbox warm pools.

- **Tests**
  - End-to-end tests now detect RBAC denial messages in controller logs and report them as test failures when appropriate.
  - Added coverage for RBAC access issues across both standard and extension test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->