### PR TITLE
fix(ci): retry Node.js download to reduce presubmit-test-unit infra flakes

### DIFF
--- a/dev/tools/shared/node.py
+++ b/dev/tools/shared/node.py
@@ -133,13 +133,25 @@ def install_node(install_dir):
     # persistent outage (e.g. a bad version/URL, which fails every attempt).
     # Only network-shaped errors are retried, so a local/permanent failure
     # (e.g. a permission error writing tar_path) still fails on the first
-    # attempt instead of waiting out the retry delay.
+    # attempt instead of waiting out the retry delay. HTTPError is handled
+    # separately since it is a URLError subclass but a deterministic status
+    # like 404 (bad version/URL) will never succeed on retry, unlike a 429 or
+    # 5xx from the CDN.
     last_error = None
     for attempt in range(1, _DOWNLOAD_ATTEMPTS + 1):
         try:
             urllib.request.urlretrieve(url, tar_path)
             last_error = None
             break
+        except urllib.error.HTTPError as e:
+            last_error = e
+            if e.code == 429 or e.code >= 500:
+                print(f"Failed to download Node.js (attempt {attempt} of {_DOWNLOAD_ATTEMPTS}): {e}")
+                if attempt < _DOWNLOAD_ATTEMPTS:
+                    time.sleep(_DOWNLOAD_RETRY_DELAY_SECONDS)
+            else:
+                print(f"Failed to download Node.js: {e}")
+                break
         except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
             last_error = e
             print(f"Failed to download Node.js (attempt {attempt} of {_DOWNLOAD_ATTEMPTS}): {e}")

--- a/dev/tools/shared/node.py
+++ b/dev/tools/shared/node.py
@@ -20,6 +20,7 @@ import shutil
 import subprocess
 import tarfile
 import time
+import urllib.error
 import urllib.request
 
 # Number of attempts (including the first) for the Node.js tarball download.
@@ -130,17 +131,24 @@ def install_node(install_dir):
     # The nodejs.org CDN occasionally drops connections mid-download in CI;
     # retrying a couple of times recovers most of those without masking a
     # persistent outage (e.g. a bad version/URL, which fails every attempt).
+    # Only network-shaped errors are retried, so a local/permanent failure
+    # (e.g. a permission error writing tar_path) still fails on the first
+    # attempt instead of waiting out the retry delay.
     last_error = None
     for attempt in range(1, _DOWNLOAD_ATTEMPTS + 1):
         try:
             urllib.request.urlretrieve(url, tar_path)
             last_error = None
             break
-        except Exception as e:
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
             last_error = e
             print(f"Failed to download Node.js (attempt {attempt} of {_DOWNLOAD_ATTEMPTS}): {e}")
             if attempt < _DOWNLOAD_ATTEMPTS:
                 time.sleep(_DOWNLOAD_RETRY_DELAY_SECONDS)
+        except Exception as e:
+            last_error = e
+            print(f"Failed to download Node.js: {e}")
+            break
     if last_error is not None:
         return None
 

--- a/dev/tools/shared/node.py
+++ b/dev/tools/shared/node.py
@@ -19,7 +19,12 @@ import platform
 import shutil
 import subprocess
 import tarfile
+import time
 import urllib.request
+
+# Number of attempts (including the first) for the Node.js tarball download.
+_DOWNLOAD_ATTEMPTS = 3
+_DOWNLOAD_RETRY_DELAY_SECONDS = 5
 
 # SHA256 digests from https://nodejs.org/dist/<version>/SHASUMS256.txt.
 # Update both the version constant below and this table whenever Node.js is bumped.
@@ -122,10 +127,21 @@ def install_node(install_dir):
 
     print(f"Downloading {url}...")
     tar_path = os.path.join(install_dir, filename)
-    try:
-        urllib.request.urlretrieve(url, tar_path)
-    except Exception as e:
-        print(f"Failed to download Node.js: {e}")
+    # The nodejs.org CDN occasionally drops connections mid-download in CI;
+    # retrying a couple of times recovers most of those without masking a
+    # persistent outage (e.g. a bad version/URL, which fails every attempt).
+    last_error = None
+    for attempt in range(1, _DOWNLOAD_ATTEMPTS + 1):
+        try:
+            urllib.request.urlretrieve(url, tar_path)
+            last_error = None
+            break
+        except Exception as e:
+            last_error = e
+            print(f"Failed to download Node.js (attempt {attempt} of {_DOWNLOAD_ATTEMPTS}): {e}")
+            if attempt < _DOWNLOAD_ATTEMPTS:
+                time.sleep(_DOWNLOAD_RETRY_DELAY_SECONDS)
+    if last_error is not None:
         return None
 
     # Verify digest before extraction to guard against a tampered archive.

