### PR TITLE
examples(irsa-simulation-localstack): verify the WebIdentityToken's trust boundary

### DIFF
--- a/examples/irsa-simulation-localstack/README.md
+++ b/examples/irsa-simulation-localstack/README.md
@@ -26,26 +26,104 @@ This example combines two pieces that need no AWS IAM permissions at all:
 
 With both in place, the AWS SDK's default credential chain
 (`WebIdentityRoleCredentialFetcher` in boto3) picks up the injected env vars
-automatically and exchanges the token for credentials via LocalStack's mocked
-`AssumeRoleWithWebIdentity` — no application code changes needed.
+automatically and exchanges the token for credentials via a small
+**`sts-trust-verifier`** proxy sitting in front of LocalStack — no
+application code changes needed.
 
-**Important caveat:** LocalStack accepts the web identity token without
-verifying its signature against a real OIDC issuer's JWKS. This proves the
-pod correctly *discovers and uses* IRSA-style credentials — it does **not**
-prove that a real AWS account would trust the token, or that an IRSA trust
-policy is configured correctly. Treat this as a code-path smoke test, not a
-security validation of the trust boundary.
+### Trust boundary verification
+
+LocalStack's STS mock accepts any web identity token without checking it, so
+on its own it only proves the pod *discovers and uses* IRSA-style
+credentials — not that the token would be trusted by a real relying party.
+
+`sts-trust-verifier` (`trust-verifier-configmap.yaml` /
+`trust-verifier.yaml`) closes that gap for the one action this flow
+actually uses (`AssumeRoleWithWebIdentity`): it fetches this cluster's own
+JWKS from its `/openid/v1/jwks` discovery endpoint, verifies the token's
+signature against it, and checks `aud` (`sts.amazonaws.com`, the webhook's
+default), `iss`, and `exp` — the same cryptographic check a real AWS IAM
+OIDC provider performs. Only on success does it forward the request to
+LocalStack.
+
+**Remaining caveat:** this still doesn't validate a *real* AWS account's IAM
+OIDC provider registration or role trust policy — there is no real AWS
+account involved. It proves the verification mechanics work correctly
+against the cluster's actual signing key; it is not a substitute for
+validating your real EKS trust policy configuration.
+
+The proxy never derives the JWKS URL from the token being verified (that
+would let a caller redirect it to an arbitrary URL — an SSRF vector); the
+JWKS endpoint is a fixed, in-cluster constant, and the token's `iss` claim is
+only ever compared against an operator-supplied `EXPECTED_ISSUER`, never
+dereferenced.
+
+**Key rotation:** a *known* `kid` is only re-checked against the cluster's
+JWKS every `_JWKS_MAX_CACHE_AGE_SECONDS` (300s), not on every request. Without
+this, a key removed from the cluster's JWKS (rotation, or revoking a
+compromised key) would stay trusted by this proxy indefinitely, until it
+happens to restart. A token using a since-rotated-out `kid` is rejected once
+that window elapses, not never.
+
+### Transport encryption
+
+Both hops carrying the WebIdentityToken and the resulting AWS credentials
+are TLS, and both are genuinely certificate-verified (neither uses
+`verify=False`):
+
+- **sandbox → sts-trust-verifier:** this is the hop that matters most —
+  it's where the real WebIdentityToken goes out and the real (mocked)
+  credentials come back. `trust-verifier-tls.yaml` issues a certificate via
+  cert-manager's `selfsigned` `ClusterIssuer` (the one
+  `amazon-eks-pod-identity-webhook`'s own install already creates), and the
+  sandbox pod is configured to actually verify it via `AWS_CA_BUNDLE`
+  (`sandbox.yaml`).
+- **sts-trust-verifier → LocalStack:** LocalStack auto-detects TLS and
+  serves HTTPS on its edge port with no extra config, but its baked-in
+  certificate is a fixed, publicly-known test artifact shared by every
+  LocalStack install (`CN=localhost`, self-signed by "LocalStack Org") —
+  not something meaningful to verify against. `localstack-tls.yaml` instead
+  issues LocalStack its own certificate matching its real Service DNS name
+  (LocalStack reads this via `CUSTOM_SSL_CERT_PATH`, a single PEM file
+  containing both the key and cert — `localstack.yaml`'s init container
+  concatenates cert-manager's separate `tls.key`/`tls.crt` into that
+  format), and `sts-trust-verifier` verifies against it via
+  `LOCALSTACK_CA_FILE` instead of skipping verification.
+
+### Availability
+
+`sts-trust-verifier` uses `http.server.ThreadingHTTPServer`, which spawns one
+thread per connection with no cap on the total number of threads.
+`Handler.timeout` (30s) bounds how long a single slow or incomplete
+connection can hold its thread — without it, a caller that opens a
+connection and never finishes sending a request would block that thread
+indefinitely, and enough of them exhausts an otherwise uncapped server.
+There is still no hard ceiling on total concurrent threads; fine for this
+single-sandbox demo, not something to copy as-is into anything handling
+untrusted, high-volume traffic.
 
 ## Files
 
 - `namespace.yaml` — namespace for this example
 - `serviceaccount.yaml` — ServiceAccount annotated with a (non-existent, mock)
   IAM role ARN
-- `localstack.yaml` — LocalStack Deployment + Service, `SERVICES=sts` only
+- `localstack.yaml` — LocalStack Deployment + Service, `SERVICES=sts` only,
+  with an init container giving it a cert-manager-issued TLS certificate
+- `localstack-tls.yaml` — cert-manager `Certificate` for LocalStack, issued
+  by the `selfsigned` `ClusterIssuer`
+- `trust-verifier-tls.yaml` — cert-manager `Certificate` for
+  `sts-trust-verifier`, issued by the `selfsigned` `ClusterIssuer`
+- `trust-verifier-configmap.yaml` — the `sts-trust-verifier` proxy script
+- `trust-verifier.yaml` — `sts-trust-verifier` Deployment + Service, sitting
+  in front of LocalStack
 - `check-script-configmap.yaml` — the boto3 smoke-test script, mounted into
   the sandbox pod
 - `sandbox.yaml` — a Sandbox using the annotated ServiceAccount, with
-  `AWS_ENDPOINT_URL_STS` pointed at the in-cluster LocalStack Service
+  `AWS_ENDPOINT_URL_STS` pointed at the in-cluster `sts-trust-verifier`
+  Service over HTTPS, and `AWS_CA_BUNDLE` set so it actually verifies that
+  certificate
+- `run-test-kind.sh` — automated test against a live cluster: happy path,
+  forged-signature rejection, and wrong-audience/wrong-issuer rejection
+  using real cluster-signed tokens
 
 ## Prerequisites
 
@@ -72,30 +150,59 @@ issue the webhook's TLS certificate).
 
 ## Usage
 
-### 1. Apply the resources
+### 1. Apply LocalStack
 
 ```sh
 kubectl apply -f namespace.yaml
 kubectl apply -f serviceaccount.yaml
+kubectl apply -f localstack-tls.yaml
+kubectl -n irsa-sim-ns wait --for=condition=ready certificate/localstack-tls --timeout=60s
 kubectl apply -f localstack.yaml
-kubectl apply -f check-script-configmap.yaml
-kubectl apply -f sandbox.yaml
+kubectl -n irsa-sim-ns wait --for=condition=ready pod -l app=localstack --timeout=120s
 ```
 
