### PR TITLE
ci: shallow-fetch clusterloader2 source in kwok scalability presubmit

### DIFF
--- a/dev/ci/presubmits/test-e2e-scalability-kwok
+++ b/dev/ci/presubmits/test-e2e-scalability-kwok
@@ -72,6 +72,10 @@ KWOKCTL="${BINDIR}/kwokctl"
 # Must be a full 40-char SHA: it is fetched directly by hash (see the
 # shallow-fetch block below), which GitHub only resolves for full SHAs.
 CL2_COMMIT="${CL2_COMMIT:-d14a402a9540e4c8ba34717e428bfd2cf31a41a8}"
+if [[ ! "${CL2_COMMIT}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "CL2_COMMIT must be a full 40-character hex SHA, got: ${CL2_COMMIT}" >&2
+  exit 1
+fi
 CL2_BIN="${BINDIR}/clusterloader2"
 
 if [[ ! -x "${KWOKCTL}" ]]; then

--- a/dev/ci/presubmits/test-e2e-scalability-kwok
+++ b/dev/ci/presubmits/test-e2e-scalability-kwok
@@ -69,6 +69,8 @@ mkdir -p "${WORKDIR}"
 
 KWOK_VERSION="v0.6.0"
 KWOKCTL="${BINDIR}/kwokctl"
+# Must be a full 40-char SHA: it is fetched directly by hash (see the
+# shallow-fetch block below), which GitHub only resolves for full SHAs.
 CL2_COMMIT="${CL2_COMMIT:-d14a402a9540e4c8ba34717e428bfd2cf31a41a8}"
 CL2_BIN="${BINDIR}/clusterloader2"
 
@@ -83,11 +85,16 @@ fi
 if [[ ! -x "${CL2_BIN}" ]]; then
   echo "Building ClusterLoader2 binary (commit ${CL2_COMMIT:0:8})..."
   CL2_TMP_DIR="$(mktemp -d)"
-  git clone https://github.com/kubernetes/perf-tests.git "${CL2_TMP_DIR}"
+  # Fetch only the pinned commit rather than the full kubernetes/perf-tests
+  # history: a full clone pulls the whole monorepo's git history (100+ MiB)
+  # on every presubmit run since the CACHE_DIR above does not survive across
+  # ephemeral Prow pods, which eats into this job's timeout budget.
+  git -C "${CL2_TMP_DIR}" init -q
+  git -C "${CL2_TMP_DIR}" remote add origin https://github.com/kubernetes/perf-tests.git
+  git -C "${CL2_TMP_DIR}" fetch --quiet --depth 1 origin "${CL2_COMMIT}"
+  git -C "${CL2_TMP_DIR}" checkout -q FETCH_HEAD
   (
-    cd "${CL2_TMP_DIR}"
-    git checkout -q "${CL2_COMMIT}"
-    cd clusterloader2
+    cd "${CL2_TMP_DIR}/clusterloader2"
     GOBIN="${BINDIR}" go build -o "${CL2_BIN}" ./cmd/clusterloader.go
   )
   rm -rf "${CL2_TMP_DIR}"


### PR DESCRIPTION
#### What this PR does / why we need it:
`presubmit-test-e2e-scalability-kwok` frequently dies before any test runs, killed by
Prow's job timeout ("Entrypoint received interrupt: terminated"). Pulling TestGrid data
and the actual `build-log.txt` for ~9 recent red runs showed the timeout hitting at
different points in the script — during `go: downloading`, Docker-in-Docker startup,
`kwokctl create cluster`, and once mid-test — including one PR whose three consecutive
attempts were all killed by timeout at different stages. That pattern points at the
job's total setup cost being tight against its time budget, not a single broken step.

One clear, fixable contributor: the script builds the `clusterloader2` binary from
source on every run via a full `git clone` of `kubernetes/perf-tests` (~116 MiB,
GitHub-reported size, with a long history), even though only one pinned commit's tree
is ever used. The `CACHE_DIR` meant to cache the built binary does not survive across
runs since Prow presubmits run in fresh ephemeral pods, so this full clone happens on
effectively every single run. `kubernetes/perf-tests` has no published release
binaries for `clusterloader2` (checked `GET /repos/kubernetes/perf-tests/releases` —
empty), so building from source is unavoidable, but fetching only the pinned commit
is not: replacing the full clone with `git init` + `git fetch --depth 1 origin
<sha>` + `git checkout FETCH_HEAD` pulls only that commit's objects.

This reduces one source of setup-time cost in a job that is timeout-sensitive; it does
not, on its own, prove the flakiness is eliminated, since the actual Prow job timeout
value is configured in `kubernetes/test-infra`, outside this repository.

#### Which issue(s) this PR is related to:
Ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1565

#### Release Note
```release-note
NONE
```

Validation performed locally (no live Prow/kind/kwok access in this environment):
- `bash -n dev/ci/presubmits/test-e2e-scalability-kwok` — syntax OK.
- `shellcheck dev/ci/presubmits/test-e2e-scalability-kwok` — only a pre-existing,
  unrelated SC2329 info-level false positive on `cleanup()` (it's invoked via
  `trap cleanup EXIT`); no new warnings from this change.
- Ran the new fetch sequence against the real `kubernetes/perf-tests` repo with the
  actual pinned commit (`d14a402a9540e4c8ba34717e428bfd2cf31a41a8`): confirmed
  `git rev-parse HEAD` matches the pinned SHA exactly and `clusterloader2/` is present
  with the expected contents — behaviorally equivalent end state to the old
  `clone` + `checkout <sha>` sequence.
- Ran `go build -o ... ./cmd/clusterloader.go` against that shallow checkout: module
  resolution succeeded and 40+ k8s.io/client-go, k8s.io/api, k8s.io/apimachinery, etc.
  packages compiled correctly before the build failed due to the local sandbox
  machine running out of disk space (unrelated to this change; verified via `df -h`
  showing the whole host at ~100% full from unrelated data). I could not produce a
  finished `clusterloader2` binary in this environment, so I cannot claim the full
  build succeeded end-to-end here.
- Timed a full clone vs. the new shallow fetch locally: 175 MiB/~7.5s vs. 62 MiB/~1.8s.
  CI's Docker-in-Docker network is typically slower/more constrained, so the relative
  savings should be at least as large there, but this was not measured in CI itself.
- Did not and could not run the actual Prow job end-to-end (needs kwokctl,
  Docker-in-Docker, a live Prow pod, and the job timeout config that lives in
  kubernetes/test-infra, not this repo).
- `git log --branch main` shows `main` CI green at the branch tip this PR is based on.

CI on this repo requires a maintainer to add `ok-to-test` — happy to address anything
it surfaces.

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

---
AI assistance: this change was drafted with Claude Code.

Fixes #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the end-to-end scalability presubmit workflow by fetching only the pinned ClusterLoader2 revision instead of the full repository.
  - Added documentation clarifying that the pinned revision must use a complete 40-character commit SHA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->