### PR TITLE
fix: report missing template in sandbox warm pool

### DIFF
--- a/extensions/controllers/sandboxwarmpool_controller.go
+++ b/extensions/controllers/sandboxwarmpool_controller.go
@@ -78,6 +78,13 @@ const (
 	// SandboxWarmPoolReconciler.UnschedulableRecheckInterval.
 	DefaultUnschedulableRecheckInterval = time.Minute
 
+	// missingTemplateRequeueDelay is the fallback requeue when the referenced
+	// SandboxTemplate does not exist. The SandboxTemplate watch normally
+	// retriggers the pool as soon as the template appears; this only guards
+	// against lost events. Same duration as the claim controller's
+	// missing-dependency fallback.
+	missingTemplateRequeueDelay = time.Minute
+
 	// graceRequeueSlack pads the self-scheduled post-grace requeue so the
 	// re-evaluation lands strictly after the deadline despite clock jitter.
 	graceRequeueSlack = 2 * time.Second
@@ -766,16 +773,23 @@ func (r *SandboxWarmPoolReconciler) reconcilePool(ctx context.Context, warmPool 
 		}
 	}
 
-	// Surface (and clear) the not-progressing signal. A pool with
-	// unschedulable sandboxes past the readiness grace period cannot make
-	// progress toward spec.replicas until cluster capacity frees up; degrade
-	// visibly instead of churning.
-	if unschedulableReplicas > 0 {
+	// Surface (and clear) the not-progressing signal. A missing template
+	// cannot create sandboxes (#1570); unschedulable members past grace
+	// cannot make progress toward spec.replicas (#1215). Missing-template
+	// takes priority for the event: it is why replacements cannot be created.
+	// A pool scaled to zero does not need the template to satisfy desired
+	// state, so it must not warn or requeue for a missing template.
+	switch {
+	case desiredReplicas > 0 && k8serrors.IsNotFound(tmplErr):
+		r.setNotProgressing(warmPool, poolKey, true, fmt.Sprintf(
+			"SandboxTemplate %q not found", warmPool.Spec.TemplateRef.Name))
+		requeueAfter = minNonZeroDuration(requeueAfter, missingTemplateRequeueDelay)
+	case unschedulableReplicas > 0:
 		r.setNotProgressing(warmPool, poolKey, true, fmt.Sprintf(
 			"%d/%d sandboxes are unschedulable past the %s readiness grace period; holding them instead of replacing (replacements would be equally unschedulable)",
 			unschedulableReplicas, desiredReplicas, r.readinessGracePeriod()))
 		requeueAfter = minNonZeroDuration(requeueAfter, r.unschedulableRecheckInterval())
-	} else {
+	default:
 		r.setNotProgressing(warmPool, poolKey, false, "")
 	}
 
@@ -1028,7 +1042,13 @@ func (r *SandboxWarmPoolReconciler) fetchTemplateAndHash(ctx context.Context, wa
 	}
 
 	if tmplErr != nil {
-		logger.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
+		if k8serrors.IsNotFound(tmplErr) {
+			// Expected while the template is still being created; V(4) so a
+			// missing-template requeue does not Error-log every minute.
+			logger.V(4).Info("SandboxTemplate not found", "templateRef", warmPool.Spec.TemplateRef.Name)
+		} else {
+			logger.Error(tmplErr, "Failed to get sandbox template and hash", "templateRef", warmPool.Spec.TemplateRef.Name)
+		}
 	}
 	return template, currentPodTemplateHash, currentSandboxBlueprintHash, tmplErr
 }

--- a/extensions/controllers/sandboxwarmpool_controller_test.go
+++ b/extensions/controllers/sandboxwarmpool_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
 	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 	sandboxcontrollers "sigs.k8s.io/agent-sandbox/controllers"
 	extensionsv1beta1 "sigs.k8s.io/agent-sandbox/extensions/api/v1beta1"
@@ -292,6 +293,185 @@ func TestReconcilePool(t *testing.T) {
 			require.Equal(t, expectedSelector, warmPool.Status.Selector, "Status.Selector mismatch")
 		})
 	}
