### PR TITLE
feat(go-sdk): add direct connectivity options for in-cluster pods

### DIFF
--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -68,11 +68,13 @@ type connector struct {
 	lastError           error
 
 	// routerHeaders controls whether X-Sandbox-* routing headers are sent.
-	// True for router-based transports (legacy runtime); false for the
-	// sandboxd pod tunnel, which talks to the pod directly.
+	// True only for transports that actually reach the sandbox-router; false
+	// for sandboxd and for any in-cluster dial, which address the pod and so
+	// have nothing to consume them.
 	routerHeaders bool
-	// grpcTarget is the dial address for sandboxd's ProcessService,
-	// published by podTunnelStrategy after the port-forward is ready.
+	// grpcTarget is the dial address for sandboxd's ProcessService, published
+	// by whichever strategy resolved it (the pod tunnel once the port-forward
+	// is ready, or the in-cluster strategy once the address is known).
 	grpcTarget string
 	grpcConn   *grpc.ClientConn
 
@@ -171,7 +173,7 @@ func (c *connector) Connect(ctx context.Context) error {
 	c.lastError = nil
 	c.mu.Unlock()
 	mode := "direct"
-	switch c.strategy.(type) {
+	switch s := c.strategy.(type) {
 	case *gatewayStrategy:
 		mode = "gateway"
 	case *tunnelStrategy:
@@ -179,7 +181,10 @@ func (c *connector) Connect(ctx context.Context) error {
 	case *podTunnelStrategy:
 		mode = "sandboxd-pod-tunnel"
 	case *inClusterStrategy:
-		mode = "sandboxd-in-cluster"
+		mode = "in-cluster-pod-ip"
+		if s.useServiceDNS {
+			mode = "in-cluster-service"
+		}
 	}
 	c.log.Info("API URL discovered", "url", url, "mode", mode)
 	return nil

--- a/clients/go/sandbox/connector.go
+++ b/clients/go/sandbox/connector.go
@@ -178,6 +178,8 @@ func (c *connector) Connect(ctx context.Context) error {
 		mode = "port-forward"
 	case *podTunnelStrategy:
 		mode = "sandboxd-pod-tunnel"
+	case *inClusterStrategy:
+		mode = "sandboxd-in-cluster"
 	}
 	c.log.Info("API URL discovered", "url", url, "mode", mode)
 	return nil
@@ -198,8 +200,10 @@ func (c *connector) SetGRPCTarget(target string) {
 }
 
 // GRPCConn returns a (lazily dialed) client connection to sandboxd's
-// ProcessService. The connection is plaintext: it only ever traverses the
-// port-forward tunnel to the pod's loopback listener.
+// ProcessService. The connection is plaintext, and what protects it depends on
+// the strategy that published the target: podTunnelStrategy only ever traverses
+// the port-forward tunnel to the pod's loopback listener. While inClusterStrategy
+// sends it across the pod network, where NetworkPolicy (or a mesh) confines it.
 func (c *connector) GRPCConn() (*grpc.ClientConn, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/clients/go/sandbox/incluster.go
+++ b/clients/go/sandbox/incluster.go
@@ -59,6 +59,9 @@ type inClusterStrategy struct {
 	connector *connector
 }
 
+// Connect uses resolveHost to get the URL to connect to. When using sandboxd it also
+// sets the connector's gRPC target. The method exists so inClusterStrategy conforms
+// to the ConnectionStrategy interface.
 func (t *inClusterStrategy) Connect(ctx context.Context) (string, error) {
 	_, span := startSpan(ctx, t.tracer, t.svcName, "sandboxd_in_cluster")
 	defer span.End()

--- a/clients/go/sandbox/incluster.go
+++ b/clients/go/sandbox/incluster.go
@@ -63,7 +63,7 @@ type inClusterStrategy struct {
 // sets the connector's gRPC target. The method exists so inClusterStrategy conforms
 // to the ConnectionStrategy interface.
 func (t *inClusterStrategy) Connect(ctx context.Context) (string, error) {
-	_, span := startSpan(ctx, t.tracer, t.svcName, "sandboxd_in_cluster")
+	_, span := startSpan(ctx, t.tracer, t.svcName, "in_cluster_transport")
 	defer span.End()
 
 	host, via, err := t.resolveHost()

--- a/clients/go/sandbox/incluster.go
+++ b/clients/go/sandbox/incluster.go
@@ -24,28 +24,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// inClusterStrategy addresses the sandbox runtime on the pod's IP, taking
+// inClusterStrategy addresses the sandbox runtime on the pod network, taking
 // the apiserver (and, for the legacy runtime, the sandbox-router) off the data
-// path.
+// path. Connectivity picks exactly one address, with no fallback between
+// them: useServiceDNS dials the headless Service by name
+// (Status.ServiceFQDN), otherwise it dials Status.PodIP.
 //
 // A caller outside the cluster cannot use it. For the legacy runtime it also gives
 // up the router's own validation of the routing headers, which are not sent on this
 // path because nothing would consume them.
-//
-// Pod IP staleness is not handled here, and recovery differs from the
-// port-forward's. podTunnelStrategy runs a monitor that detects tunnel death
-// and calls connector.SetLastError, which clears the base URL so operations
-// fail fast with ErrNotReady and a plain Open() reconnects. A direct dial has
-// no equivalent signal: nothing clears the base URL, so after the sandbox pod
-// is rescheduled the connector still reports IsConnected, requests keep
-// failing against the dead IP with ErrRetriesExhausted rather than
-// ErrNotReady, and Open() returns ErrAlreadyOpen instead of reconnecting.
-// Recovery is therefore Disconnect() followed by Open(): Connect re-reads
-// getPodIP on every call, so the fresh address is picked up then.
-//
-// An IP the cluster has since reassigned to an unrelated pod would not be
-// detected at all — the SDK has no identity check on this path today, the
-// same as for the port-forward.
 type inClusterStrategy struct {
 	// httpPort carries the runtime's HTTP API: sandboxd's Filesystem &
 	// Runtime REST port, or the legacy runtime's ServerPort.
@@ -57,10 +44,15 @@ type inClusterStrategy struct {
 	tracer   trace.Tracer
 	svcName  string
 
-	// getPodIP returns the resolved sandbox pod IP; set after construction
-	// (the pod is only known once the sandbox is ready). Mirrors
-	// podTunnelStrategy.getPodName.
-	getPodIP func() string
+	// useServiceDNS dials the headless Service's DNS name rather than the
+	// pod IP. The two are exclusive; neither falls back to the other.
+	useServiceDNS bool
+
+	// getServiceFQDN and getPodIP return the resolved Sandbox addresses; set
+	// after construction (they are only known once the sandbox is ready).
+	// Mirrors podTunnelStrategy.getPodName.
+	getServiceFQDN func() string
+	getPodIP       func() string
 
 	// connector is set after construction so Connect can publish the gRPC
 	// dial target.
@@ -71,26 +63,43 @@ func (t *inClusterStrategy) Connect(ctx context.Context) (string, error) {
 	_, span := startSpan(ctx, t.tracer, t.svcName, "sandboxd_in_cluster")
 	defer span.End()
 
+	host, via, err := t.resolveHost()
+	if err != nil {
+		recordError(span, err)
+		return "", err
+	}
+
+	baseURL := "http://" + net.JoinHostPort(host, strconv.Itoa(t.httpPort))
+	if t.grpcPort != 0 && t.connector != nil {
+		t.connector.SetGRPCTarget(net.JoinHostPort(host, strconv.Itoa(t.grpcPort)))
+	}
+	t.log.V(1).Info("in-cluster transport resolved",
+		"host", host, "via", via, "httpPort", t.httpPort, "grpcPort", t.grpcPort)
+	return baseURL, nil
+}
+
+// resolveHost returns the address this strategy dials either the service FQDN
+// or the pod IP, and a label for logging.
+func (t *inClusterStrategy) resolveHost() (host, via string, err error) {
+	if t.useServiceDNS {
+		fqdn := ""
+		if t.getServiceFQDN != nil {
+			fqdn = t.getServiceFQDN()
+		}
+		if fqdn == "" {
+			return "", "", fmt.Errorf("sandbox: %w: cannot address it by DNS; set spec.service: true on the template, or use %q connectivity to dial the pod IP", ErrNoSandboxService, ConnectivityInClusterPodIP)
+		}
+		return fqdn, "service", nil
+	}
+
 	podIP := ""
 	if t.getPodIP != nil {
 		podIP = t.getPodIP()
 	}
 	if podIP == "" {
-		err := fmt.Errorf("sandbox: sandbox pod IP not resolved yet; cannot connect directly")
-		recordError(span, err)
-		return "", err
+		return "", "", fmt.Errorf("sandbox: sandbox pod IP not resolved yet; cannot connect directly")
 	}
-
-	// JoinHostPort brackets IPv6 literals, which both the URL and the gRPC
-	// dial target require. The IP is already normalized by selectPodIP when
-	// the sandbox status is read.
-	baseURL := "http://" + net.JoinHostPort(podIP, strconv.Itoa(t.httpPort))
-	if t.grpcPort != 0 && t.connector != nil {
-		t.connector.SetGRPCTarget(net.JoinHostPort(podIP, strconv.Itoa(t.grpcPort)))
-	}
-	t.log.V(1).Info("in-cluster transport resolved",
-		"podIP", podIP, "httpPort", t.httpPort, "grpcPort", t.grpcPort)
-	return baseURL, nil
+	return podIP, "pod-ip", nil
 }
 
 // Close is a no-op: the strategy owns no connections or goroutines. The HTTP

--- a/clients/go/sandbox/incluster.go
+++ b/clients/go/sandbox/incluster.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// inClusterStrategy addresses the sandbox runtime on the pod's IP, taking
+// the apiserver (and, for the legacy runtime, the sandbox-router) off the data
+// path.
+//
+// A caller outside the cluster cannot use it. For the legacy runtime it also gives
+// up the router's own validation of the routing headers, which are not sent on this
+// path because nothing would consume them.
+//
+// Pod IP staleness is not handled here, and recovery differs from the
+// port-forward's. podTunnelStrategy runs a monitor that detects tunnel death
+// and calls connector.SetLastError, which clears the base URL so operations
+// fail fast with ErrNotReady and a plain Open() reconnects. A direct dial has
+// no equivalent signal: nothing clears the base URL, so after the sandbox pod
+// is rescheduled the connector still reports IsConnected, requests keep
+// failing against the dead IP with ErrRetriesExhausted rather than
+// ErrNotReady, and Open() returns ErrAlreadyOpen instead of reconnecting.
+// Recovery is therefore Disconnect() followed by Open(): Connect re-reads
+// getPodIP on every call, so the fresh address is picked up then.
+//
+// An IP the cluster has since reassigned to an unrelated pod would not be
+// detected at all — the SDK has no identity check on this path today, the
+// same as for the port-forward.
+type inClusterStrategy struct {
+	// httpPort carries the runtime's HTTP API: sandboxd's Filesystem &
+	// Runtime REST port, or the legacy runtime's ServerPort.
+	httpPort int
+	// grpcPort is sandboxd's ProcessService port, or 0 for a runtime that
+	// serves no gRPC (the legacy runtime).
+	grpcPort int
+	log      logr.Logger
+	tracer   trace.Tracer
+	svcName  string
+
+	// getPodIP returns the resolved sandbox pod IP; set after construction
+	// (the pod is only known once the sandbox is ready). Mirrors
+	// podTunnelStrategy.getPodName.
+	getPodIP func() string
+
+	// connector is set after construction so Connect can publish the gRPC
+	// dial target.
+	connector *connector
+}
+
+func (t *inClusterStrategy) Connect(ctx context.Context) (string, error) {
+	_, span := startSpan(ctx, t.tracer, t.svcName, "sandboxd_in_cluster")
+	defer span.End()
+
+	podIP := ""
+	if t.getPodIP != nil {
+		podIP = t.getPodIP()
+	}
+	if podIP == "" {
+		err := fmt.Errorf("sandbox: sandbox pod IP not resolved yet; cannot connect directly")
+		recordError(span, err)
+		return "", err
+	}
+
+	// JoinHostPort brackets IPv6 literals, which both the URL and the gRPC
+	// dial target require. The IP is already normalized by selectPodIP when
+	// the sandbox status is read.
+	baseURL := "http://" + net.JoinHostPort(podIP, strconv.Itoa(t.httpPort))
+	if t.grpcPort != 0 && t.connector != nil {
+		t.connector.SetGRPCTarget(net.JoinHostPort(podIP, strconv.Itoa(t.grpcPort)))
+	}
+	t.log.V(1).Info("in-cluster transport resolved",
+		"podIP", podIP, "httpPort", t.httpPort, "grpcPort", t.grpcPort)
+	return baseURL, nil
+}
+
+// Close is a no-op: the strategy owns no connections or goroutines. The HTTP
+// and gRPC clients it hands addresses to are torn down by the connector.
+func (t *inClusterStrategy) Close() error { return nil }

--- a/clients/go/sandbox/incluster_test.go
+++ b/clients/go/sandbox/incluster_test.go
@@ -1,0 +1,410 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// inClusterTestOpts returns options selecting the in-cluster sandboxd
+// transport. It cannot reuse defaultTestOpts, which sets APIURL — that
+// combination is rejected by validation.
+func inClusterTestOpts() Options {
+	opts := Options{
+		WarmPoolName:        "test-warmpool",
+		Namespace:           "default",
+		Runtime:             RuntimeSandboxd,
+		Connectivity:        ConnectivityInCluster,
+		SandboxReadyTimeout: 5 * time.Second,
+		Quiet:               true,
+	}
+	opts.setDefaults()
+	return opts
+}
+
+// legacyInClusterTestOpts selects the in-cluster transport for the legacy
+// python runtime, which is reached on ServerPort and has no gRPC service.
+func legacyInClusterTestOpts() Options {
+	opts := Options{
+		WarmPoolName:        "test-warmpool",
+		Namespace:           "default",
+		Runtime:             RuntimeLegacyPython,
+		Connectivity:        ConnectivityInCluster,
+		SandboxReadyTimeout: 5 * time.Second,
+		Quiet:               true,
+	}
+	opts.setDefaults()
+	return opts
+}
+
+// newInClusterStrategy builds a bare strategy wired to a fresh connector,
+// bypassing Sandbox construction. Connect starts a span, so it needs a real
+// (noop) tracer.
+func newInClusterStrategy(getPodIP func() string) (*inClusterStrategy, *connector) {
+	return newInClusterStrategyPorts(getPodIP, 8080, 9090)
+}
+
+// newInClusterStrategyPorts is the same with explicit ports; grpcPort 0 models
+// a runtime with no gRPC service (the legacy runtime).
+func newInClusterStrategyPorts(getPodIP func() string, httpPort, grpcPort int) (*inClusterStrategy, *connector) {
+	tracer, svcName := newTracer(Options{TraceServiceName: "sandbox-client-test"})
+	conn := newConnector(connectorConfig{Log: logr.Discard(), Tracer: tracer, TraceServiceName: svcName})
+	return &inClusterStrategy{
+		httpPort:  httpPort,
+		grpcPort:  grpcPort,
+		log:       logr.Discard(),
+		tracer:    tracer,
+		svcName:   svcName,
+		getPodIP:  getPodIP,
+		connector: conn,
+	}, conn
+}
+
+// grpcTarget reads the connector's published gRPC dial address under its lock.
+func grpcTarget(c *connector) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.grpcTarget
+}
+
+// ---------------------------------------------------------------------------
+// Mode selection
+// ---------------------------------------------------------------------------
+
+func TestModeSelection_InCluster(t *testing.T) {
+	opts := inClusterTestOpts()
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb"))
+
+	if _, ok := c.connector.strategy.(*inClusterStrategy); !ok {
+		t.Fatalf("expected *inClusterStrategy, got %T", c.connector.strategy)
+	}
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	// readySandbox reports PodIPs 10.244.0.42; ports default to 8080/9090.
+	if got, want := c.connector.BaseURL(), "http://10.244.0.42:8080"; got != want {
+		t.Errorf("expected baseURL=%s, got %s", want, got)
+	}
+	if got, want := grpcTarget(c.connector), "10.244.0.42:9090"; got != want {
+		t.Errorf("expected grpcTarget=%s, got %s", want, got)
+	}
+}
+
+func TestModeSelection_InCluster_CustomPorts(t *testing.T) {
+	opts := inClusterTestOpts()
+	opts.SandboxdRESTPort = 18080
+	opts.SandboxdGRPCPort = 19090
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb"))
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if got, want := c.connector.BaseURL(), "http://10.244.0.42:18080"; got != want {
+		t.Errorf("expected baseURL=%s, got %s", want, got)
+	}
+	if got, want := grpcTarget(c.connector), "10.244.0.42:19090"; got != want {
+		t.Errorf("expected grpcTarget=%s, got %s", want, got)
+	}
+}
+
+// Router headers identify a sandbox to the sandbox-router, which is not in
+// the path here: the request goes to the pod. That holds for the legacy
+// runtime too, which is the only one that would otherwise send them.
+func TestInCluster_DoesNotSendRouterHeaders(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"sandboxd", inClusterTestOpts()},
+		{"legacy runtime", legacyInClusterTestOpts()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, _ := newTestSandbox(tc.opts)
+			if c.connector.routerHeaders {
+				t.Error("expected routerHeaders=false for the in-cluster transport")
+			}
+		})
+	}
+}
+
+// The legacy runtime is reached on ServerPort and serves no gRPC, so no gRPC
+// target should be published.
+func TestModeSelection_InCluster_LegacyRuntime(t *testing.T) {
+	opts := legacyInClusterTestOpts()
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb"))
+
+	if _, ok := c.connector.strategy.(*inClusterStrategy); !ok {
+		t.Fatalf("expected *inClusterStrategy, got %T", c.connector.strategy)
+	}
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if got, want := c.connector.BaseURL(), "http://10.244.0.42:8888"; got != want {
+		t.Errorf("expected baseURL=%s, got %s", want, got)
+	}
+	if got := grpcTarget(c.connector); got != "" {
+		t.Errorf("expected no gRPC target for the legacy runtime, got %s", got)
+	}
+}
+
+func TestModeSelection_InCluster_LegacyRuntime_CustomServerPort(t *testing.T) {
+	opts := legacyInClusterTestOpts()
+	opts.ServerPort = 3000
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb"))
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if got, want := c.connector.BaseURL(), "http://10.244.0.42:3000"; got != want {
+		t.Errorf("expected baseURL=%s, got %s", want, got)
+	}
+}
+
+// The legacy runtime must keep sending router headers on every transport that
+// actually goes through the sandbox-router.
+func TestPortForward_LegacyRuntime_StillSendsRouterHeaders(t *testing.T) {
+	opts := defaultTestOpts()
+	c, _, _ := newTestSandbox(opts)
+	if !c.connector.routerHeaders {
+		t.Error("expected routerHeaders=true for the legacy runtime off the in-cluster path")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Strategy behavior
+// ---------------------------------------------------------------------------
+
+func TestInClusterStrategy_Connect(t *testing.T) {
+	cases := []struct {
+		name           string
+		podIP          string
+		wantURL        string
+		wantGRPCTarget string
+	}{
+		{"IPv4", "10.244.0.42", "http://10.244.0.42:8080", "10.244.0.42:9090"},
+		{"IPv6 is bracketed", "2001:db8::1", "http://[2001:db8::1]:8080", "[2001:db8::1]:9090"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, conn := newInClusterStrategy(func() string { return tc.podIP })
+
+			gotURL, err := s.Connect(context.Background())
+			if err != nil {
+				t.Fatalf("Connect() error: %v", err)
+			}
+			if gotURL != tc.wantURL {
+				t.Errorf("expected baseURL=%s, got %s", tc.wantURL, gotURL)
+			}
+			if got := grpcTarget(conn); got != tc.wantGRPCTarget {
+				t.Errorf("expected grpcTarget=%s, got %s", tc.wantGRPCTarget, got)
+			}
+		})
+	}
+}
+
+func TestInClusterStrategy_Connect_NoGRPCPort(t *testing.T) {
+	s, conn := newInClusterStrategyPorts(func() string { return "10.244.0.42" }, 8888, 0)
+
+	gotURL, err := s.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect() error: %v", err)
+	}
+	if want := "http://10.244.0.42:8888"; gotURL != want {
+		t.Errorf("expected baseURL=%s, got %s", want, gotURL)
+	}
+	if got := grpcTarget(conn); got != "" {
+		t.Errorf("expected no gRPC target when grpcPort is 0, got %s", got)
+	}
+}
+
+func TestInClusterStrategy_Connect_UnresolvedPodIP(t *testing.T) {
+	cases := []struct {
+		name     string
+		getPodIP func() string
+	}{
+		{"nil closure", nil},
+		{"empty pod IP", func() string { return "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, conn := newInClusterStrategy(tc.getPodIP)
+
+			if _, err := s.Connect(context.Background()); err == nil {
+				t.Fatal("expected an error when the pod IP is unresolved")
+			}
+			if got := grpcTarget(conn); got != "" {
+				t.Errorf("expected no gRPC target to be published, got %s", got)
+			}
+		})
+	}
+}
+
+// A Connect that fails after an earlier success leaves the previously
+// published gRPC target in place, matching podTunnelStrategy: only a
+// successful Connect republishes it, and connector.Close clears it. Pinned
+// here so the behavior is deliberate rather than incidental.
+func TestInClusterStrategy_Connect_KeepsTargetWhenLaterConnectFails(t *testing.T) {
+	podIP := "10.244.0.42"
+	s, conn := newInClusterStrategy(func() string { return podIP })
+
+	if _, err := s.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect() error: %v", err)
+	}
+	if got, want := grpcTarget(conn), "10.244.0.42:9090"; got != want {
+		t.Fatalf("expected grpcTarget=%s after the first Connect, got %s", want, got)
+	}
+
+	// The pod went away: Connect re-reads the closure and must fail.
+	podIP = ""
+	if _, err := s.Connect(context.Background()); err == nil {
+		t.Fatal("expected an error once the pod IP is gone")
+	}
+	if got, want := grpcTarget(conn), "10.244.0.42:9090"; got != want {
+		t.Errorf("expected the previous grpcTarget %s to survive a failed Connect, got %s", want, got)
+	}
+}
+
+// Nothing signals transport death on this path, so a rescheduled pod is only
+// picked up when the caller reconnects. Connect must therefore re-read the
+// pod IP rather than caching the address from a previous call.
+func TestInClusterStrategy_Connect_RefreshesPodIP(t *testing.T) {
+	podIP := "10.244.0.42"
+	s, conn := newInClusterStrategy(func() string { return podIP })
+
+	if _, err := s.Connect(context.Background()); err != nil {
+		t.Fatalf("first Connect() error: %v", err)
+	}
+
+	podIP = "10.244.1.7"
+	gotURL, err := s.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("second Connect() error: %v", err)
+	}
+	if want := "http://10.244.1.7:8080"; gotURL != want {
+		t.Errorf("expected baseURL=%s after reschedule, got %s", want, gotURL)
+	}
+	if got, want := grpcTarget(conn), "10.244.1.7:9090"; got != want {
+		t.Errorf("expected grpcTarget=%s after reschedule, got %s", want, got)
+	}
+}
+
+func TestInClusterStrategy_Close_IsNoOp(t *testing.T) {
+	s, _ := newInClusterStrategy(nil)
+	if err := s.Close(); err != nil {
+		t.Errorf("first Close() error: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Errorf("second Close() error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+func TestValidation_Connectivity(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    Options
+		wantErr bool
+	}{
+		{
+			name: "in-cluster with sandboxd",
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInCluster},
+		},
+		{
+			name: "port-forward with sandboxd",
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityPortForward},
+		},
+		{
+			name: "port-forward with legacy runtime",
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityPortForward},
+		},
+		{
+			name: "in-cluster with legacy runtime",
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInCluster},
+		},
+		{
+			name:    "in-cluster with legacy runtime and GatewayName",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInCluster, GatewayName: "gw"},
+			wantErr: true,
+		},
+		{
+			name:    "in-cluster with legacy runtime and APIURL",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInCluster, APIURL: "http://localhost:9999"},
+			wantErr: true,
+		},
+		{
+			name:    "in-cluster with APIURL",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInCluster, APIURL: "http://localhost:9999"},
+			wantErr: true,
+		},
+		{
+			name:    "in-cluster with GatewayName",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInCluster, GatewayName: "gw"},
+			wantErr: true,
+		},
+		{
+			name:    "unknown Connectivity",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: "sidecar"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.opts.Quiet = true
+			tc.opts.setDefaults()
+			err := validateAllOptions(&tc.opts)
+			if tc.wantErr && err == nil {
+				t.Error("expected a validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}
+
+// APIURL is the documented sandboxd escape hatch and must keep working; only
+// ConnectivityInCluster conflicts with it.
+func TestValidation_APIURLStillAllowedWithSandboxdDefault(t *testing.T) {
+	opts := Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, APIURL: "http://localhost:9999", Quiet: true}
+	opts.setDefaults()
+	if opts.Connectivity != ConnectivityPortForward {
+		t.Fatalf("expected Connectivity to default to %q, got %q", ConnectivityPortForward, opts.Connectivity)
+	}
+	if err := validateAllOptions(&opts); err != nil {
+		t.Errorf("expected APIURL to remain valid with the default connectivity, got %v", err)
+	}
+}

--- a/clients/go/sandbox/incluster_test.go
+++ b/clients/go/sandbox/incluster_test.go
@@ -16,10 +16,13 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+
+	sandboxv1beta1 "sigs.k8s.io/agent-sandbox/api/v1beta1"
 )
 
 // inClusterTestOpts returns options selecting the in-cluster sandboxd
@@ -30,7 +33,7 @@ func inClusterTestOpts() Options {
 		WarmPoolName:        "test-warmpool",
 		Namespace:           "default",
 		Runtime:             RuntimeSandboxd,
-		Connectivity:        ConnectivityInCluster,
+		Connectivity:        ConnectivityInClusterPodIP,
 		SandboxReadyTimeout: 5 * time.Second,
 		Quiet:               true,
 	}
@@ -45,7 +48,7 @@ func legacyInClusterTestOpts() Options {
 		WarmPoolName:        "test-warmpool",
 		Namespace:           "default",
 		Runtime:             RuntimeLegacyPython,
-		Connectivity:        ConnectivityInCluster,
+		Connectivity:        ConnectivityInClusterPodIP,
 		SandboxReadyTimeout: 5 * time.Second,
 		Quiet:               true,
 	}
@@ -63,18 +66,30 @@ func newInClusterStrategy(getPodIP func() string) (*inClusterStrategy, *connecto
 // newInClusterStrategyPorts is the same with explicit ports; grpcPort 0 models
 // a runtime with no gRPC service (the legacy runtime).
 func newInClusterStrategyPorts(getPodIP func() string, httpPort, grpcPort int) (*inClusterStrategy, *connector) {
+	s, conn := newInClusterStrategyFull(nil, getPodIP, false)
+	s.httpPort, s.grpcPort = httpPort, grpcPort
+	return s, conn
+}
+
+// newInClusterStrategyFull builds a strategy with both address sources and
+// the useServiceDNS flag under test.
+func newInClusterStrategyFull(getServiceFQDN, getPodIP func() string, useServiceDNS bool) (*inClusterStrategy, *connector) {
 	tracer, svcName := newTracer(Options{TraceServiceName: "sandbox-client-test"})
 	conn := newConnector(connectorConfig{Log: logr.Discard(), Tracer: tracer, TraceServiceName: svcName})
 	return &inClusterStrategy{
-		httpPort:  httpPort,
-		grpcPort:  grpcPort,
-		log:       logr.Discard(),
-		tracer:    tracer,
-		svcName:   svcName,
-		getPodIP:  getPodIP,
-		connector: conn,
+		httpPort:       8080,
+		grpcPort:       9090,
+		useServiceDNS:  useServiceDNS,
+		log:            logr.Discard(),
+		tracer:         tracer,
+		svcName:        svcName,
+		getServiceFQDN: getServiceFQDN,
+		getPodIP:       getPodIP,
+		connector:      conn,
 	}, conn
 }
+
+func constFn(v string) func() string { return func() string { return v } }
 
 // grpcTarget reads the connector's published gRPC dial address under its lock.
 func grpcTarget(c *connector) string {
@@ -341,7 +356,7 @@ func TestValidation_Connectivity(t *testing.T) {
 	}{
 		{
 			name: "in-cluster with sandboxd",
-			opts: Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInCluster},
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInClusterPodIP},
 		},
 		{
 			name: "port-forward with sandboxd",
@@ -353,26 +368,44 @@ func TestValidation_Connectivity(t *testing.T) {
 		},
 		{
 			name: "in-cluster with legacy runtime",
-			opts: Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInCluster},
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInClusterPodIP},
 		},
 		{
 			name:    "in-cluster with legacy runtime and GatewayName",
-			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInCluster, GatewayName: "gw"},
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInClusterPodIP, GatewayName: "gw"},
 			wantErr: true,
 		},
 		{
 			name:    "in-cluster with legacy runtime and APIURL",
-			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInCluster, APIURL: "http://localhost:9999"},
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInClusterPodIP, APIURL: "http://localhost:9999"},
 			wantErr: true,
 		},
 		{
 			name:    "in-cluster with APIURL",
-			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInCluster, APIURL: "http://localhost:9999"},
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInClusterPodIP, APIURL: "http://localhost:9999"},
 			wantErr: true,
 		},
 		{
 			name:    "in-cluster with GatewayName",
-			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInCluster, GatewayName: "gw"},
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInClusterPodIP, GatewayName: "gw"},
+			wantErr: true,
+		},
+		{
+			name: "in-cluster-service with sandboxd",
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInClusterService},
+		},
+		{
+			name: "in-cluster-service with legacy runtime",
+			opts: Options{WarmPoolName: "pool", Runtime: RuntimeLegacyPython, Connectivity: ConnectivityInClusterService},
+		},
+		{
+			name:    "in-cluster-service with APIURL",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInClusterService, APIURL: "http://localhost:9999"},
+			wantErr: true,
+		},
+		{
+			name:    "in-cluster-service with GatewayName",
+			opts:    Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, Connectivity: ConnectivityInClusterService, GatewayName: "gw"},
 			wantErr: true,
 		},
 		{
@@ -397,7 +430,7 @@ func TestValidation_Connectivity(t *testing.T) {
 }
 
 // APIURL is the documented sandboxd escape hatch and must keep working; only
-// ConnectivityInCluster conflicts with it.
+// ConnectivityInClusterPodIP conflicts with it.
 func TestValidation_APIURLStillAllowedWithSandboxdDefault(t *testing.T) {
 	opts := Options{WarmPoolName: "pool", Runtime: RuntimeSandboxd, APIURL: "http://localhost:9999", Quiet: true}
 	opts.setDefaults()
@@ -406,5 +439,167 @@ func TestValidation_APIURLStillAllowedWithSandboxdDefault(t *testing.T) {
 	}
 	if err := validateAllOptions(&opts); err != nil {
 		t.Errorf("expected APIURL to remain valid with the default connectivity, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Service DNS addressing
+// ---------------------------------------------------------------------------
+
+const testFQDN = "sb.default.svc.cluster.local"
+
+func TestInClusterStrategy_ResolveHost(t *testing.T) {
+	cases := []struct {
+		name          string
+		fqdn          string
+		podIP         string
+		useServiceDNS bool
+		wantHost      string
+		wantVia       string
+		wantErr       error
+	}{
+		{
+			name: "service mode dials the Service DNS name",
+			fqdn: testFQDN, podIP: "10.244.0.42", useServiceDNS: true,
+			wantHost: testFQDN, wantVia: "service",
+		},
+		{
+			// The modes are exclusive: an available Service is ignored.
+			name: "pod-IP mode dials the pod IP even when a Service exists",
+			fqdn: testFQDN, podIP: "10.244.0.42",
+			wantHost: "10.244.0.42", wantVia: "pod-ip",
+		},
+		{
+			name:  "pod-IP mode needs no Service",
+			podIP: "10.244.0.42",
+			// A Sandbox with spec.service unset reports no ServiceFQDN.
+			wantHost: "10.244.0.42", wantVia: "pod-ip",
+		},
+		{
+			name:  "service mode refuses to fall back to the pod IP",
+			podIP: "10.244.0.42", useServiceDNS: true,
+			wantErr: ErrNoSandboxService,
+		},
+		{
+			// Not ErrNoSandboxService: in pod-IP mode the Service is
+			// irrelevant, the pod IP simply is not populated yet.
+			name: "pod-IP mode errors before the pod IP is resolved",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newInClusterStrategyFull(constFn(tc.fqdn), constFn(tc.podIP), tc.useServiceDNS)
+
+			host, via, err := s.resolveHost()
+			if tc.wantHost == "" {
+				if err == nil {
+					t.Fatalf("expected an error, got host=%s", host)
+				}
+				if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+					t.Errorf("expected error wrapping %v, got %v", tc.wantErr, err)
+				}
+				if tc.wantErr == nil && errors.Is(err, ErrNoSandboxService) {
+					t.Errorf("expected a plain resolution error, got ErrNoSandboxService: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveHost() error: %v", err)
+			}
+			if host != tc.wantHost {
+				t.Errorf("expected host=%s, got %s", tc.wantHost, host)
+			}
+			if via != tc.wantVia {
+				t.Errorf("expected via=%s, got %s", tc.wantVia, via)
+			}
+		})
+	}
+}
+
+// A hostname needs no bracketing, but the port join must still be correct.
+func TestInClusterStrategy_Connect_ServiceDNSTargets(t *testing.T) {
+	s, conn := newInClusterStrategyFull(constFn(testFQDN), constFn("10.244.0.42"), true)
+
+	gotURL, err := s.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect() error: %v", err)
+	}
+	if want := "http://" + testFQDN + ":8080"; gotURL != want {
+		t.Errorf("expected baseURL=%s, got %s", want, gotURL)
+	}
+	if got, want := grpcTarget(conn), testFQDN+":9090"; got != want {
+		t.Errorf("expected grpcTarget=%s, got %s", want, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Mode selection through Open()
+// ---------------------------------------------------------------------------
+
+// readySandboxWithService is readySandbox plus a populated Status.ServiceFQDN,
+// as the controller sets when spec.service is true.
+func readySandboxWithService(name string) *sandboxv1beta1.Sandbox {
+	sb := readySandbox(name)
+	sb.Status.ServiceFQDN = testFQDN
+	return sb
+}
+
+func TestModeSelection_InClusterService_UsesServiceDNS(t *testing.T) {
+	opts := inClusterTestOpts()
+	opts.Connectivity = ConnectivityInClusterService
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandboxWithService("sb"))
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if got, want := c.connector.BaseURL(), "http://"+testFQDN+":8080"; got != want {
+		t.Errorf("expected baseURL=%s, got %s", want, got)
+	}
+	if got := c.ServiceFQDN(); got != testFQDN {
+		t.Errorf("expected ServiceFQDN=%s, got %s", testFQDN, got)
+	}
+}
+
+// The strict mode must fail closed rather than silently using the pod IP.
+func TestModeSelection_InClusterService_RefusesWithoutService(t *testing.T) {
+	opts := inClusterTestOpts()
+	opts.Connectivity = ConnectivityInClusterService
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandbox("sb")) // no ServiceFQDN
+
+	err := c.Open(context.Background())
+	if err == nil {
+		defer c.Close(context.Background())
+		t.Fatalf("expected Open to fail without a Service, got baseURL=%s", c.connector.BaseURL())
+	}
+	if !errors.Is(err, ErrNoSandboxService) {
+		t.Errorf("expected error wrapping ErrNoSandboxService, got %v", err)
+	}
+	if c.connector.BaseURL() != "" {
+		t.Errorf("expected no baseURL after a refused Open, got %s", c.connector.BaseURL())
+	}
+}
+
+// Pod-IP mode ignores an available Service rather than quietly upgrading to
+// it, so the address a caller gets is the one the mode names.
+func TestModeSelection_InClusterPodIP_IgnoresServiceDNS(t *testing.T) {
+	opts := inClusterTestOpts()
+	c, agentsCS, extensionsCS := newTestSandbox(opts)
+	setupWatchWithReactor(agentsCS, extensionsCS, readySandboxWithService("sb"))
+
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatalf("Open() error: %v", err)
+	}
+	defer c.Close(context.Background())
+
+	if got, want := c.connector.BaseURL(), "http://10.244.0.42:8080"; got != want {
+		t.Errorf("expected baseURL=%s, got %s", want, got)
+	}
+	// The Service is still reported, it is just not what we dial.
+	if got := c.ServiceFQDN(); got != testFQDN {
+		t.Errorf("expected ServiceFQDN=%s, got %s", testFQDN, got)
 	}
 }

--- a/clients/go/sandbox/k8s.go
+++ b/clients/go/sandbox/k8s.go
@@ -47,6 +47,7 @@ type sandboxState struct {
 	SandboxName string
 	PodName     string
 	PodIP       string
+	ServiceFQDN string
 	Annotations map[string]string
 }
 
@@ -449,6 +450,7 @@ func extractState(sb *sandboxv1beta1.Sandbox) *sandboxState {
 		state.PodName = sb.Name
 	}
 	state.PodIP = selectPodIP(sb.Status.PodIPs)
+	state.ServiceFQDN = sb.Status.ServiceFQDN
 	return state
 }
 

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -72,12 +72,26 @@ const (
 	// its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
 	// and, for RuntimeLegacyPython, the sandbox-router, off the data path.
 	//
-	// Requires the Sandbox to have a Service, set spec.service: true on
-	// the template.
+	// Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
+	// boundary. The Service's selector only ever matches its own Sandbox's
+	// pod, so a pod IP that Kubernetes has since reassigned to another
+	// tenant would be caught when the TTL expires. A deleted Sandbox takes
+	// its Service with it: connections then fail rather than landing on a stranger.
+	// (DNS caching still leaves a TTL-bounded window)
+	//
+	// Requires the Sandbox to have a Service — set spec.service: true on
+	// the template. Open fails when Status.ServiceFQDN is empty rather than
+	// falling back to the pod IP, so the safety property cannot be lost
+	// silently.
 	ConnectivityInClusterService Connectivity = "in-cluster-service"
 
 	// ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
 	// it works against any Sandbox without template changes.
+	//
+	// It carries the pod IP's reuse hazard: nothing detects that the sandbox
+	// pod was rescheduled, so requests can continue to a stale address that
+	// Kubernetes may have since reassigned to an unrelated pod. Use
+	// ConnectivityInClusterService where that matters.
 	ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 
@@ -104,9 +118,9 @@ type Options struct {
 
 	// Connectivity selects the transport. Default: ConnectivityPortForward.
 	//
-	// The in-cluster values work with either Runtime, conflict with both
-	// GatewayName and APIURL, and require that this process runs inside the
-	// cluster.
+	// The in-cluster values conflict with both GatewayName and APIURL, and
+	// require that this process runs inside the same cluster as the sandbox
+	// pods.
 	Connectivity Connectivity
 
 	// SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -68,12 +68,24 @@ const (
 	// brokered by the apiserver. Works from anywhere a kubeconfig does,
 	// including a laptop or CI runner. Default.
 	ConnectivityPortForward Connectivity = "port-forward"
-	// ConnectivityInCluster dials the sandbox pod IP directly, taking the
-	// apiserver, and the sandbox-router, off the data path. The port
-	// dialed is SandboxdRESTPort for RuntimeSandboxd and ServerPort for
-	// RuntimeLegacyPython.
-	ConnectivityInCluster Connectivity = "in-cluster"
+	// ConnectivityInClusterService dials the Sandbox's headless Service by
+	// its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
+	// and, for RuntimeLegacyPython, the sandbox-router, off the data path.
+	//
+	// Requires the Sandbox to have a Service, set spec.service: true on
+	// the template.
+	ConnectivityInClusterService Connectivity = "in-cluster-service"
+
+	// ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
+	// it works against any Sandbox without template changes.
+	ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
+
+// isInCluster reports whether c dials the sandbox pod directly, by either
+// addressing mode.
+func (c Connectivity) isInCluster() bool {
+	return c == ConnectivityInClusterPodIP || c == ConnectivityInClusterService
+}
 
 // Options configures a Sandbox instance.
 type Options struct {
@@ -92,9 +104,9 @@ type Options struct {
 
 	// Connectivity selects the transport. Default: ConnectivityPortForward.
 	//
-	// ConnectivityInCluster works with either Runtime and conflicts with both
-	// GatewayName and APIURL. It requires that this process can route to pod
-	// IPs - i.e. that it runs inside the cluster.
+	// The in-cluster values work with either Runtime, conflict with both
+	// GatewayName and APIURL, and require that this process runs inside the
+	// cluster.
 	Connectivity Connectivity
 
 	// SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime
@@ -364,15 +376,15 @@ func (o *Options) validateCommon() error {
 	if o.Runtime != RuntimeLegacyPython && o.Runtime != RuntimeSandboxd {
 		return fmt.Errorf("sandbox: Runtime must be %q or %q, got %q", RuntimeLegacyPython, RuntimeSandboxd, o.Runtime)
 	}
-	if o.Connectivity != ConnectivityPortForward && o.Connectivity != ConnectivityInCluster {
-		return fmt.Errorf("sandbox: Connectivity must be %q or %q, got %q", ConnectivityPortForward, ConnectivityInCluster, o.Connectivity)
+	if o.Connectivity != ConnectivityPortForward && o.Connectivity != ConnectivityInClusterPodIP && o.Connectivity != ConnectivityInClusterService {
+		return fmt.Errorf("sandbox: Connectivity must be %q, %q or %q, got %q", ConnectivityPortForward, ConnectivityInClusterPodIP, ConnectivityInClusterService, o.Connectivity)
 	}
-	if o.Connectivity == ConnectivityInCluster {
+	if o.Connectivity.isInCluster() {
 		if o.APIURL != "" {
-			return fmt.Errorf("sandbox: ConnectivityInCluster cannot be combined with APIURL: both select an endpoint, so set only one")
+			return fmt.Errorf("sandbox: %s connectivity cannot be combined with APIURL: both select an endpoint, so set only one", o.Connectivity)
 		}
 		if o.GatewayName != "" {
-			return fmt.Errorf("sandbox: ConnectivityInCluster cannot be combined with GatewayName: the gateway routes through the sandbox-router, which in-cluster connectivity bypasses")
+			return fmt.Errorf("sandbox: %s connectivity cannot be combined with GatewayName: the gateway routes through the sandbox-router, which in-cluster connectivity bypasses", o.Connectivity)
 		}
 	}
 	if o.Runtime == RuntimeSandboxd {

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -72,27 +72,12 @@ const (
 	// its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
 	// and, for RuntimeLegacyPython, the sandbox-router, off the data path.
 	//
-	// Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
-	// boundary. The Service's selector only ever matches its own Sandbox's
-	// pod, so a pod IP that Kubernetes has since reassigned to another
-	// tenant cannot be reached, and a deleted Sandbox takes its Service
-	// with it: connections then fail rather than landing on a stranger.
-	// (DNS caching still leaves a TTL-bounded window; closing it entirely
-	// needs per-request identity binding or a service mesh.)
-	//
-	// Requires the Sandbox to have a Service — set spec.service: true on
-	// the template. Open fails when Status.ServiceFQDN is empty rather than
-	// falling back to the pod IP, so the safety property cannot be lost
-	// silently.
+	// Requires the Sandbox to have a Service, set spec.service: true on
+	// the template.
 	ConnectivityInClusterService Connectivity = "in-cluster-service"
 
 	// ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
 	// it works against any Sandbox without template changes.
-	//
-	// It carries the pod IP's reuse hazard: nothing detects that the sandbox
-	// pod was rescheduled, so requests can continue to a stale address that
-	// Kubernetes may have since reassigned to an unrelated pod. Use
-	// ConnectivityInClusterService where that matters.
 	ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 
@@ -121,9 +106,7 @@ type Options struct {
 	//
 	// The in-cluster values work with either Runtime, conflict with both
 	// GatewayName and APIURL, and require that this process runs inside the
-	// cluster. That cannot be checked at validation time, so a caller
-	// outside the pod network sees connection timeouts rather than an error
-	// from Open.
+	// cluster.
 	Connectivity Connectivity
 
 	// SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -50,13 +50,29 @@ type Runtime string
 const (
 	// RuntimeLegacyPython is the python-runtime HTTP API (POST /upload,
 	// GET /download|list|exists/{path}, POST /execute on port 8888),
-	// reached through the sandbox-router. Default.
+	// reached through the sandbox-router unless Connectivity selects a
+	// direct pod dial. Default.
 	RuntimeLegacyPython Runtime = "legacy-python"
 	// RuntimeSandboxd is the sandboxd hybrid API defined by KEP-539.2:
 	// REST filesystem (/v1/files/...) on port 8080 plus gRPC
-	// ProcessService on port 9090. The SDK connects over a pod port-forward
-	// to the sandbox pod.
+	// ProcessService on port 9090. The SDK reaches the sandbox pod directly
+	// or over a port-forward (default), see Connectivity.
 	RuntimeSandboxd Runtime = "sandboxd"
+)
+
+// Connectivity selects the transport used to reach the in-sandbox runtime.
+type Connectivity string
+
+const (
+	// ConnectivityPortForward reaches the sandbox over a SPDY port-forward
+	// brokered by the apiserver. Works from anywhere a kubeconfig does,
+	// including a laptop or CI runner. Default.
+	ConnectivityPortForward Connectivity = "port-forward"
+	// ConnectivityInCluster dials the sandbox pod IP directly, taking the
+	// apiserver, and the sandbox-router, off the data path. The port
+	// dialed is SandboxdRESTPort for RuntimeSandboxd and ServerPort for
+	// RuntimeLegacyPython.
+	ConnectivityInCluster Connectivity = "in-cluster"
 )
 
 // Options configures a Sandbox instance.
@@ -69,10 +85,17 @@ type Options struct {
 	WarmPoolName string
 
 	// Runtime selects the in-sandbox runtime API. Default: RuntimeLegacyPython.
-	// RuntimeSandboxd connects via a pod port-forward, so GatewayName is not
-	// supported with it. APIURL remains available as an advanced/testing
-	// escape hatch for the REST endpoint.
+	// RuntimeSandboxd talks to the sandbox pod rather than the sandbox-router,
+	// so GatewayName is not supported with it. APIURL remains available as an
+	// advanced/testing escape hatch for the REST endpoint.
 	Runtime Runtime
+
+	// Connectivity selects the transport. Default: ConnectivityPortForward.
+	//
+	// ConnectivityInCluster works with either Runtime and conflicts with both
+	// GatewayName and APIURL. It requires that this process can route to pod
+	// IPs - i.e. that it runs inside the cluster.
+	Connectivity Connectivity
 
 	// SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime
 	// REST API. Only used with RuntimeSandboxd. Default: 8080.
@@ -199,6 +222,9 @@ func (o *Options) setDefaults() {
 	}
 	if o.Runtime == "" {
 		o.Runtime = RuntimeLegacyPython
+	}
+	if o.Connectivity == "" {
+		o.Connectivity = ConnectivityPortForward
 	}
 	if o.ServerPort == 0 {
 		o.ServerPort = defaultServerPort
@@ -338,9 +364,20 @@ func (o *Options) validateCommon() error {
 	if o.Runtime != RuntimeLegacyPython && o.Runtime != RuntimeSandboxd {
 		return fmt.Errorf("sandbox: Runtime must be %q or %q, got %q", RuntimeLegacyPython, RuntimeSandboxd, o.Runtime)
 	}
+	if o.Connectivity != ConnectivityPortForward && o.Connectivity != ConnectivityInCluster {
+		return fmt.Errorf("sandbox: Connectivity must be %q or %q, got %q", ConnectivityPortForward, ConnectivityInCluster, o.Connectivity)
+	}
+	if o.Connectivity == ConnectivityInCluster {
+		if o.APIURL != "" {
+			return fmt.Errorf("sandbox: ConnectivityInCluster cannot be combined with APIURL: both select an endpoint, so set only one")
+		}
+		if o.GatewayName != "" {
+			return fmt.Errorf("sandbox: ConnectivityInCluster cannot be combined with GatewayName: the gateway routes through the sandbox-router, which in-cluster connectivity bypasses")
+		}
+	}
 	if o.Runtime == RuntimeSandboxd {
 		if o.GatewayName != "" {
-			return fmt.Errorf("sandbox: RuntimeSandboxd cannot be combined with GatewayName: sandboxd uses pod port-forward connectivity")
+			return fmt.Errorf("sandbox: RuntimeSandboxd cannot be combined with GatewayName: sandboxd is reached on the sandbox pod, not through the sandbox-router")
 		}
 		if o.SandboxdRESTPort <= 0 || o.SandboxdRESTPort > 65535 {
 			return fmt.Errorf("sandbox: SandboxdRESTPort must be between 1 and 65535, got %d", o.SandboxdRESTPort)

--- a/clients/go/sandbox/options.go
+++ b/clients/go/sandbox/options.go
@@ -72,12 +72,27 @@ const (
 	// its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
 	// and, for RuntimeLegacyPython, the sandbox-router, off the data path.
 	//
-	// Requires the Sandbox to have a Service, set spec.service: true on
-	// the template.
+	// Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
+	// boundary. The Service's selector only ever matches its own Sandbox's
+	// pod, so a pod IP that Kubernetes has since reassigned to another
+	// tenant cannot be reached, and a deleted Sandbox takes its Service
+	// with it: connections then fail rather than landing on a stranger.
+	// (DNS caching still leaves a TTL-bounded window; closing it entirely
+	// needs per-request identity binding or a service mesh.)
+	//
+	// Requires the Sandbox to have a Service — set spec.service: true on
+	// the template. Open fails when Status.ServiceFQDN is empty rather than
+	// falling back to the pod IP, so the safety property cannot be lost
+	// silently.
 	ConnectivityInClusterService Connectivity = "in-cluster-service"
 
 	// ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
 	// it works against any Sandbox without template changes.
+	//
+	// It carries the pod IP's reuse hazard: nothing detects that the sandbox
+	// pod was rescheduled, so requests can continue to a stale address that
+	// Kubernetes may have since reassigned to an unrelated pod. Use
+	// ConnectivityInClusterService where that matters.
 	ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 
@@ -106,7 +121,9 @@ type Options struct {
 	//
 	// The in-cluster values work with either Runtime, conflict with both
 	// GatewayName and APIURL, and require that this process runs inside the
-	// cluster.
+	// cluster. That cannot be checked at validation time, so a caller
+	// outside the pod network sees connection timeouts rather than an error
+	// from Open.
 	Connectivity Connectivity
 
 	// SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/clients/go/sandbox/podtunnel.go
+++ b/clients/go/sandbox/podtunnel.go
@@ -34,7 +34,7 @@ import (
 // pod, carrying both sandboxd listeners: the Filesystem & Runtime REST API
 // and the gRPC ProcessService. It is the default sandboxd transport because
 // the tunnel is brokered by the apiserver, so it works from a laptop or CI
-// runner with no route to pod IPs. The sandbox-router is is HTTP/1.1-only besides.
+// runner with no route to pod IPs. The sandbox-router is HTTP/1.1-only besides.
 //
 // Callers can go for a shorter path with inClusterStrategy (incluster.go),
 // which dials the pod IP directly and keeps the apiserver off the data path.

--- a/clients/go/sandbox/podtunnel.go
+++ b/clients/go/sandbox/podtunnel.go
@@ -32,10 +32,12 @@ import (
 
 // podTunnelStrategy establishes a SPDY port-forward directly to the sandbox
 // pod, carrying both sandboxd listeners: the Filesystem & Runtime REST API
-// and the gRPC ProcessService. This is the only external transport that can
-// reach sandboxd, which binds loopback-only inside the pod (KEP-539.2) —
-// port-forward dials from within the pod's network namespace, whereas the
-// sandbox-router dials the pod IP and is HTTP/1.1-only besides.
+// and the gRPC ProcessService. It is the default sandboxd transport because
+// the tunnel is brokered by the apiserver, so it works from a laptop or CI
+// runner with no route to pod IPs. The sandbox-router is is HTTP/1.1-only besides.
+//
+// Callers can go for a shorter path with inClusterStrategy (incluster.go),
+// which dials the pod IP directly and keeps the apiserver off the data path.
 //
 // Structure mirrors tunnelStrategy (tunnel.go), which forwards to the
 // sandbox-router service for the legacy runtime instead.

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -355,6 +355,7 @@ func (s *Sandbox) reconnect(ctx context.Context) error {
 			s.claimName = ""
 			s.sandboxName = ""
 			s.podName = ""
+			s.serviceFQDN = ""
 			s.annotations = nil
 			s.mu.Unlock()
 			retErr := fmt.Errorf("%w: %w", ErrSandboxDeleted, err)
@@ -363,6 +364,7 @@ func (s *Sandbox) reconnect(ctx context.Context) error {
 		}
 		s.sandboxName = ""
 		s.podName = ""
+		s.serviceFQDN = ""
 		s.annotations = nil
 		s.mu.Unlock()
 		recordError(span, err)
@@ -375,6 +377,7 @@ func (s *Sandbox) reconnect(ctx context.Context) error {
 		if k8serrors.IsNotFound(err) {
 			s.sandboxName = ""
 			s.podName = ""
+			s.serviceFQDN = ""
 			s.annotations = nil
 		}
 		// Non-NotFound: sandboxName preserved so the next Open() can re-verify

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -355,6 +355,7 @@ func (s *Sandbox) reconnect(ctx context.Context) error {
 			s.claimName = ""
 			s.sandboxName = ""
 			s.podName = ""
+			s.podIP = ""
 			s.serviceFQDN = ""
 			s.annotations = nil
 			s.mu.Unlock()
@@ -364,6 +365,7 @@ func (s *Sandbox) reconnect(ctx context.Context) error {
 		}
 		s.sandboxName = ""
 		s.podName = ""
+		s.podIP = ""
 		s.serviceFQDN = ""
 		s.annotations = nil
 		s.mu.Unlock()
@@ -377,6 +379,7 @@ func (s *Sandbox) reconnect(ctx context.Context) error {
 		if k8serrors.IsNotFound(err) {
 			s.sandboxName = ""
 			s.podName = ""
+			s.podIP = ""
 			s.serviceFQDN = ""
 			s.annotations = nil
 		}

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -42,6 +42,7 @@ type Sandbox struct {
 	sandboxName string
 	podName     string
 	podIP       string
+	serviceFQDN string
 	annotations map[string]string
 
 	lifecycleSem chan struct{}
@@ -86,14 +87,15 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	switch {
 	case opts.APIURL != "":
 		strategy = &DirectStrategy{URL: opts.APIURL}
-	case opts.Connectivity == ConnectivityInCluster:
+	case opts.Connectivity.isInCluster():
 		// Caller is on the pod network and has opted to dial
 		// the runtime on the pod IP.
 		ics := &inClusterStrategy{
-			httpPort: opts.ServerPort,
-			log:      opts.Logger,
-			tracer:   tracer,
-			svcName:  svcName,
+			httpPort:      opts.ServerPort,
+			useServiceDNS: opts.Connectivity == ConnectivityInClusterService,
+			log:           opts.Logger,
+			tracer:        tracer,
+			svcName:       svcName,
 		}
 		if opts.Runtime == RuntimeSandboxd {
 			ics.httpPort = opts.SandboxdRESTPort
@@ -144,7 +146,7 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 		Strategy:            strategy,
 		Namespace:           opts.Namespace,
 		ServerPort:          opts.ServerPort,
-		RouterHeaders:       opts.Runtime != RuntimeSandboxd && opts.Connectivity != ConnectivityInCluster,
+		RouterHeaders:       opts.Runtime != RuntimeSandboxd && !opts.Connectivity.isInCluster(),
 		RequestTimeout:      opts.RequestTimeout,
 		PerAttemptTimeout:   opts.PerAttemptTimeout,
 		HTTPTransport:       opts.HTTPTransport,
@@ -214,6 +216,7 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 		pts.getPodName = s.PodName
 	}
 	if ics, ok := strategy.(*inClusterStrategy); ok {
+		ics.getServiceFQDN = s.ServiceFQDN
 		ics.getPodIP = s.PodIP
 	}
 
@@ -409,6 +412,7 @@ func (s *Sandbox) rollbackOpen(originalErr error) error {
 	s.sandboxName = ""
 	s.podName = ""
 	s.podIP = ""
+	s.serviceFQDN = ""
 	s.annotations = nil
 	if cleanupErr == nil {
 		s.claimName = ""
@@ -496,6 +500,7 @@ func (s *Sandbox) Close(ctx context.Context) error {
 	s.sandboxName = ""
 	s.podName = ""
 	s.podIP = ""
+	s.serviceFQDN = ""
 	s.annotations = nil
 	if err != nil && s.claimName != "" {
 		s.log.Error(err, "orphaned claim during Close, could not delete; retry Close() to clean up", "claim", s.claimName)
@@ -633,6 +638,15 @@ func (s *Sandbox) PodIP() string {
 	return s.podIP
 }
 
+// ServiceFQDN returns the in-cluster DNS name of the Sandbox's headless
+// Service, or "" when it has none (spec.service unset or false). Not part of
+// the Info interface, which is frozen for backward compatibility.
+func (s *Sandbox) ServiceFQDN() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.serviceFQDN
+}
+
 func (s *Sandbox) Annotations() map[string]string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -676,5 +690,6 @@ func (s *Sandbox) setState(state *sandboxState) {
 	s.sandboxName = state.SandboxName
 	s.podName = state.PodName
 	s.podIP = state.PodIP
+	s.serviceFQDN = state.ServiceFQDN
 	s.annotations = state.Annotations
 }

--- a/clients/go/sandbox/sandbox.go
+++ b/clients/go/sandbox/sandbox.go
@@ -86,10 +86,25 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	switch {
 	case opts.APIURL != "":
 		strategy = &DirectStrategy{URL: opts.APIURL}
+	case opts.Connectivity == ConnectivityInCluster:
+		// Caller is on the pod network and has opted to dial
+		// the runtime on the pod IP.
+		ics := &inClusterStrategy{
+			httpPort: opts.ServerPort,
+			log:      opts.Logger,
+			tracer:   tracer,
+			svcName:  svcName,
+		}
+		if opts.Runtime == RuntimeSandboxd {
+			ics.httpPort = opts.SandboxdRESTPort
+			ics.grpcPort = opts.SandboxdGRPCPort
+		}
+		strategy = ics
 	case opts.Runtime == RuntimeSandboxd:
-		// sandboxd binds loopback-only inside the pod, so the only viable
-		// external transport is a port-forward directly to the sandbox pod
-		// (validated earlier: GatewayName is rejected with RuntimeSandboxd).
+		// sandboxd talks to the sandbox pod, not the sandbox-router, and the
+		// default transport reaches it without pod-network access: a
+		// port-forward directly to the pod (validated earlier: GatewayName is
+		// rejected with RuntimeSandboxd).
 		strategy = &podTunnelStrategy{
 			coreClient: k8s.CoreClient,
 			restConfig: k8s.RestConfig,
@@ -129,7 +144,7 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 		Strategy:            strategy,
 		Namespace:           opts.Namespace,
 		ServerPort:          opts.ServerPort,
-		RouterHeaders:       opts.Runtime != RuntimeSandboxd,
+		RouterHeaders:       opts.Runtime != RuntimeSandboxd && opts.Connectivity != ConnectivityInCluster,
 		RequestTimeout:      opts.RequestTimeout,
 		PerAttemptTimeout:   opts.PerAttemptTimeout,
 		HTTPTransport:       opts.HTTPTransport,
@@ -146,6 +161,9 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	}
 	if pts, ok := strategy.(*podTunnelStrategy); ok {
 		pts.connector = conn
+	}
+	if ics, ok := strategy.(*inClusterStrategy); ok {
+		ics.connector = conn
 	}
 
 	s := &Sandbox{
@@ -191,8 +209,12 @@ func New(_ context.Context, opts Options) (*Sandbox, error) {
 	}
 
 	// The pod tunnel needs the resolved pod name at Connect time.
+	// The in-cluster strategy needs the pod IP.
 	if pts, ok := strategy.(*podTunnelStrategy); ok {
 		pts.getPodName = s.PodName
+	}
+	if ics, ok := strategy.(*inClusterStrategy); ok {
+		ics.getPodIP = s.PodIP
 	}
 
 	return s, nil

--- a/clients/go/sandbox/types.go
+++ b/clients/go/sandbox/types.go
@@ -44,6 +44,7 @@ var (
 	ErrTimeout          = errors.New("operation timed out")
 	ErrClaimFailed      = errors.New("claim creation failed")
 	ErrPortForwardDied  = errors.New("port-forward connection lost")
+	ErrNoSandboxService = errors.New("sandbox has no headless Service")
 	ErrAlreadyOpen      = errors.New("sandbox is already open; call Close first")
 	ErrOrphanedClaim    = errors.New("orphaned claim; call Close() to retry deletion")
 	ErrRetriesExhausted = errors.New("retries exhausted")

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -66,6 +66,7 @@ import "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
   - [func \(s \*Sandbox\) Read\(ctx context.Context, path string, opts ...CallOption\) \(\[\]byte, error\)](<#Sandbox.Read>)
   - [func \(s \*Sandbox\) Run\(ctx context.Context, command string, opts ...CallOption\) \(\*ExecutionResult, error\)](<#Sandbox.Run>)
   - [func \(s \*Sandbox\) SandboxName\(\) string](<#Sandbox.SandboxName>)
+  - [func \(s \*Sandbox\) ServiceFQDN\(\) string](<#Sandbox.ServiceFQDN>)
   - [func \(s \*Sandbox\) Write\(ctx context.Context, path string, content \[\]byte, opts ...CallOption\) error](<#Sandbox.Write>)
   - [func \(s \*Sandbox\) WriteReader\(ctx context.Context, path string, content io.Reader, opts ...CallOption\) error](<#Sandbox.WriteReader>)
 
@@ -106,10 +107,13 @@ var (
 
 ```go
 var (
-    ErrNotReady         = errors.New("sandbox is not ready")
-    ErrTimeout          = errors.New("operation timed out")
-    ErrClaimFailed      = errors.New("claim creation failed")
-    ErrPortForwardDied  = errors.New("port-forward connection lost")
+    ErrNotReady        = errors.New("sandbox is not ready")
+    ErrTimeout         = errors.New("operation timed out")
+    ErrClaimFailed     = errors.New("claim creation failed")
+    ErrPortForwardDied = errors.New("port-forward connection lost")
+    // ErrNoSandboxService is returned when ConnectivityInClusterService is
+    // selected but the Sandbox has no headless Service to address.
+    ErrNoSandboxService = errors.New("sandbox has no headless Service")
     ErrAlreadyOpen      = errors.New("sandbox is already open; call Close first")
     ErrOrphanedClaim    = errors.New("orphaned claim; call Close() to retry deletion")
     ErrRetriesExhausted = errors.New("retries exhausted")
@@ -298,16 +302,36 @@ type Connectivity string
 
 ```go
 const (
-    // RuntimeLegacyPython is the python-runtime HTTP API (POST /upload,
-    // GET /download|list|exists/{path}, POST /execute on port 8888),
-    // reached through the sandbox-router unless Connectivity selects a
-    // direct pod dial. Default.
-    RuntimeLegacyPython Runtime = "legacy-python"
-    // RuntimeSandboxd is the sandboxd hybrid API defined by KEP-539.2:
-    // REST filesystem (/v1/files/...) on port 8080 plus gRPC
-    // ProcessService on port 9090. The SDK reaches the sandbox pod directly
-    // or over a port-forward (default), see Connectivity.
-    RuntimeSandboxd Runtime = "sandboxd"
+    // ConnectivityPortForward reaches the sandbox over a SPDY port-forward
+    // brokered by the apiserver. Works from anywhere a kubeconfig does,
+    // including a laptop or CI runner. Default.
+    ConnectivityPortForward Connectivity = "port-forward"
+    // ConnectivityInClusterService dials the Sandbox's headless Service by
+    // its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
+    // and, for RuntimeLegacyPython, the sandbox-router — off the data path.
+    //
+    // Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
+    // boundary. The Service's selector only ever matches its own Sandbox's
+    // pod, so a pod IP that Kubernetes has since reassigned to another
+    // tenant cannot be reached, and a deleted Sandbox takes its Service
+    // with it: connections then fail rather than landing on a stranger.
+    // (DNS caching still leaves a TTL-bounded window; closing it entirely
+    // needs per-request identity binding or a service mesh.)
+    //
+    // Requires the Sandbox to have a Service — set spec.service: true on
+    // the template. Open fails when Status.ServiceFQDN is empty rather than
+    // falling back to the pod IP, so the safety property cannot be lost
+    // silently.
+    ConnectivityInClusterService Connectivity = "in-cluster-service"
+
+    // ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
+    // it works against any Sandbox without template changes.
+    //
+    // It carries the pod IP's reuse hazard: nothing detects that the sandbox
+    // pod was rescheduled, so requests can continue to a stale address that
+    // Kubernetes may have since reassigned to an unrelated pod. Use
+    // ConnectivityInClusterService where that matters.
+    ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 ```
 
@@ -579,9 +603,11 @@ type Options struct {
 
     // Connectivity selects the transport. Default: ConnectivityPortForward.
     //
-    // ConnectivityInCluster works with either Runtime and conflicts with both
-    // GatewayName and APIURL. It requires that this process can route to pod
-    // IPs - i.e. that it runs inside the cluster.
+    // The in-cluster values work with either Runtime, conflict with both
+    // GatewayName and APIURL, and require that this process runs inside the
+    // cluster. That cannot be checked at validation time, so a caller
+    // outside the pod network sees connection timeouts rather than an error
+    // from Open.
     Connectivity Connectivity
 
     // SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime
@@ -887,6 +913,15 @@ func (s *Sandbox) SandboxName() string
 ```
 
 
+
+<a name="Sandbox.ServiceFQDN"></a>
+#### func \(\*Sandbox\) [ServiceFQDN](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go>)
+
+```go
+func (s *Sandbox) ServiceFQDN() string
+```
+
+ServiceFQDN returns the in\-cluster DNS name of the Sandbox's headless Service, or "" when it has none \(spec.service unset or false\). Not part of the Info interface, which is frozen for backward compatibility.
 
 <a name="Sandbox.Write"></a>
 #### func \(\*Sandbox\) [Write](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/sandbox.go>)

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -308,12 +308,27 @@ const (
     // its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
     // and, for RuntimeLegacyPython, the sandbox-router, off the data path.
     //
-    // Requires the Sandbox to have a Service, set spec.service: true on
-    // the template.
+    // Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
+    // boundary. The Service's selector only ever matches its own Sandbox's
+    // pod, so a pod IP that Kubernetes has since reassigned to another
+    // tenant cannot be reached, and a deleted Sandbox takes its Service
+    // with it: connections then fail rather than landing on a stranger.
+    // (DNS caching still leaves a TTL-bounded window; closing it entirely
+    // needs per-request identity binding or a service mesh.)
+    //
+    // Requires the Sandbox to have a Service — set spec.service: true on
+    // the template. Open fails when Status.ServiceFQDN is empty rather than
+    // falling back to the pod IP, so the safety property cannot be lost
+    // silently.
     ConnectivityInClusterService Connectivity = "in-cluster-service"
 
     // ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
     // it works against any Sandbox without template changes.
+    //
+    // It carries the pod IP's reuse hazard: nothing detects that the sandbox
+    // pod was rescheduled, so requests can continue to a stale address that
+    // Kubernetes may have since reassigned to an unrelated pod. Use
+    // ConnectivityInClusterService where that matters.
     ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 ```
@@ -588,7 +603,9 @@ type Options struct {
     //
     // The in-cluster values work with either Runtime, conflict with both
     // GatewayName and APIURL, and require that this process runs inside the
-    // cluster.
+    // cluster. That cannot be checked at validation time, so a caller
+    // outside the pod network sees connection timeouts rather than an error
+    // from Open.
     Connectivity Connectivity
 
     // SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -25,6 +25,7 @@ import "sigs.k8s.io/agent-sandbox/clients/go/sandbox"
 - [type Commands](<#Commands>)
   - [func \(c \*Commands\) Run\(ctx context.Context, command string, opts ...CallOption\) \(\*ExecutionResult, error\)](<#Commands.Run>)
 - [type ConnectionStrategy](<#ConnectionStrategy>)
+- [type Connectivity](<#Connectivity>)
 - [type DirectStrategy](<#DirectStrategy>)
   - [func \(s \*DirectStrategy\) Close\(\) error](<#DirectStrategy.Close>)
   - [func \(s \*DirectStrategy\) Connect\(\_ context.Context\) \(string, error\)](<#DirectStrategy.Connect>)
@@ -282,6 +283,32 @@ type ConnectionStrategy interface {
     Connect(ctx context.Context) (baseURL string, err error)
     Close() error
 }
+```
+
+<a name="Connectivity"></a>
+### type [Connectivity](<https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/go/sandbox/options.go>)
+
+Connectivity selects the transport used to reach the in\-sandbox runtime.
+
+```go
+type Connectivity string
+```
+
+<a name="ConnectivityPortForward"></a>
+
+```go
+const (
+    // RuntimeLegacyPython is the python-runtime HTTP API (POST /upload,
+    // GET /download|list|exists/{path}, POST /execute on port 8888),
+    // reached through the sandbox-router unless Connectivity selects a
+    // direct pod dial. Default.
+    RuntimeLegacyPython Runtime = "legacy-python"
+    // RuntimeSandboxd is the sandboxd hybrid API defined by KEP-539.2:
+    // REST filesystem (/v1/files/...) on port 8080 plus gRPC
+    // ProcessService on port 9090. The SDK reaches the sandbox pod directly
+    // or over a port-forward (default), see Connectivity.
+    RuntimeSandboxd Runtime = "sandboxd"
+)
 ```
 
 <a name="DirectStrategy"></a>
@@ -545,10 +572,17 @@ type Options struct {
     WarmPoolName string
 
     // Runtime selects the in-sandbox runtime API. Default: RuntimeLegacyPython.
-    // RuntimeSandboxd connects via a pod port-forward, so GatewayName is not
-    // supported with it. APIURL remains available as an advanced/testing
-    // escape hatch for the REST endpoint.
+    // RuntimeSandboxd talks to the sandbox pod rather than the sandbox-router,
+    // so GatewayName is not supported with it. APIURL remains available as an
+    // advanced/testing escape hatch for the REST endpoint.
     Runtime Runtime
+
+    // Connectivity selects the transport. Default: ConnectivityPortForward.
+    //
+    // ConnectivityInCluster works with either Runtime and conflicts with both
+    // GatewayName and APIURL. It requires that this process can route to pod
+    // IPs - i.e. that it runs inside the cluster.
+    Connectivity Connectivity
 
     // SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime
     // REST API. Only used with RuntimeSandboxd. Default: 8080.
@@ -679,12 +713,13 @@ type Runtime string
 const (
     // RuntimeLegacyPython is the python-runtime HTTP API (POST /upload,
     // GET /download|list|exists/{path}, POST /execute on port 8888),
-    // reached through the sandbox-router. Default.
+    // reached through the sandbox-router unless Connectivity selects a
+    // direct pod dial. Default.
     RuntimeLegacyPython Runtime = "legacy-python"
     // RuntimeSandboxd is the sandboxd hybrid API defined by KEP-539.2:
     // REST filesystem (/v1/files/...) on port 8080 plus gRPC
-    // ProcessService on port 9090. The SDK connects over a pod port-forward
-    // to the sandbox pod.
+    // ProcessService on port 9090. The SDK reaches the sandbox pod directly
+    // or over a port-forward (default), see Connectivity.
     RuntimeSandboxd Runtime = "sandboxd"
 )
 ```

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -308,12 +308,26 @@ const (
     // its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
     // and, for RuntimeLegacyPython, the sandbox-router, off the data path.
     //
-    // Requires the Sandbox to have a Service, set spec.service: true on
-    // the template.
+    // Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
+    // boundary. The Service's selector only ever matches its own Sandbox's
+    // pod, so a pod IP that Kubernetes has since reassigned to another
+    // tenant would be caught when the TTL expires. A deleted Sandbox takes
+    // its Service with it: connections then fail rather than landing on a stranger.
+    // (DNS caching still leaves a TTL-bounded window)
+    //
+    // Requires the Sandbox to have a Service — set spec.service: true on
+    // the template. Open fails when Status.ServiceFQDN is empty rather than
+    // falling back to the pod IP, so the safety property cannot be lost
+    // silently.
     ConnectivityInClusterService Connectivity = "in-cluster-service"
 
     // ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
     // it works against any Sandbox without template changes.
+    //
+    // It carries the pod IP's reuse hazard: nothing detects that the sandbox
+    // pod was rescheduled, so requests can continue to a stale address that
+    // Kubernetes may have since reassigned to an unrelated pod. Use
+    // ConnectivityInClusterService where that matters.
     ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 ```
@@ -586,9 +600,9 @@ type Options struct {
 
     // Connectivity selects the transport. Default: ConnectivityPortForward.
     //
-    // The in-cluster values work with either Runtime, conflict with both
-    // GatewayName and APIURL, and require that this process runs inside the
-    // cluster.
+    // The in-cluster values conflict with both GatewayName and APIURL, and
+    // require that this process runs inside the same cluster as the sandbox
+    // pods.
     Connectivity Connectivity
 
     // SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -308,27 +308,12 @@ const (
     // its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
     // and, for RuntimeLegacyPython, the sandbox-router, off the data path.
     //
-    // Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
-    // boundary. The Service's selector only ever matches its own Sandbox's
-    // pod, so a pod IP that Kubernetes has since reassigned to another
-    // tenant cannot be reached, and a deleted Sandbox takes its Service
-    // with it: connections then fail rather than landing on a stranger.
-    // (DNS caching still leaves a TTL-bounded window; closing it entirely
-    // needs per-request identity binding or a service mesh.)
-    //
-    // Requires the Sandbox to have a Service — set spec.service: true on
-    // the template. Open fails when Status.ServiceFQDN is empty rather than
-    // falling back to the pod IP, so the safety property cannot be lost
-    // silently.
+    // Requires the Sandbox to have a Service, set spec.service: true on
+    // the template.
     ConnectivityInClusterService Connectivity = "in-cluster-service"
 
     // ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
     // it works against any Sandbox without template changes.
-    //
-    // It carries the pod IP's reuse hazard: nothing detects that the sandbox
-    // pod was rescheduled, so requests can continue to a stale address that
-    // Kubernetes may have since reassigned to an unrelated pod. Use
-    // ConnectivityInClusterService where that matters.
     ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 ```
@@ -603,9 +588,7 @@ type Options struct {
     //
     // The in-cluster values work with either Runtime, conflict with both
     // GatewayName and APIURL, and require that this process runs inside the
-    // cluster. That cannot be checked at validation time, so a caller
-    // outside the pod network sees connection timeouts rather than an error
-    // from Open.
+    // cluster.
     Connectivity Connectivity
 
     // SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/docs/go_sdk_reference.md
+++ b/docs/go_sdk_reference.md
@@ -107,12 +107,10 @@ var (
 
 ```go
 var (
-    ErrNotReady        = errors.New("sandbox is not ready")
-    ErrTimeout         = errors.New("operation timed out")
-    ErrClaimFailed     = errors.New("claim creation failed")
-    ErrPortForwardDied = errors.New("port-forward connection lost")
-    // ErrNoSandboxService is returned when ConnectivityInClusterService is
-    // selected but the Sandbox has no headless Service to address.
+    ErrNotReady         = errors.New("sandbox is not ready")
+    ErrTimeout          = errors.New("operation timed out")
+    ErrClaimFailed      = errors.New("claim creation failed")
+    ErrPortForwardDied  = errors.New("port-forward connection lost")
     ErrNoSandboxService = errors.New("sandbox has no headless Service")
     ErrAlreadyOpen      = errors.New("sandbox is already open; call Close first")
     ErrOrphanedClaim    = errors.New("orphaned claim; call Close() to retry deletion")
@@ -308,29 +306,14 @@ const (
     ConnectivityPortForward Connectivity = "port-forward"
     // ConnectivityInClusterService dials the Sandbox's headless Service by
     // its in-cluster DNS name (Status.ServiceFQDN), taking the apiserver —
-    // and, for RuntimeLegacyPython, the sandbox-router — off the data path.
+    // and, for RuntimeLegacyPython, the sandbox-router, off the data path.
     //
-    // Prefer this over ConnectivityInClusterPodIP when sandboxes cross a trust
-    // boundary. The Service's selector only ever matches its own Sandbox's
-    // pod, so a pod IP that Kubernetes has since reassigned to another
-    // tenant cannot be reached, and a deleted Sandbox takes its Service
-    // with it: connections then fail rather than landing on a stranger.
-    // (DNS caching still leaves a TTL-bounded window; closing it entirely
-    // needs per-request identity binding or a service mesh.)
-    //
-    // Requires the Sandbox to have a Service — set spec.service: true on
-    // the template. Open fails when Status.ServiceFQDN is empty rather than
-    // falling back to the pod IP, so the safety property cannot be lost
-    // silently.
+    // Requires the Sandbox to have a Service, set spec.service: true on
+    // the template.
     ConnectivityInClusterService Connectivity = "in-cluster-service"
 
     // ConnectivityInClusterPodIP dials Status.PodIP. It needs no Service, so
     // it works against any Sandbox without template changes.
-    //
-    // It carries the pod IP's reuse hazard: nothing detects that the sandbox
-    // pod was rescheduled, so requests can continue to a stale address that
-    // Kubernetes may have since reassigned to an unrelated pod. Use
-    // ConnectivityInClusterService where that matters.
     ConnectivityInClusterPodIP Connectivity = "in-cluster-pod-ip"
 )
 ```
@@ -605,9 +588,7 @@ type Options struct {
     //
     // The in-cluster values work with either Runtime, conflict with both
     // GatewayName and APIURL, and require that this process runs inside the
-    // cluster. That cannot be checked at validation time, so a caller
-    // outside the pod network sees connection timeouts rather than an error
-    // from Open.
+    // cluster.
     Connectivity Connectivity
 
     // SandboxdRESTPort is the pod port of sandboxd's Filesystem & Runtime

--- a/packages/sandboxd/spec/process/v1/process.pb.go
+++ b/packages/sandboxd/spec/process/v1/process.pb.go
@@ -360,7 +360,6 @@ type StartResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Event:
-	//
 	//	*StartResponse_Init
 	//	*StartResponse_Stdout
 	//	*StartResponse_Stderr
@@ -584,7 +583,6 @@ type WriteStdinRequest struct {
 
 	ProcessId int32 `protobuf:"varint,1,opt,name=process_id,json=processId,proto3" json:"process_id,omitempty"`
 	// Types that are assignable to Payload:
-	//
 	//	*WriteStdinRequest_Input
 	//	*WriteStdinRequest_Eof
 	Payload isWriteStdinRequest_Payload `protobuf_oneof:"payload"`


### PR DESCRIPTION
#### What this PR does / why we need it:
<!-- Provide a clear and concise description of the changes in this PR. -->
Adds a direct in-cluster transport to the Go SDK, so a we can reach the sandbox pod without going through the apiserver or the `sandbox-router`.

Adds a new `Options.Connectivity`.

| Value | Method | If unavailable |
| --- | --- | --- |
| `port-forward` (default) | SPDY via apiserver |  |
| `in-cluster-service` | Headless Service DNS (`Status.ServiceFQDN`) | `ErrNoSandboxService` |
| `in-cluster-pod-ip` | `Status.PodIP` | not-ready error |

<!--
To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.

Examples:
Fixes #<issue number>
Ref <issue link> (issue in a different repository)
-->
Fixes #1526

#### Release Note
<!--
If this PR requires a release note (for features, fixes, or breaking changes), please add it below.
If no release note is needed, you can leave this block empty or write "NONE".

Note: Automated release notes are generated by Gemini using the PR description in the first section.
Please ensure that description is clear and comprehensive.
For breaking changes, ensure you describe the required actions clearly and the PR is labeled with `release-note-action-required`.
-->
```release-note
Go SDK: add `Options.Connectivity` to reach the sandbox pod directly from inside the cluster, without needing to go through the apiserver or sandbox-router. Default behavior is unchanged.

- `ConnectivityInClusterService` uses the headless Service DNS name and requires `spec.service: true`.
- `ConnectivityInClusterPodIP` uses the pod IP.
```

<!--
=======================================================================
⚠️ CONTRIBUTOR NOTICES (Please read before submitting)
By submitting this PR, you acknowledge our [Contributing Guidelines](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/CONTRIBUTING.md):

* CLA REQUIRED: You must sign the Kubernetes CLA before your PR can be reviewed.
* AI REVIEWS:
  * We use Copilot and CodeRabbit for initial reviews. Do NOT click "Commit suggestion" in the GitHub UI, as AI bots cannot sign the CLA and will block your PR. Please apply suggestions locally instead.
  * Once automated reviews finish the first pass, please resolve their comments so the PR can be labeled `ready-for-review` for maintainers!
* PR TAKEOVERS: To speed up delivery, maintainers may push final changes and directly merge your PR if it is close to completion.
* STALE POLICY: PRs inactive for 30 days are marked stale and closed 15 days later.
=======================================================================
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable sandbox connectivity through port forwarding, Service DNS, or pod IP.
  - Added direct in-cluster connections with custom ports and IPv4/IPv6 support.
  - Added access to a sandbox’s Service DNS name.
  - Added clear errors when Service DNS connectivity is unavailable.
  - Added connectivity reporting for in-cluster connection strategies.

- **Documentation**
  - Updated the Go SDK reference with connectivity options and related APIs.
  - Clarified connectivity behavior for sandbox runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->