--- a/dev/tools/shared/node_test.py
+++ b/dev/tools/shared/node_test.py
@@ -17,6 +17,7 @@
 import os
 import sys
 import unittest
+import urllib.error
 from unittest import mock
 
 # Make the test importable regardless of how it is invoked (python -m unittest,
@@ -41,10 +42,11 @@ class InstallNodeDownloadRetryTest(unittest.TestCase):
         self.addCleanup(patcher.stop)
         patcher.start()
 
-        # Avoid sleeping for real during retries.
+        # Avoid sleeping for real during retries; kept so tests can assert on
+        # the retry-delay calls.
         patcher = mock.patch("node.time.sleep")
         self.addCleanup(patcher.stop)
-        patcher.start()
+        self.sleep = patcher.start()
 
         # Skip touching the real filesystem for the tar extraction path.
         patcher = mock.patch("node.os.makedirs")
@@ -62,7 +64,7 @@ class InstallNodeDownloadRetryTest(unittest.TestCase):
     def test_retries_after_transient_failure_then_succeeds(self):
         with mock.patch(
             "node.urllib.request.urlretrieve",
-            side_effect=[OSError("connection reset"), None],
+            side_effect=[urllib.error.URLError("connection reset"), None],
         ) as urlretrieve, mock.patch(
             "node._verify_sha256"
         ), mock.patch(
@@ -71,17 +73,34 @@ class InstallNodeDownloadRetryTest(unittest.TestCase):
             bin_dir = node.install_node("/fake/install/dir")
 
         self.assertEqual(urlretrieve.call_count, 2)
+        self.sleep.assert_called_once_with(node._DOWNLOAD_RETRY_DELAY_SECONDS)
         self.assertIsNotNone(bin_dir)
 
     def test_gives_up_after_exhausting_all_attempts(self):
         with mock.patch(
             "node.urllib.request.urlretrieve",
-            side_effect=OSError("connection reset"),
+            side_effect=urllib.error.URLError("connection reset"),
         ) as urlretrieve:
             result = node.install_node("/fake/install/dir")
 
         self.assertIsNone(result)
         self.assertEqual(urlretrieve.call_count, node._DOWNLOAD_ATTEMPTS)
+        self.assertEqual(
+            self.sleep.call_args_list,
+            [mock.call(node._DOWNLOAD_RETRY_DELAY_SECONDS)]
+            * (node._DOWNLOAD_ATTEMPTS - 1),
+        )
+
+    def test_does_not_retry_non_network_errors(self):
+        with mock.patch(
+            "node.urllib.request.urlretrieve",
+            side_effect=PermissionError("permission denied"),
+        ) as urlretrieve:
+            result = node.install_node("/fake/install/dir")
+
+        self.assertIsNone(result)
+        self.assertEqual(urlretrieve.call_count, 1)
+        self.sleep.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/dev/tools/shared/node_test.py
+++ b/dev/tools/shared/node_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import sys
 import unittest
@@ -101,6 +102,39 @@ class InstallNodeDownloadRetryTest(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(urlretrieve.call_count, 1)
         self.sleep.assert_not_called()
+
+    def test_does_not_retry_deterministic_http_error(self):
+        with mock.patch(
+            "node.urllib.request.urlretrieve",
+            side_effect=urllib.error.HTTPError(
+                "https://nodejs.org/dist/bad", 404, "Not Found", {}, io.BytesIO()
+            ),
+        ) as urlretrieve:
+            result = node.install_node("/fake/install/dir")
+
+        self.assertIsNone(result)
+        self.assertEqual(urlretrieve.call_count, 1)
+        self.sleep.assert_not_called()
+
+    def test_retries_transient_http_error(self):
+        with mock.patch(
+            "node.urllib.request.urlretrieve",
+            side_effect=[
+                urllib.error.HTTPError(
+                    "https://nodejs.org/dist/x", 503, "Service Unavailable", {}, io.BytesIO()
+                ),
+                None,
+            ],
+        ) as urlretrieve, mock.patch(
+            "node._verify_sha256"
+        ), mock.patch(
+            "node.tarfile.open"
+        ):
+            bin_dir = node.install_node("/fake/install/dir")
+
+        self.assertEqual(urlretrieve.call_count, 2)
+        self.sleep.assert_called_once_with(node._DOWNLOAD_RETRY_DELAY_SECONDS)
+        self.assertIsNotNone(bin_dir)
 
 
 if __name__ == "__main__":

--- a/dev/tools/shared/node_test.py
+++ b/dev/tools/shared/node_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+# Make the test importable regardless of how it is invoked (python -m unittest,
+# pytest from any cwd, etc.).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import node
+
+
+class InstallNodeDownloadRetryTest(unittest.TestCase):
+    """Regression test: a transient download failure must not fail the whole
+    install on the first attempt, since presubmit-test-unit was seen failing
+    before any test ran due to a single dropped connection to the nodejs.org
+    CDN."""
+
+    def setUp(self):
+        patcher = mock.patch("node.platform.system", return_value="Linux")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        patcher = mock.patch("node.platform.machine", return_value="x86_64")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        # Avoid sleeping for real during retries.
+        patcher = mock.patch("node.time.sleep")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        # Skip touching the real filesystem for the tar extraction path.
+        patcher = mock.patch("node.os.makedirs")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        patcher = mock.patch("node.os.path.exists", return_value=True)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        patcher = mock.patch("node.shutil.rmtree")
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_retries_after_transient_failure_then_succeeds(self):
+        with mock.patch(
+            "node.urllib.request.urlretrieve",
+            side_effect=[OSError("connection reset"), None],
+        ) as urlretrieve, mock.patch(
+            "node._verify_sha256"
+        ), mock.patch(
+            "node.tarfile.open"
+        ):
+            bin_dir = node.install_node("/fake/install/dir")
+
+        self.assertEqual(urlretrieve.call_count, 2)
+        self.assertIsNotNone(bin_dir)
+
+    def test_gives_up_after_exhausting_all_attempts(self):
+        with mock.patch(
+            "node.urllib.request.urlretrieve",
+            side_effect=OSError("connection reset"),
+        ) as urlretrieve:
+            result = node.install_node("/fake/install/dir")
+
+        self.assertIsNone(result)
+        self.assertEqual(urlretrieve.call_count, node._DOWNLOAD_ATTEMPTS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dev/tools/shared/node_test.py
+++ b/dev/tools/shared/node_test.py
@@ -136,6 +136,26 @@ class InstallNodeDownloadRetryTest(unittest.TestCase):
         self.sleep.assert_called_once_with(node._DOWNLOAD_RETRY_DELAY_SECONDS)
         self.assertIsNotNone(bin_dir)
 
+    def test_retries_http_429(self):
+        with mock.patch(
+            "node.urllib.request.urlretrieve",
+            side_effect=[
+                urllib.error.HTTPError(
+                    "https://nodejs.org/dist/x", 429, "Too Many Requests", {}, io.BytesIO()
+                ),
+                None,
+            ],
+        ) as urlretrieve, mock.patch(
+            "node._verify_sha256"
+        ), mock.patch(
+            "node.tarfile.open"
+        ):
+            bin_dir = node.install_node("/fake/install/dir")
+
+        self.assertEqual(urlretrieve.call_count, 2)
+        self.sleep.assert_called_once_with(node._DOWNLOAD_RETRY_DELAY_SECONDS)
+        self.assertIsNotNone(bin_dir)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:
`presubmit-test-unit` has been failing before any test runs in 56 of 57 recent
red runs (per the auto-generated flake report). `dev/tools/test-unit` calls
`ensure_node()` to install Node.js for the TypeScript unit test suite, and
`install_node()` downloaded the Node.js tarball via a single, un-retried
`urllib.request.urlretrieve()` call. Any transient network drop against the
nodejs.org CDN fails the whole presubmit before a single test executes,
matching the issue's symptom exactly. `dev/ci/shared/runner.py` already
retries its own bring-up steps (kind cluster create, image push, deploy) for
the same class of transient CI failure; this applies the same idea to the
Node.js download.

This PR wraps the download in a bounded retry loop (3 attempts, 5s delay
between attempts), returning failure only once all attempts are exhausted.

Disclosure: I could not reproduce a live CDN network drop or run the actual
Prow `presubmit-test-unit` job. Validation is a mocked unit test that
demonstrates the code-level defect (no retry on a call that can transiently
fail): it fails without the fix and passes with it, plus a full run of the
existing `dev/tools` unit test suite with no regressions. Whether this
reduces the observed flake rate in Prow is not something I could confirm
directly, but the mechanism matches the reported symptom.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1566

#### Release Note
```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #1566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node.js downloads now retry up to three times for temporary network failures and server errors, with a delay between attempts.
  * Downloads fail immediately for non-retryable errors, including permission issues, missing files, and other client errors.
  * Installation reports failure after all eligible retry attempts are exhausted.

* **Tests**
  * Added coverage for successful retries, retry delays, exhausted attempts, and non-retryable failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->