+}
+
+func TestReconcilePool_MissingTemplateEmitsNotProgressing(t *testing.T) {
+	poolName := "testing-pool"
+	poolNamespace := "default"
+	templateName := "does-not-exist"
+	replicas := int32(1)
+	poolUID := types.UID("warmpool-uid-1570")
+	scheme := newTestScheme()
+	poolNameHash := sandboxcontrollers.NameHash(poolName)
+
+	newPool := func() *extensionsv1beta1.SandboxWarmPool {
+		return &extensionsv1beta1.SandboxWarmPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      poolName,
+				Namespace: poolNamespace,
+				UID:       poolUID,
+			},
+			Spec: extensionsv1beta1.SandboxWarmPoolSpec{
+				Replicas: &replicas,
+				TemplateRef: extensionsv1beta1.SandboxTemplateRef{
+					Name: templateName,
+				},
+			},
+		}
+	}
+
+	countPoolSandboxes := func(t *testing.T, c client.Client) int {
+		t.Helper()
+		list := &sandboxv1beta1.SandboxList{}
+		require.NoError(t, c.List(context.Background(), list, &client.ListOptions{Namespace: poolNamespace}))
+		n := 0
+		for _, sb := range list.Items {
+			if sb.Labels[warmPoolSandboxLabel] == poolNameHash {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("missing template emits one warning and creates nothing", func(t *testing.T) {
+		warmPool := newPool()
+		recorder := events.NewFakeRecorder(16)
+		r := SandboxWarmPoolReconciler{
+			Client:       newFakeClient(scheme),
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
+			Recorder:     recorder,
+		}
+		ctx := context.Background()
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, missingTemplateRequeueDelay, requeue)
+		require.Equal(t, 0, countPoolSandboxes(t, r.Client))
+		require.Equal(t, int32(0), warmPool.Status.Replicas)
+		require.Equal(t, int32(0), warmPool.Status.ReadyReplicas)
+
+		select {
+		case e := <-recorder.Events:
+			require.Contains(t, e, reasonWarmPoolNotProgressing)
+			require.Contains(t, e, corev1.EventTypeWarning)
+			require.Contains(t, e, `SandboxTemplate "does-not-exist" not found`)
+		default:
+			t.Fatal("expected a WarmPoolNotProgressing event for a missing template")
+		}
+
+		requeue, err = r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, missingTemplateRequeueDelay, requeue)
+		select {
+		case e := <-recorder.Events:
+			t.Fatalf("unexpected duplicate event while the template is still missing: %s", e)
+		default:
+		}
+	})
+
+	t.Run("template appearing resumes progress and creates sandboxes", func(t *testing.T) {
+		warmPool := newPool()
+		recorder := events.NewFakeRecorder(16)
+		r := SandboxWarmPoolReconciler{
+			Client:       newFakeClient(scheme),
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
+			Recorder:     recorder,
+		}
+		ctx := context.Background()
+
+		_, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		select {
+		case e := <-recorder.Events:
+			require.Contains(t, e, reasonWarmPoolNotProgressing)
+		default:
+			t.Fatal("expected a WarmPoolNotProgressing event before the template appears")
+		}
+
+		template := createTemplate(poolNamespace)
+		template.Name = templateName
+		require.NoError(t, r.Create(ctx, template))
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue)
+		require.Equal(t, int(replicas), countPoolSandboxes(t, r.Client))
+
+		select {
+		case e := <-recorder.Events:
+			require.Contains(t, e, reasonWarmPoolProgressing)
+			require.Contains(t, e, corev1.EventTypeNormal)
+		default:
+			t.Fatal("expected a WarmPoolProgressing event once the template appears")
+		}
+	})
+
+	t.Run("missing template does not delete existing members", func(t *testing.T) {
+		warmPool := newPool()
+		existing := createPoolSandbox(poolName, poolNamespace, poolNameHash, nil, "-keep")
+		existing.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: extensionsv1beta1.GroupVersion.String(),
+			Kind:       extensionsv1beta1.SandboxWarmPoolKind,
+			Name:       poolName,
+			UID:        poolUID,
+			Controller: new(true),
+		}}
+
+		recorder := events.NewFakeRecorder(16)
+		r := SandboxWarmPoolReconciler{
+			Client:       newFakeClient(scheme, existing),
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
+			Recorder:     recorder,
+		}
+		ctx := context.Background()
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Equal(t, missingTemplateRequeueDelay, requeue)
+		require.Equal(t, 1, countPoolSandboxes(t, r.Client), "existing pool members must not be deleted when the template is missing")
+		require.Equal(t, int32(1), warmPool.Status.Replicas)
+
+		got := &sandboxv1beta1.Sandbox{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Namespace: poolNamespace, Name: existing.Name}, got))
+
+		select {
+		case e := <-recorder.Events:
+			require.Contains(t, e, reasonWarmPoolNotProgressing)
+			require.Contains(t, e, corev1.EventTypeWarning)
+			require.Contains(t, e, `SandboxTemplate "does-not-exist" not found`)
+		default:
+			t.Fatal("expected a WarmPoolNotProgressing event when the template is missing")
+		}
+	})
+
+	t.Run("scaled to zero does not warn or requeue for a missing template", func(t *testing.T) {
+		zero := int32(0)
+		warmPool := newPool()
+		warmPool.Spec.Replicas = &zero
+		recorder := events.NewFakeRecorder(16)
+		r := SandboxWarmPoolReconciler{
+			Client:       newFakeClient(scheme),
+			Scheme:       scheme,
+			MaxBatchSize: sandboxCreateDeleteMaxBatchSize,
+			Recorder:     recorder,
+		}
+		ctx := context.Background()
+
+		requeue, err := r.reconcilePool(ctx, warmPool)
+		require.NoError(t, err)
+		require.Zero(t, requeue, "a scaled-to-zero pool must not requeue for a missing template")
+		require.Equal(t, 0, countPoolSandboxes(t, r.Client))
+		require.Equal(t, int32(0), warmPool.Status.Replicas)
+
+		select {
+		case e := <-recorder.Events:
+			t.Fatalf("scaled-to-zero pool must not emit WarmPoolNotProgressing for a missing template: %s", e)
+		default:
+		}
+	})
 }
 
 func TestReconcilePoolControllerRef(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it:
When a `SandboxWarmPool` references a missing `SandboxTemplate`, the
controller silently creates no sandboxes and emits no status or event.
This change emits a single `Warning` event with reason
`WarmPoolNotProgressing`, requeues the pool after one minute, and emits a
normal progress event when the template becomes available.
Existing warm-pool sandboxes are preserved while the template is missing.
#### Which issue(s) this PR is related to:
Fixes #1570
#### Release Note
```release-note
Reports a warning event when a SandboxWarmPool references a missing SandboxTemplate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Missing SandboxTemplates are now handled as a non-error condition.
  - Warm pools report a clear “SandboxTemplate not found” status and retry automatically after one minute.
  - Existing pool members are preserved while the template is unavailable.
  - Normal sandbox creation resumes automatically when the template becomes available.
  - A warning event is emitted only once while the template remains missing.
  - Pools scaled to zero do not emit warnings or schedule unnecessary retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->