-### 2. Wait for both to be ready
+### 2. Issue `sts-trust-verifier`'s TLS certificate
 
 ```sh
-kubectl -n irsa-sim-ns wait --for=condition=Ready pod -l app=localstack --timeout=120s
-kubectl -n irsa-sim-ns get sandbox irsa-sim-sandbox
+kubectl apply -f trust-verifier-tls.yaml
+kubectl -n irsa-sim-ns wait --for=condition=ready certificate/sts-trust-verifier-tls --timeout=60s
 ```
 
-### 3. Confirm the webhook injected IRSA env vars
+### 3. Point `sts-trust-verifier` at this cluster's real issuer
+
+`EXPECTED_ISSUER` in `trust-verifier.yaml` is a placeholder — every cluster's
+OIDC issuer is different, and the verifier must be pinned to the real one
+(never derived from an incoming token; see "Trust boundary verification"
+above):
+
+```sh
+ISSUER=$(kubectl get --raw /.well-known/openid-configuration | python3 -c 'import json,sys; print(json.load(sys.stdin)["issuer"])')
+kubectl apply -f trust-verifier-configmap.yaml
+kubectl apply -f trust-verifier.yaml
+kubectl -n irsa-sim-ns set env deployment/sts-trust-verifier "EXPECTED_ISSUER=${ISSUER}"
+# rollout status, not wait --for=condition=available: on a single-replica
+# Deployment, `set env` surges a new pod before terminating the old one, so
+# condition=available can pass while the Service still routes to the stale
+# pod (still running with the old EXPECTED_ISSUER). rollout status blocks
+# until the old ReplicaSet is fully scaled down.
+kubectl -n irsa-sim-ns rollout status deployment/sts-trust-verifier --timeout=120s
+```
+
+### 4. Apply the sandbox
+
+```sh
+kubectl apply -f check-script-configmap.yaml
+kubectl apply -f sandbox.yaml
+kubectl -n irsa-sim-ns wait --for=condition=Ready pod irsa-sim-sandbox --timeout=120s
+```
+
+### 5. Confirm the webhook injected IRSA env vars
 
 ```sh
 kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- printenv AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
 ```
 
