### PR TITLE
feat: add --enable-rest-client-metrics flag and strengthen related tests

### DIFF
--- a/cmd/agent-sandbox-controller/main.go
+++ b/cmd/agent-sandbox-controller/main.go
@@ -63,6 +63,7 @@ func main() {
 	var enableTracing bool
 	var enablePprof bool
 	var enablePprofDebug bool
+	var enableRESTClientMetrics bool
 	var pprofBlockProfileRate int
 	var pprofMutexProfileFraction int
 	var kubeAPIQPS float64
@@ -100,6 +101,10 @@ func main() {
 	flag.BoolVar(&enablePprofDebug, "enable-pprof-debug", false,
 		"Enable all pprof endpoints including sensitive ones (cmdline, symbol, heap, goroutine, etc). "+
 			"Implies --enable-pprof. WARNING: May expose sensitive information and comes with performance overhead.")
+	flag.BoolVar(&enableRESTClientMetrics, "enable-rest-client-metrics", true,
+		"Enable client-go REST client metrics (request latency, DNS resolution latency, request/response sizes, "+
+			"rate limiter latency, request retries). These metrics provide visibility into Kubernetes API client health. "+
+			"Set to false to disable if the additional histogram overhead is not acceptable.")
 	flag.IntVar(&pprofBlockProfileRate, "pprof-block-profile-rate", 1000000,
 		"Block profile sampling rate for /debug/pprof/block when --enable-pprof-debug is set. "+
 			"<=0 disables; 1 samples all blocking events; >=2 sets the rate in nanoseconds (e.g. 1000000 ~= 1ms).")
@@ -258,15 +263,19 @@ func main() {
 
 	// Register client-go REST client metrics.
 	// These metrics provide visibility into API server interactions.
-	setupLog.Info("client-go REST client metrics enabled")
-	metrics.RegisterRESTClientMetrics(
-		metrics.MetricRequestLatency,
-		metrics.MetricDNSResolutionLatency,
-		metrics.MetricRequestSize,
-		metrics.MetricResponseSize,
-		metrics.MetricRateLimiterLatency,
-		metrics.MetricRequestRetry,
-	)
+	if enableRESTClientMetrics {
+		setupLog.Info("client-go REST client metrics enabled")
+		metrics.RegisterRESTClientMetrics(
+			metrics.MetricRequestLatency,
+			metrics.MetricDNSResolutionLatency,
+			metrics.MetricRequestSize,
+			metrics.MetricResponseSize,
+			metrics.MetricRateLimiterLatency,
+			metrics.MetricRequestRetry,
+		)
+	} else {
+		setupLog.Info("client-go REST client metrics disabled (--enable-rest-client-metrics=false)")
+	}
 
 	// Importing net/http/pprof registers handlers on the global DefaultServeMux.
 	// Reset it to avoid accidentally exposing pprof via any server that uses the default mux.

--- a/cmd/agent-sandbox-controller/rest_client_metrics_test.go
+++ b/cmd/agent-sandbox-controller/rest_client_metrics_test.go
@@ -17,15 +17,73 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"net/url"
 	"testing"
+	"time"
 
+	clientmetrics "k8s.io/client-go/tools/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-// TestRESTClientMetricsRegistration verifies that REST client metrics can be
-// registered without errors and that the metrics registry remains functional.
-func TestRESTClientMetricsRegistration(t *testing.T) {
-	// Register the REST client metrics (same as in main())
+// expectedOptInMetricFamilies lists the six opt-in REST client metric families
+// that should be registered after calling RegisterRESTClientMetrics with all
+// supported metric types.
+var expectedOptInMetricFamilies = []string{
+	"rest_client_request_duration_seconds",
+	"rest_client_dns_resolution_duration_seconds",
+	"rest_client_request_size_bytes",
+	"rest_client_response_size_bytes",
+	"rest_client_rate_limiter_duration_seconds",
+	"rest_client_request_retries_total",
+}
+
+// allExpectedMetricFamilies includes both the opt-in metrics and the default
+// rest_client_requests_total metric that is always registered by client-go.
+var allExpectedMetricFamilies = append(append([]string{}, expectedOptInMetricFamilies...), "rest_client_requests_total")
+
+// gatherMetricFamilyNames collects all metric family names from the
+// controller-runtime metrics registry.
+func gatherMetricFamilyNames(t *testing.T) map[string]struct{} {
+	t.Helper()
+	mfs, err := metrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics from registry: %v", err)
+	}
+	names := make(map[string]struct{}, len(mfs))
+	for _, mf := range mfs {
+		names[mf.GetName()] = struct{}{}
+	}
+	return names
+}
+
+// assertMetricFamiliesPresent verifies that all expected metric families are
+// present in the gathered names map.
+func assertMetricFamiliesPresent(t *testing.T, names map[string]struct{}, expected []string) {
+	t.Helper()
+	for _, name := range expected {
+		if _, ok := names[name]; !ok {
+			t.Errorf("Expected metric family %q to be registered, but not found in registry", name)
+		}
+	}
+}
+
+// observeAllRESTClientMetrics triggers representative observations for all
+// REST client metrics via the client-go metrics adapters, ensuring each metric
+// family has at least one data point in the registry.
+func observeAllRESTClientMetrics(ctx context.Context) {
+	clientmetrics.RequestResult.Increment(ctx, "200", "GET", "example.com")
+	clientmetrics.RequestLatency.Observe(ctx, "GET", url.URL{Host: "example.com"}, 1*time.Second)
+	clientmetrics.ResolverLatency.Observe(ctx, "example.com", 1*time.Second)
+	clientmetrics.RequestSize.Observe(ctx, "GET", "example.com", 1024)
+	clientmetrics.ResponseSize.Observe(ctx, "GET", "example.com", 1024)
+	clientmetrics.RateLimiterLatency.Observe(ctx, "GET", url.URL{Host: "example.com"}, 1*time.Second)
+	clientmetrics.RequestRetry.IncrementRetry(ctx, "200", "GET", "example.com")
+}
+
+// registerAllRESTClientMetrics registers all six opt-in REST client metrics,
+// matching the call made in main().
+func registerAllRESTClientMetrics() {
 	metrics.RegisterRESTClientMetrics(
 		metrics.MetricRequestLatency,
 		metrics.MetricDNSResolutionLatency,
@@ -34,25 +92,29 @@ func TestRESTClientMetricsRegistration(t *testing.T) {
 		metrics.MetricRateLimiterLatency,
 		metrics.MetricRequestRetry,
 	)
+}
 
-	// Verify the registry is still functional
-	mfs, err := metrics.Registry.Gather()
-	if err != nil {
-		t.Fatalf("Failed to gather metrics after registration: %v", err)
-	}
+// TestRESTClientMetricsRegistration verifies that REST client metrics can be
+// registered without errors and that all six expected opt-in metric families
+// plus the default rest_client_requests_total are present in the
+// controller-runtime metrics registry after triggering observations.
+func TestRESTClientMetricsRegistration(t *testing.T) {
+	registerAllRESTClientMetrics()
 
-	// Verify we have some metrics registered
-	if len(mfs) == 0 {
-		t.Errorf("Expected some metrics to be registered, got 0")
-	}
+	ctx := context.Background()
+	observeAllRESTClientMetrics(ctx)
 
-	t.Logf("Successfully registered REST client metrics, found %d total metrics in registry", len(mfs))
+	names := gatherMetricFamilyNames(t)
+	assertMetricFamiliesPresent(t, names, allExpectedMetricFamilies)
+
+	t.Logf("Successfully registered REST client metrics, found %d total metric families in registry", len(names))
 }
 
 // TestRESTClientMetricsIdempotent verifies that calling RegisterRESTClientMetrics
-// multiple times does not cause errors (due to sync.Once protection).
+// multiple times does not cause errors (due to sync.Once protection) and that
+// all metric families remain registered and gatherable after repeated calls.
 func TestRESTClientMetricsIdempotent(t *testing.T) {
-	// Call registration multiple times - should not panic or error
+	// Call registration multiple times — should not panic or error.
 	for i := range 3 {
 		func() {
 			defer func() {
@@ -60,20 +122,57 @@ func TestRESTClientMetricsIdempotent(t *testing.T) {
 					t.Errorf("RegisterRESTClientMetrics panicked on call %d: %v", i, r)
 				}
 			}()
-			metrics.RegisterRESTClientMetrics(
-				metrics.MetricRequestLatency,
-				metrics.MetricDNSResolutionLatency,
-				metrics.MetricRequestSize,
-				metrics.MetricResponseSize,
-				metrics.MetricRateLimiterLatency,
-				metrics.MetricRequestRetry,
-			)
+			registerAllRESTClientMetrics()
 		}()
 	}
 
-	// Verify we can still gather metrics without errors
-	_, err := metrics.Registry.Gather()
+	// Trigger observations to populate metrics.
+	ctx := context.Background()
+	observeAllRESTClientMetrics(ctx)
+
+	// Verify all expected metric families remain present.
+	names := gatherMetricFamilyNames(t)
+	assertMetricFamiliesPresent(t, names, allExpectedMetricFamilies)
+
+	t.Logf("Idempotence test passed, all %d expected metric families remain registered", len(allExpectedMetricFamilies))
+}
+
+// TestRESTClientMetricsControllerRuntimeRegistry verifies that REST client
+// metrics are properly registered with controller-runtime's global metrics
+// registry and can be gathered through the standard prometheus Gatherer
+// interface. This ensures the metrics are exposed via the controller's
+// monitoring endpoint alongside all other controller-runtime metrics.
+func TestRESTClientMetricsControllerRuntimeRegistry(t *testing.T) {
+	registerAllRESTClientMetrics()
+
+	ctx := context.Background()
+	observeAllRESTClientMetrics(ctx)
+
+	// Use controller-runtime's registry directly as a prometheus.Gatherer.
+	gatherer := metrics.Registry
+
+	mfs, err := gatherer.Gather()
 	if err != nil {
-		t.Fatalf("Failed to gather metrics after multiple registrations: %v", err)
+		t.Fatalf("Failed to gather metrics from controller-runtime registry: %v", err)
+	}
+
+	if len(mfs) == 0 {
+		t.Fatal("Expected metrics to be gathered from controller-runtime registry, got 0")
+	}
+
+	// Build a set of found metric names and verify each expected family.
+	found := make(map[string]int, len(mfs))
+	for _, mf := range mfs {
+		name := mf.GetName()
+		found[name] = len(mf.GetMetric())
+	}
+
+	for _, name := range allExpectedMetricFamilies {
+		count, ok := found[name]
+		if !ok {
+			t.Errorf("Expected metric family %q not found in controller-runtime registry", name)
+			continue
+		}
+		t.Logf("Found metric family %q with %d series in controller-runtime registry", name, count)
 	}
 }

--- a/controllers/sandbox_podtemplate_fields_test.go
+++ b/controllers/sandbox_podtemplate_fields_test.go
@@ -99,12 +99,18 @@ func TestPodCreateRejectedUnsupportedFields(t *testing.T) {
 
 	// Simulate an older API server that rejects Pod creation because of the
 	// bindMountOptions field. The error message mirrors the real API server
-	// response for unknown fields.
+	// response for unknown fields. Verify the field is actually present on the
+	// submitted Pod so a regression that drops BindMountOptions during Pod
+	// construction fails the test instead of silently passing.
 	inner := newFakeClient(sandbox)
 	rejectingClient := interceptor.NewClient(inner, interceptor.Funcs{
 		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-			if _, isPod := obj.(*corev1.Pod); isPod {
-				return newInvalidFieldError("Pod", obj.GetName(), "spec.containers[0].volumeMounts[0].bindMountOptions")
+			if pod, isPod := obj.(*corev1.Pod); isPod {
+				require.NotEmpty(t, pod.Spec.Containers, "Pod must have containers")
+				require.NotEmpty(t, pod.Spec.Containers[0].VolumeMounts, "container must have volumeMounts")
+				require.NotEmpty(t, pod.Spec.Containers[0].VolumeMounts[0].BindMountOptions,
+					"regression: BindMountOptions missing from submitted Pod — field copy is broken")
+				return newInvalidFieldError("Pod", pod.GetName(), "spec.containers[0].volumeMounts[0].bindMountOptions")
 			}
 			return c.Create(ctx, obj, opts...)
 		},
@@ -129,7 +135,8 @@ func TestPodCreateRejectedUnsupportedFields(t *testing.T) {
 		"error message should reference the unsupported field")
 
 	// Even on error, the reconciler must update the Sandbox status so the
-	// operator can see why the Pod failed to create.
+	// operator can see why the Pod failed to create. The error must propagate
+	// into the Ready condition's Reason and Message.
 	updatedSandbox := &sandboxv1beta1.Sandbox{}
 	require.NoError(t, rejectingClient.Get(t.Context(), req.NamespacedName, updatedSandbox))
 
@@ -137,6 +144,10 @@ func TestPodCreateRejectedUnsupportedFields(t *testing.T) {
 	require.NotNil(t, ready, "Ready condition must be set even when Pod creation fails")
 	require.Equal(t, metav1.ConditionFalse, ready.Status,
 		"Ready must be False when Pod creation is rejected")
+	require.Equal(t, "ReconcilerError", ready.Reason,
+		"Ready reason must be ReconcilerError when Pod creation fails")
+	require.Contains(t, ready.Message, "bindMountOptions",
+		"Ready message must reference the unsupported field")
 }
 
 // TestPodCreateRejectedEvictionResponders verifies that evictionResponders
@@ -176,8 +187,10 @@ func TestPodCreateRejectedEvictionResponders(t *testing.T) {
 	inner := newFakeClient(sandbox)
 	rejectingClient := interceptor.NewClient(inner, interceptor.Funcs{
 		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-			if _, isPod := obj.(*corev1.Pod); isPod {
-				return newInvalidFieldError("Pod", obj.GetName(), "spec.evictionResponders")
+			if pod, isPod := obj.(*corev1.Pod); isPod {
+				require.NotEmpty(t, pod.Spec.EvictionResponders,
+					"regression: EvictionResponders missing from submitted Pod — field copy is broken")
+				return newInvalidFieldError("Pod", pod.GetName(), "spec.evictionResponders")
 			}
 			return c.Create(ctx, obj, opts...)
 		},
@@ -206,4 +219,8 @@ func TestPodCreateRejectedEvictionResponders(t *testing.T) {
 	require.NotNil(t, ready, "Ready condition must be set even when Pod creation fails")
 	require.Equal(t, metav1.ConditionFalse, ready.Status,
 		"Ready must be False when Pod creation is rejected")
+	require.Equal(t, "ReconcilerError", ready.Reason,
+		"Ready reason must be ReconcilerError when Pod creation fails")
+	require.Contains(t, ready.Message, "evictionResponders",
+		"Ready message must reference the unsupported field")
 }

--- a/controllers/sandbox_podtemplate_fields_test.go
+++ b/controllers/sandbox_podtemplate_fields_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
+	asmetrics "sigs.k8s.io/agent-sandbox/internal/metrics"
+)
+
+// newInvalidFieldError constructs an API server-style "invalid" error for an
+// unsupported field, mirroring the response a real kube-apiserver returns when
+// it encounters a field it does not recognise in the submitted object.
+func newInvalidFieldError(kind, name, fieldName string) error {
+	return k8serrors.NewInvalid(
+		schema.GroupKind{Group: "", Kind: kind},
+		name,
+		field.ErrorList{field.Invalid(field.NewPath(fieldName), "", fmt.Sprintf("unknown field %q", fieldName))},
+	)
+}
+
+// TestPodCreateRejectedUnsupportedFields verifies that when the API server
+// rejects Pod creation because the Sandbox podTemplate contains fields not
+// supported by the cluster version (e.g., bindMountOptions, evictionResponders
+// introduced in newer Kubernetes releases), the reconciler surfaces the error
+// through the Sandbox status conditions rather than silently ignoring it.
+//
+// This addresses review feedback from justinsb on PR #1547: new fields in
+// corev1.PodSpec (added by the controller-runtime v0.25.0 / k8s 1.37 dep bump)
+// are deep-copied from the Sandbox podTemplate into the Pod verbatim. On older
+// clusters that don't recognise these fields, the API server rejects the Pod
+// create. The reconciler must propagate that error.
+func TestPodCreateRejectedUnsupportedFields(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-sandbox-unsupported",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "main",
+								Image: "busybox",
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:             "data",
+										MountPath:        "/data",
+										BindMountOptions: []string{"rbind", "rw"},
+									},
+								},
+							},
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "data",
+								VolumeSource: corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Simulate an older API server that rejects Pod creation because of the
+	// bindMountOptions field. The error message mirrors the real API server
+	// response for unknown fields.
+	inner := newFakeClient(sandbox)
+	rejectingClient := interceptor.NewClient(inner, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				return newInvalidFieldError("Pod", obj.GetName(), "spec.containers[0].volumeMounts[0].bindMountOptions")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	r := &SandboxReconciler{
+		Client: rejectingClient,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name:      sandbox.Name,
+		Namespace: sandbox.Namespace,
+	}}
+
+	// The reconciler must return an error so the workqueue requeues and the
+	// operator can observe the failure.
+	_, err := r.Reconcile(t.Context(), req)
+	require.Error(t, err, "reconcile must return an error when Pod creation is rejected")
+	require.Contains(t, err.Error(), "bindMountOptions",
+		"error message should reference the unsupported field")
+
+	// Even on error, the reconciler must update the Sandbox status so the
+	// operator can see why the Pod failed to create.
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, rejectingClient.Get(t.Context(), req.NamespacedName, updatedSandbox))
+
+	ready := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, ready, "Ready condition must be set even when Pod creation fails")
+	require.Equal(t, metav1.ConditionFalse, ready.Status,
+		"Ready must be False when Pod creation is rejected")
+}
+
+// TestPodCreateRejectedEvictionResponders verifies that evictionResponders
+// (a new corev1.PodSpec field from k8s 1.37) propagates a Pod create rejection
+// into the Sandbox status, mirroring TestPodCreateRejectedUnsupportedFields
+// for a different field.
+func TestPodCreateRejectedEvictionResponders(t *testing.T) {
+	sandbox := &sandboxv1beta1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-sandbox-eviction",
+			Namespace:  "default",
+			UID:        sandboxUID,
+			Generation: 1,
+		},
+		Spec: sandboxv1beta1.SandboxSpec{
+			SandboxBlueprint: sandboxv1beta1.SandboxBlueprint{
+				PodTemplate: sandboxv1beta1.PodTemplate{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "main",
+								Image: "busybox",
+							},
+						},
+						EvictionResponders: []corev1.EvictionResponder{
+							{
+								Name:     "custom-responder",
+								Priority: ptr.To[int32](100),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	inner := newFakeClient(sandbox)
+	rejectingClient := interceptor.NewClient(inner, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				return newInvalidFieldError("Pod", obj.GetName(), "spec.evictionResponders")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+
+	r := &SandboxReconciler{
+		Client: rejectingClient,
+		Scheme: Scheme,
+		Tracer: asmetrics.NewNoOp(),
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Name:      sandbox.Name,
+		Namespace: sandbox.Namespace,
+	}}
+
+	_, err := r.Reconcile(t.Context(), req)
+	require.Error(t, err, "reconcile must return an error when Pod creation is rejected")
+	require.Contains(t, err.Error(), "evictionResponders",
+		"error message should reference the unsupported field")
+
+	updatedSandbox := &sandboxv1beta1.Sandbox{}
+	require.NoError(t, rejectingClient.Get(t.Context(), req.NamespacedName, updatedSandbox))
+
+	ready := meta.FindStatusCondition(updatedSandbox.Status.Conditions, string(sandboxv1beta1.SandboxConditionReady))
+	require.NotNil(t, ready, "Ready condition must be set even when Pod creation fails")
+	require.Equal(t, metav1.ConditionFalse, ready.Status,
+		"Ready must be False when Pod creation is rejected")
+}

--- a/controllers/sandbox_podtemplate_fields_test.go
+++ b/controllers/sandbox_podtemplate_fields_test.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow-up to #1547 addressing review feedback:

- Add `--enable-rest-client-metrics` CLI flag (default `true`) so operators can disable the REST client metric histograms when the overhead is not acceptable.
- Strengthen `rest_client_metrics_test.go`: replace the weak non-empty registry check with explicit assertions for all six opt-in metric families plus the default `rest_client_requests_total`. Trigger real client-go observations via the metric adapters and verify families remain present after repeated registration (idempotence).
- Add `sandbox_podtemplate_fields_test.go`: verify that when the API server rejects Pod creation due to new `corev1.PodSpec` fields (e.g. `bindMountOptions`, `evictionResponders` from the k8s 1.37 dep bump) flowing through from the Sandbox podTemplate, the reconciler surfaces the error in the Sandbox `Ready` condition instead of silently ignoring it. Uses `interceptor.NewClient` to simulate `k8serrors.NewInvalid` rejections.

#### Which issue(s) this PR is related to:

Follow-up to #1547

#### Release Note

```release-note
Added `--enable-rest-client-metrics` flag (default `true`) to allow operators to disable client-go REST client metrics.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration flag to enable or disable REST client metrics, enabled by default.
  * Added logging that indicates whether REST client metrics are active, including request, latency, size, rate-limiter, DNS, and retry metrics.

* **Bug Fixes**
  * Improved handling when unsupported pod template fields are rejected during Pod creation, including clearer field-specific errors and an updated Sandbox readiness status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->