### PR TITLE
Fix stale olm lint pin and regenerate drifted protobuf file

### DIFF
--- a/olm/Makefile
+++ b/olm/Makefile
@@ -247,7 +247,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
-GOLANGCI_LINT_VERSION ?= v2.1.0
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/packages/sandboxd/spec/process/v1/process.pb.go
+++ b/packages/sandboxd/spec/process/v1/process.pb.go
@@ -360,7 +360,6 @@ type StartResponse struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Event:
-	//
 	//	*StartResponse_Init
 	//	*StartResponse_Stdout
 	//	*StartResponse_Stderr
@@ -584,7 +583,6 @@ type WriteStdinRequest struct {
 
 	ProcessId int32 `protobuf:"varint,1,opt,name=process_id,json=processId,proto3" json:"process_id,omitempty"`
 	// Types that are assignable to Payload:
-	//
 	//	*WriteStdinRequest_Input
 	//	*WriteStdinRequest_Eof
 	Payload isWriteStdinRequest_Payload `protobuf_oneof:"payload"`


### PR DESCRIPTION
#### What this PR does / why we need it:
Two presubmit checks (`presubmit-agent-sandbox-lint-olm`, `presubmit-test-autogen-up-to-date`) are currently failing on `main` and on every PR rebased against it, unrelated to whatever those PRs actually change.

**`lint-olm`:** `olm/Makefile` pins `GOLANGCI_LINT_VERSION ?= v2.1.0`, which predates the repo's `go 1.26.0` requirement (toolchain `go1.26.4`). Elsewhere in the repo, golangci-lint is already managed via `dev/tools/go.mod`'s `tool` block and is on `v2.12.2`. The stale `olm`-local pin can't type-check code under Go 1.26, so every symbol pulled in through the ginkgo/gomega dot-imports in `olm/test/e2e/*.go` and `olm/test/utils/utils.go` shows up as `undefined: X (typecheck)` -- not a real code defect, just a version pin that never got bumped alongside the rest of the repo. Bumping it to `v2.12.2` for consistency fixes it.

**`test-autogen-up-to-date`:** `packages/sandboxd/spec/process/v1/process.pb.go` had drifted from what `dev/tools/fix-go-generate` produces under the current Go toolchain -- `gofmt` now drops a redundant blank `//` line immediately before two `oneof` type lists (`Types that are assignable to Event:` / `...to Payload:`). Regenerated and committed the up-to-date file.

Verified both failures reproduce identically on other open, unrelated PRs (#1579, #1572), confirming this is pre-existing drift on `main` and not specific to any one PR's changes.

#### Which issue(s) this PR is related to:
None

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated code-quality checks to use a newer linting tool version.
  - No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->