-### 4. Run the credential check
+### 6. Run the credential check
 
 The base sandbox image doesn't ship `boto3`, so install it once inside the
 pod before running the script (a real deployment would bake this into a
@@ -126,15 +233,70 @@ Assumed identity ARN: arn:aws:sts::000000000000:assumed-role/irsa-sim-role/botoc
 ```
 
 This confirms the sandbox pod correctly discovered the webhook-injected
-credentials and exchanged them via LocalStack's mocked STS — with no
-application code aware that it isn't talking to real AWS.
+credentials, that `sts-trust-verifier` verified the token's signature,
+issuer, and audience over a TLS connection the sandbox actually validated
+(via `AWS_CA_BUNDLE`), and that the exchange succeeded via LocalStack's
+mocked STS — with no application code aware that it isn't talking to real
+AWS.
+
+### 7. Demonstrate that a forged token is rejected
+
+The check above only shows the happy path. To confirm the verification
+actually has teeth, send a syntactically valid JWT with a garbage signature
+straight to `sts-trust-verifier` and confirm it's rejected:
+
+```sh
+kubectl -n irsa-sim-ns exec irsa-sim-sandbox -- python3 -c '
+import base64, json, ssl, urllib.parse, urllib.request, urllib.error
+
+def b64u(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+token = ".".join([
+    b64u(json.dumps({"alg": "RS256", "kid": "not-a-real-kid"}).encode()),
+    b64u(json.dumps({"iss": "https://kubernetes.default.svc.cluster.local", "aud": "sts.amazonaws.com", "exp": 9999999999, "iat": 0}).encode()),
+    b64u(b"not-a-real-signature"),
+])
+body = urllib.parse.urlencode({
+    "Action": "AssumeRoleWithWebIdentity",
+    "Version": "2011-06-15",
+    "RoleArn": "arn:aws:iam::000000000000:role/irsa-sim-role",
+    "RoleSessionName": "forged-token-test",
+    "WebIdentityToken": token,
+}).encode()
+# Same CA sandbox.yaml mounts for AWS_CA_BUNDLE -- verify the verifier's
+# real cert-manager-issued cert rather than skip verification.
+ssl_ctx = ssl.create_default_context(cafile="/irsa-sim-tls/ca.crt")
+req = urllib.request.Request("https://sts-trust-verifier.irsa-sim-ns.svc.cluster.local:4566", data=body, method="POST")
+try:
+    print(urllib.request.urlopen(req, context=ssl_ctx).read().decode())
+except urllib.error.HTTPError as e:
+    print(e.read().decode())
+'
+```
+
+Expected output contains `<Code>InvalidIdentityToken</Code>` — the request
+is rejected before it ever reaches LocalStack. `run-test-kind.sh` automates
+this, the happy path, and two more cases as a regression test: a
+genuinely cluster-signed token with the wrong audience, and a genuinely
+cluster-signed token checked against a deliberately mismatched
+`EXPECTED_ISSUER`. Both use `kubectl create token` to mint a real,
+correctly-signed token rather than a hand-built one, so they can only pass
+if the audience/issuer checks themselves are enforced — the forged-token
+cases above are rejected earlier (at JWKS lookup or signature
+verification) and wouldn't catch a regression that dropped those two
+checks specifically.
 
 ## Cleanup
 
 ```sh
 kubectl delete -f sandbox.yaml
 kubectl delete -f check-script-configmap.yaml
+kubectl delete -f trust-verifier.yaml
+kubectl delete -f trust-verifier-tls.yaml
+kubectl delete -f trust-verifier-configmap.yaml
 kubectl delete -f localstack.yaml
+kubectl delete -f localstack-tls.yaml
 kubectl delete -f serviceaccount.yaml
 kubectl delete -f namespace.yaml
 ```
@@ -145,10 +307,11 @@ kubectl delete -f namespace.yaml
   auto-generated per-template `NetworkPolicy` restricts egress to the public
   internet and blocks other in-cluster services by default (see
   [`docs/security/threat_model.md`](../../docs/security/threat_model.md)).
-  Reaching LocalStack from a `SandboxTemplate`-managed pod needs a
-  supplemental, additive `NetworkPolicy` scoped to the LocalStack
-  Service/namespace — additional `NetworkPolicy` objects selecting the same
-  pods are unioned, not overridden.
+  Reaching `sts-trust-verifier` (which the sandbox now talks to instead of
+  LocalStack directly) from a `SandboxTemplate`-managed pod needs a
+  supplemental, additive `NetworkPolicy` scoped to its Service/namespace —
+  additional `NetworkPolicy` objects selecting the same pods are unioned, not
+  overridden.
 - **Moving to real EKS:** swap the mock `eks.amazonaws.com/role-arn` for a
   real IAM role ARN, remove `AWS_ENDPOINT_URL_STS` so the SDK talks to real
   AWS STS, and register the cluster's actual OIDC provider with that role's

--- a/examples/irsa-simulation-localstack/check-script-configmap.yaml
+++ b/examples/irsa-simulation-localstack/check-script-configmap.yaml
@@ -6,12 +6,16 @@ metadata:
 data:
   check_irsa.py: |
     """Validates the IRSA credential-loading code path against a
-    LocalStack-mocked STS. Does NOT validate the real AWS OIDC trust
-    boundary (issuer/JWKS signature checks) -- LocalStack accepts any web
-    identity token without verifying it. This only proves the pod correctly
-    discovers AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE (injected by
+    LocalStack-mocked STS, reached through the sts-trust-verifier proxy
+    (see trust-verifier-configmap.yaml). The proxy verifies the
+    WebIdentityToken's signature against the cluster's own JWKS plus its
+    issuer/audience/expiry before forwarding to LocalStack -- the same
+    cryptographic check a real AWS IAM OIDC provider would perform. It does
+    NOT validate a real AWS account's IAM role trust policy; there is no
+    real AWS account involved here. This proves the pod correctly discovers
+    AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE (injected by
     amazon-eks-pod-identity-webhook) and can exchange the projected token
-    for credentials via the standard boto3 credential chain -- no
+    for verified credentials via the standard boto3 credential chain -- no
     application code changes needed.
     """
     import os

--- a/examples/irsa-simulation-localstack/localstack-tls.yaml
+++ b/examples/irsa-simulation-localstack/localstack-tls.yaml
@@ -1,0 +1,26 @@
+# TLS for the sts-trust-verifier -> LocalStack hop: gives LocalStack a
+# certificate matching its real Service DNS name, issued by the same
+# selfsigned ClusterIssuer as sts-trust-verifier-tls.yaml, so the verifier
+# can genuinely verify it (see LOCALSTACK_CA_FILE in
+# trust-verifier-configmap.yaml) instead of connecting with verify=False.
+#
+# LocalStack reads CUSTOM_SSL_CERT_PATH as a single PEM file containing both
+# the private key and certificate concatenated together (see
+# localstack/utils/crypto.py's generate_ssl_cert, which parses both blocks
+# out of one file) -- cert-manager's Secret keeps them as separate
+# tls.key/tls.crt entries, so localstack.yaml's initContainer concatenates
+# them into that combined file on a shared emptyDir before the main
+# container starts.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: localstack-tls
+  namespace: irsa-sim-ns
+spec:
+  secretName: localstack-tls
+  dnsNames:
+    - localstack.irsa-sim-ns.svc.cluster.local
+    - localstack.irsa-sim-ns.svc
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer

--- a/examples/irsa-simulation-localstack/localstack.yaml
+++ b/examples/irsa-simulation-localstack/localstack.yaml
@@ -19,6 +19,30 @@ spec:
       # and so ownership isn't left to an implementation detail of emptyDir.
       securityContext:
         fsGroup: 1000
+      # cert-manager's Secret keeps tls.key/tls.crt as separate files, but
+      # LocalStack's CUSTOM_SSL_CERT_PATH expects one PEM file containing
+      # both (see localstack-tls.yaml). This concatenates them once into the
+      # shared tls-combined emptyDir before the main container starts.
+      initContainers:
+      - name: combine-tls-cert
+        image: python:3.12-slim
+        command:
+          - sh
+          - -c
+          - "cat /tls-secret/tls.key /tls-secret/tls.crt > /tls-combined/localstack.pem"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: tls-secret
+          mountPath: /tls-secret
+          readOnly: true
+        - name: tls-combined
+          mountPath: /tls-combined
       containers:
       - name: localstack
         image: localstack/localstack:3.8
@@ -27,6 +51,8 @@ spec:
         env:
         - name: SERVICES
           value: "sts"
+        - name: CUSTOM_SSL_CERT_PATH
+          value: "/tls-combined/localstack.pem"
         # The image runs as root by default and writes to /tmp/localstack and
         # /var/lib/localstack/cache at startup; without the emptyDir mounts
         # below, running as non-root fails with repeated PermissionErrors on
@@ -44,6 +70,14 @@ spec:
           mountPath: /tmp
         - name: localstack-var
           mountPath: /var/lib/localstack
+        - name: tls-combined
+          mountPath: /tls-combined
+          readOnly: true
+        # Plain HTTP, not HTTPS: LocalStack's edge proxy auto-detects the
+        # protocol per connection and serves both on the same port
+        # regardless of CUSTOM_SSL_CERT_PATH, so a plain readiness check
+        # avoids needing this probe to trust the (at this point, possibly
+        # not-yet-loaded) custom cert.
         readinessProbe:
           httpGet:
             path: /_localstack/health
@@ -54,6 +88,11 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: localstack-var
+        emptyDir: {}
+      - name: tls-secret
+        secret:
+          secretName: localstack-tls
+      - name: tls-combined
         emptyDir: {}
 ---
 apiVersion: v1

--- a/examples/irsa-simulation-localstack/run-test-kind.sh
+++ b/examples/irsa-simulation-localstack/run-test-kind.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Exercises the sts-trust-verifier proxy against a live cluster:
+#   1. Happy path: the real pod-identity-webhook-injected WebIdentityToken
+#      verifies and the sandbox obtains credentials (existing check_irsa.py).
+#   2. Negative path (unknown kid): a syntactically valid but
+#      garbage-signature JWT with an unrecognized kid is rejected.
+#   3. Negative path (real kid, forged signature): proves the RSA signature
+#      check itself is enforced, not just kid lookup.
+#   4. Negative path (wrong audience): a genuinely cluster-signed token
+#      (via `kubectl create token`) with the wrong audience is rejected --
+#      proves the audience check specifically, since cases 2-3 never reach
+#      claim validation.
+#   5. Negative path (mismatched issuer): a genuinely cluster-signed,
+#      correct-audience token is rejected when the verifier is pointed at a
+#      different EXPECTED_ISSUER -- proves the issuer check specifically.
+#
+# Assumes cert-manager and amazon-eks-pod-identity-webhook are already
+# installed on the target cluster (see README.md prerequisites) -- this
+# script does not install cluster-wide dependencies for you.
+
+set -e
+# Without pipefail, a failing `kubectl ... | python3 -c ...` (e.g. the issuer
+# discovery and REAL_KID pipelines below) only fails the script if python3
+# itself exits non-zero -- a kubectl error upstream in the pipe would
+# otherwise be silently swallowed, since only the last command's exit status
+# counts under plain set -e.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+NS="irsa-sim-ns"
+VERIFIER_URL="https://sts-trust-verifier.${NS}.svc.cluster.local:4566"
+
+if ! kubectl get deployment pod-identity-webhook -n default >/dev/null 2>&1; then
+    echo "amazon-eks-pod-identity-webhook not found in the 'default' namespace." >&2
+    echo "Install it first -- see README.md Prerequisites." >&2
+    exit 1
+fi
+
+cleanup() {
+    echo "Cleaning up..."
+    kubectl delete --ignore-not-found -f sandbox.yaml
+    kubectl delete --ignore-not-found -f check-script-configmap.yaml
+    kubectl delete --ignore-not-found -f trust-verifier.yaml
+    kubectl delete --ignore-not-found -f trust-verifier-tls.yaml
+    kubectl delete --ignore-not-found -f trust-verifier-configmap.yaml
+    kubectl delete --ignore-not-found -f localstack.yaml
+    kubectl delete --ignore-not-found -f localstack-tls.yaml
+    kubectl delete --ignore-not-found -f serviceaccount.yaml
+    kubectl delete --ignore-not-found -f namespace.yaml
+}
+trap cleanup EXIT
+
+# Every python3 -c snippet below runs inside irsa-sim-sandbox and posts to
+# VERIFIER_URL (https). They all need to trust sts-trust-verifier's
+# cert-manager-issued cert, mounted into the sandbox pod at
+# /irsa-sim-tls/ca.crt (see sandbox.yaml) -- this helper builds that once so
+# each snippet below doesn't repeat the ssl.create_default_context() setup.
+ssl_helper() {
+    cat <<'PY'
+import ssl
+_ssl_ctx = ssl.create_default_context(cafile="/irsa-sim-tls/ca.crt")
+PY
+}
+
+post_token() {
+    local role_session_name="$1"
+    local token="$2"
+    kubectl -n "${NS}" exec irsa-sim-sandbox -- python3 -c "
+$(ssl_helper)
+import urllib.parse, urllib.request
+body = urllib.parse.urlencode({
+    'Action': 'AssumeRoleWithWebIdentity',
+    'Version': '2011-06-15',
+    'RoleArn': 'arn:aws:iam::000000000000:role/irsa-sim-role',
+    'RoleSessionName': '${role_session_name}',
+    'WebIdentityToken': '${token}',
+}).encode()
+req = urllib.request.Request('${VERIFIER_URL}', data=body, method='POST')
+try:
+    print(urllib.request.urlopen(req, context=_ssl_ctx).read().decode())
+except urllib.error.HTTPError as e:
+    print(e.read().decode())
+"
+}
+
+# `kubectl rollout status` blocks until the control plane reports the new
+# ReplicaSet fully up and the old one scaled down, but kube-proxy's local
+# dataplane (iptables/ipvs) converges to match asynchronously -- there's a
+# brief window, observed directly in practice, where a request made the
+# instant rollout status returns can still land on connection state pointed
+# at the just-terminated old pod. Retrying briefly absorbs that window
+# without masking a real rejection failure (an actual bug fails every
+# attempt, not just the first).
+assert_rejected() {
+    local role_session_name="$1"
+    local token="$2"
+    local failure_message="$3"
+    local response
+    for attempt in 1 2 3 4 5; do
+        response=$(post_token "${role_session_name}" "${token}")
+        if echo "${response}" | grep -q "InvalidIdentityToken"; then
+            echo "${response}"
+            return 0
+        fi
+        echo "attempt ${attempt}: not yet rejected, retrying in 2s..." >&2
+        sleep 2
+    done
+    echo "${response}"
+    echo "" >&2
+    echo "${failure_message}" >&2
+    exit 1
+}
+
+echo "Applying namespace, ServiceAccount..."
+kubectl apply -f namespace.yaml
+kubectl apply -f serviceaccount.yaml
+
+echo "Issuing LocalStack's TLS certificate..."
+kubectl apply -f localstack-tls.yaml
+kubectl -n "${NS}" wait --for=condition=ready certificate/localstack-tls --timeout=60s
+
+echo "Applying LocalStack..."
+kubectl apply -f localstack.yaml
+kubectl -n "${NS}" wait --for=condition=ready pod -l app=localstack --timeout=120s
+
+echo "Discovering this cluster's real OIDC issuer..."
+ISSUER=$(kubectl get --raw /.well-known/openid-configuration | python3 -c 'import json,sys; print(json.load(sys.stdin)["issuer"])')
+echo "Issuer: ${ISSUER}"
+
+echo "Issuing sts-trust-verifier's TLS certificate..."
+kubectl apply -f trust-verifier-tls.yaml
+kubectl -n "${NS}" wait --for=condition=ready certificate/sts-trust-verifier-tls --timeout=60s
+
+echo "Applying sts-trust-verifier (pinned to the discovered issuer)..."
+kubectl apply -f trust-verifier-configmap.yaml
+kubectl apply -f trust-verifier.yaml
+kubectl -n "${NS}" set env deployment/sts-trust-verifier "EXPECTED_ISSUER=${ISSUER}"
+kubectl -n "${NS}" rollout status deployment/sts-trust-verifier --timeout=120s
+
+echo "Applying check script and sandbox..."
+kubectl apply -f check-script-configmap.yaml
+kubectl apply -f sandbox.yaml
+# 300s, not 120s: the sandbox image is a few hundred MB and a cold pull on a
+# fresh kind node (no local cache) can comfortably exceed 120s.
+kubectl -n "${NS}" wait --for=condition=Ready pod irsa-sim-sandbox --timeout=300s
+
+echo "=== Happy path: real webhook-injected token ==="
+kubectl -n "${NS}" exec irsa-sim-sandbox -- printenv AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE >/dev/null
+kubectl -n "${NS}" exec irsa-sim-sandbox -- sh -c 'HOME=/tmp python3 -m pip install --user --quiet "boto3>=1.29"'
+kubectl -n "${NS}" exec irsa-sim-sandbox -- sh -c 'HOME=/tmp python3 /irsa-sim/check_irsa.py'
+echo "Happy path OK."
+
+echo "=== Negative path: forged token (unknown kid) must be rejected ==="
+# Builds a syntactically valid JWT (three base64url segments) whose
+# signature is garbage -- no crypto library needed, since any signature
+# that doesn't match the cluster's real signing key must be rejected.
+FORGED_TOKEN=$(kubectl -n "${NS}" exec irsa-sim-sandbox -- python3 -c '
+import base64, json
+def b64u(b):
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+header = b64u(json.dumps({"alg": "RS256", "kid": "not-a-real-kid"}).encode())
+payload = b64u(json.dumps({"iss": "https://kubernetes.default.svc.cluster.local", "aud": "sts.amazonaws.com", "exp": 9999999999, "iat": 0}).encode())
+sig = b64u(b"not-a-real-signature")
+print(f"{header}.{payload}.{sig}")
+')
+
+assert_rejected "forged-token-test" "${FORGED_TOKEN}" \
+    "Forged token was NOT rejected -- trust-boundary verification is broken."
+echo "Negative path OK (unknown kid): forged token correctly rejected."
+
+echo "=== Negative path: real kid, forged signature, must still be rejected ==="
+# The check above proves the kid-lookup rejects an unrecognized key, but
+# doesn't exercise the actual RSA signature check. Reuse the real webhook
+# token's own kid (a real key the verifier will find) with a bogus
+# signature, so this only passes if the signature bytes are cryptographically
+# verified, not merely if a matching kid is found in the JWKS.
+REAL_KID=$(kubectl -n "${NS}" exec irsa-sim-sandbox -- sh -c 'cat "$AWS_WEB_IDENTITY_TOKEN_FILE"' | python3 -c "
+import sys, base64, json
+token = sys.stdin.read().strip()
+header_b64 = token.split('.')[0]
+header_b64 += '=' * (-len(header_b64) % 4)
+print(json.loads(base64.urlsafe_b64decode(header_b64))['kid'])
+")
+
+FORGED_TOKEN_REAL_KID=$(kubectl -n "${NS}" exec irsa-sim-sandbox -- python3 -c "
+import base64, json
+def b64u(b):
+    return base64.urlsafe_b64encode(b).rstrip(b'=').decode()
+header = b64u(json.dumps({'alg': 'RS256', 'kid': '${REAL_KID}'}).encode())
+payload = b64u(json.dumps({'iss': 'https://kubernetes.default.svc.cluster.local', 'aud': 'sts.amazonaws.com', 'exp': 9999999999, 'iat': 0}).encode())
+sig = b64u(b'still-not-a-real-signature-bytes')
+print(f'{header}.{payload}.{sig}')
+")
+
+assert_rejected "forged-real-kid-test" "${FORGED_TOKEN_REAL_KID}" \
+    "Real-kid/forged-signature token was NOT rejected -- signature verification is broken."
+echo "Negative path OK (real kid, forged signature): correctly rejected."
+
+echo "=== Negative path: real signature, wrong audience, must be rejected ==="
+# The two checks above never reach claim validation -- an unknown kid fails
+# at JWKS lookup, and a forged signature fails at the signature check. A
+# regression that silently dropped the audience/issuer checks in
+# jwt.decode() would still pass both. This uses kubectl's own TokenRequest
+# API to mint a token that is genuinely signed by the cluster's real key
+# (same kid, same issuer) but with a deliberately wrong audience, so
+# rejection here can only come from the audience check itself.
+WRONG_AUDIENCE_TOKEN=$(kubectl create token irsa-sim-sa -n "${NS}" --audience="not-sts.amazonaws.com" --duration=10m)
+
+assert_rejected "wrong-audience-test" "${WRONG_AUDIENCE_TOKEN}" \
+    "Wrong-audience token was NOT rejected -- audience validation is broken."
+echo "Negative path OK (real signature, wrong audience): correctly rejected."
+
+echo "=== Negative path: real signature, mismatched EXPECTED_ISSUER, must be rejected ==="
+# Same idea for the issuer check: mint a genuinely cluster-signed,
+# correct-audience token, but point the verifier at a different
+# EXPECTED_ISSUER than the one that actually signed it, so rejection here
+# can only come from the issuer check.
+CORRECT_AUDIENCE_TOKEN=$(kubectl create token irsa-sim-sa -n "${NS}" --audience="sts.amazonaws.com" --duration=10m)
+kubectl -n "${NS}" set env deployment/sts-trust-verifier "EXPECTED_ISSUER=https://wrong-issuer.example.com"
+kubectl -n "${NS}" rollout status deployment/sts-trust-verifier --timeout=120s
+
+assert_rejected "wrong-issuer-test" "${CORRECT_AUDIENCE_TOKEN}" \
+    "Token with a mismatched EXPECTED_ISSUER was NOT rejected -- issuer validation is broken."
+echo "Negative path OK (real signature, mismatched issuer): correctly rejected."
+
+echo ""
+echo "Test finished."

--- a/examples/irsa-simulation-localstack/run-test-kind.sh
+++ b/examples/irsa-simulation-localstack/run-test-kind.sh
@@ -83,7 +83,7 @@ post_token() {
     local token="$2"
     kubectl -n "${NS}" exec irsa-sim-sandbox -- python3 -c "
 $(ssl_helper)
-import urllib.parse, urllib.request
+import urllib.parse, urllib.request, urllib.error
 body = urllib.parse.urlencode({
     'Action': 'AssumeRoleWithWebIdentity',
     'Version': '2011-06-15',
@@ -96,6 +96,13 @@ try:
     print(urllib.request.urlopen(req, context=_ssl_ctx).read().decode())
 except urllib.error.HTTPError as e:
     print(e.read().decode())
+except urllib.error.URLError as e:
+    # A connection refused/reset during the kube-proxy dataplane-convergence
+    # window (see assert_rejected below) raises this, not HTTPError. Printing
+    # instead of letting it propagate keeps this a plain non-zero-exit-free
+    # script output, so 'set -e' doesn't kill the whole test on a transient
+    # connection error that assert_rejected's retry loop is meant to absorb.
+    print(f'URLError: {e.reason}')
 "
 }
 

--- a/examples/irsa-simulation-localstack/sandbox.yaml
+++ b/examples/irsa-simulation-localstack/sandbox.yaml
@@ -12,13 +12,44 @@ spec:
         image: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/python-runtime-sandbox:latest-main
         env:
         - name: AWS_ENDPOINT_URL_STS
-          value: "http://localstack.irsa-sim-ns.svc.cluster.local:4566"
+          # Routed through sts-trust-verifier, not straight to LocalStack: the
+          # verifier checks the WebIdentityToken's signature/issuer/audience
+          # before forwarding to LocalStack's STS mock (see
+          # trust-verifier-configmap.yaml and the README's "Trust boundary
+          # verification" section). https, not http: this carries the real
+          # WebIdentityToken and the resulting AWS credentials, so it's
+          # TLS-encrypted end to end -- see AWS_CA_BUNDLE below for how this
+          # pod actually verifies the verifier's certificate, rather than
+          # just encrypting to an unverified endpoint.
+          value: "https://sts-trust-verifier.irsa-sim-ns.svc.cluster.local:4566"
         - name: AWS_REGION
           value: "us-east-1"
+        - name: AWS_CA_BUNDLE
+          # botocore reads this for every client it constructs, including the
+          # one the WebIdentityRoleCredentialFetcher builds internally for
+          # AssumeRoleWithWebIdentity -- there's no separate "verify=" knob
+          # exposed for that internal client, so this is the supported way to
+          # make it trust sts-trust-verifier's cert-manager-issued
+          # certificate instead of either failing closed or (worse) someone
+          # reaching for verify=False on a hop that actually carries
+          # credentials.
+          value: "/irsa-sim-tls/ca.crt"
         volumeMounts:
         - name: check-script
           mountPath: /irsa-sim
+        - name: verifier-ca
+          mountPath: /irsa-sim-tls
+          readOnly: true
       volumes:
       - name: check-script
         configMap:
           name: irsa-sim-check-script
+      - name: verifier-ca
+        # Same Secret sts-trust-verifier.yaml mounts tls.crt/tls.key from
+        # (trust-verifier-tls.yaml); this pod only needs the public ca.crt
+        # (identical to tls.crt for a self-signed cert-manager Certificate).
+        secret:
+          secretName: sts-trust-verifier-tls
+          items:
+            - key: ca.crt
+              path: ca.crt

--- a/examples/irsa-simulation-localstack/trust-verifier-configmap.yaml
+++ b/examples/irsa-simulation-localstack/trust-verifier-configmap.yaml
@@ -1,0 +1,299 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sts-trust-verifier-script
+  namespace: irsa-sim-ns
+data:
+  verify_and_proxy.py: |
+    """Minimal STS-shaped proxy that actually verifies the WebIdentityToken's
+    signature, issuer, and audience before forwarding to LocalStack.
+
+    This closes the gap called out in the README: LocalStack's STS mock
+    accepts any WebIdentityToken without checking it, so on its own it only
+    proves the pod *discovers and uses* IRSA-style credentials, not that the
+    token would be trusted by a real relying party. This proxy performs the
+    same cryptographic check AWS IAM performs when an OIDC provider is
+    registered: fetch the issuer's JWKS, verify the JWT signature against it,
+    and check `aud`/`iss`/`exp`.
+
+    It does NOT validate a real AWS account's IAM OIDC provider registration
+    or role trust policy -- there is no real AWS account involved. It proves
+    the verification *mechanics* work against the cluster's real signing key,
+    nothing about a specific AWS account's configuration.
+
+    Only the AssumeRoleWithWebIdentity action is verified. Any other STS
+    action is passed straight through to LocalStack unauthenticated, matching
+    LocalStack's own local-only trust model -- this proxy only adds a check
+    for the one action this example's credential flow actually uses.
+
+    Uses http.server.ThreadingHTTPServer, which spawns one thread per
+    connection with no cap on the total number of threads. A per-connection
+    socket timeout (Handler.timeout below) bounds how long a single slow or
+    incomplete connection can hold a thread, but there is still no hard
+    concurrency ceiling. Fine for this single-sandbox kind-cluster demo; do
+    not copy this as-is into anything reachable by more than a handful of
+    trusted callers.
+
+    Both hops are TLS, not cleartext, and both are genuinely
+    certificate-verified: this server terminates HTTPS using a
+    cert-manager-issued certificate (trust-verifier-tls.yaml) that the
+    sandbox pod actually verifies (see AWS_CA_BUNDLE in sandbox.yaml), and it
+    in turn verifies LocalStack's own cert-manager-issued certificate
+    (localstack-tls.yaml, see LOCALSTACK_CA_FILE below) rather than
+    connecting with verify=False.
+    """
+    import json
+    import os
+    import ssl
+    import sys
+    import threading
+    import time
+    import urllib.parse
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    import jwt
+    import requests
+    from jwt import PyJWKSet
+
+    # Never build the JWKS URL from a claim inside the token being verified --
+    # that would let a caller supplying an arbitrary token make this proxy
+    # fetch an attacker-controlled URL (SSRF). The JWKS location is always
+    # this fixed, in-cluster, well-known endpoint; the token's own `iss` claim
+    # is only ever *compared* against EXPECTED_ISSUER below, never dereferenced.
+    JWKS_URL = os.environ.get("JWKS_URL", "https://kubernetes.default.svc/openid/v1/jwks")
+    SA_CA_CERT = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    SA_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    EXPECTED_ISSUER = os.environ["EXPECTED_ISSUER"]  # no default: force an explicit, reviewed value
+    EXPECTED_AUDIENCE = os.environ.get("EXPECTED_AUDIENCE", "sts.amazonaws.com")
+    LOCALSTACK_URL = os.environ.get("LOCALSTACK_URL", "https://localstack.irsa-sim-ns.svc.cluster.local:4566")
+    # localstack-tls.yaml issues LocalStack a certificate matching its real
+    # Service DNS name; this pod verifies against it genuinely, not verify=False.
+    LOCALSTACK_CA_FILE = os.environ.get("LOCALSTACK_CA_FILE", "/localstack-tls/ca.crt")
+
+    # cert-manager Certificate/trust-verifier-tls.yaml issues into this Secret,
+    # mounted read-only at this path by trust-verifier.yaml.
+    TLS_CERT_FILE = os.environ.get("TLS_CERT_FILE", "/tls/tls.crt")
+    TLS_KEY_FILE = os.environ.get("TLS_KEY_FILE", "/tls/tls.key")
+
+    # Kubernetes' own OIDC JWKS is always RS256-signed. Hardcoded rather than
+    # read from the token header (`jwt.get_unverified_header(token)["alg"]`)
+    # so the caller-controlled token can never choose its own algorithm --
+    # that's the alg-confusion class of attack, and this example exists to
+    # demonstrate the *correct* verification pattern, not merely one that
+    # happens to be safe because of the pinned library version.
+    EXPECTED_ALGORITHM = "RS256"
+
+    # ThreadingHTTPServer runs each request in its own thread, so reads/writes
+    # of this cache need _jwks_lock: without it, concurrent requests for the
+    # same unknown kid each observe the cache as stale and each call
+    # _fetch_jwks(), turning the 30s throttle below into a no-op (a
+    # thundering-herd correctness gap in the throttle itself, not in the
+    # verification result -- every caller still gets a correctly verified or
+    # rejected token either way).
+    _jwks_cache = {"keys_by_kid": {}, "fetched_at": 0.0}
+    _jwks_lock = threading.Lock()
+    _JWKS_MIN_REFETCH_INTERVAL_SECONDS = 30  # avoid hammering the API server if a bad kid is retried rapidly
+    # A *known* kid was, by definition, valid as of the last fetch -- but
+    # never re-checking it means a key removed from the cluster's JWKS
+    # (rotation, or a compromised key being revoked) stays trusted here
+    # indefinitely, until this process happens to restart. Force a refresh
+    # after this long even when every kid seen so far is still in cache, so
+    # a rotated-out key gets dropped (and any token still using it rejected)
+    # within a bounded window instead of never.
+    _JWKS_MAX_CACHE_AGE_SECONDS = 300
+
+
+    def _sa_bearer_token():
+        with open(SA_TOKEN_FILE) as f:
+            return f.read().strip()
+
+
+    def _fetch_jwks():
+        """(Re)fetch the cluster's own JWKS. Authenticated with this pod's own
+        ServiceAccount token: some clusters restrict the discovery endpoints to
+        `system:authenticated` rather than fully anonymous, so presenting our
+        own token (not the caller-supplied WebIdentityToken) works either way.
+        """
+        resp = requests.get(
+            JWKS_URL,
+            headers={"Authorization": f"Bearer {_sa_bearer_token()}"},
+            verify=SA_CA_CERT,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        jwks = PyJWKSet.from_dict(resp.json())
+        _jwks_cache["keys_by_kid"] = {k.key_id: k for k in jwks.keys}
+        _jwks_cache["fetched_at"] = time.monotonic()
+
+
+    def _cache_needs_refresh(kid):
+        cache_age = time.monotonic() - _jwks_cache["fetched_at"]
+        return kid not in _jwks_cache["keys_by_kid"] or cache_age > _JWKS_MAX_CACHE_AGE_SECONDS
+
+    def _get_signing_key(kid):
+        if _cache_needs_refresh(kid):
+            # Hold the lock across the throttle check *and* the fetch: without
+            # it, N concurrent requests for the same unknown kid can all pass
+            # the "stale?" check before any of them updates fetched_at, each
+            # triggering its own JWKS fetch against the API server (the
+            # thundering-herd case the 30s throttle exists to prevent).
+            with _jwks_lock:
+                if _cache_needs_refresh(kid) and (
+                    time.monotonic() - _jwks_cache["fetched_at"] > _JWKS_MIN_REFETCH_INTERVAL_SECONDS
+                ):
+                    _fetch_jwks()
+        jwk = _jwks_cache["keys_by_kid"].get(kid)
+        if jwk is None:
+            raise KeyError(f"no JWKS key found for kid={kid!r}")
+        return jwk.key
+
+
+    def _verify_web_identity_token(token):
+        """Raises on any verification failure; returns decoded claims on success."""
+        header = jwt.get_unverified_header(token)
+        kid = header.get("kid")
+        if not kid:
+            raise ValueError("token header has no 'kid'")
+        signing_key = _get_signing_key(kid)
+        return jwt.decode(
+            token,
+            key=signing_key,
+            algorithms=[EXPECTED_ALGORITHM],
+            audience=EXPECTED_AUDIENCE,
+            issuer=EXPECTED_ISSUER,
+            options={"require": ["exp", "iat", "aud", "iss"]},
+        )
+
+
+    def _sts_error_xml(code, message, fault_type="Sender"):
+        return (
+            '<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">'
+            f"<Error><Type>{fault_type}</Type><Code>{code}</Code><Message>{message}</Message></Error>"
+            "<RequestId>local-trust-verifier</RequestId></ErrorResponse>"
+        ).encode()
+
+
+    class Handler(BaseHTTPRequestHandler):
+        # Bounds how long one connection can hold its thread: without this,
+        # a caller that opens a connection (TLS or not) and never finishes
+        # sending a request blocks that thread indefinitely, and enough of
+        # them exhausts ThreadingHTTPServer's uncapped thread-per-connection
+        # model. socketserver.BaseRequestHandler honors this by calling
+        # settimeout() on the accepted socket before handling it; a timeout
+        # triggers handle_timeout() (default: just closes the connection).
+        timeout = 30
+
+        def setup(self):
+            # __main__ wraps the listening socket with
+            # do_handshake_on_connect=False, so the TLS handshake is not
+            # performed inside accept() (see the comment there); it happens
+            # here instead, in this connection's own worker thread.
+            # super().setup() runs first and calls settimeout(self.timeout)
+            # on the connection before we touch it, so a stalled handshake
+            # (no ClientHello ever sent) is bounded by the same 30s timeout
+            # as a stalled HTTP request, not left to hang.
+            super().setup()
+            self.connection.do_handshake()
+
+        def log_message(self, fmt, *args):
+            sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+        # Caller-controlled Content-Length must be validated before it's
+        # trusted to size a read() call -- an unbounded or malformed value
+        # would let any caller force a large in-memory allocation.
+        MAX_BODY_BYTES = 1 << 20  # 1 MiB; real AssumeRoleWithWebIdentity bodies are a few KB.
+
+        def do_POST(self):
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+            except ValueError:
+                return self._respond(400, _sts_error_xml("InvalidIdentityToken", "invalid Content-Length"))
+            if length < 0 or length > self.MAX_BODY_BYTES:
+                return self._respond(400, _sts_error_xml("InvalidIdentityToken", "request body too large"))
+            body = self.rfile.read(length)
+            params = urllib.parse.parse_qs(body.decode())
+            action = params.get("Action", [None])[0]
+
+            if action == "AssumeRoleWithWebIdentity":
+                token = params.get("WebIdentityToken", [None])[0]
+                if not token:
+                    return self._respond(400, _sts_error_xml("InvalidIdentityToken", "missing WebIdentityToken"))
+                try:
+                    _verify_web_identity_token(token)
+                except Exception as e:
+                    # Full reason goes to server logs only -- echoing exception
+                    # text back to the caller in the response body is a minor
+                    # info-disclosure smell for something demonstrating a
+                    # security check, and str(e) isn't guaranteed XML-safe.
+                    print(f"REJECTED AssumeRoleWithWebIdentity: {e}", file=sys.stderr)
+                    return self._respond(400, _sts_error_xml("InvalidIdentityToken", "WebIdentityToken failed verification"))
+                print("VERIFIED AssumeRoleWithWebIdentity: signature/issuer/audience/expiry OK", file=sys.stderr)
+
+            # Verified (or not an action this proxy checks) -- forward untouched.
+            # verify=LOCALSTACK_CA_FILE, not verify=False: localstack-tls.yaml
+            # gives LocalStack a certificate matching its real Service DNS
+            # name (unlike LocalStack's own baked-in, publicly-known test
+            # cert), so this hop is genuinely certificate-verified, the same
+            # as the sandbox -> verifier hop below (__main__).
+            try:
+                upstream = requests.post(
+                    LOCALSTACK_URL,
+                    data=body,
+                    headers={"Content-Type": self.headers.get("Content-Type", "application/x-www-form-urlencoded")},
+                    timeout=10,
+                    verify=LOCALSTACK_CA_FILE,
+                    # The body being forwarded carries the now-verified
+                    # WebIdentityToken. requests follows POST redirects
+                    # (307/308 preserve the body) by default, so a redirecting
+                    # LocalStack response could otherwise cause the token to
+                    # be re-sent to a URL outside our TLS-verified endpoint.
+                    allow_redirects=False,
+                )
+            except requests.exceptions.RequestException as e:
+                # timeout=10 bounds the call itself, but a connection error,
+                # timeout, or bad TLS handshake still raises here -- without
+                # this, do_POST would exit with no _respond() call at all,
+                # leaving the caller hanging on a half-open connection
+                # instead of getting a clean error back.
+                print(f"LocalStack request failed: {e}", file=sys.stderr)
+                return self._respond(502, _sts_error_xml("InternalFailure", "upstream STS request failed", fault_type="Receiver"))
+            self._respond(upstream.status_code, upstream.content)
+
+        def _respond(self, status, body_bytes):
+            self.send_response(status)
+            self.send_header("Content-Type", "text/xml")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.end_headers()
+            self.wfile.write(body_bytes)
+
+
+    if __name__ == "__main__":
+        _fetch_jwks()
+        server = ThreadingHTTPServer(("0.0.0.0", 4566), Handler)
+        # Terminates TLS here with the cert-manager-issued cert/key mounted
+        # from trust-verifier-tls.yaml's Secret -- this is the hop that
+        # carries the real WebIdentityToken and the resulting AWS
+        # credentials, so unlike the LocalStack hop above, callers (the
+        # sandbox pod, via AWS_CA_BUNDLE) are expected to actually verify
+        # this certificate, not skip verification.
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(certfile=TLS_CERT_FILE, keyfile=TLS_KEY_FILE)
+        # do_handshake_on_connect=False: ThreadingHTTPServer's accept loop is
+        # single-threaded -- a client that opens a raw TCP connection and
+        # never sends a TLS ClientHello would otherwise block *inside
+        # accept() itself* (the default performs the handshake synchronously
+        # as part of accepting), stalling every other connection before a
+        # worker thread even exists. Handler.timeout only bounds a
+        # connection's own thread once accept() has already returned, so it
+        # cannot protect the accept loop from this. With the handshake
+        # deferred, it happens lazily on first read/write inside the
+        # per-connection worker thread instead, where Handler.timeout does
+        # apply.
+        server.socket = ssl_context.wrap_socket(
+            server.socket,
+            server_side=True,
+            do_handshake_on_connect=False,
+        )
+        print(f"sts-trust-verifier listening on :4566 (TLS), issuer={EXPECTED_ISSUER!r} audience={EXPECTED_AUDIENCE!r}", file=sys.stderr)
+        server.serve_forever()

--- a/examples/irsa-simulation-localstack/trust-verifier-tls.yaml
+++ b/examples/irsa-simulation-localstack/trust-verifier-tls.yaml
@@ -1,0 +1,23 @@
+# TLS for the sandbox <-> sts-trust-verifier hop: this is the leg that
+# carries the real WebIdentityToken outbound and the resulting AWS
+# credentials back, so it gets a certificate the sandbox pod actually
+# trusts and verifies (unlike the verifier -> LocalStack hop -- see the
+# verify=False comment in trust-verifier-configmap.yaml for why that one is
+# different).
+#
+# Uses the "selfsigned" ClusterIssuer that amazon-eks-pod-identity-webhook's
+# own install already creates (see README.md Prerequisites) rather than
+# introducing a second cert-manager issuer just for this.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sts-trust-verifier-tls
+  namespace: irsa-sim-ns
+spec:
+  secretName: sts-trust-verifier-tls
+  dnsNames:
+    - sts-trust-verifier.irsa-sim-ns.svc.cluster.local
+    - sts-trust-verifier.irsa-sim-ns.svc
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer

--- a/examples/irsa-simulation-localstack/trust-verifier.yaml
+++ b/examples/irsa-simulation-localstack/trust-verifier.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sts-trust-verifier
+  namespace: irsa-sim-ns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sts-trust-verifier
+  template:
+    metadata:
+      labels:
+        app: sts-trust-verifier
+    spec:
+      # Needs its own projected ServiceAccount token to authenticate to the
+      # cluster's /openid/v1/jwks discovery endpoint (see verify_and_proxy.py)
+      # -- this is unrelated to, and must not be confused with, the
+      # WebIdentityToken it verifies on incoming requests.
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: verifier
+        image: python:3.12-slim
+        command:
+          - sh
+          - -c
+          - |
+            pip install --user --quiet --no-cache-dir "pyjwt[crypto]>=2.8,<3" "requests>=2.31,<3" && \
+            exec python3 /verifier/verify_and_proxy.py
+        env:
+        # The image's /usr/local/lib site-packages isn't writable by non-root
+        # UID 1000, so install with --user; HOME=/tmp gives pip (and Python's
+        # automatic user-site lookup) a writable home. /tmp is world-writable
+        # (sticky 1777) in this base image already, so no extra volume mount
+        # is needed for it.
+        - name: HOME
+          value: "/tmp"
+        # Discover this on your cluster with:
+        #   kubectl get --raw /.well-known/openid-configuration | python3 -c 'import json,sys; print(json.load(sys.stdin)["issuer"])'
+        # Set explicitly (not derived from any incoming token) so a caller
+        # can never redirect this proxy's trust to an issuer of their choosing.
+        - name: EXPECTED_ISSUER
+          value: "https://kubernetes.default.svc.cluster.local"
+        - name: EXPECTED_AUDIENCE
+          value: "sts.amazonaws.com"
+        - name: LOCALSTACK_URL
+          # https, not http: LocalStack auto-detects TLS and serves HTTPS on
+          # this same port with no extra config.
+          value: "https://localstack.irsa-sim-ns.svc.cluster.local:4566"
+        - name: LOCALSTACK_CA_FILE
+          # localstack-tls.yaml issues LocalStack a certificate matching its
+          # real Service DNS name; this hop is genuinely certificate-verified
+          # against it, not verify=False.
+          value: "/localstack-tls/ca.crt"
+        ports:
+        - containerPort: 4566
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        volumeMounts:
+        - name: verifier-script
+          mountPath: /verifier
+        - name: tls
+          mountPath: /tls
+          readOnly: true
+        - name: localstack-ca
+          mountPath: /localstack-tls
+          readOnly: true
+        readinessProbe:
+          tcpSocket:
+            port: 4566
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: verifier-script
+        configMap:
+          name: sts-trust-verifier-script
+      - name: tls
+        # Issued by trust-verifier-tls.yaml's Certificate; apply that before
+        # this Deployment or the pod will fail to start (missing Secret).
+        secret:
+          secretName: sts-trust-verifier-tls
+      - name: localstack-ca
+        # Only the public ca.crt is needed here (to verify LocalStack's
+        # cert), unlike the "tls" volume above which needs tls.crt/tls.key
+        # for this pod's own server-side TLS termination.
+        secret:
+          secretName: localstack-tls
+          items:
+            - key: ca.crt
+              path: ca.crt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sts-trust-verifier
+  namespace: irsa-sim-ns
+spec:
+  selector:
+    app: sts-trust-verifier
+  ports:
+  - port: 4566
+    targetPort: 4566


### PR DESCRIPTION
#### What this PR does / why we need it:
`irsa-simulation-localstack` (#1340) documents that LocalStack's STS mock accepts any `WebIdentityToken` without checking it, so on its own it only proves the sandbox pod *discovers and uses* IRSA-style credentials — not that the token would be trusted by a real relying party.

This adds `sts-trust-verifier`, a small proxy sitting in front of LocalStack that, for the one action this flow uses (`AssumeRoleWithWebIdentity`), fetches the cluster's own JWKS from its `/openid/v1/jwks` discovery endpoint and verifies the token's signature, issuer, and audience before forwarding to LocalStack — the same cryptographic check a real AWS IAM OIDC provider performs. The JWKS location is always a fixed, in-cluster constant, never derived from the token being verified, to avoid an SSRF vector.

This still doesn't validate a real AWS account's IAM OIDC provider registration or role trust policy (there is no real AWS account involved) — it proves the verification mechanics work correctly against the cluster's actual signing key, which is what the original example's caveat called out as unverified.

**Hardening baked into the verifier:**
- Verification is pinned to `algorithms=["RS256"]` rather than trusting the token's own header `alg` — closes the alg-confusion class of attack.
- A *known* `kid` is re-checked against the cluster's real JWKS every 300s, not trusted forever — otherwise a rotated/revoked key stays trusted indefinitely.
- Concurrent requests for the same not-yet-cached `kid` are serialized with a lock so they collapse into a single JWKS fetch instead of a thundering herd.
- Rejections return a generic error message to the caller; the real reason goes to server logs only.
- `Handler.timeout = 30` bounds how long a caller can hold a thread open with a stalled connection.
- `do_handshake_on_connect=False` + an explicit handshake in `Handler.setup()`: the TLS handshake used to happen inside the server's single-threaded accept loop, so a client that opens a connection and never sends a ClientHello could block *all* other connections. Now the handshake happens per-connection in that connection's own thread, bounded by the same timeout.
- Upstream request failures (LocalStack unreachable/timeout) now return a clean `502 InternalFailure` instead of leaving the caller hanging.
- The Deployment sets CPU/memory requests and limits.

**Transport encryption — both hops TLS, both genuinely certificate-verified (no `verify=False` anywhere):**
- **sandbox → sts-trust-verifier** (carries the real WebIdentityToken and the resulting AWS credentials): `trust-verifier-tls.yaml` issues a certificate via cert-manager's `selfsigned` `ClusterIssuer` (the one `amazon-eks-pod-identity-webhook`'s own install already creates), and the sandbox pod genuinely verifies it via `AWS_CA_BUNDLE`.
- **sts-trust-verifier → LocalStack**: LocalStack supports `CUSTOM_SSL_CERT_PATH` for a custom certificate. `localstack-tls.yaml` issues LocalStack its own certificate matching its real Service DNS name; `localstack.yaml`'s init container concatenates cert-manager's separate `tls.key`/`tls.crt` into the single combined PEM file LocalStack expects. The verifier verifies against it (`LOCALSTACK_CA_FILE`).

`run-test-kind.sh` automates the happy path (a real webhook-injected token) and four rejection cases against a live cluster:
- an unrecognized `kid`
- a real `kid` with a forged signature (exercises the RSA signature check itself, not just the key lookup)
- a genuinely cluster-signed token (minted via `kubectl create token`) with the wrong audience
- a genuinely cluster-signed, correct-audience token checked against a deliberately mismatched `EXPECTED_ISSUER`

The last two specifically exercise the audience/issuer checks in `jwt.decode()` — the first two are rejected earlier and wouldn't catch a regression that dropped those two checks. Expired-token rejection is verified separately via an isolated cryptographic test rather than the live script, since Kubernetes' TokenRequest API hard-rejects any token duration under 10 minutes, making a live already-expired cluster-signed token impractical to obtain quickly.

Verified live end-to-end against a kind cluster with cert-manager + `amazon-eks-pod-identity-webhook` installed: all five cases behave correctly over real, mutually-verified TLS on both hops. Also verified in isolation: a hand-built alg-confusion token is rejected purely because the algorithm is pinned server-side; 20 concurrent requests for the same unknown `kid` trigger exactly one JWKS fetch; a simulated key rotation causes a previously-cached, now-rotated-out `kid` to be rejected once the cache-age window elapses; a stalled/incomplete connection is dropped after ~30s instead of hanging forever; a stalled TLS handshake no longer blocks a second, legitimate connection; an unreachable upstream returns a clean 502; and an expired-but-correctly-signed token is rejected while an otherwise-identical non-expired one is accepted.

One test-harness bug found and fixed along the way: `kubectl rollout status` confirms the control plane's view of a rollout, but kube-proxy's dataplane converges asynchronously — a request made the instant `rollout status` returns can occasionally still race a just-terminated pod. Replaced ad hoc response checks with an `assert_rejected` helper that retries briefly; this caught the exact race live during testing.

#### Which issue(s) this PR is related to:
Ref #818 (cites this example directly when discussing the static/unverified nature of IRSA-style credentials in agent-sandbox)

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a trust-verifier proxy for the IRSA LocalStack simulation.
  * Added JWT signature and claim validation for issuer, audience, expiry, key rotation, and forged tokens.
  * Added HTTPS protection and certificate verification for both credential-bearing connections.
  * Added Kubernetes deployment, certificates, configuration, and sandbox integration.

* **Documentation**
  * Expanded setup, verification, cleanup, network policy, and security guidance.

* **Tests**
  * Added end-to-end Kind coverage for valid requests and multiple invalid-token scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->