### PR TITLE
fix(python-sdk): keep the connection open on 4xx responses

### DIFF
--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/async_connector.py
@@ -245,12 +245,14 @@ class AsyncSandboxConnector:
                 return response
             except httpx.HTTPStatusError as e:
                 logger.error(f"Request to sandbox failed: {e}")
-                # Clear cached URLs that may have gone stale.
-                if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
-                    self._base_url = None
-                self._pod_ip_resolved = False
-                self._cached_pod_ip_url = None
-                self._pod_ip = None
+                # 5xx: often a stale Pod IP after a pod swap, clear the cached
+                # routing state so the next request re-resolves.
+                if e.response.status_code >= 500:
+                    if isinstance(self.connection_config, SandboxGatewayConnectionConfig):
+                        self._base_url = None
+                    self._pod_ip_resolved = False
+                    self._cached_pod_ip_url = None
+                    self._pod_ip = None
                 raise SandboxRequestError(
                     f"Failed to communicate with the sandbox at {url}.",
                     status_code=e.response.status_code,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -615,10 +615,10 @@ class SandboxConnector:
             resp = getattr(e, "response", None)
             status_code = resp.status_code if resp is not None else None
 
-            # A 4xx means the sandbox answered, so the connection is fine. 
-            # Only a transport failure should reset the Pod IP and close the tunnel.
-            is_client_error = status_code is not None and 400 <= status_code < 500
-            if not is_client_error:
+            # If we got an HTTP response (4xx or 5xx), the sandbox/router
+            # answered and the connection is still usable. Only a transport
+            # failure (no response) should reset the Pod IP and close the tunnel.
+            if status_code is None:
                 logging.error(f"Request to sandbox failed: {e}")
                 self._pod_ip_resolved = False
                 self._pod_ip = None

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -615,10 +615,14 @@ class SandboxConnector:
             resp = getattr(e, "response", None)
             status_code = resp.status_code if resp is not None else None
 
-            logging.error(f"Request to sandbox failed: {e}")
-            self._pod_ip_resolved = False
-            self._pod_ip = None
-            self.close()
+            # A 4xx means the sandbox answered, so the connection is fine. 
+            # Only a transport failure should reset the Pod IP and close the tunnel.
+            is_client_error = status_code is not None and 400 <= status_code < 500
+            if not is_client_error:
+                logging.error(f"Request to sandbox failed: {e}")
+                self._pod_ip_resolved = False
+                self._pod_ip = None
+                self.close()
             raise SandboxRequestError(
                 f"Failed to communicate with the sandbox at {url}.",
                 status_code=status_code,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -615,14 +615,17 @@ class SandboxConnector:
             resp = getattr(e, "response", None)
             status_code = resp.status_code if resp is not None else None
 
-            # If we got an HTTP response (4xx or 5xx), the sandbox/router
-            # answered and the connection is still usable. Only a transport
-            # failure (no response) should reset the Pod IP and close the tunnel.
+            # No response: transport may be dead, reset the Pod IP and close.
+            # 5xx: often a stale Pod IP after a pod swap, drop it but keep the tunnel.
+            # 4xx: sandbox answered a client error, routing is fine, keep all.
             if status_code is None:
                 logging.error(f"Request to sandbox failed: {e}")
                 self._pod_ip_resolved = False
                 self._pod_ip = None
                 self.close()
+            elif status_code >= 500:
+                self._pod_ip_resolved = False
+                self._pod_ip = None
             raise SandboxRequestError(
                 f"Failed to communicate with the sandbox at {url}.",
                 status_code=status_code,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -436,6 +436,10 @@ class SandboxConnector:
             backoff_factor=0.5,
             status_forcelist=[500, 502, 503, 504],
             allowed_methods=RETRYABLE_METHODS,
+            # Return the final 5xx response instead of raising RetryError (which
+            # carries no response): send_request's raise_for_status then sees the
+            # status, so a stale-Pod-IP 5xx keeps the tunnel instead of closing.
+            raise_on_status=False,
         )
         self.session.mount("http://", HTTPAdapter(max_retries=retries))
         self.session.mount("https://", HTTPAdapter(max_retries=retries))

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/connector.py
@@ -84,6 +84,11 @@ class ConnectionStrategy(ABC):
         """Returns True if X-Sandbox-* router headers should be injected into requests."""
         pass
 
+    def invalidate_pod_ip(self):
+        """Drops any Pod IP cached by the strategy so the next connect() re-resolves it,
+        without tearing down the connection. No-op unless the strategy caches a Pod IP."""
+        pass
+
 class DirectConnectionStrategy(ConnectionStrategy):
     def __init__(self, config: SandboxDirectConnectionConfig):
         self.config = config
@@ -397,6 +402,10 @@ class InClusterConnectionStrategy(ConnectionStrategy):
         self._resolved = False
         self._cached_pod_ip_url = None
 
+    def invalidate_pod_ip(self):
+        self._resolved = False
+        self._cached_pod_ip_url = None
+
     def should_inject_router_headers(self) -> bool:
         return False
 
@@ -630,6 +639,10 @@ class SandboxConnector:
             elif status_code >= 500:
                 self._pod_ip_resolved = False
                 self._pod_ip = None
+                # In-cluster routing caches the Pod IP in the strategy's base
+                # URL, not the header above; invalidate it too so connect()
+                # re-resolves instead of reusing the stale Pod.
+                self.strategy.invalidate_pod_ip()
             raise SandboxRequestError(
                 f"Failed to communicate with the sandbox at {url}.",
                 status_code=status_code,

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -1120,8 +1120,12 @@ class TestAsyncSandboxClientInClusterConnectionConfig(unittest.IsolatedAsyncioTe
 class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
     """Tests for Bug Fix #2: Cache invalidation on HTTPStatusError."""
 
-    async def test_http_status_error_clears_pod_ip_cache(self):
-        """Verify HTTPStatusError (4xx/5xx) clears pod IP cache (Bug Fix #2)."""
+    async def test_server_error_clears_pod_ip_cache(self):
+        """Verify a 5xx clears the pod IP cache so the next request re-resolves.
+
+        A 5xx is how a stale cached Pod IP commonly surfaces after the pod is
+        replaced, so the cached routing state is dropped.
+        """
         config = SandboxInClusterConnectionConfig(server_port=8888)
 
         # Mock get_pod_ip to track how many times it's called
@@ -1138,7 +1142,63 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
             get_pod_ip=mock_get_pod_ip,
         )
 
-        # Mock httpx client to return 404 on first request
+        # Mock httpx client to return 503 on first request
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.is_redirect = False
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503 Service Unavailable",
+            request=MagicMock(),
+            response=mock_response
+        )
+
+        connector.client.request = AsyncMock(return_value=mock_response)
+
+        try:
+            # First request should fail with 503
+            with self.assertRaises(SandboxRequestError):
+                await connector.send_request("GET", "test")
+
+            # Verify cache was cleared (pod_ip_resolved reset)
+            self.assertFalse(connector._pod_ip_resolved,
+                           "A 5xx should clear pod_ip_resolved flag")
+            self.assertIsNone(connector._cached_pod_ip_url,
+                            "A 5xx should clear cached pod IP URL")
+
+            # Second request should re-resolve pod IP (call count increases)
+            initial_count = call_count[0]
+            mock_response.status_code = 200
+            mock_response.raise_for_status.side_effect = None
+            connector.client.request = AsyncMock(return_value=mock_response)
+
+            await connector.send_request("GET", "test")
+
+            self.assertEqual(call_count[0], initial_count + 1,
+                           "After cache invalidation, pod IP should be re-resolved")
+        finally:
+            await connector.close()
+
+    async def test_client_error_keeps_pod_ip_cache(self):
+        """Verify a 4xx leaves the pod IP cache intact.
+
+        A 4xx means the sandbox answered a well-formed request with a client
+        error; routing is fine, so the cached Pod IP must be preserved.
+        """
+        config = SandboxInClusterConnectionConfig(server_port=8888)
+
+        call_count = [0]
+        async def mock_get_pod_ip():
+            call_count[0] += 1
+            return "10.244.0.5"
+
+        connector = AsyncSandboxConnector(
+            sandbox_id="test-sandbox",
+            namespace="default",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+            get_pod_ip=mock_get_pod_ip,
+        )
+
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.is_redirect = False
@@ -1151,17 +1211,16 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
         connector.client.request = AsyncMock(return_value=mock_response)
 
         try:
-            # First request should fail with 404
             with self.assertRaises(SandboxRequestError):
                 await connector.send_request("GET", "test")
 
-            # Verify cache was cleared (pod_ip_resolved reset)
-            self.assertFalse(connector._pod_ip_resolved,
-                           "HTTPStatusError should clear pod_ip_resolved flag")
-            self.assertIsNone(connector._cached_pod_ip_url,
-                            "HTTPStatusError should clear cached pod IP URL")
+            # The 404 resolved a Pod IP once, it must stay cached.
+            self.assertTrue(connector._pod_ip_resolved,
+                            "A 4xx must not clear pod_ip_resolved flag")
+            self.assertIsNotNone(connector._cached_pod_ip_url,
+                                 "A 4xx must not clear cached pod IP URL")
 
-            # Second request should re-resolve pod IP (call count increases)
+            # A second request must reuse the cache.
             initial_count = call_count[0]
             mock_response.status_code = 200
             mock_response.raise_for_status.side_effect = None
@@ -1169,8 +1228,8 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
 
             await connector.send_request("GET", "test")
 
-            self.assertEqual(call_count[0], initial_count + 1,
-                           "After cache invalidation, pod IP should be re-resolved")
+            self.assertEqual(call_count[0], initial_count,
+                             "A 4xx must leave the pod IP cached")
         finally:
             await connector.close()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_async_sandboxclient.py
@@ -1155,26 +1155,30 @@ class TestAsyncConnectorCacheInvalidation(unittest.IsolatedAsyncioTestCase):
         connector.client.request = AsyncMock(return_value=mock_response)
 
         try:
-            # First request should fail with 503
-            with self.assertRaises(SandboxRequestError):
+            with patch(
+                "k8s_agent_sandbox.async_connector.asyncio.sleep",
+                new=AsyncMock(),
+            ):
+                # First request should fail with 503
+                with self.assertRaises(SandboxRequestError):
+                    await connector.send_request("GET", "test")
+
+                # Verify cache was cleared (pod_ip_resolved reset)
+                self.assertFalse(connector._pod_ip_resolved,
+                               "A 5xx should clear pod_ip_resolved flag")
+                self.assertIsNone(connector._cached_pod_ip_url,
+                                "A 5xx should clear cached pod IP URL")
+
+                # Second request should re-resolve pod IP (call count increases)
+                initial_count = call_count[0]
+                mock_response.status_code = 200
+                mock_response.raise_for_status.side_effect = None
+                connector.client.request = AsyncMock(return_value=mock_response)
+
                 await connector.send_request("GET", "test")
 
-            # Verify cache was cleared (pod_ip_resolved reset)
-            self.assertFalse(connector._pod_ip_resolved,
-                           "A 5xx should clear pod_ip_resolved flag")
-            self.assertIsNone(connector._cached_pod_ip_url,
-                            "A 5xx should clear cached pod IP URL")
-
-            # Second request should re-resolve pod IP (call count increases)
-            initial_count = call_count[0]
-            mock_response.status_code = 200
-            mock_response.raise_for_status.side_effect = None
-            connector.client.request = AsyncMock(return_value=mock_response)
-
-            await connector.send_request("GET", "test")
-
-            self.assertEqual(call_count[0], initial_count + 1,
-                           "After cache invalidation, pod IP should be re-resolved")
+                self.assertEqual(call_count[0], initial_count + 1,
+                               "After cache invalidation, pod IP should be re-resolved")
         finally:
             await connector.close()
 

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -367,5 +367,56 @@ class TestSandboxConnectorHeaderInjection(unittest.TestCase):
 
         connector.send_request("GET", "/execute")
 
+class TestSandboxConnectorErrorHandling(unittest.TestCase):
+    def _make_connector(self):
+        config = SandboxDirectConnectionConfig(api_url="http://router")
+        connector = SandboxConnector(
+            sandbox_id="sb",
+            namespace="ns",
+            connection_config=config,
+            k8s_helper=MagicMock(),
+        )
+        connector.strategy = DirectConnectionStrategy(config)
+        connector.session = MagicMock()
+        # Pretend a Pod IP was already resolved so a reset is detectable.
+        connector._pod_ip = "10.0.0.5"
+        connector._pod_ip_resolved = True
+        return connector
+
+    def _error_response(self, status_code):
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = status_code
+        resp.is_redirect = False
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        return resp
+
+    def test_client_error_keeps_connection(self):
+        from k8s_agent_sandbox.connector import SandboxRequestError
+        connector = self._make_connector()
+        connector.session.request.return_value = self._error_response(404)
+
+        with self.assertRaises(SandboxRequestError) as ctx:
+            connector.send_request("GET", "download/missing.txt")
+
+        # A 404 means the sandbox answered: the connection must be left intact.
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertEqual(connector._pod_ip, "10.0.0.5")
+        self.assertTrue(connector._pod_ip_resolved)
+        connector.session.close.assert_not_called()
+
+    def test_transport_failure_resets_connection(self):
+        from k8s_agent_sandbox.connector import SandboxRequestError
+        connector = self._make_connector()
+        connector.session.request.side_effect = requests.exceptions.ConnectionError("refused")
+
+        with self.assertRaises(SandboxRequestError):
+            connector.send_request("GET", "download/x")
+
+        # A genuine transport failure should reset the Pod IP and close the tunnel.
+        self.assertIsNone(connector._pod_ip)
+        self.assertFalse(connector._pod_ip_resolved)
+        connector.session.close.assert_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -404,6 +404,22 @@ class TestSandboxConnectorErrorHandling(unittest.TestCase):
         self.assertTrue(connector._pod_ip_resolved)
         connector.session.close.assert_not_called()
 
+    def test_server_error_clears_pod_ip_but_keeps_tunnel(self):
+        from k8s_agent_sandbox.connector import SandboxRequestError
+        connector = self._make_connector()
+        connector.session.request.return_value = self._error_response(503)
+
+        with self.assertRaises(SandboxRequestError) as ctx:
+            connector.send_request("GET", "run")
+
+        # A 5xx often means the cached Pod IP went stale after a pod
+        # replacement: drop it so the next request re-resolves, but the
+        # tunnel carried a full response and must stay open.
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertIsNone(connector._pod_ip)
+        self.assertFalse(connector._pod_ip_resolved)
+        connector.session.close.assert_not_called()
+
     def test_transport_failure_resets_connection(self):
         from k8s_agent_sandbox.connector import SandboxRequestError
         connector = self._make_connector()

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 import unittest
-from unittest.mock import MagicMock
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
 
 import requests
 
@@ -432,6 +434,51 @@ class TestSandboxConnectorErrorHandling(unittest.TestCase):
         self.assertIsNone(connector._pod_ip)
         self.assertFalse(connector._pod_ip_resolved)
         connector.session.close.assert_called()
+
+
+class TestSandboxConnectorRetryExhaustion(unittest.TestCase):
+    """A 5xx that exhausts urllib3's status retries must still reach the 5xx
+    branch rather than surface as a responseless RetryError."""
+
+    def _serve_503(self):
+        class _H(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(503)
+                self.end_headers()
+                self.wfile.write(b"unavailable")
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), _H)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        self.addCleanup(server.shutdown)
+        return f"http://127.0.0.1:{server.server_address[1]}"
+
+    def test_exhausted_retry_5xx_preserves_status_and_keeps_tunnel(self):
+        from k8s_agent_sandbox.connector import SandboxRequestError
+        connector = SandboxConnector(
+            sandbox_id="sb",
+            namespace="ns",
+            connection_config=SandboxDirectConnectionConfig(api_url=self._serve_503()),
+            k8s_helper=MagicMock(),
+        )
+        connector._pod_ip = "10.0.0.5"
+        connector._pod_ip_resolved = True
+        close_spy = MagicMock(wraps=connector.session.close)
+        connector.session.close = close_spy
+
+        # Patch sleep so urllib3's real backoff between the 5 retries is instant.
+        with patch("time.sleep"):
+            with self.assertRaises(SandboxRequestError) as ctx:
+                connector.send_request("GET", "run")
+
+        # raise_on_status=False lets the final 503 reach raise_for_status, so
+        # the 5xx branch fires: status preserved, Pod IP dropped, tunnel kept.
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertIsNone(connector._pod_ip)
+        self.assertFalse(connector._pod_ip_resolved)
+        close_spy.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
+++ b/clients/python/agentic-sandbox-client/k8s_agent_sandbox/test/unit/test_connector.py
@@ -480,6 +480,29 @@ class TestSandboxConnectorRetryExhaustion(unittest.TestCase):
         self.assertFalse(connector._pod_ip_resolved)
         close_spy.assert_not_called()
 
+    def test_in_cluster_5xx_reresolves_pod_ip(self):
+        from k8s_agent_sandbox.connector import SandboxRequestError
+        api = self._serve_503()
+        port = int(api.rsplit(":", 1)[1])
+        ips = iter(["127.0.0.1", "10.0.0.99"])
+        connector = SandboxConnector(
+            sandbox_id="sb",
+            namespace="ns",
+            connection_config=SandboxInClusterConnectionConfig(server_port=port),
+            k8s_helper=MagicMock(),
+            get_pod_ip=lambda: next(ips),
+        )
+
+        with patch("time.sleep"):
+            with self.assertRaises(SandboxRequestError) as ctx:
+                connector.send_request("GET", "run")
+
+        # In-cluster caches the Pod IP in the strategy's base URL; a 5xx must
+        # invalidate it so the next connect() resolves the replacement Pod.
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertFalse(connector.strategy._resolved)
+        self.assertEqual(connector.connect(), f"http://10.0.0.99:{port}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
The connector caught every RequestException, including a 404, and reset the resolved Pod IP and closed the port-forward tunnel. A 4xx is a successful round trip, so a normal missing-file read tore the tunnel down and forced the next call to rebuild it. Go SDK and async connector already handle this correctly.

### Repro
```python 
from k8s_agent_sandbox import SandboxClient
from k8s_agent_sandbox.models import SandboxLocalTunnelConnectionConfig

WARMPOOL = "testing"
NAMESPACE = "default"

def main():
    client = SandboxClient(connection_config=SandboxLocalTunnelConnectionConfig())
    sandbox = client.create_sandbox(warmpool=WARMPOOL, namespace=NAMESPACE)
    conn = sandbox.connector            # holds the resolved Pod IP
    strat = conn.strategy               # holds base_url + the port-forward subprocess
    try:
        sandbox.commands.run("true")
        old_proc = strat.port_forward_process
        print("before 404:")
        print(f"  pod_ip                = {conn._pod_ip}")
        print(f"  base_url              = {strat.base_url}")
        print(f"  port-forward pid      = {old_proc.pid} (alive={old_proc.poll() is None})")

        # A normal "file not found" read.
        try:
            sandbox.files.read("does-not-exist.txt")
        except Exception as exc:
            print(f"\nread() raised: {type(exc).__name__} status_code={getattr(exc, 'status_code', None)}\n")

        # The teardown has already run: state is cleared and the process killed.
        print("after 404 (no new call yet):")
        print(f"  pod_ip                = {conn._pod_ip}")
        print(f"  base_url              = {strat.base_url}")
        print(f"  port-forward process  = {strat.port_forward_process}")
        print(f"  pid {old_proc.pid} alive          = {old_proc.poll() is None}  <- killed")

        # The sandbox itself was never broken: this succeeds, but only after the connector rebuilds the tunnel.
        result = sandbox.commands.run("echo still-usable")
        new_proc = strat.port_forward_process
        print("\nafter follow-up run() (tunnel rebuilt):")
        print(f"  stdout                = {result.stdout.strip()!r}")
        print(f"  base_url              = {strat.base_url}")
        print(f"  port-forward pid      = {new_proc.pid}  <- new process")

        print(f"\nresult: a 404 killed pid {old_proc.pid} and forced a rebuild to pid {new_proc.pid} (bug)")
    finally:
        sandbox.terminate()


if __name__ == "__main__":
    main()
```

```sh
before 404:
  pod_ip                = 10.244.0.112
  base_url              = http://127.0.0.1:60568
  port-forward pid      = 23002 (alive=True)
ERROR:root:Request to sandbox failed: 404 Client Error: Not Found for url: http://127.0.0.1:60568/download/does-not-exist.txt

read() raised: SandboxRequestError status_code=404

after 404 (no new call yet):
  pod_ip                = None
  base_url              = None
  port-forward process  = None
  pid 23002 alive          = False  <- killed

after follow-up run() (tunnel rebuilt):
  stdout                = 'still-usable'
  base_url              = http://127.0.0.1:60580
  port-forward pid      = 23006  <- new process
```

### Proposed fix

Only reset the Pod IP and close the connection for genuine transport failures.

### After
```python
before 404:
  pod_ip                = 10.244.0.114
  base_url              = http://127.0.0.1:62800
  port-forward pid      = 61485 (alive=True)

read() raised: SandboxRequestError status_code=404

after 404 (no new call yet):
  pod_ip                = 10.244.0.114
  base_url              = http://127.0.0.1:62800
  port-forward process  = <Popen: returncode: None args: ['kubectl', 'port-forward', 'svc/sandbox-rout...>
  pid 61485 alive          = True  <- killed

after follow-up run() (tunnel rebuilt):
  stdout                = 'still-usable'
  base_url              = http://127.0.0.1:62800
  port-forward pid      = 61485  <- same process
```

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
NONE
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP 4xx responses no longer disconnect active sandbox connections or clear cached routing state.
  * HTTP 5xx responses now clear cached routing state while keeping the connection open for recovery.
  * Subsequent requests can re-resolve updated sandbox routing after server errors.
  * Exhausted retries now return the final 5xx response for explicit error handling.
  * Transport-level failures reset cached routing state and close the connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->